### PR TITLE
Prozessübersicht: Aktionen und Statushandling verbessern

### DIFF
--- a/api-dto/workspaces/process-dto.ts
+++ b/api-dto/workspaces/process-dto.ts
@@ -1,7 +1,7 @@
 export interface ProcessDto {
   id: string | number;
   queueName: string;
-  status: 'active' | 'waiting' | 'delayed' | 'completed' | 'failed' | 'paused' | 'unknown';
+  status: 'active' | 'waiting' | 'delayed' | 'completed' | 'failed' | 'paused' | 'cancelled' | 'unknown';
   progress: number | unknown;
   data?: Record<string, unknown>; // Sanitized job metadata payload
   failedReason?: string;

--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -214,6 +214,12 @@ describe('JobQueueService', () => {
 
     await expect(service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')).resolves.toBe(true);
     expect(pausedJob.remove).toHaveBeenCalled();
+
+    const cancelledJob = createJob({ workspaceId: 1 }, 'cancelled');
+    queues[1].getJob.mockResolvedValue(cancelledJob);
+
+    await expect(service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')).resolves.toBe(true);
+    expect(cancelledJob.remove).toHaveBeenCalled();
   });
 
   it('handles missing jobs and failing queue operations', async () => {
@@ -262,7 +268,7 @@ describe('JobQueueService', () => {
     ]);
   });
 
-  it('uses validation task progress and errors from the task entity in the process overview', async () => {
+  it('uses validation task progress and metadata from the task entity in the process overview', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
     queues[7].getJobs.mockResolvedValue([
       createJob({ taskId: 7 }, 'active')
@@ -284,11 +290,75 @@ describe('JobQueueService', () => {
         queueName: 'validation-task',
         status: 'active',
         progress: 65,
-        failedReason: 'Schema validation failed',
+        failedReason: undefined,
         data: {
           taskId: 7,
           validationType: 'testFiles',
           progressMessage: 'Testdateien werden geprüft...'
+        }
+      })
+    ]);
+  });
+
+  it('shows cancelled validation task entity statuses in the process overview', async () => {
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[7].getJobs.mockResolvedValue([
+      createJob({ taskId: 7 }, 'completed')
+    ]);
+    validationTaskRepository.find.mockResolvedValueOnce([{
+      id: 7,
+      workspace_id: 1,
+      validation_type: 'testFiles',
+      status: 'cancelled',
+      progress: 30,
+      progress_message: 'Validierung abgebrochen.',
+      error: 'Cancelled by user'
+    }]);
+
+    const workspaceJobs = await service.getAllWorkspaceJobs(1);
+
+    expect(workspaceJobs).toEqual([
+      expect.objectContaining({
+        queueName: 'validation-task',
+        status: 'cancelled',
+        progress: 30,
+        failedReason: undefined,
+        data: {
+          taskId: 7,
+          validationType: 'testFiles',
+          progressMessage: 'Validierung abgebrochen.'
+        }
+      })
+    ]);
+  });
+
+  it('keeps active Bull validation tasks active even when the task entity is cancelled', async () => {
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[7].getJobs.mockResolvedValue([
+      createJob({ taskId: 7 }, 'active')
+    ]);
+    validationTaskRepository.find.mockResolvedValueOnce([{
+      id: 7,
+      workspace_id: 1,
+      validation_type: 'testFiles',
+      status: 'cancelled',
+      progress: 30,
+      progress_message: 'Validierung abgebrochen.',
+      error: 'Cancelled by user'
+    }]);
+
+    const workspaceJobs = await service.getAllWorkspaceJobs(1);
+
+    expect(workspaceJobs).toEqual([
+      expect.objectContaining({
+        queueName: 'validation-task',
+        status: 'active',
+        progress: 30,
+        failedReason: undefined,
+        data: {
+          taskId: 7,
+          validationType: 'testFiles',
+          progressMessage: 'Validierung abgebrochen.'
         }
       })
     ]);

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -287,7 +287,8 @@ export class JobQueueService {
       state === 'delayed' ||
       state === 'completed' ||
       state === 'failed' ||
-      state === 'paused'
+      state === 'paused' ||
+      state === 'cancelled'
     ) {
       return state;
     }
@@ -299,12 +300,13 @@ export class JobQueueService {
     status: string | undefined,
     fallbackBullState: string
   ): ProcessDto['status'] {
+    if (fallbackBullState === 'active') return 'active';
     if (status === 'pending') return 'waiting';
     if (status === 'processing') return 'active';
     if (status === 'completed') return 'completed';
     if (status === 'failed') return 'failed';
     if (status === 'paused') return 'paused';
-    if (status === 'cancelled') return 'unknown';
+    if (status === 'cancelled') return 'cancelled';
 
     return this.mapBullStateToProcessStatus(fallbackBullState);
   }
@@ -332,6 +334,15 @@ export class JobQueueService {
     return this.mapBullStateToProcessStatus(bullState);
   }
 
+  private getProcessFailedReason(
+    status: ProcessDto['status'],
+    job: Job,
+    validationTask?: ProcessOverviewValidationTask
+  ): string | undefined {
+    if (status !== 'failed') return undefined;
+    return validationTask?.error || job.failedReason;
+  }
+
   private async jobBelongsToWorkspace(
     queueName: string,
     job: Job,
@@ -355,7 +366,8 @@ export class JobQueueService {
   private async cancelKnownJob(queueName: string, job: Job): Promise<boolean> {
     try {
       const state = await job.getState();
-      if (state === 'waiting' || state === 'delayed' || state === 'paused' || state === 'completed' || state === 'failed') {
+      const removableStates = ['waiting', 'delayed', 'paused', 'completed', 'failed', 'cancelled'];
+      if (removableStates.includes(state)) {
         await job.remove();
         return true;
       }
@@ -484,7 +496,7 @@ export class JobQueueService {
                 validationType: validationTask?.validation_type,
                 progressMessage: validationTask?.progress_message
               }),
-              failedReason: validationTask?.error || job.failedReason,
+              failedReason: this.getProcessFailedReason(status, job, validationTask),
               timestamp: job.timestamp,
               processedOn: job.processedOn,
               finishedOn: job.finishedOn

--- a/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.scss
+++ b/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.scss
@@ -137,6 +137,12 @@
       color: #424242;
     }
 
+    &.status-cancelled {
+      border-color: #c62828;
+      background: #ffebee;
+      color: #8e0000;
+    }
+
     &.status-unknown {
       border-color: #9e9e9e;
       background: #fafafa;

--- a/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.spec.ts
@@ -90,6 +90,7 @@ describe('ProcessOverviewComponent', () => {
           completed: 'Abgeschlossen',
           failed: 'Fehlgeschlagen',
           paused: 'Pausiert',
+          cancelled: 'Abgebrochen',
           unknown: 'Unbekannt'
         },
         'status-tooltips': {
@@ -99,6 +100,7 @@ describe('ProcessOverviewComponent', () => {
           completed: 'Der Prozess wurde erfolgreich abgeschlossen.',
           failed: 'Der Prozess ist mit einem Fehler beendet worden.',
           paused: 'Der Prozess wurde angehalten.',
+          cancelled: 'Der Prozess wurde abgebrochen.',
           unknown: 'Der aktuelle Prozessstatus ist nicht eindeutig bekannt.'
         },
         progress: {
@@ -108,6 +110,7 @@ describe('ProcessOverviewComponent', () => {
           completed: 'Abgeschlossen',
           failed: 'Keine Fortschrittsangabe',
           paused: 'Pausiert',
+          cancelled: 'Abgebrochen',
           unknown: 'Keine Fortschrittsangabe'
         },
         time: {
@@ -238,6 +241,14 @@ describe('ProcessOverviewComponent', () => {
       progress: 0,
       timestamp: 100
     })).toBe(false);
+
+    expect(component.getProcessAction({
+      id: 'job-5',
+      queueName: 'validation-task',
+      status: 'cancelled',
+      progress: 30,
+      timestamp: 100
+    })).toBe('remove');
   });
 
   it('keeps the tooltip on a wrapper around disabled action buttons', () => {
@@ -261,6 +272,7 @@ describe('ProcessOverviewComponent', () => {
     expect(component.getQueueLabel('data-export')).toBe('Datenexport');
     expect(component.getQueueLabel('unknown-queue')).toBe('unknown-queue');
     expect(component.getStatusLabel('waiting')).toBe('Wartet');
+    expect(component.getStatusLabel('cancelled')).toBe('Abgebrochen');
     expect(component.getStatusIcon('failed')).toBe('error');
   });
 

--- a/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/process-overview/process-overview.component.ts
@@ -77,6 +77,12 @@ const STATUS_PRESENTATIONS: Record<ProcessStatus, ProcessStatusPresentation> = {
     icon: 'pause_circle',
     cssClass: 'paused'
   },
+  cancelled: {
+    labelKey: 'process-overview.status.cancelled',
+    tooltipKey: 'process-overview.status-tooltips.cancelled',
+    icon: 'cancel',
+    cssClass: 'cancelled'
+  },
   unknown: {
     labelKey: 'process-overview.status.unknown',
     tooltipKey: 'process-overview.status-tooltips.unknown',
@@ -245,7 +251,7 @@ export class ProcessOverviewComponent implements OnInit, AfterViewInit {
   typeFilter = '';
   searchFilter = '';
   availableTypes: string[] = [];
-  statusOptions: ProcessStatus[] = ['active', 'waiting', 'delayed', 'completed', 'failed', 'paused', 'unknown'];
+  statusOptions: ProcessStatus[] = ['active', 'waiting', 'delayed', 'completed', 'failed', 'paused', 'cancelled', 'unknown'];
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
@@ -472,7 +478,7 @@ export class ProcessOverviewComponent implements OnInit, AfterViewInit {
       return null;
     }
 
-    if (['waiting', 'delayed', 'paused', 'completed', 'failed'].includes(process.status)) {
+    if (['waiting', 'delayed', 'paused', 'completed', 'failed', 'cancelled'].includes(process.status)) {
       return 'remove';
     }
 

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -97,6 +97,7 @@
       "completed": "Abgeschlossen",
       "failed": "Fehlgeschlagen",
       "paused": "Pausiert",
+      "cancelled": "Abgebrochen",
       "unknown": "Unbekannt"
     },
     "status-tooltips": {
@@ -106,6 +107,7 @@
       "completed": "Der Prozess wurde erfolgreich abgeschlossen.",
       "failed": "Der Prozess ist mit einem Fehler beendet worden.",
       "paused": "Der Prozess wurde angehalten.",
+      "cancelled": "Der Prozess wurde abgebrochen.",
       "unknown": "Der aktuelle Prozessstatus ist nicht eindeutig bekannt."
     },
     "progress": {
@@ -115,6 +117,7 @@
       "completed": "Abgeschlossen",
       "failed": "Keine Fortschrittsangabe",
       "paused": "Pausiert",
+      "cancelled": "Abgebrochen",
       "unknown": "Keine Fortschrittsangabe"
     },
     "time": {


### PR DESCRIPTION
## Überblick

Refs #498.

Dieser PR verbessert die Prozessübersicht für laufende und abgeschlossene Jobs:

- Prozessstatus `cancelled` wird im DTO, Backend-Mapping und Frontend dargestellt.
- Abbrechbare/entfernbare Prozessaktionen werden konsistenter behandelt.
- Aktive Bull-Jobs überstimmen veraltete Validation-Task-Status aus der Datenbank, damit laufende Jobs nicht fälschlich als entfernt/fehlgeschlagen erscheinen.
- Fehlergründe werden nur noch bei effektiv fehlgeschlagenen Prozessen ausgegeben.
- UI-Texte, Filter, Badge-Farbe und Tests für `cancelled` wurden ergänzt.

Nicht enthalten ist die bewusst ausgelassene Auffindbarkeits-Änderung mit eigenem Workspace-Admin-Tab `Prozesse`.

## Validierung

- `git diff --check`
- `npx nx lint backend`
- `npx nx lint frontend`
- `npx nx test backend --runInBand`
- `npx nx test frontend --runInBand`
