### PR TITLE
Instrument replay client timings

### DIFF
--- a/apps/backend/src/app/admin/replay-statistics/replay-statistics.controller.ts
+++ b/apps/backend/src/app/admin/replay-statistics/replay-statistics.controller.ts
@@ -55,6 +55,7 @@ export class ReplayStatisticsController {
                              success?: boolean;
                              errorMessage?: string;
                              clientTimings?: Record<string, number | null>;
+                             serverTimings?: Record<string, number | null>;
                            }
   ): Promise<ReplayStatistics> {
     return this.replayStatisticsService.storeReplayStatistics({

--- a/apps/backend/src/app/admin/replay-statistics/replay-statistics.controller.ts
+++ b/apps/backend/src/app/admin/replay-statistics/replay-statistics.controller.ts
@@ -54,6 +54,7 @@ export class ReplayStatisticsController {
                              replayUrl?: string;
                              success?: boolean;
                              errorMessage?: string;
+                             clientTimings?: Record<string, number | null>;
                            }
   ): Promise<ReplayStatistics> {
     return this.replayStatisticsService.storeReplayStatistics({

--- a/apps/backend/src/app/admin/workspace/workspace-coding-replay.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-replay.controller.ts
@@ -113,6 +113,7 @@ export class WorkspaceCodingReplayController {
         };
         player: FilesDto[];
         vocs: FilesDto[];
+        serverTimings: Record<string, number>;
       }> {
     const startedAt = performance.now();
     const timings: Record<string, number> = {};
@@ -167,18 +168,20 @@ export class WorkspaceCodingReplayController {
       }
 
       const totalMs = Number((performance.now() - startedAt).toFixed(2));
+      const serverTimings = {
+        ...timings,
+        totalMs
+      };
       this.logger.debug(
-        `Replay payload timings ws=${workspaceId} unit=${normalizedUnitId}: ${JSON.stringify({
-          ...timings,
-          totalMs
-        })}`
+        `Replay payload timings ws=${workspaceId} unit=${normalizedUnitId}: ${JSON.stringify(serverTimings)}`
       );
 
       return {
         unitDef,
         response,
         player,
-        vocs
+        vocs,
+        serverTimings
       };
     } catch (error) {
       const totalMs = Number((performance.now() - startedAt).toFixed(2));

--- a/apps/backend/src/app/database/entities/replay-statistics.entity.ts
+++ b/apps/backend/src/app/database/entities/replay-statistics.entity.ts
@@ -46,4 +46,7 @@ export class ReplayStatistics {
 
   @Column({ type: 'jsonb', nullable: true })
     client_timings: Record<string, number | null>;
+
+  @Column({ type: 'jsonb', nullable: true })
+    server_timings: Record<string, number | null>;
 }

--- a/apps/backend/src/app/database/entities/replay-statistics.entity.ts
+++ b/apps/backend/src/app/database/entities/replay-statistics.entity.ts
@@ -43,4 +43,7 @@ export class ReplayStatistics {
 
   @Column({ type: 'varchar', length: 2000, nullable: true })
     error_message: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+    client_timings: Record<string, number | null>;
 }

--- a/apps/backend/src/app/database/services/test-results/replay-statistics.service.ts
+++ b/apps/backend/src/app/database/services/test-results/replay-statistics.service.ts
@@ -62,6 +62,7 @@ export class ReplayStatisticsService {
     replayUrl?: string;
     success?: boolean;
     errorMessage?: string;
+    clientTimings?: Record<string, number | null>;
   }): Promise<ReplayStatistics> {
     try {
       const mappedData = {
@@ -73,7 +74,8 @@ export class ReplayStatisticsService {
         duration_milliseconds: data.durationMilliseconds,
         replay_url: data.replayUrl,
         success: data.success !== undefined ? data.success : true,
-        error_message: data.errorMessage
+        error_message: data.errorMessage,
+        client_timings: data.clientTimings
       };
 
       const replayStatistics =

--- a/apps/backend/src/app/database/services/test-results/replay-statistics.service.ts
+++ b/apps/backend/src/app/database/services/test-results/replay-statistics.service.ts
@@ -63,6 +63,7 @@ export class ReplayStatisticsService {
     success?: boolean;
     errorMessage?: string;
     clientTimings?: Record<string, number | null>;
+    serverTimings?: Record<string, number | null>;
   }): Promise<ReplayStatistics> {
     try {
       const mappedData = {
@@ -75,7 +76,8 @@ export class ReplayStatisticsService {
         replay_url: data.replayUrl,
         success: data.success !== undefined ? data.success : true,
         error_message: data.errorMessage,
-        client_timings: data.clientTimings
+        client_timings: data.clientTimings,
+        server_timings: data.serverTimings
       };
 
       const replayStatistics =

--- a/apps/frontend/src/app/replay/components/replay/replay.component.html
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.html
@@ -14,7 +14,8 @@
       @if (!!player && unitDef) {
       @for (key of [reloadKey]; track $index) {
       <coding-box-unit-player [unitDef]="unitDef" [unitPlayer]="player" [unitResponses]="responses" [pageId]="page"
-        [printMode]="isPrintMode" (invalidPage)="checkPageError($event)" (responseVisible)="onResponseVisible()">
+        [printMode]="isPrintMode" (invalidPage)="checkPageError($event)" (playerReady)="onPlayerReady()"
+        (responseVisible)="onResponseVisible()">
       </coding-box-unit-player>
       }
       }
@@ -56,7 +57,8 @@
   @if (!!player && unitDef) {
   @for (key of [reloadKey]; track $index) {
   <coding-box-unit-player [unitDef]="unitDef" [unitPlayer]="player" [unitResponses]="responses" [pageId]="page"
-    [printMode]="isPrintMode" (invalidPage)="checkPageError($event)" (responseVisible)="onResponseVisible()">
+    [printMode]="isPrintMode" (invalidPage)="checkPageError($event)" (playerReady)="onPlayerReady()"
+    (responseVisible)="onResponseVisible()">
   </coding-box-unit-player>
   }
   }

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -39,7 +39,8 @@ class ReplayBackendServiceMock {
     unitDef: [{ data: 'unitDef data', file_id: 'UNIT-123.VOUD' }],
     response: { responses: [{ id: '1', content: 'response data' }] },
     vocs: [],
-    player: [{ data: 'player data', file_id: 'PLAYER-1.0' }]
+    player: [{ data: 'player data', file_id: 'PLAYER-1.0' }],
+    serverTimings: { totalMs: 111, findPlayerMs: 99 }
   }));
 
   storeReplayStatistics = jest.fn().mockReturnValue(of({ success: true }));
@@ -70,6 +71,7 @@ describe('ReplayComponent', () => {
   let component: ReplayComponent;
   let fixture: ComponentFixture<ReplayComponent>;
   let snackBar: MatSnackBarMock;
+  let replayBackendService: ReplayBackendServiceMock;
 
   beforeEach(async () => {
     // Spy on token validation
@@ -97,6 +99,7 @@ describe('ReplayComponent', () => {
     fixture = TestBed.createComponent(ReplayComponent);
     component = fixture.componentInstance;
     snackBar = TestBed.inject(MatSnackBar) as unknown as MatSnackBarMock;
+    replayBackendService = TestBed.inject(ReplayBackendService) as unknown as ReplayBackendServiceMock;
     fixture.detectChanges();
     await fixture.whenStable();
   });
@@ -114,6 +117,11 @@ describe('ReplayComponent', () => {
     expect(component.player).toBe('player data');
     expect(component.unitDef).toBe('unitDef data');
     expect(component.responses).toBeDefined();
+  });
+
+  it('should keep server timings from replay payload', () => {
+    expect((component as unknown as { serverTimings: Record<string, number> | null }).serverTimings)
+      .toEqual({ totalMs: 111, findPlayerMs: 99 });
   });
 
   it('should handle invalid testPerson in setTestPerson', () => {
@@ -232,6 +240,99 @@ describe('ReplayComponent', () => {
     expect(resetSpy).toHaveBeenCalled();
     expect(component.unitId).toBe('');
     expect(component.player).toBe('');
+  });
+
+  it('should calculate route and load timings for route-driven loads', () => {
+    const privateComponent = component as unknown as {
+      routeStartTime: number;
+      loadStartTime: number;
+      payloadRequestStartTime: number;
+      payloadResponseTime: number;
+      playerReadyTime: number;
+      getClientTimings: (visibleTime: number) => Record<string, number | null>;
+    };
+
+    privateComponent.routeStartTime = 100;
+    privateComponent.loadStartTime = 300;
+    privateComponent.payloadRequestStartTime = 300;
+    privateComponent.payloadResponseTime = 500;
+    privateComponent.playerReadyTime = 650;
+
+    expect(privateComponent.getClientTimings(900)).toEqual({
+      routeToVisibleMs: 800,
+      loadToVisibleMs: 600,
+      routeToPayloadRequestMs: 200,
+      payloadMs: 200,
+      payloadToVisibleMs: 400,
+      payloadToPlayerReadyMs: 150,
+      playerReadyToVisibleMs: 250
+    });
+  });
+
+  it('should omit route timings for non-route unit changes', () => {
+    const privateComponent = component as unknown as {
+      routeStartTime: number;
+      loadStartTime: number;
+      payloadRequestStartTime: number;
+      payloadResponseTime: number;
+      playerReadyTime: number;
+      getClientTimings: (visibleTime: number) => Record<string, number | null>;
+    };
+
+    privateComponent.routeStartTime = 0;
+    privateComponent.loadStartTime = 200;
+    privateComponent.payloadRequestStartTime = 200;
+    privateComponent.payloadResponseTime = 450;
+    privateComponent.playerReadyTime = 600;
+
+    expect(privateComponent.getClientTimings(900)).toEqual({
+      routeToVisibleMs: null,
+      loadToVisibleMs: 700,
+      routeToPayloadRequestMs: null,
+      payloadMs: 250,
+      payloadToVisibleMs: 450,
+      payloadToPlayerReadyMs: 150,
+      playerReadyToVisibleMs: 300
+    });
+  });
+
+  it('should store server timings together with replay statistics', () => {
+    const privateComponent = component as unknown as {
+      routeStartTime: number;
+      loadStartTime: number;
+      payloadRequestStartTime: number;
+      payloadResponseTime: number;
+      playerReadyTime: number;
+      serverTimings: Record<string, number> | null;
+      storeReplayStatistics: (success: boolean, duration: number, errorMessage?: string) => void;
+    };
+
+    replayBackendService.storeReplayStatistics.mockClear();
+    privateComponent.routeStartTime = 100;
+    privateComponent.loadStartTime = 300;
+    privateComponent.payloadRequestStartTime = 300;
+    privateComponent.payloadResponseTime = 500;
+    privateComponent.playerReadyTime = 650;
+    privateComponent.serverTimings = { totalMs: 111, findPlayerMs: 99 };
+
+    privateComponent.storeReplayStatistics(true, 800);
+
+    expect(replayBackendService.storeReplayStatistics).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.objectContaining({
+        durationMilliseconds: 800,
+        success: true,
+        serverTimings: { totalMs: 111, findPlayerMs: 99 },
+        clientTimings: expect.objectContaining({
+          routeToVisibleMs: expect.any(Number),
+          loadToVisibleMs: expect.any(Number),
+          routeToPayloadRequestMs: 200,
+          payloadMs: 200,
+          payloadToPlayerReadyMs: 150,
+          playerReadyToVisibleMs: expect.any(Number)
+        })
+      })
+    );
   });
   describe('onKeyDown', () => {
     it('should ignore shortcuts when an input is focused', () => {

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -20,7 +20,11 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { logger } from 'nx/src/utils/logger';
 import { UnitPlayerComponent } from '../unit-player/unit-player.component';
 import { FileService } from '../../../shared/services/file/file.service';
-import { ReplayBackendService, ReplayClientTimings } from '../../services/replay-backend.service';
+import {
+  ReplayBackendService,
+  ReplayClientTimings,
+  ReplayServerTimings
+} from '../../services/replay-backend.service';
 import { AppService } from '../../../core/services/app.service';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { FilesDto } from '../../../../../../../api-dto/files/files.dto';
@@ -100,9 +104,11 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
   private replayStartTime: number = 0; // Track when replay viewing starts
   private routeStartTime: number = 0;
+  private loadStartTime: number = 0;
   private payloadRequestStartTime: number = 0;
   private payloadResponseTime: number = 0;
   private playerReadyTime: number = 0;
+  private serverTimings: ReplayServerTimings | null = null;
   private successStoredForCurrentReplay: boolean = false;
   protected reloadKey: number = 0;
   workspaceId: number = 0;
@@ -377,6 +383,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
       const { unitIdInput } = changes;
       try {
+        this.routeStartTime = 0;
         this.unitId = unitIdInput.currentValue;
         this.setTestPerson(this.testPersonInput() || '');
         const unitData = await this.getUnitData(this.appService.selectedWorkspaceId, this.authToken);
@@ -400,13 +407,15 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         }[];
       },
       player: FilesDto[],
-      vocs: FilesDto[]
+      vocs: FilesDto[],
+      serverTimings?: ReplayServerTimings
     }
   ) {
     this.player = unitData.player[0].data;
     this.unitDef = unitData.unitDef[0].data;
     this.reloadKey += 1;
     this.responses = unitData.response;
+    this.serverTimings = unitData.serverTimings ?? null;
 
     if (this.isCodingMode && unitData.vocs && unitData.vocs[0] && unitData.vocs[0].data) {
       this.codingService.setCodingSchemeFromVocsData(unitData.vocs[0].data);
@@ -443,12 +452,15 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         }[];
       },
       player: FilesDto[],
-      vocs: FilesDto[]
+      vocs: FilesDto[],
+      serverTimings?: ReplayServerTimings
     }> {
     this.replayStartTime = performance.now();
-    this.payloadRequestStartTime = performance.now();
+    this.loadStartTime = this.replayStartTime;
+    this.payloadRequestStartTime = this.replayStartTime;
     this.payloadResponseTime = 0;
     this.playerReadyTime = 0;
+    this.serverTimings = null;
     this.successStoredForCurrentReplay = false;
     this.isLoaded.next(false);
     const unitData = await firstValueFrom(
@@ -467,7 +479,8 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       unitDef: unitData.unitDef,
       response: unitData.response,
       vocs: unitData.vocs,
-      player: unitData.player
+      player: unitData.player,
+      serverTimings: unitData.serverTimings
     };
   }
 
@@ -521,7 +534,11 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       return;
     }
     const now = performance.now();
-    const routeToVisible = this.routeStartTime ? Math.round(now - this.routeStartTime) : 0;
+    const routeToVisible = this.routeStartTime ? Math.round(now - this.routeStartTime) : null;
+    const loadToVisible = this.loadStartTime ? Math.round(now - this.loadStartTime) : null;
+    const routeToPayloadRequest = (this.routeStartTime && this.payloadRequestStartTime) ?
+      Math.round(this.payloadRequestStartTime - this.routeStartTime) :
+      null;
     const payloadDuration = (this.payloadRequestStartTime && this.payloadResponseTime) ?
       Math.round(this.payloadResponseTime - this.payloadRequestStartTime) :
       0;
@@ -533,7 +550,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       Math.round(now - this.playerReadyTime) :
       null;
     logger.log(
-      `Replay timings unit=${this.unitId} routeToVisible=${routeToVisible}ms ` +
+      `Replay timings unit=${this.unitId} routeToVisible=${routeToVisible ?? 'n/a'}ms ` +
+      `loadToVisible=${loadToVisible ?? 'n/a'}ms ` +
+      `routeToPayloadRequest=${routeToPayloadRequest ?? 'n/a'}ms ` +
       `payload=${payloadDuration}ms payloadToVisible=${payloadToVisible}ms ` +
       `payloadToPlayerReady=${payloadToPlayerReady ?? 'n/a'}ms ` +
       `playerReadyToVisible=${playerReadyToVisible ?? 'n/a'}ms`
@@ -545,6 +564,10 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
   private getClientTimings(visibleTime: number = performance.now()): ReplayClientTimings {
     const routeToVisible = this.routeStartTime ? Math.round(visibleTime - this.routeStartTime) : null;
+    const loadToVisibleMs = this.loadStartTime ? Math.round(visibleTime - this.loadStartTime) : null;
+    const routeToPayloadRequestMs = (this.routeStartTime && this.payloadRequestStartTime) ?
+      Math.round(this.payloadRequestStartTime - this.routeStartTime) :
+      null;
     const payloadMs = (this.payloadRequestStartTime && this.payloadResponseTime) ?
       Math.round(this.payloadResponseTime - this.payloadRequestStartTime) :
       null;
@@ -560,6 +583,8 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
     return {
       routeToVisibleMs: routeToVisible,
+      loadToVisibleMs,
+      routeToPayloadRequestMs,
       payloadMs,
       payloadToVisibleMs,
       payloadToPlayerReadyMs,
@@ -587,7 +612,8 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       replayUrl,
       success,
       errorMessage,
-      clientTimings: this.getClientTimings()
+      clientTimings: this.getClientTimings(),
+      serverTimings: this.serverTimings ?? undefined
     }).subscribe({
       next: () => {
         logger.log(
@@ -638,6 +664,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
   async handleUnitChanged(unit: UnitsReplayUnit): Promise<void> {
     if (!unit) return;
+    this.routeStartTime = 0;
     const unitAny = unit as unknown as { name: string; testPerson?: string; variableId?: string };
     const incomingTestPerson = unitAny.testPerson;
 
@@ -710,6 +737,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     this.unitDef = '';
     this.page = undefined;
     this.responses = undefined;
+    this.serverTimings = null;
     this.codingService.resetCodingData();
   }
 

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -20,7 +20,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { logger } from 'nx/src/utils/logger';
 import { UnitPlayerComponent } from '../unit-player/unit-player.component';
 import { FileService } from '../../../shared/services/file/file.service';
-import { ReplayBackendService } from '../../services/replay-backend.service';
+import { ReplayBackendService, ReplayClientTimings } from '../../services/replay-backend.service';
 import { AppService } from '../../../core/services/app.service';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { FilesDto } from '../../../../../../../api-dto/files/files.dto';
@@ -102,6 +102,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private routeStartTime: number = 0;
   private payloadRequestStartTime: number = 0;
   private payloadResponseTime: number = 0;
+  private playerReadyTime: number = 0;
   private successStoredForCurrentReplay: boolean = false;
   protected reloadKey: number = 0;
   workspaceId: number = 0;
@@ -446,6 +447,8 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     }> {
     this.replayStartTime = performance.now();
     this.payloadRequestStartTime = performance.now();
+    this.payloadResponseTime = 0;
+    this.playerReadyTime = 0;
     this.successStoredForCurrentReplay = false;
     this.isLoaded.next(false);
     const unitData = await firstValueFrom(
@@ -507,6 +510,12 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     this.storeReplayStatistics(false, duration, errorMessage);
   }
 
+  onPlayerReady(): void {
+    if (!this.playerReadyTime) {
+      this.playerReadyTime = performance.now();
+    }
+  }
+
   onResponseVisible(): void {
     if (this.successStoredForCurrentReplay) {
       return;
@@ -517,13 +526,45 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       Math.round(this.payloadResponseTime - this.payloadRequestStartTime) :
       0;
     const payloadToVisible = this.payloadResponseTime ? Math.round(now - this.payloadResponseTime) : 0;
+    const payloadToPlayerReady = (this.payloadResponseTime && this.playerReadyTime) ?
+      Math.round(this.playerReadyTime - this.payloadResponseTime) :
+      null;
+    const playerReadyToVisible = this.playerReadyTime ?
+      Math.round(now - this.playerReadyTime) :
+      null;
     logger.log(
       `Replay timings unit=${this.unitId} routeToVisible=${routeToVisible}ms ` +
-      `payload=${payloadDuration}ms payloadToVisible=${payloadToVisible}ms`
+      `payload=${payloadDuration}ms payloadToVisible=${payloadToVisible}ms ` +
+      `payloadToPlayerReady=${payloadToPlayerReady ?? 'n/a'}ms ` +
+      `playerReadyToVisible=${playerReadyToVisible ?? 'n/a'}ms`
     );
     const duration = this.replayStartTime ? Math.round(performance.now() - this.replayStartTime) : 0;
     this.storeReplayStatistics(true, duration);
     this.successStoredForCurrentReplay = true;
+  }
+
+  private getClientTimings(visibleTime: number = performance.now()): ReplayClientTimings {
+    const routeToVisible = this.routeStartTime ? Math.round(visibleTime - this.routeStartTime) : null;
+    const payloadMs = (this.payloadRequestStartTime && this.payloadResponseTime) ?
+      Math.round(this.payloadResponseTime - this.payloadRequestStartTime) :
+      null;
+    const payloadToVisibleMs = this.payloadResponseTime ?
+      Math.round(visibleTime - this.payloadResponseTime) :
+      null;
+    const payloadToPlayerReadyMs = (this.payloadResponseTime && this.playerReadyTime) ?
+      Math.round(this.playerReadyTime - this.payloadResponseTime) :
+      null;
+    const playerReadyToVisibleMs = this.playerReadyTime ?
+      Math.round(visibleTime - this.playerReadyTime) :
+      null;
+
+    return {
+      routeToVisibleMs: routeToVisible,
+      payloadMs,
+      payloadToVisibleMs,
+      payloadToPlayerReadyMs,
+      playerReadyToVisibleMs
+    };
   }
 
   private storeReplayStatistics(success: boolean, duration: number, errorMessage?: string): void {
@@ -545,7 +586,8 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       durationMilliseconds: Math.max(0, duration),
       replayUrl,
       success,
-      errorMessage
+      errorMessage,
+      clientTimings: this.getClientTimings()
     }).subscribe({
       next: () => {
         logger.log(

--- a/apps/frontend/src/app/replay/components/unit-player/unit-player.component.ts
+++ b/apps/frontend/src/app/replay/components/unit-player/unit-player.component.ts
@@ -40,6 +40,7 @@ export class UnitPlayerComponent implements AfterViewInit, OnChanges, OnDestroy 
   readonly printMode = input<boolean>(false);
   iFrameHeight = input<number>();
   readonly invalidPage = output<'notInList' | 'notCurrent' | null>();
+  readonly playerReady = output<void>();
   readonly responseVisible = output<void>();
   // Track the last emitted page error to prevent flickering
   private lastPageError: 'notInList' | 'notCurrent' | null = null;
@@ -276,6 +277,7 @@ export class UnitPlayerComponent implements AfterViewInit, OnChanges, OnDestroy 
               window.crypto.getRandomValues(array);
               this.sessionId = ((array[0] % 20_000_000) + 10_000_000).toString(); // Session ID between 10M and 30M
               this.postMessageTarget = m.source as Window;
+              this.playerReady.emit();
               this.sendUnitData();
               break;
             }

--- a/apps/frontend/src/app/replay/services/replay-backend.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-backend.service.ts
@@ -17,9 +17,11 @@ export type ReplayStatisticsResponse = {
   success?: boolean;
   errorMessage?: string;
   clientTimings?: Record<string, number | null>;
+  serverTimings?: Record<string, number | null>;
 };
 
 export type ReplayClientTimings = Record<string, number | null>;
+export type ReplayServerTimings = Record<string, number | null>;
 
 @Injectable({
   providedIn: 'root'
@@ -44,6 +46,7 @@ export class ReplayBackendService {
       success?: boolean;
       errorMessage?: string;
       clientTimings?: ReplayClientTimings;
+      serverTimings?: ReplayServerTimings;
     }
   ): Observable<ReplayStatisticsResponse> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/replay-statistics`;
@@ -65,6 +68,7 @@ export class ReplayBackendService {
       };
       player: FilesDto[];
       vocs: FilesDto[];
+      serverTimings?: ReplayServerTimings;
     }> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/replay-payload/${encodeURIComponent(testPerson)}/${encodeURIComponent(unitId)}`;
     const headers = authToken ?
@@ -80,6 +84,7 @@ export class ReplayBackendService {
       };
       player: FilesDto[];
       vocs: FilesDto[];
+      serverTimings?: ReplayServerTimings;
     }>(url, { headers });
   }
 

--- a/apps/frontend/src/app/replay/services/replay-backend.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-backend.service.ts
@@ -16,7 +16,10 @@ export type ReplayStatisticsResponse = {
   replayUrl?: string;
   success?: boolean;
   errorMessage?: string;
+  clientTimings?: Record<string, number | null>;
 };
+
+export type ReplayClientTimings = Record<string, number | null>;
 
 @Injectable({
   providedIn: 'root'
@@ -40,6 +43,7 @@ export class ReplayBackendService {
       replayUrl?: string;
       success?: boolean;
       errorMessage?: string;
+      clientTimings?: ReplayClientTimings;
     }
   ): Observable<ReplayStatisticsResponse> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/replay-statistics`;

--- a/apps/frontend/src/app/services/facades/coding-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/coding-facade.service.ts
@@ -8,6 +8,7 @@ import { CodingJobBackendService, CodingExportConfig, JobDefinition } from '../.
 import {
   ReplayBackendService,
   ReplayClientTimings,
+  ReplayServerTimings,
   ReplayStatisticsResponse
 } from '../../replay/services/replay-backend.service';
 import {
@@ -317,6 +318,7 @@ export class CodingFacadeService {
     success?: boolean;
     errorMessage?: string;
     clientTimings?: ReplayClientTimings;
+    serverTimings?: ReplayServerTimings;
   }): Observable<ReplayStatisticsResponse> {
     return this.replayBackendService.storeReplayStatistics(workspaceId, data);
   }

--- a/apps/frontend/src/app/services/facades/coding-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/coding-facade.service.ts
@@ -5,7 +5,11 @@ import {
   VariableBundle
 } from '../../coding/models/coding-job.model';
 import { CodingJobBackendService, CodingExportConfig, JobDefinition } from '../../coding/services/coding-job-backend.service';
-import { ReplayBackendService, ReplayStatisticsResponse } from '../../replay/services/replay-backend.service';
+import {
+  ReplayBackendService,
+  ReplayClientTimings,
+  ReplayStatisticsResponse
+} from '../../replay/services/replay-backend.service';
 import {
   CodingTrainingBackendService,
   CreateCoderTrainingJobsResponse,
@@ -303,7 +307,17 @@ export class CodingFacadeService {
     return this.codingExportService.getCodingBook(workspaceId, missingsProfile, contentOptions, unitList);
   }
 
-  storeReplayStatistics(workspaceId: number, data: { unitId: string; bookletId?: string; testPersonLogin?: string; testPersonCode?: string; durationMilliseconds: number; replayUrl?: string; success?: boolean; errorMessage?: string }): Observable<ReplayStatisticsResponse> {
+  storeReplayStatistics(workspaceId: number, data: {
+    unitId: string;
+    bookletId?: string;
+    testPersonLogin?: string;
+    testPersonCode?: string;
+    durationMilliseconds: number;
+    replayUrl?: string;
+    success?: boolean;
+    errorMessage?: string;
+    clientTimings?: ReplayClientTimings;
+  }): Observable<ReplayStatisticsResponse> {
     return this.replayBackendService.storeReplayStatistics(workspaceId, data);
   }
 

--- a/database/changelog/coding-box.changelog-1.15.0.sql
+++ b/database/changelog/coding-box.changelog-1.15.0.sql
@@ -4,4 +4,8 @@
 ALTER TABLE "public"."replay_statistics"
   ADD COLUMN "client_timings" JSONB NULL;
 
+ALTER TABLE "public"."replay_statistics"
+  ADD COLUMN "server_timings" JSONB NULL;
+
+-- rollback ALTER TABLE "public"."replay_statistics" DROP COLUMN "server_timings";
 -- rollback ALTER TABLE "public"."replay_statistics" DROP COLUMN "client_timings";

--- a/database/changelog/coding-box.changelog-1.15.0.sql
+++ b/database/changelog/coding-box.changelog-1.15.0.sql
@@ -1,0 +1,7 @@
+-- liquibase formatted sql
+
+-- changeset jurei733:1
+ALTER TABLE "public"."replay_statistics"
+  ADD COLUMN "client_timings" JSONB NULL;
+
+-- rollback ALTER TABLE "public"."replay_statistics" DROP COLUMN "client_timings";

--- a/database/changelog/coding-box.changelog-root.xml
+++ b/database/changelog/coding-box.changelog-root.xml
@@ -37,4 +37,5 @@
   <include file="coding-box.changelog-1.12.0.sql"/>
   <include file="coding-box.changelog-1.13.0.sql"/>
   <include file="coding-box.changelog-1.14.1.sql"/>
+  <include file="coding-box.changelog-1.15.0.sql"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- add `client_timings` JSONB storage for replay statistics via the 1.15.0 changelog
- record payload, player-ready, and response-visible timing segments in replay statistics
- expose a `playerReady` event from the unit player so slow replays can be split between player startup and response visibility

## Checks
- `git diff --check`
- `npx nx test frontend --runInBand --testPathPattern=apps/frontend/src/app/replay/components/replay/replay.component.spec.ts --testPathPattern=apps/frontend/src/app/replay/services/replay-backend.service.spec.ts`
- `npx nx test frontend --runInBand --testPathPattern=apps/frontend/src/app/replay/components/unit-player/unit-player.component.spec.ts`
- `npx nx build backend`
- `npx nx build frontend --configuration development`