### PR TITLE
Kodierfälle zwischen Kodierern übertragen

### DIFF
--- a/apps/backend/src/app/admin/coding-job/dto/transfer-coding-cases-result.dto.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/transfer-coding-cases-result.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TransferCodingCasesResultDto {
+  @ApiProperty({
+    description: 'Source coder user ID',
+    example: 12
+  })
+    sourceCoderId: number;
+
+  @ApiProperty({
+    description: 'Target coder user ID',
+    example: 34
+  })
+    targetCoderId: number;
+
+  @ApiProperty({
+    description: 'Number of affected coding jobs',
+    example: 8
+  })
+    affectedJobs: number;
+
+  @ApiProperty({
+    description: 'Number of updated coder assignments',
+    example: 6
+  })
+    updatedAssignments: number;
+
+  @ApiProperty({
+    description: 'Number of duplicate source assignments removed because target coder was already assigned',
+    example: 2
+  })
+    removedDuplicateAssignments: number;
+
+  @ApiProperty({
+    description: 'Number of coding job units (cases) associated with affected jobs',
+    example: 254
+  })
+    transferredCases: number;
+}

--- a/apps/backend/src/app/admin/coding-job/dto/transfer-coding-cases.dto.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/transfer-coding-cases.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, Min } from 'class-validator';
+
+export class TransferCodingCasesDto {
+  @ApiProperty({
+    description: 'Source coder user ID',
+    example: 12
+  })
+  @IsInt()
+  @Min(1)
+    sourceCoderId: number;
+
+  @ApiProperty({
+    description: 'Target coder user ID',
+    example: 34
+  })
+  @IsInt()
+  @Min(1)
+    targetCoderId: number;
+}

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -1,5 +1,5 @@
 import {
-  Injectable, Logger, NotFoundException
+  BadRequestException, Injectable, Logger, NotFoundException
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -56,6 +56,15 @@ interface JobCreationWarning {
   message: string;
   casesInJobs: number;
   availableCases: number;
+}
+
+export interface TransferCodingCasesResult {
+  sourceCoderId: number;
+  targetCoderId: number;
+  affectedJobs: number;
+  updatedAssignments: number;
+  removedDuplicateAssignments: number;
+  transferredCases: number;
 }
 
 type VariableReference = { unitName: string; variableId: string };
@@ -459,6 +468,90 @@ export class CodingJobService {
     }));
 
     return repo.save(coders);
