### PR TITLE
Improve comparison replay and process overview actions

### DIFF
--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -243,6 +243,110 @@ describe('JobQueueService', () => {
     await expect(service.getActiveResetCodingVersionJob(1)).resolves.toHaveProperty('id', 'job-1');
   });
 
+  it('covers all registered process overview queues', async () => {
+    const workspaceJobs = await service.getAllWorkspaceJobs(1);
+
+    expect(workspaceJobs.map(job => job.queueName).sort()).toEqual([
+      'codebook-generation',
+      'coding-statistics',
+      'data-export',
+      'database-export',
+      'external-coding-import',
+      'flat-response-filter-options',
+      'reset-coding-version',
+      'response-analysis',
+      'test-person-coding',
+      'test-results-upload',
+      'validation-task',
+      'variable-analysis'
+    ]);
+  });
+
+  it('uses validation task progress and errors from the task entity in the process overview', async () => {
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[7].getJobs.mockResolvedValue([
+      createJob({ taskId: 7 }, 'active')
+    ]);
+    validationTaskRepository.find.mockResolvedValueOnce([{
+      id: 7,
+      workspace_id: 1,
+      validation_type: 'testFiles',
+      status: 'processing',
+      progress: 65,
+      progress_message: 'Testdateien werden geprüft...',
+      error: 'Schema validation failed'
+    }]);
+
+    const workspaceJobs = await service.getAllWorkspaceJobs(1);
+
+    expect(workspaceJobs).toEqual([
+      expect.objectContaining({
+        queueName: 'validation-task',
+        status: 'active',
+        progress: 65,
+        failedReason: 'Schema validation failed',
+        data: {
+          taskId: 7,
+          validationType: 'testFiles',
+          progressMessage: 'Testdateien werden geprüft...'
+        }
+      })
+    ]);
+  });
+
+  it('uses the validation task entity status even when Bull completed the job', async () => {
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[7].getJobs.mockResolvedValue([
+      createJob({ taskId: 7 }, 'completed')
+    ]);
+    validationTaskRepository.find.mockResolvedValueOnce([{
+      id: 7,
+      workspace_id: 1,
+      validation_type: 'testFiles',
+      status: 'failed',
+      progress: 100,
+      progress_message: 'Validierung fehlgeschlagen.',
+      error: 'Schema validation failed'
+    }]);
+
+    const workspaceJobs = await service.getAllWorkspaceJobs(1);
+
+    expect(workspaceJobs).toEqual([
+      expect.objectContaining({
+        queueName: 'validation-task',
+        status: 'failed',
+        progress: 100,
+        failedReason: 'Schema validation failed',
+        data: {
+          taskId: 7,
+          validationType: 'testFiles',
+          progressMessage: 'Validierung fehlgeschlagen.'
+        }
+      })
+    ]);
+  });
+
+  it('shows completed paused auto-coding jobs as paused in the process overview', async () => {
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[0].getJobs.mockResolvedValue([
+      createJob({ workspaceId: 1, isPaused: true }, 'completed')
+    ]);
+
+    const workspaceJobs = await service.getAllWorkspaceJobs(1);
+
+    expect(workspaceJobs).toEqual([
+      expect.objectContaining({
+        queueName: 'test-person-coding',
+        status: 'paused',
+        progress: 40,
+        data: {
+          workspaceId: 1,
+          isPaused: true
+        }
+      })
+    ]);
+  });
+
   it('sanitizes workspace job data before exposing process metadata', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
     queues[2].getJobs.mockResolvedValue([

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -12,6 +12,11 @@ import { ValidationTask } from '../database/entities/validation-task.entity';
 import { ProcessDto } from '../../../../../api-dto/workspaces/process-dto';
 import { CodebookExportFormat } from '../../../../../api-dto/coding/codebook-content-setting';
 
+type ProcessOverviewValidationTask = Pick<
+ValidationTask,
+'id' | 'workspace_id' | 'validation_type' | 'status' | 'progress' | 'progress_message' | 'error'
+>;
+
 export interface TestResultsUploadJobData {
   workspaceId: number;
   file: FileIo;
@@ -275,6 +280,58 @@ export class JobQueueService {
     ]);
   }
 
+  private mapBullStateToProcessStatus(state: string): ProcessDto['status'] {
+    if (
+      state === 'active' ||
+      state === 'waiting' ||
+      state === 'delayed' ||
+      state === 'completed' ||
+      state === 'failed' ||
+      state === 'paused'
+    ) {
+      return state;
+    }
+
+    return 'unknown';
+  }
+
+  private mapValidationTaskStatus(
+    status: string | undefined,
+    fallbackBullState: string
+  ): ProcessDto['status'] {
+    if (status === 'pending') return 'waiting';
+    if (status === 'processing') return 'active';
+    if (status === 'completed') return 'completed';
+    if (status === 'failed') return 'failed';
+    if (status === 'paused') return 'paused';
+    if (status === 'cancelled') return 'unknown';
+
+    return this.mapBullStateToProcessStatus(fallbackBullState);
+  }
+
+  private getProcessOverviewStatus(
+    queueName: string,
+    bullState: string,
+    jobData: unknown,
+    validationTask?: ProcessOverviewValidationTask
+  ): ProcessDto['status'] {
+    if (queueName === 'validation-task') {
+      return this.mapValidationTaskStatus(validationTask?.status, bullState);
+    }
+
+    if (
+      queueName === 'test-person-coding' &&
+      bullState === 'completed' &&
+      jobData &&
+      typeof jobData === 'object' &&
+      (jobData as { isPaused?: unknown }).isPaused === true
+    ) {
+      return 'paused';
+    }
+
+    return this.mapBullStateToProcessStatus(bullState);
+  }
+
   private async jobBelongsToWorkspace(
     queueName: string,
     job: Job,
@@ -369,25 +426,47 @@ export class JobQueueService {
         queue.getJobs(['active', 'waiting', 'delayed', 'completed', 'failed', 'paused']).then(async jobs => {
           const existingJobs = jobs.filter(Boolean);
           let matchedJobs = existingJobs;
+          let validationTaskMap = new Map<number, ProcessOverviewValidationTask>();
           if (queueName === 'validation-task') {
             const taskIds = existingJobs.map(j => j.data?.taskId as number).filter(Boolean);
             if (taskIds.length === 0) return [];
             const tasks = await this.validationTaskRepository.find({
               where: { id: In(taskIds) },
-              select: ['id', 'workspace_id']
-            });
-            const taskWorkspaceMap = new Map(tasks.map(t => [t.id, t.workspace_id]));
-            matchedJobs = existingJobs.filter(j => taskWorkspaceMap.get(j.data?.taskId) === workspaceId);
+              select: [
+                'id',
+                'workspace_id',
+                'validation_type',
+                'status',
+                'progress',
+                'progress_message',
+                'error'
+              ]
+            }) as ProcessOverviewValidationTask[];
+            validationTaskMap = new Map(tasks.map(t => [Number(t.id), t]));
+            matchedJobs = existingJobs.filter(j => (
+              Number(validationTaskMap.get(Number(j.data?.taskId))?.workspace_id) === Number(workspaceId)
+            ));
           } else {
             matchedJobs = existingJobs.filter(j => j.data && j.data.workspaceId === workspaceId);
           }
 
           const mappedPromises = matchedJobs.map(async job => {
-            const state = await job.getState();
-            let progress: unknown = job.progress();
+            const bullState = await job.getState();
+            const validationTask = queueName === 'validation-task' ?
+              validationTaskMap.get(Number(job.data?.taskId)) :
+              undefined;
+            const status = this.getProcessOverviewStatus(
+              queueName,
+              bullState,
+              job.data,
+              validationTask
+            );
+            let progress: unknown = typeof validationTask?.progress === 'number' ?
+              validationTask.progress :
+              job.progress();
 
             // For completed jobs, ensure progress shows as 100% if it's numeric/empty
-            if (state === 'completed') {
+            if (status === 'completed') {
               if (typeof progress !== 'object' || progress === null) {
                 progress = 100;
               }
@@ -398,10 +477,14 @@ export class JobQueueService {
             return {
               id: job.id,
               queueName: queueName,
-              status: state as ProcessDto['status'],
+              status: status,
               progress: progress,
-              data: this.sanitizeJobData(job.data),
-              failedReason: job.failedReason,
+              data: this.sanitizeJobData({
+                ...job.data,
+                validationType: validationTask?.validation_type,
+                progressMessage: validationTask?.progress_message
+              }),
+              failedReason: validationTask?.error || job.failedReason,
               timestamp: job.timestamp,
               processedOn: job.processedOn,
               finishedOn: job.finishedOn
@@ -444,6 +527,8 @@ export class JobQueueService {
       'sourceVersion',
       'scoreMode',
       'existingCodingMode',
+      'validationType',
+      'progressMessage',
       'isPaused',
       'isCancelled'
     ];

--- a/apps/backend/src/app/job-queue/processors/test-person-coding.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/test-person-coding.processor.spec.ts
@@ -1,0 +1,92 @@
+import { Job } from 'bull';
+import { Logger } from '@nestjs/common';
+import { WorkspaceCodingService } from '../../database/services/workspace';
+import { TestPersonCodingJobData } from '../job-queue.service';
+import { TestPersonCodingProcessor } from './test-person-coding.processor';
+
+describe('TestPersonCodingProcessor', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const createJob = (
+    getLatestJob: jest.Mock<Promise<{ data?: Partial<TestPersonCodingJobData> } | null>, []>
+  ): Job<TestPersonCodingJobData> => ({
+    id: 'job-1',
+    data: {
+      workspaceId: 1,
+      personIds: Array.from({ length: 100 }, (_, index) => `person-${index + 1}`)
+    },
+    getState: jest.fn().mockResolvedValue('active'),
+    progress: jest.fn().mockResolvedValue(undefined),
+    queue: {
+      getJob: getLatestJob
+    }
+  } as unknown as Job<TestPersonCodingJobData>);
+
+  it('stops before the next batch when an active job was marked as paused in Bull', async () => {
+    const workspaceCodingService = {
+      processTestPersonsBatch: jest.fn().mockResolvedValue({
+        totalResponses: 5,
+        statusCounts: { CODED: 5 }
+      })
+    };
+    const getLatestJob = jest.fn()
+      .mockResolvedValueOnce({
+        data: { isPaused: false }
+      })
+      .mockResolvedValueOnce({
+        data: { isPaused: true }
+      });
+    const processor = new TestPersonCodingProcessor(
+      workspaceCodingService as unknown as WorkspaceCodingService
+    );
+
+    const result = await processor.process(createJob(getLatestJob));
+
+    expect(workspaceCodingService.processTestPersonsBatch).toHaveBeenCalledTimes(1);
+    expect(workspaceCodingService.processTestPersonsBatch).toHaveBeenCalledWith(
+      1,
+      expect.arrayContaining(['person-1', 'person-50']),
+      1,
+      expect.any(Function),
+      'job-1',
+      undefined,
+      undefined
+    );
+    expect(getLatestJob).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      totalResponses: 5,
+      statusCounts: { CODED: 5 }
+    });
+  });
+
+  it('continues processing when refreshing the latest job data fails', async () => {
+    const workspaceCodingService = {
+      processTestPersonsBatch: jest.fn().mockResolvedValue({
+        totalResponses: 5,
+        statusCounts: { CODED: 5 }
+      })
+    };
+    const getLatestJob = jest.fn()
+      .mockRejectedValueOnce(new Error('Redis unavailable'))
+      .mockResolvedValue({
+        data: { isPaused: false }
+      });
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const processor = new TestPersonCodingProcessor(
+      workspaceCodingService as unknown as WorkspaceCodingService
+    );
+
+    const result = await processor.process(createJob(getLatestJob));
+
+    expect(workspaceCodingService.processTestPersonsBatch).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Redis unavailable')
+    );
+    expect(result).toEqual({
+      totalResponses: 10,
+      statusCounts: { CODED: 10 }
+    });
+  });
+});

--- a/apps/backend/src/app/job-queue/processors/test-person-coding.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/test-person-coding.processor.ts
@@ -17,6 +17,35 @@ export class TestPersonCodingProcessor {
     private readonly workspaceCodingService: WorkspaceCodingService
   ) { }
 
+  private async shouldStopBeforeBatch(
+    job: Job<TestPersonCodingJobData>,
+    batchNumber: number
+  ): Promise<boolean> {
+    const currentState = await job.getState();
+    if (currentState === 'failed' || currentState === 'paused') {
+      this.logger.log(`Job ${job.id} was ${currentState} before processing batch ${batchNumber}`);
+      return true;
+    }
+
+    let isPausedInLatestJob = false;
+    try {
+      const latestJob = await job.queue.getJob(job.id);
+      isPausedInLatestJob = Boolean(latestJob?.data?.isPaused);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not refresh pause state for job ${job.id} before processing batch ${batchNumber}: ${message}`
+      );
+    }
+
+    if (job.data.isPaused || isPausedInLatestJob) {
+      this.logger.log(`Job ${job.id} was paused before processing batch ${batchNumber}`);
+      return true;
+    }
+
+    return false;
+  }
+
   @Process()
   async process(job: Job<TestPersonCodingJobData>): Promise<CodingStatistics> {
     this.logger.log(`Processing test person coding job ${job.id} for workspace ${job.data.workspaceId}`);
@@ -29,19 +58,12 @@ export class TestPersonCodingProcessor {
       await job.progress(0);
 
       for (let i = 0; i < job.data.personIds.length; i += BATCH_SIZE) {
-        const currentJob = await job.getState();
-        if (currentJob === 'failed' || currentJob === 'paused') {
-          this.logger.log(`Job ${job.id} was ${currentJob} before processing batch ${(i / BATCH_SIZE) + 1}`);
-          return combinedResult;
-        }
-
-        if (job.data.isPaused) {
-          this.logger.log(`Job ${job.id} was paused before processing batch ${(i / BATCH_SIZE) + 1}`);
+        const batchNumber = (i / BATCH_SIZE) + 1;
+        if (await this.shouldStopBeforeBatch(job, batchNumber)) {
           return combinedResult;
         }
 
         const batchPersonIds = job.data.personIds.slice(i, i + BATCH_SIZE);
-        const batchNumber = (i / BATCH_SIZE) + 1;
         const totalBatches = Math.ceil(totalPersons / BATCH_SIZE);
         this.logger.log(`Processing batch ${batchNumber} of ${totalBatches} (${batchPersonIds.length} persons)`);
 

--- a/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.html
+++ b/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.html
@@ -1,46 +1,50 @@
 <h2 mat-dialog-title>
-  Zentrale Prozess-Übersicht
+  {{ 'process-overview.title' | translate }}
 </h2>
 
 <mat-dialog-content>
   <div class="process-overview-container">
     <div class="filter-row">
       <mat-form-field appearance="outline" class="filter-field">
-        <mat-label>Status</mat-label>
+        <mat-label>{{ 'process-overview.filters.status' | translate }}</mat-label>
         <mat-select [(ngModel)]="statusFilter" (selectionChange)="applyFilter()">
-          <mat-option value="">Alle Status</mat-option>
+          <mat-option value="">{{ 'process-overview.filters.all-status' | translate }}</mat-option>
           <mat-option *ngFor="let status of statusOptions" [value]="status">
-            {{ status | uppercase }}
+            {{ getStatusLabel(status) }}
           </mat-option>
         </mat-select>
       </mat-form-field>
 
       <mat-form-field appearance="outline" class="filter-field">
-        <mat-label>Typ (Queue)</mat-label>
+        <mat-label>{{ 'process-overview.filters.type' | translate }}</mat-label>
         <mat-select [(ngModel)]="typeFilter" (selectionChange)="applyFilter()">
-          <mat-option value="">Alle Typen</mat-option>
+          <mat-option value="">{{ 'process-overview.filters.all-types' | translate }}</mat-option>
           <mat-option *ngFor="let type of availableTypes" [value]="type">
-            {{ type }}
+            {{ getQueueLabel(type) }}
           </mat-option>
         </mat-select>
       </mat-form-field>
 
       <mat-form-field appearance="outline" class="filter-field search-field">
-        <mat-label>Suchen...</mat-label>
-        <input matInput [(ngModel)]="searchFilter" (keyup)="applyFilter()" placeholder="ID oder Name">
+        <mat-label>{{ 'process-overview.filters.search' | translate }}</mat-label>
+        <input
+          matInput
+          [(ngModel)]="searchFilter"
+          (keyup)="applyFilter()"
+          [placeholder]="'process-overview.filters.search-placeholder' | translate">
         <mat-icon matSuffix>search</mat-icon>
       </mat-form-field>
 
       <div class="filter-actions">
         <button mat-button (click)="clearFilters()" [disabled]="!statusFilter && !typeFilter && !searchFilter">
-          <mat-icon>filter_list_off</mat-icon> Filter leeren
+          <mat-icon>filter_list_off</mat-icon> {{ 'process-overview.filters.clear' | translate }}
         </button>
       </div>
     </div>
 
     <div class="table-actions">
       <button mat-raised-button color="primary" (click)="loadProcesses()">
-        <mat-icon>refresh</mat-icon> Aktualisieren
+        <mat-icon>refresh</mat-icon> {{ 'process-overview.refresh' | translate }}
       </button>
     </div>
 
@@ -53,45 +57,99 @@
         <table mat-table [dataSource]="processes" class="mat-table" [class.loading-table]="isLoading">
           
           <ng-container matColumnDef="queueName">
-            <th mat-header-cell *matHeaderCellDef> Typ (Queue) </th>
-            <td mat-cell *matCellDef="let element"> {{ element.queueName }} </td>
+            <th mat-header-cell *matHeaderCellDef>{{ 'process-overview.columns.type' | translate }}</th>
+            <td mat-cell *matCellDef="let element">
+              <div class="queue-cell" [matTooltip]="getQueueDescription(element.queueName)">
+                <span class="queue-label">{{ getQueueLabel(element.queueName) }}</span>
+                <span class="queue-name">{{ element.queueName }}</span>
+              </div>
+            </td>
           </ng-container>
 
           <ng-container matColumnDef="status">
-            <th mat-header-cell *matHeaderCellDef> Status </th>
-            <td mat-cell *matCellDef="let element" class="status-cell" [ngClass]="element.status">
-              {{ element.status | uppercase }}
+            <th mat-header-cell *matHeaderCellDef>{{ 'process-overview.columns.status' | translate }}</th>
+            <td mat-cell *matCellDef="let element" class="status-cell">
+              <span
+                class="status-chip"
+                [ngClass]="getStatusClass(element.status)"
+                [matTooltip]="getStatusTooltip(element.status)">
+                <mat-icon>{{ getStatusIcon(element.status) }}</mat-icon>
+                {{ getStatusLabel(element.status) }}
+              </span>
             </td>
           </ng-container>
 
           <ng-container matColumnDef="progress">
-            <th mat-header-cell *matHeaderCellDef> Fortschritt </th>
+            <th mat-header-cell *matHeaderCellDef>{{ 'process-overview.columns.progress' | translate }}</th>
             <td mat-cell *matCellDef="let element">
-              <ng-container *ngIf="isNumber(element.progress); else defaultProgress">
-                {{ element.progress }} %
+              <ng-container *ngIf="hasProgressPercent(element); else progressTextOnly">
+                <div class="progress-cell">
+                  <mat-progress-bar mode="determinate" [value]="getProgressPercent(element) || 0"></mat-progress-bar>
+                  <span>{{ getProgressLabel(element) }}</span>
+                </div>
               </ng-container>
-              <ng-template #defaultProgress>
-                {{ element.progress | json }}
+              <ng-template #progressTextOnly>
+                <span class="muted-text">{{ getProgressLabel(element) }}</span>
               </ng-template>
             </td>
           </ng-container>
 
-          <ng-container matColumnDef="timestamp">
-            <th mat-header-cell *matHeaderCellDef> Erstellt / Aktualisiert </th>
-            <td mat-cell *matCellDef="let element"> 
-              {{ element.timestamp | date:'short' }} 
+          <ng-container matColumnDef="time">
+            <th mat-header-cell *matHeaderCellDef>{{ 'process-overview.columns.time' | translate }}</th>
+            <td mat-cell *matCellDef="let element">
+              <div class="time-cell">
+                <div>
+                  <span>{{ 'process-overview.time.created' | translate }}</span>
+                  <strong>{{ element.timestamp | date:'short' }}</strong>
+                </div>
+                <div *ngIf="element.processedOn">
+                  <span>{{ 'process-overview.time.started' | translate }}</span>
+                  <strong>{{ element.processedOn | date:'short' }}</strong>
+                </div>
+                <div *ngIf="element.finishedOn">
+                  <span>{{ 'process-overview.time.finished' | translate }}</span>
+                  <strong>{{ element.finishedOn | date:'short' }}</strong>
+                </div>
+                <div *ngIf="getDurationLabel(element) as duration">
+                  <span>{{ 'process-overview.time.duration' | translate }}</span>
+                  <strong>{{ duration }}</strong>
+                </div>
+              </div>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="details">
+            <th mat-header-cell *matHeaderCellDef>{{ 'process-overview.columns.details' | translate }}</th>
+            <td mat-cell *matCellDef="let element">
+              <div class="details-cell">
+                <div *ngIf="element.failedReason" class="failed-reason">
+                  <mat-icon>error</mat-icon>
+                  <span>{{ element.failedReason }}</span>
+                </div>
+                <div *ngIf="getProcessDetailItems(element).length > 0; else noDetails" class="detail-list">
+                  <span class="detail-item" *ngFor="let detail of getProcessDetailItems(element)">
+                    <span class="detail-label">{{ detail.label }}</span>
+                    <span class="detail-value">{{ detail.value }}</span>
+                  </span>
+                </div>
+                <ng-template #noDetails>
+                  <span *ngIf="!element.failedReason" class="muted-text">
+                    {{ 'process-overview.details.none' | translate }}
+                  </span>
+                </ng-template>
+              </div>
             </td>
           </ng-container>
 
           <ng-container matColumnDef="actions">
-            <th mat-header-cell *matHeaderCellDef> Aktionen </th>
+            <th mat-header-cell *matHeaderCellDef>{{ 'process-overview.columns.actions' | translate }}</th>
             <td mat-cell *matCellDef="let element">
               <span class="action-tooltip-wrapper" [matTooltip]="getActionTooltip(element)">
                 <button mat-icon-button
                         color="warn"
                         (click)="deleteProcess(element)"
                         [disabled]="!canRemoveProcess(element)">
-                  <mat-icon>delete</mat-icon>
+                  <mat-icon>{{ getActionIcon(element) }}</mat-icon>
                 </button>
               </span>
             </td>
@@ -107,7 +165,11 @@
         </mat-paginator>
 
         <div *ngIf="processes.filteredData.length === 0 && !isLoading" class="no-data">
-          {{ processes.data.length === 0 ? 'Keine Prozesse in der Warteschlange.' : 'Keine Prozesse für die aktuellen Filter.' }}
+          {{
+            processes.data.length === 0 ?
+              ('process-overview.no-data' | translate) :
+              ('process-overview.no-filter-data' | translate)
+          }}
         </div>
       </div>
     </div>
@@ -115,5 +177,5 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-button mat-dialog-close>Schließen</button>
+  <button mat-button mat-dialog-close>{{ 'close' | translate }}</button>
 </mat-dialog-actions>

--- a/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.scss
+++ b/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.scss
@@ -40,6 +40,10 @@
     min-height: 200px;
   }
 
+  .table-wrapper {
+    overflow-x: auto;
+  }
+
   .loading-overlay {
     position: absolute;
     top: 0;
@@ -60,14 +64,174 @@
 
   table {
     width: 100%;
+    min-width: 1120px;
+  }
+
+  .queue-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 160px;
+
+    .queue-label {
+      font-weight: 600;
+      color: #222;
+    }
+
+    .queue-name {
+      color: #666;
+      font-family: monospace;
+      font-size: 12px;
+    }
   }
 
   .status-cell {
-    font-weight: bold;
-    &.active { color: #00bcd4; }
-    &.completed { color: #4caf50; }
-    &.failed { color: #f44336; }
-    &.delayed, &.waiting { color: #ff9800; }
+    min-width: 130px;
+  }
+
+  .status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 28px;
+    padding: 3px 8px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    font-weight: 600;
+    line-height: 1.2;
+
+    mat-icon {
+      width: 18px;
+      height: 18px;
+      font-size: 18px;
+    }
+
+    &.status-active {
+      border-color: #0288d1;
+      background: #e1f5fe;
+      color: #01579b;
+    }
+
+    &.status-waiting,
+    &.status-delayed {
+      border-color: #f9a825;
+      background: #fff8e1;
+      color: #6d4c00;
+    }
+
+    &.status-completed {
+      border-color: #43a047;
+      background: #e8f5e9;
+      color: #1b5e20;
+    }
+
+    &.status-failed {
+      border-color: #d32f2f;
+      background: #ffebee;
+      color: #b71c1c;
+    }
+
+    &.status-paused {
+      border-color: #757575;
+      background: #f5f5f5;
+      color: #424242;
+    }
+
+    &.status-unknown {
+      border-color: #9e9e9e;
+      background: #fafafa;
+      color: #424242;
+    }
+  }
+
+  .progress-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 140px;
+
+    mat-progress-bar {
+      height: 8px;
+      border-radius: 4px;
+      overflow: hidden;
+    }
+  }
+
+  .time-cell {
+    display: grid;
+    gap: 4px;
+    min-width: 180px;
+    font-size: 13px;
+
+    div {
+      display: grid;
+      grid-template-columns: 72px minmax(0, 1fr);
+      gap: 8px;
+      align-items: baseline;
+    }
+
+    span {
+      color: #666;
+    }
+
+    strong {
+      font-weight: 500;
+      color: #222;
+      white-space: nowrap;
+    }
+  }
+
+  .details-cell {
+    min-width: 220px;
+    max-width: 320px;
+  }
+
+  .detail-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .detail-item {
+    display: inline-flex;
+    gap: 4px;
+    align-items: baseline;
+    max-width: 100%;
+    padding: 3px 6px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background: #fafafa;
+    font-size: 12px;
+  }
+
+  .detail-label {
+    color: #666;
+  }
+
+  .detail-value {
+    color: #222;
+    font-weight: 600;
+    overflow-wrap: anywhere;
+  }
+
+  .failed-reason {
+    display: flex;
+    gap: 6px;
+    align-items: flex-start;
+    margin-bottom: 8px;
+    color: #b71c1c;
+    font-size: 13px;
+
+    mat-icon {
+      width: 18px;
+      height: 18px;
+      font-size: 18px;
+      flex: 0 0 auto;
+    }
+  }
+
+  .muted-text {
+    color: #777;
   }
 
   .action-tooltip-wrapper {

--- a/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.spec.ts
@@ -3,7 +3,7 @@ import { By } from '@angular/platform-browser';
 import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { WorkspaceProcessesService } from '../../services/workspace-processes.service';
 import { ProcessOverviewComponent } from './process-overview.component';
@@ -57,6 +57,130 @@ describe('ProcessOverviewComponent', () => {
       }
     }).compileComponents();
 
+    const translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('de', {
+      close: 'Schließen',
+      'process-overview': {
+        title: 'Zentrale Prozess-Übersicht',
+        refresh: 'Aktualisieren',
+        'no-data': 'Keine Prozesse in der Warteschlange.',
+        'no-filter-data': 'Keine Prozesse für die aktuellen Filter.',
+        'confirm-content': 'Möchten Sie den Prozess "{{queue}}" (ID: {{id}}) wirklich {{action}}?',
+        filters: {
+          status: 'Status',
+          'all-status': 'Alle Status',
+          type: 'Typ',
+          'all-types': 'Alle Typen',
+          search: 'Suchen',
+          'search-placeholder': 'ID, Name oder Detail',
+          clear: 'Filter leeren'
+        },
+        columns: {
+          type: 'Typ',
+          status: 'Status',
+          progress: 'Fortschritt',
+          time: 'Zeit',
+          details: 'Details',
+          actions: 'Aktionen'
+        },
+        status: {
+          active: 'Läuft',
+          waiting: 'Wartet',
+          delayed: 'Geplant',
+          completed: 'Abgeschlossen',
+          failed: 'Fehlgeschlagen',
+          paused: 'Pausiert',
+          unknown: 'Unbekannt'
+        },
+        'status-tooltips': {
+          active: 'Der Prozess wird gerade bearbeitet.',
+          waiting: 'Der Prozess wartet auf einen freien Worker oder auf vorgelagerte Arbeit.',
+          delayed: 'Der Prozess ist für einen späteren Start eingeplant.',
+          completed: 'Der Prozess wurde erfolgreich abgeschlossen.',
+          failed: 'Der Prozess ist mit einem Fehler beendet worden.',
+          paused: 'Der Prozess wurde angehalten.',
+          unknown: 'Der aktuelle Prozessstatus ist nicht eindeutig bekannt.'
+        },
+        progress: {
+          active: 'Läuft ohne Fortschrittsangabe',
+          waiting: 'Wartet auf Start',
+          delayed: 'Start geplant',
+          completed: 'Abgeschlossen',
+          failed: 'Keine Fortschrittsangabe',
+          paused: 'Pausiert',
+          unknown: 'Keine Fortschrittsangabe'
+        },
+        time: {
+          created: 'Erstellt',
+          started: 'Gestartet',
+          finished: 'Beendet',
+          duration: 'Dauer'
+        },
+        queues: {
+          'test-person-coding': {
+            label: 'Auto-Kodierung',
+            description: 'Automatisches Kodieren von Testpersonen-Antworten'
+          },
+          'coding-statistics': {
+            label: 'Kodierstatistiken',
+            description: 'Berechnung der Kodierstatistiken für den Arbeitsbereich'
+          },
+          'data-export': {
+            label: 'Datenexport',
+            description: 'Export von Kodier- oder Testergebnisdaten'
+          },
+          'variable-analysis': {
+            label: 'Variablenanalyse',
+            description: 'Analyse von Variablenwerten und Häufigkeiten'
+          }
+        },
+        details: {
+          none: 'Keine Details',
+          'unknown-key': '{{key}}',
+          exportType: 'Exporttyp',
+          fileName: 'Datei',
+          isCancelled: 'Abgebrochen',
+          personCount: 'Personen',
+          unitId: 'Unit',
+          variableId: 'Variable'
+        },
+        actions: {
+          'not-safe': 'Für diesen Status oder Prozesstyp gibt es keine sichere Aktion.',
+          cancel: {
+            label: 'Abbrechen',
+            tooltip: 'Laufenden Prozess abbrechen',
+            'confirm-title': 'Prozess abbrechen',
+            infinitive: 'abbrechen',
+            success: 'Prozess wurde abgebrochen'
+          },
+          pause: {
+            label: 'Anhalten',
+            tooltip: 'Laufenden Prozess anhalten',
+            'confirm-title': 'Prozess anhalten',
+            infinitive: 'anhalten',
+            success: 'Prozess wurde angehalten'
+          },
+          remove: {
+            label: 'Entfernen',
+            tooltip: 'Prozess aus der Warteschlange entfernen',
+            'confirm-title': 'Prozess entfernen',
+            infinitive: 'entfernen',
+            success: 'Prozess wurde entfernt'
+          }
+        },
+        messages: {
+          'load-error': 'Fehler beim Laden der Prozesse',
+          'action-failed': 'Prozess konnte nicht aktualisiert werden',
+          'action-error': 'Fehler beim Aktualisieren des Prozesses'
+        },
+        values: {
+          yes: 'Ja',
+          no: 'Nein'
+        }
+      }
+    });
+    translateService.use('de');
+
     fixture = TestBed.createComponent(ProcessOverviewComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -76,13 +200,13 @@ describe('ProcessOverviewComponent', () => {
     expect(dialog.open).toHaveBeenCalled();
     expect(processesService.deleteProcess).toHaveBeenCalledWith(7, 'data-export', 'job-1');
     expect(snackBar.open).toHaveBeenCalledWith(
-      'Prozess wurde abgebrochen oder entfernt',
-      'OK',
+      'Prozess wurde entfernt',
+      'Schließen',
       { duration: 3000 }
     );
   });
 
-  it('allows paused jobs but disables unsupported active jobs', () => {
+  it('uses precise action semantics for active and inactive jobs', () => {
     expect(component.canRemoveProcess({
       id: 'job-1',
       queueName: 'coding-statistics',
@@ -91,8 +215,16 @@ describe('ProcessOverviewComponent', () => {
       timestamp: 100
     })).toBe(true);
 
-    expect(component.canRemoveProcess({
+    expect(component.getProcessAction({
       id: 'job-2',
+      queueName: 'test-person-coding',
+      status: 'active',
+      progress: 20,
+      timestamp: 100
+    })).toBe('pause');
+
+    expect(component.canRemoveProcess({
+      id: 'job-3',
       queueName: 'database-export',
       status: 'active',
       progress: 50,
@@ -100,7 +232,7 @@ describe('ProcessOverviewComponent', () => {
     })).toBe(true);
 
     expect(component.canRemoveProcess({
-      id: 'job-3',
+      id: 'job-4',
       queueName: 'coding-statistics',
       status: 'active',
       progress: 0,
@@ -123,5 +255,63 @@ describe('ProcessOverviewComponent', () => {
 
     expect(wrapper).toBeTruthy();
     expect(button.nativeElement.disabled).toBe(true);
+  });
+
+  it('maps queue names and statuses to user-facing labels', () => {
+    expect(component.getQueueLabel('data-export')).toBe('Datenexport');
+    expect(component.getQueueLabel('unknown-queue')).toBe('unknown-queue');
+    expect(component.getStatusLabel('waiting')).toBe('Wartet');
+    expect(component.getStatusIcon('failed')).toBe('error');
+  });
+
+  it('formats progress, duration and details for real process rows', () => {
+    const process: ProcessDto = {
+      id: 'job-1',
+      queueName: 'data-export',
+      status: 'completed',
+      progress: 99.7,
+      timestamp: 1000,
+      processedOn: 2000,
+      finishedOn: 65000,
+      data: {
+        workspaceId: 7,
+        exportType: 'test-results',
+        isCancelled: false,
+        personCount: 2
+      }
+    };
+
+    expect(component.getProgressPercent(process)).toBe(100);
+    expect(component.getProgressLabel(process)).toBe('100 %');
+    expect(component.getDurationLabel(process)).toBe('1 min 3 s');
+    expect(component.getProcessDetailItems(process)).toEqual([
+      { label: 'Exporttyp', value: 'test-results' },
+      { label: 'Personen', value: '2' },
+      { label: 'Abgebrochen', value: 'Nein' }
+    ]);
+  });
+
+  it('shows status chip, progress bar, time metadata and process details', () => {
+    component.processes.data = [{
+      id: 'job-5',
+      queueName: 'data-export',
+      status: 'failed',
+      progress: { processed: 4 },
+      failedReason: 'Export error',
+      timestamp: 1000,
+      processedOn: 2000,
+      finishedOn: 5000,
+      data: {
+        exportType: 'test-results',
+        fileName: 'export.csv'
+      }
+    }];
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.status-chip')).nativeElement.textContent).toContain('Fehlgeschlagen');
+    expect(fixture.debugElement.query(By.css('.muted-text')).nativeElement.textContent).toContain('Keine Fortschrittsangabe');
+    expect(fixture.debugElement.query(By.css('.time-cell')).nativeElement.textContent).toContain('Gestartet');
+    expect(fixture.debugElement.query(By.css('.failed-reason')).nativeElement.textContent).toContain('Export error');
+    expect(fixture.debugElement.query(By.css('.detail-list')).nativeElement.textContent).toContain('export.csv');
   });
 });

--- a/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.ts
@@ -2,12 +2,13 @@ import {
   Component, OnInit, inject, ViewChild, AfterViewInit
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatDialog, MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -19,6 +20,192 @@ import { WorkspaceProcessesService } from '../../services/workspace-processes.se
 import { ProcessDto } from '../../../../../../../api-dto/workspaces/process-dto';
 import { ConfirmDialogComponent, ConfirmDialogData } from '../../../shared/dialogs/confirm-dialog.component';
 
+type ProcessStatus = ProcessDto['status'];
+type ProcessActionKind = 'cancel' | 'pause' | 'remove';
+
+interface ProcessStatusPresentation {
+  labelKey: string;
+  tooltipKey: string;
+  icon: string;
+  cssClass: string;
+}
+
+interface QueuePresentation {
+  labelKey: string;
+  descriptionKey: string;
+}
+
+interface ProcessDetailItem {
+  label: string;
+  value: string;
+}
+
+const STATUS_PRESENTATIONS: Record<ProcessStatus, ProcessStatusPresentation> = {
+  active: {
+    labelKey: 'process-overview.status.active',
+    tooltipKey: 'process-overview.status-tooltips.active',
+    icon: 'play_circle',
+    cssClass: 'active'
+  },
+  waiting: {
+    labelKey: 'process-overview.status.waiting',
+    tooltipKey: 'process-overview.status-tooltips.waiting',
+    icon: 'hourglass_empty',
+    cssClass: 'waiting'
+  },
+  delayed: {
+    labelKey: 'process-overview.status.delayed',
+    tooltipKey: 'process-overview.status-tooltips.delayed',
+    icon: 'schedule',
+    cssClass: 'delayed'
+  },
+  completed: {
+    labelKey: 'process-overview.status.completed',
+    tooltipKey: 'process-overview.status-tooltips.completed',
+    icon: 'check_circle',
+    cssClass: 'completed'
+  },
+  failed: {
+    labelKey: 'process-overview.status.failed',
+    tooltipKey: 'process-overview.status-tooltips.failed',
+    icon: 'error',
+    cssClass: 'failed'
+  },
+  paused: {
+    labelKey: 'process-overview.status.paused',
+    tooltipKey: 'process-overview.status-tooltips.paused',
+    icon: 'pause_circle',
+    cssClass: 'paused'
+  },
+  unknown: {
+    labelKey: 'process-overview.status.unknown',
+    tooltipKey: 'process-overview.status-tooltips.unknown',
+    icon: 'help',
+    cssClass: 'unknown'
+  }
+};
+
+const QUEUE_PRESENTATIONS: Record<string, QueuePresentation> = {
+  'test-person-coding': {
+    labelKey: 'process-overview.queues.test-person-coding.label',
+    descriptionKey: 'process-overview.queues.test-person-coding.description'
+  },
+  'coding-statistics': {
+    labelKey: 'process-overview.queues.coding-statistics.label',
+    descriptionKey: 'process-overview.queues.coding-statistics.description'
+  },
+  'data-export': {
+    labelKey: 'process-overview.queues.data-export.label',
+    descriptionKey: 'process-overview.queues.data-export.description'
+  },
+  'flat-response-filter-options': {
+    labelKey: 'process-overview.queues.flat-response-filter-options.label',
+    descriptionKey: 'process-overview.queues.flat-response-filter-options.description'
+  },
+  'test-results-upload': {
+    labelKey: 'process-overview.queues.test-results-upload.label',
+    descriptionKey: 'process-overview.queues.test-results-upload.description'
+  },
+  'codebook-generation': {
+    labelKey: 'process-overview.queues.codebook-generation.label',
+    descriptionKey: 'process-overview.queues.codebook-generation.description'
+  },
+  'reset-coding-version': {
+    labelKey: 'process-overview.queues.reset-coding-version.label',
+    descriptionKey: 'process-overview.queues.reset-coding-version.description'
+  },
+  'validation-task': {
+    labelKey: 'process-overview.queues.validation-task.label',
+    descriptionKey: 'process-overview.queues.validation-task.description'
+  },
+  'response-analysis': {
+    labelKey: 'process-overview.queues.response-analysis.label',
+    descriptionKey: 'process-overview.queues.response-analysis.description'
+  },
+  'variable-analysis': {
+    labelKey: 'process-overview.queues.variable-analysis.label',
+    descriptionKey: 'process-overview.queues.variable-analysis.description'
+  },
+  'external-coding-import': {
+    labelKey: 'process-overview.queues.external-coding-import.label',
+    descriptionKey: 'process-overview.queues.external-coding-import.description'
+  },
+  'database-export': {
+    labelKey: 'process-overview.queues.database-export.label',
+    descriptionKey: 'process-overview.queues.database-export.description'
+  }
+};
+
+const DETAIL_LABEL_KEYS: Record<string, string> = {
+  taskId: 'process-overview.details.taskId',
+  resultType: 'process-overview.details.resultType',
+  overwriteExisting: 'process-overview.details.overwriteExisting',
+  personMatchMode: 'process-overview.details.personMatchMode',
+  overwriteMode: 'process-overview.details.overwriteMode',
+  scope: 'process-overview.details.scope',
+  exportType: 'process-overview.details.exportType',
+  version: 'process-overview.details.version',
+  format: 'process-overview.details.format',
+  source: 'process-overview.details.source',
+  autoCoderRun: 'process-overview.details.autoCoderRun',
+  freshnessVersion: 'process-overview.details.freshnessVersion',
+  processingDurationThresholdMs: 'process-overview.details.processingDurationThresholdMs',
+  missingsProfile: 'process-overview.details.missingsProfile',
+  unitId: 'process-overview.details.unitId',
+  variableId: 'process-overview.details.variableId',
+  fileName: 'process-overview.details.fileName',
+  sourceFormat: 'process-overview.details.sourceFormat',
+  sourceVersion: 'process-overview.details.sourceVersion',
+  scoreMode: 'process-overview.details.scoreMode',
+  existingCodingMode: 'process-overview.details.existingCodingMode',
+  validationType: 'process-overview.details.validationType',
+  progressMessage: 'process-overview.details.progressMessage',
+  isPaused: 'process-overview.details.isPaused',
+  isCancelled: 'process-overview.details.isCancelled',
+  personCount: 'process-overview.details.personCount',
+  unitCount: 'process-overview.details.unitCount',
+  groupCount: 'process-overview.details.groupCount',
+  jobDefinitionCount: 'process-overview.details.jobDefinitionCount',
+  coderTrainingCount: 'process-overview.details.coderTrainingCount',
+  coderCount: 'process-overview.details.coderCount',
+  matchingFlagCount: 'process-overview.details.matchingFlagCount'
+};
+
+const DETAIL_ORDER = [
+  'fileName',
+  'taskId',
+  'resultType',
+  'exportType',
+  'version',
+  'format',
+  'source',
+  'sourceFormat',
+  'sourceVersion',
+  'scoreMode',
+  'existingCodingMode',
+  'validationType',
+  'progressMessage',
+  'scope',
+  'personCount',
+  'unitCount',
+  'groupCount',
+  'jobDefinitionCount',
+  'coderTrainingCount',
+  'coderCount',
+  'matchingFlagCount',
+  'unitId',
+  'variableId',
+  'autoCoderRun',
+  'freshnessVersion',
+  'missingsProfile',
+  'processingDurationThresholdMs',
+  'overwriteExisting',
+  'personMatchMode',
+  'overwriteMode',
+  'isPaused',
+  'isCancelled'
+];
+
 @Component({
   selector: 'coding-box-process-overview-dialog',
   imports: [
@@ -29,6 +216,7 @@ import { ConfirmDialogComponent, ConfirmDialogData } from '../../../shared/dialo
     MatIconModule,
     MatTooltipModule,
     MatProgressSpinnerModule,
+    MatProgressBarModule,
     MatDialogModule,
     MatPaginatorModule,
     MatFormFieldModule,
@@ -43,19 +231,21 @@ export class ProcessOverviewComponent implements OnInit, AfterViewInit {
   private processesService = inject(WorkspaceProcessesService);
   private dialog = inject(MatDialog);
   private snackBar = inject(MatSnackBar);
+  private translateService = inject(TranslateService);
   data: { workspaceId: number } = inject(MAT_DIALOG_DATA);
 
   workspaceId: number = this.data.workspaceId;
   processes = new MatTableDataSource<ProcessDto>([]);
-  displayedColumns: string[] = ['queueName', 'status', 'progress', 'timestamp', 'actions'];
+  displayedColumns: string[] = ['queueName', 'status', 'progress', 'time', 'details', 'actions'];
   isLoading = false;
+  lastLoadedAt = Date.now();
 
   // Filter properties
   statusFilter = '';
   typeFilter = '';
   searchFilter = '';
   availableTypes: string[] = [];
-  statusOptions = ['active', 'waiting', 'delayed', 'completed', 'failed', 'paused', 'unknown'];
+  statusOptions: ProcessStatus[] = ['active', 'waiting', 'delayed', 'completed', 'failed', 'paused', 'unknown'];
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
@@ -72,12 +262,23 @@ export class ProcessOverviewComponent implements OnInit, AfterViewInit {
 
   setupFilterPredicate(): void {
     this.processes.filterPredicate = (data: ProcessDto, filter: string) => {
-      const searchTerms = JSON.parse(filter);
+      const searchTerms = JSON.parse(filter) as { status?: ProcessStatus; type?: string; search?: string };
 
       const statusMatch = !searchTerms.status || data.status === searchTerms.status;
       const typeMatch = !searchTerms.type || data.queueName === searchTerms.type;
+      const searchableDetails = this.getProcessDetailItems(data)
+        .map(item => `${item.label} ${item.value}`)
+        .join(' ');
 
-      const searchStr = (data.queueName + data.id + data.status).toLowerCase();
+      const searchStr = [
+        data.queueName,
+        this.getQueueLabel(data.queueName),
+        data.id,
+        data.status,
+        this.getStatusLabel(data.status),
+        data.failedReason || '',
+        searchableDetails
+      ].join(' ').toLowerCase();
       const searchMatch = !searchTerms.search || searchStr.includes(searchTerms.search.toLowerCase());
 
       return statusMatch && typeMatch && searchMatch;
@@ -108,66 +309,247 @@ export class ProcessOverviewComponent implements OnInit, AfterViewInit {
     this.processesService.getProcesses(this.workspaceId).subscribe({
       next: data => {
         this.processes.data = data;
-        this.availableTypes = [...new Set(data.map(d => d.queueName))].sort();
+        this.availableTypes = [...new Set(data.map(d => d.queueName))]
+          .sort((a, b) => this.getQueueLabel(a).localeCompare(this.getQueueLabel(b), 'de'));
+        this.lastLoadedAt = Date.now();
         this.isLoading = false;
         this.applyFilter();
       },
       error: () => {
-        this.snackBar.open('Fehler beim Laden der Prozesse', 'Schließen', { duration: 3000 });
+        this.snackBar.open(
+          this.translateService.instant('process-overview.messages.load-error'),
+          this.translateService.instant('close'),
+          { duration: 3000 }
+        );
         this.isLoading = false;
       }
     });
   }
 
   deleteProcess(process: ProcessDto): void {
+    const action = this.getProcessAction(process);
+    if (!action) return;
+
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
       width: '440px',
       data: <ConfirmDialogData>{
-        title: 'Prozess abbrechen oder entfernen',
-        content: `Möchten Sie den Prozess "${process.queueName}" (ID: ${process.id}) wirklich abbrechen oder entfernen?`,
-        confirmButtonLabel: 'Entfernen',
+        title: this.getConfirmTitle(action),
+        content: this.translateService.instant('process-overview.confirm-content', {
+          queue: this.getQueueLabel(process.queueName),
+          id: process.id,
+          action: this.getActionInfinitive(action)
+        }),
+        confirmButtonLabel: this.getActionLabel(action),
         showCancel: true
       }
     });
 
     dialogRef.afterClosed().subscribe((confirmed: boolean) => {
       if (confirmed) {
-        this.confirmDeleteProcess(process);
+        this.confirmDeleteProcess(process, action);
       }
     });
   }
 
-  confirmDeleteProcess(process: ProcessDto): void {
+  confirmDeleteProcess(process: ProcessDto, action: ProcessActionKind = this.getProcessAction(process) as ProcessActionKind): void {
+    if (!action) return;
+
     this.isLoading = true;
     this.processesService.deleteProcess(this.workspaceId, process.queueName, process.id.toString()).subscribe({
       next: success => {
         if (success) {
-          this.snackBar.open('Prozess wurde abgebrochen oder entfernt', 'OK', { duration: 3000 });
+          this.snackBar.open(this.getActionSuccessMessage(action), this.translateService.instant('close'), { duration: 3000 });
           this.loadProcesses();
         } else {
-          this.snackBar.open('Prozess konnte nicht abgebrochen oder entfernt werden', 'Schließen', { duration: 4000 });
+          this.snackBar.open(
+            this.translateService.instant('process-overview.messages.action-failed'),
+            this.translateService.instant('close'),
+            { duration: 4000 }
+          );
           this.isLoading = false;
         }
       },
       error: () => {
-        this.snackBar.open('Fehler beim Abbrechen oder Entfernen des Prozesses', 'Schließen', { duration: 4000 });
+        this.snackBar.open(
+          this.translateService.instant('process-overview.messages.action-error'),
+          this.translateService.instant('close'),
+          { duration: 4000 }
+        );
         this.isLoading = false;
       }
     });
   }
 
   canRemoveProcess(process: ProcessDto): boolean {
-    if (process.status !== 'active') return true;
-    return ['data-export', 'database-export', 'test-person-coding'].includes(process.queueName);
+    return this.getProcessAction(process) !== null;
   }
 
   getActionTooltip(process: ProcessDto): string {
-    return this.canRemoveProcess(process) ?
-      'Abbrechen / Entfernen' :
-      'Aktive Prozesse dieses Typs können nicht sicher abgebrochen werden';
+    const action = this.getProcessAction(process);
+    if (!action) {
+      return this.translateService.instant('process-overview.actions.not-safe');
+    }
+    return this.translateService.instant(`process-overview.actions.${action}.tooltip`);
   }
 
   isNumber(val: unknown): boolean {
     return typeof val === 'number';
+  }
+
+  getQueueLabel(queueName: string): string {
+    const presentation = QUEUE_PRESENTATIONS[queueName];
+    return presentation ? this.translateService.instant(presentation.labelKey) : queueName;
+  }
+
+  getQueueDescription(queueName: string): string {
+    const presentation = QUEUE_PRESENTATIONS[queueName];
+    return presentation ? this.translateService.instant(presentation.descriptionKey) : queueName;
+  }
+
+  getStatusLabel(status: ProcessStatus): string {
+    return this.translateService.instant(STATUS_PRESENTATIONS[status].labelKey);
+  }
+
+  getStatusIcon(status: ProcessStatus): string {
+    return STATUS_PRESENTATIONS[status].icon;
+  }
+
+  getStatusClass(status: ProcessStatus): string {
+    return `status-${STATUS_PRESENTATIONS[status].cssClass}`;
+  }
+
+  getStatusTooltip(status: ProcessStatus): string {
+    return this.translateService.instant(STATUS_PRESENTATIONS[status].tooltipKey);
+  }
+
+  hasProgressPercent(process: ProcessDto): boolean {
+    return this.getProgressPercent(process) !== null;
+  }
+
+  getProgressPercent(process: ProcessDto): number | null {
+    if (typeof process.progress !== 'number' || !Number.isFinite(process.progress)) {
+      return null;
+    }
+
+    return Math.max(0, Math.min(100, Math.round(process.progress)));
+  }
+
+  getProgressLabel(process: ProcessDto): string {
+    const progress = this.getProgressPercent(process);
+    if (progress !== null) {
+      return `${progress} %`;
+    }
+
+    return this.translateService.instant(`process-overview.progress.${process.status}`);
+  }
+
+  getDurationLabel(process: ProcessDto): string | null {
+    const duration = this.getDurationMs(process);
+    if (duration === null) return null;
+
+    return this.formatDuration(duration);
+  }
+
+  getProcessDetailItems(process: ProcessDto): ProcessDetailItem[] {
+    if (!process.data || typeof process.data !== 'object') return [];
+
+    return Object.entries(process.data)
+      .filter(([key, value]) => key !== 'workspaceId' && this.isDisplayableDetailValue(value))
+      .sort(([a], [b]) => this.getDetailOrder(a) - this.getDetailOrder(b))
+      .map(([key, value]) => ({
+        label: this.translateService.instant(
+          DETAIL_LABEL_KEYS[key] || 'process-overview.details.unknown-key',
+          { key }
+        ),
+        value: this.formatDetailValue(value)
+      }));
+  }
+
+  getProcessAction(process: ProcessDto): ProcessActionKind | null {
+    if (process.status === 'active') {
+      if (process.queueName === 'test-person-coding') return 'pause';
+      if (['data-export', 'database-export'].includes(process.queueName)) return 'cancel';
+      return null;
+    }
+
+    if (['waiting', 'delayed', 'paused', 'completed', 'failed'].includes(process.status)) {
+      return 'remove';
+    }
+
+    return null;
+  }
+
+  getActionIcon(process: ProcessDto): string {
+    const action = this.getProcessAction(process);
+    if (action === 'cancel') return 'cancel';
+    if (action === 'pause') return 'pause_circle';
+    if (action === 'remove') return 'delete';
+    return 'block';
+  }
+
+  getActionLabel(action: ProcessActionKind): string {
+    return this.translateService.instant(`process-overview.actions.${action}.label`);
+  }
+
+  private getConfirmTitle(action: ProcessActionKind): string {
+    return this.translateService.instant(`process-overview.actions.${action}.confirm-title`);
+  }
+
+  private getActionInfinitive(action: ProcessActionKind): string {
+    return this.translateService.instant(`process-overview.actions.${action}.infinitive`);
+  }
+
+  private getActionSuccessMessage(action: ProcessActionKind): string {
+    return this.translateService.instant(`process-overview.actions.${action}.success`);
+  }
+
+  private getDurationMs(process: ProcessDto): number | null {
+    if (!process.processedOn) return null;
+
+    if (process.finishedOn) {
+      return Math.max(0, process.finishedOn - process.processedOn);
+    }
+
+    if (process.status === 'active') {
+      return Math.max(0, this.lastLoadedAt - process.processedOn);
+    }
+
+    return null;
+  }
+
+  private formatDuration(milliseconds: number): string {
+    const totalSeconds = Math.max(1, Math.round(milliseconds / 1000));
+    if (totalSeconds < 60) {
+      return `${totalSeconds} s`;
+    }
+
+    const totalMinutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    if (totalMinutes < 60) {
+      return seconds > 0 ? `${totalMinutes} min ${seconds} s` : `${totalMinutes} min`;
+    }
+
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return minutes > 0 ? `${hours} h ${minutes} min` : `${hours} h`;
+  }
+
+  private isDisplayableDetailValue(value: unknown): boolean {
+    return typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean';
+  }
+
+  private formatDetailValue(value: unknown): string {
+    if (typeof value === 'boolean') {
+      return this.translateService.instant(value ? 'process-overview.values.yes' : 'process-overview.values.no');
+    }
+
+    return String(value);
+  }
+
+  private getDetailOrder(key: string): number {
+    const index = DETAIL_ORDER.indexOf(key);
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
   }
 }

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -67,6 +67,182 @@
       "results-by-version": "Finale Ergebnisdaten"
     }
   },
+  "process-overview": {
+    "title": "Zentrale Prozess-Übersicht",
+    "refresh": "Aktualisieren",
+    "no-data": "Keine Prozesse in der Warteschlange.",
+    "no-filter-data": "Keine Prozesse für die aktuellen Filter.",
+    "confirm-content": "Möchten Sie den Prozess \"{{queue}}\" (ID: {{id}}) wirklich {{action}}?",
+    "filters": {
+      "status": "Status",
+      "all-status": "Alle Status",
+      "type": "Typ",
+      "all-types": "Alle Typen",
+      "search": "Suchen",
+      "search-placeholder": "ID, Name oder Detail",
+      "clear": "Filter leeren"
+    },
+    "columns": {
+      "type": "Typ",
+      "status": "Status",
+      "progress": "Fortschritt",
+      "time": "Zeit",
+      "details": "Details",
+      "actions": "Aktionen"
+    },
+    "status": {
+      "active": "Läuft",
+      "waiting": "Wartet",
+      "delayed": "Geplant",
+      "completed": "Abgeschlossen",
+      "failed": "Fehlgeschlagen",
+      "paused": "Pausiert",
+      "unknown": "Unbekannt"
+    },
+    "status-tooltips": {
+      "active": "Der Prozess wird gerade bearbeitet.",
+      "waiting": "Der Prozess wartet auf einen freien Worker oder auf vorgelagerte Arbeit.",
+      "delayed": "Der Prozess ist für einen späteren Start eingeplant.",
+      "completed": "Der Prozess wurde erfolgreich abgeschlossen.",
+      "failed": "Der Prozess ist mit einem Fehler beendet worden.",
+      "paused": "Der Prozess wurde angehalten.",
+      "unknown": "Der aktuelle Prozessstatus ist nicht eindeutig bekannt."
+    },
+    "progress": {
+      "active": "Läuft ohne Fortschrittsangabe",
+      "waiting": "Wartet auf Start",
+      "delayed": "Start geplant",
+      "completed": "Abgeschlossen",
+      "failed": "Keine Fortschrittsangabe",
+      "paused": "Pausiert",
+      "unknown": "Keine Fortschrittsangabe"
+    },
+    "time": {
+      "created": "Erstellt",
+      "started": "Gestartet",
+      "finished": "Beendet",
+      "duration": "Dauer"
+    },
+    "queues": {
+      "test-person-coding": {
+        "label": "Auto-Kodierung",
+        "description": "Automatisches Kodieren von Testpersonen-Antworten"
+      },
+      "coding-statistics": {
+        "label": "Kodierstatistiken",
+        "description": "Berechnung der Kodierstatistiken für den Arbeitsbereich"
+      },
+      "data-export": {
+        "label": "Datenexport",
+        "description": "Export von Kodier- oder Testergebnisdaten"
+      },
+      "flat-response-filter-options": {
+        "label": "Filteroptionen",
+        "description": "Vorberechnung von Filteroptionen für die Ergebnisansicht"
+      },
+      "test-results-upload": {
+        "label": "Testergebnis-Import",
+        "description": "Import von Responses oder Logs"
+      },
+      "codebook-generation": {
+        "label": "Codebook-Erstellung",
+        "description": "Erstellung eines Codebooks"
+      },
+      "reset-coding-version": {
+        "label": "Kodierung zurücksetzen",
+        "description": "Zurücksetzen einer Kodier-Version"
+      },
+      "validation-task": {
+        "label": "Validierung",
+        "description": "Validierungsaufgabe für den Arbeitsbereich"
+      },
+      "response-analysis": {
+        "label": "Antwortanalyse",
+        "description": "Analyse von Antworten und Auffälligkeiten"
+      },
+      "variable-analysis": {
+        "label": "Variablenanalyse",
+        "description": "Analyse von Variablenwerten und Häufigkeiten"
+      },
+      "external-coding-import": {
+        "label": "Externer Kodierimport",
+        "description": "Import externer Kodierungen"
+      },
+      "database-export": {
+        "label": "Datenbankexport",
+        "description": "Export der Arbeitsbereichsdatenbank"
+      }
+    },
+    "details": {
+      "none": "Keine Details",
+      "unknown-key": "{{key}}",
+      "taskId": "Task",
+      "resultType": "Ergebnistyp",
+      "overwriteExisting": "Bestehende überschreiben",
+      "personMatchMode": "Personenabgleich",
+      "overwriteMode": "Überschreibmodus",
+      "scope": "Umfang",
+      "exportType": "Exporttyp",
+      "version": "Version",
+      "format": "Format",
+      "source": "Quelle",
+      "autoCoderRun": "Auto-Kodierlauf",
+      "freshnessVersion": "Freshness-Version",
+      "processingDurationThresholdMs": "Schwellwert",
+      "missingsProfile": "Missing-Profil",
+      "unitId": "Unit",
+      "variableId": "Variable",
+      "fileName": "Datei",
+      "sourceFormat": "Quellformat",
+      "sourceVersion": "Quellversion",
+      "scoreMode": "Score-Modus",
+      "existingCodingMode": "Importmodus",
+      "validationType": "Validierung",
+      "progressMessage": "Statusmeldung",
+      "isPaused": "Pausiert",
+      "isCancelled": "Abgebrochen",
+      "personCount": "Personen",
+      "unitCount": "Units",
+      "groupCount": "Gruppen",
+      "jobDefinitionCount": "Job-Definitionen",
+      "coderTrainingCount": "Trainings",
+      "coderCount": "Kodierer:innen",
+      "matchingFlagCount": "Matching-Flags"
+    },
+    "actions": {
+      "not-safe": "Für diesen Status oder Prozesstyp gibt es keine sichere Aktion.",
+      "cancel": {
+        "label": "Abbrechen",
+        "tooltip": "Laufenden Prozess abbrechen",
+        "confirm-title": "Prozess abbrechen",
+        "infinitive": "abbrechen",
+        "success": "Prozess wurde abgebrochen"
+      },
+      "pause": {
+        "label": "Anhalten",
+        "tooltip": "Laufenden Prozess anhalten",
+        "confirm-title": "Prozess anhalten",
+        "infinitive": "anhalten",
+        "success": "Prozess wurde angehalten"
+      },
+      "remove": {
+        "label": "Entfernen",
+        "tooltip": "Prozess aus der Warteschlange entfernen",
+        "confirm-title": "Prozess entfernen",
+        "infinitive": "entfernen",
+        "success": "Prozess wurde entfernt"
+      }
+    },
+    "messages": {
+      "load-error": "Fehler beim Laden der Prozesse",
+      "action-failed": "Prozess konnte nicht aktualisiert werden",
+      "action-error": "Fehler beim Aktualisieren des Prozesses"
+    },
+    "values": {
+      "yes": "Ja",
+      "no": "Nein"
+    }
+  },
   "status-cancelled": "Abgebrochen",
   "status-paused": "Pausiert",
   "home": {


### PR DESCRIPTION
## Summary
- Add a replay action to coding result comparison rows, including disabled/loading states and focused component coverage.
- Improve process overview action/status handling for queued and paused validation/coding jobs.

Fixes #529

## Verification
- `npx nx lint frontend`
- `npx nx test frontend`
- `npx nx lint backend`
- `npx nx test backend`
- Targeted backend/frontend specs for the changed areas
- Manual replay smoke check in Chrome against the local dev environment

Note: Cypress was not usable locally because `npx cypress info` terminated with `SIGILL`; the replay path was checked manually in a real browser session instead.