### PR TITLE
Iterative Kodierschema-Änderungen unterstützen

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Get,
   Param,
@@ -45,6 +46,13 @@ export class WorkspaceCodingController {
     enum: [1, 2],
     example: 1
   })
+  @ApiQuery({
+    name: 'variables',
+    required: false,
+    description:
+      'Optional comma-separated list of changed variables in the form UNIT::VARIABLE. When set, only these variables are re-coded.',
+    example: 'UNIT_A::VAR_1,UNIT_B::VAR_2'
+  })
   @ApiOkResponse({
     description: 'Coding statistics retrieved successfully.'
   })
@@ -54,16 +62,37 @@ export class WorkspaceCodingController {
   async codeTestPersons(
     @Query('testPersons') testPersons: string,
       @WorkspaceId() workspace_id: number,
-      @Query('autoCoderRun') autoCoderRun: string
+      @Query('autoCoderRun') autoCoderRun: string,
+      @Query('variables') variables: string
   ): Promise<CodingStatistics> {
     await this.jobQueueService.assertNoDependencyConflicts('test-person-coding', workspace_id);
 
     const autoCoderRunNumber = parseInt(autoCoderRun, 10) || 1;
+    const variableFilters = this.parseVariableFilters(variables);
     return this.codingProcessService.codeTestPersons(
       workspace_id,
       testPersons,
-      autoCoderRunNumber
+      autoCoderRunNumber,
+      variableFilters
     );
+  }
+
+  private parseVariableFilters(variables?: string): { unitName: string; variableId: string }[] {
+    if (!variables) {
+      return [];
+    }
+
+    return variables
+      .split(',')
+      .map(item => item.trim())
+      .filter(Boolean)
+      .map(item => {
+        const [unitName, variableId, extra] = item.split('::').map(part => part.trim());
+        if (!unitName || !variableId || extra) {
+          throw new BadRequestException(`Invalid variable filter "${item}". Expected UNIT::VARIABLE.`);
+        }
+        return { unitName, variableId };
+      });
   }
 
   @Get(':workspace_id/coding/manual')

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -58,6 +58,16 @@ interface JobCreationWarning {
   availableCases: number;
 }
 
+export interface ObsoleteCodingJobUnitsSummary {
+  totalUnits: number;
+  affectedJobs: number;
+  jobs: {
+    jobId: number;
+    jobName: string;
+    obsoleteUnits: number;
+  }[];
+}
+
 export interface TransferCodingCasesResult {
   sourceCoderId: number;
   targetCoderId: number;
@@ -552,6 +562,80 @@ export class CodingJobService {
         transferredCases
       };
     });
