### PR TITLE
Fix: Replay aus Kodierergebnisse-Vergleich startet wieder

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
@@ -1,14 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { provideHttpClient } from '@angular/common/http';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateModule } from '@ngx-translate/core';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 import { CodingJobResultDialogComponent } from './coding-job-result-dialog.component';
-import { SERVER_URL } from '../../../../injection-tokens';
-import { environment } from '../../../../../environments/environment';
+import { CodingJobBackendService } from '../../../services/coding-job-backend.service';
+import { FileService } from '../../../../shared/services/file/file.service';
+import { AppService } from '../../../../core/services/app.service';
 
 class MatSnackBarMock {
-  open = jest.fn();
+  open = jest.fn(() => ({
+    dismiss: jest.fn()
+  }));
 }
 
 describe('CodingJobResultDialogComponent', () => {
@@ -24,15 +28,44 @@ describe('CodingJobResultDialogComponent', () => {
     workspaceId: 123
   };
 
+  const mockCodingJobBackendService = {
+    getCodingJobUnits: jest.fn(() => of([])),
+    getCodingProgress: jest.fn(() => of({})),
+    getCodingNotes: jest.fn(() => of({}))
+  };
+
+  const mockFileService = {
+    getCodingSchemeFile: jest.fn()
+  };
+
+  const mockAppService = {
+    createToken: jest.fn(() => of('test-token')),
+    loggedUser: { sub: 'test-user' }
+  };
+
+  const mockRouter = {
+    createUrlTree: jest.fn(() => ({})),
+    serializeUrl: jest.fn(() => '/replay/path')
+  };
+
+  const mockMatDialog = {
+    open: jest.fn()
+  };
+
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     await TestBed.configureTestingModule({
       imports: [CodingJobResultDialogComponent, TranslateModule.forRoot()],
       providers: [
-        provideHttpClient(),
         { provide: MatDialogRef, useValue: mockDialogRef },
         { provide: MAT_DIALOG_DATA, useValue: mockDialogData },
-        { provide: SERVER_URL, useValue: environment.backendUrl },
-        { provide: MatSnackBar, useClass: MatSnackBarMock }
+        { provide: MatSnackBar, useClass: MatSnackBarMock },
+        { provide: CodingJobBackendService, useValue: mockCodingJobBackendService },
+        { provide: FileService, useValue: mockFileService },
+        { provide: AppService, useValue: mockAppService },
+        { provide: Router, useValue: mockRouter },
+        { provide: MatDialog, useValue: mockMatDialog }
       ]
     })
       .compileComponents();
@@ -44,5 +77,29 @@ describe('CodingJobResultDialogComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should open replay with a valid hash route URL', () => {
+    const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+    component.reviewCodingResult({
+      unitName: 'UNIT_1',
+      unitAlias: 'UNIT_1',
+      variableId: 'VAR_1',
+      variableAnchor: 'VAR_1',
+      bookletName: 'BOOKLET_A',
+      personLogin: 'login',
+      personCode: 'code',
+      personGroup: 'group',
+      testPerson: 'login@code@group@BOOKLET_A',
+      codingIssueOptionLabel: 'Unsichere Kodierung'
+    } as never);
+
+    expect(windowOpenSpy).toHaveBeenCalledWith(expect.any(String), '_blank');
+    const openedUrl = windowOpenSpy.mock.calls[0][0] as string;
+    expect(openedUrl).toContain('/#/replay/path');
+    expect(openedUrl).not.toContain('#//replay');
+
+    windowOpenSpy.mockRestore();
   });
 });

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
@@ -478,7 +478,7 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy {
               { queryParams: queryParams })
           );
 
-        window.open(`#/${url}`, '_blank');
+        window.open(`${window.location.origin}/#${url}`, '_blank');
       },
       error: () => {
         loadingSnackBar.dismiss();


### PR DESCRIPTION
## Zusammenfassung
- behebt die URL-Erzeugung für Replay aus dem Dialog **„Kodierergebnisse vergleichen“**
- verwendet eine absolute Hash-URL (`.../#/replay/...`) statt der fehlerhaften Variante mit doppeltem Slash
- ergänzt einen Unit-Test, der genau diesen URL-Fall absichert

## Hintergrund
Im Review-Flow wurde der Replay-Link als `#//replay...` geöffnet. Dadurch konnte Replay aus den Kodierergebnissen nicht zuverlässig starten.

## Test
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts`

Closes #458
