### PR TITLE
[codex] Exclude DERIVE_ERROR from manual coding candidates

### DIFF
--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -21,6 +21,7 @@ import { CoderTrainingDiscussionResult } from '../../entities/coder-training-dis
 import User from '../../entities/user.entity';
 import { MissingsProfilesService } from './missings-profiles.service';
 import type { CaseSelectionMode, ReferenceMode } from '../../entities/coder-training.entity';
+import { statusStringToNumber } from '../../utils/response-status-converter';
 
 describe('CoderTrainingService', () => {
   let service: CoderTrainingService;
@@ -967,6 +968,27 @@ describe('CoderTrainingService', () => {
           responses: []
         }
       ]);
+    });
+
+    it('does not include DERIVE_ERROR responses in training package sampling', async () => {
+      const responseQb = mockResponseRepository([]);
+
+      await service.generateCoderTrainingPackages(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [{ unitId: 'Alias Unit', variableId: 'var1', sampleCount: 5 }]
+      );
+
+      const statusFilterCall = responseQb.andWhere.mock.calls.find(
+        ([condition]) => condition === 'response.status_v1 IN (:...statuses)'
+      );
+      const statuses = statusFilterCall?.[1]?.statuses;
+
+      expect(statuses).toEqual([
+        statusStringToNumber('CODING_INCOMPLETE'),
+        statusStringToNumber('INTENDED_INCOMPLETE')
+      ]);
+      expect(statuses).not.toContain(statusStringToNumber('DERIVE_ERROR'));
     });
 
     it('should keep the same referenced cases when the training uses a unit alias', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -8,6 +8,7 @@ import { CodingJobUnit } from '../../entities/coding-job-unit.entity';
 import { JobDefinition } from '../../entities/job-definition.entity';
 import { VariableBundle } from '../../entities/variable-bundle.entity';
 import { ResponseEntity } from '../../entities/response.entity';
+import { statusStringToNumber } from '../../utils/response-status-converter';
 
 jest.mock('../workspace/workspace-files.service', () => ({
   WorkspaceFilesService: class {}
@@ -52,6 +53,19 @@ const createQueryBuilder = (result: unknown = []) => {
   qb.getCount = jest.fn().mockResolvedValue(typeof result === 'number' ? result : 0);
   qb.execute = jest.fn().mockResolvedValue(result);
   return qb;
+};
+
+const expectManualCodingCandidateStatusFilter = (qb: Record<string, jest.Mock>) => {
+  const statusFilterCall = qb.andWhere.mock.calls.find(
+    ([condition]) => condition === 'response.status_v1 IN (:...statuses)'
+  );
+  const statuses = statusFilterCall?.[1]?.statuses;
+
+  expect(statuses).toEqual([
+    statusStringToNumber('CODING_INCOMPLETE'),
+    statusStringToNumber('INTENDED_INCOMPLETE')
+  ]);
+  expect(statuses).not.toContain(statusStringToNumber('DERIVE_ERROR'));
 };
 
 describe('CodingJobService', () => {
@@ -1038,6 +1052,40 @@ describe('CodingJobService', () => {
     await expect(service.getResponsesForCodingJob(1)).resolves.toEqual([{ id: 1 }]);
     expect(qb.where).toHaveBeenCalled();
     expect(qb.andWhere).toHaveBeenCalledWith('(response.code_v2 IS NULL OR response.code_v2 != -111)');
+  });
+
+  it('does not include DERIVE_ERROR responses in coding-job variable selection', async () => {
+    const qb = createQueryBuilder([]);
+    responseRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await expect(service.getResponsesForVariables(3, [{ unitName: 'UNIT', variableId: 'VAR' }])).resolves.toEqual([]);
+
+    expectManualCodingCandidateStatusFilter(qb);
+  });
+
+  it('does not include DERIVE_ERROR responses in slim variable selection', async () => {
+    const qb = createQueryBuilder([]);
+    responseRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await expect(service.getSlimResponsesForVariables(3, [{ unitName: 'UNIT', variableId: 'VAR' }])).resolves.toEqual([]);
+
+    expectManualCodingCandidateStatusFilter(qb);
+  });
+
+  it('does not include DERIVE_ERROR responses when saving coding-job units', async () => {
+    const qb = createQueryBuilder([]);
+    responseRepository.createQueryBuilder.mockReturnValue(qb);
+    codingJobRepository.save.mockResolvedValue({ id: 1, workspace_id: 3 });
+    codingJobRepository.findOne.mockResolvedValue({ id: 1, workspace_id: 3 });
+    codingJobVariableRepository.find.mockResolvedValue([{ unit_name: 'UNIT', variable_id: 'VAR' }]);
+    codingJobVariableBundleRepository.find.mockResolvedValue([]);
+
+    await service.createCodingJob(3, {
+      name: 'Direct job',
+      variables: [{ unitName: 'UNIT', variableId: 'VAR' }]
+    } as never);
+
+    expectManualCodingCandidateStatusFilter(qb);
   });
 
   it('returns no coding-job responses when no variables are assigned', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-list-query.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-query.service.spec.ts
@@ -228,6 +228,66 @@ describe('CodingListQueryService', () => {
     });
   });
 
+  it('does not include DERIVE_ERROR responses in the default coding list selection', async () => {
+    const unitVariableMap = new Map([[
+      'UNIT',
+      new Set(['DERIVE_VAR', 'INCOMPLETE_VAR'])
+    ]]);
+    const responses = [
+      {
+        id: 1,
+        variableid: 'DERIVE_VAR',
+        value: 'O',
+        status_v1: statusStringToNumber('DERIVE_ERROR'),
+        unit: {
+          name: 'UNIT',
+          alias: 'Unit Alias',
+          booklet: {
+            person: {
+              login: 'login',
+              code: 'code',
+              group: 'group'
+            },
+            bookletinfo: {
+              name: 'BOOKLET'
+            }
+          }
+        }
+      },
+      {
+        id: 2,
+        variableid: 'INCOMPLETE_VAR',
+        value: 'Antwort',
+        status_v1: statusStringToNumber('CODING_INCOMPLETE'),
+        unit: {
+          name: 'UNIT',
+          alias: 'Unit Alias',
+          booklet: {
+            person: {
+              login: 'login',
+              code: 'code',
+              group: 'group'
+            },
+            bookletinfo: {
+              name: 'BOOKLET'
+            }
+          }
+        }
+      }
+    ] as unknown as ResponseEntity[];
+    const service = createService(responses, createFileRepository({}), {
+      unitVariableMap
+    });
+
+    const result = await service.getCodingList(
+      1,
+      'token',
+      'https://iqb-kodierbox.de'
+    );
+
+    expect(result.items.map(item => item.variable_id)).toEqual(['INCOMPLETE_VAR']);
+  });
+
   it('excludes intended source variables only when their derived variable remains in the same manual scope', async () => {
     const unitVariableMap = new Map([[
       'UNIT',
@@ -271,6 +331,33 @@ describe('CodingListQueryService', () => {
     await expect(service.getCodingListVariables(1, true)).resolves.toEqual([
       { unitName: 'UNIT', variableId: 'BASE_VAR' },
       { unitName: 'UNIT', variableId: 'STANDALONE_VAR' }
+    ]);
+  });
+
+  it('does not include DERIVE_ERROR variables in default coding-list variable selection', async () => {
+    const unitVariableMap = new Map([[
+      'UNIT',
+      new Set(['DERIVE_VAR', 'INCOMPLETE_VAR'])
+    ]]);
+    const rawVariableRows = [
+      {
+        unitName: 'UNIT',
+        variableId: 'DERIVE_VAR',
+        statusV1: statusStringToNumber('DERIVE_ERROR')
+      },
+      {
+        unitName: 'UNIT',
+        variableId: 'INCOMPLETE_VAR',
+        statusV1: statusStringToNumber('CODING_INCOMPLETE')
+      }
+    ];
+    const service = createService([], createFileRepository({}), {
+      rawVariableRows,
+      unitVariableMap
+    });
+
+    await expect(service.getCodingListVariables(1)).resolves.toEqual([
+      { unitName: 'UNIT', variableId: 'INCOMPLETE_VAR' }
     ]);
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-list-query.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-query.service.ts
@@ -18,6 +18,10 @@ import {
 } from '../../utils/manual-coding-scope.util';
 
 const PAGE_MAP_LOOKUP_BATCH_SIZE = 8;
+const MANUAL_CODING_CANDIDATE_STATUSES = [
+  statusStringToNumber('CODING_INCOMPLETE'),
+  statusStringToNumber('INTENDED_INCOMPLETE')
+].filter((status): status is number => status !== null);
 
 /**
  * Service responsible for querying coding lists and variables.
@@ -63,7 +67,7 @@ export class CodingListQueryService {
     try {
       const server = serverUrl;
 
-      // 1) Query CODING_INCOMPLETE and INTENDED_INCOMPLETE responses
+      // 1) Query explicitly selected manual-coding candidate responses.
       const queryBuilder = this.responseRepository
         .createQueryBuilder('response')
         .leftJoinAndSelect('response.unit', 'unit')
@@ -71,10 +75,7 @@ export class CodingListQueryService {
         .leftJoinAndSelect('booklet.person', 'person')
         .leftJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
         .where('response.status_v1 IN (:...statuses)', {
-          statuses: [
-            statusStringToNumber('CODING_INCOMPLETE'),
-            statusStringToNumber('INTENDED_INCOMPLETE')
-          ]
+          statuses: MANUAL_CODING_CANDIDATE_STATUSES
         })
         .andWhere('person.workspace_id = :workspace_id', { workspace_id })
         .andWhere('person.consider = :consider', { consider: true })
@@ -116,6 +117,7 @@ export class CodingListQueryService {
         const variableId = r.variableid || '';
         const hasValue = r.value != null && r.value.trim() !== '';
 
+        if (!this.isManualCodingCandidateStatus(r.status_v1)) return false;
         if (!hasValue) return false;
 
         const hasExcludedSubstring = /image|text|audio|frame|video|_0/i.test(variableId);
@@ -265,10 +267,7 @@ export class CodingListQueryService {
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
       .andWhere('response.status_v1 IN (:...statuses)', {
-        statuses: [
-          statusStringToNumber('CODING_INCOMPLETE'),
-          statusStringToNumber('INTENDED_INCOMPLETE')
-        ]
+        statuses: MANUAL_CODING_CANDIDATE_STATUSES
       })
       .andWhere("(response.value IS NOT NULL AND response.value != '')");
 
@@ -311,6 +310,8 @@ export class CodingListQueryService {
     const baseFilteredResults = rawResults.filter(row => {
       const unitNameUpper = row.unitName?.toUpperCase();
       const variableId: string = row.variableId;
+
+      if (!this.isManualCodingCandidateStatus(row.statusV1)) return false;
 
       const validVars = validVariableSets.get(unitNameUpper);
       if (!validVars?.has(variableId)) return false;
@@ -361,5 +362,9 @@ export class CodingListQueryService {
     );
 
     return filteredResults;
+  }
+
+  private isManualCodingCandidateStatus(status: unknown): boolean {
+    return MANUAL_CODING_CANDIDATE_STATUSES.includes(Number(status));
   }
 }

--- a/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
@@ -840,6 +840,76 @@ describe('CodingProcessService', () => {
         );
     });
 
+    it('should persist DERIVE_ERROR autocoder outputs without false-code completion', async () => {
+      (Autocoder.CodingSchemeFactory.code as jest.Mock).mockReturnValueOnce([
+        {
+          id: 'derived_var',
+          value: null,
+          status: 'DERIVE_ERROR',
+          code: undefined,
+          score: undefined,
+          subform: ''
+        }
+      ]);
+
+      mockQueryBuilder.getMany
+        .mockResolvedValueOnce([mockUnits[0]])
+        .mockResolvedValueOnce([mockResponses[0]]);
+
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([
+          ['TEST_UNIT_1', new Set(['var1'])]
+        ])
+      );
+
+      await service.processTestPersonsBatch(workspaceId, ['1'], 1);
+
+      expect(mockResponseManagementService.updateResponsesInDatabase)
+        .toHaveBeenCalledWith(
+          workspaceId,
+          expect.arrayContaining([
+            expect.objectContaining({
+              isNew: true,
+              isAutocoderGenerated: true,
+              variableid: 'derived_var',
+              code_v1: null,
+              score_v1: null,
+              status_v1: 'DERIVE_ERROR',
+              code_v2: null,
+              score_v2: null,
+              status_v2: null
+            })
+          ]),
+          expect.anything(),
+          undefined,
+          expect.any(Function),
+          undefined,
+          expect.any(Object),
+          expect.objectContaining({
+            unitIds: [1],
+            autoCoderRun: 1,
+            markCurrentVersion: 'v1'
+          })
+        );
+      expect(mockResponseManagementService.updateResponsesInDatabase)
+        .not.toHaveBeenCalledWith(
+          workspaceId,
+          expect.arrayContaining([
+            expect.objectContaining({
+              variableid: 'derived_var',
+              code_v1: 0,
+              status_v1: 'CODING_COMPLETE'
+            })
+          ]),
+          expect.anything(),
+          undefined,
+          expect.any(Function),
+          undefined,
+          expect.any(Object),
+          expect.any(Object)
+        );
+    });
+
     it('should call progress callback at appropriate intervals', async () => {
       mockQueryBuilder.getMany
         .mockResolvedValueOnce(mockUnits)

--- a/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
@@ -6,6 +6,7 @@ import { CodingStatisticsService } from './coding-statistics.service';
 import { CodingAnalysisService } from './coding-analysis.service';
 import { CodingFreshnessService } from './coding-freshness.service';
 import { CodingValidationService } from './coding-validation.service';
+import { statusStringToNumber } from '../../utils/response-status-converter';
 
 jest.mock('../workspace/workspace-files.service', () => ({
   WorkspaceFilesService: jest.fn()
@@ -137,6 +138,10 @@ describe('CodingResultsService', () => {
         status_v2: 5
       }
     );
+    const updateData = queryRunner.manager.update.mock.calls[0][2] as Partial<ResponseEntity>;
+    expect(updateData).not.toHaveProperty('status_v1');
+    expect(updateData).not.toHaveProperty('code_v1');
+    expect(updateData).not.toHaveProperty('score_v1');
     expect(codingJobService.markCodingJobResultsApplied).toHaveBeenCalledWith(
       10,
       17,
@@ -588,7 +593,8 @@ describe('CodingResultsService', () => {
       { id: 1 },
       { id: 2 }
     ] as ResponseEntity[];
-    responseRepository.createQueryBuilder = jest.fn(() => createQueryBuilderMock(rows)) as never;
+    const queryBuilder = createQueryBuilderMock(rows);
+    responseRepository.createQueryBuilder = jest.fn(() => queryBuilder) as never;
 
     const result = await service.applyEmptyResponseCoding(17);
 
@@ -607,6 +613,19 @@ describe('CodingResultsService', () => {
         status_v2: 5
       }
     );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'response.status_v1 IN (:...statuses)',
+      {
+        statuses: [
+          statusStringToNumber('CODING_INCOMPLETE'),
+          statusStringToNumber('INTENDED_INCOMPLETE')
+        ]
+      }
+    );
+    const statusFilterCall = queryBuilder.andWhere.mock.calls.find(call => (
+      call[0] === 'response.status_v1 IN (:...statuses)'
+    ));
+    expect(statusFilterCall?.[1].statuses).not.toContain(statusStringToNumber('DERIVE_ERROR'));
     expect(codingValidationService.invalidateIncompleteVariablesCache).toHaveBeenCalledWith(17);
     expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(17);
     expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(17);

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -105,6 +105,89 @@ describe('ExternalCodingImportService', () => {
     expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v5:17');
   });
 
+  it('imports DERIVE_ERROR without turning it into completed false coding', async () => {
+    const selectQuery = createQueryBuilder([{
+      id: 550,
+      status_v1: statusStringToNumber('DERIVE_ERROR'),
+      status_v2: null,
+      code_v1: null,
+      code_v2: null,
+      score_v1: null,
+      score_v2: null,
+      unit: { id: 7, name: 'UNIT', alias: 'UNIT' }
+    }]);
+    const updateQuery = createQueryBuilder();
+    const transactionalResponseRepository = {
+      createQueryBuilder: jest.fn()
+        .mockReturnValueOnce(selectQuery)
+        .mockReturnValueOnce(updateQuery)
+    };
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+      manager: {
+        query: jest.fn().mockResolvedValue([]),
+        getRepository: jest.fn().mockReturnValue(transactionalResponseRepository)
+      }
+    };
+    const responseRepository = {
+      manager: {
+        connection: {
+          createQueryRunner: jest.fn().mockReturnValue(queryRunner)
+        }
+      }
+    };
+    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const codingFreshnessService = {
+      markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
+    };
+    const service = new ExternalCodingImportService(
+      responseRepository as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      cacheService as never,
+      codingFreshnessService as never
+    );
+    jest.spyOn(service as unknown as {
+      validateCodeAgainstScheme: () => Promise<unknown>;
+    }, 'validateCodeAgainstScheme')
+      .mockResolvedValue({
+        isValid: false,
+        score: null,
+        status: 'CODING_INCOMPLETE'
+      });
+
+    const result = await service.importExternalCoding(17, {
+      file: Buffer.from('unit_key,variable_id,status\nUNIT,VAR,DERIVE_ERROR\n').toString('base64'),
+      fileName: 'coding.csv',
+      previewOnly: false
+    });
+
+    expect(result.updatedRows).toBe(1);
+    expect(updateQuery.set).toHaveBeenCalledWith({
+      status_v2: statusStringToNumber('DERIVE_ERROR'),
+      code_v2: null,
+      score_v2: null
+    });
+    expect(result.affectedRows[0]).toMatchObject({
+      originalCodedStatus: 'DERIVE_ERROR',
+      originalCode: null,
+      originalScore: null,
+      updatedCodedStatus: 'DERIVE_ERROR',
+      updatedCode: null,
+      updatedScore: null
+    });
+    expect(updateQuery.set).not.toHaveBeenCalledWith(expect.objectContaining({
+      status_v2: statusStringToNumber('CODING_COMPLETE'),
+      code_v2: 0
+    }));
+  });
+
   it('rolls back and fails the import when manual freshness cannot be finalized', async () => {
     const selectQuery = createQueryBuilder([{
       id: 99,


### PR DESCRIPTION
## Summary

- Exclude `DERIVE_ERROR` from default manual coding list queries by centralizing the allowed manual-coding candidate statuses.
- Add regression coverage for coding lists, coding jobs, coder training, empty-response coding, external coding import, and autocoder-derived errors.
- Preserve explicit `DERIVE_ERROR` values instead of converting them to completed false-code codings.

## Root cause

`DERIVE_ERROR` is a technical derivation state and should remain visible for diagnostics, but it must not enter regular manual coding candidate selection. The fix pins manual coding selection to `CODING_INCOMPLETE` and `INTENDED_INCOMPLETE` and adds regression tests around the adjacent paths.

Fixes #550

## Validation

- `npx nx lint backend`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job.service.spec.ts`
- `PATH=/Users/julian/.nvm/versions/node/v22.16.0/bin:$PATH npx nx test backend` (107/108 suites passed; `services-read-methods.spec.ts` hit its known timeout)
- `PATH=/Users/julian/.nvm/versions/node/v22.16.0/bin:$PATH npx nx test backend --testFile=apps/backend/src/app/database/services-read-methods.spec.ts`
