### PR TITLE
codex: fix DOCX Word error for formulas in manual instructions

### DIFF
--- a/apps/backend/src/app/admin/code-book/codebook-docx-generator.class.spec.ts
+++ b/apps/backend/src/app/admin/code-book/codebook-docx-generator.class.spec.ts
@@ -1,0 +1,49 @@
+import { CodebookDocxGenerator } from './codebook-docx-generator.class';
+
+jest.mock('docx', () => ({
+  ImportedXmlComponent: {
+    fromXmlString: jest.fn().mockReturnValue({})
+  }
+}));
+
+jest.mock('katex', () => ({
+  renderToString: jest.fn().mockReturnValue('<math>mocked-mathml</math>')
+}));
+
+jest.mock('mathml2omml', () => ({
+  mml2omml: jest.fn().mockReturnValue('<m:oMath><m:r><m:t xml:space="preserve">a<b & c</m:t></m:r></m:oMath>')
+}));
+
+describe('CodebookDocxGenerator', () => {
+  describe('OMML sanitizing', () => {
+    it('should sanitize invalid XML chars inside OMML text nodes', () => {
+      const generator = CodebookDocxGenerator as unknown as {
+        sanitizeOmmlXml: (omml: string) => string;
+      };
+      const rawOmml = '<m:oMath><m:r><m:t xml:space="preserve">a<b & c</m:t></m:r></m:oMath>';
+      const sanitizedOmml = generator.sanitizeOmmlXml(rawOmml);
+
+      expect(sanitizedOmml).toContain('a&lt;b &amp; c');
+      expect(sanitizedOmml).not.toContain('a<b & c');
+    });
+
+    it('should sanitize OMML before creating ImportedXmlComponent', () => {
+      const fromXmlString = (
+        jest.requireMock('docx') as {
+          ImportedXmlComponent: { fromXmlString: jest.Mock };
+        }
+      ).ImportedXmlComponent.fromXmlString;
+      fromXmlString.mockClear();
+
+      const generator = CodebookDocxGenerator as unknown as {
+        latexToOmml: (latex: string) => unknown;
+      };
+      const result = generator.latexToOmml('a<b');
+
+      expect(result).toEqual({});
+      expect(fromXmlString).toHaveBeenCalledWith(
+        '<m:oMath><m:r><m:t xml:space="preserve">a&lt;b &amp; c</m:t></m:r></m:oMath>'
+      );
+    });
+  });
+});

--- a/apps/backend/src/app/admin/code-book/codebook-docx-generator.class.spec.ts
+++ b/apps/backend/src/app/admin/code-book/codebook-docx-generator.class.spec.ts
@@ -45,5 +45,22 @@ describe('CodebookDocxGenerator', () => {
         '<m:oMath><m:r><m:t xml:space="preserve">a&lt;b &amp; c</m:t></m:r></m:oMath>'
       );
     });
+
+    it('should unwrap the ImportedXmlComponent wrapper before returning OMML', () => {
+      const fromXmlString = (
+        jest.requireMock('docx') as {
+          ImportedXmlComponent: { fromXmlString: jest.Mock };
+        }
+      ).ImportedXmlComponent.fromXmlString;
+      const ommlRoot = { rootKey: 'm:oMath' };
+      fromXmlString.mockReturnValueOnce({ root: [ommlRoot] });
+
+      const generator = CodebookDocxGenerator as unknown as {
+        latexToOmml: (latex: string) => unknown;
+      };
+      const result = generator.latexToOmml('a<b');
+
+      expect(result).toBe(ommlRoot);
+    });
   });
 });

--- a/apps/backend/src/app/admin/code-book/codebook-docx-generator.class.ts
+++ b/apps/backend/src/app/admin/code-book/codebook-docx-generator.class.ts
@@ -49,10 +49,29 @@ export class CodebookDocxGenerator {
         strict: 'ignore'
       });
       const omml = mml2omml(mathml);
-      return ImportedXmlComponent.fromXmlString(omml);
+      return ImportedXmlComponent.fromXmlString(this.sanitizeOmmlXml(omml));
     } catch {
       return null;
     }
