### PR TITLE
Open replay from comparison rows

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
@@ -606,20 +606,27 @@
             </td>
           </ng-container>
 
+          <!-- Replay Column -->
+          <ng-container matColumnDef="replay">
+            <th mat-header-cell *matHeaderCellDef>Replay</th>
+            <td mat-cell *matCellDef="let comparison">
+              <button
+                mat-icon-button
+                type="button"
+                color="primary"
+                (click)="openReplay(comparison)"
+                matTooltip="Replay inkl. Kodieranweisungen öffnen"
+              >
+                <mat-icon>play_circle</mat-icon>
+              </button>
+            </td>
+          </ng-container>
+
           <!-- Given Answer Column -->
           <ng-container matColumnDef="givenAnswer">
             <th mat-header-cell *matHeaderCellDef>Gegebene Antwort</th>
             <td mat-cell *matCellDef="let comparison">
               <div class="given-answer-cell">
-                <button
-                  mat-icon-button
-                  type="button"
-                  color="primary"
-                  (click)="openReplay(comparison)"
-                  matTooltip="Replay inkl. Kodieranweisungen öffnen"
-                >
-                  <mat-icon>play_circle</mat-icon>
-                </button>
                 <div class="answer-text" [matTooltip]="comparison.givenAnswer || 'N/A'">
                   {{ comparison.givenAnswer || 'N/A' }}
                 </div>

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
@@ -671,10 +671,6 @@
           }
 
           .given-answer-cell {
-            display: grid;
-            grid-template-columns: auto minmax(0, 1fr);
-            align-items: start;
-            gap: 8px;
             max-width: 340px;
 
             .answer-text {
@@ -814,6 +810,11 @@
         .mat-column-personInfo {
           width: 210px;
           max-width: 210px;
+        }
+
+        .mat-column-replay {
+          width: 74px;
+          text-align: center;
         }
 
         .mat-column-givenAnswer {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -25,6 +25,17 @@ describe('CodingResultsComparisonComponent', () => {
     saveDiscussionResult: jest.Mock;
     getTrainingCohensKappa: jest.Mock;
   };
+  let codingStatisticsService: {
+    getReplayUrl: jest.Mock;
+  };
+  let appService: {
+    authData: { userName: string };
+    loggedUser: { preferred_username?: string } | undefined;
+    createOwnToken: jest.Mock;
+  };
+  let snackBar: {
+    open: jest.Mock;
+  };
 
   beforeEach(async () => {
     codingTrainingBackendService = {
@@ -39,6 +50,17 @@ describe('CodingResultsComparisonComponent', () => {
         managerName: 'Test User'
       })),
       getTrainingCohensKappa: jest.fn()
+    };
+    codingStatisticsService = {
+      getReplayUrl: jest.fn()
+    };
+    appService = {
+      authData: { userName: 'Test User' },
+      loggedUser: undefined,
+      createOwnToken: jest.fn()
+    };
+    snackBar = {
+      open: jest.fn()
     };
 
     await TestBed.configureTestingModule({
@@ -63,7 +85,7 @@ describe('CodingResultsComparisonComponent', () => {
         },
         {
           provide: MatSnackBar,
-          useValue: { open: jest.fn() }
+          useValue: snackBar
         },
         {
           provide: CodingTrainingBackendService,
@@ -71,17 +93,11 @@ describe('CodingResultsComparisonComponent', () => {
         },
         {
           provide: CodingStatisticsService,
-          useValue: {
-            getReplayUrl: jest.fn()
-          }
+          useValue: codingStatisticsService
         },
         {
           provide: AppService,
-          useValue: {
-            authData: { userName: 'Test User' },
-            loggedUser: undefined,
-            createOwnToken: jest.fn()
-          }
+          useValue: appService
         }
       ]
     }).compileComponents();
@@ -91,8 +107,73 @@ describe('CodingResultsComparisonComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should expose replay as its own table column', () => {
+    expect(component.displayedColumns).toEqual([
+      'index',
+      'unitVariable',
+      'personInfo',
+      'replay',
+      'givenAnswer',
+      'match'
+    ]);
+  });
+
+  it('should open replay for the row response with coding context', () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    appService.createOwnToken.mockReturnValue(of('token-123'));
+    codingStatisticsService.getReplayUrl.mockReturnValue(of({
+      replayUrl: 'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?auth=token-123'
+    }));
+
+    component.openReplay({
+      responseId: 77,
+      unitName: 'UNIT_1',
+      variableId: 'VAR_1',
+      personCode: 'code',
+      personLogin: 'login',
+      personGroup: '',
+      testPerson: 'login@code@booklet',
+      coders: []
+    } as never);
+
+    expect(appService.createOwnToken).toHaveBeenCalledWith(1, 1);
+    expect(codingStatisticsService.getReplayUrl).toHaveBeenCalledWith(1, 77, 'token-123');
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?auth=token-123&mode=coding&originResponseId=77',
+      '_blank'
+    );
+  });
+
+  it('should show feedback when no replay URL is returned', () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    appService.createOwnToken.mockReturnValue(of('token-123'));
+    codingStatisticsService.getReplayUrl.mockReturnValue(of({ replayUrl: '' }));
+
+    component.openReplay({
+      responseId: 77,
+      unitName: 'UNIT_1',
+      variableId: 'VAR_1',
+      personCode: 'code',
+      personLogin: 'login',
+      personGroup: '',
+      testPerson: 'login@code@booklet',
+      coders: []
+    } as never);
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Replay-URL konnte nicht erzeugt werden.',
+      'common.close',
+      { duration: 3000 }
+    );
   });
 
   it('should format and filter trainings with stable disambiguation data', () => {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -207,7 +207,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   isLoading = false;
   isLoadingKappa = false;
   dataSource = new MatTableDataSource<TrainingComparison | WithinTrainingComparison>([]);
-  displayedColumns: string[] = ['index', 'unitVariable', 'personInfo', 'givenAnswer', 'match'];
+  displayedColumns: string[] = ['index', 'unitVariable', 'personInfo', 'replay', 'givenAnswer', 'match'];
   dynamicCoderColumns: string[] = [];
   availableTrainings: CoderTraining[] = [];
   filteredTrainings: CoderTraining[] = [];
@@ -833,13 +833,38 @@ export class CodingResultsComparisonComponent implements OnInit {
         this.codingStatisticsService.getReplayUrl(workspaceId, responseId, token).subscribe({
           next: result => {
             if (result.replayUrl) {
-              const separator = result.replayUrl.includes('?') ? '&' : '?';
-              window.open(`${result.replayUrl}${separator}mode=coding&originResponseId=${responseId}`, '_blank');
+              window.open(this.buildReplayUrl(result.replayUrl, responseId), '_blank');
+            } else {
+              this.snackBar.open('Replay-URL konnte nicht erzeugt werden.', this.translate.instant('common.close'), { duration: 3000 });
             }
+          },
+          error: () => {
+            this.snackBar.open('Replay konnte nicht geöffnet werden.', this.translate.instant('common.close'), { duration: 3000 });
           }
         });
+      },
+      error: () => {
+        this.snackBar.open('Replay-Token konnte nicht erzeugt werden.', this.translate.instant('common.close'), { duration: 3000 });
       }
     });
+  }
+
+  private buildReplayUrl(replayUrl: string, responseId: number): string {
+    const [baseUrl, fragment = ''] = replayUrl.split('#', 2);
+    const appendParams = (value: string): string => {
+      const [path, query = ''] = value.split('?', 2);
+      const params = new URLSearchParams(query);
+      params.set('mode', 'coding');
+      params.set('originResponseId', responseId.toString());
+      const serializedParams = params.toString();
+      return serializedParams ? `${path}?${serializedParams}` : path;
+    };
+
+    if (fragment) {
+      return `${baseUrl}#${appendParams(fragment)}`;
+    }
+
+    return appendParams(baseUrl);
   }
 
   loadCoderTrainings(): Promise<void> {
@@ -925,7 +950,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   private updateDisplayedColumns(): void {
-    const baseColumns = ['index', 'unitVariable', 'personInfo', 'givenAnswer'];
+    const baseColumns = ['index', 'unitVariable', 'personInfo', 'replay', 'givenAnswer'];
     this.dynamicCoderColumns = [];
 
     if (this.comparisonMode === 'between-trainings') {


### PR DESCRIPTION
## Summary

- add a dedicated replay column to the coding results comparison table
- open replay for the selected row response with coding mode and origin response context
- handle missing replay URLs with user feedback and cover URL construction in tests

Closes #529.

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts`
- `npx nx lint frontend`