### PR TITLE
Add bookletlog indexes for flat-response filters

### DIFF
--- a/database/changelog/coding-box.changelog-1.15.0.sql
+++ b/database/changelog/coding-box.changelog-1.15.0.sql
@@ -427,3 +427,17 @@ CREATE INDEX IF NOT EXISTS "idx_journal_entries_workspace_result"
 -- rollback ALTER TABLE "public"."journal_entries" DROP COLUMN IF EXISTS "event_type";
 -- rollback ALTER TABLE "public"."journal_entries" DROP COLUMN IF EXISTS "actor_type";
 -- rollback ALTER TABLE "public"."journal_entries" DROP COLUMN IF EXISTS "actor_user_id";
+
+-- changeset jurei733:17
+-- comment: Add bookletlog indexes for flat-response filter option queries
+
+CREATE INDEX IF NOT EXISTS "idx_bookletlog_controller_booklet_parameter_id"
+  ON "public"."bookletlog" ("bookletid", "parameter", "id")
+  WHERE "key" = 'CONTROLLER';
+
+CREATE INDEX IF NOT EXISTS "idx_bookletlog_current_unit_booklet_parameter"
+  ON "public"."bookletlog" ("bookletid", "parameter")
+  WHERE "key" = 'CURRENT_UNIT_ID';
+
+-- rollback DROP INDEX IF EXISTS "public"."idx_bookletlog_current_unit_booklet_parameter";
+-- rollback DROP INDEX IF EXISTS "public"."idx_bookletlog_controller_booklet_parameter_id";


### PR DESCRIPTION
## Summary
- add a partial bookletlog index for CONTROLLER log lookups used by processing-duration filter options
- add a partial bookletlog index for CURRENT_UNIT_ID lookups used by unit-progress filter options
- keep the first fix scoped to DB indexing for the production query-load issue

Refs #476

## Verification
- git diff --check
- make dev-db-validate-changelog