### PR TITLE
Variablenanalyse: Export CSV und XLSX

### DIFF
--- a/apps/backend/src/app/admin/variable-analysis/variable-analysis.controller.ts
+++ b/apps/backend/src/app/admin/variable-analysis/variable-analysis.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Post,
   Query,
+  Res,
   UseGuards
 } from '@nestjs/common';
 import {
@@ -22,6 +23,7 @@ import {
   ApiQuery,
   ApiTags
 } from '@nestjs/swagger';
+import { Response } from 'express';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from '../workspace/workspace.guard';
 import { WorkspaceId } from '../workspace/workspace.decorator';
@@ -328,6 +330,184 @@ export class VariableAnalysisController {
     }
   }
 
+  @Get('jobs/:job_id/results/export/csv')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Export variable analysis results as CSV',
+    description:
+      'Exports all filtered results of a completed variable analysis job as CSV'
+  })
+  @ApiParam({
+    name: 'workspace_id',
+    type: Number,
+    required: true,
+    description: 'The ID of the workspace'
+  })
+  @ApiParam({
+    name: 'job_id',
+    type: Number,
+    required: true,
+    description: 'The ID of the job'
+  })
+  @ApiQuery({
+    name: 'search',
+    type: String,
+    required: false,
+    description: 'Search term matched against unit name and variable ID'
+  })
+  @ApiQuery({
+    name: 'onlyEmpty',
+    type: Boolean,
+    required: false,
+    description: 'Only include variables with empty responses'
+  })
+  @ApiOkResponse({
+    description: 'Variable analysis results exported as CSV.',
+    content: {
+      'text/csv': {
+        schema: {
+          type: 'string',
+          format: 'binary'
+        }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid input data or job not completed.'
+  })
+  @ApiNotFoundResponse({
+    description: 'Job not found.'
+  })
+  async exportAnalysisResultsAsCsv(
+    @WorkspaceId() workspaceId: number,
+      @Param('job_id') jobId: string,
+      @Query('search') search: string | undefined,
+      @Query('onlyEmpty') onlyEmpty: string | undefined,
+      @Res() res: Response
+  ): Promise<void> {
+    try {
+      const csv = await this.variableAnalysisService.exportAnalysisResultsAsCsv(
+        jobId,
+        workspaceId,
+        {
+          search,
+          onlyEmpty
+        }
+      );
+      const timestamp = new Date().toISOString().slice(0, 10);
+      const safeJobId = this.toSafeFilenamePart(jobId);
+
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="variable-analysis-${workspaceId}-${safeJobId}-${timestamp}.csv"`
+      );
+      res.send(csv);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      if (error.message && error.message.includes('not found in workspace')) {
+        throw new NotFoundException(error.message);
+      }
+      throw new BadRequestException(
+        `Failed to export variable analysis results as CSV: ${error.message}`
+      );
+    }
+  }
+
+  @Get('jobs/:job_id/results/export/xlsx')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Export variable analysis results as XLSX',
+    description:
+      'Exports all filtered results of a completed variable analysis job as XLSX'
+  })
+  @ApiParam({
+    name: 'workspace_id',
+    type: Number,
+    required: true,
+    description: 'The ID of the workspace'
+  })
+  @ApiParam({
+    name: 'job_id',
+    type: Number,
+    required: true,
+    description: 'The ID of the job'
+  })
+  @ApiQuery({
+    name: 'search',
+    type: String,
+    required: false,
+    description: 'Search term matched against unit name and variable ID'
+  })
+  @ApiQuery({
+    name: 'onlyEmpty',
+    type: Boolean,
+    required: false,
+    description: 'Only include variables with empty responses'
+  })
+  @ApiOkResponse({
+    description: 'Variable analysis results exported as XLSX.',
+    content: {
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': {
+        schema: {
+          type: 'string',
+          format: 'binary'
+        }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid input data or job not completed.'
+  })
+  @ApiNotFoundResponse({
+    description: 'Job not found.'
+  })
+  async exportAnalysisResultsAsXlsx(
+    @WorkspaceId() workspaceId: number,
+      @Param('job_id') jobId: string,
+      @Query('search') search: string | undefined,
+      @Query('onlyEmpty') onlyEmpty: string | undefined,
+      @Res() res: Response
+  ): Promise<void> {
+    try {
+      const xlsx =
+        await this.variableAnalysisService.exportAnalysisResultsAsXlsx(
+          jobId,
+          workspaceId,
+          {
+            search,
+            onlyEmpty
+          }
+        );
+      const timestamp = new Date().toISOString().slice(0, 10);
+      const safeJobId = this.toSafeFilenamePart(jobId);
+
+      res.setHeader(
+        'Content-Type',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      );
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="variable-analysis-${workspaceId}-${safeJobId}-${timestamp}.xlsx"`
+      );
+      res.send(xlsx);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      if (error.message && error.message.includes('not found in workspace')) {
+        throw new NotFoundException(error.message);
+      }
+      throw new BadRequestException(
+        `Failed to export variable analysis results as XLSX: ${error.message}`
+      );
+    }
+  }
+
   @Delete('jobs/:job_id')
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   @ApiBearerAuth()
@@ -437,5 +617,9 @@ export class VariableAnalysisController {
         `Failed to cancel variable analysis job: ${error.message}`
       );
     }
