### PR TITLE
Fix double-coded review error handling

### DIFF
--- a/.gitlab-ci/Branch&PreRelease-Pipelines.gitlab-ci.yml
+++ b/.gitlab-ci/Branch&PreRelease-Pipelines.gitlab-ci.yml
@@ -460,7 +460,7 @@ test-app:
     - !reference [ .default_rules, rules ]
   image: ${CI_REGISTRY_IMAGE}/${CICD_BASE_IMAGE}
   script:
-    - npx nx affected --base=HEAD~1 --target=test --parallel=2
+    - npx nx affected --base=HEAD~1 --target=test --parallel=1 -- --maxWorkers=2
 
 lint-app:
   stage: lint

--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -1,0 +1,308 @@
+import { CodingReviewService } from './coding-review.service';
+
+jest.mock('./coding-statistics.service', () => ({
+  CodingStatisticsService: jest.fn()
+}));
+
+jest.mock('../workspace/workspace-exclusion.service', () => ({
+  applyResolvedExclusionsToQuery: jest.fn(),
+  isExcludedByResolvedExclusions: jest.fn().mockReturnValue(false),
+  WorkspaceExclusionService: jest.fn()
+}));
+
+describe('CodingReviewService', () => {
+  const workspaceId = 123;
+  const emptyExclusions = {
+    globalIgnoredUnits: [],
+    ignoredBooklets: [],
+    testletIgnoredUnits: []
+  };
+
+  let queryBuilder: {
+    leftJoin: jest.Mock;
+    select: jest.Mock;
+    addSelect: jest.Mock;
+    where: jest.Mock;
+    groupBy: jest.Mock;
+    addGroupBy: jest.Mock;
+    having: jest.Mock;
+    andHaving: jest.Mock;
+    andWhere: jest.Mock;
+    orderBy: jest.Mock;
+    offset: jest.Mock;
+    limit: jest.Mock;
+    getQueryAndParameters: jest.Mock;
+    getRawMany: jest.Mock;
+  };
+  let codingJobUnitRepository: {
+    createQueryBuilder: jest.Mock;
+    query: jest.Mock;
+    find: jest.Mock;
+  };
+  let service: CodingReviewService;
+
+  const makeCodingJobUnit = (
+    overrides: Record<string, unknown> = {}
+  ): Record<string, unknown> => ({
+    response_id: 10,
+    variable_id: 'VAR_1',
+    coding_job_id: 100,
+    code: 1,
+    score: 1,
+    notes: null,
+    supervisor_comment: null,
+    created_at: new Date('2026-05-18T00:00:00.000Z'),
+    booklet_name: 'BOOKLET_1',
+    unit_name: 'UNIT_1',
+    coding_job: {
+      workspace_id: workspaceId,
+      job_definition_id: 11,
+      training_id: null,
+      name: 'Job A',
+      codingJobCoders: [{
+        user_id: 1,
+        user: { username: 'Coder 1' }
+      }]
+    },
+    response: {
+      value: 'answer',
+      unit: {
+        name: 'UNIT_1',
+        booklet: {
+          bookletinfo: { name: 'BOOKLET_1' },
+          person: {
+            login: 'person-1',
+            code: 'P001'
+          }
+        }
+      }
+    },
+    ...overrides
+  });
+
+  beforeEach(() => {
+    queryBuilder = {
+      leftJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
+      having: jest.fn().mockReturnThis(),
+      andHaving: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getQueryAndParameters: jest.fn().mockReturnValue(['SELECT response ids', []]),
+      getRawMany: jest.fn().mockResolvedValue([{ responseId: 10, responseStatus: null }])
+    };
+
+    codingJobUnitRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+      query: jest.fn().mockResolvedValue([{ total: '1' }]),
+      find: jest.fn().mockResolvedValue([
+        makeCodingJobUnit(),
+        makeCodingJobUnit({
+          coding_job_id: 101,
+          code: 2,
+          coding_job: {
+            workspace_id: workspaceId,
+            job_definition_id: 11,
+            training_id: null,
+            name: 'Job B',
+            codingJobCoders: [{
+              user_id: 2,
+              user: { username: 'Coder 2' }
+            }]
+          }
+        }),
+        makeCodingJobUnit({
+          coding_job_id: 102,
+          coding_job: null
+        }),
+        makeCodingJobUnit({
+          coding_job_id: 103,
+          coding_job: {
+            workspace_id: 999,
+            job_definition_id: 11,
+            training_id: null,
+            name: 'Wrong workspace',
+            codingJobCoders: [{
+              user_id: 3,
+              user: { username: 'Coder 3' }
+            }]
+          }
+        }),
+        makeCodingJobUnit({
+          coding_job_id: 104,
+          coding_job: {
+            workspace_id: workspaceId,
+            job_definition_id: 99,
+            training_id: null,
+            name: 'Out of scope',
+            codingJobCoders: [{
+              user_id: 4,
+              user: { username: 'Coder 4' }
+            }]
+          }
+        })
+      ])
+    };
+
+    service = new CodingReviewService(
+      {} as never,
+      codingJobUnitRepository as never,
+      {} as never,
+      {
+        resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
+      } as never
+    );
+  });
+
+  it('applies conflict filters and keeps only scoped double-coded rows', async () => {
+    const result = await service.getDoubleCodedVariablesForReview(
+      workspaceId,
+      1,
+      50,
+      false,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'differ',
+      [11],
+      undefined
+    );
+
+    expect(queryBuilder.andHaving).toHaveBeenCalledWith('COUNT(cju.code) > 1');
+    expect(queryBuilder.andHaving).toHaveBeenCalledWith('COUNT(DISTINCT cju.code) > 1');
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      '(resp.status_v2 IS NULL OR resp.status_v2 != :completeStatus)',
+      { completeStatus: 5 }
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      '(cj.job_definition_id IN (:...jobDefinitionIds))',
+      { jobDefinitionIds: [11] }
+    );
+    expect(codingJobUnitRepository.find).toHaveBeenCalledWith({
+      where: { response_id: expect.any(Object) },
+      relations: [
+        'coding_job',
+        'coding_job.codingJobCoders',
+        'coding_job.codingJobCoders.user',
+        'response',
+        'response.unit',
+        'response.unit.booklet',
+        'response.unit.booklet.person'
+      ]
+    });
+    expect(result).toMatchObject({
+      total: 1,
+      page: 1,
+      limit: 50,
+      data: [{
+        responseId: 10,
+        variableId: 'VAR_1',
+        coderResults: [
+          { coderId: 1, jobId: 100, code: 1 },
+          { coderId: 2, jobId: 101, code: 2 }
+        ]
+      }]
+    });
+  });
+
+  it('applies the match agreement filter', async () => {
+    await service.getDoubleCodedVariablesForReview(
+      workspaceId,
+      1,
+      50,
+      false,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'match'
+    );
+
+    expect(queryBuilder.andHaving).toHaveBeenCalledWith('COUNT(DISTINCT cju.code) <= 1');
+    expect(queryBuilder.andHaving).not.toHaveBeenCalledWith('COUNT(cju.code) > 1');
+  });
+
+  it('keeps legacy only-conflicts behavior for older clients', async () => {
+    await service.getDoubleCodedVariablesForReview(
+      workspaceId,
+      1,
+      50,
+      true
+    );
+
+    expect(queryBuilder.andHaving).toHaveBeenCalledWith('COUNT(cju.code) > 1');
+    expect(queryBuilder.andHaving).toHaveBeenCalledWith('COUNT(DISTINCT cju.code) > 1');
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      '(resp.status_v2 IS NULL OR resp.status_v2 != :completeStatus)',
+      { completeStatus: 5 }
+    );
+  });
+
+  it('applies resolved and coding-status filters independently', async () => {
+    await service.getDoubleCodedVariablesForReview(
+      workspaceId,
+      1,
+      50,
+      false,
+      false,
+      undefined,
+      undefined,
+      'done',
+      'resolved'
+    );
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'resp.status_v2 = :completeStatus',
+      { completeStatus: 5 }
+    );
+    expect(queryBuilder.andHaving).toHaveBeenCalledWith('COUNT(cju.code) = COUNT(cju.coding_job_id)');
+  });
+
+  it('combines job-definition and coder-training scopes with OR', async () => {
+    await service.getDoubleCodedVariablesForReview(
+      workspaceId,
+      1,
+      50,
+      false,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'all',
+      [11],
+      [21]
+    );
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      '(cj.job_definition_id IN (:...jobDefinitionIds) OR cj.training_id IN (:...coderTrainingIds))',
+      {
+        jobDefinitionIds: [11],
+        coderTrainingIds: [21]
+      }
+    );
+  });
+
+  it('returns an empty page without loading relations when no double-coded rows match', async () => {
+    codingJobUnitRepository.query.mockResolvedValueOnce([{ total: '0' }]);
+
+    const result = await service.getDoubleCodedVariablesForReview(workspaceId);
+
+    expect(codingJobUnitRepository.find).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 50
+    });
+  });
+});

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -466,6 +466,85 @@ describe('TestPersonCodingService', () => {
     });
   });
 
