### PR TITLE
Release 1.15.1 into develop

### DIFF
--- a/apps/frontend/src/app/components/home/home.component.html
+++ b/apps/frontend/src/app/components/home/home.component.html
@@ -9,7 +9,7 @@
     [appTitle]="'Web application for coding'"
     [introHtml]="'appService.appConfig.introHtml'"
     [appName]="'IQB-Kodierbox'"
-    [appVersion]="'1.15.0'"
+    [appVersion]="'1.15.1'"
     [userName]="authData.userName"
     [userLongName]="appService.userProfile.firstName + ' ' + appService.userProfile.lastName"
     [isUserLoggedIn]="Number(authData.userId) > 0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coding-box",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coding-box",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "20.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-box",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepares release `1.15.1` on top of `develop`.

## Changes

- Bumps the project version from `1.15.0` to `1.15.1` in `package.json` and `package-lock.json`.
- Updates the home screen app version display to `1.15.1`.

## Validation

- Parsed `package.json` and `package-lock.json` successfully.
- Ran `git diff --check` successfully.

The production Node 22 runtime stabilization is already included on the branch history.
