### PR TITLE
Scope manual coding coverage counts

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -1,3 +1,4 @@
+import { Brackets } from 'typeorm';
 import { CodingProgressService } from './coding-progress.service';
 import { getManualCodingScopeKey } from '../../utils/manual-coding-scope.util';
 import { statusStringToNumber } from '../../utils/response-status-converter';
@@ -12,8 +13,46 @@ const createRepository = () => ({
   findOne: jest.fn()
 });
 
+type MockQueryBuilder = Record<string, jest.Mock> & {
+  subQueryProbes: Record<string, jest.Mock>[];
+};
+
+const createSubQueryProbe = (queryBuilder: MockQueryBuilder) => {
+  const subQueryBuilder: Record<string, jest.Mock> = {};
+  [
+    'select',
+    'from',
+    'innerJoin',
+    'where',
+    'andWhere'
+  ].forEach(method => {
+    subQueryBuilder[method] = jest.fn().mockReturnValue(subQueryBuilder);
+  });
+  subQueryBuilder.getQuery = jest.fn().mockReturnValue('SELECT 1');
+  queryBuilder.subQueryProbes.push(subQueryBuilder);
+  return subQueryBuilder;
+};
+
+const executeBrackets = (condition: unknown, queryBuilder: MockQueryBuilder) => {
+  if (!(condition instanceof Brackets)) {
+    return;
+  }
+
+  const bracketBuilder: Record<string, jest.Mock> = {};
+  bracketBuilder.where = jest.fn().mockReturnValue(bracketBuilder);
+  bracketBuilder.orWhere = jest.fn((callback: (builder: { subQuery: jest.Mock }) => string) => {
+    callback({
+      subQuery: jest.fn().mockReturnValue(createSubQueryProbe(queryBuilder))
+    });
+    return bracketBuilder;
+  });
+  condition.whereFactory(bracketBuilder as never);
+};
+
 const createQueryBuilder = (rawResults: unknown[] = []) => {
-  const queryBuilder: Record<string, jest.Mock> = {};
+  const queryBuilder: MockQueryBuilder = {
+    subQueryProbes: []
+  } as MockQueryBuilder;
   [
     'select',
     'addSelect',
@@ -25,11 +64,27 @@ const createQueryBuilder = (rawResults: unknown[] = []) => {
     'addGroupBy',
     'orderBy'
   ].forEach(method => {
-    queryBuilder[method] = jest.fn().mockReturnValue(queryBuilder);
+    queryBuilder[method] = jest.fn((condition?: unknown) => {
+      executeBrackets(condition, queryBuilder);
+      return queryBuilder;
+    });
   });
   queryBuilder.getRawMany = jest.fn().mockResolvedValue(rawResults);
   queryBuilder.getCount = jest.fn().mockResolvedValue(0);
   return queryBuilder;
+};
+
+const expectProductiveManualPoolExists = (queryBuilder: MockQueryBuilder) => {
+  expect(queryBuilder.subQueryProbes).toHaveLength(1);
+  const [existsBuilder] = queryBuilder.subQueryProbes;
+  expect(existsBuilder.from).toHaveBeenCalledWith('coding_job_unit', 'manual_cju');
+  expect(existsBuilder.innerJoin).toHaveBeenCalledWith(
+    'coding_job',
+    'manual_cj',
+    'manual_cj.id = manual_cju.coding_job_id'
+  );
+  expect(existsBuilder.where).toHaveBeenCalledWith('manual_cju.response_id = response.id');
+  expect(existsBuilder.andWhere).toHaveBeenCalledWith('manual_cj.training_id IS NULL');
 };
 
 describe('CodingProgressService variable coverage conflicts', () => {
@@ -128,6 +183,99 @@ describe('CodingProgressService variable coverage conflicts', () => {
       coveredSourceVariableCount: 1,
       coveredSourceResponseCount: 1
     });
+  });
+
+  it('does not let unassigned pre-coded derived responses cover source responses in manual totals', async () => {
+    const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+    const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    const allResponses = [
+      {
+        responseId: '100',
+        unitName: 'UnitA',
+        variableId: 'derived-var',
+        value: 'derived value',
+        codeV2: '1',
+        statusV2: null,
+        statusV1: String(codingIncompleteStatus)
+      },
+      {
+        responseId: '101',
+        unitName: 'UnitA',
+        variableId: 'base-var',
+        value: 'base value',
+        codeV2: null,
+        statusV2: null,
+        statusV1: String(intendedIncompleteStatus)
+      },
+      {
+        responseId: '102',
+        unitName: 'UnitA',
+        variableId: 'standalone-var',
+        value: 'standalone value',
+        codeV2: null,
+        statusV2: null,
+        statusV1: String(intendedIncompleteStatus)
+      }
+    ];
+    const manualPoolResponses = allResponses.slice(1);
+
+    responseRepository.createQueryBuilder
+      .mockReturnValueOnce(createQueryBuilder(allResponses))
+      .mockReturnValueOnce(createQueryBuilder(manualPoolResponses))
+      .mockReturnValueOnce(createQueryBuilder(allResponses))
+      .mockReturnValueOnce(createQueryBuilder(manualPoolResponses));
+    codingJobUnitRepository.createQueryBuilder
+      .mockReturnValueOnce(createQueryBuilder([]))
+      .mockReturnValueOnce(createQueryBuilder([]))
+      .mockReturnValueOnce(createQueryBuilder([]));
+    settingRepository.findOne.mockResolvedValue({ content: 'disabled' });
+    workspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map([
+      [getManualCodingScopeKey('UnitA', 'base-var'), new Set(['derived-var'])]
+    ]));
+
+    const progress = await service.getCodingProgressOverview(5);
+    const coverage = await service.getCaseCoverageOverview(5);
+
+    expect(progress).toMatchObject({
+      rawTotalCasesToCode: 2,
+      rawCompletedCases: 0,
+      totalCasesToCode: 2,
+      completedCases: 0,
+      statusTotalCasesToCode: 3,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0
+    });
+    expect(coverage).toMatchObject({
+      totalCasesToCode: 2,
+      effectiveTotalCasesToCode: 2,
+      casesInJobs: 0,
+      effectiveCasesInJobs: 0,
+      unassignedCases: 2,
+      effectiveUnassignedCases: 2,
+      statusTotalCasesToCode: 3,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0
+    });
+  });
+
+  it('limits manual pool existence checks to non-training coding jobs', async () => {
+    const allResponsesQuery = createQueryBuilder([]);
+    const manualPoolQuery = createQueryBuilder([]);
+    const variableCoverageQuery = createQueryBuilder([]);
+
+    responseRepository.createQueryBuilder
+      .mockReturnValueOnce(allResponsesQuery)
+      .mockReturnValueOnce(manualPoolQuery)
+      .mockReturnValueOnce(variableCoverageQuery);
+    codingJobUnitRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([]));
+    settingRepository.findOne.mockResolvedValue({ content: 'disabled' });
+    jobDefinitionRepository.find.mockResolvedValue([]);
+
+    await service.getCodingProgressOverview(5);
+    await service.getVariableCoverageOverview(5);
+
+    expectProductiveManualPoolExists(manualPoolQuery);
+    expectProductiveManualPoolExists(variableCoverageQuery);
   });
 
   it('excludes covered source responses from case coverage while preserving status totals', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -296,12 +296,15 @@ export class CodingProgressService {
   }
 
   private async getCoverageResponseScope(workspaceId: number): Promise<CoverageResponseScope> {
-    const allResponses = await this.getCoverageResponses(workspaceId);
+    const [allResponses, manualPoolResponses] = await Promise.all([
+      this.getCoverageResponses(workspaceId),
+      this.getCoverageResponses(workspaceId, true)
+    ]);
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const derivedVariablesBySourceMap =
       await this.workspaceFilesService.getDerivedVariablesBySourceMap(workspaceId);
     const coveredSourceKeys = getCoveredSourceKeysForManualDerivedVariables(
-      allResponses
+      manualPoolResponses
         .filter(response => response.statusV1 === codingIncompleteStatus)
         .map(response => ({
           unitName: response.unitName,
@@ -309,12 +312,12 @@ export class CodingProgressService {
         })),
       derivedVariablesBySourceMap
     );
-    const manualResponses = allResponses.filter(response => (
+    const manualResponses = manualPoolResponses.filter(response => (
       response.statusV1 === codingIncompleteStatus ||
       !isCoveredSourceVariable(response, coveredSourceKeys)
     ));
     const excludedSourceSummary = summarizeCoveredSourceVariables(
-      allResponses
+      manualPoolResponses
         .filter(response => response.statusV1 !== codingIncompleteStatus)
         .map(response => ({
           unitName: response.unitName,
@@ -397,7 +400,10 @@ export class CodingProgressService {
     };
   }
 
-  private async getCoverageResponses(workspaceId: number): Promise<CoverageResponse[]> {
+  private async getCoverageResponses(
+    workspaceId: number,
+    manualPoolOnly = false
+  ): Promise<CoverageResponse[]> {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     const query = this.responseRepository
       .createQueryBuilder('response')
@@ -420,9 +426,36 @@ export class CodingProgressService {
       })
       .andWhere('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('(response.code_v2 IS NULL OR (response.code_v2 != -111 AND response.code_v2 != -98))')
       .orderBy('response.id', 'ASC');
-    applyResolvedExclusionsToQuery(query, exclusions, { parameterPrefix: 'coverageResponses' });
+
+    if (manualPoolOnly) {
+      query.andWhere(new Brackets(qb => {
+        qb.where('response.code_v2 IS NULL')
+          .orWhere(subQuery => {
+            const exists = subQuery
+              .subQuery()
+              .select('1')
+              .from('coding_job_unit', 'manual_cju')
+              .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
+              .where('manual_cju.response_id = response.id')
+              .andWhere('manual_cj.training_id IS NULL')
+              .getQuery();
+            return `EXISTS (${exists})`;
+          });
+      }));
+    } else {
+      query.andWhere('(response.code_v2 IS NULL OR (response.code_v2 != -111 AND response.code_v2 != -98))');
+    }
+
+    applyResolvedExclusionsToQuery(
+      query,
+      exclusions,
+      {
+        parameterPrefix: manualPoolOnly ?
+          'coverageResponsesManualPool' :
+          'coverageResponses'
+      }
+    );
     const raw = await query.getRawMany();
 
     return raw.map(row => ({
@@ -661,8 +694,10 @@ export class CodingProgressService {
               const exists = subQuery
                 .subQuery()
                 .select('1')
-                .from('coding_job_unit', 'cju')
-                .where('cju.response_id = response.id')
+                .from('coding_job_unit', 'manual_cju')
+                .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
+                .where('manual_cju.response_id = response.id')
+                .andWhere('manual_cj.training_id IS NULL')
                 .getQuery();
               return `EXISTS (${exists})`;
             });


### PR DESCRIPTION
## Summary

- Scope manual coding coverage to responses that are still uncoded or already part of productive manual coding jobs.
- Keep pre-coded, unassigned derived responses from making their source variables look covered in manual coding progress and case coverage.
- Exclude coder-training jobs from the manual pool existence checks and add regression coverage for the query path.

## Why

Related to #584. `INTENDED_INCOMPLETE` source variables should not be offered for manual coding when their derived variables are already covered by productive manual coding, but imported/preprocessed derived values and training jobs must not distort the manual coding statistics.

## Validation

- `npx nx lint backend`
- `npx nx test backend --runInBand --testPathPatterns=coding-progress.service.spec.ts` (Nx ran all backend suites: 108 passed)
- `npx nx build backend`
- `git diff --check`
- `npx nx lint frontend --skip-nx-cache`
- `npx nx test frontend --runInBand --skip-nx-cache` (169 passed)
- `npx nx build frontend --skip-nx-cache` (successful; known Angular/budget warnings only)
- Browser smoke on `http://localhost:4200/#/workspace-admin/5/coding/manual`: manual coding page, transparency note, and the job-definition single-variable tab checked without new console errors.
