### PR TITLE
Fix double-coded review filters and GeoGebra display

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -21,6 +21,7 @@ describe('CodingReviewService', () => {
 
   let queryBuilder: {
     leftJoin: jest.Mock;
+    innerJoin: jest.Mock;
     select: jest.Mock;
     addSelect: jest.Mock;
     where: jest.Mock;
@@ -84,6 +85,7 @@ describe('CodingReviewService', () => {
   beforeEach(() => {
     queryBuilder = {
       leftJoin: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
       select: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),

--- a/apps/backend/src/app/database/services/coding/coding-review.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { ResponseEntity } from '../../entities/response.entity';
 import { CodingJobUnit } from '../../entities/coding-job-unit.entity';
@@ -150,12 +150,34 @@ export class CodingReviewService {
           const sub = subQuery
             .subQuery()
             .select('cju2.response_id')
-            .from('coding_job_unit', 'cju2')
-            .leftJoin('cju2.coding_job', 'cj2')
+            .from(CodingJobUnit, 'cju2')
+            .innerJoin('cju2.coding_job', 'cj2')
             .leftJoin('cj2.codingJobCoders', 'cjc2')
-            .where('cjc2.user_id = :coderId', { coderId })
-            .getQuery();
-          return `cju.response_id IN ${sub}`;
+            .where('cj2.workspace_id = :workspaceId', { workspaceId })
+            .andWhere('cjc2.user_id = :coderId', { coderId });
+
+          if (excludeTrainings) {
+            sub.andWhere('cj2.training_id IS NULL');
+          }
+
+          if (this.hasScopeFilters(jobDefinitionIds, coderTrainingIds)) {
+            const scopeClauses: string[] = [];
+            const scopeParams: Record<string, number[]> = {};
+
+            if (jobDefinitionIds?.length) {
+              scopeClauses.push('cj2.job_definition_id IN (:...coderFilterJobDefinitionIds)');
+              scopeParams.coderFilterJobDefinitionIds = jobDefinitionIds;
+            }
+
+            if (coderTrainingIds?.length) {
+              scopeClauses.push('cj2.training_id IN (:...coderFilterTrainingIds)');
+              scopeParams.coderFilterTrainingIds = coderTrainingIds;
+            }
+
+            sub.andWhere(`(${scopeClauses.join(' OR ')})`, scopeParams);
+          }
+
+          return `cju.response_id IN ${sub.getQuery()}`;
         });
       }
 
@@ -423,10 +445,10 @@ export class CodingReviewService {
               updatedValue = parts[parts.length - 1];
             }
 
-            await transactionalEntityManager.update(
-              CodingJobUnit,
-              { response_id: decision.responseId },
-              { supervisor_comment: null }
+            await this.clearWorkspaceSupervisorComments(
+              transactionalEntityManager,
+              workspaceId,
+              decision.responseId
             );
 
             if (decision.resolutionComment && decision.resolutionComment.trim()) {
@@ -475,6 +497,35 @@ export class CodingReviewService {
         'Could not apply double-coded resolutions. Please check the database connection.'
       );
     }
+  }
+
+  private async clearWorkspaceSupervisorComments(
+    manager: EntityManager,
+    workspaceId: number,
+    responseId: number
+  ): Promise<void> {
+    const rows = await manager
+      .getRepository(CodingJobUnit)
+      .createQueryBuilder('cju')
+      .innerJoin('cju.coding_job', 'cj')
+      .select('cju.id', 'id')
+      .where('cju.response_id = :responseId', { responseId })
+      .andWhere('cj.workspace_id = :workspaceId', { workspaceId })
+      .getRawMany<{ id: number | string }>();
+
+    const ids = rows
+      .map(row => Number(row.id))
+      .filter(id => Number.isFinite(id));
+
+    if (ids.length === 0) {
+      return;
+    }
+
+    await manager.update(
+      CodingJobUnit,
+      { id: In(ids) },
+      { supervisor_comment: null }
+    );
   }
 
   async getWorkspaceCohensKappaSummary(

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
@@ -23,6 +23,9 @@
               <mat-label>{{ 'double-coded-review.filter.scope-label' | translate }}</mat-label>
               <mat-select [formControl]="scopeControl" multiple>
                 <mat-select-trigger>{{ getScopeSelectionSummary() }}</mat-select-trigger>
+                @if (!hasScopeOptions()) {
+                  <mat-option disabled>{{ 'double-coded-review.filter.scope-none' | translate }}</mat-option>
+                }
                 <mat-optgroup [label]="'double-coded-review.filter.scope-job-definitions' | translate">
                   @for (definition of availableJobDefinitions; track definition.id) {
                     <mat-option [value]="'job_' + definition.id">{{ definition.label }}</mat-option>
@@ -171,8 +174,11 @@
                           (click)="openReplay(element.responseId)">
                           <mat-icon>{{ replayLoadingByResponseId[element.responseId] ? 'hourglass_top' : 'play_circle' }}</mat-icon>
                         </button>
-                        <div class="answer-text" [matTooltip]="element.givenAnswer || 'N/A'">
-                          {{ element.givenAnswer || 'N/A' }}
+                        <div
+                          class="answer-text"
+                          [class.geogebra-answer]="isGeoGebraAnswer(element.givenAnswer)"
+                          [matTooltip]="getAnswerTooltip(element.givenAnswer)">
+                          {{ getAnswerDisplay(element.givenAnswer) }}
                         </div>
                       </div>
                     </td>
@@ -319,6 +325,9 @@
             <mat-label>{{ 'double-coded-review.filter.scope-label' | translate }}</mat-label>
             <mat-select [formControl]="scopeControl" multiple>
               <mat-select-trigger>{{ getScopeSelectionSummary() }}</mat-select-trigger>
+              @if (!hasScopeOptions()) {
+                <mat-option disabled>{{ 'double-coded-review.filter.scope-none' | translate }}</mat-option>
+              }
               <mat-optgroup [label]="'double-coded-review.filter.scope-job-definitions' | translate">
                 @for (definition of availableJobDefinitions; track definition.id) {
                   <mat-option [value]="'job_' + definition.id">{{ definition.label }}</mat-option>
@@ -467,8 +476,11 @@
                         (click)="openReplay(element.responseId)">
                         <mat-icon>{{ replayLoadingByResponseId[element.responseId] ? 'hourglass_top' : 'play_circle' }}</mat-icon>
                       </button>
-                      <div class="answer-text" [matTooltip]="element.givenAnswer || 'N/A'">
-                        {{ element.givenAnswer || 'N/A' }}
+                      <div
+                        class="answer-text"
+                        [class.geogebra-answer]="isGeoGebraAnswer(element.givenAnswer)"
+                        [matTooltip]="getAnswerTooltip(element.givenAnswer)">
+                        {{ getAnswerDisplay(element.givenAnswer) }}
                       </div>
                     </div>
                   </td>

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.scss
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.scss
@@ -328,6 +328,14 @@
           -webkit-box-orient: vertical;
           word-break: break-word;
           width: 100%;
+
+          &.geogebra-answer {
+            font-family: inherit;
+            font-weight: 600;
+            color: #1565c0;
+            background-color: #eaf3ff;
+            border: 1px solid #bbd7f5;
+          }
         }
       }
 

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -130,6 +130,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
   availableCoders: { id: number; name: string }[] = [];
   availableJobDefinitions: Array<{ id: number; label: string }> = [];
   availableCoderTrainings: Array<{ id: number; label: string }> = [];
+  private filterOptionsLoaded = false;
   private resultsApplied = false;
   private destroy$ = new Subject<void>();
 
@@ -200,7 +201,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(({ jobDefinitions, coderTrainings }) => {
         const sortedJobDefinitions = [...jobDefinitions]
-          .filter(definition => definition.id !== undefined)
+          .filter(definition => definition.id !== undefined && (definition.createdJobsCount ?? 0) > 0)
           .sort((a, b) => (b.id || 0) - (a.id || 0));
 
         this.availableJobDefinitions = sortedJobDefinitions.map(definition => ({
@@ -208,13 +209,34 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
           label: this.getJobDefinitionLabel(definition)
         }));
 
-        this.availableCoderTrainings = coderTrainings.map(training => ({
-          id: training.id,
-          label: training.label || `Training #${training.id}`
-        }));
+        this.availableCoderTrainings = coderTrainings
+          .filter(training => (training.jobsCount ?? 0) > 0)
+          .map(training => ({
+            id: training.id,
+            label: this.getCoderTrainingLabel(training)
+          }));
 
-        if ((!this.scopeControl.value || this.scopeControl.value.length === 0) && this.availableJobDefinitions.length > 0) {
+        const validScopes = new Set([
+          ...this.availableJobDefinitions.map(definition => `job_${definition.id}`),
+          ...this.availableCoderTrainings.map(training => `training_${training.id}`)
+        ]);
+        const currentScopes = (this.scopeControl.value || [])
+          .filter(scope => validScopes.has(scope));
+
+        if (currentScopes.length > 0) {
+          this.scopeControl.setValue(currentScopes, { emitEvent: false });
+        } else if (this.availableJobDefinitions.length > 0) {
           this.scopeControl.setValue([`job_${this.availableJobDefinitions[0].id}`], { emitEvent: false });
+        } else if (this.availableCoderTrainings.length > 0) {
+          this.scopeControl.setValue([`training_${this.availableCoderTrainings[0].id}`], { emitEvent: false });
+        } else {
+          this.scopeControl.setValue([], { emitEvent: false });
+        }
+
+        this.filterOptionsLoaded = true;
+        if (!this.hasScopeOptions()) {
+          this.clearReviewData();
+          return;
         }
 
         this.loadData();
@@ -223,11 +245,48 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
 
   private getJobDefinitionLabel(definition: JobDefinition): string {
     const definitionId = definition.id ?? 0;
-    const status = definition.status ? ` (${definition.status})` : '';
-    return `Definition #${definitionId}${status}`;
+    const statusLabel = this.getJobDefinitionStatusLabel(definition.status);
+    const status = statusLabel ? ` (${statusLabel})` : '';
+    const jobsCount = definition.createdJobsCount ?? 0;
+    return `Definition #${definitionId}${status}, ${jobsCount} ${this.getJobCountLabel(jobsCount)}`;
+  }
+
+  private getCoderTrainingLabel(training: CoderTraining): string {
+    const jobsCount = training.jobsCount ?? 0;
+    const trainingLabel = training.label || this.translateService.instant('double-coded-review.filter.training-fallback', {
+      id: training.id
+    });
+    return `${trainingLabel} (${jobsCount} ${this.getJobCountLabel(jobsCount)})`;
+  }
+
+  private getJobDefinitionStatusLabel(status: JobDefinition['status']): string {
+    if (!status) {
+      return '';
+    }
+
+    const statusKey = status === 'pending_review' ?
+      'coding-job-definition-dialog.status.definition.pending-review' :
+      `coding-job-definition-dialog.status.definition.${status}`;
+    return this.translateService.instant(statusKey);
+  }
+
+  private getJobCountLabel(count: number): string {
+    return this.translateService.instant(
+      count === 1 ?
+        'double-coded-review.filter.job-count-singular' :
+        'double-coded-review.filter.job-count-plural'
+    );
+  }
+
+  hasScopeOptions(): boolean {
+    return this.availableJobDefinitions.length > 0 || this.availableCoderTrainings.length > 0;
   }
 
   getScopeSelectionSummary(): string {
+    if (this.filterOptionsLoaded && !this.hasScopeOptions()) {
+      return this.translateService.instant('double-coded-review.filter.scope-none');
+    }
+
     const selectedScopes = this.scopeControl.value || [];
     if (selectedScopes.length === 0) {
       return this.translateService.instant('double-coded-review.filter.scope-all');
@@ -253,7 +312,8 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
 
     if (scope.startsWith('training_')) {
       const scopeId = parseInt(scope.replace('training_', ''), 10);
-      return this.availableCoderTrainings.find(training => training.id === scopeId)?.label || `Training #${scopeId}`;
+      return this.availableCoderTrainings.find(training => training.id === scopeId)?.label ||
+        this.translateService.instant('double-coded-review.filter.training-fallback', { id: scopeId });
     }
 
     return scope;
@@ -364,6 +424,35 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     return item.coderResults.find(result => result.jobId === meta.jobId);
   }
 
+  isGeoGebraAnswer(value: string | null | undefined): boolean {
+    const normalizedValue = (value || '').trim();
+    return normalizedValue.startsWith('UEsD') || /^data:[^,]*;base64,UEsD/i.test(normalizedValue);
+  }
+
+  getAnswerDisplay(value: string | null | undefined): string {
+    if (!value) {
+      return 'N/A';
+    }
+
+    if (this.isGeoGebraAnswer(value)) {
+      return this.translateService.instant('double-coded-review.values.geogebra-answer');
+    }
+
+    return value;
+  }
+
+  getAnswerTooltip(value: string | null | undefined): string {
+    if (!value) {
+      return 'N/A';
+    }
+
+    if (this.isGeoGebraAnswer(value)) {
+      return this.translateService.instant('double-coded-review.values.geogebra-tooltip');
+    }
+
+    return value;
+  }
+
   openReplay(responseId: number): void {
     const workspaceId = this.appService.selectedWorkspaceId;
 
@@ -471,6 +560,11 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       return;
     }
 
+    if (this.filterOptionsLoaded && !this.hasScopeOptions()) {
+      this.clearReviewData();
+      return;
+    }
+
     this.testPersonCodingService.getDoubleCodedVariablesForReview(
       workspaceId,
       this.currentPage,
@@ -505,6 +599,17 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
         this.isLoading = false;
       }
     });
+  }
+
+  private clearReviewData(): void {
+    this.allData = [];
+    this.dataSource.data = [];
+    this.totalItems = 0;
+    this.updateDisplayedColumns([]);
+    if (this.selectionForm) {
+      this.updateForm();
+    }
+    this.isLoading = false;
   }
 
   onPageChange(event: PageEvent): void {

--- a/apps/frontend/src/app/high-coverage-component-methods.spec.ts
+++ b/apps/frontend/src/app/high-coverage-component-methods.spec.ts
@@ -469,6 +469,128 @@ describe('high coverage component method smoke tests', () => {
     })).toBe(false);
   });
 
+  it('keeps GeoGebra answers compact in double-coded review rows', async () => {
+    const { DoubleCodedReviewComponent } = await import('./coding/components/double-coded-review/double-coded-review.component');
+    const instance = createInstance(DoubleCodedReviewComponent as ConstructorExport) as {
+      isGeoGebraAnswer: (value: string) => boolean;
+      getAnswerDisplay: (value: string) => string;
+      getAnswerTooltip: (value: string) => string;
+    };
+
+    expect(instance.isGeoGebraAnswer('UEsDBAoAAAAAA')).toBe(true);
+    expect(instance.isGeoGebraAnswer('data:application/zip;base64,UEsDBAoAAAAAA')).toBe(true);
+    expect(instance.getAnswerDisplay('UEsDBAoAAAAAA')).toBe('double-coded-review.values.geogebra-answer');
+    expect(instance.getAnswerTooltip('UEsDBAoAAAAAA')).toBe('double-coded-review.values.geogebra-tooltip');
+  });
+
+  it('defaults double-coded review scope to the newest active job definition', async () => {
+    const { DoubleCodedReviewComponent } = await import('./coding/components/double-coded-review/double-coded-review.component');
+    const instance = createInstance(DoubleCodedReviewComponent as ConstructorExport) as {
+      appService: { selectedWorkspaceId: number };
+      scopeControl: FormControl<string[]>;
+      availableJobDefinitions: Array<{ id: number; label: string }>;
+      availableCoderTrainings: Array<{ id: number; label: string }>;
+      codingFacadeService: {
+        getJobDefinitions: jest.Mock;
+        getCoderTrainings: jest.Mock;
+      };
+      translateService: { instant: jest.Mock };
+      destroy$: Subject<void>;
+      loadData: jest.Mock;
+      hasScopeOptions: () => boolean;
+      loadFilterOptions: () => void;
+    };
+
+    instance.appService = { selectedWorkspaceId: 1 };
+    instance.scopeControl = new FormControl<string[]>(['job_99']) as FormControl<string[]>;
+    instance.availableJobDefinitions = [];
+    instance.availableCoderTrainings = [];
+    instance.destroy$ = new Subject<void>();
+    instance.loadData = jest.fn();
+    instance.translateService = {
+      instant: jest.fn((key: string, params?: Record<string, unknown>) => {
+        const translations: Record<string, string> = {
+          'coding-job-definition-dialog.status.definition.approved': 'Genehmigt',
+          'coding-job-definition-dialog.status.definition.pending-review': 'Warten auf Genehmigung',
+          'double-coded-review.filter.job-count-singular': 'Kodierjob',
+          'double-coded-review.filter.job-count-plural': 'Kodierjobs',
+          'double-coded-review.filter.training-fallback': `Schulung #${params?.id}`
+        };
+        return translations[key] || key;
+      })
+    };
+    instance.codingFacadeService = {
+      getJobDefinitions: jest.fn(() => of([
+        { id: 1, status: 'approved', createdJobsCount: 0 },
+        { id: 3, status: 'approved', createdJobsCount: 2 },
+        { id: 2, status: 'pending_review', createdJobsCount: 1 }
+      ])),
+      getCoderTrainings: jest.fn(() => of([
+        { id: 5, label: 'Training A', jobsCount: 0 },
+        { id: 6, label: 'Training B', jobsCount: 1 }
+      ]))
+    };
+
+    instance.loadFilterOptions();
+
+    expect(instance.scopeControl.value).toEqual(['job_3']);
+    expect(instance.availableJobDefinitions.map(definition => definition.id)).toEqual([3, 2]);
+    expect(instance.availableCoderTrainings.map(training => training.id)).toEqual([6]);
+    expect(instance.availableJobDefinitions.map(definition => definition.label)).toEqual([
+      'Definition #3 (Genehmigt), 2 Kodierjobs',
+      'Definition #2 (Warten auf Genehmigung), 1 Kodierjob'
+    ]);
+    expect(instance.availableCoderTrainings[0].label).toBe('Training B (1 Kodierjob)');
+    expect(instance.hasScopeOptions()).toBe(true);
+    expect(instance.loadData).toHaveBeenCalled();
+  });
+
+  it('does not load double-coded review data without active scopes', async () => {
+    const { DoubleCodedReviewComponent } = await import('./coding/components/double-coded-review/double-coded-review.component');
+    const instance = createInstance(DoubleCodedReviewComponent as ConstructorExport) as {
+      appService: { selectedWorkspaceId: number };
+      scopeControl: FormControl<string[]>;
+      availableJobDefinitions: Array<{ id: number; label: string }>;
+      availableCoderTrainings: Array<{ id: number; label: string }>;
+      codingFacadeService: {
+        getJobDefinitions: jest.Mock;
+        getCoderTrainings: jest.Mock;
+      };
+      destroy$: Subject<void>;
+      loadData: jest.Mock;
+      allData: unknown[];
+      dataSource: MatTableDataSource<unknown>;
+      totalItems: number;
+      loadFilterOptions: () => void;
+      getScopeSelectionSummary: () => string;
+    };
+
+    instance.appService = { selectedWorkspaceId: 1 };
+    instance.scopeControl = new FormControl<string[]>(['job_99']) as FormControl<string[]>;
+    instance.availableJobDefinitions = [{ id: 99, label: 'Stale scope' }];
+    instance.availableCoderTrainings = [];
+    instance.destroy$ = new Subject<void>();
+    instance.loadData = jest.fn();
+    instance.allData = [sampleReviewItem];
+    instance.dataSource = new MatTableDataSource<unknown>([sampleReviewItem]);
+    instance.totalItems = 1;
+    instance.codingFacadeService = {
+      getJobDefinitions: jest.fn(() => of([{ id: 1, status: 'approved', createdJobsCount: 0 }])),
+      getCoderTrainings: jest.fn(() => of([{ id: 5, label: 'Training A', jobsCount: 0 }]))
+    };
+
+    instance.loadFilterOptions();
+
+    expect(instance.scopeControl.value).toEqual([]);
+    expect(instance.availableJobDefinitions).toEqual([]);
+    expect(instance.availableCoderTrainings).toEqual([]);
+    expect(instance.allData).toEqual([]);
+    expect(instance.dataSource.data).toEqual([]);
+    expect(instance.totalItems).toBe(0);
+    expect(instance.getScopeSelectionSummary()).toBe('double-coded-review.filter.scope-none');
+    expect(instance.loadData).not.toHaveBeenCalled();
+  });
+
   it.each([
     [
       'DoubleCodedReviewComponent',

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1967,6 +1967,10 @@
       "scope-summary": "{{jobs}} Definition(en), {{trainings}} Schulung(en)",
       "scope-job-definitions": "Job-Definitionen",
       "scope-trainings": "Schulungen",
+      "scope-none": "Keine Job-Definition oder Schulung mit aktiven Kodierjobs gefunden",
+      "training-fallback": "Schulung #{{id}}",
+      "job-count-singular": "Kodierjob",
+      "job-count-plural": "Kodierjobs",
       "search-label": "Suchen",
       "search-placeholder": "Einheit, Variable, Login, Code oder Gruppe...",
       "coder-label": "Kodierer",
@@ -1985,6 +1989,10 @@
       "coder-notes": "Anmerkungen der Kodierer",
       "no-notes": "Keine Anmerkungen vorhanden.",
       "person-context": "Personen-Kontext"
+    },
+    "values": {
+      "geogebra-answer": "GeoGebra-Antwort",
+      "geogebra-tooltip": "Diese Antwort enthält GeoGebra-Daten. Öffnen Sie das Replay, um sie zu prüfen."
     },
     "statistics": {
       "showing-conflicts": "Zeige {{visible}} von {{total}} Konflikten",


### PR DESCRIPTION
## Summary
- filters double-coded review scopes to active job definitions and trainings
- prevents unscoped loading when no active review scope exists
- ignores deleted or orphaned coding jobs during review assembly
- shows GeoGebra answers compactly and keeps Replay accessible

## Issues
Refs #441, #443, #444, #445.
Builds on the conflict-detection fix from #490.

## Verification
- nx lint frontend
- nx lint backend
- nx test frontend --testPathPattern=high-coverage-component-methods.spec.ts --runInBand
- nx test backend --testFile=coding-review.service.spec.ts --runInBand
- git diff --check