+  }
+
+  async transferCodingCases(
+    workspaceId: number,
+    sourceCoderId: number,
+    targetCoderId: number
+  ): Promise<TransferCodingCasesResult> {
+    if (sourceCoderId === targetCoderId) {
+      throw new BadRequestException('Source and target coder must be different');
+    }
+
+    return this.connection.transaction(async manager => {
+      const codingJobCoderRepo = manager.getRepository(CodingJobCoder);
+      const codingJobUnitRepo = manager.getRepository(CodingJobUnit);
+
+      const sourceAssignments = await codingJobCoderRepo
+        .createQueryBuilder('assignment')
+        .innerJoin(CodingJob, 'job', 'job.id = assignment.coding_job_id')
+        .where('assignment.user_id = :sourceCoderId', { sourceCoderId })
+        .andWhere('job.workspace_id = :workspaceId', { workspaceId })
+        .getMany();
+
+      if (sourceAssignments.length === 0) {
+        return {
+          sourceCoderId,
+          targetCoderId,
+          affectedJobs: 0,
+          updatedAssignments: 0,
+          removedDuplicateAssignments: 0,
+          transferredCases: 0
+        };
+      }
+
+      const affectedJobIds = [...new Set(sourceAssignments.map(assignment => assignment.coding_job_id))];
+
+      const existingTargetAssignments = await codingJobCoderRepo.find({
+        where: {
+          coding_job_id: In(affectedJobIds),
+          user_id: targetCoderId
+        },
+        select: ['coding_job_id']
+      });
+
+      const existingTargetJobIds = new Set(
+        existingTargetAssignments.map(assignment => assignment.coding_job_id)
+      );
+
+      const updateAssignmentIds: number[] = [];
+      const deleteAssignmentIds: number[] = [];
+
+      sourceAssignments.forEach(assignment => {
+        if (existingTargetJobIds.has(assignment.coding_job_id)) {
+          deleteAssignmentIds.push(assignment.id);
+          return;
+        }
+        updateAssignmentIds.push(assignment.id);
+      });
+
+      if (updateAssignmentIds.length > 0) {
+        await codingJobCoderRepo
+          .createQueryBuilder()
+          .update(CodingJobCoder)
+          .set({ user_id: targetCoderId })
+          .whereInIds(updateAssignmentIds)
+          .execute();
+      }
+
+      if (deleteAssignmentIds.length > 0) {
+        await codingJobCoderRepo.delete(deleteAssignmentIds);
+      }
+
+      const transferredCases = await codingJobUnitRepo.count({
+        where: { coding_job_id: In(affectedJobIds) }
+      });
+
+      return {
+        sourceCoderId,
+        targetCoderId,
+        affectedJobs: affectedJobIds.length,
+        updatedAssignments: updateAssignmentIds.length,
+        removedDuplicateAssignments: deleteAssignmentIds.length,
+        transferredCases
+      };
+    });
   }
 
   private async assignVariables(

--- a/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
+++ b/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
@@ -29,11 +29,14 @@ import {
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from '../../admin/workspace/workspace.guard';
 import { WorkspaceId } from '../../admin/workspace/workspace.decorator';
+import { AccessLevelGuard, RequireAccessLevel } from '../../admin/workspace/access-level.guard';
 import { CodingJobService, CodingReplayService } from '../../database/services/coding';
 import { CodingJobDto } from '../../admin/coding-job/dto/coding-job.dto';
 import { CreateCodingJobDto } from '../../admin/coding-job/dto/create-coding-job.dto';
 import { UpdateCodingJobDto } from '../../admin/coding-job/dto/update-coding-job.dto';
 import { SaveCodingProgressDto } from '../../admin/coding-job/dto/save-coding-progress.dto';
+import { TransferCodingCasesDto } from '../../admin/coding-job/dto/transfer-coding-cases.dto';
+import { TransferCodingCasesResultDto } from '../../admin/coding-job/dto/transfer-coding-cases-result.dto';
 
 @ApiTags('WSG Admin Coding Jobs')
 @Controller('wsg-admin/workspace/:workspace_id/coding-job')
@@ -42,6 +45,38 @@ export class WsgCodingJobController {
     private readonly codingJobService: CodingJobService,
     private readonly codingReplayService: CodingReplayService
   ) { }
+
+  @Post('transfer-cases')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
+  @RequireAccessLevel(2)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Transfer coding cases between coders',
+    description: 'Transfers coding jobs/cases assigned to one coder to another coder within the same workspace'
+  })
+  @ApiParam({
+    name: 'workspace_id',
+    type: Number,
+    required: true,
+    description: 'The ID of the workspace'
+  })
+  @ApiOkResponse({
+    description: 'Coding cases transferred successfully',
+    type: TransferCodingCasesResultDto
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid transfer request.'
+  })
+  async transferCodingCases(
+    @WorkspaceId() workspaceId: number,
+      @Body() transferCodingCasesDto: TransferCodingCasesDto
+  ): Promise<TransferCodingCasesResultDto> {
+    return this.codingJobService.transferCodingCases(
+      workspaceId,
+      transferCodingCasesDto.sourceCoderId,
+      transferCodingCasesDto.targetCoderId
+    );
+  }
 
   @Get()
   @UseGuards(JwtAuthGuard, WorkspaceGuard)

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.html
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.html
@@ -57,6 +57,10 @@
         <mat-icon>rule</mat-icon>
         Alle Ergebnisse anwenden
       </button>
