### PR TITLE
Improve double-coded review decision column

### DIFF
--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
@@ -20,7 +20,6 @@
         <mat-label>{{ 'double-coded-review.decision.select-label' | translate }}</mat-label>
         <mat-select
           [formControl]="getItemControl(element)"
-          [disabled]="isLoading"
           (selectionChange)="onSelectionChange(element, $event.value)">
           <mat-select-trigger>
             @if (getSelectedDecisionResult(element); as selectedResult) {

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
@@ -1,3 +1,82 @@
+<ng-template #decisionCell let-element="element">
+  <div class="selection-cell">
+    <div
+      class="decision-status"
+      [ngClass]="getDecisionStatusClass(element)"
+      [matTooltip]="element.isResolved ? ('double-coded-review.applied' | translate) : (getCodedCount(element) + '/' + element.coderResults.length + ' ' + ('double-coded-review.coders-done' | translate))">
+      <mat-icon>{{ getDecisionStatusIcon(element) }}</mat-icon>
+      <span class="status-label">{{ getDecisionStatusLabel(element) }}</span>
+      @if (!element.isResolved) {
+        <span class="progress-dots">
+          @for (result of element.coderResults; track result.coderId + '-' + result.jobId) {
+            <span class="dot" [ngClass]="result.code !== null ? 'filled' : 'empty'"></span>
+          }
+        </span>
+      }
+    </div>
+
+    @if (!element.isResolved) {
+      <mat-form-field class="decision-select-field" appearance="outline">
+        <mat-label>{{ 'double-coded-review.decision.select-label' | translate }}</mat-label>
+        <mat-select
+          [formControl]="getItemControl(element)"
+          [disabled]="isLoading"
+          (selectionChange)="onSelectionChange(element, $event.value)">
+          <mat-select-trigger>
+            @if (getSelectedDecisionResult(element); as selectedResult) {
+              <span class="decision-trigger">
+                <span class="decision-code-value" [matTooltip]="getCodeLabel(selectedResult.code)">
+                  {{ getCodeDisplay(selectedResult.code) || 'N/A' }}
+                </span>
+                @if (selectedResult.score !== null) {
+                  <span class="decision-score-value">({{ selectedResult.score }})</span>
+                }
+                <span class="decision-source">{{ selectedResult.coderName }}</span>
+              </span>
+            } @else {
+              <span class="pending-coder">{{ 'double-coded-review.decision.no-selection' | translate }}</span>
+            }
+          </mat-select-trigger>
+
+          @for (result of element.coderResults; track result.coderId + '-' + result.jobId) {
+            <mat-option [value]="result.jobId.toString()" [disabled]="result.code === null">
+              <span class="decision-option" [matTooltip]="result.jobName || ''">
+                <span class="decision-option-source">{{ result.coderName }}</span>
+                <span class="decision-option-code">{{ getCodeDisplay(result.code) || 'N/A' }}</span>
+                @if (result.score !== null) {
+                  <span class="decision-option-score">({{ result.score }})</span>
+                }
+                @if (result.code === null) {
+                  <span class="pending-coder">({{ 'double-coded-review.pending' | translate }})</span>
+                }
+              </span>
+            </mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      @if (shouldShowDecisionComment(element)) {
+        <mat-form-field class="comment-field" appearance="outline">
+          <mat-label>{{ 'double-coded-review.comment-label' | translate }}</mat-label>
+          <textarea matInput
+                    [formControl]="getCommentControl(element)"
+                    rows="2"
+                    [placeholder]="'double-coded-review.comment-placeholder' | translate"></textarea>
+        </mat-form-field>
+      }
+
+      <div class="row-actions">
+        <button mat-mini-fab color="primary"
+                [disabled]="!getItemControl(element).value || isLoading"
+                (click)="applySingleDecision(element)"
+                matTooltip="{{ 'double-coded-review.apply-single-tooltip' | translate }}">
+          <mat-icon>check</mat-icon>
+        </button>
+      </div>
+    }
+  </div>
+</ng-template>
+
 <div *ngIf="dialogRef" class="dialog-layout">
   <h1 mat-dialog-title>
     <mat-icon>compare</mat-icon>
@@ -216,58 +295,7 @@
                   <ng-container matColumnDef="selection">
                     <th mat-header-cell *matHeaderCellDef>{{ getSelectionColumnHeader() }}</th>
                     <td mat-cell *matCellDef="let element; let i = index" [ngClass]="{'incomplete-row': !isAllCodersDone(element)}">
-                      <div class="selection-cell">
-                        <div class="coding-status" 
-                             [ngClass]="element.isResolved ? 'resolved' : (isAllCodersDone(element) ? 'complete' : 'incomplete')"
-                             [matTooltip]="element.isResolved ? ('double-coded-review.applied' | translate) : (getCodedCount(element) + '/' + element.coderResults.length + ' ' + ('double-coded-review.coders-done' | translate))">
-                          @if (hasConflict(element) && !element.isResolved) {
-                            <mat-icon class="conflict-icon" color="warn" [matTooltip]="'double-coded-review.conflict-indicator' | translate">warning</mat-icon>
-                          }
-                          <div class="progress-dots" *ngIf="!element.isResolved">
-                            @for (result of element.coderResults; track $index) {
-                              <div class="dot" [ngClass]="result.code !== null ? 'filled' : 'empty'"></div>
-                            }
-                          </div>
-                          <mat-icon *ngIf="element.isResolved" color="primary">check_circle</mat-icon>
-                          <span *ngIf="element.isResolved" class="status-label resolved">{{ 'double-coded-review.applied' | translate }}</span>
-                        </div>
-
-                        <ng-container *ngIf="!element.isResolved">
-                          <mat-radio-group
-                            [formControlName]="getItemControlName(element)"
-                            (change)="onSelectionChange(element, $event.value)"
-                            class="coder-selection">
-                            @for (result of element.coderResults; track result.coderId + '-' + result.jobId) {
-                              <mat-radio-button [value]="result.jobId.toString()" class="coder-radio" [disabled]="result.code === null">
-                                  <span class="radio-coder-name" [matTooltip]="result.jobName || ''">{{ result.coderName }}</span>
-                                  <span class="radio-coder-code">{{ getCodeDisplay(result.code) || 'N/A' }}</span>
-                                  @if (result.code === null) {
-                                    <span class="pending-coder">({{ 'double-coded-review.pending' | translate }})</span>
-                                  }
-                              </mat-radio-button>
-                            }
-                          </mat-radio-group>
-                          
-                          @if (hasConflict(element) || selectionForm.get(getCommentControlName(element))?.value) {
-                            <mat-form-field class="comment-field" appearance="outline">
-                              <mat-label>{{ 'double-coded-review.comment-label' | translate }}</mat-label>
-                              <textarea matInput
-                                        [formControlName]="getCommentControlName(element)"
-                                        rows="2"
-                                        [placeholder]="'double-coded-review.comment-placeholder' | translate"></textarea>
-                            </mat-form-field>
-                          }
-
-                          <div class="row-actions">
-                            <button mat-mini-fab color="primary"
-                                    [disabled]="!selectionForm.get(getItemControlName(element))?.value || isLoading"
-                                    (click)="applySingleDecision(element)"
-                                    matTooltip="{{ 'double-coded-review.apply-single-tooltip' | translate }}">
-                              <mat-icon>check</mat-icon>
-                            </button>
-                          </div>
-                        </ng-container>
-                      </div>
+                      <ng-container *ngTemplateOutlet="decisionCell; context: { element: element }"></ng-container>
                     </td>
                   </ng-container>
 
@@ -518,58 +546,7 @@
                 <ng-container matColumnDef="selection">
                   <th mat-header-cell *matHeaderCellDef>{{ getSelectionColumnHeader() }}</th>
                   <td mat-cell *matCellDef="let element; let i = index" [ngClass]="{'incomplete-row': !isAllCodersDone(element)}">
-                    <div class="selection-cell">
-                      <div class="coding-status" 
-                           [ngClass]="element.isResolved ? 'resolved' : (isAllCodersDone(element) ? 'complete' : 'incomplete')"
-                           [matTooltip]="element.isResolved ? ('double-coded-review.applied' | translate) : (getCodedCount(element) + '/' + element.coderResults.length + ' ' + ('double-coded-review.coders-done' | translate))">
-                        @if (hasConflict(element) && !element.isResolved) {
-                          <mat-icon class="conflict-icon" color="warn" [matTooltip]="'double-coded-review.conflict-indicator' | translate">warning</mat-icon>
-                        }
-                        <div class="progress-dots" *ngIf="!element.isResolved">
-                          @for (result of element.coderResults; track $index) {
-                            <div class="dot" [ngClass]="result.code !== null ? 'filled' : 'empty'"></div>
-                          }
-                        </div>
-                        <mat-icon *ngIf="element.isResolved" color="primary">check_circle</mat-icon>
-                        <span *ngIf="element.isResolved" class="status-label resolved">{{ 'double-coded-review.applied' | translate }}</span>
-                      </div>
-
-                      <ng-container *ngIf="!element.isResolved">
-                        <mat-radio-group
-                          [formControlName]="getItemControlName(element)"
-                          (change)="onSelectionChange(element, $event.value)"
-                          class="coder-selection">
-                          @for (result of element.coderResults; track result.coderId + '-' + result.jobId) {
-                            <mat-radio-button [value]="result.jobId.toString()" class="coder-radio" [disabled]="result.code === null">
-                                <span class="radio-coder-name" [matTooltip]="result.jobName || ''">{{ result.coderName }}</span>
-                                <span class="radio-coder-code">{{ getCodeDisplay(result.code) || 'N/A' }}</span>
-                                @if (result.code === null) {
-                                  <span class="pending-coder">({{ 'double-coded-review.pending' | translate }})</span>
-                                }
-                            </mat-radio-button>
-                          }
-                        </mat-radio-group>
-                        
-                        @if (hasConflict(element) || selectionForm.get(getCommentControlName(element))?.value) {
-                          <mat-form-field class="comment-field" appearance="outline">
-                            <mat-label>{{ 'double-coded-review.comment-label' | translate }}</mat-label>
-                            <textarea matInput
-                                      [formControlName]="getCommentControlName(element)"
-                                      rows="2"
-                                      [placeholder]="'double-coded-review.comment-placeholder' | translate"></textarea>
-                          </mat-form-field>
-                        }
-
-                        <div class="row-actions">
-                          <button mat-mini-fab color="primary"
-                                  [disabled]="!selectionForm.get(getItemControlName(element))?.value || isLoading"
-                                  (click)="applySingleDecision(element)"
-                                  matTooltip="{{ 'double-coded-review.apply-single-tooltip' | translate }}">
-                            <mat-icon>check</mat-icon>
-                          </button>
-                        </div>
-                      </ng-container>
-                    </div>
+                    <ng-container *ngTemplateOutlet="decisionCell; context: { element: element }"></ng-container>
                   </td>
                 </ng-container>
 

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.scss
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.scss
@@ -393,25 +393,73 @@
       .selection-cell {
         display: flex;
         flex-direction: column;
-        gap: 10px;
+        gap: 8px;
+        min-width: 0;
 
-        .coder-selection {
+        .decision-trigger,
+        .decision-option {
           display: flex;
-          flex-direction: column;
-          gap: 6px;
+          align-items: center;
+          min-width: 0;
+        }
 
-          .coder-radio {
-            margin-bottom: 2px;
+        .decision-source {
+          max-width: 100%;
+          overflow: hidden;
+          color: #64748b;
+          font-size: 12px;
+          line-height: 1.3;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .decision-trigger {
+          gap: 5px;
+
+          .decision-source {
+            margin-left: 2px;
           }
         }
 
-        .radio-coder-name {
-          margin-right: 6px;
+        .decision-code-value {
+          color: #1e293b;
+          font-weight: 700;
         }
 
-        .radio-coder-code {
-          font-weight: 700;
-          color: #1e293b;
+        .decision-score-value {
+          color: #64748b;
+          font-size: 12px;
+        }
+
+        .decision-select-field {
+          width: 100%;
+
+          ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+            display: none;
+          }
+        }
+
+        .decision-option {
+          gap: 6px;
+          width: 100%;
+
+          .decision-option-source {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+
+          .decision-option-code {
+            margin-left: auto;
+            color: #1e293b;
+            font-weight: 700;
+          }
+
+          .decision-option-score {
+            color: #64748b;
+            font-size: 12px;
+          }
         }
 
         .comment-field {
@@ -429,7 +477,7 @@
   }
 }
 
-.coding-status {
+.decision-status {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -439,17 +487,29 @@
   background-color: #f5f5f5;
   color: #666;
   width: fit-content;
+  max-width: 100%;
   margin-top: 4px;
   cursor: help;
+
+  mat-icon {
+    width: 16px;
+    height: 16px;
+    font-size: 16px;
+  }
 
   &.incomplete {
     background-color: #fff3e0;
     color: #ef6c00;
   }
 
-  &.complete {
+  &.match {
     background-color: #e8f5e9;
     color: #2e7d32;
+  }
+
+  &.conflict {
+    background-color: #ffebee;
+    color: #c62828;
   }
 
   &.resolved {
@@ -459,19 +519,14 @@
     border: 1px solid #1976d2;
   }
 
-  .conflict-icon {
-    font-size: 16px;
-    width: 16px;
-    height: 16px;
-  }
-
   .status-label {
-    &.resolved {
-      font-weight: 600;
-      text-transform: uppercase;
-      font-size: 10px;
-      letter-spacing: 0.5px;
-    }
+    min-width: 0;
+    overflow: hidden;
+    font-size: 11px;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
   }
 
   .progress-dots {
@@ -494,6 +549,32 @@
         border: 1px solid #bdbdbd;
       }
     }
+  }
+}
+
+.decision-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+
+  .decision-option-source {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .decision-option-code {
+    margin-left: auto;
+    color: #1e293b;
+    font-weight: 700;
+  }
+
+  .decision-option-score {
+    color: #64748b;
+    font-size: 12px;
   }
 }
 

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
@@ -1,0 +1,174 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { AppService } from '../../../core/services/app.service';
+import { WorkspaceBackendService } from '../../../workspace/services/workspace-backend.service';
+import { CodingFacadeService } from '../../../services/facades/coding-facade.service';
+import { TestPersonCodingService } from '../../services/test-person-coding.service';
+import { CodingStatisticsService } from '../../services/coding-statistics.service';
+import { DoubleCodedReviewComponent } from './double-coded-review.component';
+
+describe('DoubleCodedReviewComponent', () => {
+  let component: DoubleCodedReviewComponent;
+  let fixture: ComponentFixture<DoubleCodedReviewComponent>;
+  let overlayContainer: OverlayContainer;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        DoubleCodedReviewComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: AppService,
+          useValue: {
+            selectedWorkspaceId: 1,
+            authData: { userName: 'Reviewer' },
+            loggedUser: undefined,
+            createOwnToken: jest.fn(() => of('token'))
+          }
+        },
+        {
+          provide: WorkspaceBackendService,
+          useValue: {
+            getWorkspaceCoders: jest.fn(() => of({
+              data: [
+                { userId: 10, username: 'Coder A' },
+                { userId: 20, username: 'Coder B' }
+              ]
+            }))
+          }
+        },
+        {
+          provide: CodingFacadeService,
+          useValue: {
+            getJobDefinitions: jest.fn(() => of([
+              { id: 99, status: 'approved', createdJobsCount: 2 }
+            ])),
+            getCoderTrainings: jest.fn(() => of([]))
+          }
+        },
+        {
+          provide: TestPersonCodingService,
+          useValue: {
+            getDoubleCodedVariablesForReview: jest.fn(() => of({
+              data: [
+                {
+                  responseId: 501,
+                  unitName: 'Unit A',
+                  variableId: 'VAR_1',
+                  personLogin: 'person-1',
+                  personCode: 'P001',
+                  bookletName: 'Booklet 1',
+                  givenAnswer: 'answer',
+                  isResolved: false,
+                  coderResults: [
+                    {
+                      coderId: 10,
+                      coderName: 'Coder A',
+                      jobId: 1001,
+                      jobName: 'Definition 99 / A',
+                      code: 1,
+                      score: 0,
+                      notes: null,
+                      supervisorComment: null,
+                      codedAt: '2026-05-20T09:00:00.000Z'
+                    },
+                    {
+                      coderId: 20,
+                      coderName: 'Coder B',
+                      jobId: 1002,
+                      jobName: 'Definition 99 / B',
+                      code: 2,
+                      score: 1,
+                      notes: 'Check manually',
+                      supervisorComment: null,
+                      codedAt: '2026-05-20T09:10:00.000Z'
+                    }
+                  ]
+                }
+              ],
+              total: 1,
+              page: 1,
+              limit: 50
+            })),
+            applyDoubleCodedResolutions: jest.fn(() => of({
+              success: true,
+              appliedCount: 1,
+              failedCount: 0,
+              skippedCount: 0,
+              message: 'ok'
+            }))
+          }
+        },
+        {
+          provide: CodingStatisticsService,
+          useValue: {
+            getReplayUrl: jest.fn(() => of({ replayUrl: '' }))
+          }
+        },
+        {
+          provide: MatSnackBar,
+          useValue: { open: jest.fn() }
+        },
+        {
+          provide: MatDialog,
+          useValue: {
+            open: jest.fn(() => ({ afterClosed: () => of(false) }))
+          }
+        }
+      ]
+    }).compileComponents();
+
+    overlayContainer = TestBed.inject(OverlayContainer);
+    fixture = TestBed.createComponent(DoubleCodedReviewComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('renders the reusable decision cell and updates its selection through Material select', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const selectionCell = nativeElement.querySelector('td.mat-column-selection .selection-cell') as HTMLElement;
+
+    expect(selectionCell).toBeTruthy();
+    expect(selectionCell.querySelector('.decision-status.conflict')?.textContent)
+      .toContain('double-coded-review.decision.status-conflict');
+    expect(selectionCell.querySelector('.decision-code-value')?.textContent?.trim()).toBe('1');
+    expect(selectionCell.querySelector('.decision-source')?.textContent).toContain('Coder A');
+    expect(selectionCell.querySelector('.comment-field')).toBeTruthy();
+
+    const selectTrigger = selectionCell.querySelector('.mat-mdc-select-trigger') as HTMLElement;
+    selectTrigger.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const options = Array.from(
+      overlayContainer.getContainerElement().querySelectorAll('mat-option')
+    ) as HTMLElement[];
+
+    expect(options).toHaveLength(2);
+
+    options[1].click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const reviewItem = component.dataSource.data[0];
+    expect(component.selectionForm.get(component.getItemControlName(reviewItem))?.value).toBe('1002');
+    expect(selectionCell.querySelector('.decision-code-value')?.textContent?.trim()).toBe('2');
+    expect(selectionCell.querySelector('.decision-source')?.textContent).toContain('Coder B');
+  });
+});

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -8,7 +8,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatPaginatorModule, PageEvent, MatPaginatorIntl } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatRadioModule } from '@angular/material/radio';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSnackBarModule, MatSnackBar } from '@angular/material/snack-bar';
@@ -80,7 +79,6 @@ interface CoderColumnMeta {
     MatIconModule,
     MatPaginatorModule,
     MatProgressSpinnerModule,
-    MatRadioModule,
     MatFormFieldModule,
     MatInputModule,
     MatSnackBarModule,
@@ -345,6 +343,25 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     return `comment_${item.responseId}`;
   }
 
