### PR TITLE
fix: improve variable validation diagnostics

### DIFF
--- a/api-dto/files/variable-validation.dto.ts
+++ b/api-dto/files/variable-validation.dto.ts
@@ -1,3 +1,12 @@
+export type VariableValidationErrorCode =
+  | 'UNIT_FILE_NOT_FOUND'
+  | 'VARIABLE_NOT_DEFINED_IN_UNIT';
+
+export interface VariableValidationSummaryDto {
+  unitFileNotFound: number;
+  variableNotDefinedInUnit: number;
+}
+
 export interface InvalidVariableDto {
   fileName: string;
   variableId: string;
@@ -5,6 +14,7 @@ export interface InvalidVariableDto {
   responseId?: number;
   expectedType?: string;
   errorReason?: string;
+  errorCode?: VariableValidationErrorCode;
 }
 
 export interface VariableValidationDto {

--- a/apps/backend/src/app/admin/workspace/workspace-files-validation.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-files-validation.controller.ts
@@ -20,7 +20,10 @@ import { WorkspaceGuard } from './workspace.guard';
 import { AccessLevelGuard, RequireAccessLevel } from './access-level.guard';
 import { WorkspaceFilesService } from '../../database/services/workspace';
 import { FileValidationResultDto } from '../../../../../../api-dto/files/file-validation-result.dto';
-import { InvalidVariableDto } from '../../../../../../api-dto/files/variable-validation.dto';
+import {
+  InvalidVariableDto,
+  VariableValidationSummaryDto
+} from '../../../../../../api-dto/files/variable-validation.dto';
 import { TestTakersValidationDto } from '../../../../../../api-dto/files/testtakers-validation.dto';
 import { DuplicateResponsesResultDto } from '../../../../../../api-dto/files/duplicate-response.dto';
 import { CacheService } from '../../cache/cache.service';
@@ -232,6 +235,7 @@ export class WorkspaceFilesValidationController {
         total: number;
         page: number;
         limit: number;
+        summary: VariableValidationSummaryDto;
       }> {
     return this.workspaceFilesService.validateVariables(
       workspace_id,

--- a/apps/backend/src/app/database/services/validation/workspace-response-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/validation/workspace-response-validation.service.spec.ts
@@ -148,6 +148,61 @@ describe('WorkspaceResponseValidationService.validateVariables', () => {
     expect(result.data).toEqual([]);
   });
 
+  it('matches unit XML by uploaded file id when metadata id differs', async () => {
+    const filesRepository = {
+      find: jest.fn().mockResolvedValue([
+        {
+          file_id: 'UNIT1',
+          filename: 'UNIT1.xml',
+          data: makeUnitXml('UNIT-FROM-METADATA', [
+            { id: 'V1', alias: 'A1', type: 'string' }
+          ])
+        } as unknown as FileUpload
+      ])
+    } as unknown as Repository<FileUpload>;
+
+    const personsRepository = {
+      find: jest
+        .fn()
+        .mockResolvedValue([{ id: 1, workspace_id: 1, consider: true }])
+    } as unknown as Repository<Persons>;
+
+    const unitRepository = {
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValue(
+          makeQueryBuilder([{ id: 10, name: 'UNIT1' } as unknown as Unit])
+        )
+    } as unknown as Repository<Unit>;
+
+    const responseRepository = {
+      find: jest.fn().mockResolvedValue([
+        {
+          id: 100,
+          unitid: 10,
+          variableid: 'A1',
+          value: 'x',
+          unit: {
+            id: 10,
+            name: 'UNIT1'
+          } as unknown as Unit
+        } as unknown as ResponseEntity
+      ])
+    } as unknown as Repository<ResponseEntity>;
+
+    const service = new WorkspaceResponseValidationService(
+      responseRepository,
+      unitRepository,
+      personsRepository,
+      {} as unknown as Repository<Booklet>,
+      filesRepository
+    );
+
+    const result = await service.validateVariables(1, 1, 10);
+    expect(result.total).toBe(0);
+    expect(result.data).toEqual([]);
+  });
+
   it('flags response as invalid when variable is neither alias nor id in unit xml', async () => {
     const filesRepository = {
       find: jest.fn().mockResolvedValue([
@@ -202,8 +257,164 @@ describe('WorkspaceResponseValidationService.validateVariables', () => {
       fileName: 'UNIT1',
       variableId: 'UNKNOWN',
       responseId: 100,
-      errorReason: 'Variable not defined in unit'
+      errorReason: 'Variable not defined in unit',
+      errorCode: 'VARIABLE_NOT_DEFINED_IN_UNIT'
     });
+    expect(result.summary).toEqual({
+      unitFileNotFound: 0,
+      variableNotDefinedInUnit: 1
+    });
+  });
+
+  it('ignores undefined variable placeholders when their value is missing', async () => {
+    const filesRepository = {
+      find: jest.fn().mockResolvedValue([
+        {
+          data: makeUnitXml('UNIT1', [
+            { id: 'V1', alias: 'A1', type: 'string' }
+          ])
+        } as unknown as FileUpload
+      ])
+    } as unknown as Repository<FileUpload>;
+
+    const personsRepository = {
+      find: jest
+        .fn()
+        .mockResolvedValue([{ id: 1, workspace_id: 1, consider: true }])
+    } as unknown as Repository<Persons>;
+
+    const unitRepository = {
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValue(
+          makeQueryBuilder([{ id: 10, name: 'UNIT1' } as unknown as Unit])
+        )
+    } as unknown as Repository<Unit>;
+
+    const responseRepository = {
+      find: jest.fn().mockResolvedValue([
+        {
+          id: 100,
+          unitid: 10,
+          variableid: 'drop-list_1',
+          value: '',
+          unit: {
+            id: 10,
+            name: 'UNIT1'
+          } as unknown as Unit
+        } as unknown as ResponseEntity,
+        {
+          id: 101,
+          unitid: 10,
+          variableid: 'drop-list_2',
+          value: '[]',
+          unit: {
+            id: 10,
+            name: 'UNIT1'
+          } as unknown as Unit
+        } as unknown as ResponseEntity
+      ])
+    } as unknown as Repository<ResponseEntity>;
+
+    const service = new WorkspaceResponseValidationService(
+      responseRepository,
+      unitRepository,
+      personsRepository,
+      {} as unknown as Repository<Booklet>,
+      filesRepository
+    );
+
+    const result = await service.validateVariables(1, 1, 10);
+    expect(result.total).toBe(0);
+    expect(result.summary).toEqual({
+      unitFileNotFound: 0,
+      variableNotDefinedInUnit: 0
+    });
+  });
+
+  it('separates missing unit files from undefined variables in the summary', async () => {
+    const filesRepository = {
+      find: jest.fn().mockResolvedValue([
+        {
+          file_id: 'UNIT1',
+          filename: 'UNIT1.xml',
+          data: makeUnitXml('UNIT1', [
+            { id: 'V1', alias: 'A1', type: 'string' }
+          ])
+        } as unknown as FileUpload
+      ])
+    } as unknown as Repository<FileUpload>;
+
+    const personsRepository = {
+      find: jest
+        .fn()
+        .mockResolvedValue([{ id: 1, workspace_id: 1, consider: true }])
+    } as unknown as Repository<Persons>;
+
+    const unitRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(
+        makeQueryBuilder([
+          { id: 10, name: 'UNIT1' } as unknown as Unit,
+          { id: 11, name: 'MISSING_UNIT' } as unknown as Unit,
+          { id: 12, name: 'MISSING_EMPTY_UNIT' } as unknown as Unit
+        ])
+      )
+    } as unknown as Repository<Unit>;
+
+    const responseRepository = {
+      find: jest.fn().mockResolvedValue([
+        {
+          id: 100,
+          unitid: 10,
+          variableid: 'UNKNOWN',
+          value: 'x',
+          unit: {
+            id: 10,
+            name: 'UNIT1'
+          } as unknown as Unit
+        } as unknown as ResponseEntity,
+        {
+          id: 101,
+          unitid: 11,
+          variableid: 'A1',
+          value: 'y',
+          unit: {
+            id: 11,
+            name: 'MISSING_UNIT'
+          } as unknown as Unit
+        } as unknown as ResponseEntity,
+        {
+          id: 102,
+          unitid: 12,
+          variableid: 'A1',
+          value: '[]',
+          unit: {
+            id: 12,
+            name: 'MISSING_EMPTY_UNIT'
+          } as unknown as Unit
+        } as unknown as ResponseEntity
+      ])
+    } as unknown as Repository<ResponseEntity>;
+
+    const service = new WorkspaceResponseValidationService(
+      responseRepository,
+      unitRepository,
+      personsRepository,
+      {} as unknown as Repository<Booklet>,
+      filesRepository
+    );
+
+    const result = await service.validateVariables(1, 1, 10);
+    expect(result.total).toBe(3);
+    expect(result.summary).toEqual({
+      unitFileNotFound: 2,
+      variableNotDefinedInUnit: 1
+    });
+    expect(result.data.map(item => item.errorCode)).toEqual([
+      'VARIABLE_NOT_DEFINED_IN_UNIT',
+      'UNIT_FILE_NOT_FOUND',
+      'UNIT_FILE_NOT_FOUND'
+    ]);
   });
 
   it('accepts response variableid matching alias for a no-value variable', async () => {

--- a/apps/backend/src/app/database/services/validation/workspace-response-validation.service.ts
+++ b/apps/backend/src/app/database/services/validation/workspace-response-validation.service.ts
@@ -12,12 +12,22 @@ import { Booklet } from '../../entities/booklet.entity';
 import Workspace from '../../entities/workspace.entity';
 import { WorkspaceSettingsDto } from '../../../../../../../api-dto/workspaces/workspace-settings-dto';
 
-import { InvalidVariableDto } from '../../../../../../../api-dto/files/variable-validation.dto';
+import {
+  InvalidVariableDto,
+  VariableValidationSummaryDto
+} from '../../../../../../../api-dto/files/variable-validation.dto';
 import {
   DuplicateResponseDto,
   DuplicateResponsesResultDto
 } from '../../../../../../../api-dto/files/duplicate-response.dto';
 import { statusNumberToString } from '../../utils/response-status-converter';
+
+interface UnitVariableDefinitions {
+  aliases: Set<string>;
+  ids: Set<string>;
+  noValueAliases: Set<string>;
+  noValueIds: Set<string>;
+}
 
 @Injectable()
 export class WorkspaceResponseValidationService {
@@ -48,6 +58,96 @@ export class WorkspaceResponseValidationService {
     return WorkspaceResponseValidationService
       .normalizeExclusionKey(value)
       .replace(/\.XML$/i, '');
+  }
+
+  private static normalizeVariableKey(value: string | null | undefined): string {
+    return String(value || '').trim();
+  }
+
+  private static createUnitVariableDefinitions(): UnitVariableDefinitions {
+    return {
+      aliases: new Set<string>(),
+      ids: new Set<string>(),
+      noValueAliases: new Set<string>(),
+      noValueIds: new Set<string>()
+    };
+  }
+
+  private static asArray<T>(value: T | T[] | undefined): T[] {
+    if (!value) {
+      return [];
+    }
+    return Array.isArray(value) ? value : [value];
+  }
+
+  private static baseFileName(value: string | null | undefined): string {
+    return String(value || '').trim().replace(/\.[^.]+$/u, '');
+  }
+
+  private static addVariableDefinition(
+    definitions: UnitVariableDefinitions,
+    variable: { $?: Record<string, string | boolean | undefined> } | undefined
+  ): void {
+    const variableAttributes = variable?.$;
+    if (!variableAttributes) {
+      return;
+    }
+
+    const alias = WorkspaceResponseValidationService.normalizeVariableKey(
+      typeof variableAttributes.alias === 'string' ?
+        variableAttributes.alias :
+        undefined
+    );
+    const id = WorkspaceResponseValidationService.normalizeVariableKey(
+      typeof variableAttributes.id === 'string' ?
+        variableAttributes.id :
+        undefined
+    );
+    const type =
+      typeof variableAttributes.type === 'string' ?
+        variableAttributes.type :
+        '';
+    const isNoValue = type === 'no-value';
+
+    if (alias) {
+      definitions.aliases.add(alias);
+      if (isNoValue) {
+        definitions.noValueAliases.add(alias);
+      }
+    }
+    if (id) {
+      definitions.ids.add(id);
+      if (isNoValue) {
+        definitions.noValueIds.add(id);
+      }
+    }
+  }
+
+  private static mergeUnitVariableDefinitions(
+    target: UnitVariableDefinitions,
+    source: UnitVariableDefinitions
+  ): void {
+    source.aliases.forEach(value => target.aliases.add(value));
+    source.ids.forEach(value => target.ids.add(value));
+    source.noValueAliases.forEach(value => target.noValueAliases.add(value));
+    source.noValueIds.forEach(value => target.noValueIds.add(value));
+  }
+
+  private static unitFileKeys(
+    unitFile: FileUpload,
+    metadataId: string | null | undefined
+  ): string[] {
+    return Array.from(
+      new Set(
+        [
+          metadataId,
+          unitFile.file_id,
+          WorkspaceResponseValidationService.baseFileName(unitFile.filename)
+        ]
+          .map(value => WorkspaceResponseValidationService.normalizeUnitKey(value))
+          .filter(Boolean)
+      )
+    );
   }
 
   private static hasValue(value: string | null | undefined): number {
@@ -243,14 +343,21 @@ export class WorkspaceResponseValidationService {
       total: number;
       page: number;
       limit: number;
+      summary: VariableValidationSummaryDto;
     }> {
+    const emptySummary: VariableValidationSummaryDto = {
+      unitFileNotFound: 0,
+      variableNotDefinedInUnit: 0
+    };
+
     if (!workspaceId) {
       this.logger.error('Workspace ID is required');
       return {
         data: [],
         total: 0,
         page,
-        limit
+        limit,
+        summary: emptySummary
       };
     }
 
@@ -259,15 +366,7 @@ export class WorkspaceResponseValidationService {
     const unitFiles = await this.filesRepository.find({
       where: { workspace_id: workspaceId, file_type: 'Unit' }
     });
-    const unitVariables = new Map<
-    string,
-    {
-      aliases: Set<string>;
-      ids: Set<string>;
-      noValueAliases: Set<string>;
-      noValueIds: Set<string>;
-    }
-    >();
+    const unitVariables = new Map<string, UnitVariableDefinitions>();
     for (const unitFile of unitFiles) {
       try {
         const xmlContent = unitFile.data.toString();
@@ -280,55 +379,53 @@ export class WorkspaceResponseValidationService {
           parsedXml.Unit.Metadata.Id
         ) {
           const unitName = parsedXml.Unit.Metadata.Id;
-          const variables = {
-            aliases: new Set<string>(),
-            ids: new Set<string>(),
-            noValueAliases: new Set<string>(),
-            noValueIds: new Set<string>()
-          };
+          const variables =
+            WorkspaceResponseValidationService
+              .createUnitVariableDefinitions();
           if (
             parsedXml.Unit.BaseVariables &&
             parsedXml.Unit.BaseVariables.Variable
           ) {
-            const baseVariables = Array.isArray(
-              parsedXml.Unit.BaseVariables.Variable
-            ) ?
-              parsedXml.Unit.BaseVariables.Variable :
-              [parsedXml.Unit.BaseVariables.Variable];
+            const baseVariables =
+              WorkspaceResponseValidationService.asArray(
+                parsedXml.Unit.BaseVariables.Variable
+              );
             for (const variable of baseVariables) {
-              const isNoValue = variable.$?.type === 'no-value';
-              if (variable.$?.alias) {
-                variables.aliases.add(variable.$.alias);
-                if (isNoValue) variables.noValueAliases.add(variable.$.alias);
-              }
-              if (variable.$?.id) {
-                variables.ids.add(variable.$.id);
-                if (isNoValue) variables.noValueIds.add(variable.$.id);
-              }
+              WorkspaceResponseValidationService.addVariableDefinition(
+                variables,
+                variable
+              );
             }
           }
           if (
             parsedXml.Unit.DerivedVariables &&
             parsedXml.Unit.DerivedVariables.Variable
           ) {
-            const derivedVariables = Array.isArray(
-              parsedXml.Unit.DerivedVariables.Variable
-            ) ?
-              parsedXml.Unit.DerivedVariables.Variable :
-              [parsedXml.Unit.DerivedVariables.Variable];
+            const derivedVariables =
+              WorkspaceResponseValidationService.asArray(
+                parsedXml.Unit.DerivedVariables.Variable
+              );
             for (const variable of derivedVariables) {
-              const isNoValue = variable.$?.type === 'no-value';
-              if (variable.$?.alias) {
-                variables.aliases.add(variable.$.alias);
-                if (isNoValue) variables.noValueAliases.add(variable.$.alias);
-              }
-              if (variable.$?.id) {
-                variables.ids.add(variable.$.id);
-                if (isNoValue) variables.noValueIds.add(variable.$.id);
-              }
+              WorkspaceResponseValidationService.addVariableDefinition(
+                variables,
+                variable
+              );
             }
           }
-          unitVariables.set(unitName, variables);
+          WorkspaceResponseValidationService
+            .unitFileKeys(unitFile, unitName)
+            .forEach(unitKey => {
+              const existingDefinitions =
+                unitVariables.get(unitKey) ||
+                WorkspaceResponseValidationService
+                  .createUnitVariableDefinitions();
+              WorkspaceResponseValidationService
+                .mergeUnitVariableDefinitions(
+                  existingDefinitions,
+                  variables
+                );
+              unitVariables.set(unitKey, existingDefinitions);
+            });
         }
       } catch (e) {
         /* empty */
@@ -349,7 +446,8 @@ export class WorkspaceResponseValidationService {
         data: [],
         total: 0,
         page,
-        limit
+        limit,
+        summary: emptySummary
       };
     }
 
@@ -363,7 +461,8 @@ export class WorkspaceResponseValidationService {
         data: [],
         total: 0,
         page,
-        limit
+        limit,
+        summary: emptySummary
       };
     }
 
@@ -392,7 +491,8 @@ export class WorkspaceResponseValidationService {
         data: [],
         total: 0,
         page,
-        limit
+        limit,
+        summary: emptySummary
       };
     }
 
@@ -410,7 +510,8 @@ export class WorkspaceResponseValidationService {
         data: [],
         total: 0,
         page,
-        limit
+        limit,
+        summary: emptySummary
       };
     }
 
@@ -424,7 +525,8 @@ export class WorkspaceResponseValidationService {
         data: [],
         total: 0,
         page,
-        limit
+        limit,
+        summary: emptySummary
       };
     }
 
@@ -451,12 +553,17 @@ export class WorkspaceResponseValidationService {
         data: [],
         total: 0,
         page,
-        limit
+        limit,
+        summary: emptySummary
       };
     }
 
     const totalResponses = allResponses.length;
     let processedResponses = 0;
+    const summary: VariableValidationSummaryDto = {
+      unitFileNotFound: 0,
+      variableNotDefinedInUnit: 0
+    };
 
     for (const response of allResponses) {
       processedResponses += 1;
@@ -470,25 +577,35 @@ export class WorkspaceResponseValidationService {
       }
 
       const unitName = unit.name;
-      const variableId = response.variableid;
+      const unitKey = WorkspaceResponseValidationService.normalizeUnitKey(
+        unitName
+      );
+      const variableId =
+        WorkspaceResponseValidationService.normalizeVariableKey(
+          response.variableid
+        );
 
       if (!variableId) {
         this.logger.warn(`Response ${response.id} has no variable ID`);
         continue;
       }
 
-      if (!unitVariables.has(unitName)) {
+      const value = response.value || '';
+
+      if (!unitVariables.has(unitKey)) {
+        summary.unitFileNotFound += 1;
         invalidVariables.push({
           fileName: `${unitName}`,
           variableId: variableId,
-          value: response.value || '',
+          value,
           responseId: response.id,
-          errorReason: 'Unit not found'
+          errorReason: 'Unit file not found for response unit',
+          errorCode: 'UNIT_FILE_NOT_FOUND'
         });
         continue;
       }
 
-      const unitVars = unitVariables.get(unitName);
+      const unitVars = unitVariables.get(unitKey);
 
       const isNoValueVariable =
         !!unitVars &&
@@ -503,12 +620,19 @@ export class WorkspaceResponseValidationService {
         (unitVars.aliases.has(variableId) ||
           (!unitVars.aliases.has(variableId) && unitVars.ids.has(variableId)));
       if (!isDefinedInUnit) {
+        // Legacy imports may contain stale UI variable placeholders without data.
+        if (this.isMissingVariableValue(value, false)) {
+          continue;
+        }
+
+        summary.variableNotDefinedInUnit += 1;
         invalidVariables.push({
           fileName: `${unitName}`,
           variableId: variableId,
-          value: response.value || '',
+          value,
           responseId: response.id,
-          errorReason: 'Variable not defined in unit'
+          errorReason: 'Variable not defined in unit',
+          errorCode: 'VARIABLE_NOT_DEFINED_IN_UNIT'
         });
       }
     }
@@ -526,7 +650,8 @@ export class WorkspaceResponseValidationService {
       data: paginatedData,
       total: invalidVariables.length,
       page: validPage,
-      limit: validLimit
+      limit: validLimit,
+      summary
     };
   }
 

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -28,7 +28,10 @@ import {
 } from '../../../../../../../api-dto/files/test-files-upload-result.dto';
 import { FileValidationResultDto } from '../../../../../../../api-dto/files/file-validation-result.dto';
 import { ResponseDto } from '../../../../../../../api-dto/responses/response-dto';
-import { InvalidVariableDto } from '../../../../../../../api-dto/files/variable-validation.dto';
+import {
+  InvalidVariableDto,
+  VariableValidationSummaryDto
+} from '../../../../../../../api-dto/files/variable-validation.dto';
 import { DuplicateResponsesResultDto } from '../../../../../../../api-dto/files/duplicate-response.dto';
 import { Unit } from '../../entities/unit.entity';
 import { UnitVariableDetailsDto } from '../../../models/unit-variable-details.dto';
@@ -2043,6 +2046,7 @@ ${bookletRefs}
       total: number;
       page: number;
       limit: number;
+      summary: VariableValidationSummaryDto;
     }> {
     return this.workspaceResponseValidationService.validateVariables(
       workspaceId,

--- a/apps/frontend/src/app/shared/services/validation/validation.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/validation/validation.service.spec.ts
@@ -45,7 +45,14 @@ describe('ValidationService', () => {
   describe('validateVariables', () => {
     it('should fetch variables validation results', () => {
       const mockResponse = {
-        data: [], total: 0, page: 1, limit: 10
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+        summary: {
+          unitFileNotFound: 0,
+          variableNotDefinedInUnit: 0
+        }
       };
 
       service.validateVariables(mockWorkspaceId, 1, 10).subscribe(res => {

--- a/apps/frontend/src/app/shared/services/validation/validation.service.ts
+++ b/apps/frontend/src/app/shared/services/validation/validation.service.ts
@@ -12,7 +12,10 @@ import {
   take,
   throwError
 } from 'rxjs';
-import { InvalidVariableDto } from '../../../../../../../api-dto/files/variable-validation.dto';
+import {
+  InvalidVariableDto,
+  VariableValidationSummaryDto
+} from '../../../../../../../api-dto/files/variable-validation.dto';
 import { TestTakersValidationDto } from '../../../../../../../api-dto/files/testtakers-validation.dto';
 import { DuplicateResponsesResultDto } from '../../../../../../../api-dto/files/duplicate-response.dto';
 import { SERVER_URL } from '../../../injection-tokens';
@@ -29,6 +32,11 @@ interface PaginatedResponse<T> {
   limit: number;
 }
 
+interface VariablesValidationResponse
+  extends PaginatedResponse<InvalidVariableDto> {
+  summary: VariableValidationSummaryDto;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -40,14 +48,14 @@ export class ValidationService {
     workspaceId: number,
     page: number = 1,
     limit: number = 10
-  ): Observable<PaginatedResponse<InvalidVariableDto>> {
+  ): Observable<VariablesValidationResponse> {
     const params = new HttpParams()
       .set('page', page.toString())
       .set('limit', limit.toString());
 
     return this.http
       .get<
-    PaginatedResponse<InvalidVariableDto>
+    VariablesValidationResponse
     >(`${this.serverUrl}admin/workspace/${workspaceId}/files/validate-variables`, { params })
       .pipe(
         catchError(error => throwError(() => error))

--- a/apps/frontend/src/app/ws-admin/components/validation-dialog/panels/variables-validation-panel/variables-validation-panel.component.html
+++ b/apps/frontend/src/app/ws-admin/components/validation-dialog/panels/variables-validation-panel/variables-validation-panel.component.html
@@ -57,6 +57,21 @@
         gefunden.</span
       >
     </div>
+    @if (
+      summary.unitFileNotFound > 0 || summary.variableNotDefinedInUnit > 0
+    ) {
+      <div class="validation-summary">
+        @if (summary.unitFileNotFound > 0) {
+          <span>{{ summary.unitFileNotFound }} ohne passende Unit.xml</span>
+        }
+        @if (summary.variableNotDefinedInUnit > 0) {
+          <span
+            >{{ summary.variableNotDefinedInUnit }} nicht in Unit.xml
+            definiert</span
+          >
+        }
+      </div>
+    }
 
     @if (invalidVariables.length > 0) {
       <div class="actions-container">

--- a/apps/frontend/src/app/ws-admin/components/validation-dialog/panels/variables-validation-panel/variables-validation-panel.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/validation-dialog/panels/variables-validation-panel/variables-validation-panel.component.ts
@@ -22,7 +22,10 @@ import {
   ValidationDataTableComponent,
   ValidationTableColumn
 } from '../../shared';
-import { InvalidVariableDto } from '../../../../../../../../../api-dto/files/variable-validation.dto';
+import {
+  InvalidVariableDto,
+  VariableValidationSummaryDto
+} from '../../../../../../../../../api-dto/files/variable-validation.dto';
 import { VariableValidationService } from '../../../../services/validation';
 import { buildCsv, downloadCsvFile } from '../../shared/validation-export.util';
 
@@ -31,6 +34,7 @@ interface VariablesValidationResult {
   total: number;
   page: number;
   limit: number;
+  summary?: VariableValidationSummaryDto;
 }
 
 /**
@@ -79,6 +83,21 @@ interface VariablesValidationResult {
         margin-right: 8px;
       }
 
+      .validation-summary {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 0 0 12px;
+      }
+
+      .validation-summary span {
+        padding: 2px 8px;
+        border: 1px solid rgba(0, 0, 0, 0.12);
+        border-radius: 999px;
+        font-size: 12px;
+        line-height: 18px;
+      }
+
       .loading-container {
         display: flex;
         align-items: center;
@@ -116,6 +135,11 @@ export class VariablesValidationPanelComponent implements OnInit, OnDestroy {
   errorMessage: string | null = null;
   invalidVariables: InvalidVariableDto[] = [];
   totalInvalid = 0;
+  summary: VariableValidationSummaryDto = {
+    unitFileNotFound: 0,
+    variableNotDefinedInUnit: 0
+  };
+
   currentPage = 1;
   pageSize = 10;
   selectedResponses: Set<number> = new Set();
@@ -133,7 +157,8 @@ export class VariablesValidationPanelComponent implements OnInit, OnDestroy {
     },
     { key: 'fileName', label: 'Dateiname', type: 'link' },
     { key: 'variableId', label: 'Variablen-ID' },
-    { key: 'value', label: 'Wert' }
+    { key: 'value', label: 'Wert' },
+    { key: 'errorReason', label: 'Fehlergrund' }
   ];
 
   private subscription?: Subscription;
@@ -157,6 +182,10 @@ export class VariablesValidationPanelComponent implements OnInit, OnDestroy {
           this.errorMessage = details.error as string;
           this.invalidVariables = [];
           this.totalInvalid = 0;
+          this.summary = {
+            unitFileNotFound: 0,
+            variableNotDefinedInUnit: 0
+          };
         } else if (result.details) {
           const variablesResult = result.details as VariablesValidationResult;
           this.errorMessage = null;
@@ -164,6 +193,10 @@ export class VariablesValidationPanelComponent implements OnInit, OnDestroy {
           this.totalInvalid = variablesResult.total || 0;
           this.currentPage = variablesResult.page || 1;
           this.pageSize = variablesResult.limit || 10;
+          this.summary = variablesResult.summary || {
+            unitFileNotFound: 0,
+            variableNotDefinedInUnit: 0
+          };
         }
       }
     });
@@ -205,6 +238,10 @@ export class VariablesValidationPanelComponent implements OnInit, OnDestroy {
           this.totalInvalid = result.total;
           this.currentPage = result.page;
           this.pageSize = result.limit;
+          this.summary = result.summary || {
+            unitFileNotFound: 0,
+            variableNotDefinedInUnit: 0
+          };
           this.wasRun = true;
           this.isRunning = false;
         },
@@ -232,6 +269,10 @@ export class VariablesValidationPanelComponent implements OnInit, OnDestroy {
           this.totalInvalid = result.total;
           this.currentPage = result.page;
           this.pageSize = result.limit;
+          this.summary = result.summary || {
+            unitFileNotFound: 0,
+            variableNotDefinedInUnit: 0
+          };
           this.isLoadingPage = false;
         },
         error: () => {
@@ -334,7 +375,8 @@ export class VariablesValidationPanelComponent implements OnInit, OnDestroy {
             { header: 'Dateiname', value: row => row.fileName },
             { header: 'Variablen-ID', value: row => row.variableId },
             { header: 'Wert', value: row => row.value },
-            { header: 'Response-ID', value: row => row.responseId ?? '' }
+            { header: 'Response-ID', value: row => row.responseId ?? '' },
+            { header: 'Fehlergrund', value: row => row.errorReason ?? '' }
           ]);
 
           downloadCsvFile('validierung-variablen.csv', csvContent);

--- a/apps/frontend/src/app/ws-admin/services/validation/variable-validation.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/validation/variable-validation.service.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { switchMap, tap, map } from 'rxjs/operators';
 import { BaseValidationService } from './base-validation.service';
-import { InvalidVariableDto } from '../../../../../../../api-dto/files/variable-validation.dto';
+import {
+  InvalidVariableDto,
+  VariableValidationSummaryDto
+} from '../../../../../../../api-dto/files/variable-validation.dto';
 import { ValidationTaskDto } from '../../../models/validation-task.dto';
 
 interface VariablesValidationResult {
@@ -10,6 +13,7 @@ interface VariablesValidationResult {
   total: number;
   page: number;
   limit: number;
+  summary?: VariableValidationSummaryDto;
 }
 
 /**


### PR DESCRIPTION
## Summary
- distinguish missing Unit.xml files from variables missing in existing Unit.xml files
- include validation summary/error codes in the variables validation response and UI
- ignore empty legacy UI placeholders only after the matching Unit.xml exists

## Why
Real-data retesting for #432 showed stale empty UI placeholder responses mixed with structural Unit-file mismatches. The validation now keeps those cases separate so old empty placeholders do not block, while missing Unit.xml files remain visible.

Refs #432

## Validation
- backend Jest: workspace-response-validation.service.spec.ts, 29 passed
- frontend Jest: validation.service.spec.ts, 17 passed
- npx nx run-many --target=lint --projects=frontend,backend --parallel
- npx nx run-many --target=build --projects=frontend,backend --parallel (frontend SCSS budget warning, build successful)

## Retest Notes
After merge/deploy, retest #432 with WS43 and WS1 real data: WS43 empty drop-list placeholders should no longer fail; WS1 missing Unit.xml cases with [] should still show UNIT_FILE_NOT_FOUND.