### PR TITLE
Harden flat response filter option queries

### DIFF
--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -47,6 +47,10 @@ const mockQueryBuilder = () => ({
   stream: jest.fn(),
   getRawOne: jest.fn().mockResolvedValue({}),
   clone: jest.fn().mockReturnThis(),
+  getQueryAndParameters: jest.fn().mockReturnValue([
+    'SELECT DISTINCT "bookletEntity"."id" AS "bookletId" FROM response',
+    []
+  ]),
   setParameter: jest.fn().mockReturnThis(),
   addGroupBy: jest.fn().mockReturnThis(),
   addOrderBy: jest.fn().mockReturnThis(),
@@ -182,6 +186,7 @@ describe('WorkspaceTestResultsService', () => {
       getRepository: jest.fn().mockReturnValue({
         createQueryBuilder: jest.fn(() => mockQueryBuilder())
       }),
+      query: jest.fn().mockResolvedValue([]),
       transaction: jest.fn()
     } as unknown as DataSource;
 
@@ -545,6 +550,66 @@ describe('WorkspaceTestResultsService', () => {
 
       expect(responseManagementService.resolveDuplicateResponses).toHaveBeenCalledWith(workspaceId, resolutionMap, userId);
       expect(result).toEqual({ resolvedCount: 1, success: true });
+    });
+  });
+
+  describe('findFlatResponseFilterOptions', () => {
+    it('keeps scoped option predicates and derives log options from filtered booklets', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getQueryAndParameters
+        .mockReturnValueOnce([
+          'SELECT DISTINCT "bookletEntity"."id" AS "bookletId" FROM response WHERE person.workspace_id = $1',
+          [1]
+        ])
+        .mockReturnValueOnce([
+          'SELECT DISTINCT "bookletEntity"."id" AS "bookletId" FROM response WHERE person.workspace_id = $1',
+          [1]
+        ]);
+      (dataSource.query as jest.Mock)
+        .mockResolvedValueOnce([{ v: 'Kurz' }, { v: 'Lang' }])
+        .mockResolvedValueOnce([{ v: 'complete' }, { v: 'incomplete' }]);
+
+      const result = await service.findFlatResponseFilterOptions(1, {});
+
+      expect(qb.where).toHaveBeenCalledWith(
+        'person.workspace_id = :workspaceId',
+        { workspaceId: 1 }
+      );
+      expect(qb.where).not.toHaveBeenCalledWith('unitTag.tag IS NOT NULL');
+      expect(qb.where).not.toHaveBeenCalledWith('session.browser IS NOT NULL');
+      expect(qb.where).not.toHaveBeenCalledWith('session.os IS NOT NULL');
+      expect(qb.where).not.toHaveBeenCalledWith('session.screen IS NOT NULL');
+      expect(qb.where).not.toHaveBeenCalledWith('session.id IS NOT NULL');
+      expect(qb.andWhere).toHaveBeenCalledWith('unitTag.tag IS NOT NULL');
+      expect(qb.andWhere).toHaveBeenCalledWith('session.browser IS NOT NULL');
+      expect(qb.andWhere).toHaveBeenCalledWith('session.os IS NOT NULL');
+      expect(qb.andWhere).toHaveBeenCalledWith('session.screen IS NOT NULL');
+      expect(qb.andWhere).toHaveBeenCalledWith('session.id IS NOT NULL');
+
+      expect(dataSource.query).toHaveBeenCalledTimes(2);
+      expect((dataSource.query as jest.Mock).mock.calls[0][0]).toContain(
+        'LEFT JOIN LATERAL'
+      );
+      expect((dataSource.query as jest.Mock).mock.calls[0][0]).toContain(
+        'first_duration.duration_ms < $2'
+      );
+      expect((dataSource.query as jest.Mock).mock.calls[0][1]).toEqual([
+        1,
+        60000
+      ]);
+      expect((dataSource.query as jest.Mock).mock.calls[1][0]).toContain(
+        'CROSS JOIN LATERAL'
+      );
+      expect((dataSource.query as jest.Mock).mock.calls[1][0]).toContain(
+        'COUNT(DISTINCT progress_unit.id)'
+      );
+      expect((dataSource.query as jest.Mock).mock.calls[1][1]).toEqual([1]);
+      expect(result.processingDurations).toEqual(['Kurz', 'Lang']);
+      expect(result.unitProgresses).toEqual([
+        'Vollständig',
+        'Unvollständig'
+      ]);
     });
   });
 

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -3062,6 +3062,93 @@ export class WorkspaceTestResultsService {
     return result;
   }
 
