### PR TITLE
Use Content Pool application tokens

### DIFF
--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ForbiddenException,
+  InternalServerErrorException,
   NotFoundException
 } from '@nestjs/common';
 import { ContentPoolIntegrationService } from './content-pool-integration.service';
@@ -270,6 +271,24 @@ describe('ContentPoolIntegrationService settings', () => {
       baseUrl: 'http://content-pool.test'
     })).rejects.toThrow(NotFoundException);
     expect(httpService.axiosRef.post).not.toHaveBeenCalled();
+  });
+
+  it('should not treat unsupported media type as a successful write scope probe', async () => {
+    const httpService = createHttpServiceMock();
+    const settingRepository = createEnabledSettings();
+    const service = createService(httpService, undefined, settingRepository);
+    httpService.axiosRef.get
+      .mockResolvedValueOnce({
+        data: [{ id: 'acp-1', name: 'ACP 1' }]
+      })
+      .mockResolvedValueOnce({ data: [] });
+    httpService.axiosRef.post.mockRejectedValueOnce(
+      createAxiosError(415, 'Unsupported Media Type')
+    );
+
+    await expect(service.testConnection({
+      baseUrl: 'http://content-pool.test'
+    })).rejects.toThrow(InternalServerErrorException);
   });
 
   it('should validate file scopes without ACP side effects when no ACP is visible', async () => {

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
@@ -4,7 +4,6 @@ import { WorkspaceFilesService } from '../../database/services/workspace';
 
 type HttpServiceMock = {
   axiosRef: {
-    delete: jest.Mock;
     get: jest.Mock;
     post: jest.Mock;
   };
@@ -14,10 +13,16 @@ type WorkspaceFilesServiceMock = {
   uploadTestFiles: jest.Mock;
 };
 
+type SettingRepositoryMock = {
+  findOne: jest.Mock;
+  create: jest.Mock;
+  save: jest.Mock;
+  getContent: (key: string) => string | undefined;
+};
+
 function createHttpServiceMock(): HttpServiceMock {
   return {
     axiosRef: {
-      delete: jest.fn(),
       get: jest.fn(),
       post: jest.fn()
     }
@@ -30,18 +35,45 @@ function createWorkspaceFilesServiceMock(): WorkspaceFilesServiceMock {
   };
 }
 
+function createSettingRepositoryMock(
+  initial: Record<string, string> = {}
+): SettingRepositoryMock {
+  const store = new Map(Object.entries(initial));
+
+  return {
+    findOne: jest.fn(({ where }: { where: { key: string } }) => Promise.resolve(
+      store.has(where.key) ? { key: where.key, content: store.get(where.key) } : null
+    )),
+    create: jest.fn(entity => entity),
+    save: jest.fn(entity => {
+      store.set(entity.key, entity.content);
+      return Promise.resolve(entity);
+    }),
+    getContent: (key: string) => store.get(key)
+  };
+}
+
 function createService(
   httpService: HttpServiceMock = createHttpServiceMock(),
-  workspaceFilesService: WorkspaceFilesServiceMock = createWorkspaceFilesServiceMock()
+  workspaceFilesService: WorkspaceFilesServiceMock = createWorkspaceFilesServiceMock(),
+  settingRepository: SettingRepositoryMock = createSettingRepositoryMock()
 ): ContentPoolIntegrationService {
   type CtorParams = ConstructorParameters<typeof ContentPoolIntegrationService>;
 
   return new ContentPoolIntegrationService(
-    {} as unknown as CtorParams[0],
+    settingRepository as unknown as CtorParams[0],
     {} as unknown as CtorParams[1],
     httpService as unknown as CtorParams[2],
     workspaceFilesService as unknown as CtorParams[3]
   );
+}
+
+function createEnabledSettings(): SettingRepositoryMock {
+  return createSettingRepositoryMock({
+    'system-content-pool-enabled': 'true',
+    'system-content-pool-base-url': 'http://content-pool.test',
+    'system-content-pool-application-token': 'cp_test_token'
+  });
 }
 
 function normalizeApiBaseUrl(
@@ -51,23 +83,6 @@ function normalizeApiBaseUrl(
   return (
     service as unknown as { normalizeApiBaseUrl: (x: string) => string }
   ).normalizeApiBaseUrl(rawBaseUrl);
-}
-
-function authenticate(
-  service: ContentPoolIntegrationService,
-  apiBaseUrl: string,
-  username: string,
-  password: string
-): Promise<string> {
-  return (
-    service as unknown as {
-      authenticate: (
-        apiBaseUrl: string,
-        username: string,
-        password: string
-      ) => Promise<string>;
-    }
-  ).authenticate(apiBaseUrl, username, password);
 }
 
 describe('ContentPoolIntegrationService.normalizeApiBaseUrl', () => {
@@ -108,109 +123,76 @@ describe('ContentPoolIntegrationService.normalizeApiBaseUrl', () => {
   });
 });
 
-describe('ContentPoolIntegrationService.authenticate', () => {
-  it('should return token from Content Pool password login', async () => {
-    const httpService = createHttpServiceMock();
-    const service = createService(httpService);
-    httpService.axiosRef.post.mockResolvedValueOnce({
-      data: { accessToken: 'content-pool-token' }
+describe('ContentPoolIntegrationService settings', () => {
+  it('should report whether an application token is configured without returning it', async () => {
+    const settingRepository = createEnabledSettings();
+    const service = createService(undefined, undefined, settingRepository);
+
+    await expect(service.getSettings()).resolves.toEqual({
+      enabled: true,
+      baseUrl: 'http://content-pool.test',
+      hasApplicationToken: true
     });
-
-    const token = await authenticate(
-      service,
-      'http://content-pool.test/api',
-      'local-user',
-      'local-password'
-    );
-
-    expect(token).toBe('content-pool-token');
-    expect(httpService.axiosRef.post).toHaveBeenCalledWith(
-      'http://content-pool.test/api/auth/login',
-      {
-        username: 'local-user',
-        password: 'local-password'
-      }
-    );
   });
 
-  it('should fall back to Keycloak password grant after invalid local login', async () => {
-    const httpService = createHttpServiceMock();
-    const service = createService(httpService);
-    const unauthorizedError = {
-      isAxiosError: true,
-      response: { status: 401, data: { message: 'Invalid credentials' } }
-    };
+  it('should store a new application token and only return token presence', async () => {
+    const settingRepository = createSettingRepositoryMock();
+    const service = createService(undefined, undefined, settingRepository);
 
-    httpService.axiosRef.post
-      .mockRejectedValueOnce(unauthorizedError)
-      .mockResolvedValueOnce({
-        data: { id_token: 'keycloak-id-token' }
-      })
-      .mockResolvedValueOnce({
-        data: { accessToken: 'content-pool-oidc-token' }
-      });
+    await expect(service.updateSettings({
+      enabled: true,
+      baseUrl: 'http://content-pool.test',
+      applicationToken: 'cp_new_token'
+    })).resolves.toEqual({
+      enabled: true,
+      baseUrl: 'http://content-pool.test',
+      hasApplicationToken: true
+    });
+    expect(settingRepository.getContent('system-content-pool-application-token'))
+      .toBe('cp_new_token');
+  });
+
+  it('should reject enabling the integration without an application token', async () => {
+    const service = createService();
+
+    await expect(service.updateSettings({
+      enabled: true,
+      baseUrl: 'http://content-pool.test'
+    })).rejects.toThrow(BadRequestException);
+  });
+});
+
+describe('ContentPoolIntegrationService.listAccessibleAcps', () => {
+  it('should list ACPs through the Content Pool server API token', async () => {
+    const httpService = createHttpServiceMock();
+    const settingRepository = createEnabledSettings();
+    const service = createService(httpService, undefined, settingRepository);
     httpService.axiosRef.get.mockResolvedValueOnce({
-      data: {
-        enabled: true,
-        issuerUrl: 'http://keycloak.test/realms/iqb/',
-        clientId: 'contentpool',
-        scope: 'openid profile email'
-      }
+      data: [{ id: 'acp-1', name: 'ACP 1' }]
     });
 
-    const token = await authenticate(
-      service,
-      'http://content-pool.test/api',
-      'keycloak-user',
-      'keycloak-password'
-    );
-
-    expect(token).toBe('content-pool-oidc-token');
+    await expect(service.listAccessibleAcps()).resolves.toEqual({
+      settings: {
+        enabled: true,
+        baseUrl: 'http://content-pool.test',
+        hasApplicationToken: true
+      },
+      acps: [expect.objectContaining({ id: 'acp-1', name: 'ACP 1' })]
+    });
     expect(httpService.axiosRef.get).toHaveBeenCalledWith(
-      'http://content-pool.test/api/auth/oidc-config'
-    );
-    expect(httpService.axiosRef.post).toHaveBeenNthCalledWith(
-      2,
-      'http://keycloak.test/realms/iqb/protocol/openid-connect/token',
-      expect.stringContaining('grant_type=password'),
-      {
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded'
-        }
-      }
-    );
-    expect(httpService.axiosRef.post).toHaveBeenNthCalledWith(
-      3,
-      'http://content-pool.test/api/auth/oidc-callback',
-      { idToken: 'keycloak-id-token' }
+      'http://content-pool.test/api/server/acp',
+      { headers: { 'X-Server-Token': 'cp_test_token' } }
     );
   });
 });
 
 describe('ContentPoolIntegrationService.importAcpFilesToWorkspace', () => {
-  it('should download ACP files and pass them through the workspace upload pipeline', async () => {
+  it('should download ACP files through the server API and pass them through the workspace upload pipeline', async () => {
     const httpService = createHttpServiceMock();
     const workspaceFilesService = createWorkspaceFilesServiceMock();
-    const settingRepository = {
-      findOne: jest.fn(({ where }: { where: { key: string } }) => Promise.resolve(
-        {
-          content:
-            where.key === 'system-content-pool-enabled' ?
-              'true' :
-              'http://content-pool.test'
-        }
-      ))
-    };
-    const service = new ContentPoolIntegrationService(
-      settingRepository as never,
-      {} as never,
-      httpService as never,
-      workspaceFilesService as unknown as WorkspaceFilesService
-    );
+    const settingRepository = createEnabledSettings();
+    const service = createService(httpService, workspaceFilesService, settingRepository);
 
-    httpService.axiosRef.post.mockResolvedValueOnce({
-      data: { accessToken: 'content-pool-token' }
-    });
     httpService.axiosRef.get
       .mockResolvedValueOnce({
         data: [{ id: 'acp-1', name: 'ACP 1' }]
@@ -239,8 +221,6 @@ describe('ContentPoolIntegrationService.importAcpFilesToWorkspace', () => {
     const result = await service.importAcpFilesToWorkspace({
       workspaceId: 123,
       acpId: 'acp-1',
-      username: 'user',
-      password: 'pass',
       overwriteExisting: true,
       overwriteFileIds: ['UNIT']
     }, reportProgress);
@@ -252,8 +232,11 @@ describe('ContentPoolIntegrationService.importAcpFilesToWorkspace', () => {
     });
     expect(httpService.axiosRef.get).toHaveBeenNthCalledWith(
       3,
-      'http://content-pool.test/api/acp/acp-1/files/file-1/download',
-      expect.objectContaining({ responseType: 'arraybuffer' })
+      'http://content-pool.test/api/server/acp/acp-1/files/file-1/download',
+      expect.objectContaining({
+        headers: { 'X-Server-Token': 'cp_test_token' },
+        responseType: 'arraybuffer'
+      })
     );
     expect(workspaceFilesService.uploadTestFiles).toHaveBeenCalledWith(
       123,
@@ -286,26 +269,17 @@ describe('ContentPoolIntegrationService.importAcpFilesToWorkspace', () => {
 });
 
 describe('ContentPoolIntegrationService.uploadWorkspaceFilesToAcp', () => {
-  it('should replace matching ACP files and report skipped files', async () => {
+  it('should replace matching coding schemes through the server API and report skipped files', async () => {
     const httpService = createHttpServiceMock();
     const workspaceFilesService = createWorkspaceFilesServiceMock();
-    const settingRepository = {
-      findOne: jest.fn(({ where }: { where: { key: string } }) => Promise.resolve(
-        {
-          content:
-            where.key === 'system-content-pool-enabled' ?
-              'true' :
-              'http://content-pool.test'
-        }
-      ))
-    };
+    const settingRepository = createEnabledSettings();
     const fileUploadRepository = {
       find: jest.fn().mockResolvedValue([
         {
           id: 11,
-          filename: 'unit.xml',
+          filename: 'scheme.vocs',
           workspace_id: 123,
-          data: Buffer.from('<Unit/>').toString('base64')
+          data: Buffer.from('{}').toString('base64')
         },
         {
           id: 12,
@@ -322,31 +296,21 @@ describe('ContentPoolIntegrationService.uploadWorkspaceFilesToAcp', () => {
       workspaceFilesService as unknown as WorkspaceFilesService
     );
 
-    httpService.axiosRef.post
-      .mockResolvedValueOnce({
-        data: { accessToken: 'content-pool-token' }
-      })
-      .mockResolvedValueOnce({
-        data: {}
-      })
-      .mockResolvedValueOnce({
-        data: { id: 'snapshot-1', versionNumber: 7 }
-      });
     httpService.axiosRef.get
       .mockResolvedValueOnce({
         data: [{ id: 'acp-1', name: 'ACP 1' }]
       })
       .mockResolvedValueOnce({
-        data: [{ id: 'target-file-1', originalName: 'unit.xml' }]
+        data: [{ id: 'target-file-1', originalName: 'scheme.vocs' }]
       });
-    httpService.axiosRef.delete.mockResolvedValueOnce({});
+    httpService.axiosRef.post.mockResolvedValueOnce({
+      data: { snapshot: { id: 'snapshot-1', versionNumber: 7 } }
+    });
     const reportProgress = jest.fn();
 
     const result = await service.uploadWorkspaceFilesToAcp({
       workspaceId: 123,
       acpId: 'acp-1',
-      username: 'user',
-      password: 'pass',
       fileIds: [11, 12],
       changelog: 'manual changelog'
     }, reportProgress);
@@ -357,7 +321,7 @@ describe('ContentPoolIntegrationService.uploadWorkspaceFilesToAcp', () => {
       replaced: 1,
       skipped: 1,
       failed: 0,
-      replacedFiles: [{ fileId: 11, filename: 'unit.xml' }],
+      replacedFiles: [{ fileId: 11, filename: 'scheme.vocs' }],
       skippedFiles: [{
         fileId: 12,
         filename: 'missing.vocs',
@@ -368,31 +332,19 @@ describe('ContentPoolIntegrationService.uploadWorkspaceFilesToAcp', () => {
       versionNumber: 7,
       changelog: 'manual changelog'
     });
-    expect(httpService.axiosRef.delete).toHaveBeenCalledWith(
-      'http://content-pool.test/api/acp/acp-1/files/target-file-1',
-      expect.anything()
-    );
-    expect(httpService.axiosRef.post).toHaveBeenNthCalledWith(
-      2,
-      'http://content-pool.test/api/acp/acp-1/files/upload',
+    expect(httpService.axiosRef.post).toHaveBeenCalledWith(
+      'http://content-pool.test/api/server/acp/acp-1/coding-schemes/replace',
       expect.anything(),
-      expect.objectContaining({ maxBodyLength: Infinity })
-    );
-    expect(httpService.axiosRef.post).toHaveBeenNthCalledWith(
-      3,
-      'http://content-pool.test/api/acp/acp-1/snapshots',
-      { changelog: 'manual changelog' },
-      expect.anything()
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Server-Token': 'cp_test_token' }),
+        maxBodyLength: Infinity
+      })
     );
     expect(reportProgress).toHaveBeenCalledWith(expect.objectContaining({
       phase: 'replacing-files',
       processedFiles: 2,
       totalFiles: 2,
       progress: 90
-    }));
-    expect(reportProgress).toHaveBeenCalledWith(expect.objectContaining({
-      phase: 'creating-snapshot',
-      progress: 94
     }));
   });
 });

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { ContentPoolIntegrationService } from './content-pool-integration.service';
 import { WorkspaceFilesService } from '../../database/services/workspace';
 
@@ -25,6 +25,16 @@ function createHttpServiceMock(): HttpServiceMock {
     axiosRef: {
       get: jest.fn(),
       post: jest.fn()
+    }
+  };
+}
+
+function createAxiosError(status: number, message: string): unknown {
+  return {
+    isAxiosError: true,
+    response: {
+      status,
+      data: { message }
     }
   };
 }
@@ -165,12 +175,17 @@ describe('ContentPoolIntegrationService settings', () => {
     const httpService = createHttpServiceMock();
     const settingRepository = createEnabledSettings();
     const service = createService(httpService, undefined, settingRepository);
-    httpService.axiosRef.get.mockResolvedValueOnce({
-      data: [
-        { id: 'acp-1', name: 'ACP 1' },
-        { id: 'acp-2', name: 'ACP 2' }
-      ]
-    });
+    httpService.axiosRef.get
+      .mockResolvedValueOnce({
+        data: [
+          { id: 'acp-1', name: 'ACP 1' },
+          { id: 'acp-2', name: 'ACP 2' }
+        ]
+      })
+      .mockResolvedValueOnce({ data: [] });
+    httpService.axiosRef.post.mockRejectedValueOnce(
+      createAxiosError(400, 'At least one file is required')
+    );
 
     await expect(service.testConnection({
       baseUrl: 'http://content-pool.test',
@@ -178,14 +193,33 @@ describe('ContentPoolIntegrationService settings', () => {
     })).resolves.toEqual({
       success: true,
       acpCount: 2,
-      message: 'Verbindung erfolgreich. 2 ACPs erreichbar.'
+      validatedScopes: ['acp.read', 'files.read', 'files.write'],
+      message:
+        'Verbindung erfolgreich. 2 ACPs erreichbar. Benötigte Scopes geprüft.'
     });
-    expect(httpService.axiosRef.get).toHaveBeenCalledWith(
+    expect(httpService.axiosRef.get).toHaveBeenNthCalledWith(
+      1,
       'http://content-pool.test/api/server/acp',
+      { headers: { 'X-Server-Token': 'cp_unsaved_token' } }
+    );
+    expect(httpService.axiosRef.get).toHaveBeenNthCalledWith(
+      2,
+      'http://content-pool.test/api/server/acp/acp-1/files',
+      { headers: { 'X-Server-Token': 'cp_unsaved_token' } }
+    );
+    expect(httpService.axiosRef.post).toHaveBeenCalledWith(
+      'http://content-pool.test/api/server/acp/acp-1/files/upload?conflictStrategy=reject',
+      null,
       { headers: { 'X-Server-Token': 'cp_unsaved_token' } }
     );
     expect(settingRepository.getContent('system-content-pool-application-token'))
       .toBe('cp_test_token');
+  });
+
+  it('should reject testing with an empty request body as a bad request', async () => {
+    const service = createService();
+
+    await expect(service.testConnection()).rejects.toThrow(BadRequestException);
   });
 
   it('should reject testing without a usable application token', async () => {
@@ -196,6 +230,56 @@ describe('ContentPoolIntegrationService settings', () => {
       baseUrl: 'http://content-pool.test',
       clearApplicationToken: true
     })).rejects.toThrow(BadRequestException);
+  });
+
+  it('should reject testing when a required file scope is missing', async () => {
+    const httpService = createHttpServiceMock();
+    const settingRepository = createEnabledSettings();
+    const service = createService(httpService, undefined, settingRepository);
+    httpService.axiosRef.get
+      .mockResolvedValueOnce({
+        data: [{ id: 'acp-1', name: 'ACP 1' }]
+      })
+      .mockRejectedValueOnce(
+        createAxiosError(403, 'Missing required scopes: files.read')
+      );
+
+    await expect(service.testConnection({
+      baseUrl: 'http://content-pool.test'
+    })).rejects.toThrow(ForbiddenException);
+    expect(httpService.axiosRef.post).not.toHaveBeenCalled();
+  });
+
+  it('should validate file scopes without ACP side effects when no ACP is visible', async () => {
+    const httpService = createHttpServiceMock();
+    const settingRepository = createEnabledSettings();
+    const service = createService(httpService, undefined, settingRepository);
+    httpService.axiosRef.get
+      .mockResolvedValueOnce({ data: [] })
+      .mockRejectedValueOnce(createAxiosError(404, 'ACP not found'));
+    httpService.axiosRef.post.mockRejectedValueOnce(
+      createAxiosError(404, 'ACP not found')
+    );
+
+    await expect(service.testConnection({
+      baseUrl: 'http://content-pool.test'
+    })).resolves.toEqual({
+      success: true,
+      acpCount: 0,
+      validatedScopes: ['acp.read', 'files.read', 'files.write'],
+      message:
+        'Verbindung erfolgreich. 0 ACPs erreichbar. Benötigte Scopes geprüft.'
+    });
+    expect(httpService.axiosRef.get).toHaveBeenNthCalledWith(
+      2,
+      'http://content-pool.test/api/server/acp/__coding-box-connection-test__/files',
+      { headers: { 'X-Server-Token': 'cp_test_token' } }
+    );
+    expect(httpService.axiosRef.post).toHaveBeenCalledWith(
+      'http://content-pool.test/api/server/acp/__coding-box-connection-test__/files/upload?conflictStrategy=reject',
+      null,
+      { headers: { 'X-Server-Token': 'cp_test_token' } }
+    );
   });
 });
 

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException
+} from '@nestjs/common';
 import { ContentPoolIntegrationService } from './content-pool-integration.service';
 import { WorkspaceFilesService } from '../../database/services/workspace';
 
@@ -219,7 +223,7 @@ describe('ContentPoolIntegrationService settings', () => {
   it('should reject testing with an empty request body as a bad request', async () => {
     const service = createService();
 
-    await expect(service.testConnection()).rejects.toThrow(BadRequestException);
+    await expect(service.testConnection(null)).rejects.toThrow(BadRequestException);
   });
 
   it('should reject testing without a usable application token', async () => {
@@ -247,6 +251,24 @@ describe('ContentPoolIntegrationService settings', () => {
     await expect(service.testConnection({
       baseUrl: 'http://content-pool.test'
     })).rejects.toThrow(ForbiddenException);
+    expect(httpService.axiosRef.post).not.toHaveBeenCalled();
+  });
+
+  it('should not treat a real ACP file route 404 as a successful scope probe', async () => {
+    const httpService = createHttpServiceMock();
+    const settingRepository = createEnabledSettings();
+    const service = createService(httpService, undefined, settingRepository);
+    httpService.axiosRef.get
+      .mockResolvedValueOnce({
+        data: [{ id: 'acp-1', name: 'ACP 1' }]
+      })
+      .mockRejectedValueOnce(
+        createAxiosError(404, 'Cannot GET /api/server/acp/acp-1/files')
+      );
+
+    await expect(service.testConnection({
+      baseUrl: 'http://content-pool.test'
+    })).rejects.toThrow(NotFoundException);
     expect(httpService.axiosRef.post).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
@@ -160,6 +160,43 @@ describe('ContentPoolIntegrationService settings', () => {
       baseUrl: 'http://content-pool.test'
     })).rejects.toThrow(BadRequestException);
   });
+
+  it('should test a new application token without storing it', async () => {
+    const httpService = createHttpServiceMock();
+    const settingRepository = createEnabledSettings();
+    const service = createService(httpService, undefined, settingRepository);
+    httpService.axiosRef.get.mockResolvedValueOnce({
+      data: [
+        { id: 'acp-1', name: 'ACP 1' },
+        { id: 'acp-2', name: 'ACP 2' }
+      ]
+    });
+
+    await expect(service.testConnection({
+      baseUrl: 'http://content-pool.test',
+      applicationToken: 'cp_unsaved_token'
+    })).resolves.toEqual({
+      success: true,
+      acpCount: 2,
+      message: 'Verbindung erfolgreich. 2 ACPs erreichbar.'
+    });
+    expect(httpService.axiosRef.get).toHaveBeenCalledWith(
+      'http://content-pool.test/api/server/acp',
+      { headers: { 'X-Server-Token': 'cp_unsaved_token' } }
+    );
+    expect(settingRepository.getContent('system-content-pool-application-token'))
+      .toBe('cp_test_token');
+  });
+
+  it('should reject testing without a usable application token', async () => {
+    const settingRepository = createEnabledSettings();
+    const service = createService(undefined, undefined, settingRepository);
+
+    await expect(service.testConnection({
+      baseUrl: 'http://content-pool.test',
+      clearApplicationToken: true
+    })).rejects.toThrow(BadRequestException);
+  });
 });
 
 describe('ContentPoolIntegrationService.listAccessibleAcps', () => {

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
@@ -1057,10 +1057,9 @@ export class ContentPoolIntegrationService {
     }
 
     const normalizedMessage = message.toLowerCase();
-    return status === 415 ||
-      (status === 400 &&
-        normalizedMessage.includes('file') &&
-        normalizedMessage.includes('required'));
+    return status === 400 &&
+      normalizedMessage.includes('file') &&
+      normalizedMessage.includes('required');
   }
 
   private isExpectedFallbackAcpNotFound(

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
@@ -46,6 +46,11 @@ export interface ContentPoolConnectionTestResult {
   message: string;
 }
 
+interface ScopeProbeOptions {
+  acceptsEmptyUploadRejection?: boolean;
+  acceptsFallbackAcpNotFound?: boolean;
+}
+
 interface ContentPoolRuntimeSettings extends ContentPoolSettings {
   applicationToken: string;
 }
@@ -267,13 +272,14 @@ export class ContentPoolIntegrationService {
   }
 
   async testConnection(
-    input: TestContentPoolConnectionInput = {}
+    input: TestContentPoolConnectionInput | null = {}
   ): Promise<ContentPoolConnectionTestResult> {
+    const request = input ?? {};
     const storedSettings = await this.getRuntimeSettings();
-    const baseUrl = (input.baseUrl || storedSettings.baseUrl || '').trim();
-    const tokenInput = (input.applicationToken || '').trim();
+    const baseUrl = (request.baseUrl || storedSettings.baseUrl || '').trim();
+    const tokenInput = (request.applicationToken || '').trim();
     const applicationToken = tokenInput ||
-      (input.clearApplicationToken ? '' : storedSettings.applicationToken);
+      (request.clearApplicationToken ? '' : storedSettings.applicationToken);
 
     if (!baseUrl) {
       throw new BadRequestException(
@@ -976,26 +982,38 @@ export class ContentPoolIntegrationService {
     token: string,
     acps: ContentPoolAcpSummary[]
   ): Promise<void> {
-    const probeAcpId =
-      acps.find(acp => (acp.id || '').trim())?.id ||
-      this.scopeProbeAcpId;
+    const visibleAcp = acps.find(acp => (acp.id || '').trim());
+    const probeAcpId = visibleAcp?.id || this.scopeProbeAcpId;
+    const isFallbackProbe = !visibleAcp;
     const encodedAcpId = encodeURIComponent(probeAcpId);
     const filesUrl = `${apiBaseUrl}/server/acp/${encodedAcpId}/files`;
     const uploadUrl = `${filesUrl}/upload?conflictStrategy=reject`;
     const headers = this.getApplicationTokenHeaders(token);
 
-    await this.assertScopeProbe('files.read', () => this.httpService.axiosRef.get(filesUrl, { headers }));
-    await this.assertScopeProbe('files.write', () => this.httpService.axiosRef.post(uploadUrl, null, { headers }));
+    await this.assertScopeProbe(
+      'files.read',
+      () => this.httpService.axiosRef.get(filesUrl, { headers }),
+      { acceptsFallbackAcpNotFound: isFallbackProbe }
+    );
+    await this.assertScopeProbe(
+      'files.write',
+      () => this.httpService.axiosRef.post(uploadUrl, null, { headers }),
+      {
+        acceptsEmptyUploadRejection: true,
+        acceptsFallbackAcpNotFound: isFallbackProbe
+      }
+    );
   }
 
   private async assertScopeProbe(
     scope: string,
-    request: () => Promise<unknown>
+    request: () => Promise<unknown>,
+    options: ScopeProbeOptions = {}
   ): Promise<void> {
     try {
       await request();
     } catch (error) {
-      if (this.isNonAuthScopeProbeRejection(error)) {
+      if (this.isNonAuthScopeProbeRejection(error, options)) {
         return;
       }
 
@@ -1006,15 +1024,58 @@ export class ContentPoolIntegrationService {
     }
   }
 
-  private isNonAuthScopeProbeRejection(error: unknown): boolean {
+  private isNonAuthScopeProbeRejection(
+    error: unknown,
+    options: ScopeProbeOptions
+  ): boolean {
     if ((error as AxiosError)?.isAxiosError) {
-      const status = (error as AxiosError).response?.status;
+      const axiosError = error as AxiosError;
+      const status = axiosError.response?.status;
+      const message = this.extractResponseMessage(axiosError.response?.data) || '';
       // These responses happen after the Content-Pool scope guard has accepted the token.
-      return status === 400 || status === 404 || status === 415;
+      return this.isExpectedEmptyUploadRejection(status, message, options) ||
+        this.isExpectedFallbackAcpNotFound(status, message, options);
     }
 
-    return error instanceof BadRequestException ||
-      error instanceof NotFoundException;
+    if (error instanceof HttpException) {
+      const status = error.getStatus();
+      const message = this.extractExceptionMessage(error, '');
+      return this.isExpectedEmptyUploadRejection(status, message, options) ||
+        this.isExpectedFallbackAcpNotFound(status, message, options);
+    }
+
+    return false;
+  }
+
+  private isExpectedEmptyUploadRejection(
+    status: number | undefined,
+    message: string,
+    options: ScopeProbeOptions
+  ): boolean {
+    if (!options.acceptsEmptyUploadRejection) {
+      return false;
+    }
+
+    const normalizedMessage = message.toLowerCase();
+    return status === 415 ||
+      (status === 400 &&
+        normalizedMessage.includes('file') &&
+        normalizedMessage.includes('required'));
+  }
+
+  private isExpectedFallbackAcpNotFound(
+    status: number | undefined,
+    message: string,
+    options: ScopeProbeOptions
+  ): boolean {
+    if (!options.acceptsFallbackAcpNotFound || status !== 404) {
+      return false;
+    }
+
+    const normalizedMessage = message.toLowerCase();
+    return normalizedMessage.includes('acp') &&
+      (normalizedMessage.includes('not found') ||
+        normalizedMessage.includes('nicht gefunden'));
   }
 
   private async fetchAcps(

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
@@ -42,6 +42,7 @@ export interface TestContentPoolConnectionInput {
 export interface ContentPoolConnectionTestResult {
   success: boolean;
   acpCount: number;
+  validatedScopes: string[];
   message: string;
 }
 
@@ -172,6 +173,10 @@ ContentPoolUploadFilesJobProgress,
 
 @Injectable()
 export class ContentPoolIntegrationService {
+  private readonly requiredCodingBoxScopes = ['acp.read', 'files.read', 'files.write'];
+
+  private readonly scopeProbeAcpId = '__coding-box-connection-test__';
+
   private readonly enabledSettingKey = 'system-content-pool-enabled';
 
   private readonly baseUrlSettingKey = 'system-content-pool-base-url';
@@ -262,7 +267,7 @@ export class ContentPoolIntegrationService {
   }
 
   async testConnection(
-    input: TestContentPoolConnectionInput
+    input: TestContentPoolConnectionInput = {}
   ): Promise<ContentPoolConnectionTestResult> {
     const storedSettings = await this.getRuntimeSettings();
     const baseUrl = (input.baseUrl || storedSettings.baseUrl || '').trim();
@@ -283,15 +288,24 @@ export class ContentPoolIntegrationService {
     }
 
     try {
+      const apiBaseUrl = this.normalizeApiBaseUrl(baseUrl);
       const acps = await this.fetchAcps(
-        this.normalizeApiBaseUrl(baseUrl),
+        apiBaseUrl,
         applicationToken
+      );
+      await this.validateRequiredCodingBoxScopes(
+        apiBaseUrl,
+        applicationToken,
+        acps
       );
 
       return {
         success: true,
         acpCount: acps.length,
-        message: `Verbindung erfolgreich. ${acps.length} ACPs erreichbar.`
+        validatedScopes: [...this.requiredCodingBoxScopes],
+        message:
+          `Verbindung erfolgreich. ${acps.length} ACPs erreichbar. ` +
+          'Benötigte Scopes geprüft.'
       };
     } catch (error) {
       const message = this.extractExceptionMessage(
@@ -955,6 +969,52 @@ export class ContentPoolIntegrationService {
 
   private getApplicationTokenHeaders(token: string): { 'X-Server-Token': string } {
     return { 'X-Server-Token': token };
+  }
+
+  private async validateRequiredCodingBoxScopes(
+    apiBaseUrl: string,
+    token: string,
+    acps: ContentPoolAcpSummary[]
+  ): Promise<void> {
+    const probeAcpId =
+      acps.find(acp => (acp.id || '').trim())?.id ||
+      this.scopeProbeAcpId;
+    const encodedAcpId = encodeURIComponent(probeAcpId);
+    const filesUrl = `${apiBaseUrl}/server/acp/${encodedAcpId}/files`;
+    const uploadUrl = `${filesUrl}/upload?conflictStrategy=reject`;
+    const headers = this.getApplicationTokenHeaders(token);
+
+    await this.assertScopeProbe('files.read', () => this.httpService.axiosRef.get(filesUrl, { headers }));
+    await this.assertScopeProbe('files.write', () => this.httpService.axiosRef.post(uploadUrl, null, { headers }));
+  }
+
+  private async assertScopeProbe(
+    scope: string,
+    request: () => Promise<unknown>
+  ): Promise<void> {
+    try {
+      await request();
+    } catch (error) {
+      if (this.isNonAuthScopeProbeRejection(error)) {
+        return;
+      }
+
+      this.throwHttpError(
+        error,
+        `Content-Pool-Scope ${scope} konnte nicht geprüft werden.`
+      );
+    }
+  }
+
+  private isNonAuthScopeProbeRejection(error: unknown): boolean {
+    if ((error as AxiosError)?.isAxiosError) {
+      const status = (error as AxiosError).response?.status;
+      // These responses happen after the Content-Pool scope guard has accepted the token.
+      return status === 400 || status === 404 || status === 415;
+    }
+
+    return error instanceof BadRequestException ||
+      error instanceof NotFoundException;
   }
 
   private async fetchAcps(

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
@@ -23,6 +23,18 @@ import { TestFilesUploadResultDto } from '../../../../../../api-dto/files/test-f
 export interface ContentPoolSettings {
   enabled: boolean;
   baseUrl: string;
+  hasApplicationToken: boolean;
+}
+
+export interface UpdateContentPoolSettingsInput {
+  enabled: boolean;
+  baseUrl: string;
+  applicationToken?: string;
+  clearApplicationToken?: boolean;
+}
+
+interface ContentPoolRuntimeSettings extends ContentPoolSettings {
+  applicationToken: string;
 }
 
 export interface ContentPoolAcpSummary {
@@ -35,8 +47,6 @@ export interface ContentPoolAcpSummary {
 export interface ImportAcpToWorkspaceInput {
   workspaceId: number;
   acpId: string;
-  username: string;
-  password: string;
   overwriteExisting?: boolean;
   overwriteFileIds?: string[];
 }
@@ -44,8 +54,6 @@ export interface ImportAcpToWorkspaceInput {
 export interface UploadWorkspaceFilesToAcpInput {
   workspaceId: number;
   acpId: string;
-  username: string;
-  password: string;
   fileIds: number[];
   changelog?: string;
 }
@@ -150,18 +158,13 @@ ContentPoolUploadFilesJobProgress,
 >
 >;
 
-interface ContentPoolOidcConfig {
-  enabled?: boolean;
-  issuerUrl?: string;
-  clientId?: string;
-  scope?: string;
-}
-
 @Injectable()
 export class ContentPoolIntegrationService {
   private readonly enabledSettingKey = 'system-content-pool-enabled';
 
   private readonly baseUrlSettingKey = 'system-content-pool-base-url';
+
+  private readonly applicationTokenSettingKey = 'system-content-pool-application-token';
 
   private readonly importJobTtlMs = 30 * 60 * 1000;
 
@@ -179,27 +182,34 @@ export class ContentPoolIntegrationService {
   ) {}
 
   async getSettings(): Promise<ContentPoolSettings> {
-    const [enabledSetting, baseUrlSetting] = await Promise.all([
-      this.settingRepository.findOne({
-        where: { key: this.enabledSettingKey }
-      }),
-      this.settingRepository.findOne({
-        where: { key: this.baseUrlSettingKey }
-      })
-    ]);
+    const settings = await this.getRuntimeSettings();
 
     return {
-      enabled: enabledSetting?.content === 'true',
-      baseUrl: (baseUrlSetting?.content || '').trim()
+      enabled: settings.enabled,
+      baseUrl: settings.baseUrl,
+      hasApplicationToken: settings.hasApplicationToken
     };
   }
 
-  async updateSettings(input: ContentPoolSettings): Promise<ContentPoolSettings> {
+  async updateSettings(
+    input: UpdateContentPoolSettingsInput
+  ): Promise<ContentPoolSettings> {
     const baseUrl = (input.baseUrl || '').trim();
+    const tokenInput = (input.applicationToken || '').trim();
+    const existingToken = await this.getStoredApplicationToken();
+    const applicationToken = input.clearApplicationToken && !tokenInput ?
+      '' :
+      tokenInput || existingToken;
 
     if (input.enabled && !baseUrl) {
       throw new BadRequestException(
         'Content-Pool URL darf bei aktiviertem Feature nicht leer sein.'
+      );
+    }
+
+    if (input.enabled && !applicationToken) {
+      throw new BadRequestException(
+        'Content-Pool Application-Token darf bei aktiviertem Feature nicht leer sein.'
       );
     }
 
@@ -212,25 +222,68 @@ export class ContentPoolIntegrationService {
       input.enabled ? 'true' : 'false'
     );
     await this.upsertSetting(this.baseUrlSettingKey, baseUrl);
+    if (input.clearApplicationToken || tokenInput) {
+      await this.upsertSetting(this.applicationTokenSettingKey, applicationToken);
+    }
 
     return {
       enabled: input.enabled,
-      baseUrl
+      baseUrl,
+      hasApplicationToken: !!applicationToken
     };
   }
 
-  async listAccessibleAcps(
-    username: string,
-    password: string
-  ): Promise<{ settings: ContentPoolSettings; acps: ContentPoolAcpSummary[] }> {
-    const settings = await this.getSettings();
+  async listAccessibleAcps(): Promise<{
+    settings: ContentPoolSettings;
+    acps: ContentPoolAcpSummary[];
+  }> {
+    const settings = await this.getRuntimeSettings();
     this.assertFeatureEnabled(settings);
 
     const apiBaseUrl = this.normalizeApiBaseUrl(settings.baseUrl);
-    const token = await this.authenticate(apiBaseUrl, username, password);
-    const acps = await this.fetchAcps(apiBaseUrl, token);
+    const acps = await this.fetchAcps(apiBaseUrl, settings.applicationToken);
 
-    return { settings, acps };
+    return {
+      settings: this.toPublicSettings(settings),
+      acps
+    };
+  }
+
+  private async getRuntimeSettings(): Promise<ContentPoolRuntimeSettings> {
+    const [enabledSetting, baseUrlSetting, applicationTokenSetting] = await Promise.all([
+      this.settingRepository.findOne({
+        where: { key: this.enabledSettingKey }
+      }),
+      this.settingRepository.findOne({
+        where: { key: this.baseUrlSettingKey }
+      }),
+      this.settingRepository.findOne({
+        where: { key: this.applicationTokenSettingKey }
+      })
+    ]);
+    const applicationToken = (applicationTokenSetting?.content || '').trim();
+
+    return {
+      enabled: enabledSetting?.content === 'true',
+      baseUrl: (baseUrlSetting?.content || '').trim(),
+      hasApplicationToken: !!applicationToken,
+      applicationToken
+    };
+  }
+
+  private async getStoredApplicationToken(): Promise<string> {
+    const tokenSetting = await this.settingRepository.findOne({
+      where: { key: this.applicationTokenSettingKey }
+    });
+    return (tokenSetting?.content || '').trim();
+  }
+
+  private toPublicSettings(settings: ContentPoolRuntimeSettings): ContentPoolSettings {
+    return {
+      enabled: settings.enabled,
+      baseUrl: settings.baseUrl,
+      hasApplicationToken: settings.hasApplicationToken
+    };
   }
 
   async importAcpFilesToWorkspace(
@@ -239,11 +292,11 @@ export class ContentPoolIntegrationService {
   ): Promise<TestFilesUploadResultDto> {
     reportProgress?.({
       phase: 'authenticating',
-      message: 'Authentifizierung am Content Pool...',
+      message: 'Content-Pool-Verbindung wird vorbereitet...',
       progress: 5
     });
 
-    const settings = await this.getSettings();
+    const settings = await this.getRuntimeSettings();
     this.assertFeatureEnabled(settings);
 
     if (!input.acpId || !input.acpId.trim()) {
@@ -251,13 +304,12 @@ export class ContentPoolIntegrationService {
     }
 
     const apiBaseUrl = this.normalizeApiBaseUrl(settings.baseUrl);
-    const token = await this.authenticate(apiBaseUrl, input.username, input.password);
     reportProgress?.({
       phase: 'checking-acp',
       message: 'ACP-Zugriff wird geprüft...',
       progress: 12
     });
-    const acps = await this.fetchAcps(apiBaseUrl, token);
+    const acps = await this.fetchAcps(apiBaseUrl, settings.applicationToken);
     const targetAcp = acps.find(acp => acp.id === input.acpId);
 
     if (!targetAcp) {
@@ -271,7 +323,11 @@ export class ContentPoolIntegrationService {
       message: 'Dateiliste des ACP wird geladen...',
       progress: 18
     });
-    const acpFiles = await this.fetchAcpFiles(apiBaseUrl, token, input.acpId);
+    const acpFiles = await this.fetchAcpFiles(
+      apiBaseUrl,
+      settings.applicationToken,
+      input.acpId
+    );
     reportProgress?.({
       phase: 'downloading-files',
       message: 'Dateien werden aus dem Content Pool geladen...',
@@ -281,7 +337,7 @@ export class ContentPoolIntegrationService {
     });
     const fileIos = await this.downloadAcpFilesAsFileIo(
       apiBaseUrl,
-      token,
+      settings.applicationToken,
       input.acpId,
       acpFiles,
       reportProgress
@@ -363,11 +419,11 @@ export class ContentPoolIntegrationService {
 
     reportProgress?.({
       phase: 'authenticating',
-      message: 'Authentifizierung am Content Pool...',
+      message: 'Content-Pool-Verbindung wird vorbereitet...',
       progress: 5
     });
 
-    const settings = await this.getSettings();
+    const settings = await this.getRuntimeSettings();
     this.assertFeatureEnabled(settings);
 
     if (!input.acpId || !input.acpId.trim()) {
@@ -392,14 +448,13 @@ export class ContentPoolIntegrationService {
     }
 
     const apiBaseUrl = this.normalizeApiBaseUrl(settings.baseUrl);
-    const token = await this.authenticate(apiBaseUrl, input.username, input.password);
 
     reportProgress?.({
       phase: 'checking-acp',
       message: 'ACP-Zugriff wird geprüft...',
       progress: 12
     });
-    const acps = await this.fetchAcps(apiBaseUrl, token);
+    const acps = await this.fetchAcps(apiBaseUrl, settings.applicationToken);
     const targetAcp = acps.find(acp => acp.id === input.acpId);
 
     if (!targetAcp) {
@@ -413,7 +468,11 @@ export class ContentPoolIntegrationService {
       message: 'Dateiliste des ACP wird geladen...',
       progress: 18
     });
-    const acpFiles = await this.fetchAcpFiles(apiBaseUrl, token, input.acpId);
+    const acpFiles = await this.fetchAcpFiles(
+      apiBaseUrl,
+      settings.applicationToken,
+      input.acpId
+    );
     const acpFileByName = new Map(
       acpFiles.map(file => [file.originalName.toLowerCase(), file])
     );
@@ -430,7 +489,28 @@ export class ContentPoolIntegrationService {
     };
 
     let processedFiles = 0;
+    const replacementPlan: Array<{
+      workspaceFile: FileUpload;
+      targetFileName: string;
+    }> = [];
     for (const workspaceFile of orderedWorkspaceFiles) {
+      if (!this.isCodingSchemeFile(workspaceFile.filename)) {
+        processedFiles += 1;
+        result.skipped += 1;
+        result.skippedFiles.push({
+          fileId: workspaceFile.id,
+          filename: workspaceFile.filename,
+          reason: 'Nur Kodierschemata (.vocs) können im Content Pool ersetzt werden.'
+        });
+        this.reportUploadFileProgress(
+          reportProgress,
+          workspaceFile.filename,
+          processedFiles,
+          orderedWorkspaceFiles.length
+        );
+        continue;
+      }
+
       const targetFile = acpFileByName.get(workspaceFile.filename.toLowerCase());
       if (!targetFile?.id) {
         processedFiles += 1;
@@ -449,12 +529,24 @@ export class ContentPoolIntegrationService {
         continue;
       }
 
+      replacementPlan.push({
+        workspaceFile,
+        targetFileName: targetFile.originalName || workspaceFile.filename
+      });
+    }
+
+    if (replacementPlan.length > 0) {
+      const changelog = (input.changelog || '').trim() ||
+        `Dateien aus Coding-Box ersetzt: ${
+          replacementPlan.map(plan => plan.workspaceFile.filename).join(', ')
+        }`;
+
       reportProgress?.({
         phase: 'replacing-files',
-        message: `Datei wird ersetzt: ${workspaceFile.filename}`,
+        message: 'Kodierschemata werden im Content Pool ersetzt...',
         processedFiles,
         totalFiles: orderedWorkspaceFiles.length,
-        currentFileName: workspaceFile.filename,
+        currentFileName: undefined,
         progress: this.calculateUploadFilesProgress(
           processedFiles,
           orderedWorkspaceFiles.length
@@ -462,66 +554,55 @@ export class ContentPoolIntegrationService {
       });
 
       try {
-        await this.deleteAcpFile(apiBaseUrl, token, input.acpId, targetFile.id);
-        await this.uploadAcpFile(
+        const replacement = await this.replaceCodingSchemeFiles(
           apiBaseUrl,
-          token,
+          settings.applicationToken,
           input.acpId,
-          workspaceFile,
-          targetFile.originalName || workspaceFile.filename
+          replacementPlan,
+          changelog
         );
-        result.replaced += 1;
-        result.replacedFiles.push({
-          fileId: workspaceFile.id,
-          filename: workspaceFile.filename
-        });
+        result.snapshotId = replacement.snapshot?.id ?
+          String(replacement.snapshot.id) :
+          undefined;
+        result.versionNumber = Number.isFinite(replacement.snapshot?.versionNumber) ?
+          Number(replacement.snapshot.versionNumber) :
+          undefined;
+        result.changelog = changelog;
+
+        for (const plan of replacementPlan) {
+          processedFiles += 1;
+          result.replaced += 1;
+          result.replacedFiles.push({
+            fileId: plan.workspaceFile.id,
+            filename: plan.workspaceFile.filename
+          });
+          this.reportUploadFileProgress(
+            reportProgress,
+            plan.workspaceFile.filename,
+            processedFiles,
+            orderedWorkspaceFiles.length
+          );
+        }
       } catch (error) {
-        result.failed += 1;
-        result.failedFiles.push({
-          fileId: workspaceFile.id,
-          filename: workspaceFile.filename,
-          reason: this.extractExceptionMessage(
-            error,
-            'Datei konnte nicht in den Content Pool übertragen werden.'
-          )
-        });
+        for (const plan of replacementPlan) {
+          processedFiles += 1;
+          result.failed += 1;
+          result.failedFiles.push({
+            fileId: plan.workspaceFile.id,
+            filename: plan.workspaceFile.filename,
+            reason: this.extractExceptionMessage(
+              error,
+              'Datei konnte nicht in den Content Pool übertragen werden.'
+            )
+          });
+          this.reportUploadFileProgress(
+            reportProgress,
+            plan.workspaceFile.filename,
+            processedFiles,
+            orderedWorkspaceFiles.length
+          );
+        }
       }
-
-      processedFiles += 1;
-      this.reportUploadFileProgress(
-        reportProgress,
-        workspaceFile.filename,
-        processedFiles,
-        orderedWorkspaceFiles.length
-      );
-    }
-
-    if (result.replaced > 0) {
-      const changelog = (input.changelog || '').trim() ||
-        `Dateien aus Coding-Box ersetzt: ${
-          result.replacedFiles.map(file => file.filename).join(', ')
-        }`;
-
-      reportProgress?.({
-        phase: 'creating-snapshot',
-        message: 'ACP-Snapshot wird erstellt...',
-        processedFiles,
-        totalFiles: orderedWorkspaceFiles.length,
-        currentFileName: undefined,
-        progress: 94
-      });
-      const snapshot = await this.createSnapshot(
-        apiBaseUrl,
-        token,
-        input.acpId,
-        changelog
-      );
-
-      result.snapshotId = snapshot?.id ? String(snapshot.id) : undefined;
-      result.versionNumber = Number.isFinite(snapshot?.versionNumber) ?
-        Number(snapshot.versionNumber) :
-        undefined;
-      result.changelog = changelog;
     }
 
     return result;
@@ -744,7 +825,7 @@ export class ContentPoolIntegrationService {
     return fallback;
   }
 
-  private assertFeatureEnabled(settings: ContentPoolSettings): void {
+  private assertFeatureEnabled(settings: ContentPoolRuntimeSettings): void {
     if (!settings.enabled) {
       throw new ForbiddenException(
         'Die Content-Pool-Integration ist in den Systemeinstellungen deaktiviert.'
@@ -753,6 +834,12 @@ export class ContentPoolIntegrationService {
 
     if (!settings.baseUrl) {
       throw new BadRequestException('Keine Content-Pool-URL konfiguriert.');
+    }
+
+    if (!settings.applicationToken) {
+      throw new BadRequestException(
+        'Kein Content-Pool Application-Token konfiguriert.'
+      );
     }
   }
 
@@ -803,141 +890,8 @@ export class ContentPoolIntegrationService {
       `${normalized}/api`;
   }
 
-  private async authenticate(
-    apiBaseUrl: string,
-    username: string,
-    password: string
-  ): Promise<string> {
-    if (!username || !password) {
-      throw new BadRequestException(
-        'Benutzername und Passwort für den Content Pool sind erforderlich.'
-      );
-    }
-
-    try {
-      return await this.authenticateWithPasswordLogin(
-        apiBaseUrl,
-        username,
-        password
-      );
-    } catch (error) {
-      if (this.shouldTryOidcAuthentication(error)) {
-        try {
-          return await this.authenticateWithOidcPasswordGrant(
-            apiBaseUrl,
-            username,
-            password
-          );
-        } catch (oidcError) {
-          return this.throwHttpError(
-            oidcError,
-            'Authentifizierung am Content Pool über Keycloak fehlgeschlagen',
-            UnauthorizedException
-          );
-        }
-      }
-
-      return this.throwHttpError(
-        error,
-        'Authentifizierung am Content Pool fehlgeschlagen',
-        UnauthorizedException
-      );
-    }
-  }
-
-  private async authenticateWithPasswordLogin(
-    apiBaseUrl: string,
-    username: string,
-    password: string
-  ): Promise<string> {
-    const response = await this.httpService.axiosRef.post(
-      `${apiBaseUrl}/auth/login`,
-      {
-        username,
-        password
-      }
-    );
-
-    return this.extractContentPoolAccessToken(response.data);
-  }
-
-  private async authenticateWithOidcPasswordGrant(
-    apiBaseUrl: string,
-    username: string,
-    password: string
-  ): Promise<string> {
-    const configResponse = await this.httpService.axiosRef.get(
-      `${apiBaseUrl}/auth/oidc-config`
-    );
-    const oidcConfig = configResponse.data as ContentPoolOidcConfig;
-
-    if (!oidcConfig?.enabled || !oidcConfig.issuerUrl || !oidcConfig.clientId) {
-      throw new UnauthorizedException(
-        'Keycloak-Anmeldung ist im Content Pool nicht konfiguriert.'
-      );
-    }
-
-    let issuerUrl = oidcConfig.issuerUrl;
-    while (issuerUrl.endsWith('/')) {
-      issuerUrl = issuerUrl.slice(0, -1);
-    }
-
-    const tokenRequest = new URLSearchParams({
-      grant_type: 'password',
-      client_id: oidcConfig.clientId,
-      username,
-      password,
-      scope: oidcConfig.scope || 'openid profile email'
-    });
-
-    const tokenResponse = await this.httpService.axiosRef.post(
-      `${issuerUrl}/protocol/openid-connect/token`,
-      tokenRequest.toString(),
-      {
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded'
-        }
-      }
-    );
-
-    const oidcToken = tokenResponse.data?.id_token ||
-      tokenResponse.data?.access_token;
-
-    if (!oidcToken) {
-      throw new UnauthorizedException(
-        'Keycloak-Login war erfolgreich, aber es wurde kein Token geliefert.'
-      );
-    }
-
-    const callbackResponse = await this.httpService.axiosRef.post(
-      `${apiBaseUrl}/auth/oidc-callback`,
-      { idToken: oidcToken }
-    );
-
-    return this.extractContentPoolAccessToken(callbackResponse.data);
-  }
-
-  private extractContentPoolAccessToken(data: unknown): string {
-    const source = data as {
-      accessToken?: string;
-      access_token?: string;
-      token?: string;
-    };
-    const token = source?.accessToken || source?.access_token || source?.token;
-
-    if (!token) {
-      throw new UnauthorizedException(
-        'Content-Pool-Login war erfolgreich, aber es wurde kein Token geliefert.'
-      );
-    }
-
-    return String(token);
-  }
-
-  private shouldTryOidcAuthentication(error: unknown): boolean {
-    const status = (error as AxiosError)?.response?.status;
-    return Boolean((error as AxiosError)?.isAxiosError) &&
-      (status === 401 || status === 404);
+  private getApplicationTokenHeaders(token: string): { 'X-Server-Token': string } {
+    return { 'X-Server-Token': token };
   }
 
   private async fetchAcps(
@@ -946,9 +900,9 @@ export class ContentPoolIntegrationService {
   ): Promise<ContentPoolAcpSummary[]> {
     try {
       const response = await this.httpService.axiosRef.get(
-        `${apiBaseUrl}/acp`,
+        `${apiBaseUrl}/server/acp`,
         {
-          headers: { Authorization: `Bearer ${token}` }
+          headers: this.getApplicationTokenHeaders(token)
         }
       );
 
@@ -986,9 +940,9 @@ export class ContentPoolIntegrationService {
   ): Promise<Array<{ id: string; originalName: string }>> {
     try {
       const response = await this.httpService.axiosRef.get(
-        `${apiBaseUrl}/acp/${encodeURIComponent(acpId)}/files`,
+        `${apiBaseUrl}/server/acp/${encodeURIComponent(acpId)}/files`,
         {
-          headers: { Authorization: `Bearer ${token}` }
+          headers: this.getApplicationTokenHeaders(token)
         }
       );
 
@@ -1044,9 +998,9 @@ export class ContentPoolIntegrationService {
 
       try {
         const response = await this.httpService.axiosRef.get(
-          `${apiBaseUrl}/acp/${encodeURIComponent(acpId)}/files/${encodeURIComponent(file.id)}/download`,
+          `${apiBaseUrl}/server/acp/${encodeURIComponent(acpId)}/files/${encodeURIComponent(file.id)}/download`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: this.getApplicationTokenHeaders(token),
             responseType: 'arraybuffer'
           }
         );
@@ -1116,79 +1070,48 @@ export class ContentPoolIntegrationService {
     return normalizedContentType || 'application/octet-stream';
   }
 
-  private async deleteAcpFile(
-    apiBaseUrl: string,
-    token: string,
-    acpId: string,
-    fileId: string
-  ): Promise<void> {
-    try {
-      await this.httpService.axiosRef.delete(
-        `${apiBaseUrl}/acp/${encodeURIComponent(acpId)}/files/${encodeURIComponent(fileId)}`,
-        {
-          headers: { Authorization: `Bearer ${token}` }
-        }
-      );
-    } catch (error) {
-      this.throwHttpError(
-        error,
-        'Bestehende Datei im Content Pool konnte nicht gelöscht werden.'
-      );
-    }
+  private isCodingSchemeFile(fileName: string): boolean {
+    return fileName.toLowerCase().endsWith('.vocs');
   }
 
-  private async uploadAcpFile(
+  private async replaceCodingSchemeFiles(
     apiBaseUrl: string,
     token: string,
     acpId: string,
-    workspaceFile: FileUpload,
-    targetFileName: string
-  ): Promise<void> {
+    replacementPlan: Array<{ workspaceFile: FileUpload; targetFileName: string }>,
+    changelog: string
+  ): Promise<{
+      snapshot?: {
+        id?: string;
+        versionNumber?: number;
+      };
+    }> {
     const formData = new FormData();
-    formData.append('files', this.decodeStoredFileData(workspaceFile.data), {
-      filename: targetFileName,
-      contentType: this.inferMimeType(targetFileName)
-    });
+    for (const plan of replacementPlan) {
+      formData.append('files', this.decodeStoredFileData(plan.workspaceFile.data), {
+        filename: plan.targetFileName,
+        contentType: this.inferMimeType(plan.targetFileName)
+      });
+    }
+    formData.append('changelog', changelog);
 
     try {
-      await this.httpService.axiosRef.post(
-        `${apiBaseUrl}/acp/${encodeURIComponent(acpId)}/files/upload`,
+      const response = await this.httpService.axiosRef.post(
+        `${apiBaseUrl}/server/acp/${encodeURIComponent(acpId)}/coding-schemes/replace`,
         formData,
         {
           headers: {
-            Authorization: `Bearer ${token}`,
+            ...this.getApplicationTokenHeaders(token),
             ...formData.getHeaders()
           },
           maxBodyLength: Infinity
-        }
-      );
-    } catch (error) {
-      this.throwHttpError(
-        error,
-        'Neue Datei konnte nicht in den Content Pool hochgeladen werden.'
-      );
-    }
-  }
-
-  private async createSnapshot(
-    apiBaseUrl: string,
-    token: string,
-    acpId: string,
-    changelog: string
-  ): Promise<{ id?: string; versionNumber?: number }> {
-    try {
-      const response = await this.httpService.axiosRef.post(
-        `${apiBaseUrl}/acp/${encodeURIComponent(acpId)}/snapshots`,
-        { changelog },
-        {
-          headers: { Authorization: `Bearer ${token}` }
         }
       );
       return response.data || {};
     } catch (error) {
       return this.throwHttpError(
         error,
-        'Snapshot im Content Pool konnte nicht erstellt werden.'
+        'Kodierschemata konnten nicht im Content Pool ersetzt werden.'
       );
     }
   }

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
@@ -33,6 +33,18 @@ export interface UpdateContentPoolSettingsInput {
   clearApplicationToken?: boolean;
 }
 
+export interface TestContentPoolConnectionInput {
+  baseUrl?: string;
+  applicationToken?: string;
+  clearApplicationToken?: boolean;
+}
+
+export interface ContentPoolConnectionTestResult {
+  success: boolean;
+  acpCount: number;
+  message: string;
+}
+
 interface ContentPoolRuntimeSettings extends ContentPoolSettings {
   applicationToken: string;
 }
@@ -247,6 +259,57 @@ export class ContentPoolIntegrationService {
       settings: this.toPublicSettings(settings),
       acps
     };
+  }
+
+  async testConnection(
+    input: TestContentPoolConnectionInput
+  ): Promise<ContentPoolConnectionTestResult> {
+    const storedSettings = await this.getRuntimeSettings();
+    const baseUrl = (input.baseUrl || storedSettings.baseUrl || '').trim();
+    const tokenInput = (input.applicationToken || '').trim();
+    const applicationToken = tokenInput ||
+      (input.clearApplicationToken ? '' : storedSettings.applicationToken);
+
+    if (!baseUrl) {
+      throw new BadRequestException(
+        'Content-Pool URL ist für den Verbindungstest erforderlich.'
+      );
+    }
+
+    if (!applicationToken) {
+      throw new BadRequestException(
+        'Content-Pool Application-Token ist für den Verbindungstest erforderlich.'
+      );
+    }
+
+    try {
+      const acps = await this.fetchAcps(
+        this.normalizeApiBaseUrl(baseUrl),
+        applicationToken
+      );
+
+      return {
+        success: true,
+        acpCount: acps.length,
+        message: `Verbindung erfolgreich. ${acps.length} ACPs erreichbar.`
+      };
+    } catch (error) {
+      const message = this.extractExceptionMessage(
+        error,
+        'Content-Pool-Verbindung konnte nicht getestet werden.'
+      );
+      const scopeHint =
+        'Benötigte Scopes: acp.read, files.read, files.write.';
+
+      if (error instanceof UnauthorizedException) {
+        throw new UnauthorizedException(`${message} Token prüfen. ${scopeHint}`);
+      }
+      if (error instanceof ForbiddenException) {
+        throw new ForbiddenException(`${message} Token-Scopes prüfen. ${scopeHint}`);
+      }
+
+      throw error;
+    }
   }
 
   private async getRuntimeSettings(): Promise<ContentPoolRuntimeSettings> {

--- a/apps/backend/src/app/admin/content-pool/content-pool-settings.controller.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-settings.controller.ts
@@ -1,12 +1,14 @@
 import {
-  Body, Controller, Get, Put, UseGuards
+  Body, Controller, Get, Post, Put, UseGuards
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { AdminGuard } from '../admin.guard';
 import {
   ContentPoolIntegrationService,
+  ContentPoolConnectionTestResult,
   ContentPoolSettings,
+  TestContentPoolConnectionInput,
   UpdateContentPoolSettingsInput
 } from './content-pool-integration.service';
 
@@ -31,5 +33,13 @@ export class ContentPoolSettingsController {
     @Body() body: UpdateContentPoolSettingsInput
   ): Promise<ContentPoolSettings> {
     return this.contentPoolIntegrationService.updateSettings(body);
+  }
+
+  @Post('test')
+  @ApiOperation({ summary: 'Test Content-Pool integration settings' })
+  async testConnection(
+    @Body() body: TestContentPoolConnectionInput
+  ): Promise<ContentPoolConnectionTestResult> {
+    return this.contentPoolIntegrationService.testConnection(body);
   }
 }

--- a/apps/backend/src/app/admin/content-pool/content-pool-settings.controller.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-settings.controller.ts
@@ -6,7 +6,8 @@ import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { AdminGuard } from '../admin.guard';
 import {
   ContentPoolIntegrationService,
-  ContentPoolSettings
+  ContentPoolSettings,
+  UpdateContentPoolSettingsInput
 } from './content-pool-integration.service';
 
 @ApiTags('admin')
@@ -27,7 +28,7 @@ export class ContentPoolSettingsController {
   @Put()
   @ApiOperation({ summary: 'Update Content-Pool integration settings' })
   async updateSettings(
-    @Body() body: ContentPoolSettings
+    @Body() body: UpdateContentPoolSettingsInput
   ): Promise<ContentPoolSettings> {
     return this.contentPoolIntegrationService.updateSettings(body);
   }

--- a/apps/backend/src/app/admin/workspace/workspace-content-pool.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-content-pool.controller.ts
@@ -16,13 +16,7 @@ import {
 import { WorkspaceGuard } from './workspace.guard';
 import { ContentPoolIntegrationService } from '../content-pool/content-pool-integration.service';
 
-interface ContentPoolCredentialsDto {
-  username: string;
-
-  password: string;
-}
-
-interface ImportAcpDto extends ContentPoolCredentialsDto {
+interface ImportAcpDto {
   acpId: string;
 
   overwriteExisting?: boolean;
@@ -30,7 +24,7 @@ interface ImportAcpDto extends ContentPoolCredentialsDto {
   overwriteFileIds?: string[];
 }
 
-interface UploadFilesToAcpDto extends ContentPoolCredentialsDto {
+interface UploadFilesToAcpDto {
   acpId: string;
 
   fileIds: number[];
@@ -59,13 +53,10 @@ export class WorkspaceContentPoolController {
   @Post('acps')
   @RequireAccessLevel(3)
   @ApiOperation({
-    summary: 'Authenticate against Content Pool and list accessible ACPs'
+    summary: 'List ACPs available through the configured Content-Pool token'
   })
-  async listAcps(@Body() body: ContentPoolCredentialsDto) {
-    return this.contentPoolIntegrationService.listAccessibleAcps(
-      body.username,
-      body.password
-    );
+  async listAcps() {
+    return this.contentPoolIntegrationService.listAccessibleAcps();
   }
 
   @Post('import-acp')
@@ -80,8 +71,6 @@ export class WorkspaceContentPoolController {
     return this.contentPoolIntegrationService.importAcpFilesToWorkspace({
       workspaceId,
       acpId: body.acpId,
-      username: body.username,
-      password: body.password,
       overwriteExisting: body.overwriteExisting,
       overwriteFileIds: body.overwriteFileIds
     });
@@ -99,8 +88,6 @@ export class WorkspaceContentPoolController {
     return this.contentPoolIntegrationService.startAcpImportToWorkspace({
       workspaceId,
       acpId: body.acpId,
-      username: body.username,
-      password: body.password,
       overwriteExisting: body.overwriteExisting,
       overwriteFileIds: body.overwriteFileIds
     });
@@ -127,8 +114,6 @@ export class WorkspaceContentPoolController {
     return this.contentPoolIntegrationService.startUploadWorkspaceFilesToAcp({
       workspaceId,
       acpId: body.acpId,
-      username: body.username,
-      password: body.password,
       fileIds: body.fileIds,
       changelog: body.changelog
     });

--- a/apps/frontend/src/app/core/services/system-settings.service.ts
+++ b/apps/frontend/src/app/core/services/system-settings.service.ts
@@ -3,6 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { SERVER_URL } from '../../injection-tokens';
 import {
+  ContentPoolConnectionTestRequest,
+  ContentPoolConnectionTestResponse,
   ContentPoolSettings,
   ContentPoolSettingsUpdate
 } from '../../ws-admin/models/content-pool.model';
@@ -33,6 +35,18 @@ export class SystemSettingsService {
   ): Observable<ContentPoolSettings> {
     return this.http.put<ContentPoolSettings>(
       `${this.serverUrl}admin/content-pool/settings`,
+      settings,
+      {
+        headers: this.authHeader
+      }
+    );
+  }
+
+  testContentPoolConnection(
+    settings: ContentPoolConnectionTestRequest
+  ): Observable<ContentPoolConnectionTestResponse> {
+    return this.http.post<ContentPoolConnectionTestResponse>(
+      `${this.serverUrl}admin/content-pool/settings/test`,
       settings,
       {
         headers: this.authHeader

--- a/apps/frontend/src/app/core/services/system-settings.service.ts
+++ b/apps/frontend/src/app/core/services/system-settings.service.ts
@@ -2,7 +2,10 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { SERVER_URL } from '../../injection-tokens';
-import { ContentPoolSettings } from '../../ws-admin/models/content-pool.model';
+import {
+  ContentPoolSettings,
+  ContentPoolSettingsUpdate
+} from '../../ws-admin/models/content-pool.model';
 
 @Injectable({
   providedIn: 'root'
@@ -26,7 +29,7 @@ export class SystemSettingsService {
   }
 
   updateContentPoolSettings(
-    settings: ContentPoolSettings
+    settings: ContentPoolSettingsUpdate
   ): Observable<ContentPoolSettings> {
     return this.http.put<ContentPoolSettings>(
       `${this.serverUrl}admin/content-pool/settings`,

--- a/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.html
+++ b/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.html
@@ -109,7 +109,8 @@
       <div class="content-pool-settings-container">
         <p class="content-pool-description">
           Steuert die Übertragung von Kodierschemata aus der Coding-Box in den Content Pool.
-          Die URL kann flexibel als Domain oder IP hinterlegt werden.
+          Die URL kann flexibel als Domain oder IP hinterlegt werden; der Zugriff erfolgt
+          über ein Application-Token aus dem Content Pool.
         </p>
 
         <div class="content-pool-toggle">
@@ -130,6 +131,27 @@
           </mat-hint>
         </mat-form-field>
 
+        <mat-form-field class="full-width">
+          <mat-label>Content-Pool Application-Token</mat-label>
+          <input
+            matInput
+            type="password"
+            autocomplete="new-password"
+            [(ngModel)]="contentPoolApplicationToken"
+            (ngModelChange)="onContentPoolTokenInputChange($event)"
+            [disabled]="isSavingContentPoolSettings"
+            placeholder="Neues Token eintragen">
+          <mat-hint>
+            @if (contentPoolSettings.hasApplicationToken && !clearContentPoolApplicationToken) {
+              Token ist gespeichert. Feld nur zum Ersetzen ausfüllen.
+            } @else if (clearContentPoolApplicationToken) {
+              Gespeichertes Token wird beim Speichern entfernt.
+            } @else {
+              Token wird nur backendseitig gespeichert und nicht wieder angezeigt.
+            }
+          </mat-hint>
+        </mat-form-field>
+
         <div class="content-pool-actions">
           <button
             mat-raised-button
@@ -139,6 +161,16 @@
             <mat-icon>save</mat-icon>
             {{ isSavingContentPoolSettings ? 'Speichere...' : 'Einstellungen speichern' }}
           </button>
+          @if (contentPoolSettings.hasApplicationToken && !clearContentPoolApplicationToken) {
+            <button
+              mat-stroked-button
+              color="warn"
+              [disabled]="isSavingContentPoolSettings || isLoadingContentPoolSettings"
+              (click)="clearStoredContentPoolToken()">
+              <mat-icon>delete</mat-icon>
+              Token entfernen
+            </button>
+          }
         </div>
       </div>
     </mat-card-content>

--- a/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.html
+++ b/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.html
@@ -154,7 +154,7 @@
 
         <p class="content-pool-description">
           Benötigte Content-Pool-Scopes: acp.read, files.read, files.write.
-          Der Verbindungstest prüft URL, Token und ACP-Lesezugriff.
+          Der Verbindungstest prüft URL, Token und diese Scopes.
         </p>
 
         <div class="content-pool-actions">

--- a/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.html
+++ b/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.html
@@ -124,7 +124,7 @@
           <input
             matInput
             [(ngModel)]="contentPoolSettings.baseUrl"
-            [disabled]="isSavingContentPoolSettings"
+            [disabled]="isSavingContentPoolSettings || isTestingContentPoolConnection"
             placeholder="z. B. content-pool.example.org oder https://192.168.10.11:4201">
           <mat-hint>
             Wenn kein Protokoll gesetzt ist, wird HTTPS verwendet. Der API-Pfad wird automatisch ergänzt.
@@ -139,7 +139,7 @@
             autocomplete="new-password"
             [(ngModel)]="contentPoolApplicationToken"
             (ngModelChange)="onContentPoolTokenInputChange($event)"
-            [disabled]="isSavingContentPoolSettings"
+            [disabled]="isSavingContentPoolSettings || isTestingContentPoolConnection"
             placeholder="Neues Token eintragen">
           <mat-hint>
             @if (contentPoolSettings.hasApplicationToken && !clearContentPoolApplicationToken) {
@@ -152,20 +152,33 @@
           </mat-hint>
         </mat-form-field>
 
+        <p class="content-pool-description">
+          Benötigte Content-Pool-Scopes: acp.read, files.read, files.write.
+          Der Verbindungstest prüft URL, Token und ACP-Lesezugriff.
+        </p>
+
         <div class="content-pool-actions">
           <button
             mat-raised-button
             color="primary"
-            [disabled]="isSavingContentPoolSettings || isLoadingContentPoolSettings"
+            [disabled]="isSavingContentPoolSettings || isLoadingContentPoolSettings || isTestingContentPoolConnection"
             (click)="saveContentPoolSettings()">
             <mat-icon>save</mat-icon>
             {{ isSavingContentPoolSettings ? 'Speichere...' : 'Einstellungen speichern' }}
+          </button>
+          <button
+            mat-stroked-button
+            color="primary"
+            [disabled]="isSavingContentPoolSettings || isLoadingContentPoolSettings || isTestingContentPoolConnection"
+            (click)="testContentPoolConnection()">
+            <mat-icon>{{ isTestingContentPoolConnection ? 'hourglass_empty' : 'wifi_tethering' }}</mat-icon>
+            {{ isTestingContentPoolConnection ? 'Teste...' : 'Verbindung testen' }}
           </button>
           @if (contentPoolSettings.hasApplicationToken && !clearContentPoolApplicationToken) {
             <button
               mat-stroked-button
               color="warn"
-              [disabled]="isSavingContentPoolSettings || isLoadingContentPoolSettings"
+              [disabled]="isSavingContentPoolSettings || isLoadingContentPoolSettings || isTestingContentPoolConnection"
               (click)="clearStoredContentPoolToken()">
               <mat-icon>delete</mat-icon>
               Token entfernen
@@ -189,8 +202,9 @@
         </p>
         <p class="export-description">
           Enthalten sind unter anderem Benutzer- und Rechteverwaltung, Arbeitsbereiche,
-          Kodierungen, Antworten, Logs und Systemeinstellungen. Die Datei kann sensible
-          Daten enthalten und sollte entsprechend geschützt abgelegt werden.
+          Kodierungen, Antworten, Logs und Systemeinstellungen. Dazu zählen auch
+          System-Secrets wie ein gespeichertes Content-Pool Application-Token. Die Datei
+          kann sensible Daten enthalten und sollte entsprechend geschützt abgelegt werden.
         </p>
         <div class="export-actions">
           <button

--- a/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.spec.ts
+++ b/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.spec.ts
@@ -21,9 +21,31 @@ describe('SysAdminSettingsComponent', () => {
   let fixture: ComponentFixture<SysAdminSettingsComponent>;
   let httpMock: HttpTestingController;
   let snackBar: { open: jest.Mock };
+  let systemSettingsService: {
+    getContentPoolSettings: jest.Mock;
+    updateContentPoolSettings: jest.Mock;
+    testContentPoolConnection: jest.Mock;
+  };
 
   beforeEach(async () => {
     snackBar = { open: jest.fn() };
+    systemSettingsService = {
+      getContentPoolSettings: jest.fn(() => of({
+        enabled: false,
+        baseUrl: '',
+        hasApplicationToken: false
+      })),
+      updateContentPoolSettings: jest.fn(() => of({
+        enabled: false,
+        baseUrl: '',
+        hasApplicationToken: false
+      })),
+      testContentPoolConnection: jest.fn(() => of({
+        success: true,
+        acpCount: 2,
+        message: 'Verbindung erfolgreich. 2 ACPs erreichbar.'
+      }))
+    };
 
     await TestBed.configureTestingModule({
       providers: [
@@ -53,10 +75,7 @@ describe('SysAdminSettingsComponent', () => {
         },
         {
           provide: SystemSettingsService,
-          useValue: {
-            getContentPoolSettings: () => of({ enabled: false, baseUrl: '' }),
-            updateContentPoolSettings: () => of({ enabled: false, baseUrl: '' })
-          }
+          useValue: systemSettingsService
         },
         provideNoopAnimations() // Hier hinzufügen
       ],
@@ -75,6 +94,50 @@ describe('SysAdminSettingsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('testContentPoolConnection', () => {
+    it('tests the current URL with an unsaved token and shows the result', () => {
+      component.contentPoolSettings = {
+        enabled: true,
+        baseUrl: ' http://content-pool.test ',
+        hasApplicationToken: false
+      };
+      component.contentPoolApplicationToken = ' cp_unsaved_token ';
+
+      component.testContentPoolConnection();
+
+      expect(systemSettingsService.testContentPoolConnection)
+        .toHaveBeenCalledWith({
+          baseUrl: 'http://content-pool.test',
+          applicationToken: 'cp_unsaved_token',
+          clearApplicationToken: false
+        });
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'Verbindung erfolgreich. 2 ACPs erreichbar.',
+        'Schließen',
+        { duration: 4000 }
+      );
+      expect(component.isTestingContentPoolConnection).toBe(false);
+    });
+
+    it('requires a token when no stored token is available', () => {
+      component.contentPoolSettings = {
+        enabled: true,
+        baseUrl: 'http://content-pool.test',
+        hasApplicationToken: false
+      };
+      component.contentPoolApplicationToken = '';
+
+      component.testContentPoolConnection();
+
+      expect(systemSettingsService.testContentPoolConnection).not.toHaveBeenCalled();
+      expect(snackBar.open).toHaveBeenCalledWith(
+        'Bitte ein Content-Pool Application-Token für den Verbindungstest hinterlegen.',
+        'Schließen',
+        { duration: 4000 }
+      );
+    });
   });
 
   describe('exportDatabase', () => {

--- a/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.spec.ts
+++ b/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.spec.ts
@@ -43,7 +43,9 @@ describe('SysAdminSettingsComponent', () => {
       testContentPoolConnection: jest.fn(() => of({
         success: true,
         acpCount: 2,
-        message: 'Verbindung erfolgreich. 2 ACPs erreichbar.'
+        validatedScopes: ['acp.read', 'files.read', 'files.write'],
+        message:
+          'Verbindung erfolgreich. 2 ACPs erreichbar. Benötigte Scopes geprüft.'
       }))
     };
 
@@ -114,7 +116,7 @@ describe('SysAdminSettingsComponent', () => {
           clearApplicationToken: false
         });
       expect(snackBar.open).toHaveBeenCalledWith(
-        'Verbindung erfolgreich. 2 ACPs erreichbar.',
+        'Verbindung erfolgreich. 2 ACPs erreichbar. Benötigte Scopes geprüft.',
         'Schließen',
         { duration: 4000 }
       );

--- a/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.ts
+++ b/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.ts
@@ -77,8 +77,12 @@ export class SysAdminSettingsComponent implements OnInit, OnDestroy {
   isSavingContentPoolSettings = false;
   contentPoolSettings: ContentPoolSettings = {
     enabled: false,
-    baseUrl: ''
+    baseUrl: '',
+    hasApplicationToken: false
   };
+
+  contentPoolApplicationToken = '';
+  clearContentPoolApplicationToken = false;
 
   private readonly ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml', 'image/webp'];
   constructor() {
@@ -277,8 +281,11 @@ export class SysAdminSettingsComponent implements OnInit, OnDestroy {
       next: settings => {
         this.contentPoolSettings = {
           enabled: !!settings.enabled,
-          baseUrl: (settings.baseUrl || '').trim()
+          baseUrl: (settings.baseUrl || '').trim(),
+          hasApplicationToken: !!settings.hasApplicationToken
         };
+        this.contentPoolApplicationToken = '';
+        this.clearContentPoolApplicationToken = false;
         this.isLoadingContentPoolSettings = false;
       },
       error: () => {
@@ -294,9 +301,22 @@ export class SysAdminSettingsComponent implements OnInit, OnDestroy {
 
   saveContentPoolSettings(): void {
     const normalizedBaseUrl = (this.contentPoolSettings.baseUrl || '').trim();
+    const applicationToken = this.contentPoolApplicationToken.trim();
     if (this.contentPoolSettings.enabled && !normalizedBaseUrl) {
       this.snackBar.open(
         'Bitte eine Content-Pool URL hinterlegen, bevor das Feature aktiviert wird.',
+        'Schließen',
+        { duration: 4000 }
+      );
+      return;
+    }
+    if (
+      this.contentPoolSettings.enabled &&
+      !applicationToken &&
+      (!this.contentPoolSettings.hasApplicationToken || this.clearContentPoolApplicationToken)
+    ) {
+      this.snackBar.open(
+        'Bitte ein Content-Pool Application-Token hinterlegen, bevor das Feature aktiviert wird.',
         'Schließen',
         { duration: 4000 }
       );
@@ -307,14 +327,19 @@ export class SysAdminSettingsComponent implements OnInit, OnDestroy {
     this.systemSettingsService
       .updateContentPoolSettings({
         enabled: this.contentPoolSettings.enabled,
-        baseUrl: normalizedBaseUrl
+        baseUrl: normalizedBaseUrl,
+        applicationToken: applicationToken || undefined,
+        clearApplicationToken: this.clearContentPoolApplicationToken && !applicationToken
       })
       .subscribe({
         next: settings => {
           this.contentPoolSettings = {
             enabled: !!settings.enabled,
-            baseUrl: (settings.baseUrl || '').trim()
+            baseUrl: (settings.baseUrl || '').trim(),
+            hasApplicationToken: !!settings.hasApplicationToken
           };
+          this.contentPoolApplicationToken = '';
+          this.clearContentPoolApplicationToken = false;
           this.isSavingContentPoolSettings = false;
           this.snackBar.open(
             'Content-Pool-Einstellungen wurden gespeichert.',
@@ -331,6 +356,17 @@ export class SysAdminSettingsComponent implements OnInit, OnDestroy {
           this.snackBar.open(message, 'Schließen', { duration: 4000 });
         }
       });
+  }
+
+  clearStoredContentPoolToken(): void {
+    this.contentPoolApplicationToken = '';
+    this.clearContentPoolApplicationToken = true;
+  }
+
+  onContentPoolTokenInputChange(value: string): void {
+    if ((value || '').trim()) {
+      this.clearContentPoolApplicationToken = false;
+    }
   }
 
   exportDatabase(): void {

--- a/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.ts
+++ b/apps/frontend/src/app/sys-admin/components/sys-admin-settings/sys-admin-settings.component.ts
@@ -75,6 +75,7 @@ export class SysAdminSettingsComponent implements OnInit, OnDestroy {
   databaseExportError: string | null = null;
   isLoadingContentPoolSettings = false;
   isSavingContentPoolSettings = false;
+  isTestingContentPoolConnection = false;
   contentPoolSettings: ContentPoolSettings = {
     enabled: false,
     baseUrl: '',
@@ -367,6 +368,58 @@ export class SysAdminSettingsComponent implements OnInit, OnDestroy {
     if ((value || '').trim()) {
       this.clearContentPoolApplicationToken = false;
     }
+  }
+
+  testContentPoolConnection(): void {
+    const normalizedBaseUrl = (this.contentPoolSettings.baseUrl || '').trim();
+    const applicationToken = this.contentPoolApplicationToken.trim();
+    if (!normalizedBaseUrl) {
+      this.snackBar.open(
+        'Bitte eine Content-Pool URL für den Verbindungstest hinterlegen.',
+        'Schließen',
+        { duration: 4000 }
+      );
+      return;
+    }
+
+    if (
+      !applicationToken &&
+      (!this.contentPoolSettings.hasApplicationToken || this.clearContentPoolApplicationToken)
+    ) {
+      this.snackBar.open(
+        'Bitte ein Content-Pool Application-Token für den Verbindungstest hinterlegen.',
+        'Schließen',
+        { duration: 4000 }
+      );
+      return;
+    }
+
+    this.isTestingContentPoolConnection = true;
+    this.systemSettingsService
+      .testContentPoolConnection({
+        baseUrl: normalizedBaseUrl,
+        applicationToken: applicationToken || undefined,
+        clearApplicationToken: this.clearContentPoolApplicationToken && !applicationToken
+      })
+      .subscribe({
+        next: result => {
+          this.isTestingContentPoolConnection = false;
+          this.snackBar.open(
+            result.message ||
+              `Verbindung erfolgreich. ${result.acpCount} ACPs erreichbar.`,
+            'Schließen',
+            { duration: 4000 }
+          );
+        },
+        error: error => {
+          this.isTestingContentPoolConnection = false;
+          const message = this.extractErrorMessage(
+            error,
+            'Content-Pool-Verbindung konnte nicht getestet werden. Token und Scopes prüfen.'
+          );
+          this.snackBar.open(message, 'Schließen', { duration: 6000 });
+        }
+      });
   }
 
   exportDatabase(): void {

--- a/apps/frontend/src/app/ws-admin/components/content-pool-import-dialog/content-pool-import-dialog.component.html
+++ b/apps/frontend/src/app/ws-admin/components/content-pool-import-dialog/content-pool-import-dialog.component.html
@@ -5,37 +5,21 @@
     Content-Pool: <strong>{{ data.settings.baseUrl || 'nicht konfiguriert' }}</strong>
   </p>
 
-  <div class="credentials-grid">
-    <mat-form-field appearance="outline">
-      <mat-label>Benutzername</mat-label>
-      <input matInput [(ngModel)]="username" [disabled]="isLoadingAcps || isImporting">
-    </mat-form-field>
-
-    <mat-form-field appearance="outline">
-      <mat-label>Passwort</mat-label>
-      <input
-        matInput
-        type="password"
-        [(ngModel)]="password"
-        [disabled]="isLoadingAcps || isImporting">
-    </mat-form-field>
-  </div>
-
   <div class="load-acps-actions">
     <button
       mat-stroked-button
       color="primary"
       (click)="loadAcps()"
       [disabled]="isLoadingAcps || isImporting">
-      <mat-icon>login</mat-icon>
-      {{ isLoadingAcps ? 'Lade ACPs...' : 'Anmelden und ACPs laden' }}
+      <mat-icon>sync</mat-icon>
+      {{ isLoadingAcps ? 'Lade ACPs...' : 'ACPs laden' }}
     </button>
     @if (isLoadingAcps) {
       <mat-spinner diameter="20"></mat-spinner>
     }
   </div>
 
-  @if (hasAuthenticated) {
+  @if (hasLoadedAcps) {
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>ACP auswählen</mat-label>
       <mat-select [(ngModel)]="selectedAcpId" [disabled]="isImporting">
@@ -74,7 +58,7 @@
     mat-raised-button
     color="primary"
     (click)="importAcp()"
-    [disabled]="isImporting || !hasAuthenticated || !selectedAcpId">
+    [disabled]="isImporting || !hasLoadedAcps || !selectedAcpId">
     <mat-icon>download</mat-icon>
     {{ isImporting ? 'Importiere...' : 'ACP importieren' }}
   </button>

--- a/apps/frontend/src/app/ws-admin/components/content-pool-import-dialog/content-pool-import-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/content-pool-import-dialog/content-pool-import-dialog.component.ts
@@ -30,8 +30,6 @@ export interface ContentPoolImportDialogData {
 
 export interface ContentPoolImportDialogResult {
   success: boolean;
-  username: string;
-  password: string;
   acpId: string;
   result: TestFilesUploadResultDto;
 }
@@ -62,10 +60,6 @@ export class ContentPoolImportDialogComponent implements OnDestroy {
     MatDialogRef<ContentPoolImportDialogComponent>
   );
 
-  username = '';
-
-  password = '';
-
   acps: ContentPoolAcpSummary[] = [];
 
   selectedAcpId = '';
@@ -74,7 +68,7 @@ export class ContentPoolImportDialogComponent implements OnDestroy {
 
   isImporting = false;
 
-  hasAuthenticated = false;
+  hasLoadedAcps = false;
 
   errorMessage = '';
 
@@ -91,28 +85,18 @@ export class ContentPoolImportDialogComponent implements OnDestroy {
   }
 
   loadAcps(): void {
-    if (!this.username.trim() || !this.password.trim()) {
-      this.errorMessage =
-        'Bitte Benutzername und Passwort für den Content Pool eingeben.';
-      return;
-    }
-
     this.errorMessage = '';
     this.isLoadingAcps = true;
-    this.hasAuthenticated = false;
+    this.hasLoadedAcps = false;
     this.selectedAcpId = '';
     this.acps = [];
 
     this.contentPoolIntegrationService
-      .listAccessibleAcps(
-        this.data.workspaceId,
-        this.username.trim(),
-        this.password
-      )
+      .listAccessibleAcps(this.data.workspaceId)
       .subscribe({
         next: response => {
           this.isLoadingAcps = false;
-          this.hasAuthenticated = true;
+          this.hasLoadedAcps = true;
           this.acps = response.acps || [];
           if (this.acps.length === 0) {
             this.errorMessage = 'Keine ACPs gefunden oder kein Zugriff vorhanden.';
@@ -122,7 +106,7 @@ export class ContentPoolImportDialogComponent implements OnDestroy {
           this.isLoadingAcps = false;
           this.errorMessage = this.extractErrorMessage(
             error,
-            'Anmeldung am Content Pool fehlgeschlagen.'
+            'ACP-Liste konnte nicht aus dem Content Pool geladen werden.'
           );
         }
       });
@@ -151,8 +135,6 @@ export class ContentPoolImportDialogComponent implements OnDestroy {
 
     this.importSubscription = this.contentPoolIntegrationService
       .importAcpWithProgress(this.data.workspaceId, {
-        username: this.username.trim(),
-        password: this.password,
         acpId: this.selectedAcpId
       })
       .subscribe({
@@ -170,8 +152,6 @@ export class ContentPoolImportDialogComponent implements OnDestroy {
             this.isImporting = false;
             this.dialogRef.close({
               success: true,
-              username: this.username.trim(),
-              password: this.password,
               acpId: this.selectedAcpId,
               result: progress.result
             });

--- a/apps/frontend/src/app/ws-admin/components/content-pool-upload-dialog/content-pool-upload-dialog.component.html
+++ b/apps/frontend/src/app/ws-admin/components/content-pool-upload-dialog/content-pool-upload-dialog.component.html
@@ -20,37 +20,21 @@
     </div>
   </div>
 
-  <div class="credentials-grid">
-    <mat-form-field appearance="outline">
-      <mat-label>Benutzername</mat-label>
-      <input matInput [(ngModel)]="username" [disabled]="isLoadingAcps || isUploading">
-    </mat-form-field>
-
-    <mat-form-field appearance="outline">
-      <mat-label>Passwort</mat-label>
-      <input
-        matInput
-        type="password"
-        [(ngModel)]="password"
-        [disabled]="isLoadingAcps || isUploading">
-    </mat-form-field>
-  </div>
-
   <div class="load-acps-actions">
     <button
       mat-stroked-button
       color="primary"
       (click)="loadAcps()"
       [disabled]="isLoadingAcps || isUploading">
-      <mat-icon>login</mat-icon>
-      {{ isLoadingAcps ? 'Lade ACPs...' : 'Anmelden und ACPs laden' }}
+      <mat-icon>sync</mat-icon>
+      {{ isLoadingAcps ? 'Lade ACPs...' : 'ACPs laden' }}
     </button>
     @if (isLoadingAcps) {
       <mat-spinner diameter="20"></mat-spinner>
     }
   </div>
 
-  @if (hasAuthenticated) {
+  @if (hasLoadedAcps) {
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>ACP auswählen</mat-label>
       <mat-select [(ngModel)]="selectedAcpId" [disabled]="isUploading">
@@ -98,7 +82,7 @@
     mat-raised-button
     color="primary"
     (click)="uploadFiles()"
-    [disabled]="isUploading || !hasAuthenticated || !selectedAcpId">
+    [disabled]="isUploading || !hasLoadedAcps || !selectedAcpId">
     <mat-icon>publish</mat-icon>
     {{ isUploading ? 'Übertrage...' : 'Dateien ersetzen' }}
   </button>

--- a/apps/frontend/src/app/ws-admin/components/content-pool-upload-dialog/content-pool-upload-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/content-pool-upload-dialog/content-pool-upload-dialog.component.ts
@@ -65,10 +65,6 @@ export class ContentPoolUploadDialogComponent implements OnDestroy {
     MatDialogRef<ContentPoolUploadDialogComponent>
   );
 
-  username = '';
-
-  password = '';
-
   changelog = '';
 
   acps: ContentPoolAcpSummary[] = [];
@@ -79,7 +75,7 @@ export class ContentPoolUploadDialogComponent implements OnDestroy {
 
   isUploading = false;
 
-  hasAuthenticated = false;
+  hasLoadedAcps = false;
 
   errorMessage = '';
 
@@ -100,28 +96,18 @@ export class ContentPoolUploadDialogComponent implements OnDestroy {
   }
 
   loadAcps(): void {
-    if (!this.username.trim() || !this.password.trim()) {
-      this.errorMessage =
-        'Bitte Benutzername und Passwort für den Content Pool eingeben.';
-      return;
-    }
-
     this.errorMessage = '';
     this.isLoadingAcps = true;
-    this.hasAuthenticated = false;
+    this.hasLoadedAcps = false;
     this.selectedAcpId = '';
     this.acps = [];
 
     this.contentPoolIntegrationService
-      .listAccessibleAcps(
-        this.data.workspaceId,
-        this.username.trim(),
-        this.password
-      )
+      .listAccessibleAcps(this.data.workspaceId)
       .subscribe({
         next: response => {
           this.isLoadingAcps = false;
-          this.hasAuthenticated = true;
+          this.hasLoadedAcps = true;
           this.acps = response.acps || [];
           if (this.acps.length === 0) {
             this.errorMessage = 'Keine ACPs gefunden oder kein Zugriff vorhanden.';
@@ -131,7 +117,7 @@ export class ContentPoolUploadDialogComponent implements OnDestroy {
           this.isLoadingAcps = false;
           this.errorMessage = this.extractErrorMessage(
             error,
-            'Anmeldung am Content Pool fehlgeschlagen.'
+            'ACP-Liste konnte nicht aus dem Content Pool geladen werden.'
           );
         }
       });
@@ -160,8 +146,6 @@ export class ContentPoolUploadDialogComponent implements OnDestroy {
 
     this.uploadSubscription = this.contentPoolIntegrationService
       .uploadFilesToAcpWithProgress(this.data.workspaceId, {
-        username: this.username.trim(),
-        password: this.password,
         acpId: this.selectedAcpId,
         fileIds: this.data.files.map(file => file.id),
         changelog: this.changelog.trim()

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.html
@@ -52,7 +52,7 @@
       <a
         mat-raised-button
         color="accent"
-        [disabled]="isBusy || isLoadingContentPoolConfig"
+        [disabled]="isBusy || isLoadingContentPoolConfig || !contentPoolSettings.hasApplicationToken"
         (click)="openContentPoolImportDialog()"
         matTooltip="Importiert alle Dateien eines Content-Pool-ACP in diese Testdateien-Abteilung">
         <mat-icon>cloud_download</mat-icon>

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.ts
@@ -217,7 +217,8 @@ export class TestFilesComponent implements OnInit, OnDestroy {
   resourcePackagesModified = false;
   contentPoolSettings: ContentPoolSettings = {
     enabled: false,
-    baseUrl: ''
+    baseUrl: '',
+    hasApplicationToken: false
   };
 
   textFilterValue: string = '';
@@ -384,13 +385,15 @@ export class TestFilesComponent implements OnInit, OnDestroy {
         next: settings => {
           this.contentPoolSettings = {
             enabled: !!settings.enabled,
-            baseUrl: (settings.baseUrl || '').trim()
+            baseUrl: (settings.baseUrl || '').trim(),
+            hasApplicationToken: !!settings.hasApplicationToken
           };
         },
         error: () => {
           this.contentPoolSettings = {
             enabled: false,
-            baseUrl: ''
+            baseUrl: '',
+            hasApplicationToken: false
           };
         }
       });
@@ -401,6 +404,7 @@ export class TestFilesComponent implements OnInit, OnDestroy {
       !this.isLoadingContentPoolConfig &&
       this.contentPoolSettings.enabled &&
       this.contentPoolSettings.baseUrl &&
+      this.contentPoolSettings.hasApplicationToken &&
       this.tableCheckboxSelection.selected.length > 0
     );
   }
@@ -418,6 +422,15 @@ export class TestFilesComponent implements OnInit, OnDestroy {
     if (!this.contentPoolSettings.baseUrl) {
       this.snackBar.open(
         'In den Systemeinstellungen ist keine Content-Pool URL hinterlegt.',
+        'OK',
+        { duration: 4000 }
+      );
+      return;
+    }
+
+    if (!this.contentPoolSettings.hasApplicationToken) {
+      this.snackBar.open(
+        'In den Systemeinstellungen ist kein Content-Pool Application-Token hinterlegt.',
         'OK',
         { duration: 4000 }
       );
@@ -468,6 +481,15 @@ export class TestFilesComponent implements OnInit, OnDestroy {
     if (!this.contentPoolSettings.baseUrl) {
       this.snackBar.open(
         'In den Systemeinstellungen ist keine Content-Pool URL hinterlegt.',
+        'OK',
+        { duration: 4000 }
+      );
+      return;
+    }
+
+    if (!this.contentPoolSettings.hasApplicationToken) {
+      this.snackBar.open(
+        'In den Systemeinstellungen ist kein Content-Pool Application-Token hinterlegt.',
         'OK',
         { duration: 4000 }
       );
@@ -533,8 +555,6 @@ export class TestFilesComponent implements OnInit, OnDestroy {
           .length;
         this.contentPoolIntegrationService
           .importAcp(this.appService.selectedWorkspaceId, {
-            username: payload.username,
-            password: payload.password,
             acpId: payload.acpId,
             overwriteExisting: true,
             overwriteFileIds: resultChoice.overwriteFileIds

--- a/apps/frontend/src/app/ws-admin/models/content-pool.model.ts
+++ b/apps/frontend/src/app/ws-admin/models/content-pool.model.ts
@@ -13,6 +13,18 @@ export interface ContentPoolSettingsUpdate {
   clearApplicationToken?: boolean;
 }
 
+export interface ContentPoolConnectionTestRequest {
+  baseUrl?: string;
+  applicationToken?: string;
+  clearApplicationToken?: boolean;
+}
+
+export interface ContentPoolConnectionTestResponse {
+  success: boolean;
+  acpCount: number;
+  message: string;
+}
+
 export interface ContentPoolAcpSummary {
   id: string;
   packageId?: string;

--- a/apps/frontend/src/app/ws-admin/models/content-pool.model.ts
+++ b/apps/frontend/src/app/ws-admin/models/content-pool.model.ts
@@ -22,6 +22,7 @@ export interface ContentPoolConnectionTestRequest {
 export interface ContentPoolConnectionTestResponse {
   success: boolean;
   acpCount: number;
+  validatedScopes: string[];
   message: string;
 }
 

--- a/apps/frontend/src/app/ws-admin/models/content-pool.model.ts
+++ b/apps/frontend/src/app/ws-admin/models/content-pool.model.ts
@@ -3,6 +3,14 @@ import { TestFilesUploadResultDto } from '../../../../../../api-dto/files/test-f
 export interface ContentPoolSettings {
   enabled: boolean;
   baseUrl: string;
+  hasApplicationToken: boolean;
+}
+
+export interface ContentPoolSettingsUpdate {
+  enabled: boolean;
+  baseUrl: string;
+  applicationToken?: string;
+  clearApplicationToken?: boolean;
 }
 
 export interface ContentPoolAcpSummary {
@@ -18,8 +26,6 @@ export interface ContentPoolAcpListResponse {
 }
 
 export interface ContentPoolImportAcpRequest {
-  username: string;
-  password: string;
   acpId: string;
   overwriteExisting?: boolean;
   overwriteFileIds?: string[];
@@ -69,8 +75,6 @@ export interface ContentPoolUploadFileResult {
 }
 
 export interface ContentPoolUploadFilesRequest {
-  username: string;
-  password: string;
   acpId: string;
   fileIds: number[];
   changelog?: string;

--- a/apps/frontend/src/app/ws-admin/services/content-pool-integration.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/content-pool-integration.service.ts
@@ -34,14 +34,10 @@ export class ContentPoolIntegrationService {
     );
   }
 
-  listAccessibleAcps(
-    workspaceId: number,
-    username: string,
-    password: string
-  ): Observable<ContentPoolAcpListResponse> {
+  listAccessibleAcps(workspaceId: number): Observable<ContentPoolAcpListResponse> {
     return this.http.post<ContentPoolAcpListResponse>(
       `${this.serverUrl}admin/workspace/${workspaceId}/content-pool/acps`,
-      { username, password },
+      {},
       { headers: this.authHeader }
     );
   }


### PR DESCRIPTION
## Summary

- Switch Coding-Box Content Pool access from per-user Content Pool login credentials to the configured server-side application token.
- Store the token write-only in system settings and expose only `hasApplicationToken` to the frontend.
- Use the Content Pool server API for ACP listing, file download, and coding-scheme replacement.
- Remove username/password fields from import and upload dialogs, and gate Content Pool actions on a configured token.

## Workflow Impact

Admins configure the Content Pool base URL and application token once in system settings. Workspace admins can then load ACPs, import ACP files, and replace coding schemes without entering Content Pool credentials in the dialogs.

## Validation

- `npx jest --config apps/backend/jest.config.ts apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts --runInBand`
- `npx nx build backend`
- `npx nx build frontend`
- `npx nx test backend --runInBand`
- `npx nx test frontend --runInBand`
- `npx nx run-many -t lint -p backend,frontend`
- `git diff --check`