+  }
+
+  private toSafeFilenamePart(value: string): string {
+    return value.replace(/[^a-zA-Z0-9_-]/g, '-');
   }
 }

--- a/apps/backend/src/app/database/services/test-results/variable-analysis.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis.service.spec.ts
@@ -1,4 +1,5 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
+import * as ExcelJS from 'exceljs';
 import { VariableAnalysisService } from './variable-analysis.service';
 
 const createJob = (
@@ -278,6 +279,151 @@ describe('VariableAnalysisService', () => {
       pageSize: 1,
       totalPages: 1
     });
+  });
+
+  it('exports filtered chunked cached results as formula-safe CSV', async () => {
+    jobQueueService.getVariableAnalysisJob.mockResolvedValue(
+      createJob({
+        returnvalue: {
+          cacheKey: 'variable-analysis:1:job-1',
+          workspaceId: 1,
+          total: 2,
+          storage: 'chunked',
+          variableComboChunks: 1,
+          frequencyChunks: 1,
+          storedAt: '2026-05-26T00:00:00.000Z'
+        }
+      })
+    );
+    cacheService.get
+      .mockResolvedValueOnce({
+        storage: 'chunked',
+        workspaceId: 1,
+        total: 2,
+        variableComboChunks: 1,
+        frequencyChunks: 1,
+        storedAt: '2026-05-26T00:00:00.000Z'
+      })
+      .mockResolvedValueOnce([
+        {
+          unitId: 1,
+          unitName: '=UNIT',
+          variableId: '+VAR',
+          totalCount: 10,
+          emptyCount: 2,
+          emptyPercentage: 20,
+          distinctValueCount: 2,
+          statusCounts: [
+            { status: 3, count: 8, percentage: 80 },
+            { status: 8, count: 2, percentage: 20 }
+          ]
+        },
+        {
+          unitId: 2,
+          unitName: 'OTHER',
+          variableId: 'VAR_FULL',
+          totalCount: 5,
+          emptyCount: 0,
+          emptyPercentage: 0,
+          distinctValueCount: 1,
+          statusCounts: []
+        }
+      ])
+      .mockResolvedValueOnce([
+        [
+          '1:+VAR',
+          [
+            {
+              unitId: 1,
+              unitName: '=UNIT',
+              variableId: '+VAR',
+              value: '@value',
+              count: 8,
+              percentage: 80
+            },
+            {
+              unitId: 1,
+              unitName: '=UNIT',
+              variableId: '+VAR',
+              value: '',
+              count: 2,
+              percentage: 20
+            }
+          ]
+        ],
+        [
+          '2:VAR_FULL',
+          [
+            {
+              unitId: 2,
+              unitName: 'OTHER',
+              variableId: 'VAR_FULL',
+              value: 'x',
+              count: 5,
+              percentage: 100
+            }
+          ]
+        ]
+      ]);
+
+    const csv = await service.exportAnalysisResultsAsCsv('job-1', 1, {
+      search: '=UNIT',
+      onlyEmpty: true
+    });
+
+    expect(csv).toContain('Unit-ID;Unit-Name;Variablen-ID');
+    expect(csv).toContain(";'=UNIT;'+VAR;'@value;");
+    expect(csv).toContain('VALUE_CHANGED: 8 (80%)');
+    expect(csv).toContain('CODING_INCOMPLETE: 2 (20%)');
+    expect(csv).not.toContain('OTHER');
+  });
+
+  it('exports direct cached results as XLSX with typed numeric columns', async () => {
+    jobQueueService.getVariableAnalysisJob.mockResolvedValue(
+      createJob({
+        data: { workspaceId: 1 },
+        returnvalue: {
+          variableCombos: [
+            {
+              unitId: 1,
+              unitName: 'UNIT',
+              variableId: 'VAR',
+              totalCount: 10,
+              emptyCount: 1,
+              emptyPercentage: 10,
+              distinctValueCount: 1,
+              statusCounts: [{ status: 5, count: 10, percentage: 100 }]
+            }
+          ],
+          frequencies: {
+            '1:VAR': [
+              {
+                unitId: 1,
+                unitName: 'UNIT',
+                variableId: 'VAR',
+                value: '=kept-as-text',
+                count: 10,
+                percentage: 100
+              }
+            ]
+          },
+          total: 1
+        }
+      })
+    );
+
+    const xlsx = await service.exportAnalysisResultsAsXlsx('job-1', 1);
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(xlsx);
+    const worksheet = workbook.getWorksheet('Antwortwerte');
+
+    expect(worksheet).toBeDefined();
+    expect(worksheet?.getRow(1).getCell(1).value).toBe('Unit-ID');
+    expect(worksheet?.getRow(2).getCell(2).value).toBe('UNIT');
+    expect(worksheet?.getRow(2).getCell(4).value).toBe('=kept-as-text');
+    expect(worksheet?.getRow(2).getCell(6).value).toBe(10);
+    expect(worksheet?.getRow(2).getCell(7).value).toBe(100);
+    expect(worksheet?.getColumn(7).numFmt).toBe('0.0');
   });
 
   it('lists, deletes and cancels jobs', async () => {

--- a/apps/backend/src/app/database/services/test-results/variable-analysis.service.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis.service.ts
@@ -5,11 +5,14 @@ import {
   NotFoundException
 } from '@nestjs/common';
 import { randomUUID } from 'crypto';
+import * as ExcelJS from 'exceljs';
+import * as fastCsv from 'fast-csv';
 import {
   VariableAnalysisResultDto,
   VariableCombo
 } from '../../../admin/variable-analysis/dto/variable-analysis-result.dto';
 import { VariableAnalysisResultPageDto } from '../../../admin/variable-analysis/dto/variable-analysis-result-page.dto';
+import { statusNumberToString } from '../../utils/response-status-converter';
 import {
   JobQueueService,
   VariableAnalysisJobData,
@@ -26,6 +29,37 @@ interface NormalizedVariableAnalysisPaging {
   search: string;
   onlyEmpty: boolean;
 }
+
+interface NormalizedVariableAnalysisFilter {
+  search: string;
+  onlyEmpty: boolean;
+}
+
+const VARIABLE_ANALYSIS_EXPORT_COLUMNS = [
+  { header: 'Unit-ID', key: 'unitId', width: 12 },
+  { header: 'Unit-Name', key: 'unitName', width: 24 },
+  { header: 'Variablen-ID', key: 'variableId', width: 22 },
+  { header: 'Wert', key: 'value', width: 36 },
+  { header: 'Wert ist leer', key: 'isEmptyValue', width: 14 },
+  { header: 'Anzahl', key: 'count', width: 12 },
+  { header: 'Anteil (%)', key: 'percentage', width: 14 },
+  { header: 'Antworten gesamt', key: 'totalCount', width: 18 },
+  { header: 'Leere Werte', key: 'emptyCount', width: 14 },
+  { header: 'Leere Werte (%)', key: 'emptyPercentage', width: 18 },
+  { header: 'Unterschiedliche Werte', key: 'distinctValueCount', width: 22 },
+  { header: 'Weitere Werte nicht enthalten', key: 'hiddenValueCount', width: 28 },
+  { header: 'Antwortstatus', key: 'statusSummary', width: 42 }
+] as const;
+
+type VariableAnalysisExportColumnKey =
+  typeof VARIABLE_ANALYSIS_EXPORT_COLUMNS[number]['key'];
+
+type VariableAnalysisExportCell = string | number;
+
+type VariableAnalysisExportRow = Record<
+VariableAnalysisExportColumnKey,
+VariableAnalysisExportCell
+>;
 
 @Injectable()
 export class VariableAnalysisService {
@@ -173,6 +207,90 @@ export class VariableAnalysisService {
       job.returnvalue as VariableAnalysisResultDto,
       paging
     );
+  }
+
+  async exportAnalysisResultsAsCsv(
+    jobId: number | string,
+    workspaceId: number,
+    options: {
+      search?: string;
+      onlyEmpty?: boolean | string;
+    } = {}
+  ): Promise<string> {
+    const result = await this.getAnalysisResultsForExport(
+      jobId,
+      workspaceId,
+      options
+    );
+    const rows = this.createExportRows(result);
+    const csvRows = rows.map(row => this.toCsvExportRow(row));
+    const csvContent = await fastCsv.writeToString(csvRows, {
+      headers: VARIABLE_ANALYSIS_EXPORT_COLUMNS.map(column => column.header),
+      alwaysWriteHeaders: true,
+      delimiter: ';',
+      quote: '"'
+    });
+
+    return `\uFEFF${csvContent}`;
+  }
+
+  async exportAnalysisResultsAsXlsx(
+    jobId: number | string,
+    workspaceId: number,
+    options: {
+      search?: string;
+      onlyEmpty?: boolean | string;
+    } = {}
+  ): Promise<Buffer> {
+    const result = await this.getAnalysisResultsForExport(
+      jobId,
+      workspaceId,
+      options
+    );
+    const rows = this.createExportRows(result);
+    const workbook = new ExcelJS.Workbook();
+    workbook.created = new Date();
+    workbook.modified = new Date();
+
+    const worksheet = workbook.addWorksheet('Antwortwerte');
+    worksheet.columns = VARIABLE_ANALYSIS_EXPORT_COLUMNS.map(column => ({
+      header: column.header,
+      key: column.key,
+      width: column.width
+    }));
+    worksheet.views = [{ state: 'frozen', ySplit: 1 }];
+    worksheet.autoFilter = {
+      from: { row: 1, column: 1 },
+      to: {
+        row: Math.max(1, rows.length + 1),
+        column: VARIABLE_ANALYSIS_EXPORT_COLUMNS.length
+      }
+    };
+
+    worksheet.getRow(1).font = { bold: true };
+    worksheet.getRow(1).fill = {
+      type: 'pattern',
+      pattern: 'solid',
+      fgColor: { argb: 'FFE0E0E0' }
+    };
+
+    rows.forEach(row => worksheet.addRow(row));
+    ['percentage', 'emptyPercentage'].forEach(columnKey => {
+      worksheet.getColumn(columnKey).numFmt = '0.0';
+    });
+    [
+      'unitId',
+      'count',
+      'totalCount',
+      'emptyCount',
+      'distinctValueCount',
+      'hiddenValueCount'
+    ].forEach(columnKey => {
+      worksheet.getColumn(columnKey).numFmt = '0';
+    });
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    return Buffer.from(buffer);
   }
 
   async getAnalysisJobs(
@@ -370,6 +488,101 @@ export class VariableAnalysisService {
     return this.getChunkedResultPage(cacheKey, cachedValue, paging);
   }
 
+  private async getAnalysisResultsForExport(
+    jobId: number | string,
+    workspaceId: number,
+    options: {
+      search?: string;
+      onlyEmpty?: boolean | string;
+    }
+  ): Promise<VariableAnalysisResultDto> {
+    const job = await this.getCompletedAnalysisJob(jobId, workspaceId);
+    const filter = this.normalizeFilterOptions(options);
+    const cacheKey = this.getResultCacheKey(job.returnvalue, job.data.cacheKey);
+
+    if (cacheKey) {
+      const cachedResult = await this.getCachedResultForExport(cacheKey, filter);
+      if (cachedResult) {
+        return cachedResult;
+      }
+
+      throw new Error(`Job with ID ${jobId} has no cached results`);
+    }
+
+    if (!this.isVariableAnalysisResult(job.returnvalue)) {
+      throw new Error(`Job with ID ${jobId} has no results`);
+    }
+
+    return this.getFilteredResultForExport(
+      job.returnvalue as VariableAnalysisResultDto,
+      filter
+    );
+  }
+
+  private async getCachedResultForExport(
+    cacheKey: string,
+    filter: NormalizedVariableAnalysisFilter
+  ): Promise<VariableAnalysisResultDto | null> {
+    const cachedValue = await this.cacheService.get<
+    VariableAnalysisResultDto | VariableAnalysisResultCacheManifest
+    >(cacheKey);
+
+    if (!cachedValue) {
+      return null;
+    }
+
+    if (this.isVariableAnalysisResult(cachedValue)) {
+      return this.getFilteredResultForExport(cachedValue, filter);
+    }
+
+    if (!this.isChunkedResultManifest(cachedValue)) {
+      return null;
+    }
+
+    return this.getChunkedResultForExport(cacheKey, cachedValue, filter);
+  }
+
+  private async getChunkedResultForExport(
+    cacheKey: string,
+    manifest: VariableAnalysisResultCacheManifest,
+    filter: NormalizedVariableAnalysisFilter
+  ): Promise<VariableAnalysisResultDto | null> {
+    const variableCombos: VariableCombo[] = [];
+
+    for (let index = 0; index < manifest.variableComboChunks; index += 1) {
+      const chunk = await this.cacheService.get<VariableCombo[]>(
+        this.getVariableComboChunkKey(cacheKey, index)
+      );
+      if (!chunk) {
+        return null;
+      }
+
+      chunk.forEach(combo => {
+        if (this.matchesFilter(combo, filter)) {
+          variableCombos.push(combo);
+        }
+      });
+    }
+
+    const selectedComboKeys = new Set(
+      variableCombos.map(combo => this.getComboKey(combo))
+    );
+    const frequencies = await this.getFrequenciesForCombos(
+      cacheKey,
+      manifest,
+      selectedComboKeys
+    );
+    if (!frequencies) {
+      return null;
+    }
+
+    return {
+      variableCombos,
+      frequencies,
+      total: variableCombos.length
+    };
+  }
+
   private async getChunkedResultPage(
     cacheKey: string,
     manifest: VariableAnalysisResultCacheManifest,
@@ -486,6 +699,113 @@ export class VariableAnalysisService {
     };
   }
 
+  private getFilteredResultForExport(
+    result: VariableAnalysisResultDto,
+    filter: NormalizedVariableAnalysisFilter
+  ): VariableAnalysisResultDto {
+    const variableCombos = result.variableCombos.filter(combo => this.matchesFilter(combo, filter)
+    );
+    const selectedComboKeys = new Set(
+      variableCombos.map(combo => this.getComboKey(combo))
+    );
+    const frequencies: Record<string, VariableFrequencyDto[]> = {};
+
+    selectedComboKeys.forEach(comboKey => {
+      frequencies[comboKey] = result.frequencies[comboKey] || [];
+    });
+
+    return {
+      variableCombos,
+      frequencies,
+      total: variableCombos.length
+    };
+  }
+
+  private createExportRows(
+    result: VariableAnalysisResultDto
+  ): VariableAnalysisExportRow[] {
+    const rows: VariableAnalysisExportRow[] = [];
+
+    result.variableCombos.forEach(combo => {
+      const comboKey = this.getComboKey(combo);
+      const frequencies = result.frequencies[comboKey] || [];
+      const totalCount = combo.totalCount ?? this.sumCounts(frequencies);
+      const emptyCount = combo.emptyCount ?? this.sumCounts(
+        frequencies.filter(frequency => frequency.value === '')
+      );
+      const emptyPercentage = combo.emptyPercentage ??
+        this.calculatePercentage(emptyCount, totalCount);
+      const distinctValueCount =
+        combo.distinctValueCount ?? frequencies.length;
+      const hiddenValueCount = Math.max(
+        0,
+        distinctValueCount - frequencies.length
+      );
+      const statusSummary = this.formatStatusSummary(combo.statusCounts || []);
+
+      frequencies.forEach(frequency => {
+        rows.push({
+          unitId: combo.unitId,
+          unitName: combo.unitName,
+          variableId: combo.variableId,
+          value: frequency.value,
+          isEmptyValue: frequency.value === '' ? 'ja' : 'nein',
+          count: frequency.count,
+          percentage: this.roundPercentage(frequency.percentage),
+          totalCount,
+          emptyCount,
+          emptyPercentage: this.roundPercentage(emptyPercentage),
+          distinctValueCount,
+          hiddenValueCount,
+          statusSummary
+        });
+      });
+    });
+
+    return rows;
+  }
+
+  private toCsvExportRow(
+    row: VariableAnalysisExportRow
+  ): Record<string, VariableAnalysisExportCell> {
+    return VARIABLE_ANALYSIS_EXPORT_COLUMNS.reduce<
+    Record<string, VariableAnalysisExportCell>
+    >((csvRow, column) => {
+      const value = row[column.key];
+      csvRow[column.header] = typeof value === 'string' ?
+        this.sanitizeCsvText(value) :
+        value;
+      return csvRow;
+    }, {});
+  }
+
+  private sanitizeCsvText(value: string): string {
+    const normalized = value.replace(/[\r\n\t]+/g, ' ');
+    return /^\s*[=+\-@]/.test(normalized) ? `'${normalized}` : normalized;
+  }
+
+  private sumCounts(frequencies: VariableFrequencyDto[]): number {
+    return frequencies.reduce((sum, frequency) => sum + frequency.count, 0);
+  }
+
+  private calculatePercentage(count: number, total: number): number {
+    return total > 0 ? (count / total) * 100 : 0;
+  }
+
+  private roundPercentage(value: number): number {
+    return Math.round(value * 10) / 10;
+  }
+
+  private formatStatusSummary(
+    statusCounts: Array<{ status: number; count: number; percentage: number }>
+  ): string {
+    return statusCounts.map(statusCount => `${this.getStatusLabel(statusCount.status)}: ${statusCount.count} (${this.roundPercentage(statusCount.percentage)}%)`).join(', ');
+  }
+
+  private getStatusLabel(status: number): string {
+    return statusNumberToString(status) || status.toString();
+  }
+
   private normalizePagingOptions(options: {
     page?: number | string;
     pageSize?: number | string;
@@ -515,22 +835,39 @@ export class VariableAnalysisService {
     };
   }
 
+  private normalizeFilterOptions(options: {
+    search?: string;
+    onlyEmpty?: boolean | string;
+  }): NormalizedVariableAnalysisFilter {
+    return {
+      search: (options.search || '').trim().toLowerCase(),
+      onlyEmpty: options.onlyEmpty === true || options.onlyEmpty === 'true'
+    };
+  }
+
   private matchesPagingFilter(
     combo: VariableCombo,
     paging: NormalizedVariableAnalysisPaging
   ): boolean {
-    if (paging.search) {
+    return this.matchesFilter(combo, paging);
+  }
+
+  private matchesFilter(
+    combo: VariableCombo,
+    filter: NormalizedVariableAnalysisFilter
+  ): boolean {
+    if (filter.search) {
       const unitName = combo.unitName.toLowerCase();
       const variableId = combo.variableId.toLowerCase();
       if (
-        !unitName.includes(paging.search) &&
-        !variableId.includes(paging.search)
+        !unitName.includes(filter.search) &&
+        !variableId.includes(filter.search)
       ) {
         return false;
       }
     }
 
-    if (paging.onlyEmpty && (combo.emptyCount || 0) <= 0) {
+    if (filter.onlyEmpty && (combo.emptyCount || 0) <= 0) {
       return false;
     }
 

--- a/apps/frontend/src/app/shared/services/response/variable-analysis.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/response/variable-analysis.service.spec.ts
@@ -96,4 +96,45 @@ describe('VariableAnalysisService', () => {
       req.flush({});
     });
   });
+
+  describe('exports', () => {
+    it('should export results as CSV with filters', () => {
+      service
+        .exportAnalysisResultsAsCsv(mockWorkspaceId, 5, {
+          search: 'VAR',
+          onlyEmpty: true
+        })
+        .subscribe();
+
+      const req = httpMock.expectOne(
+        r => r.url ===
+            `${mockServerUrl}admin/workspace/${mockWorkspaceId}/variable-analysis/jobs/5/results/export/csv` &&
+          r.params.get('search') === 'VAR' &&
+          r.params.get('onlyEmpty') === 'true'
+      );
+      expect(req.request.method).toBe('GET');
+      expect(req.request.responseType).toBe('blob');
+      req.flush(new Blob(['csv'], { type: 'text/csv' }));
+    });
+
+    it('should export results as XLSX with filters', () => {
+      service
+        .exportAnalysisResultsAsXlsx(mockWorkspaceId, 5, {
+          search: 'VAR'
+        })
+        .subscribe();
+
+      const req = httpMock.expectOne(
+        r => r.url ===
+            `${mockServerUrl}admin/workspace/${mockWorkspaceId}/variable-analysis/jobs/5/results/export/xlsx` &&
+          r.params.get('search') === 'VAR' &&
+          !r.params.has('onlyEmpty')
+      );
+      expect(req.request.method).toBe('GET');
+      expect(req.request.responseType).toBe('blob');
+      req.flush(new Blob(['xlsx'], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      }));
+    });
+  });
 });

--- a/apps/frontend/src/app/shared/services/response/variable-analysis.service.ts
+++ b/apps/frontend/src/app/shared/services/response/variable-analysis.service.ts
@@ -55,6 +55,11 @@ export interface VariableAnalysisResultPageOptions {
   onlyEmpty?: boolean;
 }
 
+export interface VariableAnalysisExportOptions {
+  search?: string;
+  onlyEmpty?: boolean;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -86,6 +91,36 @@ export class VariableAnalysisService {
       null,
       { headers: this.authHeader, params }
     );
+  }
+
+  exportAnalysisResultsAsCsv(
+    workspaceId: number,
+    jobId: number | string,
+    options: VariableAnalysisExportOptions = {}
+  ): Observable<Blob> {
+    return this.http.get(
+      `${this.serverUrl}admin/workspace/${workspaceId}/variable-analysis/jobs/${jobId}/results/export/csv`,
+      {
+        headers: this.authHeader,
+        params: this.buildExportParams(options),
+        responseType: 'blob' as 'json'
+      }
+    ) as unknown as Observable<Blob>;
+  }
+
+  exportAnalysisResultsAsXlsx(
+    workspaceId: number,
+    jobId: number | string,
+    options: VariableAnalysisExportOptions = {}
+  ): Observable<Blob> {
+    return this.http.get(
+      `${this.serverUrl}admin/workspace/${workspaceId}/variable-analysis/jobs/${jobId}/results/export/xlsx`,
+      {
+        headers: this.authHeader,
+        params: this.buildExportParams(options),
+        responseType: 'blob' as 'json'
+      }
+    ) as unknown as Observable<Blob>;
   }
 
   getAnalysisJob(
@@ -167,5 +202,21 @@ export class VariableAnalysisService {
       `${this.serverUrl}admin/workspace/${workspaceId}/variable-analysis/jobs`,
       { headers: this.authHeader }
     );
+  }
+
+  private buildExportParams(
+    options: VariableAnalysisExportOptions
+  ): HttpParams {
+    let params = new HttpParams();
+
+    if (options.search) {
+      params = params.set('search', options.search);
+    }
+
+    if (options.onlyEmpty) {
+      params = params.set('onlyEmpty', 'true');
+    }
+
+    return params;
   }
 }

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.html
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.html
@@ -22,6 +22,14 @@
             <mat-icon>add</mat-icon>
             {{ 'variable-analysis.start-new-analysis' | translate }}
           </button>
+          <button mat-button (click)="downloadAnalysisResults('csv')" [disabled]="!canExportAnalysisResults()">
+            <mat-icon>download</mat-icon>
+            {{ 'variable-analysis.export-csv' | translate }}
+          </button>
+          <button mat-button (click)="downloadAnalysisResults('xlsx')" [disabled]="!canExportAnalysisResults()">
+            <mat-icon>download</mat-icon>
+            {{ 'variable-analysis.export-xlsx' | translate }}
+          </button>
           <button mat-button (click)="isInfoVisible = !isInfoVisible" class="info-toggle">
             <mat-icon>{{ isInfoVisible ? 'expand_less' : 'help_outline' }}</mat-icon>
             {{ (isInfoVisible ? 'variable-analysis.hide-info' : 'variable-analysis.show-info') | translate }}

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.spec.ts
@@ -86,6 +86,14 @@ describe('VariableAnalysisDialogComponent', () => {
       createAnalysisJob: jest.fn().mockReturnValue(of(mockJobs[0])),
       cancelJob: jest.fn().mockReturnValue(of({ success: true })),
       deleteJob: jest.fn().mockReturnValue(of({ success: true })),
+      exportAnalysisResultsAsCsv: jest.fn().mockReturnValue(
+        of(new Blob(['csv'], { type: 'text/csv' }))
+      ),
+      exportAnalysisResultsAsXlsx: jest.fn().mockReturnValue(
+        of(new Blob(['xlsx'], {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        }))
+      ),
       getAnalysisResults: jest
         .fn()
         .mockReturnValue(of({ variableCombos: [], frequencies: {}, total: 0 })),
@@ -342,5 +350,41 @@ describe('VariableAnalysisDialogComponent', () => {
       expect(firstDismiss).toHaveBeenCalled();
       expect(component.data.analysisResults?.total).not.toBe(1);
     }));
+  });
+
+  describe('downloadAnalysisResults', () => {
+    it('should export the current completed analysis with active filters', () => {
+      Object.defineProperty(window.URL, 'createObjectURL', {
+        value: jest.fn().mockReturnValue('blob:variable-analysis'),
+        writable: true
+      });
+      Object.defineProperty(window.URL, 'revokeObjectURL', {
+        value: jest.fn(),
+        writable: true
+      });
+      const clickSpy = jest
+        .spyOn(HTMLAnchorElement.prototype, 'click')
+        .mockImplementation(jest.fn());
+
+      component.viewJobResults(1);
+      component.searchText = 'VAR';
+      component.onlyWithEmptyValues = true;
+
+      expect(component.canExportAnalysisResults()).toBe(true);
+      component.downloadAnalysisResults('csv');
+
+      expect(
+        mockVariableAnalysisService.exportAnalysisResultsAsCsv
+      ).toHaveBeenCalledWith(1, 1, {
+        search: 'VAR',
+        onlyEmpty: true
+      });
+      expect(window.URL.createObjectURL).toHaveBeenCalled();
+      expect(window.URL.revokeObjectURL).toHaveBeenCalledWith(
+        'blob:variable-analysis'
+      );
+
+      clickSpy.mockRestore();
+    });
   });
 });

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
@@ -120,6 +120,8 @@ interface VariableComboSummary {
   statusSummary: string;
 }
 