+  private buildFlatResponseFilteredBookletsSubquery(
+    baseQb: SelectQueryBuilder<ResponseEntity>
+  ): [string, unknown[]] {
+    return baseQb
+      .clone()
+      .select('"bookletEntity"."id"', 'bookletId')
+      .distinct(true)
+      .getQueryAndParameters();
+  }
+
+  private async queryFlatResponseProcessingDurationOptions(
+    baseQb: SelectQueryBuilder<ResponseEntity>,
+    maxOptions: number,
+    processingDurationThresholdMs: number
+  ): Promise<Array<{ v: string }>> {
+    const [filteredBookletsSql, filteredBookletsParams] =
+      this.buildFlatResponseFilteredBookletsSubquery(baseQb);
+    const thresholdParam = `$${filteredBookletsParams.length + 1}`;
+    const limit = Math.max(1, Math.floor(maxOptions));
+
+    return this.connection.query(
+      `
+        SELECT DISTINCT
+          CASE
+            WHEN first_duration.duration_ms IS NULL THEN 'Unbekannt'
+            WHEN first_duration.duration_ms < ${thresholdParam} THEN 'Kurz'
+            ELSE 'Lang'
+          END AS v
+        FROM (${filteredBookletsSql}) filtered_booklets
+        LEFT JOIN LATERAL (
+          SELECT (bl_terminated.ts - bl_running.ts) AS duration_ms
+          FROM bookletlog bl_running
+          JOIN bookletlog bl_terminated
+            ON bl_terminated.bookletid = bl_running.bookletid
+          WHERE bl_running.bookletid = filtered_booklets."bookletId"
+            AND bl_running.key = 'CONTROLLER'
+            AND bl_running.parameter = 'RUNNING'
+            AND bl_terminated.key = 'CONTROLLER'
+            AND bl_terminated.parameter = 'TERMINATED'
+          ORDER BY bl_running.id ASC, bl_terminated.id ASC
+          LIMIT 1
+        ) first_duration ON TRUE
+        ORDER BY v ASC
+        LIMIT ${limit}
+      `,
+      [...filteredBookletsParams, processingDurationThresholdMs]
+    );
+  }
+
+  private async queryFlatResponseUnitProgressOptions(
+    baseQb: SelectQueryBuilder<ResponseEntity>,
+    maxOptions: number
+  ): Promise<Array<{ v: string }>> {
+    const [filteredBookletsSql, filteredBookletsParams] =
+      this.buildFlatResponseFilteredBookletsSubquery(baseQb);
+    const limit = Math.max(1, Math.floor(maxOptions));
+
+    return this.connection.query(
+      `
+        SELECT DISTINCT progress.v AS v
+        FROM (${filteredBookletsSql}) filtered_booklets
+        CROSS JOIN LATERAL (
+          SELECT
+            CASE
+              WHEN COUNT(DISTINCT progress_unit.id) > 0
+                AND COUNT(DISTINCT progress_unit.id) =
+                  COUNT(DISTINCT CASE
+                    WHEN progress_log.id IS NOT NULL THEN progress_unit.id
+                  END)
+              THEN 'complete'
+              ELSE 'incomplete'
+            END AS v
+          FROM unit progress_unit
+          LEFT JOIN bookletlog progress_log
+            ON progress_log.bookletid = filtered_booklets."bookletId"
+            AND progress_log.key = 'CURRENT_UNIT_ID'
+            AND progress_log.parameter = progress_unit.alias
+          WHERE progress_unit.bookletid = filtered_booklets."bookletId"
+            AND progress_unit.alias IS NOT NULL
+        ) progress
+        ORDER BY progress.v ASC
+        LIMIT ${limit}
+      `,
+      filteredBookletsParams
+    );
+  }
+
   async findFlatResponseFilterOptions(
     workspaceId: number,
     options: {
@@ -3431,8 +3518,6 @@ export class WorkspaceTestResultsService {
       responseRows,
       responseStatusRows,
       tagRows,
-      processingDurationRows,
-      unitProgressRows,
       sessionBrowserRows,
       sessionOsRows,
       sessionScreenRows,
@@ -3483,86 +3568,15 @@ export class WorkspaceTestResultsService {
       baseQb
         .clone()
         .select('DISTINCT unitTag.tag', 'v')
-        .where('unitTag.tag IS NOT NULL')
+        .andWhere('unitTag.tag IS NOT NULL')
         .orderBy('unitTag.tag', 'ASC')
-        .limit(MAX_OPTIONS)
-        .getRawMany<{ v: string }>(),
-      baseQb
-        .clone()
-        .select(
-          `DISTINCT (
-            CASE
-              WHEN (
-                SELECT (bl_terminated.ts - bl_running.ts)
-                FROM bookletlog bl_running
-                JOIN bookletlog bl_terminated ON bl_terminated.bookletid = bl_running.bookletid
-                WHERE bl_running.bookletid = "bookletEntity"."id"
-                  AND bl_running.key = 'CONTROLLER'
-                  AND bl_running.parameter = 'RUNNING'
-                  AND bl_terminated.key = 'CONTROLLER'
-                  AND bl_terminated.parameter = 'TERMINATED'
-                ORDER BY bl_running.id ASC, bl_terminated.id ASC
-                LIMIT 1
-              ) IS NULL THEN 'Unbekannt'
-              WHEN (
-                SELECT (bl_terminated.ts - bl_running.ts)
-                FROM bookletlog bl_running
-                JOIN bookletlog bl_terminated ON bl_terminated.bookletid = bl_running.bookletid
-                WHERE bl_running.bookletid = "bookletEntity"."id"
-                  AND bl_running.key = 'CONTROLLER'
-                  AND bl_running.parameter = 'RUNNING'
-                  AND bl_terminated.key = 'CONTROLLER'
-                  AND bl_terminated.parameter = 'TERMINATED'
-                ORDER BY bl_running.id ASC, bl_terminated.id ASC
-                LIMIT 1
-              ) < :processingDurationThresholdMs THEN 'Kurz'
-              ELSE 'Lang'
-            END
-          )`,
-          'v'
-        )
-        .orderBy('v', 'ASC')
-        .limit(MAX_OPTIONS)
-        .setParameter(
-          'processingDurationThresholdMs',
-          processingDurationThresholdMs
-        )
-        .getRawMany<{ v: string }>(),
-      baseQb
-        .clone()
-        .select(
-          `DISTINCT (
-            CASE
-              WHEN EXISTS (
-                SELECT 1 FROM unit u2
-                WHERE u2.bookletid = "bookletEntity"."id"
-                  AND u2.alias IS NOT NULL
-              )
-              AND NOT EXISTS (
-                SELECT 1 FROM unit u3
-                WHERE u3.bookletid = "bookletEntity"."id"
-                  AND u3.alias IS NOT NULL
-                  AND NOT EXISTS (
-                    SELECT 1 FROM bookletlog bl
-                    WHERE bl.bookletid = "bookletEntity"."id"
-                      AND bl.key = 'CURRENT_UNIT_ID'
-                      AND bl.parameter = u3.alias
-                  )
-              )
-              THEN 'complete'
-              ELSE 'incomplete'
-            END
-          )`,
-          'v'
-        )
-        .orderBy('v', 'ASC')
         .limit(MAX_OPTIONS)
         .getRawMany<{ v: string }>(),
       baseQb
         .clone()
         .leftJoin('bookletEntity.sessions', 'session')
         .select('DISTINCT session.browser', 'v')
-        .where('session.browser IS NOT NULL')
+        .andWhere('session.browser IS NOT NULL')
         .orderBy('session.browser', 'ASC')
         .limit(MAX_OPTIONS)
         .getRawMany<{ v: string }>(),
@@ -3570,7 +3584,7 @@ export class WorkspaceTestResultsService {
         .clone()
         .leftJoin('bookletEntity.sessions', 'session')
         .select('DISTINCT session.os', 'v')
-        .where('session.os IS NOT NULL')
+        .andWhere('session.os IS NOT NULL')
         .orderBy('session.os', 'ASC')
         .limit(MAX_OPTIONS)
         .getRawMany<{ v: string }>(),
@@ -3578,7 +3592,7 @@ export class WorkspaceTestResultsService {
         .clone()
         .leftJoin('bookletEntity.sessions', 'session')
         .select('DISTINCT session.screen', 'v')
-        .where('session.screen IS NOT NULL')
+        .andWhere('session.screen IS NOT NULL')
         .orderBy('session.screen', 'ASC')
         .limit(MAX_OPTIONS)
         .getRawMany<{ v: string }>(),
@@ -3586,10 +3600,19 @@ export class WorkspaceTestResultsService {
         .clone()
         .leftJoin('bookletEntity.sessions', 'session')
         .select('DISTINCT session.id', 'v')
-        .where('session.id IS NOT NULL')
+        .andWhere('session.id IS NOT NULL')
         .orderBy('session.id', 'ASC')
         .limit(MAX_OPTIONS)
         .getRawMany<{ v: string }>()
+    ]);
+
+    const [processingDurationRows, unitProgressRows] = await Promise.all([
+      this.queryFlatResponseProcessingDurationOptions(
+        baseQb,
+        MAX_OPTIONS,
+        processingDurationThresholdMs
+      ),
+      this.queryFlatResponseUnitProgressOptions(baseQb, MAX_OPTIONS)
     ]);
 
     const mapVals = (rows: Array<{ v: string }>) => (rows || []).map(r => String(r.v || '').trim()).filter(Boolean);


### PR DESCRIPTION
## Summary
- derive the expensive `processingDurations` and `unitProgresses` filter options from the already-filtered booklet set instead of evaluating correlated `bookletlog` subqueries per response row
- keep workspace/exclusion scoping intact for tag and session option queries by using `andWhere` on cloned query builders
- add a focused regression test for scoped option predicates and the new log-option query path

## Verification
- `npx nx test backend --testFile=workspace-test-results.service.spec.ts --runInBand`
- `npx nx lint backend`
- `npx nx test backend --runInBand`
- local PostgreSQL `EXPLAIN ANALYZE` on dev workspace 5:
  - `processingDurations`: ~367 ms old vs. ~42 ms new
  - `unitProgress`: ~7.2 s old vs. ~224 ms new, with most execution before JIT around ~50 ms
- old/new result parity checked for the same workspace:
  - `processingDurations`: `Kurz, Lang, Unbekannt`
  - `unitProgress`: `complete, incomplete`

Related to #476.