+  }
+
+  private static sanitizeOmmlXml(omml: string): string {
+    if (!omml) return omml;
+    return omml.replace(
+      /(<m:t\b[^>]*>)([\s\S]*?)(<\/m:t>)/g,
+      (_, prefix: string, rawText: string, suffix: string) =>
+        `${prefix}${this.escapeXmlText(rawText)}${suffix}`
+    );
+  }
+
+  private static escapeXmlText(text: string): string {
+    return text
+      .replace(
+        /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9a-fA-F]+);)/g,
+        '&amp;'
+      )
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
   }
 
   private static normalizeMathTokens(html: string): string {

--- a/apps/backend/src/app/admin/code-book/codebook-docx-generator.class.ts
+++ b/apps/backend/src/app/admin/code-book/codebook-docx-generator.class.ts
@@ -49,18 +49,79 @@ export class CodebookDocxGenerator {
         strict: 'ignore'
       });
       const omml = mml2omml(mathml);
-      return ImportedXmlComponent.fromXmlString(this.sanitizeOmmlXml(omml));
+      return this.unwrapImportedXmlRoot(
+        ImportedXmlComponent.fromXmlString(this.sanitizeOmmlXml(omml))
+      );
     } catch {
       return null;
     }
+  }
+
+  private static unwrapImportedXmlRoot(
+    component: ImportedXmlComponent
+  ): ImportedXmlComponent {
+    const importedComponent = component as ImportedXmlComponent & {
+      root?: Array<ImportedXmlComponent | string>;
+      rootKey?: string;
+    };
+    if (importedComponent.rootKey !== undefined) {
+      return component;
+    }
+
+    const firstChild = importedComponent.root?.[0];
+    return typeof firstChild === 'object' && firstChild !== null ?
+      firstChild as ImportedXmlComponent :
+      component;
+  }
+
+  private static isMathComponent(
+    child: ParagraphChild
+  ): child is ImportedXmlComponent {
+    if (typeof child !== 'object' || child === null) {
+      return false;
+    }
+    const importedChild = child as ImportedXmlComponent & {
+      rootKey?: string;
+    };
+    return importedChild.rootKey === 'm:oMath' ||
+      importedChild.rootKey === 'm:oMathPara';
+  }
+
+  private static createLeftAlignedMathParagraph(
+    mathChildren: ImportedXmlComponent[]
+  ): ImportedXmlComponent {
+    const mathParagraph = new ImportedXmlComponent('m:oMathPara');
+    const mathParagraphProperties = new ImportedXmlComponent('m:oMathParaPr');
+    mathParagraphProperties.push(
+      new ImportedXmlComponent('m:jc', { 'm:val': 'left' })
+    );
+    mathParagraph.push(mathParagraphProperties);
+    mathChildren.forEach(mathChild => mathParagraph.push(mathChild));
+    return mathParagraph;
+  }
+
+  private static normalizeParagraphChildren(
+    children: ParagraphChild[]
+  ): ParagraphChild[] {
+    if (!children.length) {
+      return children;
+    }
+
+    const mathChildren = children.filter(
+      this.isMathComponent
+    ) as ImportedXmlComponent[];
+    if (mathChildren.length === children.length) {
+      return [this.createLeftAlignedMathParagraph(mathChildren)];
+    }
+
+    return children;
   }
 
   private static sanitizeOmmlXml(omml: string): string {
     if (!omml) return omml;
     return omml.replace(
       /(<m:t\b[^>]*>)([\s\S]*?)(<\/m:t>)/g,
-      (_, prefix: string, rawText: string, suffix: string) =>
-        `${prefix}${this.escapeXmlText(rawText)}${suffix}`
+      (_, prefix: string, rawText: string, suffix: string) => `${prefix}${this.escapeXmlText(rawText)}${suffix}`
     );
   }
 
