### PR TITLE
Erleichterte Auswahl gleicher Testlets über viele Testhefte

### DIFF
--- a/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.html
+++ b/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.html
@@ -599,6 +599,12 @@
                           <li class="testlet-nested-item" [class.ignored-testlet]="isTestletIgnored(file.filename, testlet.id)">
                             <mat-icon class="testlet-icon">layers</mat-icon>
                             <span class="testlet-label">{{ testlet.label || testlet.id }}</span>
+                            <button mat-icon-button class="testlet-action-button testlet-bulk-action-button"
+                                    [disabled]="isApplyingTestletBulk"
+                                    (click)="toggleTestletIgnoreForAllBooklets(file.filename, testlet.id); $event.stopPropagation()"
+                                    matTooltip="{{ isTestletIgnored(file.filename, testlet.id) ? 'Dieses Testlet in allen Testheften wiederherstellen' : 'Dieses Testlet in allen Testheften ignorieren' }}">
+                              <mat-icon>{{ isApplyingTestletBulk ? 'hourglass_top' : 'done_all' }}</mat-icon>
+                            </button>
                             <button mat-icon-button class="testlet-action-button"
                                     (click)="toggleTestletIgnore(file.filename, testlet.id); $event.stopPropagation()"
                                     matTooltip="{{ isTestletIgnored(file.filename, testlet.id) ? 'Testlet wiederherstellen' : 'Testlet ignorieren' }}">

--- a/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.scss
+++ b/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.scss
@@ -924,6 +924,10 @@ h4 {
               width: 16px;
               margin: 0;
             }
+
+            &.testlet-bulk-action-button {
+              margin-right: 2px;
+            }
           }
         }
 