+      <button mat-button (click)="openTransferCodingCasesDialog()">
+        <mat-icon>swap_horiz</mat-icon>
+        Fälle übertragen
+      </button>
       }
       <button mat-raised-button color="warn" (click)="bulkDeleteCodingJobs()"
         [disabled]="selection.selected.length === 0" class="bulk-delete-button">

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
@@ -67,6 +67,14 @@ describe('CodingJobsComponent', () => {
       deleteCodingJob: jest.fn().mockReturnValue(of({ success: true })),
       startCodingJob: jest.fn().mockReturnValue(of({ items: [], total: 0 })),
       restartCodingJobWithOpenUnits: jest.fn().mockReturnValue(of({})),
+      transferCodingCases: jest.fn().mockReturnValue(of({
+        sourceCoderId: 1,
+        targetCoderId: 2,
+        affectedJobs: 2,
+        updatedAssignments: 2,
+        removedDuplicateAssignments: 0,
+        transferredCases: 10
+      })),
       applyCodingResults: jest.fn().mockReturnValue(of({ success: true })),
       bulkApplyCodingResults: jest.fn().mockReturnValue(of({
         success: true, jobsProcessed: 0, totalUpdatedResponses: 0, results: []
@@ -398,6 +406,24 @@ describe('CodingJobsComponent', () => {
     expect(codingJobBackendServiceMock.bulkApplyCodingResults).toHaveBeenCalledWith(1);
     expect(matSnackBarMock.open).toHaveBeenCalledWith(
       expect.stringContaining('Massenanwendung abgeschlossen'),
+      'Schließen',
+      expect.objectContaining({})
+    );
+  });
+
+  it('should transfer coding cases between coders', () => {
+    (matDialogMock.open as jest.Mock).mockReturnValue({
+      afterClosed: () => of({
+        sourceCoderId: 1,
+        targetCoderId: 2
+      })
+    });
+
+    component.openTransferCodingCasesDialog();
+
+    expect(codingJobBackendServiceMock.transferCodingCases).toHaveBeenCalledWith(1, 1, 2);
+    expect(matSnackBarMock.open).toHaveBeenCalledWith(
+      expect.stringContaining('Übertragung erfolgreich'),
       'Schließen',
       expect.objectContaining({})
     );

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
@@ -40,6 +40,10 @@ import { CodingJobResultDialogComponent } from './coding-job-result-dialog/codin
 import { CoderTraining } from '../../models/coder-training.model';
 import { DoubleCodedReviewComponent } from '../double-coded-review/double-coded-review.component';
 import { CohensKappaStatisticsComponent } from '../cohens-kappa-statistics/cohens-kappa-statistics.component';
+import {
+  TransferCodingCasesDialogComponent,
+  TransferCodingCasesDialogResult
+} from './transfer-coding-cases-dialog/transfer-coding-cases-dialog.component';
 
 interface BulkApplyResultItem {
   jobId: number;
@@ -819,6 +823,55 @@ export class CodingJobsComponent implements OnInit, AfterViewInit {
       if (result?.resultsApplied) {
         this.jobsChanged.emit();
       }
+    });
+  }
+
+  openTransferCodingCasesDialog(): void {
+    if (!this.allCoders?.length) {
+      this.snackBar.open('Keine Kodierer verfügbar', 'Schließen', { duration: 3000 });
+      return;
+    }
+
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      this.snackBar.open('Kein Workspace ausgewählt', 'Schließen', { duration: 3000 });
+      return;
+    }
+
+    const dialogRef = this.dialog.open(TransferCodingCasesDialogComponent, {
+      width: '560px',
+      maxWidth: '95vw',
+      data: { coders: this.allCoders }
+    });
+
+    dialogRef.afterClosed().subscribe((result?: TransferCodingCasesDialogResult) => {
+      if (!result) {
+        return;
+      }
+
+      this.codingJobBackendService.transferCodingCases(
+        workspaceId,
+        result.sourceCoderId,
+        result.targetCoderId
+      ).subscribe({
+        next: transferResult => {
+          this.snackBar.open(
+            `Übertragung erfolgreich: ${transferResult.transferredCases} Fälle in ${transferResult.affectedJobs} Job(s) angepasst`,
+            'Schließen',
+            { duration: 4000 }
+          );
+          this.loadCodingJobs();
+          this.jobsChanged.emit();
+        },
+        error: error => {
+          const apiMessage = error?.error?.message;
+          this.snackBar.open(
+            apiMessage || 'Fehler beim Übertragen der Kodierfälle',
+            'Schließen',
+            { duration: 5000 }
+          );
+        }
+      });
     });
   }
 

--- a/apps/frontend/src/app/coding/components/coding-jobs/transfer-coding-cases-dialog/transfer-coding-cases-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-jobs/transfer-coding-cases-dialog/transfer-coding-cases-dialog.component.html
@@ -1,0 +1,32 @@
+<h2 mat-dialog-title>Kodierfälle übertragen</h2>
+
+<mat-dialog-content class="fx-column-start-stretch fx-gap-16 dialog-content">
+  <p class="description">
+    Überträgt alle Kodierfälle von einem Kodierer auf einen anderen innerhalb des aktuellen Arbeitsbereichs.
+  </p>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Von Kodierer</mat-label>
+    <mat-select [(value)]="sourceCoderId">
+      <mat-option *ngFor="let coder of coders" [value]="coder.id">
+        {{ coder.displayName || coder.name }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Zu Kodierer</mat-label>
+    <mat-select [(value)]="targetCoderId">
+      <mat-option *ngFor="let coder of coders" [value]="coder.id">
+        {{ coder.displayName || coder.name }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Abbrechen</button>
+  <button mat-raised-button color="primary" [disabled]="submitDisabled" (click)="submit()">
+    Übertragen
+  </button>
+</mat-dialog-actions>

--- a/apps/frontend/src/app/coding/components/coding-jobs/transfer-coding-cases-dialog/transfer-coding-cases-dialog.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-jobs/transfer-coding-cases-dialog/transfer-coding-cases-dialog.component.scss
@@ -1,0 +1,7 @@
+.dialog-content {
+  min-width: min(520px, 80vw);
+}
+
+.description {
+  margin: 0;
+}

--- a/apps/frontend/src/app/coding/components/coding-jobs/transfer-coding-cases-dialog/transfer-coding-cases-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/transfer-coding-cases-dialog/transfer-coding-cases-dialog.component.ts
@@ -1,0 +1,83 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component, Inject
+} from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle
+} from '@angular/material/dialog';
+import {
+  MatFormField,
+  MatLabel,
+  MatOption,
+  MatSelect
+} from '@angular/material/select';
+import { MatButton } from '@angular/material/button';
+import { Coder } from '../../../models/coder.model';
+
+export interface TransferCodingCasesDialogData {
+  coders: Coder[];
+}
+
+export interface TransferCodingCasesDialogResult {
+  sourceCoderId: number;
+  targetCoderId: number;
+}
+
+@Component({
+  selector: 'coding-box-transfer-coding-cases-dialog',
+  standalone: true,
+  templateUrl: './transfer-coding-cases-dialog.component.html',
+  styleUrls: ['./transfer-coding-cases-dialog.component.scss'],
+  imports: [
+    CommonModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatFormField,
+    MatLabel,
+    MatSelect,
+    MatOption,
+    MatButton
+  ]
+})
+export class TransferCodingCasesDialogComponent {
+  sourceCoderId: number | null = null;
+  targetCoderId: number | null = null;
+
+  readonly coders: Coder[];
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<
+    TransferCodingCasesDialogComponent,
+    TransferCodingCasesDialogResult
+    >,
+    @Inject(MAT_DIALOG_DATA) public data: TransferCodingCasesDialogData
+  ) {
+    this.coders = [...(data.coders || [])].sort((a, b) => {
+      const labelA = a.displayName || a.name || '';
+      const labelB = b.displayName || b.name || '';
+      return labelA.localeCompare(labelB);
+    });
+  }
+
+  get submitDisabled(): boolean {
+    return !this.sourceCoderId || !this.targetCoderId || this.sourceCoderId === this.targetCoderId;
+  }
+
+  submit(): void {
+    if (this.submitDisabled) {
+      return;
+    }
+
+    this.dialogRef.close({
+      sourceCoderId: this.sourceCoderId!,
+      targetCoderId: this.targetCoderId!
+    });
+  }
+}

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -83,4 +83,27 @@ describe('CodingJobBackendService', () => {
       req.flush({});
     });
   });
+
+  describe('transferCodingCases', () => {
+    it('should post transfer request for coder cases', () => {
+      service.transferCodingCases(7, 11, 22).subscribe(response => {
+        expect(response.affectedJobs).toBe(3);
+      });
+
+      const req = httpMock.expectOne(`${mockServerUrl}wsg-admin/workspace/7/coding-job/transfer-cases`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        sourceCoderId: 11,
+        targetCoderId: 22
+      });
+      req.flush({
+        sourceCoderId: 11,
+        targetCoderId: 22,
+        affectedJobs: 3,
+        updatedAssignments: 3,
+        removedDuplicateAssignments: 0,
+        transferredCases: 42
+      });
+    });
+  });
 });

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -75,6 +75,15 @@ interface PaginatedResponse<T> {
   limit: number;
 }
 
