### PR TITLE
Implement coding manager view

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
@@ -1,9 +1,14 @@
+import 'reflect-metadata';
 import { PassThrough, Writable } from 'stream';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { BadRequestException } from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { WorkspaceCodingExportController } from './workspace-coding-export.controller';
+import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
+import { WorkspaceGuard } from './workspace.guard';
+import { AccessLevelGuard } from './access-level.guard';
 import {
   CodingExportService,
   CodingExportOrchestratorService,
@@ -416,5 +421,40 @@ describe('WorkspaceCodingExportController', () => {
     await expect(controller.getExportJobStatus(5, 'job-1')).resolves.toEqual({
       error: 'Access denied to this export'
     });
+  });
+
+  it('requires coding-manager access at controller level', () => {
+    expect(Reflect.getMetadata(
+      'accessLevel',
+      WorkspaceCodingExportController
+    )).toBe(2);
+  });
+
+  it.each([
+    'getCodingListAsCsv',
+    'getCodingListAsExcel',
+    'getCodingListAsJson',
+    'getCodingResultsByVersion',
+    'getCodingResultsByVersionAsExcel',
+    'exportCodingResultsAggregated',
+    'exportCodingResultsByCoder',
+    'exportCodingResultsByVariable',
+    'exportCodingResultsDetailed',
+    'exportCodingTimesReport',
+    'estimateExportJob',
+    'startExportJob',
+    'getExportJobStatus',
+    'downloadExport',
+    'getExportJobs',
+    'deleteExportJob',
+    'cancelExportJob'
+  ] as const)('uses access-level guard for %s', methodName => {
+    const handler = WorkspaceCodingExportController.prototype[methodName];
+
+    expect(Reflect.getMetadata(GUARDS_METADATA, handler)).toEqual([
+      JwtAuthGuard,
+      WorkspaceGuard,
+      AccessLevelGuard
+    ]);
   });
 });

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
@@ -31,6 +31,7 @@ import { CacheService } from '../../cache/cache.service';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
 import { WorkspaceId } from './workspace.decorator';
