### PR TITLE
[codex] Fix coding reset analysis cache invalidation

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
@@ -613,7 +613,8 @@ export class WorkspaceCodingAnalysisController {
     await this.codingAnalysisService.startAnalysis(
       workspace_id,
       undefined,
-      threshold
+      threshold,
+      { forceRefresh: true }
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-analysis-cache-key.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis-cache-key.util.ts
@@ -1,0 +1,13 @@
+export const CODING_ANALYSIS_CACHE_KEY_PREFIX = 'response-analysis';
+
+export function getCodingAnalysisCacheKey(
+  workspaceId: number,
+  matchingFlags: readonly string[],
+  threshold: number
+): string {
+  return `${CODING_ANALYSIS_CACHE_KEY_PREFIX}:${workspaceId}_${[...matchingFlags].sort().join(',')}_t${threshold}`;
+}
+
+export function getCodingAnalysisRunMarkerKey(cacheKey: string): string {
+  return `${cacheKey}:run`;
+}

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
@@ -55,6 +55,7 @@ describe('CodingAnalysisService aggregation settings', () => {
     };
     const cacheService = {
       delete: jest.fn().mockResolvedValue(undefined),
+      set: jest.fn().mockResolvedValue(true),
       deleteByPattern: jest.fn().mockResolvedValue(undefined)
     };
     const jobQueueService = {
@@ -145,11 +146,44 @@ describe('CodingAnalysisService aggregation settings', () => {
     });
 
     expect(cacheService.delete).toHaveBeenCalledWith('response-analysis:7_IGNORE_CASE_t4');
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'response-analysis:7_IGNORE_CASE_t4:run',
+      expect.any(String),
+      0
+    );
     expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith({
       workspaceId: 7,
       matchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
       threshold: 4,
-      cacheKey: 'response-analysis:7_IGNORE_CASE_t4'
+      cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
+      runId: expect.any(String)
     });
+  });
+
+  it('queues a superseding forced restart even when an older workspace analysis is active', async () => {
+    const {
+      service,
+      jobQueueService
+    } = createService();
+    jobQueueService.getActiveCodingAnalysisJob.mockResolvedValue({
+      id: 'old-job',
+      data: {
+        workspaceId: 7,
+        matchingFlags: [],
+        threshold: 2,
+        cacheKey: 'response-analysis:7__t2',
+        runId: 'old-run'
+      }
+    });
+
+    await service.startAnalysis(7, [ResponseMatchingFlag.IGNORE_CASE], 4, {
+      forceRefresh: true
+    });
+
+    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceId: 7,
+      cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
+      runId: expect.any(String)
+    }));
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
@@ -54,9 +54,13 @@ describe('CodingAnalysisService aggregation settings', () => {
       invalidateCache: jest.fn().mockResolvedValue(undefined)
     };
     const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
       deleteByPattern: jest.fn().mockResolvedValue(undefined)
     };
