### PR TITLE
Add duplicate guards for queue jobs

### DIFF
--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -53,6 +53,9 @@ describe('JobQueueService', () => {
   });
 
   it('adds and retrieves queue jobs', async () => {
+    queues[0].getJobs.mockResolvedValue([]);
+    queues[6].getJobs.mockResolvedValue([]);
+
     await expect(service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })).resolves.toMatchObject({ data: { workspaceId: 1 } });
     await expect(service.getTestPersonCodingJob('job-1')).resolves.toHaveProperty('id', 'job-1');
     await expect(service.addUploadJob({
@@ -76,6 +79,7 @@ describe('JobQueueService', () => {
   });
 
   it('prevents duplicate active jobs where required', async () => {
+    await expect(service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })).rejects.toBeInstanceOf(ConflictException);
     await expect(service.addCodingStatisticsJob(1, 'v2')).rejects.toBeInstanceOf(ConflictException);
     await expect(service.addFlatResponseFilterOptionsJob(1, 250)).resolves.toBeNull();
     await expect(service.addCodebookGenerationJob({
@@ -95,6 +99,7 @@ describe('JobQueueService', () => {
       },
       unitIds: [1]
     })).rejects.toBeInstanceOf(ConflictException);
+    await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).rejects.toBeInstanceOf(ConflictException);
     await expect(service.addValidationTaskJob({ taskId: 7 })).rejects.toBeInstanceOf(ConflictException);
     await expect(service.addExternalCodingImportJob({ workspaceId: 1, tempFilePath: '/tmp/a', fileName: 'a.csv' })).rejects.toBeInstanceOf(ConflictException);
   });
@@ -102,6 +107,7 @@ describe('JobQueueService', () => {
   it('allows jobs when no duplicate active job exists', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
 
+    await expect(service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })).resolves.toHaveProperty('data.workspaceId', 1);
     await expect(service.addCodingStatisticsJob(1, 'v1')).resolves.toHaveProperty('data.version', 'v1');
     await expect(service.addFlatResponseFilterOptionsJob(1, 100)).resolves.toHaveProperty('data.processingDurationThresholdMs', 100);
     await expect(service.addCodebookGenerationJob({
@@ -121,6 +127,7 @@ describe('JobQueueService', () => {
       },
       unitIds: [1]
     })).resolves.toHaveProperty('data.workspaceId', 1);
+    await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).resolves.toHaveProperty('data.version', 'v1');
     await expect(service.addValidationTaskJob({ taskId: 8 })).resolves.toHaveProperty('data.taskId', 8);
     await expect(service.addExportJob({ workspaceId: 1, userId: 2, exportType: 'coding-list' })).resolves.toHaveProperty('data.exportType', 'coding-list');
   });

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -492,7 +492,7 @@ export class JobQueueService {
     queue: Queue,
     matchFn: (data: T) => boolean
   ): Promise<Job<T> | undefined> {
-    const jobs = await queue.getJobs(['active', 'waiting', 'delayed']);
+    const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(Boolean);
     return jobs.find(job => matchFn(job.data));
   }
 
@@ -500,6 +500,15 @@ export class JobQueueService {
     data: TestPersonCodingJobData,
     options?: JobOptions
   ): Promise<Job<TestPersonCodingJobData>> {
+    const existing = await this.findActiveJob<TestPersonCodingJobData>(
+      this.testPersonCodingQueue,
+      d => d.workspaceId === data.workspaceId
+    );
+    if (existing) {
+      throw new ConflictException(
+        `A test person coding job is already running for workspace ${data.workspaceId} (job ${existing.id})`
+      );
+    }
     this.logger.log(
       `Adding test person coding job for workspace ${data.workspaceId}`
     );
@@ -844,6 +853,15 @@ export class JobQueueService {
     data: ResetCodingVersionJobData,
     options?: JobOptions
   ): Promise<Job<ResetCodingVersionJobData>> {
+    const existing = await this.findActiveJob<ResetCodingVersionJobData>(
+      this.resetCodingVersionQueue,
+      d => d.workspaceId === data.workspaceId
+    );
+    if (existing) {
+      throw new ConflictException(
+        `A reset coding version job is already running for workspace ${data.workspaceId} (job ${existing.id})`
+      );
+    }
     this.logger.log(
       `Adding reset coding version job for workspace ${data.workspaceId}, version ${data.version}`
     );


### PR DESCRIPTION
## Summary
- add duplicate guards for workspace-level test-person-coding jobs
- add duplicate guards for reset-coding-version jobs
- ignore stale null Bull jobs when scanning active jobs
- extend JobQueueService coverage for guarded and unguarded queue starts

Refs #495

## Verification
- npx nx test backend --testFile=apps/backend/src/app/job-queue/job-queue.service.spec.ts
- npx nx lint backend