### PR TITLE
feat: include response values in coding results export

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
@@ -238,6 +238,12 @@ export class WorkspaceCodingExportController {
     description: 'Include replay URLs in the export',
     type: Boolean
   })
+  @ApiQuery({
+    name: 'includeResponseValues',
+    required: false,
+    description: 'Include response values in the export',
+    type: Boolean
+  })
   @ApiOkResponse({
     description: 'Coding results for specified version exported as CSV',
     content: {
@@ -256,6 +262,8 @@ export class WorkspaceCodingExportController {
       @Query('serverUrl') serverUrl: string,
       @Query('includeReplayUrls', { transform: value => value === 'true' })
                    includeReplayUrls: boolean,
+      @Query('includeResponseValues', { transform: value => value !== 'false' })
+                   includeResponseValues: boolean,
                    @Res() res: Response
   ): Promise<void> {
     const csvStream = await this.codingResultsExportService.exportCodingResultsByVersionAsCsv(
@@ -263,7 +271,9 @@ export class WorkspaceCodingExportController {
       version,
       authToken,
       serverUrl,
-      includeReplayUrls
+      includeReplayUrls,
+      undefined,
+      includeResponseValues
     );
 
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
@@ -307,6 +317,12 @@ export class WorkspaceCodingExportController {
     description: 'Include replay URLs in the export',
     type: Boolean
   })
+  @ApiQuery({
+    name: 'includeResponseValues',
+    required: false,
+    description: 'Include response values in the export',
+    type: Boolean
+  })
   @ApiOkResponse({
     description: 'Coding results for specified version exported as Excel',
     content: {
@@ -325,6 +341,8 @@ export class WorkspaceCodingExportController {
       @Query('serverUrl') serverUrl: string,
       @Query('includeReplayUrls', { transform: value => value === 'true' })
                    includeReplayUrls: boolean,
+      @Query('includeResponseValues', { transform: value => value !== 'false' })
+                   includeResponseValues: boolean,
                    @Res() res: Response
   ): Promise<void> {
     const buffer = await this.codingResultsExportService.exportCodingResultsByVersionAsExcel(
@@ -332,7 +350,9 @@ export class WorkspaceCodingExportController {
       version,
       authToken,
       serverUrl,
-      includeReplayUrls
+      includeReplayUrls,
+      undefined,
+      includeResponseValues
     );
 
     res.setHeader(
@@ -891,6 +911,7 @@ export class WorkspaceCodingExportController {
         },
         outputCommentsInsteadOfCodes: { type: 'boolean' },
         includeReplayUrl: { type: 'boolean' },
+        includeResponseValues: { type: 'boolean' },
         anonymizeCoders: { type: 'boolean' },
         usePseudoCoders: { type: 'boolean' },
         doubleCodingMethod: {

--- a/apps/backend/src/app/database/services/coding/coding-export.high-coverage.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.high-coverage.spec.ts
@@ -174,8 +174,8 @@ describe('CodingExportService high coverage paths', () => {
     const jsonStream = await service.exportCodingListForJobAsJson(1, '', '', jest.fn());
     jsonStream.resume();
 
-    await expect(service.exportCodingResultsByVersionAsCsv(1, 'v1', '', '', true, jest.fn())).resolves.toBeDefined();
-    await expect(service.exportCodingResultsByVersionAsExcel(1, 'v2', '', '', false, jest.fn())).resolves.toBeInstanceOf(Buffer);
+    await expect(service.exportCodingResultsByVersionAsCsv(1, 'v1', '', '', true, jest.fn(), true)).resolves.toBeDefined();
+    await expect(service.exportCodingResultsByVersionAsExcel(1, 'v2', '', '', false, jest.fn(), true)).resolves.toBeInstanceOf(Buffer);
   });
 
   it('builds replay URLs through the page lookup cache', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.ts
@@ -312,7 +312,8 @@ export class CodingExportService {
     authToken: string,
     serverUrl: string,
     includeReplayUrls: boolean,
-    progressCallback?: (percentage: number) => Promise<void>
+    progressCallback?: (percentage: number) => Promise<void>,
+    includeResponseValues: boolean = true
   ): Promise<Readable> {
     return this.codingListService.getCodingResultsByVersionCsvStream(
       workspaceId,
@@ -320,7 +321,8 @@ export class CodingExportService {
       authToken || '',
       serverUrl || '',
       includeReplayUrls,
-      progressCallback
+      progressCallback,
+      includeResponseValues
     );
   }
 
@@ -330,7 +332,8 @@ export class CodingExportService {
     authToken: string,
     serverUrl: string,
     includeReplayUrls: boolean,
-    progressCallback?: (percentage: number) => Promise<void>
+    progressCallback?: (percentage: number) => Promise<void>,
+    includeResponseValues: boolean = true
   ): Promise<Buffer> {
     return this.codingListService.getCodingResultsByVersionAsExcel(
       workspaceId,
@@ -338,7 +341,8 @@ export class CodingExportService {
       authToken || '',
       serverUrl || '',
       includeReplayUrls,
-      progressCallback
+      progressCallback,
+      includeResponseValues
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-item-builder.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-item-builder.service.ts
@@ -14,6 +14,7 @@ export interface CodingItem {
   variable_id: string;
   variable_page: string;
   variable_anchor: string;
+  value?: string;
   url?: string;
 }
 
@@ -101,7 +102,8 @@ export class CodingItemBuilderService {
     authToken: string,
     serverUrl: string,
     workspaceId: number,
-    includeReplayUrls: boolean = false
+    includeReplayUrls: boolean = false,
+    includeResponseValues: boolean = true
   ): Promise<CodingItem | null> {
     try {
       const unit = response.unit;
@@ -143,6 +145,10 @@ export class CodingItemBuilderService {
         variable_page: variablePage,
         variable_anchor: variableAnchor
       };
+
+      if (includeResponseValues) {
+        baseItem.value = response.value ?? '';
+      }
 
       // Add version-specific data (include all lower versions) and convert status numbers to strings
       if (targetVersion === 'v1') {
@@ -204,7 +210,10 @@ export class CodingItemBuilderService {
   /**
    * Get headers for version-specific exports.
    */
-  getHeadersForVersion(version: 'v1' | 'v2' | 'v3'): string[] {
+  getHeadersForVersion(
+    version: 'v1' | 'v2' | 'v3',
+    includeResponseValues: boolean = true
+  ): string[] {
     const baseHeaders = [
       'unit_key',
       'unit_alias',
@@ -216,14 +225,15 @@ export class CodingItemBuilderService {
       'variable_page',
       'variable_anchor'
     ];
+    const headers = includeResponseValues ? [...baseHeaders, 'value'] : baseHeaders;
 
     // Add version-specific columns for comparison
     if (version === 'v1') {
-      return [...baseHeaders, 'status_v1', 'code_v1', 'score_v1'];
+      return [...headers, 'status_v1', 'code_v1', 'score_v1'];
     }
     if (version === 'v2') {
       return [
-        ...baseHeaders,
+        ...headers,
         'status_v1',
         'code_v1',
         'score_v1',
@@ -234,7 +244,7 @@ export class CodingItemBuilderService {
     }
     // v3
     return [
-      ...baseHeaders,
+      ...headers,
       'status_v1',
       'code_v1',
       'score_v1',

--- a/apps/backend/src/app/database/services/coding/coding-list-stream.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-stream.service.spec.ts
@@ -142,6 +142,51 @@ describe('CodingListStreamService', () => {
       expect(stream).toBeDefined();
       expect(mockFileCacheService.clearCaches).toHaveBeenCalled();
     });
+
+    it('should pass response value option to versioned CSV item builder', async () => {
+      const response = createMockResponse(1);
+      mockResponseFilterService.getResponsesBatch
+        .mockResolvedValueOnce([response])
+        .mockResolvedValueOnce([]);
+      mockItemBuilderService.buildCodingItemWithVersions.mockResolvedValue({
+        unit_key: 'unit1',
+        unit_alias: 'Unit 1',
+        person_login: 'user1',
+        person_code: 'code1',
+        person_group: 'group1',
+        booklet_name: 'booklet1',
+        variable_id: 'var1',
+        variable_page: '1',
+        variable_anchor: 'var1',
+        status_v1: 'VALUE_CHANGED',
+        code_v1: '',
+        score_v1: ''
+      } as never);
+
+      const stream = await service.getCodingResultsByVersionCsvStream(
+        1,
+        'v1',
+        'token',
+        'http://server',
+        false,
+        undefined,
+        false
+      );
+      stream.on('data', () => {});
+      await new Promise(resolve => {
+        stream.on('end', resolve);
+      });
+
+      expect(mockItemBuilderService.buildCodingItemWithVersions).toHaveBeenCalledWith(
+        response,
+        'v1',
+        'token',
+        'http://server',
+        1,
+        false,
+        false
+      );
+    });
   });
 
   describe('CSV formatting', () => {
@@ -251,6 +296,26 @@ describe('CodingListStreamService', () => {
       );
 
       expect(result).toBeInstanceOf(Buffer);
+    });
+
+    it('should pass response value option to versioned Excel headers', async () => {
+      mockResponseFilterService.getResponsesBatch.mockResolvedValueOnce([]);
+      mockItemBuilderService.getHeadersForVersion.mockReturnValue([
+        'unit_key',
+        'status_v1'
+      ]);
+
+      await service.getCodingResultsByVersionAsExcel(
+        1,
+        'v1',
+        'token',
+        'http://server',
+        false,
+        undefined,
+        false
+      );
+
+      expect(mockItemBuilderService.getHeadersForVersion).toHaveBeenCalledWith('v1', false);
     });
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-list-stream.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-stream.service.ts
@@ -409,10 +409,11 @@ export class CodingListStreamService {
     authToken: string,
     serverUrl?: string,
     includeReplayUrls: boolean = false,
-    progressCallback?: (percentage: number) => Promise<void>
+    progressCallback?: (percentage: number) => Promise<void>,
+    includeResponseValues: boolean = true
   ) {
     this.logger.log(
-      `Memory-efficient CSV export for coding results version ${version}, workspace ${workspace_id} (replay URLs: ${includeReplayUrls})`
+      `Memory-efficient CSV export for coding results version ${version}, workspace ${workspace_id} (replay URLs: ${includeReplayUrls}, response values: ${includeResponseValues})`
     );
     this.fileCacheService.clearCaches();
     const csvStream = fastCsv.format({ headers: true, delimiter: ';' });
@@ -445,7 +446,8 @@ export class CodingListStreamService {
             authToken,
             serverUrl!,
             workspace_id,
-            includeReplayUrls
+            includeReplayUrls,
+            includeResponseValues
           ));
 
           const results = await Promise.allSettled(processingPromises);
@@ -508,10 +510,11 @@ export class CodingListStreamService {
     authToken?: string,
     serverUrl?: string,
     includeReplayUrls: boolean = false,
-    progressCallback?: (percentage: number) => Promise<void>
+    progressCallback?: (percentage: number) => Promise<void>,
+    includeResponseValues: boolean = true
   ): Promise<Buffer> {
     this.logger.log(
-      `Starting streaming Excel export for coding results version ${version}, workspace ${workspace_id} (replay URLs: ${includeReplayUrls})`
+      `Starting streaming Excel export for coding results version ${version}, workspace ${workspace_id} (replay URLs: ${includeReplayUrls}, response values: ${includeResponseValues})`
     );
     this.fileCacheService.clearCaches();
 
@@ -535,7 +538,7 @@ export class CodingListStreamService {
     const worksheet = workbook.addWorksheet('Coding Results');
 
     // Define headers based on version (include lower versions)
-    let headers = this.itemBuilderService.getHeadersForVersion(version);
+    let headers = this.itemBuilderService.getHeadersForVersion(version, includeResponseValues);
 
     // Add URL column if replay URLs are included
     if (includeReplayUrls) {
@@ -568,7 +571,8 @@ export class CodingListStreamService {
           authToken || '',
           serverUrl || '',
           workspace_id,
-          includeReplayUrls
+          includeReplayUrls,
+          includeResponseValues
         )
         );
 

--- a/apps/backend/src/app/database/services/coding/coding-list.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list.service.spec.ts
@@ -10,7 +10,7 @@ import { CodingListStreamService } from './coding-list-stream.service';
 import { CodingItemBuilderService } from './coding-item-builder.service';
 
 type CodingItemBuilderServiceHeaderGetter = {
-  getHeadersForVersion: (version: 'v1' | 'v2' | 'v3') => string[];
+  getHeadersForVersion: (version: 'v1' | 'v2' | 'v3', includeResponseValues?: boolean) => string[];
 };
 
 describe('CodingListService', () => {
@@ -53,9 +53,11 @@ describe('CodingListService', () => {
         'person_login',
         'person_code',
         'person_group',
-        'booklet_name'
+        'booklet_name',
+        'value'
       ])
     );
+    expect(headersV1.indexOf('value')).toBe(headersV1.indexOf('variable_anchor') + 1);
 
     expect(headersV1).not.toEqual(
       expect.arrayContaining([
@@ -65,5 +67,102 @@ describe('CodingListService', () => {
         'booklet_id'
       ])
     );
+  });
+
+  it('should omit value from results-by-version headers when response values are disabled', () => {
+    const fileUploadRepository = {} as unknown as Repository<FileUpload>;
+    const fileCacheService = new CodingFileCacheService(fileUploadRepository);
+    const itemBuilderService = new CodingItemBuilderService(fileCacheService);
+
+    const headersV1 = (
+      itemBuilderService as unknown as CodingItemBuilderServiceHeaderGetter
+    ).getHeadersForVersion('v1', false);
+
+    expect(headersV1).toEqual([
+      'unit_key',
+      'unit_alias',
+      'person_login',
+      'person_code',
+      'person_group',
+      'booklet_name',
+      'variable_id',
+      'variable_page',
+      'variable_anchor',
+      'status_v1',
+      'code_v1',
+      'score_v1'
+    ]);
+  });
+
+  it('should include response value in versioned coding items by default', async () => {
+    const fileCacheService = {
+      loadVoudData: jest.fn().mockResolvedValue(new Map([['VAR1', '2']]))
+    } as unknown as CodingFileCacheService;
+    const itemBuilderService = new CodingItemBuilderService(fileCacheService);
+    const response = {
+      id: 1,
+      variableid: 'VAR1',
+      value: 'Antworttext',
+      status_v1: null,
+      code_v1: null,
+      score_v1: null,
+      unit: {
+        name: 'UNIT1',
+        alias: 'Unit 1',
+        booklet: {
+          person: { login: 'login', code: 'code', group: 'group' },
+          bookletinfo: { name: 'BOOKLET1' }
+        }
+      }
+    } as unknown as ResponseEntity;
+
+    await expect(
+      itemBuilderService.buildCodingItemWithVersions(
+        response,
+        'v1',
+        'token',
+        'http://server',
+        1
+      )
+    ).resolves.toMatchObject({
+      variable_anchor: 'VAR1',
+      value: 'Antworttext',
+      status_v1: ''
+    });
+  });
+
+  it('should omit response value in versioned coding items when disabled', async () => {
+    const fileCacheService = {
+      loadVoudData: jest.fn().mockResolvedValue(new Map())
+    } as unknown as CodingFileCacheService;
+    const itemBuilderService = new CodingItemBuilderService(fileCacheService);
+    const response = {
+      id: 1,
+      variableid: 'VAR1',
+      value: 'Antworttext',
+      status_v1: null,
+      code_v1: null,
+      score_v1: null,
+      unit: {
+        name: 'UNIT1',
+        alias: 'Unit 1',
+        booklet: {
+          person: { login: 'login', code: 'code', group: 'group' },
+          bookletinfo: { name: 'BOOKLET1' }
+        }
+      }
+    } as unknown as ResponseEntity;
+
+    const item = await itemBuilderService.buildCodingItemWithVersions(
+      response,
+      'v1',
+      'token',
+      'http://server',
+      1,
+      false,
+      false
+    );
+
+    expect(item).not.toHaveProperty('value');
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-list.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list.service.ts
@@ -15,6 +15,7 @@ export interface CodingItem {
   variable_id: string;
   variable_page: string;
   variable_anchor: string;
+  value?: string;
   url?: string;
 }
 
@@ -150,7 +151,8 @@ export class CodingListService {
     authToken: string,
     serverUrl?: string,
     includeReplayUrls: boolean = false,
-    progressCallback?: (percentage: number) => Promise<void>
+    progressCallback?: (percentage: number) => Promise<void>,
+    includeResponseValues: boolean = true
   ) {
     return this.streamService.getCodingResultsByVersionCsvStream(
       workspace_id,
@@ -158,7 +160,8 @@ export class CodingListService {
       authToken,
       serverUrl,
       includeReplayUrls,
-      progressCallback
+      progressCallback,
+      includeResponseValues
     );
   }
 
@@ -172,7 +175,8 @@ export class CodingListService {
     authToken?: string,
     serverUrl?: string,
     includeReplayUrls: boolean = false,
-    progressCallback?: (percentage: number) => Promise<void>
+    progressCallback?: (percentage: number) => Promise<void>,
+    includeResponseValues: boolean = true
   ): Promise<Buffer> {
     return this.streamService.getCodingResultsByVersionAsExcel(
       workspace_id,
@@ -180,7 +184,8 @@ export class CodingListService {
       authToken,
       serverUrl,
       includeReplayUrls,
-      progressCallback
+      progressCallback,
+      includeResponseValues
     );
   }
 }

--- a/apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts
@@ -106,8 +106,8 @@ describe('CodingResultsExportService', () => {
     await expect(service.exportCodingResultsByVersionAsCsv(1, 'v2', '', '', true)).resolves.toBeInstanceOf(Readable);
     await expect(service.exportCodingResultsByVersionAsExcel(1, 'v3', '', '', false)).resolves.toEqual(Buffer.from('xlsx'));
 
-    expect(codingListService.getCodingResultsByVersionCsvStream).toHaveBeenCalledWith(1, 'v2', '', '', true);
-    expect(codingListService.getCodingResultsByVersionAsExcel).toHaveBeenCalledWith(1, 'v3', '', '', false);
+    expect(codingListService.getCodingResultsByVersionCsvStream).toHaveBeenCalledWith(1, 'v2', '', '', true, undefined, true);
+    expect(codingListService.getCodingResultsByVersionAsExcel).toHaveBeenCalledWith(1, 'v3', '', '', false, undefined, true);
   });
 
   it('caches variable page maps per workspace and falls back to page zero', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-results-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results-export.service.ts
@@ -80,14 +80,18 @@ export class CodingResultsExportService {
     version: 'v1' | 'v2' | 'v3',
     authToken: string,
     serverUrl: string,
-    includeReplayUrls: boolean
+    includeReplayUrls: boolean,
+    progressCallback?: (percentage: number) => Promise<void>,
+    includeResponseValues: boolean = true
   ): Promise<Readable> {
     return this.codingListService.getCodingResultsByVersionCsvStream(
       workspaceId,
       version,
       authToken || '',
       serverUrl || '',
-      includeReplayUrls
+      includeReplayUrls,
+      progressCallback,
+      includeResponseValues
     );
   }
 
@@ -96,14 +100,18 @@ export class CodingResultsExportService {
     version: 'v1' | 'v2' | 'v3',
     authToken: string,
     serverUrl: string,
-    includeReplayUrls: boolean
+    includeReplayUrls: boolean,
+    progressCallback?: (percentage: number) => Promise<void>,
+    includeResponseValues: boolean = true
   ): Promise<Buffer> {
     return this.codingListService.getCodingResultsByVersionAsExcel(
       workspaceId,
       version,
       authToken || '',
       serverUrl || '',
-      includeReplayUrls
+      includeReplayUrls,
+      progressCallback,
+      includeResponseValues
     );
   }
 

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -110,6 +110,7 @@ export interface ExportJobData {
   format?: 'csv' | 'json' | 'excel';
   outputCommentsInsteadOfCodes?: boolean;
   includeReplayUrl?: boolean;
+  includeResponseValues?: boolean;
   anonymizeCoders?: boolean;
   usePseudoCoders?: boolean;
   doubleCodingMethod?:

--- a/apps/backend/src/app/job-queue/processors/export-job.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/export-job.processor.ts
@@ -126,7 +126,8 @@ export class ExportJobProcessor {
               job.data.authToken || '',
               job.data.serverUrl || '',
               job.data.includeReplayUrl || false,
-              onProgress
+              onProgress,
+              job.data.includeResponseValues !== false
             );
           } else {
             // CSV Stream
@@ -136,7 +137,8 @@ export class ExportJobProcessor {
               job.data.authToken || '',
               job.data.serverUrl || '',
               job.data.includeReplayUrl || false,
-              onProgress
+              onProgress,
+              job.data.includeResponseValues !== false
             );
 
             const writeStream = fs.createWriteStream(filePath);

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -577,8 +577,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-        const { version, format, includeReplayUrls } = result;
-        this.codingManagementService.downloadCodingResults(version, format, includeReplayUrls)
+        const {
+          version, format, includeReplayUrls, includeResponseValues
+        } = result;
+        this.codingManagementService.downloadCodingResults(version, format, includeReplayUrls, includeResponseValues)
           .finally(() => {
             this.isDownloadInProgress = false;
           });

--- a/apps/frontend/src/app/coding/components/coding-management/download-coding-results-dialog/download-coding-results-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/download-coding-results-dialog/download-coding-results-dialog.component.ts
@@ -118,6 +118,14 @@ export interface DownloadCodingResultsDialogData {
               {{ 'coding-management.download-dialog.replay-urls-description' | translate }}
             </p>
           </div>
+          <div class="option-item">
+            <mat-checkbox [(ngModel)]="includeResponseValues" class="option-checkbox">
+              {{ 'coding-management.download-dialog.include-response-values' | translate }}
+            </mat-checkbox>
+            <p class="option-description">
+              {{ 'coding-management.download-dialog.response-values-description' | translate }}
+            </p>
+          </div>
         </mat-card-content>
       </mat-card>
 
@@ -207,6 +215,10 @@ export interface DownloadCodingResultsDialogData {
       display: flex;
       flex-direction: column;
       gap: 8px;
+
+      & + .option-item {
+        margin-top: 14px;
+      }
 
       .option-checkbox {
         margin: 0;
@@ -323,6 +335,7 @@ export class DownloadCodingResultsDialogComponent {
   selectedVersion: 'v1' | 'v2' | 'v3' = 'v1';
   selectedFormat: ExportFormat = 'csv';
   includeReplayUrls: boolean = false;
+  includeResponseValues: boolean = true;
 
   constructor(
     public dialogRef: MatDialogRef<DownloadCodingResultsDialogComponent>,
@@ -335,7 +348,8 @@ export class DownloadCodingResultsDialogComponent {
     this.dialogRef.close({
       version: this.selectedVersion,
       format: this.selectedFormat,
-      includeReplayUrls: this.includeReplayUrls
+      includeReplayUrls: this.includeReplayUrls,
+      includeResponseValues: this.includeResponseValues
     });
   }
 

--- a/apps/frontend/src/app/coding/services/coding-export.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-export.service.spec.ts
@@ -66,16 +66,35 @@ describe('CodingExportService', () => {
   });
 
   it('should get coding results by version', () => {
-    service.getCodingResultsByVersion(1, 'v2', true).subscribe(res => {
+    service.getCodingResultsByVersion(1, 'v2', true, false).subscribe(res => {
       expect(res).toBeDefined();
     });
 
     const req = httpMock.expectOne(request => request.url === `${mockServerUrl}admin/workspace/1/coding/results-by-version` &&
       request.params.get('version') === 'v2' &&
-      request.params.get('includeReplayUrls') === 'true'
+      request.params.get('includeReplayUrls') === 'true' &&
+      request.params.get('includeResponseValues') === 'false'
     );
     expect(req.request.method).toBe('GET');
     req.flush(new Blob());
+  });
+
+  it('should pass response value option to export jobs', () => {
+    service.startExportJob(1, 'results-by-version', 'v1', 'csv', false, undefined, false).subscribe(res => {
+      expect(res).toBeDefined();
+    });
+
+    const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/export/start`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toMatchObject({
+      exportType: 'results-by-version',
+      version: 'v1',
+      format: 'csv',
+      includeReplayUrl: false,
+      includeResponseValues: false,
+      authToken: 'auth-token'
+    });
+    req.flush({ jobId: 'job-1', message: 'started' });
   });
 
   it('should get coding book', () => {

--- a/apps/frontend/src/app/coding/services/coding-export.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-export.service.ts
@@ -59,7 +59,12 @@ export class CodingExportService {
     );
   }
 
-  getCodingResultsByVersion(workspace_id: number, version: 'v1' | 'v2' | 'v3', includeReplayUrls: boolean = false): Observable<Blob> {
+  getCodingResultsByVersion(
+    workspace_id: number,
+    version: 'v1' | 'v2' | 'v3',
+    includeReplayUrls: boolean = false,
+    includeResponseValues: boolean = true
+  ): Observable<Blob> {
     const identity = this.appService.loggedUser?.sub || '';
     return this.appService.createToken(workspace_id, identity, 60).pipe(
       catchError(() => of('')),
@@ -68,7 +73,8 @@ export class CodingExportService {
           .set('authToken', token)
           .set('serverUrl', window.location.origin)
           .set('version', version)
-          .set('includeReplayUrls', includeReplayUrls ? 'true' : 'false');
+          .set('includeReplayUrls', includeReplayUrls ? 'true' : 'false')
+          .set('includeResponseValues', includeResponseValues ? 'true' : 'false');
         return this.http.get(
           `${this.serverUrl}admin/workspace/${workspace_id}/coding/results-by-version`,
           {
@@ -80,7 +86,12 @@ export class CodingExportService {
     );
   }
 
-  getCodingResultsByVersionAsExcel(workspace_id: number, version: 'v1' | 'v2' | 'v3', includeReplayUrls: boolean = false): Observable<Blob> {
+  getCodingResultsByVersionAsExcel(
+    workspace_id: number,
+    version: 'v1' | 'v2' | 'v3',
+    includeReplayUrls: boolean = false,
+    includeResponseValues: boolean = true
+  ): Observable<Blob> {
     const identity = this.appService.loggedUser?.sub || '';
     return this.appService.createToken(workspace_id, identity, 60).pipe(
       catchError(() => of('')),
@@ -89,7 +100,8 @@ export class CodingExportService {
           .set('authToken', token)
           .set('serverUrl', window.location.origin)
           .set('version', version)
-          .set('includeReplayUrls', includeReplayUrls ? 'true' : 'false');
+          .set('includeReplayUrls', includeReplayUrls ? 'true' : 'false')
+          .set('includeResponseValues', includeResponseValues ? 'true' : 'false');
         return this.http.get(
           `${this.serverUrl}admin/workspace/${workspace_id}/coding/results-by-version/excel`,
           {
@@ -194,7 +206,8 @@ export class CodingExportService {
     version?: 'v1' | 'v2' | 'v3',
     format?: 'csv' | 'json' | 'excel',
     includeReplayUrls: boolean = false,
-    trainingRequired?: boolean
+    trainingRequired?: boolean,
+    includeResponseValues: boolean = true
   ): Observable<{ jobId: string; message: string }> {
     const identity = this.appService.loggedUser?.sub || '';
     return this.appService.createToken(workspaceId, identity, 60).pipe(
@@ -205,6 +218,7 @@ export class CodingExportService {
           version,
           format,
           includeReplayUrl: includeReplayUrls,
+          includeResponseValues,
           trainingRequired,
           authToken: token,
           serverUrl: window.location.origin

--- a/apps/frontend/src/app/coding/services/coding-management.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-management.service.spec.ts
@@ -194,4 +194,28 @@ describe('CodingManagementService', () => {
       expect(exportServiceMock.downloadExportFile).toHaveBeenCalledWith(1, 'job-1');
     });
   });
+
+  describe('downloadCodingResults', () => {
+    it('should pass response value option to background export job', async () => {
+      exportServiceMock.startExportJob.mockReturnValue(of({ jobId: 'job-1', message: 'started' }));
+      exportServiceMock.getExportJobStatus.mockReturnValue(of({ status: 'completed', progress: 100 }) as never);
+      const mockBlob = new Blob(['csv data'], { type: 'text/csv' });
+      exportServiceMock.downloadExportFile.mockReturnValue(of(mockBlob));
+
+      global.URL.createObjectURL = jest.fn();
+      global.URL.revokeObjectURL = jest.fn();
+
+      await service.downloadCodingResults('v1', 'csv', true, false);
+
+      expect(exportServiceMock.startExportJob).toHaveBeenCalledWith(
+        1,
+        'results-by-version',
+        'v1',
+        'csv',
+        true,
+        undefined,
+        false
+      );
+    });
+  });
 });

--- a/apps/frontend/src/app/coding/services/coding-management.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-management.service.ts
@@ -343,11 +343,16 @@ export class CodingManagementService {
     this.performBackgroundCodingListDownload(workspaceId, format, trainingRequired);
   }
 
-  downloadCodingResults(version: StatisticsVersion, format: ExportFormat, includeReplayUrls: boolean): Promise<void> {
+  downloadCodingResults(
+    version: StatisticsVersion,
+    format: ExportFormat,
+    includeReplayUrls: boolean,
+    includeResponseValues: boolean = true
+  ): Promise<void> {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) return Promise.resolve();
 
-    return this.performBackgroundDownload(workspaceId, version, format, includeReplayUrls);
+    return this.performBackgroundDownload(workspaceId, version, format, includeReplayUrls, includeResponseValues);
   }
 
   downloadProgress$ = new BehaviorSubject<number | null>(null);
@@ -356,7 +361,8 @@ export class CodingManagementService {
     workspaceId: number,
     version: StatisticsVersion,
     format: ExportFormat,
-    includeReplayUrls: boolean
+    includeReplayUrls: boolean,
+    includeResponseValues: boolean
   ): Promise<void> {
     this.downloadProgress$.next(0);
 
@@ -367,7 +373,9 @@ export class CodingManagementService {
         'results-by-version',
         version,
         format,
-        includeReplayUrls
+        includeReplayUrls,
+        undefined,
+        includeResponseValues
       ).toPromise();
 
       if (!jobStartResult) {

--- a/apps/frontend/src/app/services/facades/coding-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/coding-facade.service.ts
@@ -123,12 +123,32 @@ export class CodingFacadeService {
     return this.codingExportService.getCodingListAsExcel(workspaceId);
   }
 
-  getCodingResultsByVersion(workspaceId: number, version: 'v1' | 'v2' | 'v3', includeReplayUrls: boolean = false): Observable<Blob> {
-    return this.codingExportService.getCodingResultsByVersion(workspaceId, version, includeReplayUrls);
+  getCodingResultsByVersion(
+    workspaceId: number,
+    version: 'v1' | 'v2' | 'v3',
+    includeReplayUrls: boolean = false,
+    includeResponseValues: boolean = true
+  ): Observable<Blob> {
+    return this.codingExportService.getCodingResultsByVersion(
+      workspaceId,
+      version,
+      includeReplayUrls,
+      includeResponseValues
+    );
   }
 
-  getCodingResultsByVersionAsExcel(workspaceId: number, version: 'v1' | 'v2' | 'v3', includeReplayUrls: boolean = false): Observable<Blob> {
-    return this.codingExportService.getCodingResultsByVersionAsExcel(workspaceId, version, includeReplayUrls);
+  getCodingResultsByVersionAsExcel(
+    workspaceId: number,
+    version: 'v1' | 'v2' | 'v3',
+    includeReplayUrls: boolean = false,
+    includeResponseValues: boolean = true
+  ): Observable<Blob> {
+    return this.codingExportService.getCodingResultsByVersionAsExcel(
+      workspaceId,
+      version,
+      includeReplayUrls,
+      includeResponseValues
+    );
   }
 
   getCodingStatistics(workspaceId: number, version: 'v1' | 'v2' | 'v3' = 'v1'): Observable<CodingStatistics> {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -975,6 +975,8 @@
       "options-title": "Exportoptionen",
       "include-replay-urls": "Replay-URLs einschließen",
       "replay-urls-description": "Fügt eine Spalte mit direkten Links zu den Replay-Ansichten der einzelnen Antworten hinzu",
+      "include-response-values": "Antwortwerte einschließen",
+      "response-values-description": "Fügt die Antwortwerte als Spalte value in den Export ein. Bei sehr großen Antwortinhalten kann diese Option deaktiviert werden.",
       "notice-title": "Hinweis",
       "notice-message": "Die heruntergeladene Datei enthält ALLE Datensätze für die ausgewählte Version, nicht nur die derzeit angezeigten gefilterten Datensätze.",
       "download-button": "Herunterladen",


### PR DESCRIPTION
## Summary

- include response values as a `value` column in versioned coding results exports by default
- add an export dialog checkbox to disable response values for very large payloads
- pass the option through direct downloads, background export jobs, CSV/Excel stream builders, and API docs
- cover default and disabled behavior in backend and frontend tests

Fixes #478

## Validation

- `npx tsc --noEmit -p apps/backend/tsconfig.app.json`
- `npx tsc --noEmit -p apps/frontend/tsconfig.app.json`
- `npx nx test backend --runTestsByPath apps/backend/src/app/database/services-read-methods.spec.ts --runInBand`
- `npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/services/coding-management.service.spec.ts`
- `npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/services/coding-export.service.spec.ts`
- `npx nx lint backend`
- `npx nx lint frontend` (passes with one existing warning in `process-overview.component.ts`)