+type VariableAnalysisExportFormat = 'csv' | 'xlsx';
+
 @Component({
   selector: 'coding-box-variable-analysis-dialog',
   templateUrl: './variable-analysis-dialog.component.html',
@@ -203,6 +205,7 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
   isStartingJob = false;
   private hasAutoStarted = false;
   isInitializing = false;
+  isExporting = false;
 
   constructor(
     public dialogRef: MatDialogRef<VariableAnalysisDialogComponent>,
@@ -881,6 +884,76 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
     this.currentPage = 0;
     this.isUsingServerSideResults = true;
     this.loadAnalysisResultsPage(jobId, true);
+  }
+
+  canExportAnalysisResults(): boolean {
+    return Boolean(
+      this.currentAnalysisJobId &&
+        this.isUsingServerSideResults &&
+        !this.isLoading &&
+        !this.isExporting
+    );
+  }
+
+  downloadAnalysisResults(format: VariableAnalysisExportFormat): void {
+    const jobId = this.currentAnalysisJobId;
+    if (!jobId || this.isExporting) {
+      return;
+    }
+
+    this.isExporting = true;
+    const options = {
+      search: this.searchText.trim() || undefined,
+      onlyEmpty: this.onlyWithEmptyValues
+    };
+    const request = format === 'csv' ?
+      this.variableAnalysisService.exportAnalysisResultsAsCsv(
+        this.data.workspaceId,
+        jobId,
+        options
+      ) :
+      this.variableAnalysisService.exportAnalysisResultsAsXlsx(
+        this.data.workspaceId,
+        jobId,
+        options
+      );
+
+    request.subscribe({
+      next: blob => {
+        this.saveBlob(blob, this.createExportFileName(format));
+        this.isExporting = false;
+        this.snackBar.open(
+          this.translate.instant('variable-analysis.export-success'),
+          'OK',
+          { duration: 3000 }
+        );
+      },
+      error: error => {
+        this.isExporting = false;
+        const errorMessage = error?.error?.message || error?.message || '';
+        this.snackBar.open(
+          `${this.translate.instant('variable-analysis.export-error')}${errorMessage ? `: ${errorMessage}` : ''}`,
+          this.translate.instant('error'),
+          { duration: 5000 }
+        );
+      }
+    });
+  }
+
+  private createExportFileName(format: VariableAnalysisExportFormat): string {
+    const date = new Date().toISOString().slice(0, 10);
+    return `variable-analysis-${this.data.workspaceId}-${date}.${format}`;
+  }
+
+  private saveBlob(blob: Blob, fileName: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = fileName;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    window.URL.revokeObjectURL(url);
   }
 
   private loadAnalysisResultsPage(

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -940,7 +940,11 @@
     "status-cancelled": "Abgebrochen",
     "status-paused": "Pausiert",
     "loading-results": "Lade Analyse-Ergebnisse...",
-    "error-loading-results": "Fehler beim Laden der Analyse-Ergebnisse"
+    "error-loading-results": "Fehler beim Laden der Analyse-Ergebnisse",
+    "export-csv": "CSV",
+    "export-xlsx": "XLSX",
+    "export-success": "Export erfolgreich erstellt",
+    "export-error": "Fehler beim Export"
   },
   "coding-management": {
     "buttons": {


### PR DESCRIPTION
Refs #562

## Änderungen
- ergänzt CSV- und XLSX-Export-Endpunkte für abgeschlossene Variablenanalyse-Jobs
- exportiert gefilterte Analyseergebnisse inklusive Häufigkeiten, Leerwert- und Statusspalten
- schützt CSV-Zellen gegen Formula-Injection und nutzt typisierte XLSX-Zahlenspalten
- bindet CSV/XLSX-Downloads im Variablenanalyse-Dialog an

## Validierung
- npx nx test backend --runInBand
- npx nx test frontend --runInBand

Bitte Review durch @schumaki für Milestone 1.16.0.