### PR TITLE
[codex] Add optional schema codes to variable analysis

### DIFF
--- a/apps/backend/src/app/admin/variable-analysis/dto/variable-frequency.dto.ts
+++ b/apps/backend/src/app/admin/variable-analysis/dto/variable-frequency.dto.ts
@@ -3,6 +3,11 @@ export class VariableFrequencyDto {
   unitName?: string;
   variableId: string;
   value: string;
+  label?: string;
+  score?: number;
+  schemaOrder?: number;
+  isSchemaOnly?: boolean;
+  isSchemaSupplemental?: boolean;
   count: number;
   percentage: number;
 }

--- a/apps/backend/src/app/admin/variable-analysis/variable-analysis.controller.ts
+++ b/apps/backend/src/app/admin/variable-analysis/variable-analysis.controller.ts
@@ -210,6 +210,12 @@ export class VariableAnalysisController {
     required: true,
     description: 'The ID of the job'
   })
+  @ApiQuery({
+    name: 'includeSchemaCodes',
+    type: Boolean,
+    required: false,
+    description: 'Include coding scheme codes that are not part of the default top values'
+  })
   @ApiOkResponse({
     description:
       'The variable analysis results have been successfully retrieved.',
@@ -223,12 +229,14 @@ export class VariableAnalysisController {
   })
   async getAnalysisResults(
     @WorkspaceId() workspaceId: number,
-      @Param('job_id') jobId: string
+      @Param('job_id') jobId: string,
+      @Query('includeSchemaCodes') includeSchemaCodes?: string
   ): Promise<VariableAnalysisResultDto> {
     try {
       return await this.variableAnalysisService.getAnalysisResults(
         jobId,
-        workspaceId
+        workspaceId,
+        { includeSchemaCodes }
       );
     } catch (error) {
       if (error instanceof NotFoundException) {
@@ -287,6 +295,12 @@ export class VariableAnalysisController {
     required: false,
     description: 'Only include variables with empty responses'
   })
+  @ApiQuery({
+    name: 'includeSchemaCodes',
+    type: Boolean,
+    required: false,
+    description: 'Include coding scheme codes that are not part of the default top values'
+  })
   @ApiOkResponse({
     description:
       'The variable analysis result page has been successfully retrieved.',
@@ -304,7 +318,8 @@ export class VariableAnalysisController {
       @Query('page') page?: string,
       @Query('pageSize') pageSize?: string,
       @Query('search') search?: string,
-      @Query('onlyEmpty') onlyEmpty?: string
+      @Query('onlyEmpty') onlyEmpty?: string,
+      @Query('includeSchemaCodes') includeSchemaCodes?: string
   ): Promise<VariableAnalysisResultPageDto> {
     try {
       return await this.variableAnalysisService.getAnalysisResultsPage(
@@ -314,7 +329,8 @@ export class VariableAnalysisController {
           page,
           pageSize,
           search,
-          onlyEmpty
+          onlyEmpty,
+          includeSchemaCodes
         }
       );
     } catch (error) {
@@ -362,6 +378,12 @@ export class VariableAnalysisController {
     required: false,
     description: 'Only include variables with empty responses'
   })
+  @ApiQuery({
+    name: 'includeSchemaCodes',
+    type: Boolean,
+    required: false,
+    description: 'Include coding scheme codes that are not part of the default top values'
+  })
   @ApiOkResponse({
     description: 'Variable analysis results exported as CSV.',
     content: {
@@ -384,6 +406,7 @@ export class VariableAnalysisController {
       @Param('job_id') jobId: string,
       @Query('search') search: string | undefined,
       @Query('onlyEmpty') onlyEmpty: string | undefined,
+      @Query('includeSchemaCodes') includeSchemaCodes: string | undefined,
       @Res() res: Response
   ): Promise<void> {
     try {
@@ -392,7 +415,8 @@ export class VariableAnalysisController {
         workspaceId,
         {
           search,
-          onlyEmpty
+          onlyEmpty,
+          includeSchemaCodes
         }
       );
       const timestamp = new Date().toISOString().slice(0, 10);
@@ -449,6 +473,12 @@ export class VariableAnalysisController {
     required: false,
     description: 'Only include variables with empty responses'
   })
+  @ApiQuery({
+    name: 'includeSchemaCodes',
+    type: Boolean,
+    required: false,
+    description: 'Include coding scheme codes that are not part of the default top values'
+  })
   @ApiOkResponse({
     description: 'Variable analysis results exported as XLSX.',
     content: {
@@ -471,6 +501,7 @@ export class VariableAnalysisController {
       @Param('job_id') jobId: string,
       @Query('search') search: string | undefined,
       @Query('onlyEmpty') onlyEmpty: string | undefined,
+      @Query('includeSchemaCodes') includeSchemaCodes: string | undefined,
       @Res() res: Response
   ): Promise<void> {
     try {
@@ -480,7 +511,8 @@ export class VariableAnalysisController {
           workspaceId,
           {
             search,
-            onlyEmpty
+            onlyEmpty,
+            includeSchemaCodes
           }
         );
       const timestamp = new Date().toISOString().slice(0, 10);

--- a/apps/backend/src/app/database/services/test-results/variable-analysis.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis.service.spec.ts
@@ -281,6 +281,108 @@ describe('VariableAnalysisService', () => {
     });
   });
 
+  it('applies schema code visibility to chunked cached result pages', async () => {
+    const manifest = {
+      storage: 'chunked',
+      workspaceId: 1,
+      total: 1,
+      variableComboChunks: 1,
+      frequencyChunks: 1,
+      storedAt: '2026-05-26T00:00:00.000Z'
+    };
+    const variableCombos = [
+      {
+        unitId: 1,
+        unitName: 'UNIT',
+        variableId: 'VAR',
+        totalCount: 4,
+        emptyCount: 0,
+        emptyPercentage: 0,
+        distinctValueCount: 3,
+        statusCounts: []
+      }
+    ];
+    const frequencyChunks = [
+      [
+        '1:VAR',
+        [
+          {
+            unitId: 1,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'Z',
+            count: 2,
+            percentage: 50
+          },
+          {
+            unitId: 1,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'A',
+            label: 'Alpha',
+            schemaOrder: 0,
+            count: 1,
+            percentage: 25
+          },
+          {
+            unitId: 1,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'B',
+            label: 'Beta',
+            schemaOrder: 1,
+            isSchemaOnly: true,
+            isSchemaSupplemental: true,
+            count: 0,
+            percentage: 0
+          }
+        ]
+      ]
+    ];
+    jobQueueService.getVariableAnalysisJob.mockResolvedValue(
+      createJob({
+        returnvalue: manifest
+      })
+    );
+    cacheService.get
+      .mockResolvedValueOnce(manifest)
+      .mockResolvedValueOnce(variableCombos)
+      .mockResolvedValueOnce(frequencyChunks)
+      .mockResolvedValueOnce(manifest)
+      .mockResolvedValueOnce(variableCombos)
+      .mockResolvedValueOnce(frequencyChunks);
+
+    await expect(
+      service.getAnalysisResultsPage('job-1', 1, {
+        page: 1,
+        pageSize: 10
+      })
+    ).resolves.toMatchObject({
+      frequencies: {
+        '1:VAR': [
+          { value: 'Z' },
+          { value: 'A' }
+        ]
+      }
+    });
+
+    await expect(
+      service.getAnalysisResultsPage('job-1', 1, {
+        page: 1,
+        pageSize: 10,
+        includeSchemaCodes: true
+      })
+    ).resolves.toMatchObject({
+      frequencies: {
+        '1:VAR': [
+          { value: 'A' },
+          { value: 'B', count: 0 },
+          { value: 'Z' }
+        ]
+      }
+    });
+  });
+
   it('exports filtered chunked cached results as formula-safe CSV', async () => {
     jobQueueService.getVariableAnalysisJob.mockResolvedValue(
       createJob({
@@ -421,9 +523,95 @@ describe('VariableAnalysisService', () => {
     expect(worksheet?.getRow(1).getCell(1).value).toBe('Unit-ID');
     expect(worksheet?.getRow(2).getCell(2).value).toBe('UNIT');
     expect(worksheet?.getRow(2).getCell(4).value).toBe('=kept-as-text');
-    expect(worksheet?.getRow(2).getCell(6).value).toBe(10);
-    expect(worksheet?.getRow(2).getCell(7).value).toBe(100);
-    expect(worksheet?.getColumn(7).numFmt).toBe('0.0');
+    expect(worksheet?.getRow(2).getCell(7).value).toBe(10);
+    expect(worksheet?.getRow(2).getCell(8).value).toBe(100);
+    expect(worksheet?.getColumn(8).numFmt).toBe('0.0');
+  });
+
+  it('hides supplemental schema code rows by default and includes them on request', async () => {
+    const result = {
+      variableCombos: [
+        {
+          unitId: 1,
+          unitName: 'UNIT',
+          variableId: 'VAR',
+          totalCount: 4,
+          emptyCount: 0,
+          emptyPercentage: 0,
+          distinctValueCount: 3,
+          statusCounts: []
+        }
+      ],
+      frequencies: {
+        '1:VAR': [
+          {
+            unitId: 1,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'Z',
+            count: 2,
+            percentage: 50
+          },
+          {
+            unitId: 1,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'A',
+            label: 'Alpha',
+            schemaOrder: 0,
+            count: 1,
+            percentage: 25
+          },
+          {
+            unitId: 1,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'B',
+            label: 'Beta',
+            schemaOrder: 1,
+            isSchemaOnly: true,
+            isSchemaSupplemental: true,
+            count: 0,
+            percentage: 0
+          }
+        ]
+      },
+      total: 1
+    };
+    jobQueueService.getVariableAnalysisJob
+      .mockResolvedValueOnce(createJob({
+        data: { workspaceId: 1 },
+        returnvalue: result
+      }))
+      .mockResolvedValueOnce(createJob({
+        data: { workspaceId: 1 },
+        returnvalue: result
+      }));
+
+    await expect(
+      service.getAnalysisResultsPage('job-1', 1)
+    ).resolves.toMatchObject({
+      frequencies: {
+        '1:VAR': [
+          { value: 'Z' },
+          { value: 'A' }
+        ]
+      }
+    });
+
+    await expect(
+      service.getAnalysisResultsPage('job-1', 1, {
+        includeSchemaCodes: true
+      })
+    ).resolves.toMatchObject({
+      frequencies: {
+        '1:VAR': [
+          { value: 'A' },
+          { value: 'B' },
+          { value: 'Z' }
+        ]
+      }
+    });
   });
 
   it('lists, deletes and cancels jobs', async () => {

--- a/apps/backend/src/app/database/services/test-results/variable-analysis.service.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis.service.ts
@@ -28,11 +28,17 @@ interface NormalizedVariableAnalysisPaging {
   pageSize: number;
   search: string;
   onlyEmpty: boolean;
+  includeSchemaCodes: boolean;
+}
+
+interface VariableAnalysisResultOptions {
+  includeSchemaCodes?: boolean | string;
 }
 
 interface NormalizedVariableAnalysisFilter {
   search: string;
   onlyEmpty: boolean;
+  includeSchemaCodes: boolean;
 }
 
 const VARIABLE_ANALYSIS_EXPORT_COLUMNS = [
@@ -40,6 +46,7 @@ const VARIABLE_ANALYSIS_EXPORT_COLUMNS = [
   { header: 'Unit-Name', key: 'unitName', width: 24 },
   { header: 'Variablen-ID', key: 'variableId', width: 22 },
   { header: 'Wert', key: 'value', width: 36 },
+  { header: 'Label', key: 'label', width: 36 },
   { header: 'Wert ist leer', key: 'isEmptyValue', width: 14 },
   { header: 'Anzahl', key: 'count', width: 12 },
   { header: 'Anteil (%)', key: 'percentage', width: 14 },
@@ -154,16 +161,23 @@ export class VariableAnalysisService {
 
   async getAnalysisResults(
     jobId: number | string,
-    workspaceId?: number
+    workspaceId?: number,
+    options: VariableAnalysisResultOptions = {}
   ): Promise<VariableAnalysisResultDto> {
     const job = await this.getCompletedAnalysisJob(jobId, workspaceId);
+    const includeSchemaCodes = this.normalizeBooleanOption(
+      options.includeSchemaCodes
+    );
 
     const cacheKey = this.getResultCacheKey(job.returnvalue, job.data.cacheKey);
 
     if (cacheKey) {
       const cachedResult = await this.getCachedResult(cacheKey);
       if (cachedResult) {
-        return cachedResult;
+        return this.withSchemaCodeVisibility(
+          cachedResult,
+          includeSchemaCodes
+        );
       }
 
       throw new Error(`Job with ID ${jobId} has no cached results`);
@@ -173,7 +187,10 @@ export class VariableAnalysisService {
       throw new Error(`Job with ID ${jobId} has no results`);
     }
 
-    return job.returnvalue as VariableAnalysisResultDto;
+    return this.withSchemaCodeVisibility(
+      job.returnvalue as VariableAnalysisResultDto,
+      includeSchemaCodes
+    );
   }
 
   async getAnalysisResultsPage(
@@ -184,6 +201,7 @@ export class VariableAnalysisService {
       pageSize?: number | string;
       search?: string;
       onlyEmpty?: boolean | string;
+      includeSchemaCodes?: boolean | string;
     } = {}
   ): Promise<VariableAnalysisResultPageDto> {
     const job = await this.getCompletedAnalysisJob(jobId, workspaceId);
@@ -215,6 +233,7 @@ export class VariableAnalysisService {
     options: {
       search?: string;
       onlyEmpty?: boolean | string;
+      includeSchemaCodes?: boolean | string;
     } = {}
   ): Promise<string> {
     const result = await this.getAnalysisResultsForExport(
@@ -240,6 +259,7 @@ export class VariableAnalysisService {
     options: {
       search?: string;
       onlyEmpty?: boolean | string;
+      includeSchemaCodes?: boolean | string;
     } = {}
   ): Promise<Buffer> {
     const result = await this.getAnalysisResultsForExport(
@@ -494,6 +514,7 @@ export class VariableAnalysisService {
     options: {
       search?: string;
       onlyEmpty?: boolean | string;
+      includeSchemaCodes?: boolean | string;
     }
   ): Promise<VariableAnalysisResultDto> {
     const job = await this.getCompletedAnalysisJob(jobId, workspaceId);
@@ -570,7 +591,8 @@ export class VariableAnalysisService {
     const frequencies = await this.getFrequenciesForCombos(
       cacheKey,
       manifest,
-      selectedComboKeys
+      selectedComboKeys,
+      filter.includeSchemaCodes
     );
     if (!frequencies) {
       return null;
@@ -619,7 +641,8 @@ export class VariableAnalysisService {
     const frequencies = await this.getFrequenciesForCombos(
       cacheKey,
       manifest,
-      selectedComboKeys
+      selectedComboKeys,
+      paging.includeSchemaCodes
     );
     if (!frequencies) {
       return null;
@@ -639,7 +662,8 @@ export class VariableAnalysisService {
   private async getFrequenciesForCombos(
     cacheKey: string,
     manifest: VariableAnalysisResultCacheManifest,
-    selectedComboKeys: Set<string>
+    selectedComboKeys: Set<string>,
+    includeSchemaCodes: boolean
   ): Promise<Record<string, VariableFrequencyDto[]> | null> {
     const frequencies: Record<string, VariableFrequencyDto[]> = {};
     selectedComboKeys.forEach(comboKey => {
@@ -660,7 +684,10 @@ export class VariableAnalysisService {
 
       for (const [key, values] of chunk) {
         if (selectedComboKeys.has(key)) {
-          frequencies[key] = values;
+          frequencies[key] = this.getVisibleFrequencyRows(
+            values,
+            includeSchemaCodes
+          );
         }
       }
     }
@@ -685,7 +712,10 @@ export class VariableAnalysisService {
     const frequencies: Record<string, VariableFrequencyDto[]> = {};
 
     selectedComboKeys.forEach(comboKey => {
-      frequencies[comboKey] = result.frequencies[comboKey] || [];
+      frequencies[comboKey] = this.getVisibleFrequencyRows(
+        result.frequencies[comboKey] || [],
+        paging.includeSchemaCodes
+      );
     });
 
     return {
@@ -711,7 +741,10 @@ export class VariableAnalysisService {
     const frequencies: Record<string, VariableFrequencyDto[]> = {};
 
     selectedComboKeys.forEach(comboKey => {
-      frequencies[comboKey] = result.frequencies[comboKey] || [];
+      frequencies[comboKey] = this.getVisibleFrequencyRows(
+        result.frequencies[comboKey] || [],
+        filter.includeSchemaCodes
+      );
     });
 
     return {
@@ -737,9 +770,12 @@ export class VariableAnalysisService {
         this.calculatePercentage(emptyCount, totalCount);
       const distinctValueCount =
         combo.distinctValueCount ?? frequencies.length;
+      const displayedObservedValueCount = frequencies.filter(
+        frequency => !frequency.isSchemaOnly
+      ).length;
       const hiddenValueCount = Math.max(
         0,
-        distinctValueCount - frequencies.length
+        distinctValueCount - displayedObservedValueCount
       );
       const statusSummary = this.formatStatusSummary(combo.statusCounts || []);
 
@@ -749,6 +785,7 @@ export class VariableAnalysisService {
           unitName: combo.unitName,
           variableId: combo.variableId,
           value: frequency.value,
+          label: frequency.label || '',
           isEmptyValue: frequency.value === '' ? 'ja' : 'nein',
           count: frequency.count,
           percentage: this.roundPercentage(frequency.percentage),
@@ -811,6 +848,7 @@ export class VariableAnalysisService {
     pageSize?: number | string;
     search?: string;
     onlyEmpty?: boolean | string;
+    includeSchemaCodes?: boolean | string;
   }): NormalizedVariableAnalysisPaging {
     const page = Math.max(
       this.DEFAULT_PAGE,
@@ -824,25 +862,36 @@ export class VariableAnalysisService {
       Math.min(requestedPageSize, this.MAX_PAGE_SIZE)
     );
     const search = (options.search || '').trim().toLowerCase();
-    const onlyEmpty =
-      options.onlyEmpty === true || options.onlyEmpty === 'true';
+    const onlyEmpty = this.normalizeBooleanOption(options.onlyEmpty);
+    const includeSchemaCodes = this.normalizeBooleanOption(
+      options.includeSchemaCodes
+    );
 
     return {
       page,
       pageSize,
       search,
-      onlyEmpty
+      onlyEmpty,
+      includeSchemaCodes
     };
   }
 
   private normalizeFilterOptions(options: {
     search?: string;
     onlyEmpty?: boolean | string;
+    includeSchemaCodes?: boolean | string;
   }): NormalizedVariableAnalysisFilter {
     return {
       search: (options.search || '').trim().toLowerCase(),
-      onlyEmpty: options.onlyEmpty === true || options.onlyEmpty === 'true'
+      onlyEmpty: this.normalizeBooleanOption(options.onlyEmpty),
+      includeSchemaCodes: this.normalizeBooleanOption(
+        options.includeSchemaCodes
+      )
     };
+  }
+
+  private normalizeBooleanOption(value?: boolean | string): boolean {
+    return value === true || value === 'true';
   }
 
   private matchesPagingFilter(
@@ -876,6 +925,47 @@ export class VariableAnalysisService {
 
   private getComboKey(combo: { unitId: number; variableId: string }): string {
     return `${combo.unitId}:${combo.variableId}`;
+  }
+
+  private withSchemaCodeVisibility(
+    result: VariableAnalysisResultDto,
+    includeSchemaCodes: boolean
+  ): VariableAnalysisResultDto {
+    const frequencies = Object.fromEntries(
+      Object.entries(result.frequencies).map(([comboKey, rows]) => [
+        comboKey,
+        this.getVisibleFrequencyRows(rows, includeSchemaCodes)
+      ])
+    );
+
+    return {
+      ...result,
+      frequencies
+    };
+  }
+
+  private getVisibleFrequencyRows(
+    rows: VariableFrequencyDto[],
+    includeSchemaCodes: boolean
+  ): VariableFrequencyDto[] {
+    if (!includeSchemaCodes) {
+      return rows.filter(row => !row.isSchemaSupplemental);
+    }
+
+    return [...rows].sort((a, b) => {
+      const aHasSchemaOrder = Number.isFinite(a.schemaOrder);
+      const bHasSchemaOrder = Number.isFinite(b.schemaOrder);
+
+      if (aHasSchemaOrder && bHasSchemaOrder) {
+        return (a.schemaOrder as number) - (b.schemaOrder as number);
+      }
+
+      if (aHasSchemaOrder !== bHasSchemaOrder) {
+        return aHasSchemaOrder ? -1 : 1;
+      }
+
+      return 0;
+    });
   }
 
   private async deleteCachedResult(

--- a/apps/backend/src/app/job-queue/processors/variable-analysis.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/variable-analysis.processor.spec.ts
@@ -1,6 +1,7 @@
 import { Job } from 'bull';
 import { CacheService } from '../../cache/cache.service';
 import { WorkspaceExclusionService } from '../../database/services/workspace';
+import { WorkspaceFilesService } from '../../database/services/workspace/workspace-files.service';
 import { VariableAnalysisJobData } from '../job-queue.service';
 import { VariableAnalysisProcessor } from './variable-analysis.processor';
 
@@ -74,10 +75,14 @@ describe('VariableAnalysisProcessor', () => {
         testletIgnoredUnits: []
       })
     };
+    const workspaceFilesService = {
+      getUnitVariableDetails: jest.fn().mockResolvedValue([])
+    };
     const processor = new VariableAnalysisProcessor(
       responseRepository as never,
       cacheService as unknown as CacheService,
-      workspaceExclusionService as unknown as WorkspaceExclusionService
+      workspaceExclusionService as unknown as WorkspaceExclusionService,
+      workspaceFilesService as unknown as WorkspaceFilesService
     );
     const job = {
       id: 'job-1',
@@ -126,6 +131,132 @@ describe('VariableAnalysisProcessor', () => {
         variableComboChunks: 1,
         frequencyChunks: 1
       }),
+      86400
+    );
+  });
+
+  it('adds coding scheme codes as optional supplemental frequency rows', async () => {
+    const baseQuery = createQueryBuilder();
+    const variableCombosQuery = createQueryBuilder([
+      { unitId: '1', unitName: 'UNIT', variableId: 'VAR' }
+    ]);
+    const summaryQuery = createQueryBuilder([
+      {
+        unitId: '1',
+        variableId: 'VAR',
+        totalCount: '4',
+        emptyCount: '0',
+        distinctValueCount: '3'
+      }
+    ]);
+    const topValuesQuery = createQueryBuilder();
+    const schemaCountQuery = createQueryBuilder([
+      {
+        unitId: '1',
+        variableId: 'VAR',
+        value: 'B',
+        count: '1'
+      }
+    ]);
+    const statusQuery = createQueryBuilder([]);
+    baseQuery.clone = jest.fn()
+      .mockReturnValueOnce(variableCombosQuery)
+      .mockReturnValueOnce(summaryQuery)
+      .mockReturnValueOnce(topValuesQuery)
+      .mockReturnValueOnce(schemaCountQuery)
+      .mockReturnValueOnce(statusQuery);
+
+    const responseRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(baseQuery),
+      query: jest.fn().mockResolvedValue([
+        {
+          unitId: '1',
+          unitName: 'UNIT',
+          variableId: 'VAR',
+          value: 'A',
+          valueLength: '1',
+          valueHash: 'hash-a',
+          count: '2'
+        }
+      ])
+    };
+    const cacheService = {
+      set: jest.fn().mockResolvedValue(true)
+    };
+    const workspaceExclusionService = {
+      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+        globalIgnoredUnits: [],
+        ignoredBooklets: [],
+        testletIgnoredUnits: []
+      })
+    };
+    const workspaceFilesService = {
+      getUnitVariableDetails: jest.fn().mockResolvedValue([
+        {
+          unitName: 'UNIT',
+          unitId: 'UNIT',
+          variables: [
+            {
+              id: 'VAR',
+              alias: 'VAR',
+              type: 'string',
+              hasCodingScheme: true,
+              codes: [
+                { id: 'A', label: 'Alpha' },
+                { id: 'B', label: 'Beta' },
+                { id: 'C', label: 'Gamma', score: 0 }
+              ]
+            }
+          ]
+        }
+      ])
+    };
+    const processor = new VariableAnalysisProcessor(
+      responseRepository as never,
+      cacheService as unknown as CacheService,
+      workspaceExclusionService as unknown as WorkspaceExclusionService,
+      workspaceFilesService as unknown as WorkspaceFilesService
+    );
+    const job = {
+      id: 'job-1',
+      data: {
+        workspaceId: 1,
+        cacheKey: 'variable-analysis:1:job-1'
+      },
+      progress: jest.fn().mockResolvedValue(undefined)
+    } as unknown as Job<VariableAnalysisJobData>;
+
+    await processor.process(job);
+
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'variable-analysis:1:job-1:frequencies:0',
+      [['1:VAR', [
+        expect.objectContaining({
+          value: 'A',
+          label: 'Alpha',
+          count: 2,
+          percentage: 50,
+          schemaOrder: 0
+        }),
+        expect.objectContaining({
+          value: 'B',
+          label: 'Beta',
+          count: 1,
+          percentage: 25,
+          schemaOrder: 1,
+          isSchemaSupplemental: true
+        }),
+        expect.objectContaining({
+          value: 'C',
+          label: 'Gamma',
+          score: 0,
+          count: 0,
+          percentage: 0,
+          schemaOrder: 2,
+          isSchemaOnly: true,
+          isSchemaSupplemental: true
+        })
+      ]]],
       86400
     );
   });

--- a/apps/backend/src/app/job-queue/processors/variable-analysis.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/variable-analysis.processor.ts
@@ -2,7 +2,7 @@ import { Processor, Process } from '@nestjs/bull';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bull';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Brackets, Repository, SelectQueryBuilder } from 'typeorm';
 import { ResponseEntity } from '../../database/entities/response.entity';
 import { CacheService } from '../../cache/cache.service';
 import {
@@ -16,6 +16,21 @@ import {
   applyResolvedExclusionsToQuery,
   WorkspaceExclusionService
 } from '../../database/services/workspace/workspace-exclusion.service';
+import { WorkspaceFilesService } from '../../database/services/workspace/workspace-files.service';
+
+interface SchemaCodeInfo {
+  value: string;
+  label?: string;
+  score?: number;
+  order: number;
+}
+
+interface SchemaValueCountRow {
+  unitId: string | number;
+  variableId: string;
+  value: string | null;
+  count: string | number;
+}
 
 @Processor('variable-analysis')
 export class VariableAnalysisProcessor {
@@ -30,7 +45,8 @@ export class VariableAnalysisProcessor {
     @InjectRepository(ResponseEntity)
     private responseRepository: Repository<ResponseEntity>,
     private cacheService: CacheService,
-    private workspaceExclusionService: WorkspaceExclusionService
+    private workspaceExclusionService: WorkspaceExclusionService,
+    private workspaceFilesService: WorkspaceFilesService
   ) { }
 
   @Process()
@@ -107,6 +123,10 @@ export class VariableAnalysisProcessor {
         comboByKey.set(comboKey, combo);
         frequencies[comboKey] = [];
       });
+      const schemaCodesByComboKey = await this.getSchemaCodesByComboKey(
+        workspaceId,
+        variableCombos
+      );
 
       await job.progress(25);
 
@@ -206,6 +226,13 @@ export class VariableAnalysisProcessor {
           percentage: totalResponses > 0 ? (item.count / totalResponses) * 100 : 0
         }));
       });
+
+      await this.addSchemaCodeFrequencies(
+        query,
+        variableCombos,
+        frequencies,
+        schemaCodesByComboKey
+      );
 
       await job.progress(70);
 
@@ -373,5 +400,190 @@ export class VariableAnalysisProcessor {
     }
 
     return `${value}... [truncated ${valueLength} chars, md5:${valueHash || 'unknown'}]`;
+  }
+
+  private async getSchemaCodesByComboKey(
+    workspaceId: number,
+    variableCombos: VariableCombo[]
+  ): Promise<Map<string, SchemaCodeInfo[]>> {
+    const schemaCodesByComboKey = new Map<string, SchemaCodeInfo[]>();
+
+    if (variableCombos.length === 0) {
+      return schemaCodesByComboKey;
+    }
+
+    try {
+      const unitVariableDetails =
+        await this.workspaceFilesService.getUnitVariableDetails(workspaceId);
+      const detailsByUnitName = new Map(
+        unitVariableDetails.map(details => [
+          details.unitName.toUpperCase(),
+          details
+        ])
+      );
+
+      variableCombos.forEach(combo => {
+        const details = detailsByUnitName.get(combo.unitName.toUpperCase());
+        if (!details) {
+          return;
+        }
+
+        const variable = details.variables.find(
+          item => item.id === combo.variableId || item.alias === combo.variableId
+        );
+        if (!variable?.codes?.length) {
+          return;
+        }
+
+        const seenValues = new Set<string>();
+        const schemaCodes = variable.codes.reduce<SchemaCodeInfo[]>(
+          (items, code) => {
+            const value = String(code.id);
+            if (seenValues.has(value)) {
+              return items;
+            }
+            seenValues.add(value);
+            items.push({
+              value,
+              label: code.label,
+              score: code.score,
+              order: items.length
+            });
+            return items;
+          },
+          []
+        );
+
+        if (schemaCodes.length > 0) {
+          schemaCodesByComboKey.set(
+            `${combo.unitId}:${combo.variableId}`,
+            schemaCodes
+          );
+        }
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Could not enrich variable analysis with coding scheme codes: ${error.message}`
+      );
+    }
+
+    return schemaCodesByComboKey;
+  }
+
+  private async addSchemaCodeFrequencies(
+    query: SelectQueryBuilder<ResponseEntity>,
+    variableCombos: VariableCombo[],
+    frequencies: Record<string, VariableFrequencyDto[]>,
+    schemaCodesByComboKey: Map<string, SchemaCodeInfo[]>
+  ): Promise<void> {
+    if (schemaCodesByComboKey.size === 0) {
+      return;
+    }
+
+    const observedSchemaCounts = await this.getObservedSchemaValueCounts(
+      query,
+      variableCombos,
+      schemaCodesByComboKey
+    );
+
+    variableCombos.forEach(combo => {
+      const comboKey = `${combo.unitId}:${combo.variableId}`;
+      const schemaCodes = schemaCodesByComboKey.get(comboKey);
+      if (!schemaCodes?.length) {
+        return;
+      }
+
+      const rows = frequencies[comboKey] || [];
+      const rowsByValue = new Map(rows.map(row => [row.value, row]));
+      const observedCountsForCombo =
+        observedSchemaCounts.get(comboKey) || new Map<string, number>();
+      const totalResponses = combo.totalCount || 0;
+
+      schemaCodes.forEach(schemaCode => {
+        const existingRow = rowsByValue.get(schemaCode.value);
+
+        if (existingRow) {
+          existingRow.label = schemaCode.label;
+          existingRow.score = schemaCode.score;
+          existingRow.schemaOrder = schemaCode.order;
+          return;
+        }
+
+        const count = observedCountsForCombo.get(schemaCode.value) || 0;
+        rows.push({
+          unitId: combo.unitId,
+          unitName: combo.unitName,
+          variableId: combo.variableId,
+          value: schemaCode.value,
+          label: schemaCode.label,
+          score: schemaCode.score,
+          schemaOrder: schemaCode.order,
+          isSchemaOnly: count === 0,
+          isSchemaSupplemental: true,
+          count,
+          percentage: totalResponses > 0 ? (count / totalResponses) * 100 : 0
+        });
+      });
+
+      frequencies[comboKey] = rows;
+    });
+  }
+
+  private async getObservedSchemaValueCounts(
+    query: SelectQueryBuilder<ResponseEntity>,
+    variableCombos: VariableCombo[],
+    schemaCodesByComboKey: Map<string, SchemaCodeInfo[]>
+  ): Promise<Map<string, Map<string, number>>> {
+    const countsByComboKey = new Map<string, Map<string, number>>();
+    const combosWithSchemaCodes = variableCombos.filter(combo => {
+      const comboKey = `${combo.unitId}:${combo.variableId}`;
+      return (schemaCodesByComboKey.get(comboKey)?.length || 0) > 0;
+    });
+    const chunkSize = 100;
+
+    for (let index = 0; index < combosWithSchemaCodes.length; index += chunkSize) {
+      const comboChunk = combosWithSchemaCodes.slice(index, index + chunkSize);
+      const schemaCountQuery = query.clone()
+        .select('unit.id', 'unitId')
+        .addSelect('response.variableid', 'variableId')
+        .addSelect("COALESCE(response.value, '')", 'value')
+        .addSelect('COUNT(*)', 'count')
+        .andWhere(new Brackets(qb => {
+          comboChunk.forEach((combo, comboIndex) => {
+            const comboKey = `${combo.unitId}:${combo.variableId}`;
+            const schemaValues = (schemaCodesByComboKey.get(comboKey) || [])
+              .map(schemaCode => schemaCode.value);
+            const params = {
+              [`schemaUnitId${comboIndex}`]: combo.unitId,
+              [`schemaVariableId${comboIndex}`]: combo.variableId,
+              [`schemaValues${comboIndex}`]: schemaValues
+            };
+            const condition =
+              `unit.id = :schemaUnitId${comboIndex} ` +
+              `AND response.variableid = :schemaVariableId${comboIndex} ` +
+              `AND COALESCE(response.value, '') IN (:...schemaValues${comboIndex})`;
+
+            if (comboIndex === 0) {
+              qb.where(condition, params);
+            } else {
+              qb.orWhere(condition, params);
+            }
+          });
+        }))
+        .groupBy('unit.id')
+        .addGroupBy('response.variableid')
+        .addGroupBy("COALESCE(response.value, '')");
+
+      const rows: SchemaValueCountRow[] = await schemaCountQuery.getRawMany();
+
+      rows.forEach(row => {
+        const comboKey = `${Number(row.unitId)}:${row.variableId}`;
+        const valueCounts = countsByComboKey.get(comboKey) || new Map<string, number>();
+        valueCounts.set(row.value || '', parseInt(String(row.count), 10));
+        countsByComboKey.set(comboKey, valueCounts);
+      });
+    }
+
+    return countsByComboKey;
   }
 }

--- a/apps/frontend/src/app/shared/services/response/variable-analysis.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/response/variable-analysis.service.spec.ts
@@ -80,7 +80,8 @@ describe('VariableAnalysisService', () => {
           page: 2,
           pageSize: 100,
           search: 'VAR',
-          onlyEmpty: true
+          onlyEmpty: true,
+          includeSchemaCodes: true
         })
         .subscribe();
 
@@ -90,7 +91,8 @@ describe('VariableAnalysisService', () => {
           r.params.get('page') === '2' &&
           r.params.get('pageSize') === '100' &&
           r.params.get('search') === 'VAR' &&
-          r.params.get('onlyEmpty') === 'true'
+          r.params.get('onlyEmpty') === 'true' &&
+          r.params.get('includeSchemaCodes') === 'true'
       );
       expect(req.request.method).toBe('GET');
       req.flush({});
@@ -102,7 +104,8 @@ describe('VariableAnalysisService', () => {
       service
         .exportAnalysisResultsAsCsv(mockWorkspaceId, 5, {
           search: 'VAR',
-          onlyEmpty: true
+          onlyEmpty: true,
+          includeSchemaCodes: true
         })
         .subscribe();
 
@@ -110,7 +113,8 @@ describe('VariableAnalysisService', () => {
         r => r.url ===
             `${mockServerUrl}admin/workspace/${mockWorkspaceId}/variable-analysis/jobs/5/results/export/csv` &&
           r.params.get('search') === 'VAR' &&
-          r.params.get('onlyEmpty') === 'true'
+          r.params.get('onlyEmpty') === 'true' &&
+          r.params.get('includeSchemaCodes') === 'true'
       );
       expect(req.request.method).toBe('GET');
       expect(req.request.responseType).toBe('blob');

--- a/apps/frontend/src/app/shared/services/response/variable-analysis.service.ts
+++ b/apps/frontend/src/app/shared/services/response/variable-analysis.service.ts
@@ -14,6 +14,11 @@ export interface VariableFrequencyDto {
   unitName?: string;
   variableId: string;
   value: string;
+  label?: string;
+  score?: number;
+  schemaOrder?: number;
+  isSchemaOnly?: boolean;
+  isSchemaSupplemental?: boolean;
   count: number;
   percentage: number;
 }
@@ -53,11 +58,13 @@ export interface VariableAnalysisResultPageOptions {
   pageSize: number;
   search?: string;
   onlyEmpty?: boolean;
+  includeSchemaCodes?: boolean;
 }
 
 export interface VariableAnalysisExportOptions {
   search?: string;
   onlyEmpty?: boolean;
+  includeSchemaCodes?: boolean;
 }
 
 @Injectable({
@@ -163,6 +170,10 @@ export class VariableAnalysisService {
       params = params.set('onlyEmpty', 'true');
     }
 
+    if (options.includeSchemaCodes) {
+      params = params.set('includeSchemaCodes', 'true');
+    }
+
     return this.http.get<VariableAnalysisResultPageDto>(
       `${this.serverUrl}admin/workspace/${workspaceId}/variable-analysis/jobs/${jobId}/results/page`,
       { headers: this.authHeader, params }
@@ -215,6 +226,10 @@ export class VariableAnalysisService {
 
     if (options.onlyEmpty) {
       params = params.set('onlyEmpty', 'true');
+    }
+
+    if (options.includeSchemaCodes) {
+      params = params.set('includeSchemaCodes', 'true');
     }
 
     return params;

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.html
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.html
@@ -90,6 +90,9 @@
           <mat-checkbox [(ngModel)]="onlyWithEmptyValues" (change)="onEmptyValuesFilterChange()">
             {{ 'variable-analysis.only-empty-values' | translate }}
           </mat-checkbox>
+          <mat-slide-toggle [(ngModel)]="includeSchemaCodes" (change)="onSchemaCodesToggleChange()" color="primary">
+            {{ 'variable-analysis.include-schema-codes' | translate }}
+          </mat-slide-toggle>
         </div>
 
         @if (variableCombos.length === 0) {
@@ -150,6 +153,9 @@
                       <span class="empty-value">{{ 'variable-analysis.empty-value' | translate }}</span>
                       } @else {
                       <span>{{ item.value | slice:0:100 }}{{ item.value.length > 100 ? '...' : '' }}</span>
+                      }
+                      @if (item.label && item.label !== item.value) {
+                      <span class="value-label">{{ item.label }}</span>
                       }
                     </div>
                   </td>

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.scss
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.scss
@@ -182,12 +182,20 @@
 }
 
 .value-cell {
+  display: flex;
+  flex-direction: column;
   max-width: 400px;
   word-break: break-word;
 
   .empty-value {
     font-style: italic;
     color: #888;
+  }
+
+  .value-label {
+    color: #666;
+    font-size: 12px;
+    line-height: 1.3;
   }
 }
 

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.spec.ts
@@ -315,9 +315,28 @@ describe('VariableAnalysisDialogComponent', () => {
         page: 1,
         pageSize: 50,
         search: '',
-        onlyEmpty: false
+        onlyEmpty: false,
+        includeSchemaCodes: false
       });
       expect(analyzeSpy).toHaveBeenCalled();
+    });
+
+    it('reloads server-side results when schema code visibility changes', () => {
+      component.viewJobResults(1);
+      mockVariableAnalysisService.getAnalysisResultsPage.mockClear();
+
+      component.includeSchemaCodes = true;
+      component.onSchemaCodesToggleChange();
+
+      expect(
+        mockVariableAnalysisService.getAnalysisResultsPage
+      ).toHaveBeenCalledWith(1, 1, {
+        page: 1,
+        pageSize: 50,
+        search: '',
+        onlyEmpty: false,
+        includeSchemaCodes: true
+      });
     });
 
     it('should dismiss stale loading snackbars without applying stale results', fakeAsync(() => {
@@ -377,7 +396,8 @@ describe('VariableAnalysisDialogComponent', () => {
         mockVariableAnalysisService.exportAnalysisResultsAsCsv
       ).toHaveBeenCalledWith(1, 1, {
         search: 'VAR',
-        onlyEmpty: true
+        onlyEmpty: true,
+        includeSchemaCodes: false
       });
       expect(window.URL.createObjectURL).toHaveBeenCalled();
       expect(window.URL.revokeObjectURL).toHaveBeenCalledWith(

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
@@ -22,6 +22,7 @@ import {
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { FormsModule } from '@angular/forms';
 import { Subject, Subscription, timer } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
@@ -74,6 +75,11 @@ export interface VariableAnalysisData {
         unitName?: string;
         variableId: string;
         value: string;
+        label?: string;
+        score?: number;
+        schemaOrder?: number;
+        isSchemaOnly?: boolean;
+        isSchemaSupplemental?: boolean;
         count: number;
         percentage: number;
       }[];
@@ -92,6 +98,11 @@ export interface VariableFrequency {
   unitName?: string;
   variableid: string;
   value: string;
+  label?: string;
+  score?: number;
+  schemaOrder?: number;
+  isSchemaOnly?: boolean;
+  isSchemaSupplemental?: boolean;
   count: number;
   percentage: number;
 }
@@ -142,6 +153,7 @@ type VariableAnalysisExportFormat = 'csv' | 'xlsx';
     MatInputModule,
     MatFormFieldModule,
     MatCheckboxModule,
+    MatSlideToggleModule,
     MatTabsModule,
     MatTooltipModule,
     TranslateModule
@@ -168,6 +180,7 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
 
   searchText = '';
   onlyWithEmptyValues = false;
+  includeSchemaCodes = false;
   isInfoVisible = false;
   private searchSubject = new Subject<string>();
   private searchSubscription: Subscription | undefined;
@@ -347,6 +360,11 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
                 unitName: freq.unitName,
                 variableid: freq.variableId,
                 value: freq.value,
+                label: freq.label,
+                score: freq.score,
+                schemaOrder: freq.schemaOrder,
+                isSchemaOnly: freq.isSchemaOnly,
+                isSchemaSupplemental: freq.isSchemaSupplemental,
                 count: freq.count,
                 percentage: freq.percentage
               }));
@@ -559,7 +577,10 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
   getHiddenValueCount(combo: VariableCombo): number {
     const frequencies = this.variableFrequencies[this.getComboKey(combo)] || [];
     const distinctValueCount = combo.distinctValueCount ?? frequencies.length;
-    return Math.max(0, distinctValueCount - frequencies.length);
+    const displayedObservedValueCount = frequencies.filter(
+      item => !item.isSchemaOnly
+    ).length;
+    return Math.max(0, distinctValueCount - displayedObservedValueCount);
   }
 
   private getFilteredCombos(): VariableCombo[] {
@@ -610,6 +631,15 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
   }
 
   onEmptyValuesFilterChange(): void {
+    this.currentPage = 0;
+    if (this.currentAnalysisJobId && this.isUsingServerSideResults) {
+      this.loadAnalysisResultsPage(this.currentAnalysisJobId);
+      return;
+    }
+    this.filterVariables();
+  }
+
+  onSchemaCodesToggleChange(): void {
     this.currentPage = 0;
     if (this.currentAnalysisJobId && this.isUsingServerSideResults) {
       this.loadAnalysisResultsPage(this.currentAnalysisJobId);
@@ -904,7 +934,8 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
     this.isExporting = true;
     const options = {
       search: this.searchText.trim() || undefined,
-      onlyEmpty: this.onlyWithEmptyValues
+      onlyEmpty: this.onlyWithEmptyValues,
+      includeSchemaCodes: this.includeSchemaCodes
     };
     const request = format === 'csv' ?
       this.variableAnalysisService.exportAnalysisResultsAsCsv(
@@ -978,7 +1009,8 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
         page: this.currentPage + 1,
         pageSize: this.pageSize,
         search: this.searchText,
-        onlyEmpty: this.onlyWithEmptyValues
+        onlyEmpty: this.onlyWithEmptyValues,
+        includeSchemaCodes: this.includeSchemaCodes
       })
       .subscribe({
         next: (results: VariableAnalysisResultPageDto) => {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -890,6 +890,7 @@
     "search-variables": "Variablen suchen",
     "search-placeholder": "Variablenname eingeben...",
     "only-empty-values": "Nur Variablen mit leeren Werten",
+    "include-schema-codes": "Schema-Codes mit 0 anzeigen",
     "no-variables-found": "Keine Variablen gefunden.",
     "no-results-yet": "Noch keine Antwortwertanalyse geladen.",
     "max-values-info": "Es werden maximal die {{max}} häufigsten Werte pro Variable angezeigt.",


### PR DESCRIPTION
Closes #558

## Zusammenfassung
- Ergaenzt die Variablenanalyse um Kodierschema-Metadaten wie Label, Score und stabile Schema-Reihenfolge.
- Blendet supplemental Schema-Codes standardmaessig aus, damit die Standardansicht nur tatsaechlich abgegebene Antwortwerte zeigt.
- Fuegt Toggle/API-Parameter `includeSchemaCodes=true` hinzu, um Schema-Codes optional einzublenden.
- Uebernimmt dieselbe Einstellung fuer paginierte Ergebnisse sowie CSV- und XLSX-Exporte.

## Fachlicher Hinweis
Issue #558 formuliert nicht beobachtete Codes als auszugebende 0-Haeufigkeiten. Um die Standardansicht schlank zu halten, werden diese Codes default versteckt und ueber `Schema-Codes mit 0 anzeigen` sichtbar gemacht. Nie beobachtete Codes erscheinen dann mit `count: 0`; beobachtete Schema-Codes ausserhalb der Standard-Top-Werte erscheinen mit ihrer echten Haeufigkeit.

## Validierung
- `npx nx lint backend`
- `npx nx lint frontend`
- `npx nx test backend --runInBand`
- `npx nx test frontend --runInBand`
- `npx nx test backend --runInBand --testFile=apps/backend/src/app/database/services/test-results/variable-analysis.service.spec.ts`