+  }
+
+  async getObsoleteCodingJobUnits(
+    workspaceId: number
+  ): Promise<ObsoleteCodingJobUnitsSummary> {
+    const incompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+    const activeStatuses = ['pending', 'active', 'open'];
+
+    const rows = await this.codingJobUnitRepository
+      .createQueryBuilder('unit')
+      .innerJoin(CodingJob, 'job', 'job.id = unit.coding_job_id')
+      .innerJoin(ResponseEntity, 'response', 'response.id = unit.response_id')
+      .select('job.id', 'jobId')
+      .addSelect('job.name', 'jobName')
+      .addSelect('COUNT(unit.id)', 'obsoleteUnits')
+      .where('job.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('job.status IN (:...activeStatuses)', { activeStatuses })
+      .andWhere('(response.status_v1 IS NULL OR response.status_v1 != :incompleteStatus)', {
+        incompleteStatus
+      })
+      .groupBy('job.id')
+      .addGroupBy('job.name')
+      .orderBy('job.name', 'ASC')
+      .getRawMany<{
+      jobId: string;
+      jobName: string;
+      obsoleteUnits: string;
+    }>();
+
+    const jobs = rows.map(row => ({
+      jobId: Number(row.jobId),
+      jobName: row.jobName,
+      obsoleteUnits: Number(row.obsoleteUnits)
+    }));
+
+    return {
+      totalUnits: jobs.reduce((sum, job) => sum + job.obsoleteUnits, 0),
+      affectedJobs: jobs.length,
+      jobs
+    };
+  }
+
+  async deleteObsoleteCodingJobUnits(
+    workspaceId: number
+  ): Promise<ObsoleteCodingJobUnitsSummary> {
+    const summary = await this.getObsoleteCodingJobUnits(workspaceId);
+
+    if (summary.totalUnits === 0) {
+      return summary;
+    }
+
+    const incompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+    const activeStatuses = ['pending', 'active', 'open'];
+
+    const obsoleteRows = await this.codingJobUnitRepository
+      .createQueryBuilder('unit')
+      .innerJoin(CodingJob, 'job', 'job.id = unit.coding_job_id')
+      .innerJoin(ResponseEntity, 'response', 'response.id = unit.response_id')
+      .select('unit.id', 'id')
+      .where('job.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('job.status IN (:...activeStatuses)', { activeStatuses })
+      .andWhere('(response.status_v1 IS NULL OR response.status_v1 != :incompleteStatus)', {
+        incompleteStatus
+      })
+      .getRawMany<{ id: string }>();
+
+    const ids = obsoleteRows.map(row => Number(row.id));
+    const batchSize = 500;
+    for (let i = 0; i < ids.length; i += batchSize) {
+      await this.codingJobUnitRepository.delete(ids.slice(i, i + batchSize));
+    }
+
+    await this.invalidateIncompleteVariablesCache(workspaceId);
+    return summary;
   }
 
   private async assignVariables(

--- a/apps/backend/src/app/database/services/coding/coding-process.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.ts
@@ -27,6 +27,8 @@ import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import { WorkspaceCoreService } from '../workspace/workspace-core.service';
 import { WorkspaceExclusionService } from '../workspace/workspace-exclusion.service';
 
+type AutocoderVariableFilter = { unitName: string; variableId: string };
+
 @Injectable()
 export class CodingProcessService {
   private readonly logger = new Logger(CodingProcessService.name);
@@ -66,7 +68,8 @@ export class CodingProcessService {
   async codeTestPersons(
     workspace_id: number,
     testPersonIdsOrGroups: string,
-    autoCoderRun: number = 1
+    autoCoderRun: number = 1,
+    variableFilters: AutocoderVariableFilter[] = []
   ): Promise<CodingStatisticsWithJob> {
     if (
       !workspace_id ||
@@ -147,7 +150,8 @@ export class CodingProcessService {
       workspaceId: workspace_id,
       personIds,
       groupNames: !areAllNumbers ? groupsOrIds.join(',') : undefined,
-      autoCoderRun
+      autoCoderRun,
+      variableFilters
     });
 
     this.logger.log(`Added job to Redis queue with ID ${bullJob.id}`);
@@ -165,7 +169,8 @@ export class CodingProcessService {
     personIds: string[],
     autoCoderRun: number = 1,
     progressCallback?: (progress: number) => void,
-    jobId?: string
+    jobId?: string,
+    variableFilters: AutocoderVariableFilter[] = []
   ): Promise<CodingStatistics> {
     this.cleanupCaches();
 
@@ -335,11 +340,22 @@ export class CodingProcessService {
         units
       );
 
+      const scopedResponses = this.filterResponsesByVariables(
+        filteredResponses,
+        units,
+        variableFilters
+      );
+
       this.logger.log(
         `Filtered responses: ${allResponses.length} -> ${filteredResponses.length
-        } (removed ${allResponses.length - filteredResponses.length
-        } invalid variable responses)`
+        } valid -> ${scopedResponses.length} scoped (removed ${allResponses.length - filteredResponses.length
+        } invalid and ${filteredResponses.length - scopedResponses.length} outside variable scope)`
       );
+
+      if (scopedResponses.length === 0) {
+        this.logger.log('Keine Antworten für die gewählte Variablen-Einschränkung gefunden.');
+        return statistics;
+      }
 
       if (jobId && (await this.isJobCancelled(jobId))) {
         this.logger.log(
@@ -351,7 +367,7 @@ export class CodingProcessService {
 
       // Step 7: Process responses and build maps - 60% progress
       const unitToResponsesMap = new Map<number, ResponseEntity[]>();
-      for (const response of filteredResponses) {
+      for (const response of scopedResponses) {
         if (!unitToResponsesMap.has(response.unitid)) {
           unitToResponsesMap.set(response.unitid, []);
         }
@@ -461,7 +477,7 @@ export class CodingProcessService {
         unitToResponsesMap,
         unitToCodingSchemeRefMap,
         fileIdToCodingSchemeMap,
-        filteredResponses,
+        scopedResponses,
         statistics,
         autoCoderRun,
         jobId,
@@ -625,6 +641,30 @@ export class CodingProcessService {
       const unitName = unitIdToNameMap.get(response.unitid)?.toUpperCase();
       const validVars = validVariableSets.get(unitName || '');
       return validVars?.has(response.variableid);
+    });
+  }
+
+  private filterResponsesByVariables(
+    responses: ResponseEntity[],
+    units: Unit[],
+    variableFilters: AutocoderVariableFilter[]
+  ): ResponseEntity[] {
+    if (variableFilters.length === 0) {
+      return responses;
+    }
+
+    const unitIdToNameMap = new Map<number, string>();
+    units.forEach(unit => {
+      unitIdToNameMap.set(unit.id, unit.name.toUpperCase());
+    });
+
+    const filterKeys = new Set(
+      variableFilters.map(filter => `${filter.unitName.toUpperCase()}::${filter.variableId}`)
+    );
+
+    return responses.filter(response => {
+      const unitName = unitIdToNameMap.get(response.unitid);
+      return filterKeys.has(`${unitName}::${response.variableid}`);
     });
   }
 

--- a/apps/backend/src/app/database/services/jobs/bull-job-management.service.ts
+++ b/apps/backend/src/app/database/services/jobs/bull-job-management.service.ts
@@ -86,7 +86,9 @@ export class BullJobManagementService {
       const newJob = await this.jobQueueService.addTestPersonCodingJob({
         workspaceId: bullJob.data.workspaceId,
         personIds: bullJob.data.personIds,
-        groupNames: bullJob.data.groupNames
+        groupNames: bullJob.data.groupNames,
+        autoCoderRun: bullJob.data.autoCoderRun,
+        variableFilters: bullJob.data.variableFilters
       });
 
       await this.jobQueueService.deleteTestPersonCodingJob(jobId);

--- a/apps/backend/src/app/database/services/workspace/workspace-coding.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-coding.service.spec.ts
@@ -305,7 +305,8 @@ describe('WorkspaceCodingService', () => {
         personIds,
         autoCoderRun,
         undefined,
-        jobId
+        jobId,
+        []
       );
 
       expect(
@@ -315,7 +316,8 @@ describe('WorkspaceCodingService', () => {
         personIds,
         autoCoderRun,
         undefined,
-        jobId
+        jobId,
+        []
       );
       expect(result).toEqual(expectedResult);
     });
@@ -340,7 +342,8 @@ describe('WorkspaceCodingService', () => {
       expect(mockCodingProcessService.codeTestPersons).toHaveBeenCalledWith(
         workspaceId,
         '1,2',
-        1
+        1,
+        []
       );
       expect(result).toEqual(expectedResult);
     });

--- a/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
@@ -49,14 +49,16 @@ export class WorkspaceCodingService {
     personIds: string[],
     autoCoderRun: number = 1,
     progressCallback?: (progress: number) => void,
-    jobId?: string
+    jobId?: string,
+    variableFilters: { unitName: string; variableId: string }[] = []
   ): Promise<CodingStatistics> {
     const statistics = await this.codingProcessService.processTestPersonsBatch(
       workspace_id,
       personIds,
       autoCoderRun,
       progressCallback,
-      jobId
+      jobId,
+      variableFilters
     );
 
     await this.invalidateIncompleteVariablesCache(workspace_id);
@@ -69,12 +71,14 @@ export class WorkspaceCodingService {
   async codeTestPersons(
     workspace_id: number,
     testPersonIdsOrGroups: string,
-    autoCoderRun: number = 1
+    autoCoderRun: number = 1,
+    variableFilters: { unitName: string; variableId: string }[] = []
   ): Promise<CodingStatisticsWithJob> {
     return this.codingProcessService.codeTestPersons(
       workspace_id,
       testPersonIdsOrGroups,
-      autoCoderRun
+      autoCoderRun,
+      variableFilters
     );
   }
 

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -28,6 +28,7 @@ export interface TestPersonCodingJobData {
   groupNames?: string;
   isPaused?: boolean;
   autoCoderRun?: number;
+  variableFilters?: { unitName: string; variableId: string }[];
 }
 
 export interface FlatResponseFilterOptionsJobData {

--- a/apps/backend/src/app/job-queue/processors/test-person-coding.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/test-person-coding.processor.ts
@@ -62,7 +62,8 @@ export class TestPersonCodingProcessor {
           batchPersonIds,
           job.data.autoCoderRun || 1,
           progressCallback,
-          job.id.toString()
+          job.id.toString(),
+          job.data.variableFilters || []
         );
 
         combinedResult.totalResponses += batchResult.totalResponses;

--- a/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
+++ b/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
@@ -137,6 +137,42 @@ export class WsgCodingJobController {
     };
   }
 
+  @Get('obsolete-units')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
+  @RequireAccessLevel(2)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Preview obsolete coding job units',
+    description: 'Finds units in active coding jobs that are no longer relevant because the latest autocoder result no longer requires manual coding.'
+  })
+  async getObsoleteCodingJobUnits(
+    @WorkspaceId() workspaceId: number
+  ): Promise<{
+        totalUnits: number;
+        affectedJobs: number;
+        jobs: { jobId: number; jobName: string; obsoleteUnits: number }[];
+      }> {
+    return this.codingJobService.getObsoleteCodingJobUnits(workspaceId);
+  }
+
+  @Delete('obsolete-units')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
+  @RequireAccessLevel(2)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Delete obsolete coding job units',
+    description: 'Deletes units from active coding jobs after the user confirms that they are no longer relevant.'
+  })
+  async deleteObsoleteCodingJobUnits(
+    @WorkspaceId() workspaceId: number
+  ): Promise<{
+        totalUnits: number;
+        affectedJobs: number;
+        jobs: { jobId: number; jobName: string; obsoleteUnits: number }[];
+      }> {
+    return this.codingJobService.deleteObsoleteCodingJobUnits(workspaceId);
+  }
+
   @Get(':id')
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   @ApiBearerAuth()

--- a/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.html
+++ b/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.html
@@ -47,6 +47,22 @@
             <h4><mat-icon>info</mat-icon> {{ 'test-person-coding.autocoder-run-selection.hint.v2.title' | translate }}</h4>
             <p [innerHTML]="'test-person-coding.autocoder-run-selection.hint.v2.text' | translate"></p>
           </div>
+
+          <div class="changed-variables-container">
+            <mat-checkbox [(ngModel)]="limitToChangedVariables">
+              {{ 'test-person-coding.changed-variables.limit-label' | translate }}
+            </mat-checkbox>
+
+            <mat-form-field appearance="outline" class="full-width" *ngIf="limitToChangedVariables">
+              <mat-label>{{ 'test-person-coding.changed-variables.input-label' | translate }}</mat-label>
+              <textarea
+                matInput
+                rows="4"
+                [(ngModel)]="changedVariablesText"
+                [placeholder]="'test-person-coding.changed-variables.placeholder' | translate"></textarea>
+              <mat-hint>{{ 'test-person-coding.changed-variables.hint' | translate }}</mat-hint>
+            </mat-form-field>
+          </div>
         </div>
 
         <div class="button-container">

--- a/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.scss
+++ b/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.scss
@@ -45,6 +45,17 @@
       margin-top: 8px;
     }
 
+    .changed-variables-container {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-top: 12px;
+
+      .full-width {
+        width: 100%;
+      }
+    }
+
     .autocoder-hint-box {
       margin-top: 8px;
       padding: 12px;

--- a/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.ts
+++ b/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.ts
@@ -28,6 +28,7 @@ import {
   tap
 } from 'rxjs';
 import {
+  AutocoderVariableFilter,
   CodingStatistics,
   JobInfo,
   JobStatus,
@@ -39,6 +40,8 @@ import { AppService } from '../../../core/services/app.service';
 import { TestResultService } from '../../../shared/services/test-result/test-result.service';
 import { BackendMessageTranslatorService } from '../../services/backend-message-translator.service';
 import { TestPersonCodingJobResultDialogComponent } from '../test-person-coding-job-result-dialog/test-person-coding-job-result-dialog.component';
+import { CodingJobBackendService } from '../../services/coding-job-backend.service';
+import { ConfirmDialogComponent } from '../../../shared/confirm-dialog/confirm-dialog.component';
 
 @Component({
   selector: 'coding-box-test-person-coding',
@@ -76,6 +79,7 @@ export class TestPersonCodingComponent implements OnInit {
   private translateService = inject(TranslateService);
   private backendMessageTranslator = inject(BackendMessageTranslatorService);
   private dialog = inject(MatDialog);
+  private codingJobBackendService = inject(CodingJobBackendService);
   Math = Math;
   get workspaceId(): number {
     return this.appService.selectedWorkspaceId;
@@ -117,6 +121,8 @@ export class TestPersonCodingComponent implements OnInit {
   groupsLoading = false;
 
   autoCoderRun: number = 1;
+  limitToChangedVariables = false;
+  changedVariablesText = '';
   private lastNotifiedCompletedJobId: string | null = null;
 
   ngOnInit(): void {
@@ -230,9 +236,14 @@ export class TestPersonCodingComponent implements OnInit {
     }
 
     this.isLoading = true;
+    const variableFilters = this.getChangedVariableFilters();
+    if (variableFilters === null) {
+      this.isLoading = false;
+      return;
+    }
 
     this.testPersonCodingService
-      .codeTestPersons(this.workspaceId, testPersonIds, this.autoCoderRun)
+      .codeTestPersons(this.workspaceId, testPersonIds, this.autoCoderRun, variableFilters)
       .pipe(
         tap(result => {
           if (result && result.jobId) {
@@ -374,6 +385,97 @@ export class TestPersonCodingComponent implements OnInit {
     this.loadCodingList(this.currentPage, this.pageSize);
     this.loadWorkspaceGroups();
     this.testPersonCodingService.notifyAutoCodingCompleted();
+    this.checkObsoleteCodingJobUnits();
+  }
+
+  private getChangedVariableFilters(): AutocoderVariableFilter[] | null {
+    if (!this.limitToChangedVariables) {
+      return [];
+    }
+
+    const entries = this.changedVariablesText
+      .split(/[\n,;]+/)
+      .map(entry => entry.trim())
+      .filter(Boolean);
+
+    if (entries.length === 0) {
+      this.snackBar.open(
+        this.translateService.instant('test-person-coding.changed-variables.required'),
+        this.translateService.instant('close'),
+        { duration: 4000 }
+      );
+      return null;
+    }
+
+    const filters: AutocoderVariableFilter[] = [];
+    for (const entry of entries) {
+      const [unitName, variableId, extra] = entry.split('::').map(part => part.trim());
+      if (!unitName || !variableId || extra) {
+        this.snackBar.open(
+          this.translateService.instant('test-person-coding.changed-variables.invalid', { entry }),
+          this.translateService.instant('close'),
+          { duration: 5000 }
+        );
+        return null;
+      }
+      filters.push({ unitName, variableId });
+    }
+
+    return filters;
+  }
+
+  private checkObsoleteCodingJobUnits(): void {
+    this.codingJobBackendService.getObsoleteCodingJobUnits(this.workspaceId)
+      .pipe(catchError(() => of({
+        totalUnits: 0,
+        affectedJobs: 0,
+        jobs: []
+      })))
+      .subscribe(summary => {
+        if (summary.totalUnits === 0) {
+          return;
+        }
+
+        const jobList = summary.jobs
+          .slice(0, 5)
+          .map(job => `${job.jobName}: ${job.obsoleteUnits}`)
+          .join('<br>');
+        const moreJobs = summary.jobs.length > 5 ?
+          `<br>${this.translateService.instant('test-person-coding.obsolete-units.more-jobs', { count: summary.jobs.length - 5 })}` :
+          '';
+
+        const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+          width: '520px',
+          data: {
+            title: this.translateService.instant('test-person-coding.obsolete-units.title'),
+            message: this.translateService.instant('test-person-coding.obsolete-units.message', {
+              total: summary.totalUnits,
+              jobs: summary.affectedJobs,
+              jobList: `${jobList}${moreJobs}`
+            }),
+            confirmButtonText: this.translateService.instant('test-person-coding.obsolete-units.confirm'),
+            cancelButtonText: this.translateService.instant('test-person-coding.obsolete-units.cancel')
+          }
+        });
+
+        dialogRef.afterClosed().subscribe(confirmed => {
+          if (!confirmed) {
+            return;
+          }
+
+          this.codingJobBackendService.deleteObsoleteCodingJobUnits(this.workspaceId)
+            .subscribe(result => {
+              this.snackBar.open(
+                this.translateService.instant('test-person-coding.obsolete-units.deleted', {
+                  total: result.totalUnits
+                }),
+                this.translateService.instant('close'),
+                { duration: 5000 }
+              );
+              this.loadAllJobs();
+            });
+        });
+      });
   }
 
   cancelJob(jobId?: string): void {

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -84,6 +84,16 @@ export interface TransferCodingCasesResponse {
   transferredCases: number;
 }
 
+export interface ObsoleteCodingJobUnitsSummary {
+  totalUnits: number;
+  affectedJobs: number;
+  jobs: {
+    jobId: number;
+    jobName: string;
+    obsoleteUnits: number;
+  }[];
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -211,6 +221,20 @@ export class CodingJobBackendService {
   ): Observable<{ success: boolean }> {
     const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/${codingJobId}`;
     return this.http.delete<{ success: boolean }>(url, { headers: this.authHeader });
+  }
+
+  getObsoleteCodingJobUnits(
+    workspaceId: number
+  ): Observable<ObsoleteCodingJobUnitsSummary> {
+    const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/obsolete-units`;
+    return this.http.get<ObsoleteCodingJobUnitsSummary>(url, { headers: this.authHeader });
+  }
+
+  deleteObsoleteCodingJobUnits(
+    workspaceId: number
+  ): Observable<ObsoleteCodingJobUnitsSummary> {
+    const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/obsolete-units`;
+    return this.http.delete<ObsoleteCodingJobUnitsSummary>(url, { headers: this.authHeader });
   }
 
   transferCodingCases(

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -78,6 +78,11 @@ export interface WorkspaceGroupCodingStats {
   responsesToCode: number;
 }
 
+export interface AutocoderVariableFilter {
+  unitName: string;
+  variableId: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -95,10 +100,22 @@ export class TestPersonCodingService {
     this.autoCodingCompletedSubject.next();
   }
 
-  codeTestPersons(workspaceId: number, testPersonIds: string, autoCoderRun: number = 1): Observable<CodingStatisticsWithJob> {
-    const params = new HttpParams()
+  codeTestPersons(
+    workspaceId: number,
+    testPersonIds: string,
+    autoCoderRun: number = 1,
+    variableFilters: AutocoderVariableFilter[] = []
+  ): Observable<CodingStatisticsWithJob> {
+    let params = new HttpParams()
       .set('testPersons', testPersonIds)
       .set('autoCoderRun', autoCoderRun.toString());
+
+    if (variableFilters.length > 0) {
+      params = params.set(
+        'variables',
+        variableFilters.map(filter => `${filter.unitName}::${filter.variableId}`).join(',')
+      );
+    }
 
     return this.http
       .get<CodingStatisticsWithJob>(

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1146,6 +1146,22 @@
         }
       }
     },
+    "changed-variables": {
+      "limit-label": "Nur geänderte Variablen erneut kodieren",
+      "input-label": "Geänderte Variablen",
+      "placeholder": "UNIT_ID::VARIABLE_ID",
+      "hint": "Mehrere Einträge mit Komma, Semikolon oder Zeilenumbruch trennen.",
+      "required": "Bitte mindestens eine geänderte Variable im Format UNIT::VARIABLE angeben.",
+      "invalid": "Ungültiger Variablen-Eintrag: {{entry}}. Erwartet wird UNIT::VARIABLE."
+    },
+    "obsolete-units": {
+      "title": "Nicht mehr relevante Fälle entfernen?",
+      "message": "Der Autocoder-Lauf hat {{total}} Fälle in {{jobs}} laufenden Kodierjob(s) gefunden, die nicht mehr manuell kodiert werden müssen.<br><br>{{jobList}}<br><br>Sollen diese Fälle aus den laufenden Kodierjobs gelöscht werden?",
+      "more-jobs": "... und {{count}} weitere",
+      "confirm": "Fälle löschen",
+      "cancel": "Behalten",
+      "deleted": "{{total}} nicht mehr relevante Fälle wurden aus laufenden Kodierjobs gelöscht."
+    },
     "select-groups-label": "Testpersonengruppen auswählen",
     "select-groups-hint": "Wählen Sie eine oder mehrere Gruppen zum Kodieren aus",
     "select-all-groups": "Alle auswählen",


### PR DESCRIPTION
## Summary
- ermöglicht gezielte Autocoder-Neuläufe für explizit angegebene `UNIT::VARIABLE`-Paare
- zeigt nach dem Neulauf veraltete manuelle Kodierfälle zur Bestätigung an und löscht sie nur nach Freigabe
- erhält die Filterinformationen auch beim Neustart von Coding-Jobs

## Validation
- `npx nx lint backend`
- `npx nx lint frontend` (bestehende Warnung in `process-overview.component.ts`)
- `npx nx test frontend --runInBand`
- `npx nx test backend --runInBand`

Closes #459