@@ -621,7 +682,9 @@ export class CodebookDocxGenerator {
           const children: ParagraphChild[] = [];
           this.processInlineElements(element.children, children);
           if (children.length > 0) {
-            paragraphs.push(new Paragraph({ children }));
+            paragraphs.push(new Paragraph({
+              children: this.normalizeParagraphChildren(children)
+            }));
           }
         } else if (tagName === 'ul' || tagName === 'ol') {
           this.processListElements(element.children, paragraphs, tagName === 'ol');
@@ -700,7 +763,7 @@ export class CodebookDocxGenerator {
           this.processInlineElements(element.children, children);
           if (children.length > 0) {
             paragraphs.push(new Paragraph({
-              children,
+              children: this.normalizeParagraphChildren(children),
               bullet: {
                 level: 0
               },

--- a/apps/backend/src/app/admin/code-book/codebook-docx-generator.integration.spec.ts
+++ b/apps/backend/src/app/admin/code-book/codebook-docx-generator.integration.spec.ts
@@ -1,0 +1,114 @@
+import AdmZip = require('adm-zip');
+import {
+  CodeBookContentSetting,
+  CodebookUnitDto
+} from './codebook.interfaces';
+import { CodebookDocxGenerator } from './codebook-docx-generator.class';
+
+const defaultSettings: CodeBookContentSetting = {
+  exportFormat: 'docx',
+  missingsProfile: '',
+  hasOnlyManualCoding: false,
+  hasGeneralInstructions: false,
+  hasDerivedVars: false,
+  hasOnlyVarsWithCodes: false,
+  hasClosedVars: false,
+  codeLabelToUpper: false,
+  showScore: false,
+  hideItemVarRelation: true
+};
+
+const buildUnits = (description: string): CodebookUnitDto[] => [
+  {
+    key: 'U1',
+    name: 'Unit 1',
+    missings: [],
+    items: [],
+    variables: [
+      {
+        id: 'V1',
+        label: 'Variable 1',
+        sourceType: 'MANUAL',
+        generalInstruction: '',
+        codes: [
+          {
+            id: '1',
+            label: 'Label 1',
+            score: '1',
+            description
+          }
+        ]
+      }
+    ]
+  }
+];
+
+const getDocumentXml = async (description: string): Promise<string> => {
+  const buffer = await CodebookDocxGenerator.generateDocx(
+    buildUnits(description),
+    defaultSettings
+  );
+  const zip = new AdmZip(buffer);
+  return zip.readAsText('word/document.xml');
+};
+
+describe('CodebookDocxGenerator integration', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('creates DOCX XML without undefined wrappers for formula spans', async () => {
+    const description =
+      '<p>Formel: ' +
+      '<span class="iqb-math-formula" data-latex="a<b">' +
+      '<span><math><semantics><mrow><mi>a</mi><mo>&lt;</mo><mi>b</mi></mrow></semantics></math></span>' +
+      '</span>' +
+      '</p>';
+
+    const documentXml = await getDocumentXml(description);
+
+    expect(documentXml).not.toContain('<undefined>');
+    expect(documentXml).toContain('<m:oMath');
+    expect(documentXml).toContain('a&lt;b');
+    expect(documentXml).not.toContain('a<b</m:t>');
+  });
+
+  it('creates DOCX XML without undefined wrappers for iqb-math tokens', async () => {
+    const description = '<p>Formel: [[iqb-math:a%3Cb]]</p>';
+
+    const documentXml = await getDocumentXml(description);
+
+    expect(documentXml).not.toContain('<undefined>');
+    expect(documentXml).toContain('<m:oMath');
+    expect(documentXml).toContain('a&lt;b');
+    expect(documentXml).not.toContain('a<b</m:t>');
+  });
+
+  it('exports formula-only paragraphs as left-aligned math paragraphs', async () => {
+    const description = '<p><span class="iqb-math-formula" data-latex="e^2=m"></span></p>';
+
+    const documentXml = await getDocumentXml(description);
+
+    expect(documentXml).toContain('<m:oMathPara>');
+    expect(documentXml).toContain('<m:oMathParaPr><m:jc m:val="left"/></m:oMathParaPr>');
+    expect(documentXml).toContain('<m:oMath');
+  });
+
+  it('keeps inline formulas inline when paragraph text is present', async () => {
+    const description =
+      '<p>Prefix <span class="iqb-math-formula" data-latex="e^2=m"></span> suffix</p>';
+
+    const documentXml = await getDocumentXml(description);
+
+    expect(documentXml).not.toContain('<m:oMathPara>');
+    expect(documentXml).toContain('<m:oMath');
+    expect(documentXml).toContain('Prefix');
+    expect(documentXml).toContain('suffix');
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize OMML text-node content before embedding formula XML in DOCX
- prevent invalid XML characters (for example `<` and `&`) from corrupting generated Word files
- add regression tests for OMML sanitizing in the codebook DOCX generator

## Context
- same root cause as fixed in `iqb-berlin/studio-lite#1423`

## Testing
- attempted: `npx jest apps/backend/src/app/admin/code-book/codebook-docx-generator.class.spec.ts --config=apps/backend/jest.config.ts --runInBand`
- blocked locally by missing/broken workspace dependencies (`import-local` not resolvable in current local node_modules state)

Closes #461