--- a/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.spec.ts
@@ -3,15 +3,64 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { provideHttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
 import { FilesValidationDialogComponent } from './files-validation.component';
 import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
+import { WorkspaceService } from '../../../workspace/services/workspace.service';
+import { FileService } from '../../../shared/services/file/file.service';
+import { TestResultService } from '../../../shared/services/test-result/test-result.service';
+import { BookletInfoDto } from '../../../../../../../api-dto/booklet-info/booklet-info.dto';
 
 describe('FilesValidationComponent', () => {
   let component: FilesValidationDialogComponent;
   let fixture: ComponentFixture<FilesValidationDialogComponent>;
+  let workspaceService: jest.Mocked<WorkspaceService>;
+  let fileService: jest.Mocked<FileService>;
+
+  const createValidationResult = (testTaker: string, bookletNames: string[]) => ({
+    testTaker,
+    testTakerSchemaValid: true,
+    booklets: {
+      complete: true,
+      missing: [],
+      files: bookletNames.map(filename => ({ filename, exists: true }))
+    },
+    units: { complete: true, missing: [], files: [] },
+    schemes: { complete: true, missing: [], files: [] },
+    schemer: { complete: true, missing: [], files: [] },
+    definitions: { complete: true, missing: [], files: [] },
+    player: { complete: true, missing: [], files: [] },
+    metadata: { complete: true, missing: [], files: [] }
+  });
+
+  const createBookletInfo = (bookletId: string, testletIds: string[]): BookletInfoDto => ({
+    metadata: { id: bookletId },
+    units: [],
+    restrictions: [],
+    testlets: testletIds.map(testletId => ({ id: testletId, units: [] }))
+  });
 
   beforeEach(async () => {
+    const workspaceServiceMock = {
+      getWorkspaceSettings: jest.fn().mockReturnValue(of({
+        ignoredUnits: [],
+        ignoredBooklets: [],
+        ignoredTestlets: []
+      })),
+      saveWorkspaceSettings: jest.fn().mockReturnValue(of(true)),
+      markTestTakersAsExcluded: jest.fn(),
+      markTestTakersAsConsidered: jest.fn(),
+      resolveDuplicateTestTakers: jest.fn()
+    };
+
+    const fileServiceMock = {
+      getBookletInfo: jest.fn(),
+      validateFiles: jest.fn().mockReturnValue(of(true)),
+      getUnitInfo: jest.fn(),
+      downloadFile: jest.fn()
+    };
+
     await TestBed.configureTestingModule({
       imports: [FilesValidationDialogComponent, TranslateModule.forRoot()],
       providers: [
@@ -26,14 +75,29 @@ describe('FilesValidationComponent', () => {
         },
         {
           provide: MAT_DIALOG_DATA,
-          useValue: []
+          useValue: { validationResults: [] }
         },
         {
           provide: MatSnackBar,
           useValue: { open: jest.fn() }
+        },
+        {
+          provide: WorkspaceService,
+          useValue: workspaceServiceMock
+        },
+        {
+          provide: FileService,
+          useValue: fileServiceMock
+        },
+        {
+          provide: TestResultService,
+          useValue: { invalidateCache: jest.fn() }
         }
       ]
     }).compileComponents();
+
+    workspaceService = TestBed.inject(WorkspaceService) as jest.Mocked<WorkspaceService>;
+    fileService = TestBed.inject(FileService) as jest.Mocked<FileService>;
 
     fixture = TestBed.createComponent(FilesValidationDialogComponent);
     component = fixture.componentInstance;
@@ -100,5 +164,72 @@ describe('FilesValidationComponent', () => {
     expect(component.summary.units.incomplete).toBe(1);
     expect(component.summary.units.missingFiles).toBe(1);
     expect(component.summary.units.missingFileNames).toEqual(['u1']);
+  });
+
+  it('should ignore a testlet across all matching booklets', async () => {
+    component.data = {
+      workspaceId: 1,
+      validationResults: [createValidationResult('test1', ['BOOK1', 'BOOK2', 'BOOK3'])]
+    };
+
+    (component as unknown as { rebuildValidationResults: () => void }).rebuildValidationResults();
+
+    fileService.getBookletInfo.mockImplementation((_, bookletId: string) => {
+      const id = bookletId.toUpperCase();
+      if (id === 'BOOK1' || id === 'BOOK2') {
+        return of(createBookletInfo(id, ['TL1']));
+      }
+      return of(createBookletInfo(id, ['TL2']));
+    });
+
+    await component.toggleTestletIgnoreForAllBooklets('BOOK1', 'TL1');
+
+    expect(workspaceService.saveWorkspaceSettings).toHaveBeenCalled();
+    const settingsCalls = workspaceService.saveWorkspaceSettings.mock.calls;
+    const settings = settingsCalls[settingsCalls.length - 1][1];
+    expect(settings.ignoredTestlets).toEqual(
+      expect.arrayContaining([
+        { bookletId: 'BOOK1', testletId: 'TL1' },
+        { bookletId: 'BOOK2', testletId: 'TL1' }
+      ])
+    );
+    expect(settings.ignoredTestlets).toHaveLength(2);
+  });
+
+  it('should restore a testlet across all matching booklets', async () => {
+    component.data = {
+      workspaceId: 1,
+      validationResults: [createValidationResult('test1', ['BOOK1', 'BOOK2', 'BOOK3'])]
+    };
+    component.ignoredTestlets = [
+      { bookletId: 'BOOK1', testletId: 'TL1' },
+      { bookletId: 'BOOK2', testletId: 'TL1' },
+      { bookletId: 'BOOK3', testletId: 'TL9' }
+    ];
+
+    (component as unknown as { rebuildValidationResults: () => void }).rebuildValidationResults();
+
+    fileService.getBookletInfo.mockImplementation((_, bookletId: string) => {
+      const id = bookletId.toUpperCase();
+      if (id === 'BOOK1' || id === 'BOOK2') {
+        return of(createBookletInfo(id, ['TL1']));
+      }
+      return of(createBookletInfo(id, ['TL2']));
+    });
+
+    await component.toggleTestletIgnoreForAllBooklets('BOOK1', 'TL1');
+
+    expect(workspaceService.saveWorkspaceSettings).toHaveBeenCalled();
+    const settingsCalls = workspaceService.saveWorkspaceSettings.mock.calls;
+    const settings = settingsCalls[settingsCalls.length - 1][1];
+    expect(settings.ignoredTestlets).toEqual(
+      expect.arrayContaining([{ bookletId: 'BOOK3', testletId: 'TL9' }])
+    );
+    expect(settings.ignoredTestlets).not.toEqual(
+      expect.arrayContaining([
+        { bookletId: 'BOOK1', testletId: 'TL1' },
+        { bookletId: 'BOOK2', testletId: 'TL1' }
+      ])
+    );
   });
 });

--- a/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.ts
@@ -201,6 +201,7 @@ export class FilesValidationDialogComponent implements OnInit {
   bookletData: Map<string, BookletInfoDto> = new Map();
   expandedBooklets: Set<string> = new Set();
   loadingBooklets: Set<string> = new Set();
+  isApplyingTestletBulk = false;
   selectedTabIndex = 0;
 
   private workspaceService = inject(WorkspaceService);
@@ -677,6 +678,103 @@ export class FilesValidationDialogComponent implements OnInit {
     return this.ignoredTestlets.some(t => t.bookletId === normBooklet);
   }
 
+  private getExistingBookletIdsFromValidation(): string[] {
+    const bookletIds = new Set<string>();
+    this.validationResults.forEach(result => {
+      result.booklets.files.forEach(file => {
+        if (file.exists && file.filename) {
+          bookletIds.add(file.filename.toUpperCase());
+        }
+      });
+    });
+    return Array.from(bookletIds);
+  }
+
+  private async ensureBookletData(bookletId: string): Promise<BookletInfoDto | null> {
+    const normalizedBookletId = bookletId.toUpperCase();
+    const cached = this.bookletData.get(normalizedBookletId);
+    if (cached) {
+      return cached;
+    }
+    if (!this.data.workspaceId) {
+      return null;
+    }
+
+    try {
+      this.loadingBooklets.add(normalizedBookletId);
+      const info = await firstValueFrom(
+        this.fileService.getBookletInfo(this.data.workspaceId, normalizedBookletId)
+      );
+      this.bookletData.set(normalizedBookletId, info);
+      return info;
+    } catch {
+      return null;
+    } finally {
+      this.loadingBooklets.delete(normalizedBookletId);
+      this.cdr.markForCheck();
+    }
+  }
+
+  private async findBookletsWithTestlet(testletId: string): Promise<string[]> {
+    const normalizedTestletId = testletId.toUpperCase();
+    const bookletIds = this.getExistingBookletIdsFromValidation();
+    const matchingBooklets: string[] = [];
+
+    for (const bookletId of bookletIds) {
+      const info = await this.ensureBookletData(bookletId);
+      if (!info?.testlets?.length) {
+        continue;
+      }
+
+      const hasTestlet = info.testlets.some(
+        testlet => (testlet.id || '').toUpperCase() === normalizedTestletId
+      );
+      if (hasTestlet) {
+        matchingBooklets.push(bookletId);
+      }
+    }
+
+    return matchingBooklets;
+  }
+
+  private applyTestletIgnoreToBooklets(
+    bookletIds: string[],
+    testletId: string,
+    shouldIgnore: boolean
+  ): { nextIgnoredTestlets: { bookletId: string; testletId: string }[]; changedCount: number } {
+    const normalizedTestletId = testletId.toUpperCase();
+    const existingMap = new Map<string, { bookletId: string; testletId: string }>();
+    this.ignoredTestlets.forEach(entry => {
+      existingMap.set(`${entry.bookletId}|${entry.testletId}`, entry);
+    });
+
+    let changedCount = 0;
+    bookletIds.forEach(bookletId => {
+      const normalizedBookletId = bookletId.toUpperCase();
+      const key = `${normalizedBookletId}|${normalizedTestletId}`;
+      const wasIgnored = existingMap.has(key);
+
+      if (shouldIgnore) {
+        existingMap.set(key, {
+          bookletId: normalizedBookletId,
+          testletId: normalizedTestletId
+        });
+      } else {
+        existingMap.delete(key);
+      }
+
+      const isIgnoredNow = existingMap.has(key);
+      if (wasIgnored !== isIgnoredNow) {
+        changedCount += 1;
+      }
+    });
+
+    return {
+      nextIgnoredTestlets: Array.from(existingMap.values()),
+      changedCount
+    };
+  }
+
   toggleBookletExpand(bookletId: string): void {
     if (!bookletId) return;
     const normalized = bookletId.toUpperCase();
@@ -781,6 +879,58 @@ export class FilesValidationDialogComponent implements OnInit {
         () => this.snackBar.open('Testlet ignoriert', 'OK', { duration: 3000 }),
         () => this.ignoredTestlets.splice(this.ignoredTestlets.findIndex(t => t.bookletId === normBooklet && t.testletId === normTestlet), 1)
       );
+    }
+  }
+
+  async toggleTestletIgnoreForAllBooklets(bookletId: string, testletId: string): Promise<void> {
+    if (!bookletId || !testletId || !this.data.workspaceId || this.isApplyingTestletBulk) {
+      return;
+    }
+
+    const normalizedBookletId = bookletId.toUpperCase();
+    const normalizedTestletId = testletId.toUpperCase();
+    const shouldIgnore = !this.isTestletIgnored(normalizedBookletId, normalizedTestletId);
+
+    this.isApplyingTestletBulk = true;
+    this.cdr.markForCheck();
+
+    try {
+      const matchingBooklets = await this.findBookletsWithTestlet(normalizedTestletId);
+      if (matchingBooklets.length === 0) {
+        this.snackBar.open('Keine passenden Testhefte mit diesem Testlet gefunden', 'OK', { duration: 3000 });
+        return;
+      }
+
+      const previousIgnoredTestlets = [...this.ignoredTestlets];
+      const { nextIgnoredTestlets, changedCount } = this.applyTestletIgnoreToBooklets(
+        matchingBooklets,
+        normalizedTestletId,
+        shouldIgnore
+      );
+
+      if (changedCount === 0) {
+        const unchangedMessage = shouldIgnore ?
+          'Testlet ist bereits in allen betroffenen Testheften ignoriert' :
+          'Testlet ist bereits in allen betroffenen Testheften wiederhergestellt';
+        this.snackBar.open(unchangedMessage, 'OK', { duration: 3000 });
+        return;
+      }
+
+      this.ignoredTestlets = nextIgnoredTestlets;
+      this.saveCurrentWorkspaceSettings(
+        () => {
+          const bookletLabel = changedCount === 1 ? '1 Testheft' : `${changedCount} Testhefte`;
+          const actionLabel = shouldIgnore ? 'ignoriert' : 'wiederhergestellt';
+          this.snackBar.open(`Testlet in ${bookletLabel} ${actionLabel}`, 'OK', { duration: 3000 });
+        },
+        () => {
+          this.ignoredTestlets = previousIgnoredTestlets;
+          this.cdr.markForCheck();
+        }
+      );
+    } finally {
+      this.isApplyingTestletBulk = false;
+      this.cdr.markForCheck();
     }
   }
 


### PR DESCRIPTION
## Hintergrund
Bei vielen Testheften mit gleichen Testlets ist das manuelle Ein-/Ausschalten pro Testheft sehr aufwendig.

## Änderungen
- Neue Bulk-Aktion in der Validierungsansicht: Ein Testlet kann jetzt in **allen betroffenen Testheften** auf einmal ignoriert bzw. wiederhergestellt werden.
- Die Aktion lädt benötigte Booklet-Informationen bei Bedarf nach und speichert alle Änderungen in einem Schritt.
- UI-Erweiterung in der Testlet-Liste um einen zusätzlichen Button für die Sammelaktion.
- Unit-Tests für Bulk-Ignorieren und Bulk-Wiederherstellen ergänzt.

## Test
- `npx nx run frontend:test --testFile=apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.spec.ts --runInBand --skip-nx-cache`

Ergebnis:
```text
PASS frontend apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.spec.ts

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Ran all test suites matching /apps\/frontend\/src\/app\/ws-admin\/components\/files-validation-result\/files-validation.component.spec.ts/i.

NX Successfully ran target test for project frontend
```

Closes #460