-    const jobQueueService = {};
+    const jobQueueService = {
+      getActiveCodingAnalysisJob: jest.fn().mockResolvedValue(null),
+      addCodingAnalysisJob: jest.fn().mockResolvedValue(undefined)
+    };
 
     const service = new CodingAnalysisService(
       responseRepository,
@@ -76,7 +80,8 @@ describe('CodingAnalysisService aggregation settings', () => {
       codingJobService,
       codingValidationService,
       codingStatisticsService,
-      cacheService
+      cacheService,
+      jobQueueService
     };
   }
 
@@ -126,5 +131,25 @@ describe('CodingAnalysisService aggregation settings', () => {
     expect(codingJobService.setResponseMatchingMode).toHaveBeenCalledWith(7, [
       ResponseMatchingFlag.NO_AGGREGATION
     ]);
+  });
+
+  it('clears the selected analysis cache before a forced restart', async () => {
+    const {
+      service,
+      cacheService,
+      jobQueueService
+    } = createService();
+
+    await service.startAnalysis(7, [ResponseMatchingFlag.IGNORE_CASE], 4, {
+      forceRefresh: true
+    });
+
+    expect(cacheService.delete).toHaveBeenCalledWith('response-analysis:7_IGNORE_CASE_t4');
+    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith({
+      workspaceId: 7,
+      matchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
+      threshold: 4,
+      cacheKey: 'response-analysis:7_IGNORE_CASE_t4'
+    });
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
 import Persons from '../../entities/persons.entity';
 import { Unit } from '../../entities/unit.entity';
 import { Booklet } from '../../entities/booklet.entity';
@@ -21,6 +22,11 @@ import { CodingStatisticsService } from './coding-statistics.service';
 import { CacheService } from '../../../cache/cache.service';
 import { JobQueueService } from '../../../job-queue/job-queue.service';
 import { createAggregationSummary } from './aggregation-metrics.util';
+import {
+  CODING_ANALYSIS_CACHE_KEY_PREFIX,
+  getCodingAnalysisCacheKey,
+  getCodingAnalysisRunMarkerKey
+} from './coding-analysis-cache-key.util';
 
 export interface AggregationSettingsResult {
   success: boolean;
@@ -34,7 +40,6 @@ export interface AggregationSettingsResult {
 @Injectable()
 export class CodingAnalysisService {
   private readonly logger = new Logger(CodingAnalysisService.name);
-  private readonly CACHE_KEY_PREFIX = 'response-analysis';
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -190,16 +195,26 @@ export class CodingAnalysisService {
 
     // Check if job already running
     const activeJob = await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
-    if (activeJob) {
+    if (activeJob && !options.forceRefresh) {
       this.logger.log(`Analysis job already running for workspace ${workspaceId} (Job ID: ${activeJob.id})`);
       return;
     }
+
+    if (activeJob && options.forceRefresh) {
+      this.logger.log(
+        `Superseding active response analysis job for workspace ${workspaceId} (Job ID: ${activeJob.id})`
+      );
+    }
+
+    const runId = randomUUID();
+    await this.cacheService.set(getCodingAnalysisRunMarkerKey(cacheKey), runId, 0);
 
     await this.jobQueueService.addCodingAnalysisJob({
       workspaceId,
       matchingFlags: activeMatchingFlags as unknown as string[],
       threshold: effectiveThreshold,
-      cacheKey
+      cacheKey,
+      runId
     });
     this.logger.log(`Triggered background response analysis for workspace ${workspaceId}`);
   }
@@ -415,7 +430,7 @@ export class CodingAnalysisService {
   async invalidateCache(workspaceId: number): Promise<void> {
     this.logger.log(`Invalidating response analysis cache for workspace ${workspaceId}`);
     // "response-analysis:1_*" matches all variations (flags, thresholds) for workspace 1
-    const pattern = `${this.CACHE_KEY_PREFIX}:${workspaceId}_*`;
+    const pattern = `${CODING_ANALYSIS_CACHE_KEY_PREFIX}:${workspaceId}_*`;
     await this.cacheService.deleteByPattern(pattern);
   }
 
@@ -430,7 +445,7 @@ export class CodingAnalysisService {
     matchingFlags: ResponseMatchingFlag[],
     threshold: number
   ): string {
-    return `${this.CACHE_KEY_PREFIX}:${workspaceId}_${[...matchingFlags].sort().join(',')}_t${threshold}`;
+    return getCodingAnalysisCacheKey(workspaceId, matchingFlags, threshold);
   }
 
   private normalizeThreshold(threshold: number | null | undefined): number {

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
@@ -166,7 +166,8 @@ export class CodingAnalysisService {
   async startAnalysis(
     workspaceId: number,
     matchingFlags?: ResponseMatchingFlag[],
-    threshold?: number
+    threshold?: number,
+    options: { forceRefresh?: boolean } = {}
   ): Promise<void> {
     const activeMatchingFlags = matchingFlags ||
       await this.codingJobService.getResponseMatchingMode(workspaceId);
@@ -181,6 +182,11 @@ export class CodingAnalysisService {
       activeThreshold;
 
     const cacheKey = this.getCacheKey(workspaceId, activeMatchingFlags, effectiveThreshold);
+
+    if (options.forceRefresh) {
+      await this.cacheService.delete(cacheKey);
+      this.logger.log(`Invalidated response analysis cache before restart for workspace ${workspaceId}`);
+    }
 
     // Check if job already running
     const activeJob = await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);

--- a/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
@@ -1,0 +1,3 @@
+export function getCodingIncompleteVariablesCacheKey(workspaceId: number): string {
+  return `coding_incomplete_variables_v4:${workspaceId}`;
+}

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -221,7 +221,7 @@ describe('CodingJobService distribution from job definitions', () => {
     });
 
     expect(result.success).toBe(true);
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v3:5');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v4:5');
     expect(result.distribution).toEqual(preview.distribution);
     expect(result.doubleCodingInfo).toEqual(preview.doubleCodingInfo);
     expect(result.jobsCreated).toBe(createdJobCalls.length);

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -775,7 +775,7 @@ describe('CodingJobService', () => {
       job_definition_id: 42
     }));
     expect(codingJobRepository.create.mock.calls[0][0]).not.toHaveProperty('job_definition_id');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v3:7');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v4:7');
   });
 
   it('loads one coding job and expands bundle variables', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -43,6 +43,7 @@ import {
 } from '../../../../../../../api-dto/coding/job-refresh.dto';
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
 import { CodingFreshnessService } from './coding-freshness.service';
+import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
 
 function isSafeKey(key: string): boolean {
   return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
@@ -1363,7 +1364,7 @@ export class CodingJobService {
   }
 
   private async invalidateIncompleteVariablesCache(workspaceId: number): Promise<void> {
-    const cacheKey = `coding_incomplete_variables_v3:${workspaceId}`;
+    const cacheKey = getCodingIncompleteVariablesCacheKey(workspaceId);
     await this.cacheService.delete(cacheKey);
     this.logger.log(`Invalidated manual coding variables cache for workspace ${workspaceId}`);
   }

--- a/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
@@ -148,6 +148,7 @@ describe('CodingResultsService', () => {
       { codingJobId: 10, manager: queryRunner.manager }
     );
     expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(17);
+    expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(17);
   });
 
   it('rolls back response updates when manual freshness cannot be finalized', async () => {
@@ -161,6 +162,7 @@ describe('CodingResultsService', () => {
     expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
     expect(codingJobService.markCodingJobResultsApplied).not.toHaveBeenCalled();
     expect(codingStatisticsService.invalidateCache).not.toHaveBeenCalled();
+    expect(codingAnalysisService.invalidateCache).not.toHaveBeenCalled();
   });
 
   it('blocks applying a completed coding job when its source freshness is stale', async () => {
@@ -323,6 +325,7 @@ describe('CodingResultsService', () => {
       queryRunner.manager
     );
     expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(17);
+    expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(17);
   });
 
   it('does not propagate matching sibling responses when aggregation is disabled', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
@@ -1,11 +1,11 @@
 import { Repository } from 'typeorm';
 import { CodingResultsService } from './coding-results.service';
 import { ResponseEntity } from '../../entities/response.entity';
-import { CacheService } from '../../../cache/cache.service';
 import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { CodingStatisticsService } from './coding-statistics.service';
 import { CodingAnalysisService } from './coding-analysis.service';
 import { CodingFreshnessService } from './coding-freshness.service';
+import { CodingValidationService } from './coding-validation.service';
 
 jest.mock('../workspace/workspace-files.service', () => ({
   WorkspaceFilesService: jest.fn()
@@ -27,6 +27,8 @@ describe('CodingResultsService', () => {
   };
   let codingJobService: jest.Mocked<CodingJobService>;
   let codingStatisticsService: jest.Mocked<CodingStatisticsService>;
+  let codingValidationService: jest.Mocked<Pick<CodingValidationService, 'invalidateIncompleteVariablesCache'>>;
+  let codingAnalysisService: jest.Mocked<Pick<CodingAnalysisService, 'invalidateCache'>>;
   let codingFreshnessService: jest.Mocked<Pick<CodingFreshnessService, 'markManualCodingCurrent'>>;
 
   const createQueryBuilderMock = (rows: unknown[]) => ({
@@ -95,16 +97,24 @@ describe('CodingResultsService', () => {
       invalidateCache: jest.fn().mockResolvedValue(undefined)
     } as unknown as jest.Mocked<CodingStatisticsService>;
 
+    codingValidationService = {
+      invalidateIncompleteVariablesCache: jest.fn().mockResolvedValue(undefined)
+    };
+
+    codingAnalysisService = {
+      invalidateCache: jest.fn().mockResolvedValue(undefined)
+    };
+
     codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };
 
     service = new CodingResultsService(
       responseRepository,
-      { delete: jest.fn().mockResolvedValue(undefined) } as unknown as CacheService,
       codingStatisticsService,
       codingJobService,
-      {} as CodingAnalysisService,
+      codingValidationService as unknown as CodingValidationService,
+      codingAnalysisService as unknown as CodingAnalysisService,
       codingFreshnessService as unknown as CodingFreshnessService
     );
   });
@@ -568,5 +578,34 @@ describe('CodingResultsService', () => {
       100,
       expect.any(Object)
     );
+  });
+
+  it('applies empty response coding and invalidates dependent caches', async () => {
+    const rows = [
+      { id: 1 },
+      { id: 2 }
+    ] as ResponseEntity[];
+    responseRepository.createQueryBuilder = jest.fn(() => createQueryBuilderMock(rows)) as never;
+
+    const result = await service.applyEmptyResponseCoding(17);
+
+    expect(result).toEqual({
+      success: true,
+      updatedCount: 2,
+      message: '2 leere Antworten erfolgreich kodiert'
+    });
+    expect(queryRunner.manager.update).toHaveBeenCalledTimes(2);
+    expect(queryRunner.manager.update).toHaveBeenCalledWith(
+      ResponseEntity,
+      1,
+      {
+        code_v2: -98,
+        score_v2: 0,
+        status_v2: 5
+      }
+    );
+    expect(codingValidationService.invalidateIncompleteVariablesCache).toHaveBeenCalledWith(17);
+    expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(17);
+    expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(17);
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-results.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
 import { statusStringToNumber } from '../../utils/response-status-converter';
-import { CacheService } from '../../../cache/cache.service';
 import { ResponseEntity } from '../../entities/response.entity';
 import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { CodingStatisticsService } from './coding-statistics.service';
@@ -14,6 +13,7 @@ import {
 } from './coding-progress-key.util';
 import { CodingFreshnessService } from './coding-freshness.service';
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
+import { CodingValidationService } from './coding-validation.service';
 
 export interface ApplyCodingResultsOptions {
   overwriteExisting?: boolean;
@@ -36,9 +36,9 @@ export class CodingResultsService {
   constructor(
     @InjectRepository(ResponseEntity)
     private responseRepository: Repository<ResponseEntity>,
-    private cacheService: CacheService,
     private codingStatisticsService: CodingStatisticsService,
     private codingJobService: CodingJobService,
+    private codingValidationService: CodingValidationService,
     private codingAnalysisService: CodingAnalysisService,
     @Optional()
     private codingFreshnessService?: CodingFreshnessService
@@ -529,8 +529,7 @@ export class CodingResultsService {
   }
 
   private async invalidateIncompleteVariablesCache(workspaceId: number): Promise<void> {
-    const cacheKey = `coding_incomplete_variables_v3:${workspaceId}`;
-    await this.cacheService.delete(cacheKey);
+    await this.codingValidationService.invalidateIncompleteVariablesCache(workspaceId);
     this.logger.log(`Invalidated manual coding variables cache for workspace ${workspaceId}`);
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-results.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.ts
@@ -375,6 +375,7 @@ export class CodingResultsService {
 
           await this.invalidateIncompleteVariablesCache(workspaceId);
           await this.codingStatisticsService.invalidateCache(workspaceId);
+          await this.codingAnalysisService.invalidateCache(workspaceId);
         }
 
         return {
@@ -445,6 +446,7 @@ export class CodingResultsService {
 
         await this.invalidateIncompleteVariablesCache(workspaceId);
         await this.codingStatisticsService.invalidateCache(workspaceId);
+        await this.codingAnalysisService.invalidateCache(workspaceId);
 
         return {
           success: true,

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
@@ -338,7 +338,7 @@ describe('CodingStatisticsService', () => {
       await service.invalidateIncompleteVariablesCache(1);
 
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v3:1'
+        'coding_incomplete_variables_v4:1'
       );
     });
 

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
@@ -26,6 +26,7 @@ import {
   getCodingStatisticsCacheKey,
   type CodingStatisticsVersion
 } from './coding-statistics-cache-key.util';
+import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
 import { getEffectiveCodingStatusExpression } from '../../utils/effective-coding-status-expression.util';
 
 @Injectable()
@@ -276,7 +277,7 @@ export class CodingStatisticsService implements OnApplicationBootstrap {
   }
 
   async invalidateIncompleteVariablesCache(workspace_id: number): Promise<void> {
-    const cacheKey = `coding_incomplete_variables_v3:${workspace_id}`;
+    const cacheKey = getCodingIncompleteVariablesCacheKey(workspace_id);
     await this.cacheService.delete(cacheKey);
     this.logger.log(`Invalidated incomplete variables cache for workspace ${workspace_id}`);
   }

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -21,6 +21,7 @@ import {
 } from '../workspace/workspace-exclusion.service';
 import { CodingJobService } from './coding-job.service';
 import { buildAggregationGroups } from './aggregation-metrics.util';
+import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
 
 interface NormalizedExpectedCombination {
   unitKey: string;
@@ -871,7 +872,7 @@ export class CodingValidationService {
   }
 
   generateIncompleteVariablesCacheKey(workspaceId: number): string {
-    return `coding_incomplete_variables_v4:${workspaceId}`;
+    return getCodingIncompleteVariablesCacheKey(workspaceId);
   }
 
   async invalidateIncompleteVariablesCache(workspaceId: number): Promise<void> {

--- a/apps/backend/src/app/database/services/coding/coding-version.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-version.service.spec.ts
@@ -5,6 +5,8 @@ import { CodingVersionService } from './coding-version.service';
 import { ResponseEntity } from '../../entities/response.entity';
 import { CodingStatisticsService } from './coding-statistics.service';
 import { CodingFreshnessService } from './coding-freshness.service';
+import { CodingAnalysisService } from './coding-analysis.service';
+import { CodingValidationService } from './coding-validation.service';
 
 describe('CodingVersionService', () => {
   let service: CodingVersionService;
@@ -29,6 +31,14 @@ describe('CodingVersionService', () => {
 
   const mockCodingStatisticsService = {
     invalidateCache: jest.fn().mockResolvedValue(undefined)
+  };
+
+  const mockCodingAnalysisService = {
+    invalidateCache: jest.fn().mockResolvedValue(undefined)
+  };
+
+  const mockCodingValidationService = {
+    invalidateIncompleteVariablesCache: jest.fn().mockResolvedValue(undefined)
   };
 
   const mockCodingFreshnessService = {
@@ -61,6 +71,14 @@ describe('CodingVersionService', () => {
           useValue: mockCodingStatisticsService
         },
         {
+          provide: CodingAnalysisService,
+          useValue: mockCodingAnalysisService
+        },
+        {
+          provide: CodingValidationService,
+          useValue: mockCodingValidationService
+        },
+        {
           provide: CodingFreshnessService,
           useValue: mockCodingFreshnessService
         }
@@ -79,6 +97,8 @@ describe('CodingVersionService', () => {
     mockResponseRepository.delete.mockReset();
     mockResponseRepository.update.mockResolvedValue({ affected: 0 });
     mockResponseRepository.delete.mockResolvedValue({ affected: 0 });
+    mockCodingAnalysisService.invalidateCache.mockClear();
+    mockCodingValidationService.invalidateIncompleteVariablesCache.mockClear();
     mockCodingFreshnessService.markVersionsPendingAfterReset.mockClear();
     mockCodingFreshnessService.markAppliedCodingJobsResultsClearedForUnitIds.mockClear();
     mockCodingFreshnessService.markAppliedCodingJobsResultsClearedForResponseIds.mockClear();
@@ -132,6 +152,8 @@ describe('CodingVersionService', () => {
       expect(mockCodingStatisticsService.invalidateCache).toHaveBeenCalledWith(1, 'v2');
       expect(mockCodingStatisticsService.invalidateCache).toHaveBeenCalledWith(1, 'v3');
       expect(mockCodingStatisticsService.invalidateCache).toHaveBeenCalledTimes(3);
+      expect(mockCodingAnalysisService.invalidateCache).toHaveBeenCalledWith(1);
+      expect(mockCodingValidationService.invalidateIncompleteVariablesCache).toHaveBeenCalledWith(1);
     });
 
     it('should reset v2 version and cascade to v3', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-version.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-version.service.ts
@@ -7,6 +7,8 @@ import { ResponseEntity } from '../../entities/response.entity';
 import { CodingStatisticsService } from './coding-statistics.service';
 import { CodingFreshnessService } from './coding-freshness.service';
 import { CodingFreshnessVersion } from '../../../../../../../api-dto/coding/coding-freshness.dto';
+import { CodingAnalysisService } from './coding-analysis.service';
+import { CodingValidationService } from './coding-validation.service';
 
 type ResetCodingVersion = 'v1' | 'v2' | 'v3';
 type ResetUnitIdsByVersion = Record<ResetCodingVersion, Set<number>>;
@@ -21,6 +23,8 @@ export class CodingVersionService {
     private responseRepository: Repository<ResponseEntity>,
     @Inject(forwardRef(() => CodingStatisticsService))
     private codingStatisticsService: CodingStatisticsService,
+    private codingAnalysisService: CodingAnalysisService,
+    private codingValidationService: CodingValidationService,
     @Optional()
     private codingFreshnessService?: CodingFreshnessService
   ) { }
@@ -117,7 +121,7 @@ export class CodingVersionService {
           unitFilters,
           variableFilters
         );
-        await this.invalidateStatisticsCaches(workspaceId, version);
+        await this.invalidateCodingMutationCaches(workspaceId, version);
         if (progressCallback) await progressCallback(100);
         return {
           affectedResponseCount: 0,
@@ -198,7 +202,7 @@ export class CodingVersionService {
         );
       }
 
-      // Invalidate statistics cache for all affected versions
+      // Invalidate caches for all affected coding views
       await this.codingFreshnessService?.markVersionsPendingAfterReset(
         workspaceId,
         this.toResetUnitIdsByVersion(resetUnitIdsByVersion)
@@ -210,7 +214,7 @@ export class CodingVersionService {
         unitFilters,
         variableFilters
       );
-      await this.invalidateStatisticsCaches(workspaceId, version);
+      await this.invalidateCodingMutationCaches(workspaceId, version);
 
       if (progressCallback) await progressCallback(100);
 
@@ -326,6 +330,17 @@ export class CodingVersionService {
       this.logger.log(`Invalidating statistics cache for workspace ${workspaceId}, version v3 (cascade)`);
       await this.codingStatisticsService.invalidateCache(workspaceId, 'v3');
     }
+  }
+
+  private async invalidateCodingMutationCaches(
+    workspaceId: number,
+    version: ResetCodingVersion
+  ): Promise<void> {
+    await this.invalidateStatisticsCaches(workspaceId, version);
+    await Promise.all([
+      this.codingAnalysisService.invalidateCache(workspaceId),
+      this.codingValidationService.invalidateIncompleteVariablesCache(workspaceId)
+    ]);
   }
 
   private createResetUnitIdsByVersion(): ResetUnitIdsByVersion {

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -102,7 +102,7 @@ describe('ExternalCodingImportService', () => {
     expect(queryRunner.commitTransaction).toHaveBeenCalled();
     expect(queryRunner.rollbackTransaction).not.toHaveBeenCalled();
     expect(queryRunner.release).toHaveBeenCalled();
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v3:17');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v4:17');
   });
 
   it('rolls back and fails the import when manual freshness cannot be finalized', async () => {

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
@@ -14,6 +14,7 @@ import { statusStringToNumber, statusNumberToString } from '../../utils/response
 import FileUpload from '../../entities/file_upload.entity';
 import { CodingFreshnessService } from './coding-freshness.service';
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
+import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
 
 interface ExternalCodingRow {
   unit_key?: string;
@@ -1216,7 +1217,7 @@ export class ExternalCodingImportService {
   }
 
   private generateIncompleteVariablesCacheKey(workspaceId: number): string {
-    return `coding_incomplete_variables_v3:${workspaceId}`;
+    return getCodingIncompleteVariablesCacheKey(workspaceId);
   }
 
   /**

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
@@ -19,6 +19,7 @@ import {
   CODING_STATISTICS_CACHE_VERSIONS,
   getCodingStatisticsCacheKey
 } from '../coding/coding-statistics-cache-key.util';
+import { getCodingIncompleteVariablesCacheKey } from '../coding/coding-incomplete-variables-cache-key.util';
 
 @Injectable()
 export class WorkspaceCoreService {
@@ -186,7 +187,7 @@ export class WorkspaceCoreService {
       ...CODING_STATISTICS_CACHE_VERSIONS.map(version => (
         this.cacheService.delete(getCodingStatisticsCacheKey(workspaceId, version))
       )),
-      this.cacheService.delete(`coding_incomplete_variables_v3:${workspaceId}`),
+      this.cacheService.delete(getCodingIncompleteVariablesCacheKey(workspaceId)),
       this.cacheService.delete(`flat_response_filter_options:version:${workspaceId}`),
       this.cacheService.deleteByPattern(`response-analysis:${workspaceId}_*`),
       this.cacheService.deleteByPattern(`responses:${workspaceId}:*`),

--- a/apps/backend/src/app/database/utils/effective-coding-status-expression.util.spec.ts
+++ b/apps/backend/src/app/database/utils/effective-coding-status-expression.util.spec.ts
@@ -9,6 +9,7 @@ describe('getEffectiveCodingStatusExpression', () => {
     const expression = getEffectiveCodingStatusExpression('v2');
 
     expect(expression).toContain('CASE');
+    expect(expression).toContain('response.status_v2 IN (0, 1, 2, 3, 10)');
     expect(expression).toContain('response.status_v2 = 8');
     expect(expression).toContain('FROM coding_job_unit effective_status_cju');
     expect(expression).toContain("effective_status_cj.status <> 'results_applied'");
@@ -19,6 +20,7 @@ describe('getEffectiveCodingStatusExpression', () => {
   it('falls back from v3 to the effective manual status', () => {
     const expression = getEffectiveCodingStatusExpression('v3');
 
+    expect(expression).toContain('response.status_v3 IN (0, 1, 2, 3, 10)');
     expect(expression).toContain('COALESCE(response.status_v3');
     expect(expression).toContain('response.status_v2 = 8');
     expect(expression).toContain('FROM coding_job_unit effective_status_cju');

--- a/apps/backend/src/app/database/utils/effective-coding-status-expression.util.ts
+++ b/apps/backend/src/app/database/utils/effective-coding-status-expression.util.ts
@@ -1,6 +1,9 @@
+import { STATISTICS_IGNORED_STATUSES } from './response-status-converter';
+
 export type CodingVersion = 'v1' | 'v2' | 'v3';
 
 const CODING_INCOMPLETE_STATUS = 8;
+const STATISTICS_IGNORED_STATUS_LIST = STATISTICS_IGNORED_STATUSES.join(', ');
 
 export function getNumericStatusExpression(
   responseAlias: string,
@@ -19,7 +22,11 @@ export function getEffectiveCodingStatusExpression(
 
   if (version === 'v3') {
     const statusV3Expression = getNumericStatusExpression(responseAlias, 'v3');
-    return `COALESCE(${statusV3Expression}, ${getEffectiveManualCodingStatusExpression(responseAlias)})`;
+    const manualStatusExpression = getEffectiveManualCodingStatusExpression(responseAlias);
+    return `CASE
+      WHEN ${statusV3Expression} IN (${STATISTICS_IGNORED_STATUS_LIST}) THEN ${manualStatusExpression}
+      ELSE COALESCE(${statusV3Expression}, ${manualStatusExpression})
+    END`;
   }
 
   return `${responseAlias}.status_v1`;
@@ -27,6 +34,7 @@ export function getEffectiveCodingStatusExpression(
 
 function getEffectiveManualCodingStatusExpression(responseAlias: string): string {
   return `CASE
+      WHEN ${responseAlias}.status_v2 IN (${STATISTICS_IGNORED_STATUS_LIST}) THEN ${responseAlias}.status_v1
       WHEN ${getOpenManualCodingPlaceholderCondition(responseAlias)} THEN ${responseAlias}.status_v1
       ELSE COALESCE(${responseAlias}.status_v2, ${responseAlias}.status_v1)
     END`;

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -85,6 +85,7 @@ export interface CodingAnalysisJobData {
   matchingFlags: string[]; // passed as string array, converted in processor if needed or kept as is
   threshold: number;
   cacheKey: string;
+  runId?: string;
 }
 
 export interface VariableAnalysisJobData {

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.spec.ts
@@ -1,0 +1,93 @@
+import { Job } from 'bull';
+import { ResponseAnalysisDto } from '../../../../../../api-dto/coding/response-analysis.dto';
+import { CacheService } from '../../cache/cache.service';
+import { WorkspaceExclusionService, WorkspaceFilesService } from '../../database/services/workspace';
+import { CodingAnalysisJobData } from '../job-queue.service';
+import { CodingAnalysisProcessor } from './coding-analysis.processor';
+
+describe('CodingAnalysisProcessor', () => {
+  function createProcessor(cacheService: Partial<CacheService>) {
+    const processor = new CodingAnalysisProcessor(
+      {} as never,
+      cacheService as CacheService,
+      {} as WorkspaceExclusionService,
+      {} as WorkspaceFilesService
+    );
+    const analysis: ResponseAnalysisDto = {
+      emptyResponses: {
+        total: 0,
+        totalUncoded: 0,
+        items: []
+      },
+      duplicateValues: {
+        total: 0,
+        totalResponses: 0,
+        groups: [],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 0,
+        duplicateResponses: 0,
+        collapsedCases: 0,
+        rawCases: 0,
+        effectiveCases: 0,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: '2026-05-22T00:00:00.000Z'
+    };
+
+    (processor as unknown as {
+      computeResponseAnalysis: jest.Mock<Promise<ResponseAnalysisDto>, [
+        number,
+        string[],
+        number,
+        Job<CodingAnalysisJobData>
+      ]>;
+    }).computeResponseAnalysis = jest.fn().mockResolvedValue(analysis);
+
+    return {
+      processor,
+      analysis
+    };
+  }
+
+  function createJob(runId: string): Job<CodingAnalysisJobData> {
+    return {
+      id: 'analysis-job-1',
+      data: {
+        workspaceId: 7,
+        matchingFlags: [],
+        threshold: 2,
+        cacheKey: 'response-analysis:7__t2',
+        runId
+      }
+    } as unknown as Job<CodingAnalysisJobData>;
+  }
+
+  it('does not cache stale analysis results superseded by a newer run', async () => {
+    const cacheService = {
+      get: jest.fn().mockResolvedValue('newer-run'),
+      set: jest.fn().mockResolvedValue(true)
+    };
+    const { processor, analysis } = createProcessor(cacheService);
+
+    await expect(processor.handleResponseAnalysis(createJob('old-run'))).resolves.toBe(analysis);
+
+    expect(cacheService.get).toHaveBeenCalledWith('response-analysis:7__t2:run');
+    expect(cacheService.set).not.toHaveBeenCalled();
+  });
+
+  it('caches analysis results for the latest marked run', async () => {
+    const cacheService = {
+      get: jest.fn().mockResolvedValue('current-run'),
+      set: jest.fn().mockResolvedValue(true)
+    };
+    const { processor, analysis } = createProcessor(cacheService);
+
+    await expect(processor.handleResponseAnalysis(createJob('current-run'))).resolves.toBe(analysis);
+
+    expect(cacheService.set).toHaveBeenCalledWith('response-analysis:7__t2', analysis);
+  });
+});

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
@@ -24,6 +24,7 @@ import {
   isDerivedAggregationVariable,
   normalizeAggregationValue
 } from '../../database/services/coding/aggregation-metrics.util';
+import { getCodingAnalysisRunMarkerKey } from '../../database/services/coding/coding-analysis-cache-key.util';
 
 @Processor('response-analysis')
 export class CodingAnalysisProcessor {
@@ -46,6 +47,18 @@ export class CodingAnalysisProcessor {
 
     try {
       const analysis = await this.computeResponseAnalysis(workspaceId, matchingFlags as ResponseMatchingFlag[], threshold, job);
+      if (job.data.runId) {
+        const currentRunId = await this.cacheService.get<string>(
+          getCodingAnalysisRunMarkerKey(cacheKey)
+        );
+        if (currentRunId !== job.data.runId) {
+          this.logger.log(
+            `Skipping stale response analysis cache write for workspace ${workspaceId} (job ${job.id})`
+          );
+          return analysis;
+        }
+      }
+
       await this.cacheService.set(cacheKey, analysis);
 
       this.logger.log(`Response analysis for workspace ${workspaceId} completed and cached.`);

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { CodingManagementManualComponent } from './coding-management-manual.component';
 import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
@@ -142,6 +142,38 @@ describe('CodingManagementManualComponent', () => {
     expect(refreshSpy).toHaveBeenCalledWith(false);
 
     jest.useRealTimers();
+  });
+
+  it('rolls response matching flags back when saving fails', () => {
+    jest.useFakeTimers();
+    try {
+      const componentInternals = component as unknown as {
+        appService: { selectedWorkspaceId: number };
+        persistedResponseMatchingFlags: ResponseMatchingFlag[];
+        testPersonCodingService: {
+          saveAggregationSettings: (...args: unknown[]) => Observable<unknown>;
+        };
+      };
+      const appService = componentInternals.appService;
+      const testPersonCodingService = componentInternals.testPersonCodingService;
+
+      appService.selectedWorkspaceId = 5;
+      component.responseMatchingFlags = [ResponseMatchingFlag.NO_AGGREGATION];
+      componentInternals.persistedResponseMatchingFlags = [ResponseMatchingFlag.NO_AGGREGATION];
+
+      jest.spyOn(testPersonCodingService, 'saveAggregationSettings')
+        .mockReturnValue(throwError(() => new Error('save failed')));
+
+      component.toggleMatchingFlag(ResponseMatchingFlag.IGNORE_CASE);
+
+      expect(component.responseMatchingFlags).toEqual([ResponseMatchingFlag.IGNORE_CASE]);
+
+      jest.advanceTimersByTime(500);
+
+      expect(component.responseMatchingFlags).toEqual([ResponseMatchingFlag.NO_AGGREGATION]);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('should not block preparation for duplicates when aggregation is active', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -176,6 +176,55 @@ describe('CodingManagementManualComponent', () => {
     }
   });
 
+  it('allows retrying the same response matching flags after a failed save', () => {
+    jest.useFakeTimers();
+    try {
+      const componentInternals = component as unknown as {
+        appService: { selectedWorkspaceId: number };
+        persistedResponseMatchingFlags: ResponseMatchingFlag[];
+        testPersonCodingService: {
+          saveAggregationSettings: (...args: unknown[]) => Observable<unknown>;
+        };
+      };
+      const appService = componentInternals.appService;
+      const testPersonCodingService = componentInternals.testPersonCodingService;
+
+      appService.selectedWorkspaceId = 5;
+      component.duplicateAggregationThreshold = 2;
+      component.responseMatchingFlags = [ResponseMatchingFlag.NO_AGGREGATION];
+      componentInternals.persistedResponseMatchingFlags = [ResponseMatchingFlag.NO_AGGREGATION];
+
+      const saveSpy = jest.spyOn(testPersonCodingService, 'saveAggregationSettings')
+        .mockReturnValueOnce(throwError(() => new Error('save failed')))
+        .mockReturnValueOnce(of({
+          success: true,
+          threshold: 2,
+          flags: [ResponseMatchingFlag.IGNORE_CASE],
+          aggregationActive: true,
+          revertedResponses: 0,
+          message: 'saved'
+        }));
+      const restartSpy = jest.spyOn(component, 'restartAnalysis')
+        .mockImplementation(() => undefined);
+
+      component.toggleMatchingFlag(ResponseMatchingFlag.IGNORE_CASE);
+      jest.advanceTimersByTime(500);
+
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(component.responseMatchingFlags).toEqual([ResponseMatchingFlag.NO_AGGREGATION]);
+
+      component.toggleMatchingFlag(ResponseMatchingFlag.IGNORE_CASE);
+      jest.advanceTimersByTime(500);
+
+      expect(saveSpy).toHaveBeenCalledTimes(2);
+      expect(saveSpy).toHaveBeenLastCalledWith(5, 2, [ResponseMatchingFlag.IGNORE_CASE]);
+      expect(component.responseMatchingFlags).toEqual([ResponseMatchingFlag.IGNORE_CASE]);
+      expect(restartSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('should not block preparation for duplicates when aggregation is active', () => {
     component.responseAnalysis = {
       emptyResponses: { total: 0, totalUncoded: 0, items: [] },

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -4,9 +4,11 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Observable, of } from 'rxjs';
 import { CodingManagementManualComponent } from './coding-management-manual.component';
 import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
+import { ResponseMatchingFlag } from '../../../ws-admin/services/workspace-settings.service';
 
 type VariableCoverageOverview = NonNullable<CodingManagementManualComponent['variableCoverageOverview']>;
 type CaseCoverageOverview = NonNullable<CodingManagementManualComponent['caseCoverageOverview']>;
@@ -91,6 +93,55 @@ describe('CodingManagementManualComponent', () => {
 
     expect(component.hasDuplicateFindingsWithoutAggregation).toBe(true);
     expect(component.hasPreparationWarnings()).toBe(true);
+  });
+
+  it('debounces response matching changes into one analysis restart', () => {
+    jest.useFakeTimers();
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        saveAggregationSettings: (...args: unknown[]) => Observable<unknown>;
+      };
+    };
+    const appService = componentInternals.appService;
+    const testPersonCodingService = componentInternals.testPersonCodingService;
+
+    appService.selectedWorkspaceId = 5;
+    component.duplicateAggregationThreshold = 2;
+
+    const saveSpy = jest.spyOn(testPersonCodingService, 'saveAggregationSettings')
+      .mockReturnValue(of({
+        success: true,
+        threshold: 2,
+        flags: [
+          ResponseMatchingFlag.IGNORE_CASE,
+          ResponseMatchingFlag.IGNORE_WHITESPACE
+        ],
+        aggregationActive: true,
+        revertedResponses: 0,
+        message: 'saved'
+      }));
+    const restartSpy = jest.spyOn(component, 'restartAnalysis')
+      .mockImplementation(() => undefined);
+    const refreshSpy = jest.spyOn(component as unknown as { refreshAggregationDependentViews: (includeResponseAnalysis?: boolean) => void }, 'refreshAggregationDependentViews')
+      .mockImplementation(() => undefined);
+
+    component.toggleMatchingFlag(ResponseMatchingFlag.IGNORE_CASE);
+    component.toggleMatchingFlag(ResponseMatchingFlag.IGNORE_WHITESPACE);
+
+    expect(saveSpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(saveSpy).toHaveBeenCalledWith(5, 2, [
+      ResponseMatchingFlag.IGNORE_CASE,
+      ResponseMatchingFlag.IGNORE_WHITESPACE
+    ]);
+    expect(restartSpy).toHaveBeenCalledTimes(1);
+    expect(refreshSpy).toHaveBeenCalledWith(false);
+
+    jest.useRealTimers();
   });
 
   it('should not block preparation for duplicates when aggregation is active', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -16,7 +16,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import {
   Subject, takeUntil, debounceTime, finalize, Observable, of, tap,
-  distinctUntilChanged,
+  distinctUntilChanged, filter,
   firstValueFrom,
   map
 } from 'rxjs';
@@ -383,7 +383,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.matchingFlagChangeSubject
       .pipe(
         debounceTime(500),
-        distinctUntilChanged((previous, current) => this.areMatchingFlagsEqual(previous, current)),
+        filter(flags => !this.areMatchingFlagsEqual(flags, this.persistedResponseMatchingFlags)),
         takeUntil(this.destroy$)
       )
       .subscribe((flags: ResponseMatchingFlag[]) => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -208,6 +208,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private thresholdChangeSubject = new Subject<number>();
 
+  private matchingFlagChangeSubject = new Subject<ResponseMatchingFlag[]>();
+
   private statisticsRefreshSubject = new Subject<void>();
 
   codingProgressOverview: CodingProgressOverview | null = null;
@@ -374,6 +376,36 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
               }
             });
         }
+      });
+
+    this.matchingFlagChangeSubject
+      .pipe(
+        debounceTime(500),
+        distinctUntilChanged((previous, current) => this.areMatchingFlagsEqual(previous, current)),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((flags: ResponseMatchingFlag[]) => {
+        const workspaceId = this.appService.selectedWorkspaceId;
+        if (!workspaceId) {
+          return;
+        }
+
+        this.isLoadingMatchingMode = true;
+        this.saveResponseMatchingMode(flags)
+          .pipe(
+            finalize(() => {
+              this.isLoadingMatchingMode = false;
+            }),
+            takeUntil(this.destroy$)
+          )
+          .subscribe({
+            next: () => {
+              this.onResponseMatchingModeChanged();
+            },
+            error: () => {
+              // Error handling is done in saveResponseMatchingMode.
+            }
+          });
       });
 
     this.testPersonCodingService.autoCodingCompleted$
@@ -1577,8 +1609,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.codingFreshnessWarnings.every(item => item.version === 'v3');
   }
 
-  private refreshAggregationDependentViews(): void {
-    this.loadResponseAnalysis();
+  private refreshAggregationDependentViews(includeResponseAnalysis = true): void {
+    if (includeResponseAnalysis) {
+      this.loadResponseAnalysis();
+    }
     this.loadVariableCoverageOverview();
     this.loadCaseCoverageOverview();
     this.loadCodingProgressOverview();
@@ -2261,9 +2295,6 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.isLoadingResponseAnalysis = true;
-    this.isLoadingMatchingMode = true;
-
     let newFlags: ResponseMatchingFlag[];
 
     if (flag === ResponseMatchingFlag.NO_AGGREGATION) {
@@ -2283,22 +2314,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       }
     }
 
-    this.saveResponseMatchingMode(newFlags)
-      .pipe(
-        finalize(() => {
-          this.isLoadingMatchingMode = false;
-          this.isLoadingResponseAnalysis = false;
-        }),
-        takeUntil(this.destroy$)
-      )
-      .subscribe({
-        next: () => {
-          this.onResponseMatchingModeChanged();
-        },
-        error: () => {
-          // Error handling is mostly done in the individual methods (toasts)
-        }
-      });
+    this.responseMatchingFlags = newFlags;
+    this.emptyPageIndex = 0;
+    this.duplicatePageIndex = 0;
+    this.matchingFlagChangeSubject.next(newFlags);
   }
 
   private saveResponseMatchingMode(flags: ResponseMatchingFlag[]): Observable<void> {
@@ -2349,7 +2368,17 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private onResponseMatchingModeChanged(): void {
     this.restartAnalysis();
-    this.refreshAggregationDependentViews();
+    this.refreshAggregationDependentViews(false);
+  }
+
+  private areMatchingFlagsEqual(
+    previous: ResponseMatchingFlag[],
+    current: ResponseMatchingFlag[]
+  ): boolean {
+    if (previous.length !== current.length) {
+      return false;
+    }
+    return previous.every(flag => current.includes(flag));
   }
 
   isMatchingOptionDisabled(flag: ResponseMatchingFlag): boolean {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -172,6 +172,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   // Response matching mode configuration
   responseMatchingFlags: ResponseMatchingFlag[] = [];
+  private persistedResponseMatchingFlags: ResponseMatchingFlag[] = [];
   isLoadingMatchingMode = false;
   isSavingMatchingMode = false;
   ResponseMatchingFlag = ResponseMatchingFlag; // Expose enum to template
@@ -368,6 +369,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
                   return;
                 }
                 this.responseMatchingFlags = result.flags;
+                this.persistedResponseMatchingFlags = [...result.flags];
                 this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(result.threshold);
                 this.refreshAggregationDependentViews();
               },
@@ -1647,12 +1649,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .subscribe({
         next: settings => {
           this.responseMatchingFlags = settings.flags;
+          this.persistedResponseMatchingFlags = [...settings.flags];
           this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(settings.threshold);
           this.refreshAllStatistics();
           this.loadResponseAnalysis();
         },
         error: () => {
           this.responseMatchingFlags = [];
+          this.persistedResponseMatchingFlags = [];
           this.duplicateAggregationThreshold = 2;
           this.refreshAllStatistics();
           this.loadResponseAnalysis();
@@ -2251,11 +2255,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .subscribe({
         next: settings => {
           this.responseMatchingFlags = settings.flags;
+          this.persistedResponseMatchingFlags = [...settings.flags];
           this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(settings.threshold);
           this.isLoadingMatchingMode = false;
         },
         error: () => {
           this.responseMatchingFlags = [];
+          this.persistedResponseMatchingFlags = [];
           this.isLoadingMatchingMode = false;
         }
       });
@@ -2275,6 +2281,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .subscribe({
         next: settings => {
           this.responseMatchingFlags = settings.flags;
+          this.persistedResponseMatchingFlags = [...settings.flags];
           this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(settings.threshold);
           this.loadResponseAnalysis();
         },
@@ -2326,6 +2333,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return of(undefined);
     }
 
+    const rollbackFlags = [...this.persistedResponseMatchingFlags];
     this.isSavingMatchingMode = true;
     return this.testPersonCodingService
       .saveAggregationSettings(
@@ -2343,6 +2351,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         tap({
           next: result => {
             this.responseMatchingFlags = result.flags;
+            this.persistedResponseMatchingFlags = [...result.flags];
             this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(result.threshold);
             this.showSuccess(
               this.translateService.instant(
@@ -2351,6 +2360,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
             );
           },
           error: () => {
+            this.responseMatchingFlags = rollbackFlags;
             this.isSavingMatchingMode = false;
             this.showError(
               this.translateService.instant(

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -239,8 +239,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         this.resetProgress = progress;
         if (previousProgress !== undefined &&
           previousProgress !== null &&
-          progress === null &&
-          this.statisticsLoaded) {
+          progress === null) {
           this.fetchCodingStatistics();
           this.loadCodingFreshness();
           this.loadManualAppliedResultsOverview();


### PR DESCRIPTION
## Summary
- centralize the manual-coding incomplete-variable cache key on v4 and update stale invalidations
- invalidate response analysis and planning caches after reset, empty-response, and manual coding mutations
- force explicit response-analysis restarts to clear stale cache entries and supersede stale running analysis jobs
- debounce response-matching changes in manual coding, roll back optimistic UI state when saving fails, and allow retrying the same selection
- refresh reset views reliably and keep v2/v3 statistics from shrinking totals when ignored coding statuses override visible source statuses

## Issue correlation
- Fixes #347
- Fixes #368
- Addresses #346
- Addresses #369

## Retest target
- Fachlicher Retest in Version 1.16.0, sobald PR #521 im Build enthalten ist.
- #346, #347, #368 und #369 bleiben bis zum Retest offen und sind mit needs: retest markiert.
- #346 ist zusätzlich mit needs: split markiert, weil der Kern-Bug und UX-Wünsche getrennt nachverfolgt werden sollten.

## Validation
- npx nx test backend --runInBand
- npx nx test frontend --runInBand
- npx nx lint backend
- npx nx lint frontend
- npx nx build backend
- npx nx build frontend
- env -u ELECTRON_RUN_AS_NODE npx cypress verify
- env -u ELECTRON_RUN_AS_NODE npx nx e2e frontend --port=4300 --baseUrl=http://localhost:4300 --browser=chrome

## Notes
- Frontend production build still reports existing Angular warnings in test-results.component.html and ws-admin.component.ts unrelated to this change.
- Local Cypress runs require ELECTRON_RUN_AS_NODE to be unset in this environment.
- #346 remains partly UX-oriented after this fix; #369 should be retested because its reproduction steps are currently unclear.