+export interface TransferCodingCasesResponse {
+  sourceCoderId: number;
+  targetCoderId: number;
+  affectedJobs: number;
+  updatedAssignments: number;
+  removedDuplicateAssignments: number;
+  transferredCases: number;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -202,6 +211,19 @@ export class CodingJobBackendService {
   ): Observable<{ success: boolean }> {
     const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/${codingJobId}`;
     return this.http.delete<{ success: boolean }>(url, { headers: this.authHeader });
+  }
+
+  transferCodingCases(
+    workspaceId: number,
+    sourceCoderId: number,
+    targetCoderId: number
+  ): Observable<TransferCodingCasesResponse> {
+    const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/transfer-cases`;
+    return this.http.post<TransferCodingCasesResponse>(
+      url,
+      { sourceCoderId, targetCoderId },
+      { headers: this.authHeader }
+    );
   }
 
   startCodingJob(


### PR DESCRIPTION
## Bezug
Closes #456

## Was wurde umgesetzt?
- Neuer Backend-Endpoint: `POST /wsg-admin/workspace/:workspace_id/coding-job/transfer-cases`
- Neue Transfer-Logik im `CodingJobService`:
  - ersetzt Quell-Kodierer durch Ziel-Kodierer in allen betroffenen Jobs des Workspaces
  - entfernt Duplikat-Zuweisungen, wenn Ziel-Kodierer bereits zugewiesen war
  - liefert Rückgabewerte zu betroffenen Jobs, aktualisierten Zuweisungen und übertragenen Fällen
- Berechtigungsprüfung ergänzt (`RequireAccessLevel(2)`)
- Frontend-Anbindung:
  - neuer Button **"Fälle übertragen"** in der Kodierjob-Übersicht
  - neuer Dialog zur Auswahl von Quell- und Ziel-Kodierer
  - Aufruf des neuen Endpoints inkl. Erfolgs-/Fehlermeldung

## Tests / Checks
- `nx test frontend` (grün)
- `nx lint backend` (grün)
- `nx lint frontend` (grün, eine bestehende Warnung in nicht betroffener Datei)
- `nx build backend` (grün)