+  describe('getDoubleCodedVariablesForReview', () => {
+    it('should request double-coded review data with agreement and scope filters', () => {
+      const mockResponse = {
+        data: [{
+          responseId: 10,
+          unitName: 'UNIT_1',
+          variableId: 'VAR_1',
+          personLogin: 'person-1',
+          personCode: 'P001',
+          bookletName: 'BOOKLET_1',
+          givenAnswer: 'answer',
+          isResolved: false,
+          coderResults: [{
+            coderId: 1,
+            coderName: 'Coder 1',
+            jobId: 100,
+            jobName: 'Job A',
+            code: 1,
+            score: 1,
+            notes: null,
+            supervisorComment: null,
+            codedAt: '2026-05-18T00:00:00.000Z'
+          }]
+        }],
+        total: 1,
+        page: 2,
+        limit: 25
+      };
+
+      service.getDoubleCodedVariablesForReview(
+        mockWorkspaceId,
+        2,
+        25,
+        true,
+        false,
+        'VAR_1',
+        9,
+        'done',
+        'unresolved',
+        'differ',
+        [11, 12],
+        [21]
+      ).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(request => request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/double-coded-review`);
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('page')).toBe('2');
+      expect(req.request.params.get('limit')).toBe('25');
+      expect(req.request.params.get('onlyConflicts')).toBe('true');
+      expect(req.request.params.get('excludeTrainings')).toBe('false');
+      expect(req.request.params.get('search')).toBe('VAR_1');
+      expect(req.request.params.get('coderId')).toBe('9');
+      expect(req.request.params.get('statusFilter')).toBe('done');
+      expect(req.request.params.get('resolvedFilter')).toBe('unresolved');
+      expect(req.request.params.get('agreementFilter')).toBe('differ');
+      expect(req.request.params.get('jobDefinitionIds')).toBe('11,12');
+      expect(req.request.params.get('coderTrainingIds')).toBe('21');
+      req.flush(mockResponse);
+    });
+
+    it('should propagate double-coded review errors to the component', done => {
+      service.getDoubleCodedVariablesForReview(mockWorkspaceId).subscribe({
+        next: () => done.fail('expected double-coded review request to fail'),
+        error: error => {
+          expect(error.status).toBe(500);
+          done();
+        }
+      });
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/double-coded-review?page=1&limit=50&onlyConflicts=false&excludeTrainings=false`);
+      req.flush(
+        { message: 'review query failed' },
+        { status: 500, statusText: 'Server Error' }
+      );
+    });
+  });
+
   describe('coding freshness', () => {
     it('should request the freshness scope with version and states', () => {
       const mockResponse = {

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -1054,15 +1054,7 @@ export class TestPersonCodingService {
     }>(
       `${this.serverUrl}admin/workspace/${workspaceId}/coding/double-coded-review`,
       { headers: this.authHeader, params }
-    )
-      .pipe(
-        catchError(() => of({
-          data: [],
-          total: 0,
-          page,
-          limit
-        }))
-      );
+    );
   }
 
   applyDoubleCodedResolutions(


### PR DESCRIPTION
## Summary
- stop masking double-coded review API failures as an empty result set
- add frontend coverage for double-coded review request parameters and error propagation
- add backend service coverage for agreement filters, legacy conflict filtering, status filters, scope filters, and empty results

Refs #490

## Verification
- npx nx test frontend --testFile=apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
- npx nx lint frontend
- npx nx lint backend