+  getItemControl(item: DoubleCodedItem): FormControl {
+    return this.getOrCreateFormControl(this.getItemControlName(item));
+  }
+
+  getCommentControl(item: DoubleCodedItem): FormControl {
+    return this.getOrCreateFormControl(this.getCommentControlName(item));
+  }
+
+  private getOrCreateFormControl(controlName: string): FormControl {
+    const control = this.selectionForm.get(controlName);
+    if (control instanceof FormControl) {
+      return control;
+    }
+
+    const fallbackControl = new FormControl('');
+    this.selectionForm.addControl(controlName, fallbackControl);
+    return fallbackControl;
+  }
+
   private updateForm(): void {
     // Clear existing form controls
     Object.keys(this.selectionForm.controls).forEach(key => {
@@ -356,14 +373,14 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     currentItems.forEach(item => {
       const controlName = this.getItemControlName(item);
 
-      // Look for an existing resolution (a coder result that has a supervisor comment)
       const resolvedResult = item.coderResults.find(cr => !!cr.supervisorComment);
+      const firstCodedResult = item.coderResults.find(cr => cr.code !== null);
 
       let defaultValue = '';
       if (resolvedResult) {
         defaultValue = resolvedResult.jobId.toString();
-      } else if (item.coderResults.length > 0) {
-        defaultValue = item.coderResults[0].jobId.toString();
+      } else if (firstCodedResult) {
+        defaultValue = firstCodedResult.jobId.toString();
       }
 
       this.selectionForm.addControl(controlName, new FormControl(defaultValue));
@@ -422,6 +439,57 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     const meta = this.coderColumnMeta[columnId];
     if (!meta) return undefined;
     return item.coderResults.find(result => result.jobId === meta.jobId);
+  }
+
+  getSelectedDecisionResult(item: DoubleCodedItem): CoderResult | undefined {
+    const selectedJobId = this.selectionForm?.get(this.getItemControlName(item))?.value;
+    const selectedResult = selectedJobId ?
+      item.coderResults.find(result => result.jobId.toString() === selectedJobId) :
+      item.selectedCoderResult;
+
+    return selectedResult && selectedResult.code !== null ? selectedResult : undefined;
+  }
+
+  getDecisionStatusClass(item: DoubleCodedItem): string {
+    if (item.isResolved) {
+      return 'resolved';
+    }
+
+    if (this.hasConflict(item)) {
+      return 'conflict';
+    }
+
+    return this.isAllCodersDone(item) ? 'match' : 'incomplete';
+  }
+
+  getDecisionStatusIcon(item: DoubleCodedItem): string {
+    const statusClass = this.getDecisionStatusClass(item);
+
+    switch (statusClass) {
+      case 'resolved':
+        return 'check_circle';
+      case 'conflict':
+        return 'warning';
+      case 'match':
+        return 'task_alt';
+      default:
+        return 'pending';
+    }
+  }
+
+  getDecisionStatusLabel(item: DoubleCodedItem): string {
+    const statusClass = this.getDecisionStatusClass(item);
+
+    if (statusClass === 'resolved') {
+      return this.translateService.instant('double-coded-review.applied');
+    }
+
+    return this.translateService.instant(`double-coded-review.decision.status-${statusClass}`);
+  }
+
+  shouldShowDecisionComment(item: DoubleCodedItem): boolean {
+    return this.hasConflict(item) ||
+      !!this.selectionForm?.get(this.getCommentControlName(item))?.value;
   }
 
   isGeoGebraAnswer(value: string | null | undefined): boolean {
@@ -582,7 +650,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       next: response => {
         this.allData = response.data.map(item => ({
           ...item,
-          selectedCoderResult: item.coderResults[0]
+          selectedCoderResult: item.coderResults.find(result => result.code !== null)
         }));
         this.updateDisplayedColumns(this.allData);
         this.dataSource.data = this.allData;
@@ -620,7 +688,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
 
   onSelectionChange(item: DoubleCodedItem, selectedJobId: string): void {
     const selectedResult = item.coderResults.find(cr => cr.jobId.toString() === selectedJobId);
-    if (selectedResult) {
+    if (selectedResult && selectedResult.code !== null) {
       item.selectedCoderResult = selectedResult;
     }
   }
@@ -712,7 +780,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
 
     if (selectedJobId) {
       const selectedResult = item.coderResults.find(cr => cr.jobId.toString() === selectedJobId);
-      if (selectedResult) {
+      if (selectedResult && selectedResult.code !== null) {
         const decision: { responseId: number; selectedJobId: number; resolutionComment?: string } = {
           responseId: item.responseId,
           selectedJobId: selectedResult.jobId

--- a/apps/frontend/src/app/high-coverage-component-methods.spec.ts
+++ b/apps/frontend/src/app/high-coverage-component-methods.spec.ts
@@ -483,6 +483,64 @@ describe('high coverage component method smoke tests', () => {
     expect(instance.getAnswerTooltip('UEsDBAoAAAAAA')).toBe('double-coded-review.values.geogebra-tooltip');
   });
 
+  it('formats the current reviewer decision column in double-coded review rows', async () => {
+    const { DoubleCodedReviewComponent } = await import('./coding/components/double-coded-review/double-coded-review.component');
+    const instance = createInstance(DoubleCodedReviewComponent as ConstructorExport) as {
+      selectionForm: FormGroup;
+      translateService: { instant: jest.Mock };
+      getItemControlName: (item: typeof sampleReviewItem) => string;
+      getSelectedDecisionResult: (item: typeof sampleReviewItem) => typeof sampleCoderResult | undefined;
+      getDecisionStatusClass: (item: typeof sampleReviewItem) => string;
+      getDecisionStatusIcon: (item: typeof sampleReviewItem) => string;
+      getDecisionStatusLabel: (item: typeof sampleReviewItem) => string;
+    };
+
+    instance.selectionForm = new FormGroup({
+      [instance.getItemControlName(sampleReviewItem)]: new FormControl('11')
+    });
+    instance.translateService = { instant: jest.fn((key: string) => key) };
+
+    expect(instance.getSelectedDecisionResult(sampleReviewItem)?.coderName).toBe('Coder B');
+    expect(instance.getDecisionStatusClass(sampleReviewItem)).toBe('conflict');
+    expect(instance.getDecisionStatusIcon(sampleReviewItem)).toBe('warning');
+    expect(instance.getDecisionStatusLabel(sampleReviewItem)).toBe('double-coded-review.decision.status-conflict');
+    expect(instance.getDecisionStatusClass({
+      ...sampleReviewItem,
+      coderResults: [
+        { ...sampleCoderResult, code: 1, score: 2 },
+        {
+          ...sampleCoderResult, coderId: 2, coderName: 'Coder B', jobId: 11, code: 1, score: 2
+        }
+      ]
+    })).toBe('match');
+  });
+
+  it('defaults double-coded review decisions to the first completed coder result', async () => {
+    const { DoubleCodedReviewComponent } = await import('./coding/components/double-coded-review/double-coded-review.component');
+    const item = {
+      ...sampleReviewItem,
+      coderResults: [
+        { ...sampleCoderResult, code: null, jobId: 10 },
+        {
+          ...sampleCoderResult, coderId: 2, coderName: 'Coder B', jobId: 11, code: 2
+        }
+      ]
+    };
+    const instance = createInstance(DoubleCodedReviewComponent as ConstructorExport) as {
+      selectionForm: FormGroup;
+      dataSource: MatTableDataSource<unknown>;
+      getItemControlName: (item: unknown) => string;
+      updateForm: () => void;
+    };
+
+    instance.selectionForm = new FormGroup({});
+    instance.dataSource = new MatTableDataSource<unknown>([item]);
+
+    instance.updateForm();
+
+    expect(instance.selectionForm.get(instance.getItemControlName(item))?.value).toBe('11');
+  });
+
   it('defaults double-coded review scope to the newest active job definition', async () => {
     const { DoubleCodedReviewComponent } = await import('./coding/components/double-coded-review/double-coded-review.component');
     const instance = createInstance(DoubleCodedReviewComponent as ConstructorExport) as {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1965,6 +1965,13 @@
     "coders-done": "Kodierer fertig",
     "pending": "Ausstehend",
     "applied": "Angewandt",
+    "decision": {
+      "select-label": "Endgültiger Code",
+      "no-selection": "Kein Code gewählt",
+      "status-conflict": "Abweichung",
+      "status-match": "Übereinstimmung",
+      "status-incomplete": "Unvollständig"
+    },
     "filter": {
       "show-only-conflicts": "Nur Konflikte anzeigen",
       "agreement-label": "Übereinstimmung",


### PR DESCRIPTION
## Summary
- reshapes the double-coded review selection column into a compact reviewer decision column
- keeps coder results as separate comparison columns and shows decision status, selected editable code, and optional comments in one reusable cell
- defaults decisions to the first completed coder result and prevents pending coder results from being applied

## Issues
Closes #441.

## Verification
- `node ./node_modules/nx/bin/nx.js test frontend --testFile=apps/frontend/src/app/high-coverage-component-methods.spec.ts --runInBand`
- `node ./node_modules/nx/bin/nx.js lint frontend`
- `node ./node_modules/nx/bin/nx.js build frontend`
- `git diff --check`