+import { AccessLevelGuard, RequireAccessLevel } from './access-level.guard';
 import {
   CodingExportService,
   CodingExportOrchestratorService,
@@ -59,6 +60,7 @@ type ByVariableExportEstimateResponse = {
 };
 
 @ApiTags('Admin Workspace Coding')
+@RequireAccessLevel(2)
 @Controller('admin/workspace')
 export class WorkspaceCodingExportController {
   private readonly logger = new Logger(WorkspaceCodingExportController.name);
@@ -160,7 +162,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/coding-list')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -203,7 +205,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/coding-list/excel')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -258,7 +260,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/coding-list/json')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -327,7 +329,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/results-by-version')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -422,7 +424,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/results-by-version/excel')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -501,7 +503,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/export/aggregated')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -632,7 +634,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/export/by-coder')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -730,7 +732,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/export/by-variable')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -855,7 +857,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/export/detailed')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -950,7 +952,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/export/coding-times')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiQuery({
@@ -1015,7 +1017,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Post(':workspace_id/coding/export/estimate')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   async estimateExportJob(
@@ -1040,7 +1042,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Post(':workspace_id/coding/export/start')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiBody({
@@ -1142,7 +1144,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/export/job/:jobId')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiParam({
@@ -1248,7 +1250,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/export/job/:jobId/download')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiParam({
@@ -1329,7 +1331,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Get(':workspace_id/coding/export/jobs')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiOkResponse({
@@ -1384,7 +1386,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Delete(':workspace_id/coding/export/job/:jobId')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiParam({
@@ -1458,7 +1460,7 @@ export class WorkspaceCodingExportController {
   }
 
   @Post(':workspace_id/coding/export/job/:jobId/cancel')
-  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiParam({

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -951,7 +951,7 @@
                     Zu den Kodierjobs
                   </button>
                   <button
-                    *ngIf="hasCompletedJobsReadyForApply()"
+                    *ngIf="canShowCompletedJobApplyActions()"
                     mat-raised-button
                     color="accent"
                     type="button"
@@ -971,15 +971,20 @@
                     <span>{{ getCodingJobResultSummary(job) }}</span>
                   </div>
                   <button
+                    *ngIf="canApplyCompletedJobResults()"
                     mat-stroked-button
                     color="primary"
                     type="button"
                     (click)="applyCompletedJobResults(job)"
-                    [disabled]="!canApplyCompletedJobResults() || isApplyingCodingResults || isApplyingJobResults(job.id)">
+                    [disabled]="isApplyingCodingResults || isApplyingJobResults(job.id)">
                     <mat-icon *ngIf="!isApplyingJobResults(job.id)">input</mat-icon>
                     <mat-spinner *ngIf="isApplyingJobResults(job.id)" diameter="18"></mat-spinner>
                     Ergebnisse anwenden
                   </button>
+                  <span *ngIf="!canApplyCompletedJobResults()" class="completed-job-readonly-note">
+                    <mat-icon>lock</mat-icon>
+                    {{ 'coding-management-manual.completed-jobs.readonly-note' | translate }}
+                  </span>
                 </div>
               </div>
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
@@ -437,6 +437,23 @@
           }
         }
 
+        .completed-job-readonly-note {
+          display: inline-flex;
+          flex: 0 0 auto;
+          align-items: center;
+          gap: 6px;
+          color: #666;
+          font-size: 13px;
+          font-weight: 600;
+          white-space: nowrap;
+
+          mat-icon {
+            width: 18px;
+            height: 18px;
+            font-size: 18px;
+          }
+        }
+
         .completed-job-copy {
           display: flex;
           flex-direction: column;

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -55,6 +55,9 @@ describe('CodingManagementManualComponent', () => {
           'second-autocoding-ready-title': 'Auto-Coding 2 bereit',
           'second-autocoding-ready-summary': 'Die manuelle Kodierung ist abgeschlossen. Auto-Coding 2 kann nun für {{taskResults}} gestartet oder aktualisiert werden. Das betrifft {{responses}}.',
           'second-autocoding-ready-help': 'Starten Sie Auto-Coding 2 in der Kodierübersicht. {{taskResultHelp}}'
+        },
+        'completed-jobs': {
+          'readonly-note': 'Nur lesbar'
         }
       }
     });
@@ -298,6 +301,64 @@ describe('CodingManagementManualComponent', () => {
     expect(component.hasCompletedJobsReadyForApply()).toBe(true);
     expect(component.getCompletionActionTitle()).toContain('1 abgeschlossene');
     expect(component.getCodingJobResultSummary(component.completedJobsReadyForApply[0])).toBe('5/5 Ergebnisse kodiert');
+  });
+
+  it('should hide completed job apply actions without study-manager permission', () => {
+    component.completedJobsReadyForApply = [
+      {
+        id: 1,
+        workspace_id: 1,
+        name: 'Job 1',
+        status: 'completed',
+        created_at: new Date(),
+        updated_at: new Date(),
+        assignedCoders: [],
+        totalUnits: 5,
+        codedUnits: 5
+      }
+    ];
+    component.codingJobsComponent = {
+      canApplyResults: false
+    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+
+    expect(component.canShowCompletedJobApplyActions()).toBe(false);
+
+    component.codingJobsComponent = {
+      canApplyResults: true
+    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+
+    expect(component.canShowCompletedJobApplyActions()).toBe(true);
+  });
+
+  it('should keep completed jobs visible as read-only without study-manager permission', () => {
+    setAppliedResults(5, 0, 5);
+    component.completedJobsReadyForApply = [
+      {
+        id: 1,
+        workspace_id: 1,
+        name: 'Job 1',
+        status: 'completed',
+        created_at: new Date(),
+        updated_at: new Date(),
+        assignedCoders: [],
+        totalUnits: 5,
+        codedUnits: 5
+      }
+    ];
+    jest.spyOn(component, 'canApplyCompletedJobResults').mockReturnValue(false);
+
+    fixture.detectChanges();
+
+    const row = fixture.nativeElement.querySelector('.completed-job-apply-row') as HTMLElement | null;
+    const applyButtons = Array.from(
+      fixture.nativeElement.querySelectorAll('.completed-job-apply-row button')
+    ) as HTMLButtonElement[];
+    const readonlyNote = fixture.nativeElement.querySelector('.completed-job-readonly-note') as HTMLElement | null;
+
+    expect(row?.textContent).toContain('Job 1');
+    expect(row?.textContent).toContain('5/5 Ergebnisse kodiert');
+    expect(applyButtons.some(button => button.textContent?.includes('Ergebnisse anwenden'))).toBe(false);
+    expect(readonlyNote?.textContent).toContain('Nur lesbar');
   });
 
   it('should describe complete planning with open coding work as ready for execution', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -1093,6 +1093,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       (this.appService.authData.isAdmin === true);
   }
 
+  canShowCompletedJobApplyActions(): boolean {
+    return this.hasCompletedJobsReadyForApply() &&
+      this.canApplyCompletedJobResults();
+  }
+
   getCompletionActionTitle(): string {
     if (this.isCompletionComplete()) {
       return 'Alle Ergebnisse sind übernommen';

--- a/apps/frontend/src/app/core/guards/access-level.guard.spec.ts
+++ b/apps/frontend/src/app/core/guards/access-level.guard.spec.ts
@@ -1,18 +1,32 @@
 import { TestBed } from '@angular/core/testing';
 import {
-  ActivatedRouteSnapshot, Router, convertToParamMap
+  ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree, convertToParamMap
 } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { UserService } from '../../shared/services/user/user.service';
 import { AppService, AuthBootstrapStatus } from '../services/app.service';
 import { AuthDataDto } from '../../../../../../api-dto/auth-data-dto';
+import { CodingJobBackendService } from '../../coding/services/coding-job-backend.service';
+
+jest.mock('keycloak-angular', () => ({
+  createAuthGuard: jest.fn((
+    isAccessAllowed: (
+      route: ActivatedRouteSnapshot,
+      state: RouterStateSnapshot,
+      authData: { authenticated: boolean }
+    ) => Promise<boolean | UrlTree>
+  ) => (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => isAccessAllowed(route, state, {
+    authenticated: true
+  }))
+}));
 
 describe('Access Level Guard', () => {
   let mockAuthService: jest.Mocked<AuthService>;
   let mockUserService: jest.Mocked<UserService>;
   let mockAppService: jest.Mocked<AppService>;
   let mockRouter: jest.Mocked<Router>;
+  let mockCodingJobBackendService: jest.Mocked<CodingJobBackendService>;
   let authDataSubject: BehaviorSubject<AuthDataDto>;
 
   const defaultAuthData: AuthDataDto = {
@@ -36,6 +50,10 @@ describe('Access Level Guard', () => {
       getUsers: jest.fn()
     } as unknown as jest.Mocked<UserService>;
 
+    mockCodingJobBackendService = {
+      getCodingJobs: jest.fn()
+    } as unknown as jest.Mocked<CodingJobBackendService>;
+
     mockAppService = {
       authData$: authDataSubject.asObservable(),
       authBootstrapStatus$: of('ready' as AuthBootstrapStatus)
@@ -54,7 +72,8 @@ describe('Access Level Guard', () => {
         { provide: AuthService, useValue: mockAuthService },
         { provide: UserService, useValue: mockUserService },
         { provide: AppService, useValue: mockAppService },
-        { provide: Router, useValue: mockRouter }
+        { provide: Router, useValue: mockRouter },
+        { provide: CodingJobBackendService, useValue: mockCodingJobBackendService }
       ]
     });
   });
@@ -83,6 +102,48 @@ describe('Access Level Guard', () => {
       expect(guard2).toBeDefined();
       expect(guard3).toBeDefined();
       expect(guard4).toBeDefined();
+    });
+
+    it('should expose a dedicated coding management guard', async () => {
+      const { canActivateCodingManagement } = await import('./access-level.guard');
+      const guard = canActivateCodingManagement();
+
+      expect(typeof guard).toBe('function');
+    });
+
+    it('should redirect a level 2 coding manager from full management to statistics', async () => {
+      const { canActivateCodingManagement } = await import('./access-level.guard');
+      const expectedUrlTree = {} as UrlTree;
+      const route = {
+        paramMap: convertToParamMap({ ws: '123' })
+      } as ActivatedRouteSnapshot;
+      const state = {
+        url: '/workspace-admin/123/coding/management'
+      } as RouterStateSnapshot;
+
+      authDataSubject.next({
+        ...defaultAuthData,
+        userId: 42
+      });
+      mockAuthService.getRoles.mockReturnValue([]);
+      mockUserService.getUsers.mockReturnValue(of([
+        {
+          id: 42,
+          name: 'Coding Manager',
+          isAdmin: false,
+          accessLevel: 2,
+          canCode: true
+        }
+      ]));
+      mockRouter.createUrlTree.mockReturnValue(expectedUrlTree);
+
+      const result = await TestBed.runInInjectionContext(() => canActivateCodingManagement()(route, state));
+
+      expect(result).toBe(expectedUrlTree);
+      expect(mockRouter.createUrlTree).toHaveBeenCalledWith([
+        '/workspace-admin/123/coding/statistics'
+      ]);
+      expect(mockCodingJobBackendService.getCodingJobs).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/frontend/src/app/core/guards/access-level.guard.ts
+++ b/apps/frontend/src/app/core/guards/access-level.guard.ts
@@ -182,6 +182,27 @@ export function canActivateAccessLevel(minLevel: number): CanActivateFn {
   );
 }
 
+export function canActivateCodingManagement(): CanActivateFn {
+  return createWorkspaceAccessGuard(
+    context => hasMinimumWorkspaceAccess(context.currentUser, 3),
+    async context => {
+      const {
+        currentUser, router, state, userAccessLevel, workspaceId
+      } = context;
+
+      if (userAccessLevel === 2) {
+        return router.createUrlTree([`/workspace-admin/${workspaceId}/coding/statistics`]);
+      }
+
+      if (getEffectiveCanCode(currentUser) || await hasAssignedCodingJobs(context)) {
+        return router.createUrlTree([`/workspace-admin/${workspaceId}/coding/my-jobs`]);
+      }
+
+      return createAccessDeniedUrlTree(router, state.url);
+    }
+  );
+}
+
 export function canActivateCodingJobs(): CanActivateFn {
   return createWorkspaceAccessGuard(
     async context => getEffectiveCanCode(context.currentUser) || await hasAssignedCodingJobs(context),

--- a/apps/frontend/src/app/ws-admin/ws-admin.routes.ts
+++ b/apps/frontend/src/app/ws-admin/ws-admin.routes.ts
@@ -1,6 +1,10 @@
 import { Routes } from '@angular/router';
 import { canActivateAuth } from '../core/guards/auth.guard';
-import { canActivateAccessLevel, canActivateCodingJobs } from '../core/guards/access-level.guard';
+import {
+  canActivateAccessLevel,
+  canActivateCodingJobs,
+  canActivateCodingManagement
+} from '../core/guards/access-level.guard';
 
 export const wsAdminRoutes: Routes = [
   {
@@ -30,7 +34,7 @@ export const wsAdminRoutes: Routes = [
           { path: '', redirectTo: 'management', pathMatch: 'full' },
           {
             path: 'management',
-            canActivate: [canActivateAccessLevel(2)],
+            canActivate: [canActivateCodingManagement()],
             loadComponent: () => import('../coding/components/coding-management/coding-management.component').then(m => m.CodingManagementComponent)
           },
           {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1605,6 +1605,9 @@
       "second-autocoding-ready-summary": "Die manuelle Kodierung ist abgeschlossen. Auto-Coding 2 kann nun für {{taskResults}} gestartet oder aktualisiert werden. Das betrifft {{responses}}.",
       "second-autocoding-ready-help": "Starten Sie Auto-Coding 2 in der Kodierübersicht. {{taskResultHelp}}"
     },
+    "completed-jobs": {
+      "readonly-note": "Nur lesbar"
+    },
     "duplicate-aggregation": {
       "is-applied": "Aggregation angewendet",
       "config-title": "Aggregationseinstellungen",


### PR DESCRIPTION
Closes #397

## Summary
- Restrict the full coding management route to Study Managers and redirect Coding Managers to the statistics tab.
- Keep `Meine Kodierjobs` available for Coding Managers who can also code, while manager tabs remain statistics/manual/export.
- Hide apply-result actions from Coding Managers but keep completed jobs visible as read-only.
- Protect coding export endpoints with the backend access-level guard for Coding Manager access.

## Validation
- `npx nx lint frontend`
- `npx nx test frontend --runInBand`
- `npx nx lint backend`
- `npx nx test backend --runInBand`