### PR TITLE
Fix variable analysis scope and zero counts

### DIFF
--- a/apps/backend/src/app/admin/variable-analysis/dto/variable-analysis-result.dto.ts
+++ b/apps/backend/src/app/admin/variable-analysis/dto/variable-analysis-result.dto.ts
@@ -4,6 +4,12 @@ export interface VariableCombo {
   unitId: number;
   unitName: string;
   variableId: string;
+  sourceVariableId?: string;
+  variableAlias?: string;
+  selectionSource?: string;
+  sourceType?: string;
+  isDerived?: boolean;
+  hasCodingScheme?: boolean;
   totalCount?: number;
   emptyCount?: number;
   emptyPercentage?: number;

--- a/apps/backend/src/app/admin/variable-analysis/dto/variable-analysis-table-row.dto.ts
+++ b/apps/backend/src/app/admin/variable-analysis/dto/variable-analysis-table-row.dto.ts
@@ -4,6 +4,12 @@ export class VariableAnalysisTableRowDto {
   unitId: number;
   unitName: string;
   variableId: string;
+  sourceVariableId?: string;
+  variableAlias?: string;
+  selectionSource?: string;
+  sourceType?: string;
+  isDerived?: boolean;
+  hasCodingScheme?: boolean;
   value: string;
   label?: string;
   score?: number;

--- a/apps/backend/src/app/admin/variable-analysis/dto/variable-analysis.dto.ts
+++ b/apps/backend/src/app/admin/variable-analysis/dto/variable-analysis.dto.ts
@@ -10,6 +10,12 @@ export interface VariableCombo {
   unitId: number;
   unitName: string;
   variableId: string;
+  sourceVariableId?: string;
+  variableAlias?: string;
+  selectionSource?: string;
+  sourceType?: string;
+  isDerived?: boolean;
+  hasCodingScheme?: boolean;
   totalCount?: number;
   emptyCount?: number;
   emptyPercentage?: number;

--- a/apps/backend/src/app/database/services/test-results/variable-analysis.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis.service.spec.ts
@@ -698,6 +698,87 @@ describe('VariableAnalysisService', () => {
     });
   });
 
+  it('keeps chunked variables visible when default schema filtering leaves no frequency rows', async () => {
+    const manifest = {
+      storage: 'chunked',
+      workspaceId: 1,
+      total: 1,
+      variableComboChunks: 1,
+      frequencyChunks: 1,
+      storedAt: '2026-05-26T00:00:00.000Z'
+    };
+    const variableCombos = [
+      {
+        unitId: 1,
+        unitName: 'UNIT',
+        variableId: 'MISSING',
+        totalCount: 0,
+        emptyCount: 0,
+        emptyPercentage: 0,
+        distinctValueCount: 0,
+        statusCounts: []
+      }
+    ];
+    const frequencyChunks = [
+      [
+        '1:MISSING',
+        [
+          {
+            unitId: 1,
+            unitName: 'UNIT',
+            variableId: 'MISSING',
+            value: 'Z',
+            label: 'Zed',
+            schemaOrder: 0,
+            isSchemaOnly: true,
+            isSchemaSupplemental: true,
+            count: 0,
+            percentage: 0
+          }
+        ]
+      ]
+    ];
+    jobQueueService.getVariableAnalysisJob.mockResolvedValue(
+      createJob({
+        returnvalue: manifest
+      })
+    );
+    cacheService.get
+      .mockResolvedValueOnce(manifest)
+      .mockResolvedValueOnce(variableCombos)
+      .mockResolvedValueOnce(frequencyChunks);
+
+    const page = await service.getAnalysisResultsPage('job-1', 1, {
+      page: 1,
+      pageSize: 10
+    });
+
+    expect(page).toMatchObject({
+      variableCombos: [expect.objectContaining({ variableId: 'MISSING' })],
+      frequencies: {
+        '1:MISSING': [
+          expect.objectContaining({
+            value: '',
+            count: 0,
+            percentage: 0,
+            isSchemaOnly: true
+          })
+        ]
+      },
+      total: 1,
+      rowTotal: 1,
+      rows: [
+        expect.objectContaining({
+          unitName: 'UNIT',
+          variableId: 'MISSING',
+          value: '',
+          count: 0,
+          totalCount: 0
+        })
+      ]
+    });
+  });
+
   it('exports filtered chunked cached results as formula-safe CSV', async () => {
     jobQueueService.getVariableAnalysisJob.mockResolvedValue(
       createJob({
@@ -793,6 +874,64 @@ describe('VariableAnalysisService', () => {
     expect(csv).toContain('VALUE_CHANGED: 8 (80%)');
     expect(csv).toContain('CODING_INCOMPLETE: 2 (20%)');
     expect(csv).not.toContain('OTHER');
+  });
+
+  it('exports variables without visible frequency rows as zero-count rows', async () => {
+    const manifest = {
+      storage: 'chunked',
+      workspaceId: 1,
+      total: 1,
+      variableComboChunks: 1,
+      frequencyChunks: 1,
+      storedAt: '2026-05-26T00:00:00.000Z'
+    };
+    const variableCombos = [
+      {
+        unitId: 1,
+        unitName: 'UNIT',
+        variableId: 'MISSING',
+        totalCount: 0,
+        emptyCount: 0,
+        emptyPercentage: 0,
+        distinctValueCount: 0,
+        statusCounts: []
+      }
+    ];
+    const frequencyChunks = [
+      [
+        '1:MISSING',
+        [
+          {
+            unitId: 1,
+            unitName: 'UNIT',
+            variableId: 'MISSING',
+            value: 'Z',
+            label: 'Zed',
+            schemaOrder: 0,
+            isSchemaOnly: true,
+            isSchemaSupplemental: true,
+            count: 0,
+            percentage: 0
+          }
+        ]
+      ]
+    ];
+    jobQueueService.getVariableAnalysisJob.mockResolvedValue(
+      createJob({
+        returnvalue: manifest
+      })
+    );
+    cacheService.get
+      .mockResolvedValueOnce(manifest)
+      .mockResolvedValueOnce(variableCombos)
+      .mockResolvedValueOnce(frequencyChunks);
+
+    const csv = await service.exportAnalysisResultsAsCsv('job-1', 1);
+    const dataLine = csv.split(/\r?\n/).find(line => line.includes('MISSING'));
+
+    expect(dataLine).toBeDefined();
+    expect(dataLine).toContain('1;UNIT;MISSING;');
+    expect(dataLine).toContain(';ja;0;0;0;0;0;0;0;');
   });
 
   it('exports direct cached results as XLSX with typed numeric columns', async () => {

--- a/apps/backend/src/app/database/services/test-results/variable-analysis.service.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis.service.ts
@@ -989,10 +989,18 @@ export class VariableAnalysisService {
     );
     const statusSummary = this.formatStatusSummary(combo.statusCounts || []);
 
-    return rows.map(row => ({
+    const toTableRow = (
+      row: VariableFrequencyDto
+    ): VariableAnalysisTableRowDto => ({
       unitId: combo.unitId,
       unitName: combo.unitName,
       variableId: combo.variableId,
+      sourceVariableId: combo.sourceVariableId,
+      variableAlias: combo.variableAlias,
+      selectionSource: combo.selectionSource,
+      sourceType: combo.sourceType,
+      isDerived: combo.isDerived,
+      hasCodingScheme: combo.hasCodingScheme,
       value: row.value,
       label: row.label,
       score: row.score,
@@ -1008,7 +1016,21 @@ export class VariableAnalysisService {
       hiddenValueCount,
       statusCounts: combo.statusCounts || [],
       statusSummary
-    }));
+    });
+
+    if (rows.length === 0) {
+      return [toTableRow({
+        unitId: combo.unitId,
+        unitName: combo.unitName,
+        variableId: combo.variableId,
+        value: '',
+        count: 0,
+        percentage: 0,
+        isSchemaOnly: true
+      })];
+    }
+
+    return rows.map(toTableRow);
   }
 
   private sortRows(
@@ -1200,7 +1222,19 @@ export class VariableAnalysisService {
       );
       const statusSummary = this.formatStatusSummary(combo.statusCounts || []);
 
-      frequencies.forEach(frequency => {
+      const visibleFrequencies: VariableFrequencyDto[] = frequencies.length > 0 ?
+        frequencies :
+        [{
+          unitId: combo.unitId,
+          unitName: combo.unitName,
+          variableId: combo.variableId,
+          value: '',
+          count: 0,
+          percentage: 0,
+          isSchemaOnly: true
+        }];
+
+      visibleFrequencies.forEach(frequency => {
         rows.push({
           unitId: combo.unitId,
           unitName: combo.unitName,

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -3193,6 +3193,7 @@ ${bookletRefs}
                     codingSchemeRef: hasCodingScheme ?
                       codingSchemeMap.get(unitName) :
                       undefined,
+                    sourceType,
                     codes: variableCodes,
                     values: variableMetadata.values,
                     valuesComplete: variableMetadata.valuesComplete,
@@ -3267,6 +3268,7 @@ ${bookletRefs}
                     codingSchemeRef: hasCodingScheme ?
                       codingSchemeMap.get(unitName) :
                       undefined,
+                    sourceType,
                     codes: variableCodes,
                     values: variableMetadata.values,
                     valuesComplete: variableMetadata.valuesComplete,
@@ -3320,6 +3322,7 @@ ${bookletRefs}
                   type: unitVariableTypes?.get(schemeId) || 'string',
                   hasCodingScheme: true,
                   codingSchemeRef: codingSchemeMap.get(unitName),
+                  sourceType,
                   codes: variableCodes,
                   isDerived: true,
                   hasManualInstruction,

--- a/apps/backend/src/app/job-queue/processors/variable-analysis.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/variable-analysis.processor.spec.ts
@@ -5,194 +5,332 @@ import { WorkspaceFilesService } from '../../database/services/workspace/workspa
 import { VariableAnalysisJobData } from '../job-queue.service';
 import { VariableAnalysisProcessor } from './variable-analysis.processor';
 
-const createQueryBuilder = (rawRows: unknown[] = []) => ({
-  innerJoin: jest.fn().mockReturnThis(),
-  where: jest.fn().mockReturnThis(),
-  andWhere: jest.fn().mockReturnThis(),
-  select: jest.fn().mockReturnThis(),
-  addSelect: jest.fn().mockReturnThis(),
-  distinct: jest.fn().mockReturnThis(),
-  orderBy: jest.fn().mockReturnThis(),
-  addOrderBy: jest.fn().mockReturnThis(),
-  limit: jest.fn().mockReturnThis(),
-  groupBy: jest.fn().mockReturnThis(),
-  addGroupBy: jest.fn().mockReturnThis(),
-  clone: jest.fn().mockReturnThis(),
-  getRawMany: jest.fn().mockResolvedValue(rawRows),
-  getQueryAndParameters: jest.fn().mockReturnValue(['SELECT 1', []])
-});
+type MockQueryBuilder = ReturnType<typeof createQueryBuilder>;
+
+const createQueryBuilder = (rawRows: unknown[] = []) => {
+  const selectFragments: string[] = [];
+  const qb = {
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    select: jest.fn((selection?: string) => {
+      if (selection) selectFragments.push(selection);
+      return qb;
+    }),
+    addSelect: jest.fn((selection?: string, alias?: string) => {
+      if (alias === '') selectFragments.push(alias);
+      if (selection) selectFragments.push(selection);
+      return qb;
+    }),
+    distinct: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    addGroupBy: jest.fn().mockReturnThis(),
+    clone: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue(rawRows),
+    getQueryAndParameters: jest.fn(() => [
+      `SELECT ${selectFragments.join(', ') || '1'} FROM response`,
+      []
+    ])
+  };
+
+  return qb;
+};
+
+const createJob = (data: Partial<VariableAnalysisJobData> = {}) => ({
+  id: 'job-1',
+  data: {
+    workspaceId: 1,
+    cacheKey: 'variable-analysis:1:job-1',
+    ...data
+  },
+  progress: jest.fn().mockResolvedValue(undefined)
+}) as unknown as Job<VariableAnalysisJobData>;
+
+const findCacheSetPayload = <T>(
+  cacheService: { set: jest.Mock },
+  key: string
+): T => {
+  const call = cacheService.set.mock.calls.find(([cacheKey]) => cacheKey === key);
+  expect(call).toBeDefined();
+  return call[1] as T;
+};
+
+const defaultExclusions = {
+  globalIgnoredUnits: [],
+  ignoredBooklets: [],
+  testletIgnoredUnits: []
+};
+
+const createProcessor = ({
+  representativeRows = [{ unitName: 'UNIT', unitId: '1' }],
+  queryResults = [],
+  unitVariableDetails = [
+    {
+      unitName: 'UNIT',
+      unitId: 'UNIT',
+      variables: [
+        {
+          id: 'VAR',
+          alias: 'VAR',
+          type: 'string',
+          sourceType: 'BASE',
+          hasCodingScheme: true,
+          codes: [{ id: 'A', label: 'Alpha' }]
+        }
+      ]
+    }
+  ],
+  exclusions = defaultExclusions
+}: {
+  representativeRows?: unknown[];
+  queryResults?: unknown[][];
+  unitVariableDetails?: unknown[];
+  exclusions?: typeof defaultExclusions;
+} = {}) => {
+  const baseQuery = createQueryBuilder();
+  const representativeQuery = createQueryBuilder(representativeRows);
+  const analysisQuery = createQueryBuilder();
+  baseQuery.clone = jest.fn()
+    .mockReturnValueOnce(representativeQuery)
+    .mockReturnValue(analysisQuery);
+
+  const responseRepository = {
+    createQueryBuilder: jest.fn().mockReturnValue(baseQuery),
+    query: jest.fn()
+  };
+  queryResults.forEach(result => {
+    responseRepository.query.mockResolvedValueOnce(result);
+  });
+  responseRepository.query.mockResolvedValue([]);
+
+  const cacheService = {
+    set: jest.fn().mockResolvedValue(true),
+    delete: jest.fn().mockResolvedValue(true)
+  };
+  const workspaceExclusionService = {
+    resolveExclusionsForQueries: jest.fn().mockResolvedValue(exclusions)
+  };
+  const workspaceFilesService = {
+    getUnitVariableDetails: jest.fn().mockResolvedValue(unitVariableDetails)
+  };
+  const processor = new VariableAnalysisProcessor(
+    responseRepository as never,
+    cacheService as unknown as CacheService,
+    workspaceExclusionService as unknown as WorkspaceExclusionService,
+    workspaceFilesService as unknown as WorkspaceFilesService
+  );
+
+  return {
+    processor,
+    responseRepository,
+    cacheService,
+    workspaceExclusionService,
+    workspaceFilesService,
+    baseQuery: baseQuery as MockQueryBuilder,
+    analysisQuery: analysisQuery as MockQueryBuilder
+  };
+};
 
 describe('VariableAnalysisProcessor', () => {
-  it('stores full analysis results in cache and returns only small job metadata', async () => {
-    const baseQuery = createQueryBuilder();
-    const variableCombosQuery = createQueryBuilder([
-      { unitId: '1', unitName: 'UNIT', variableId: 'VAR' }
-    ]);
-    const summaryQuery = createQueryBuilder([
-      {
-        unitId: '1',
-        variableId: 'VAR',
-        totalCount: '10',
-        emptyCount: '1',
-        distinctValueCount: '2'
-      }
-    ]);
-    const topValuesQuery = createQueryBuilder();
-    const statusQuery = createQueryBuilder([
-      {
-        unitId: '1',
-        variableId: 'VAR',
-        status: '3',
-        count: '10'
-      }
-    ]);
-    baseQuery.clone = jest.fn()
-      .mockReturnValueOnce(variableCombosQuery)
-      .mockReturnValueOnce(summaryQuery)
-      .mockReturnValueOnce(topValuesQuery)
-      .mockReturnValueOnce(statusQuery);
-
-    const responseRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(baseQuery),
-      query: jest.fn().mockResolvedValue([
+  it('builds the analyzed variable set from metadata and keeps missing schema variables with zero counts', async () => {
+    const { processor, cacheService, responseRepository } = createProcessor({
+      unitVariableDetails: [
         {
-          unitId: '1',
           unitName: 'UNIT',
-          variableId: 'VAR',
-          value: 'x'.repeat(500),
-          valueLength: '1000',
-          valueHash: 'abc123',
-          count: '9'
+          unitId: 'UNIT',
+          variables: [
+            {
+              id: 'SCHEME_VAR',
+              alias: 'VAR',
+              type: 'string',
+              sourceType: 'BASE',
+              hasCodingScheme: true,
+              codes: [
+                { id: 'A', label: 'Alpha' },
+                { id: 'B', label: 'Beta' }
+              ]
+            },
+            {
+              id: 'MISSING',
+              alias: 'MISSING',
+              type: 'string',
+              sourceType: 'BASE',
+              hasCodingScheme: true,
+              codes: [{ id: 'Z', label: 'Zed' }]
+            },
+            {
+              id: 'NO_VALUE',
+              alias: 'NO_VALUE',
+              type: 'no-value',
+              sourceType: 'BASE',
+              hasCodingScheme: false
+            },
+            {
+              id: 'BASE_NO_VALUE',
+              alias: 'BASE_NO_VALUE',
+              type: 'string',
+              sourceType: 'BASE_NO_VALUE',
+              hasCodingScheme: true
+            }
+          ]
+        },
+        {
+          unitName: 'OUTSIDE',
+          unitId: 'OUTSIDE',
+          variables: [
+            {
+              id: 'OUTSIDE_VAR',
+              alias: 'OUTSIDE_VAR',
+              type: 'string',
+              sourceType: 'BASE',
+              hasCodingScheme: true,
+              codes: [{ id: 'X', label: 'Outside' }]
+            }
+          ]
         }
-      ])
-    };
-    const cacheService = {
-      set: jest.fn().mockResolvedValue(true)
-    };
-    const workspaceExclusionService = {
-      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
-        globalIgnoredUnits: [],
-        ignoredBooklets: [],
-        testletIgnoredUnits: []
-      })
-    };
-    const workspaceFilesService = {
-      getUnitVariableDetails: jest.fn().mockResolvedValue([])
-    };
-    const processor = new VariableAnalysisProcessor(
-      responseRepository as never,
-      cacheService as unknown as CacheService,
-      workspaceExclusionService as unknown as WorkspaceExclusionService,
-      workspaceFilesService as unknown as WorkspaceFilesService
-    );
-    const job = {
-      id: 'job-1',
-      data: {
-        workspaceId: 1,
-        cacheKey: 'variable-analysis:1:job-1'
-      },
-      progress: jest.fn().mockResolvedValue(undefined)
-    } as unknown as Job<VariableAnalysisJobData>;
+      ],
+      queryResults: [
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            totalCount: '2',
+            emptyCount: '0',
+            distinctValueCount: '1'
+          }
+        ],
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'A',
+            valueLength: '1',
+            valueHash: 'hash-a',
+            count: '2'
+          },
+          {
+            unitName: 'UNIT',
+            variableId: 'ROGUE',
+            value: 'ignored',
+            valueLength: '7',
+            valueHash: 'hash-rogue',
+            count: '99'
+          }
+        ],
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'A',
+            count: '2'
+          }
+        ],
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            status: '3',
+            count: '2'
+          }
+        ]
+      ]
+    });
 
-    const metadata = await processor.process(job);
+    const metadata = await processor.process(createJob());
 
     expect(metadata).toEqual(expect.objectContaining({
       cacheKey: 'variable-analysis:1:job-1',
       workspaceId: 1,
-      total: 1,
+      total: 2,
       storage: 'chunked',
       variableComboChunks: 1,
       frequencyChunks: 1,
       storedAt: expect.any(String)
     }));
-    expect(metadata).not.toHaveProperty('variableCombos');
-    expect(cacheService.set).toHaveBeenCalledWith(
-      'variable-analysis:1:job-1:variable-combos:0',
-      [expect.objectContaining({
+
+    const variableCombos = findCacheSetPayload<unknown[]>(
+      cacheService,
+      'variable-analysis:1:job-1:variable-combos:0'
+    );
+    expect(variableCombos).toEqual([
+      expect.objectContaining({
         unitId: 1,
         unitName: 'UNIT',
-        variableId: 'VAR'
-      })],
-      86400
-    );
-    expect(cacheService.set).toHaveBeenCalledWith(
-      'variable-analysis:1:job-1:frequencies:0',
-      [['1:VAR', [expect.objectContaining({
-        value: `${'x'.repeat(500)}... [truncated 1000 chars, md5:abc123]`,
-        count: 9,
-        percentage: 90
-      })]]],
-      86400
-    );
-    expect(cacheService.set).toHaveBeenCalledWith(
-      'variable-analysis:1:job-1',
-      expect.objectContaining({
-        storage: 'chunked',
-        total: 1,
-        variableComboChunks: 1,
-        frequencyChunks: 1
+        variableId: 'MISSING',
+        sourceVariableId: 'MISSING',
+        selectionSource: 'coding-scheme',
+        sourceType: 'BASE',
+        totalCount: 0
       }),
-      86400
+      expect.objectContaining({
+        unitId: 1,
+        unitName: 'UNIT',
+        variableId: 'VAR',
+        sourceVariableId: 'SCHEME_VAR',
+        variableAlias: 'VAR',
+        selectionSource: 'coding-scheme',
+        sourceType: 'BASE',
+        totalCount: 2,
+        distinctValueCount: 1
+      })
+    ]);
+    expect(variableCombos).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ variableId: 'NO_VALUE' }),
+      expect.objectContaining({ variableId: 'BASE_NO_VALUE' }),
+      expect.objectContaining({ variableId: 'OUTSIDE_VAR' })
+    ]));
+
+    const frequencies = findCacheSetPayload<Array<[string, unknown[]]>>(
+      cacheService,
+      'variable-analysis:1:job-1:frequencies:0'
     );
+    expect(frequencies).toEqual([
+      ['1:MISSING', [
+        expect.objectContaining({
+          value: 'Z',
+          label: 'Zed',
+          count: 0,
+          percentage: 0,
+          isSchemaOnly: true
+        })
+      ]],
+      ['1:VAR', [
+        expect.objectContaining({
+          value: 'A',
+          label: 'Alpha',
+          count: 2,
+          percentage: 100,
+          schemaOrder: 0
+        }),
+        expect.objectContaining({
+          value: 'B',
+          label: 'Beta',
+          count: 0,
+          percentage: 0,
+          isSchemaOnly: true
+        })
+      ]]
+    ]);
+    const schemaCountCall = responseRepository.query.mock.calls.find(([sql]) => (
+      String(sql).includes('jsonb_to_recordset')
+    ));
+    expect(schemaCountCall).toBeDefined();
+    const schemaCountParameters = schemaCountCall?.[1] as unknown[];
+    const schemaFilterParameter =
+      schemaCountParameters[schemaCountParameters.length - 1];
+    expect(JSON.parse(schemaFilterParameter as string)).toEqual([
+      { logicalKey: 'UNIT\u001FMISSING', value: 'Z' },
+      { logicalKey: 'UNIT\u001FVAR', value: 'A' },
+      { logicalKey: 'UNIT\u001FVAR', value: 'B' }
+    ]);
   });
 
-  it('adds coding scheme codes as optional supplemental frequency rows', async () => {
-    const baseQuery = createQueryBuilder();
-    const variableCombosQuery = createQueryBuilder([
-      { unitId: '1', unitName: 'UNIT', variableId: 'VAR' }
-    ]);
-    const summaryQuery = createQueryBuilder([
-      {
-        unitId: '1',
-        variableId: 'VAR',
-        totalCount: '4',
-        emptyCount: '0',
-        distinctValueCount: '3'
-      }
-    ]);
-    const topValuesQuery = createQueryBuilder();
-    const schemaCountQuery = createQueryBuilder([
-      {
-        unitId: '1',
-        variableId: 'VAR',
-        value: 'B',
-        count: '1'
-      }
-    ]);
-    const statusQuery = createQueryBuilder([]);
-    baseQuery.clone = jest.fn()
-      .mockReturnValueOnce(variableCombosQuery)
-      .mockReturnValueOnce(summaryQuery)
-      .mockReturnValueOnce(topValuesQuery)
-      .mockReturnValueOnce(schemaCountQuery)
-      .mockReturnValueOnce(statusQuery);
-
-    const responseRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(baseQuery),
-      query: jest.fn().mockResolvedValue([
-        {
-          unitId: '1',
-          unitName: 'UNIT',
-          variableId: 'VAR',
-          value: 'A',
-          valueLength: '1',
-          valueHash: 'hash-a',
-          count: '2'
-        }
-      ])
-    };
-    const cacheService = {
-      set: jest.fn().mockResolvedValue(true)
-    };
-    const workspaceExclusionService = {
-      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
-        globalIgnoredUnits: [],
-        ignoredBooklets: [],
-        testletIgnoredUnits: []
-      })
-    };
-    const workspaceFilesService = {
-      getUnitVariableDetails: jest.fn().mockResolvedValue([
+  it('filters variables through metadata without hiding missing observed responses', async () => {
+    const { processor, cacheService, baseQuery } = createProcessor({
+      unitVariableDetails: [
         {
           unitName: 'UNIT',
           unitId: 'UNIT',
@@ -201,141 +339,131 @@ describe('VariableAnalysisProcessor', () => {
               id: 'VAR',
               alias: 'VAR',
               type: 'string',
-              hasCodingScheme: true,
-              codes: [
-                { id: 'A', label: 'Alpha' },
-                { id: 'B', label: 'Beta' },
-                { id: 'C', label: 'Gamma', score: 0 }
-              ]
+              sourceType: 'BASE',
+              hasCodingScheme: false
+            },
+            {
+              id: 'MISSING',
+              alias: 'MISSING',
+              type: 'string',
+              sourceType: 'BASE',
+              hasCodingScheme: false
             }
           ]
         }
-      ])
-    };
-    const processor = new VariableAnalysisProcessor(
-      responseRepository as never,
-      cacheService as unknown as CacheService,
-      workspaceExclusionService as unknown as WorkspaceExclusionService,
-      workspaceFilesService as unknown as WorkspaceFilesService
+      ],
+      queryResults: [
+        [],
+        [],
+        []
+      ]
+    });
+
+    await processor.process(createJob({
+      unitId: 1,
+      variableId: 'MISSING'
+    }));
+
+    expect(baseQuery.andWhere).toHaveBeenCalledWith(
+      'unit.id = :unitId',
+      { unitId: 1 }
     );
-    const job = {
-      id: 'job-1',
-      data: {
-        workspaceId: 1,
-        cacheKey: 'variable-analysis:1:job-1'
+    expect(baseQuery.andWhere).not.toHaveBeenCalledWith(
+      expect.stringContaining('response.variableid LIKE'),
+      expect.anything()
+    );
+
+    const variableCombos = findCacheSetPayload<unknown[]>(
+      cacheService,
+      'variable-analysis:1:job-1:variable-combos:0'
+    );
+    expect(variableCombos).toEqual([
+      expect.objectContaining({
+        unitId: 1,
+        unitName: 'UNIT',
+        variableId: 'MISSING',
+        totalCount: 0
+      })
+    ]);
+  });
+
+  it('applies workspace exclusions and builds a deterministic duplicate-response selection query', async () => {
+    const {
+      processor,
+      responseRepository,
+      baseQuery,
+      analysisQuery
+    } = createProcessor({
+      exclusions: {
+        globalIgnoredUnits: ['IGNORED_UNIT'],
+        ignoredBooklets: ['BOOKLET_X'],
+        testletIgnoredUnits: [
+          { bookletId: 'BOOKLET_Y', unitId: 'UNIT_IN_TESTLET' }
+        ]
       },
-      progress: jest.fn().mockResolvedValue(undefined)
-    } as unknown as Job<VariableAnalysisJobData>;
+      queryResults: [
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            totalCount: '1',
+            emptyCount: '0',
+            distinctValueCount: '1'
+          }
+        ],
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'A',
+            valueLength: '1',
+            valueHash: 'hash-a',
+            count: '1'
+          }
+        ],
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            value: 'A',
+            count: '1'
+          }
+        ],
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            status: '3',
+            count: '1'
+          }
+        ]
+      ]
+    });
 
-    await processor.process(job);
+    await processor.process(createJob());
 
-    expect(cacheService.set).toHaveBeenCalledWith(
-      'variable-analysis:1:job-1:frequencies:0',
-      [['1:VAR', [
-        expect.objectContaining({
-          value: 'A',
-          label: 'Alpha',
-          count: 2,
-          percentage: 50,
-          schemaOrder: 0
-        }),
-        expect.objectContaining({
-          value: 'B',
-          label: 'Beta',
-          count: 1,
-          percentage: 25,
-          schemaOrder: 1,
-          isSchemaSupplemental: true
-        }),
-        expect.objectContaining({
-          value: 'C',
-          label: 'Gamma',
-          score: 0,
-          count: 0,
-          percentage: 0,
-          schemaOrder: 2,
-          isSchemaOnly: true,
-          isSchemaSupplemental: true
-        })
-      ]]],
-      86400
+    expect(baseQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('REGEXP_REPLACE'),
+      expect.objectContaining({ workspaceExclusionIgnoredUnits: ['IGNORED_UNIT'] })
     );
+    expect(baseQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('NOT IN (:...workspaceExclusionIgnoredBooklets)'),
+      expect.objectContaining({ workspaceExclusionIgnoredBooklets: ['BOOKLET_X'] })
+    );
+    const duplicateSelection = analysisQuery.addSelect.mock.calls
+      .find(([, alias]) => alias === 'analysisRank')?.[0] as string;
+    expect(duplicateSelection).toContain('ROW_NUMBER() OVER');
+    expect(duplicateSelection).toContain('PARTITION BY');
+    expect(duplicateSelection).toContain("CASE WHEN response.value IS NULL OR response.value = '' THEN 1 ELSE 0 END ASC");
+    expect(duplicateSelection).toContain('response.id DESC');
+    expect(responseRepository.query.mock.calls[0][1]).toEqual([
+      ['UNIT\u001FVAR']
+    ]);
   });
 
   it('splits multiple response arrays and applies metadata value labels', async () => {
-    const baseQuery = createQueryBuilder();
-    const variableCombosQuery = createQueryBuilder([
-      { unitId: '1', unitName: 'UNIT', variableId: 'MULTI' }
-    ]);
-    const summaryQuery = createQueryBuilder([
-      {
-        unitId: '1',
-        variableId: 'MULTI',
-        totalCount: '3',
-        emptyCount: '0',
-        distinctValueCount: '3'
-      }
-    ]);
-    const topValuesQuery = createQueryBuilder();
-    const multipleResponseQuery = createQueryBuilder([
-      {
-        responseId: '1',
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'MULTI',
-        value: '["A","B"]'
-      },
-      {
-        responseId: '2',
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'MULTI',
-        value: '["B"]'
-      },
-      {
-        responseId: '3',
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'MULTI',
-        value: '[]'
-      }
-    ]);
-    const schemaCountQuery = createQueryBuilder([]);
-    const statusQuery = createQueryBuilder([]);
-    baseQuery.clone = jest.fn()
-      .mockReturnValueOnce(variableCombosQuery)
-      .mockReturnValueOnce(summaryQuery)
-      .mockReturnValueOnce(topValuesQuery)
-      .mockReturnValueOnce(multipleResponseQuery)
-      .mockReturnValueOnce(schemaCountQuery)
-      .mockReturnValueOnce(statusQuery);
-
-    const responseRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(baseQuery),
-      query: jest.fn().mockResolvedValue([
-        {
-          unitId: '1',
-          unitName: 'UNIT',
-          variableId: 'MULTI',
-          value: '["A","B"]',
-          valueLength: '9',
-          valueHash: 'hash-array',
-          count: '1'
-        }
-      ])
-    };
-    const cacheService = {
-      set: jest.fn().mockResolvedValue(true)
-    };
-    const workspaceExclusionService = {
-      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
-        globalIgnoredUnits: [],
-        ignoredBooklets: [],
-        testletIgnoredUnits: []
-      })
-    };
-    const workspaceFilesService = {
-      getUnitVariableDetails: jest.fn().mockResolvedValue([
+    const { processor, cacheService } = createProcessor({
+      unitVariableDetails: [
         {
           unitName: 'UNIT',
           unitId: 'UNIT',
@@ -353,45 +481,64 @@ describe('VariableAnalysisProcessor', () => {
             }
           ]
         }
-      ])
-    };
-    const processor = new VariableAnalysisProcessor(
-      responseRepository as never,
-      cacheService as unknown as CacheService,
-      workspaceExclusionService as unknown as WorkspaceExclusionService,
-      workspaceFilesService as unknown as WorkspaceFilesService
-    );
-    const job = {
-      id: 'job-1',
-      data: {
-        workspaceId: 1,
-        cacheKey: 'variable-analysis:1:job-1'
-      },
-      progress: jest.fn().mockResolvedValue(undefined)
-    } as unknown as Job<VariableAnalysisJobData>;
+      ],
+      queryResults: [
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'MULTI',
+            totalCount: '3',
+            emptyCount: '0',
+            distinctValueCount: '3'
+          }
+        ],
+        [],
+        [
+          {
+            responseId: '1',
+            unitName: 'UNIT',
+            variableId: 'MULTI',
+            value: '["A","B"]'
+          },
+          {
+            responseId: '2',
+            unitName: 'UNIT',
+            variableId: 'MULTI',
+            value: '["B"]'
+          },
+          {
+            responseId: '3',
+            unitName: 'UNIT',
+            variableId: 'MULTI',
+            value: '[]'
+          }
+        ],
+        [],
+        []
+      ]
+    });
 
-    await processor.process(job);
+    await processor.process(createJob());
 
-    expect(multipleResponseQuery.andWhere).toHaveBeenCalledWith(
-      'response.id > :multipleLastResponseId',
-      { multipleLastResponseId: 0 }
+    const variableCombos = findCacheSetPayload<unknown[]>(
+      cacheService,
+      'variable-analysis:1:job-1:variable-combos:0'
     );
-    expect(multipleResponseQuery.limit).toHaveBeenCalledWith(5000);
-    expect(cacheService.set).toHaveBeenCalledWith(
-      'variable-analysis:1:job-1:variable-combos:0',
-      [expect.objectContaining({
-        unitId: 1,
-        unitName: 'UNIT',
+    expect(variableCombos).toEqual([
+      expect.objectContaining({
         variableId: 'MULTI',
         totalCount: 3,
         emptyCount: 1,
         distinctValueCount: 2
-      })],
-      86400
+      })
+    ]);
+
+    const frequencies = findCacheSetPayload<Array<[string, unknown[]]>>(
+      cacheService,
+      'variable-analysis:1:job-1:frequencies:0'
     );
-    expect(cacheService.set).toHaveBeenCalledWith(
-      'variable-analysis:1:job-1:frequencies:0',
-      [['1:MULTI', [
+    expect(frequencies).toEqual([
+      ['1:MULTI', [
         expect.objectContaining({
           value: 'B',
           label: 'Beta',
@@ -404,72 +551,107 @@ describe('VariableAnalysisProcessor', () => {
           count: 1,
           percentage: 33.33333333333333
         })
-      ]]],
-      86400
+      ]]
+    ]);
+  });
+
+  it('splits boolean multiple response arrays using position labels', async () => {
+    const { processor, cacheService } = createProcessor({
+      unitVariableDetails: [
+        {
+          unitName: 'UNIT',
+          unitId: 'UNIT',
+          variables: [
+            {
+              id: 'BOOL_MULTI',
+              alias: 'BOOL_MULTI',
+              type: 'boolean',
+              multiple: true,
+              hasCodingScheme: false,
+              valuePositionLabels: ['Red', 'Blue']
+            }
+          ]
+        }
+      ],
+      queryResults: [
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'BOOL_MULTI',
+            totalCount: '3',
+            emptyCount: '0',
+            distinctValueCount: '3'
+          }
+        ],
+        [],
+        [
+          {
+            responseId: '1',
+            unitName: 'UNIT',
+            variableId: 'BOOL_MULTI',
+            value: '[true,false]'
+          },
+          {
+            responseId: '2',
+            unitName: 'UNIT',
+            variableId: 'BOOL_MULTI',
+            value: '[true,true]'
+          },
+          {
+            responseId: '3',
+            unitName: 'UNIT',
+            variableId: 'BOOL_MULTI',
+            value: '[false,false]'
+          }
+        ],
+        [],
+        []
+      ]
+    });
+
+    await processor.process(createJob());
+
+    const variableCombos = findCacheSetPayload<unknown[]>(
+      cacheService,
+      'variable-analysis:1:job-1:variable-combos:0'
     );
+    expect(variableCombos).toEqual([
+      expect.objectContaining({
+        variableId: 'BOOL_MULTI',
+        totalCount: 3,
+        emptyCount: 1,
+        distinctValueCount: 2
+      })
+    ]);
+
+    const frequencies = findCacheSetPayload<Array<[string, unknown[]]>>(
+      cacheService,
+      'variable-analysis:1:job-1:frequencies:0'
+    );
+    expect(frequencies).toEqual([
+      ['1:BOOL_MULTI', [
+        expect.objectContaining({
+          value: '1',
+          label: 'Red',
+          count: 2,
+          percentage: 66.66666666666666,
+          schemaOrder: 0
+        }),
+        expect.objectContaining({
+          value: '2',
+          label: 'Blue',
+          count: 1,
+          percentage: 33.33333333333333,
+          schemaOrder: 1
+        })
+      ]]
+    ]);
   });
 
   it('paginates multiple response rows across batches', async () => {
-    const baseQuery = createQueryBuilder();
-    const variableCombosQuery = createQueryBuilder([
-      { unitId: '1', unitName: 'UNIT', variableId: 'MULTI' }
-    ]);
-    const summaryQuery = createQueryBuilder([
-      {
-        unitId: '1',
-        variableId: 'MULTI',
-        totalCount: '5001',
-        emptyCount: '0',
-        distinctValueCount: '3'
-      }
-    ]);
-    const topValuesQuery = createQueryBuilder();
-    const multipleResponseBatchSize = 5000;
-    const multipleResponsePage1Query = createQueryBuilder(
-      Array.from({ length: multipleResponseBatchSize }, (_, index) => ({
-        responseId: index + 1,
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'MULTI',
-        value: '["A"]'
-      }))
-    );
-    const multipleResponsePage2Query = createQueryBuilder([
-      {
-        responseId: multipleResponseBatchSize + 1,
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'MULTI',
-        value: '["B","C"]'
-      }
-    ]);
-    const schemaCountQuery = createQueryBuilder([]);
-    const statusQuery = createQueryBuilder([]);
-    baseQuery.clone = jest.fn()
-      .mockReturnValueOnce(variableCombosQuery)
-      .mockReturnValueOnce(summaryQuery)
-      .mockReturnValueOnce(topValuesQuery)
-      .mockReturnValueOnce(multipleResponsePage1Query)
-      .mockReturnValueOnce(multipleResponsePage2Query)
-      .mockReturnValueOnce(schemaCountQuery)
-      .mockReturnValueOnce(statusQuery);
-
-    const responseRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(baseQuery),
-      query: jest.fn().mockResolvedValue([])
-    };
-    const cacheService = {
-      set: jest.fn().mockResolvedValue(true)
-    };
-    const workspaceExclusionService = {
-      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
-        globalIgnoredUnits: [],
-        ignoredBooklets: [],
-        testletIgnoredUnits: []
-      })
-    };
-    const workspaceFilesService = {
-      getUnitVariableDetails: jest.fn().mockResolvedValue([
+    const batchSize = 5000;
+    const { processor, cacheService, responseRepository } = createProcessor({
+      unitVariableDetails: [
         {
           unitName: 'UNIT',
           unitId: 'UNIT',
@@ -488,278 +670,60 @@ describe('VariableAnalysisProcessor', () => {
             }
           ]
         }
-      ])
-    };
-    const processor = new VariableAnalysisProcessor(
-      responseRepository as never,
-      cacheService as unknown as CacheService,
-      workspaceExclusionService as unknown as WorkspaceExclusionService,
-      workspaceFilesService as unknown as WorkspaceFilesService
-    );
-    const job = {
-      id: 'job-1',
-      data: {
-        workspaceId: 1,
-        cacheKey: 'variable-analysis:1:job-1'
-      },
-      progress: jest.fn().mockResolvedValue(undefined)
-    } as unknown as Job<VariableAnalysisJobData>;
-
-    await processor.process(job);
-
-    expect(multipleResponsePage1Query.andWhere).toHaveBeenCalledWith(
-      'response.id > :multipleLastResponseId',
-      { multipleLastResponseId: 0 }
-    );
-    expect(multipleResponsePage2Query.andWhere).toHaveBeenCalledWith(
-      'response.id > :multipleLastResponseId',
-      { multipleLastResponseId: multipleResponseBatchSize }
-    );
-    expect(multipleResponsePage1Query.limit)
-      .toHaveBeenCalledWith(multipleResponseBatchSize);
-    expect(multipleResponsePage2Query.limit)
-      .toHaveBeenCalledWith(multipleResponseBatchSize);
-    expect(cacheService.set).toHaveBeenCalledWith(
-      'variable-analysis:1:job-1:frequencies:0',
-      [['1:MULTI', [
-        expect.objectContaining({
-          value: 'A',
-          label: 'Alpha',
-          count: multipleResponseBatchSize
-        }),
-        expect.objectContaining({
-          value: 'B',
-          label: 'Beta',
-          count: 1
-        }),
-        expect.objectContaining({
-          value: 'C',
-          label: 'Gamma',
-          count: 1
-        })
-      ]]],
-      86400
-    );
-  });
-
-  it('maps boolean multiple response arrays to value position labels', async () => {
-    const baseQuery = createQueryBuilder();
-    const variableCombosQuery = createQueryBuilder([
-      { unitId: '1', unitName: 'UNIT', variableId: 'BOOL_MULTI' }
-    ]);
-    const summaryQuery = createQueryBuilder([]);
-    const topValuesQuery = createQueryBuilder();
-    const multipleResponseQuery = createQueryBuilder([
-      {
-        responseId: '1',
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'BOOL_MULTI',
-        value: '[true,false]'
-      },
-      {
-        responseId: '2',
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'BOOL_MULTI',
-        value: '[true,true]'
-      },
-      {
-        responseId: '3',
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'BOOL_MULTI',
-        value: '[false,false]'
-      }
-    ]);
-    const schemaCountQuery = createQueryBuilder([]);
-    const statusQuery = createQueryBuilder([]);
-    baseQuery.clone = jest.fn()
-      .mockReturnValueOnce(variableCombosQuery)
-      .mockReturnValueOnce(summaryQuery)
-      .mockReturnValueOnce(topValuesQuery)
-      .mockReturnValueOnce(multipleResponseQuery)
-      .mockReturnValueOnce(schemaCountQuery)
-      .mockReturnValueOnce(statusQuery);
-
-    const responseRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(baseQuery),
-      query: jest.fn().mockResolvedValue([])
-    };
-    const cacheService = {
-      set: jest.fn().mockResolvedValue(true)
-    };
-    const workspaceExclusionService = {
-      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
-        globalIgnoredUnits: [],
-        ignoredBooklets: [],
-        testletIgnoredUnits: []
-      })
-    };
-    const workspaceFilesService = {
-      getUnitVariableDetails: jest.fn().mockResolvedValue([
-        {
+      ],
+      queryResults: [
+        [
+          {
+            unitName: 'UNIT',
+            variableId: 'MULTI',
+            totalCount: String(batchSize + 1),
+            emptyCount: '0',
+            distinctValueCount: '3'
+          }
+        ],
+        [],
+        Array.from({ length: batchSize }, (_, index) => ({
+          responseId: index + 1,
           unitName: 'UNIT',
-          unitId: 'UNIT',
-          variables: [
-            {
-              id: 'BOOL_MULTI',
-              alias: 'BOOL_MULTI',
-              type: 'boolean',
-              multiple: true,
-              hasCodingScheme: false,
-              valuePositionLabels: ['Red', 'Blue']
-            }
-          ]
-        }
-      ])
-    };
-    const processor = new VariableAnalysisProcessor(
-      responseRepository as never,
-      cacheService as unknown as CacheService,
-      workspaceExclusionService as unknown as WorkspaceExclusionService,
-      workspaceFilesService as unknown as WorkspaceFilesService
-    );
-    const job = {
-      id: 'job-1',
-      data: {
-        workspaceId: 1,
-        cacheKey: 'variable-analysis:1:job-1'
-      },
-      progress: jest.fn().mockResolvedValue(undefined)
-    } as unknown as Job<VariableAnalysisJobData>;
+          variableId: 'MULTI',
+          value: '["A"]'
+        })),
+        [
+          {
+            responseId: batchSize + 1,
+            unitName: 'UNIT',
+            variableId: 'MULTI',
+            value: '["B","C"]'
+          }
+        ],
+        [],
+        []
+      ]
+    });
 
-    await processor.process(job);
+    await processor.process(createJob());
 
-    expect(cacheService.set).toHaveBeenCalledWith(
-      'variable-analysis:1:job-1:frequencies:0',
-      [['1:BOOL_MULTI', [
-        expect.objectContaining({
-          value: '1',
-          label: 'Red',
-          count: 2,
-          percentage: 66.66666666666666
-        }),
-        expect.objectContaining({
-          value: '2',
-          label: 'Blue',
-          count: 1,
-          percentage: 33.33333333333333
-        })
-      ]]],
-      86400
-    );
-  });
-
-  it('maps boolean multiple response arrays to declared values without position labels', async () => {
-    const baseQuery = createQueryBuilder();
-    const variableCombosQuery = createQueryBuilder([
-      { unitId: '1', unitName: 'UNIT', variableId: 'BOOL_MULTI' }
+    expect(responseRepository.query.mock.calls[2][1]).toEqual([
+      ['UNIT\u001FMULTI'],
+      0,
+      batchSize
     ]);
-    const summaryQuery = createQueryBuilder([]);
-    const topValuesQuery = createQueryBuilder();
-    const multipleResponseQuery = createQueryBuilder([
-      {
-        responseId: '1',
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'BOOL_MULTI',
-        value: '[true,false,true]'
-      },
-      {
-        responseId: '2',
-        unitId: '1',
-        unitName: 'UNIT',
-        variableId: 'BOOL_MULTI',
-        value: '[false,true,false]'
-      }
+    expect(responseRepository.query.mock.calls[3][1]).toEqual([
+      ['UNIT\u001FMULTI'],
+      batchSize,
+      batchSize
     ]);
-    const schemaCountQuery = createQueryBuilder([]);
-    const statusQuery = createQueryBuilder([]);
-    baseQuery.clone = jest.fn()
-      .mockReturnValueOnce(variableCombosQuery)
-      .mockReturnValueOnce(summaryQuery)
-      .mockReturnValueOnce(topValuesQuery)
-      .mockReturnValueOnce(multipleResponseQuery)
-      .mockReturnValueOnce(schemaCountQuery)
-      .mockReturnValueOnce(statusQuery);
 
-    const responseRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(baseQuery),
-      query: jest.fn().mockResolvedValue([])
-    };
-    const cacheService = {
-      set: jest.fn().mockResolvedValue(true)
-    };
-    const workspaceExclusionService = {
-      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
-        globalIgnoredUnits: [],
-        ignoredBooklets: [],
-        testletIgnoredUnits: []
-      })
-    };
-    const workspaceFilesService = {
-      getUnitVariableDetails: jest.fn().mockResolvedValue([
-        {
-          unitName: 'UNIT',
-          unitId: 'UNIT',
-          variables: [
-            {
-              id: 'BOOL_MULTI',
-              alias: 'BOOL_MULTI',
-              type: 'boolean',
-              multiple: true,
-              hasCodingScheme: false,
-              values: [
-                { value: 'A', label: 'Alpha' },
-                { value: 'B', label: 'Beta' },
-                { value: 'C', label: 'Gamma' }
-              ]
-            }
-          ]
-        }
-      ])
-    };
-    const processor = new VariableAnalysisProcessor(
-      responseRepository as never,
-      cacheService as unknown as CacheService,
-      workspaceExclusionService as unknown as WorkspaceExclusionService,
-      workspaceFilesService as unknown as WorkspaceFilesService
+    const frequencies = findCacheSetPayload<Array<[string, unknown[]]>>(
+      cacheService,
+      'variable-analysis:1:job-1:frequencies:0'
     );
-    const job = {
-      id: 'job-1',
-      data: {
-        workspaceId: 1,
-        cacheKey: 'variable-analysis:1:job-1'
-      },
-      progress: jest.fn().mockResolvedValue(undefined)
-    } as unknown as Job<VariableAnalysisJobData>;
-
-    await processor.process(job);
-
-    expect(cacheService.set).toHaveBeenCalledWith(
-      'variable-analysis:1:job-1:frequencies:0',
-      [['1:BOOL_MULTI', [
-        expect.objectContaining({
-          value: 'A',
-          label: 'Alpha',
-          count: 1,
-          percentage: 50
-        }),
-        expect.objectContaining({
-          value: 'B',
-          label: 'Beta',
-          count: 1,
-          percentage: 50
-        }),
-        expect.objectContaining({
-          value: 'C',
-          label: 'Gamma',
-          count: 1,
-          percentage: 50
-        })
-      ]]],
-      86400
-    );
+    expect(frequencies).toEqual([
+      ['1:MULTI', [
+        expect.objectContaining({ value: 'A', label: 'Alpha', count: batchSize }),
+        expect.objectContaining({ value: 'B', label: 'Beta', count: 1 }),
+        expect.objectContaining({ value: 'C', label: 'Gamma', count: 1 })
+      ]]
+    ]);
   });
 });

--- a/apps/backend/src/app/job-queue/processors/variable-analysis.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/variable-analysis.processor.ts
@@ -2,7 +2,7 @@ import { Processor, Process } from '@nestjs/bull';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bull';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Brackets, Repository, SelectQueryBuilder } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import { ResponseEntity } from '../../database/entities/response.entity';
 import { CacheService } from '../../cache/cache.service';
 import {
@@ -17,6 +17,7 @@ import {
   WorkspaceExclusionService
 } from '../../database/services/workspace/workspace-exclusion.service';
 import { WorkspaceFilesService } from '../../database/services/workspace/workspace-files.service';
+import { VariableDetailDto } from '../../models/unit-variable-details.dto';
 
 interface SchemaCodeInfo {
   value: string;
@@ -32,7 +33,7 @@ interface VariableAnalysisMetadata {
 }
 
 interface SchemaValueCountRow {
-  unitId: string | number;
+  unitName: string;
   variableId: string;
   value: string | null;
   count: string | number;
@@ -40,10 +41,28 @@ interface SchemaValueCountRow {
 
 interface MultipleResponseRow {
   responseId: string | number;
-  unitId: string | number;
   unitName: string;
   variableId: string;
   value: string | null;
+}
+
+interface AnalyzedVariableScopeEntry {
+  combo: VariableCombo;
+  comboKey: string;
+  logicalKey: string;
+  multiple: boolean;
+  categoryDefinitions: SchemaCodeInfo[];
+  valuesByPosition: SchemaCodeInfo[];
+}
+
+interface AnalysisSql {
+  sql: string;
+  parameters: unknown[];
+}
+
+interface VariableAnalysisScopeOptions {
+  unitId?: number;
+  variableId?: string;
 }
 
 interface ParsedMultipleCategory {
@@ -92,7 +111,6 @@ export class VariableAnalysisProcessor {
       const cacheKey = job.data.cacheKey || this.createResultCacheKey(workspaceId, job.id);
       const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
 
-      // Build the query
       const query = this.responseRepository
         .createQueryBuilder('response')
         .innerJoin('response.unit', 'unit')
@@ -108,33 +126,13 @@ export class VariableAnalysisProcessor {
         query.andWhere('unit.id = :unitId', { unitId });
       }
 
-      if (variableId) {
-        query.andWhere('response.variableid LIKE :variableId', { variableId: `%${variableId}%` });
-      }
+      const scopeEntries = await this.getAnalysisScope(
+        workspaceId,
+        query,
+        { unitId, variableId }
+      );
+      const variableCombos = scopeEntries.map(entry => entry.combo);
 
-      // Get distinct combinations of unit name and variable ID
-      const variableCombosQuery = query.clone()
-        .select('unit.id', 'unitId')
-        .addSelect('unit.name', 'unitName')
-        .addSelect('response.variableid', 'variableId')
-        .distinct(true)
-        .orderBy('unit.name', 'ASC')
-        .addOrderBy('response.variableid', 'ASC');
-
-      // Execute the query to get variable combinations
-      const variableCombosResult = await variableCombosQuery.getRawMany();
-      const variableCombos: VariableCombo[] = variableCombosResult.map(result => ({
-        unitId: Number(result.unitId),
-        unitName: result.unitName,
-        variableId: result.variableId,
-        totalCount: 0,
-        emptyCount: 0,
-        emptyPercentage: 0,
-        distinctValueCount: 0,
-        statusCounts: []
-      }));
-
-      // If no variable combinations found, return empty result
       if (variableCombos.length === 0) {
         await job.progress(100);
         return await this.cacheAndReturnMetadata(job, cacheKey, {
@@ -148,64 +146,62 @@ export class VariableAnalysisProcessor {
 
       const frequencies: { [key: string]: VariableFrequencyDto[] } = {};
       const comboByKey = new Map<string, VariableCombo>();
-      variableCombos.forEach(combo => {
-        const comboKey = `${combo.unitId}:${combo.variableId}`;
-        comboByKey.set(comboKey, combo);
+      const scopeByLogicalKey = new Map<string, AnalyzedVariableScopeEntry>();
+      scopeEntries.forEach(entry => {
+        const comboKey = entry.comboKey;
+        comboByKey.set(comboKey, entry.combo);
+        scopeByLogicalKey.set(entry.logicalKey, entry);
         frequencies[comboKey] = [];
       });
-      const metadataByComboKey = await this.getVariableMetadataByComboKey(
-        workspaceId,
-        variableCombos
+      const metadataByComboKey = this.getVariableMetadataByComboKey(
+        scopeEntries
       );
       const categoryDefinitionsByComboKey = this.getCategoryDefinitionsByComboKey(
         metadataByComboKey
       );
+      const analysisSql = this.getDedupedAnalysisSql(
+        query,
+        scopeEntries.map(entry => entry.logicalKey)
+      );
 
       await job.progress(25);
 
-      const summaryRows = await query.clone()
-        .select('unit.id', 'unitId')
-        .addSelect('response.variableid', 'variableId')
-        .addSelect('COUNT(*)', 'totalCount')
-        .addSelect("SUM(CASE WHEN response.value IS NULL OR response.value = '' THEN 1 ELSE 0 END)", 'emptyCount')
-        .addSelect("COUNT(DISTINCT COALESCE(response.value, ''))", 'distinctValueCount')
-        .groupBy('unit.id')
-        .addGroupBy('response.variableid')
-        .getRawMany();
+      const summaryRows = await this.responseRepository.query(
+        `
+          SELECT
+            analysis_rows."unitName" AS "unitName",
+            analysis_rows."variableId" AS "variableId",
+            COUNT(*) AS "totalCount",
+            SUM(CASE WHEN analysis_rows."value" IS NULL OR analysis_rows."value" = '' THEN 1 ELSE 0 END) AS "emptyCount",
+            COUNT(DISTINCT COALESCE(analysis_rows."value", '')) AS "distinctValueCount"
+          FROM (${analysisSql.sql}) analysis_rows
+          GROUP BY analysis_rows."unitName", analysis_rows."variableId"
+        `,
+        analysisSql.parameters
+      );
 
       for (const row of summaryRows) {
-        const combo = comboByKey.get(`${Number(row.unitId)}:${row.variableId}`);
+        const scopeEntry = this.getScopeEntryForRow(
+          scopeByLogicalKey,
+          row.unitName,
+          row.variableId
+        );
+        const combo = scopeEntry ? comboByKey.get(scopeEntry.comboKey) : undefined;
 
         if (combo) {
-          combo.totalCount = parseInt(row.totalCount, 10);
-          combo.emptyCount = parseInt(row.emptyCount, 10);
-          combo.distinctValueCount = parseInt(row.distinctValueCount, 10);
+          combo.totalCount = parseInt(String(row.totalCount), 10);
+          combo.emptyCount = parseInt(String(row.emptyCount), 10);
+          combo.distinctValueCount = parseInt(String(row.distinctValueCount), 10);
         }
       }
 
       await job.progress(40);
 
-      const topValuesQuery = query.clone()
-        .select('unit.id', 'unitId')
-        .addSelect('unit.name', 'unitName')
-        .addSelect('response.variableid', 'variableId')
-        .addSelect("COALESCE(response.value, '')", 'value')
-        .addSelect('COUNT(*)', 'count')
-        .groupBy('unit.id')
-        .addGroupBy('unit.name')
-        .addGroupBy('response.variableid')
-        .addGroupBy("COALESCE(response.value, '')")
-        .orderBy('unit.name', 'ASC')
-        .addOrderBy('response.variableid', 'ASC')
-        .addOrderBy('count', 'DESC');
-
-      const [topValuesSql, topValuesParameters] = topValuesQuery.getQueryAndParameters();
-      const maxValuesParameter = `$${topValuesParameters.length + 1}`;
-      const maxValuePreviewLengthParameter = `$${topValuesParameters.length + 2}`;
+      const maxValuesParameter = `$${analysisSql.parameters.length + 1}`;
+      const maxValuePreviewLengthParameter = `$${analysisSql.parameters.length + 2}`;
       const valueRows = await this.responseRepository.query(
         `
           SELECT
-            ranked_values."unitId",
             ranked_values."unitName",
             ranked_values."variableId",
             LEFT(ranked_values."value", ${maxValuePreviewLengthParameter}) AS "value",
@@ -217,31 +213,45 @@ export class VariableAnalysisProcessor {
             SELECT
               grouped_values.*,
               ROW_NUMBER() OVER (
-                PARTITION BY grouped_values."unitId", grouped_values."variableId"
+                PARTITION BY grouped_values."unitName", grouped_values."variableId"
                 ORDER BY grouped_values."count" DESC, grouped_values."value" ASC
               ) AS "rank"
-            FROM (${topValuesSql}) grouped_values
+            FROM (
+              SELECT
+                analysis_rows."unitName" AS "unitName",
+                analysis_rows."variableId" AS "variableId",
+                COALESCE(analysis_rows."value", '') AS "value",
+                COUNT(*) AS "count"
+              FROM (${analysisSql.sql}) analysis_rows
+              GROUP BY
+                analysis_rows."unitName",
+                analysis_rows."variableId",
+                COALESCE(analysis_rows."value", '')
+            ) grouped_values
           ) ranked_values
           WHERE ranked_values."rank" <= ${maxValuesParameter}
           ORDER BY ranked_values."unitName" ASC, ranked_values."variableId" ASC, ranked_values."count" DESC
         `,
-        [...topValuesParameters, this.MAX_VALUES_PER_VARIABLE, this.MAX_VALUE_PREVIEW_LENGTH]
+        [...analysisSql.parameters, this.MAX_VALUES_PER_VARIABLE, this.MAX_VALUE_PREVIEW_LENGTH]
       );
 
       for (const row of valueRows) {
-        const unitIdNumber = Number(row.unitId);
-        const comboKey = `${unitIdNumber}:${row.variableId}`;
-        const combo = comboByKey.get(comboKey);
+        const scopeEntry = this.getScopeEntryForRow(
+          scopeByLogicalKey,
+          row.unitName,
+          row.variableId
+        );
+        const combo = scopeEntry ? comboByKey.get(scopeEntry.comboKey) : undefined;
 
-        if (combo) {
-          const count = parseInt(row.count, 10);
-          frequencies[comboKey].push({
-            unitId: unitIdNumber,
+        if (combo && scopeEntry) {
+          const count = parseInt(String(row.count), 10);
+          frequencies[scopeEntry.comboKey].push({
+            unitId: combo.unitId,
             unitName: row.unitName,
             variableId: row.variableId,
             value: this.formatValuePreview(
               row.value || '',
-              parseInt(row.valueLength, 10),
+              parseInt(String(row.valueLength), 10),
               row.valueHash
             ),
             count,
@@ -253,7 +263,7 @@ export class VariableAnalysisProcessor {
       const multipleObservedCountsByComboKey =
         await this.recalculateMultipleVariableFrequencies(
           query,
-          variableCombos,
+          scopeEntries,
           frequencies,
           metadataByComboKey
         );
@@ -270,7 +280,7 @@ export class VariableAnalysisProcessor {
 
       await this.addSchemaCodeFrequencies(
         query,
-        variableCombos,
+        scopeEntries,
         frequencies,
         categoryDefinitionsByComboKey,
         multipleObservedCountsByComboKey
@@ -278,29 +288,41 @@ export class VariableAnalysisProcessor {
 
       await job.progress(70);
 
-      const statusRows = await query.clone()
-        .select('unit.id', 'unitId')
-        .addSelect('response.variableid', 'variableId')
-        .addSelect('response.status', 'status')
-        .addSelect('COUNT(*)', 'count')
-        .groupBy('unit.id')
-        .addGroupBy('response.variableid')
-        .addGroupBy('response.status')
-        .orderBy('unit.id', 'ASC')
-        .addOrderBy('response.variableid', 'ASC')
-        .addOrderBy('count', 'DESC')
-        .getRawMany();
+      const statusRows = await this.responseRepository.query(
+        `
+          SELECT
+            analysis_rows."unitName" AS "unitName",
+            analysis_rows."variableId" AS "variableId",
+            analysis_rows."status" AS "status",
+            COUNT(*) AS "count"
+          FROM (${analysisSql.sql}) analysis_rows
+          GROUP BY
+            analysis_rows."unitName",
+            analysis_rows."variableId",
+            analysis_rows."status"
+          ORDER BY
+            analysis_rows."unitName" ASC,
+            analysis_rows."variableId" ASC,
+            COUNT(*) DESC
+        `,
+        analysisSql.parameters
+      );
 
       for (const row of statusRows) {
-        const combo = comboByKey.get(`${Number(row.unitId)}:${row.variableId}`);
+        const scopeEntry = this.getScopeEntryForRow(
+          scopeByLogicalKey,
+          row.unitName,
+          row.variableId
+        );
+        const combo = scopeEntry ? comboByKey.get(scopeEntry.comboKey) : undefined;
 
         if (combo) {
-          const count = parseInt(row.count, 10);
+          const count = parseInt(String(row.count), 10);
           const totalResponses = combo.totalCount || 0;
           combo.statusCounts = [
             ...(combo.statusCounts || []),
             {
-              status: Number(row.status),
+              status: Number(row.status ?? 0),
               count,
               percentage: totalResponses > 0 ? (count / totalResponses) * 100 : 0
             }
@@ -444,117 +466,337 @@ export class VariableAnalysisProcessor {
     return `${value}... [truncated ${valueLength} chars, md5:${valueHash || 'unknown'}]`;
   }
 
-  private async getVariableMetadataByComboKey(
+  private async getAnalysisScope(
     workspaceId: number,
-    variableCombos: VariableCombo[]
-  ): Promise<Map<string, VariableAnalysisMetadata>> {
-    const metadataByComboKey = new Map<string, VariableAnalysisMetadata>();
+    query: SelectQueryBuilder<ResponseEntity>,
+    options: VariableAnalysisScopeOptions
+  ): Promise<AnalyzedVariableScopeEntry[]> {
+    const unitVariableDetails =
+      await this.workspaceFilesService.getUnitVariableDetails(workspaceId);
 
-    if (variableCombos.length === 0) {
-      return metadataByComboKey;
+    if (unitVariableDetails.length === 0) {
+      return [];
     }
 
-    try {
-      const unitVariableDetails =
-        await this.workspaceFilesService.getUnitVariableDetails(workspaceId);
-      const detailsByUnitName = new Map(
-        unitVariableDetails.map(details => [
-          details.unitName.toUpperCase(),
-          details
-        ])
-      );
+    const representativeUnitIds =
+      await this.getRepresentativeUnitIdsByUnitName(query);
+    const allowedUnitNames = new Set(representativeUnitIds.keys());
 
-      variableCombos.forEach(combo => {
-        const details = detailsByUnitName.get(combo.unitName.toUpperCase());
-        if (!details) {
+    if (allowedUnitNames.size === 0) {
+      return [];
+    }
+    const normalizedVariableFilter = options.variableId?.trim().toLowerCase();
+    const syntheticUnitIds = new Map<string, number>();
+    let nextSyntheticUnitId = -1;
+
+    const getUnitId = (normalizedUnitName: string): number => {
+      const observedUnitId = representativeUnitIds.get(normalizedUnitName);
+      if (observedUnitId !== undefined) {
+        return observedUnitId;
+      }
+
+      const existingSyntheticUnitId = syntheticUnitIds.get(normalizedUnitName);
+      if (existingSyntheticUnitId !== undefined) {
+        return existingSyntheticUnitId;
+      }
+
+      const syntheticUnitId = nextSyntheticUnitId;
+      nextSyntheticUnitId -= 1;
+      syntheticUnitIds.set(normalizedUnitName, syntheticUnitId);
+      return syntheticUnitId;
+    };
+
+    const entries: AnalyzedVariableScopeEntry[] = [];
+    const seenLogicalKeys = new Set<string>();
+
+    unitVariableDetails.forEach(details => {
+      const unitName = String(details.unitName || '').trim();
+      const normalizedUnitName = this.normalizeUnitName(unitName);
+
+      if (!unitName) {
+        return;
+      }
+
+      if (!allowedUnitNames.has(normalizedUnitName)) {
+        return;
+      }
+
+      details.variables.forEach(variable => {
+        if (!this.isAnalyzableVariable(variable)) {
           return;
         }
 
-        const variable = details.variables.find(
-          item => item.id === combo.variableId || item.alias === combo.variableId
-        );
-        if (!variable) {
+        const variableAlias = String(variable.alias || variable.id || '').trim();
+        const sourceVariableId = String(variable.id || variableAlias).trim();
+
+        if (!variableAlias) {
           return;
         }
 
-        const seenValues = new Set<string>();
-        const categoryDefinitions = (variable.codes || []).reduce<SchemaCodeInfo[]>(
-          (items, code) => {
-            const value = String(code.id);
-            if (seenValues.has(value)) {
-              return items;
-            }
-            seenValues.add(value);
-            items.push({
-              value,
-              label: code.label,
-              score: code.score,
-              order: items.length
-            });
-            return items;
-          },
-          []
-        );
+        if (
+          normalizedVariableFilter &&
+          !variableAlias.toLowerCase().includes(normalizedVariableFilter) &&
+          !sourceVariableId.toLowerCase().includes(normalizedVariableFilter)
+        ) {
+          return;
+        }
 
-        (variable.values || []).forEach(valueInfo => {
-          const value = String(valueInfo.value);
-          if (seenValues.has(value)) {
-            return;
-          }
-          seenValues.add(value);
-          categoryDefinitions.push({
-            value,
-            label: valueInfo.label,
-            order: categoryDefinitions.length
-          });
-        });
+        const logicalKey = this.getLogicalKey(unitName, variableAlias);
+        if (seenLogicalKeys.has(logicalKey)) {
+          return;
+        }
+        seenLogicalKeys.add(logicalKey);
 
-        const variableValues = variable.values || [];
-        const valuePositionLabels = variable.valuePositionLabels || [];
-        const positionCount = Math.max(
-          variableValues.length,
-          valuePositionLabels.length
-        );
-        const valuesByPosition: SchemaCodeInfo[] = [];
-        Array.from({ length: positionCount }).forEach((_, index) => {
-          const variableValue = variableValues[index]?.value;
-          const label =
-            valuePositionLabels[index] ||
-            variableValues[index]?.label ||
-            String(variableValue ?? index + 1);
-          valuesByPosition.push({
-            value: variableValue !== undefined ?
-              String(variableValue) :
-              String(index + 1),
-            label,
-            order: index
-          });
-        });
+        const unitId = getUnitId(normalizedUnitName);
+        const metadata = this.getVariableMetadata(variable);
+        const combo: VariableCombo = {
+          unitId,
+          unitName,
+          variableId: variableAlias,
+          sourceVariableId,
+          variableAlias: variableAlias !== sourceVariableId ?
+            variableAlias :
+            undefined,
+          selectionSource: this.getSelectionSource(variable),
+          sourceType: variable.sourceType,
+          isDerived: variable.isDerived,
+          hasCodingScheme: variable.hasCodingScheme,
+          totalCount: 0,
+          emptyCount: 0,
+          emptyPercentage: 0,
+          distinctValueCount: 0,
+          statusCounts: []
+        };
 
-        valuesByPosition.forEach(positionValue => {
-          if (seenValues.has(positionValue.value)) {
-            return;
-          }
-          seenValues.add(positionValue.value);
-          categoryDefinitions.push({
-            ...positionValue,
-            order: categoryDefinitions.length
-          });
-        });
-
-        metadataByComboKey.set(`${combo.unitId}:${combo.variableId}`, {
-          multiple: variable.multiple === true,
-          categoryDefinitions,
-          valuesByPosition
+        entries.push({
+          combo,
+          comboKey: this.getComboKey(combo),
+          logicalKey,
+          multiple: metadata.multiple,
+          categoryDefinitions: metadata.categoryDefinitions,
+          valuesByPosition: metadata.valuesByPosition
         });
       });
-    } catch (error) {
-      this.logger.warn(
-        `Could not enrich variable analysis with coding scheme codes: ${error.message}`
-      );
+    });
+
+    return entries.sort((a, b) => (
+      a.combo.unitName.localeCompare(b.combo.unitName, 'de', {
+        numeric: true,
+        sensitivity: 'base'
+      }) ||
+      a.combo.variableId.localeCompare(b.combo.variableId, 'de', {
+        numeric: true,
+        sensitivity: 'base'
+      })
+    ));
+  }
+
+  private async getRepresentativeUnitIdsByUnitName(
+    query: SelectQueryBuilder<ResponseEntity>
+  ): Promise<Map<string, number>> {
+    const rows = await query.clone()
+      .select('unit.name', 'unitName')
+      .addSelect('MIN(unit.id)', 'unitId')
+      .groupBy('unit.name')
+      .getRawMany();
+
+    return new Map(
+      rows
+        .filter(row => row.unitName !== undefined && row.unitName !== null)
+        .map(row => [
+          this.normalizeUnitName(row.unitName),
+          Number(row.unitId)
+        ])
+        .filter(([, unitId]) => Number.isFinite(unitId)) as [string, number][]
+    );
+  }
+
+  private getVariableMetadata(
+    variable: VariableDetailDto
+  ): VariableAnalysisMetadata {
+    const seenValues = new Set<string>();
+    const categoryDefinitions = (variable.codes || []).reduce<SchemaCodeInfo[]>(
+      (items, code) => {
+        const value = String(code.id);
+        if (seenValues.has(value)) {
+          return items;
+        }
+        seenValues.add(value);
+        items.push({
+          value,
+          label: code.label,
+          score: code.score,
+          order: items.length
+        });
+        return items;
+      },
+      []
+    );
+
+    (variable.values || []).forEach(valueInfo => {
+      const value = String(valueInfo.value);
+      if (seenValues.has(value)) {
+        return;
+      }
+      seenValues.add(value);
+      categoryDefinitions.push({
+        value,
+        label: valueInfo.label,
+        order: categoryDefinitions.length
+      });
+    });
+
+    const variableValues = variable.values || [];
+    const valuePositionLabels = variable.valuePositionLabels || [];
+    const positionCount = Math.max(
+      variableValues.length,
+      valuePositionLabels.length
+    );
+    const valuesByPosition: SchemaCodeInfo[] = [];
+    Array.from({ length: positionCount }).forEach((_, index) => {
+      const variableValue = variableValues[index]?.value;
+      const label =
+        valuePositionLabels[index] ||
+        variableValues[index]?.label ||
+        String(variableValue ?? index + 1);
+      valuesByPosition.push({
+        value: variableValue !== undefined ?
+          String(variableValue) :
+          String(index + 1),
+        label,
+        order: index
+      });
+    });
+
+    valuesByPosition.forEach(positionValue => {
+      if (seenValues.has(positionValue.value)) {
+        return;
+      }
+      seenValues.add(positionValue.value);
+      categoryDefinitions.push({
+        ...positionValue,
+        order: categoryDefinitions.length
+      });
+    });
+
+    return {
+      multiple: variable.multiple === true,
+      categoryDefinitions,
+      valuesByPosition
+    };
+  }
+
+  private getVariableMetadataByComboKey(
+    scopeEntries: AnalyzedVariableScopeEntry[]
+  ): Map<string, VariableAnalysisMetadata> {
+    return new Map(
+      scopeEntries.map(entry => [
+        entry.comboKey,
+        {
+          multiple: entry.multiple,
+          categoryDefinitions: entry.categoryDefinitions,
+          valuesByPosition: entry.valuesByPosition
+        }
+      ])
+    );
+  }
+
+  private getSelectionSource(variable: VariableDetailDto): string {
+    if (variable.isDerived) {
+      return variable.hasCodingScheme ?
+        'coding-scheme-derived' :
+        'unit-metadata-derived';
     }
 
-    return metadataByComboKey;
+    return variable.hasCodingScheme ? 'coding-scheme' : 'unit-metadata';
+  }
+
+  private isAnalyzableVariable(variable: VariableDetailDto): boolean {
+    if (variable.type === 'no-value') {
+      return false;
+    }
+
+    if (variable.sourceType === 'BASE_NO_VALUE') {
+      return false;
+    }
+
+    return !(variable.isDerived === true && variable.sourceType === 'BASE');
+  }
+
+  private getDedupedAnalysisSql(
+    query: SelectQueryBuilder<ResponseEntity>,
+    logicalKeys: string[]
+  ): AnalysisSql {
+    const analysisRowsQuery = query.clone()
+      .select('response.id', 'responseId')
+      .addSelect('unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('response.value', 'value')
+      .addSelect('response.status', 'status')
+      .addSelect(
+        `
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              person.id,
+              booklet.id,
+              unit.name,
+              response.variableid,
+              COALESCE(response.subform, '')
+            ORDER BY
+              CASE WHEN response.value IS NULL OR response.value = '' THEN 1 ELSE 0 END ASC,
+              response.id DESC
+          )
+        `,
+        'analysisRank'
+      );
+    const [sourceSql, sourceParameters] =
+      analysisRowsQuery.getQueryAndParameters();
+
+    if (logicalKeys.length === 0) {
+      return {
+        sql: `SELECT * FROM (${sourceSql}) analysis_source WHERE 1 = 0`,
+        parameters: sourceParameters
+      };
+    }
+
+    const logicalKeysParameter = `$${sourceParameters.length + 1}`;
+    return {
+      sql: `
+        SELECT *
+        FROM (${sourceSql}) analysis_source
+        WHERE analysis_source."analysisRank" = 1
+          AND CONCAT(
+            UPPER(analysis_source."unitName"),
+            CHR(31),
+            analysis_source."variableId"
+          ) = ANY(${logicalKeysParameter})
+      `,
+      parameters: [...sourceParameters, logicalKeys]
+    };
+  }
+
+  private getScopeEntryForRow(
+    scopeByLogicalKey: Map<string, AnalyzedVariableScopeEntry>,
+    unitName: string,
+    variableId: string
+  ): AnalyzedVariableScopeEntry | undefined {
+    return scopeByLogicalKey.get(this.getLogicalKey(unitName, variableId));
+  }
+
+  private getComboKey(combo: Pick<VariableCombo, 'unitId' | 'variableId'>): string {
+    return `${combo.unitId}:${combo.variableId}`;
+  }
+
+  private normalizeUnitName(unitName: string | null | undefined): string {
+    return String(unitName || '').trim().toUpperCase();
+  }
+
+  private normalizeVariableId(variableId: string | null | undefined): string {
+    return String(variableId || '').trim();
+  }
+
+  private getLogicalKey(unitName: string, variableId: string): string {
+    return `${this.normalizeUnitName(unitName)}\u001F${this.normalizeVariableId(variableId)}`;
   }
 
   private getCategoryDefinitionsByComboKey(
@@ -576,25 +818,26 @@ export class VariableAnalysisProcessor {
 
   private async recalculateMultipleVariableFrequencies(
     query: SelectQueryBuilder<ResponseEntity>,
-    variableCombos: VariableCombo[],
+    scopeEntries: AnalyzedVariableScopeEntry[],
     frequencies: Record<string, VariableFrequencyDto[]>,
     metadataByComboKey: Map<string, VariableAnalysisMetadata>
   ): Promise<Map<string, Map<string, number>>> {
-    const multipleCombos = variableCombos.filter(combo => {
-      const comboKey = `${combo.unitId}:${combo.variableId}`;
-      return Boolean(metadataByComboKey.get(comboKey)?.multiple);
-    });
+    const multipleEntries = scopeEntries.filter(entry => (
+      Boolean(metadataByComboKey.get(entry.comboKey)?.multiple)
+    ));
     const observedCountsByComboKey = new Map<string, Map<string, number>>();
 
-    if (multipleCombos.length === 0) {
+    if (multipleEntries.length === 0) {
       return observedCountsByComboKey;
     }
 
     const summariesByComboKey = new Map<string, MultipleResponseSummary>();
+    const scopeByLogicalKey = new Map(
+      multipleEntries.map(entry => [entry.logicalKey, entry])
+    );
 
-    multipleCombos.forEach(combo => {
-      const comboKey = `${combo.unitId}:${combo.variableId}`;
-      summariesByComboKey.set(comboKey, {
+    multipleEntries.forEach(entry => {
+      summariesByComboKey.set(entry.comboKey, {
         totalCount: 0,
         emptyCount: 0,
         counts: new Map<string, number>(),
@@ -604,49 +847,47 @@ export class VariableAnalysisProcessor {
 
     for (
       let index = 0;
-      index < multipleCombos.length;
+      index < multipleEntries.length;
       index += this.MULTIPLE_RESPONSE_COMBO_CHUNK_SIZE
     ) {
-      const comboChunk = multipleCombos.slice(
+      const comboChunk = multipleEntries.slice(
         index,
         index + this.MULTIPLE_RESPONSE_COMBO_CHUNK_SIZE
+      );
+      const analysisSql = this.getDedupedAnalysisSql(
+        query,
+        comboChunk.map(entry => entry.logicalKey)
       );
       let lastResponseId: string | number = 0;
       let hasMoreRows = true;
 
       while (hasMoreRows) {
-        const responseRows: MultipleResponseRow[] = await query.clone()
-          .select('response.id', 'responseId')
-          .addSelect('unit.id', 'unitId')
-          .addSelect('unit.name', 'unitName')
-          .addSelect('response.variableid', 'variableId')
-          .addSelect('response.value', 'value')
-          .andWhere('response.id > :multipleLastResponseId', {
-            multipleLastResponseId: lastResponseId
-          })
-          .andWhere(new Brackets(qb => {
-            comboChunk.forEach((combo, comboIndex) => {
-              const params = {
-                [`multipleUnitId${comboIndex}`]: combo.unitId,
-                [`multipleVariableId${comboIndex}`]: combo.variableId
-              };
-              const condition =
-                `unit.id = :multipleUnitId${comboIndex} ` +
-                `AND response.variableid = :multipleVariableId${comboIndex}`;
-
-              if (comboIndex === 0) {
-                qb.where(condition, params);
-              } else {
-                qb.orWhere(condition, params);
-              }
-            });
-          }))
-          .orderBy('response.id', 'ASC')
-          .limit(this.MULTIPLE_RESPONSE_ROW_BATCH_SIZE)
-          .getRawMany();
+        const lastResponseIdParameter =
+          `$${analysisSql.parameters.length + 1}`;
+        const limitParameter = `$${analysisSql.parameters.length + 2}`;
+        const responseRows: MultipleResponseRow[] =
+          await this.responseRepository.query(
+            `
+              SELECT
+                analysis_rows."responseId" AS "responseId",
+                analysis_rows."unitName" AS "unitName",
+                analysis_rows."variableId" AS "variableId",
+                analysis_rows."value" AS "value"
+              FROM (${analysisSql.sql}) analysis_rows
+              WHERE analysis_rows."responseId" > ${lastResponseIdParameter}
+              ORDER BY analysis_rows."responseId" ASC
+              LIMIT ${limitParameter}
+            `,
+            [
+              ...analysisSql.parameters,
+              lastResponseId,
+              this.MULTIPLE_RESPONSE_ROW_BATCH_SIZE
+            ]
+          );
 
         responseRows.forEach(row => this.addMultipleResponseRowToSummary(
           row,
+          scopeByLogicalKey,
           metadataByComboKey,
           summariesByComboKey
         ));
@@ -666,9 +907,9 @@ export class VariableAnalysisProcessor {
       }
     }
 
-    multipleCombos.forEach(combo => {
-      const comboKey = `${combo.unitId}:${combo.variableId}`;
-      const summary = summariesByComboKey.get(comboKey);
+    multipleEntries.forEach(entry => {
+      const combo = entry.combo;
+      const summary = summariesByComboKey.get(entry.comboKey);
 
       if (!summary) {
         return;
@@ -677,7 +918,7 @@ export class VariableAnalysisProcessor {
       combo.totalCount = summary.totalCount;
       combo.emptyCount = summary.emptyCount;
       combo.distinctValueCount = summary.counts.size;
-      observedCountsByComboKey.set(comboKey, summary.counts);
+      observedCountsByComboKey.set(entry.comboKey, summary.counts);
 
       const sortedValues = Array.from(summary.counts.entries())
         .sort(([valueA, countA], [valueB, countB]) => {
@@ -688,7 +929,7 @@ export class VariableAnalysisProcessor {
         })
         .slice(0, this.MAX_VALUES_PER_VARIABLE);
 
-      frequencies[comboKey] = sortedValues.map(([value, count]) => {
+      frequencies[entry.comboKey] = sortedValues.map(([value, count]) => {
         const category = summary.categories.get(value);
         return {
           unitId: combo.unitId,
@@ -709,10 +950,17 @@ export class VariableAnalysisProcessor {
 
   private addMultipleResponseRowToSummary(
     row: MultipleResponseRow,
+    scopeByLogicalKey: Map<string, AnalyzedVariableScopeEntry>,
     metadataByComboKey: Map<string, VariableAnalysisMetadata>,
     summariesByComboKey: Map<string, MultipleResponseSummary>
   ): void {
-    const comboKey = `${Number(row.unitId)}:${row.variableId}`;
+    const scopeEntry = scopeByLogicalKey.get(
+      this.getLogicalKey(row.unitName, row.variableId)
+    );
+    const comboKey = scopeEntry?.comboKey;
+    if (!comboKey) {
+      return;
+    }
     const metadata = metadataByComboKey.get(comboKey);
     const summary = summariesByComboKey.get(comboKey);
 
@@ -857,7 +1105,7 @@ export class VariableAnalysisProcessor {
 
   private async addSchemaCodeFrequencies(
     query: SelectQueryBuilder<ResponseEntity>,
-    variableCombos: VariableCombo[],
+    scopeEntries: AnalyzedVariableScopeEntry[],
     frequencies: Record<string, VariableFrequencyDto[]>,
     schemaCodesByComboKey: Map<string, SchemaCodeInfo[]>,
     observedCountsOverrideByComboKey = new Map<string, Map<string, number>>()
@@ -868,22 +1116,22 @@ export class VariableAnalysisProcessor {
 
     const observedSchemaCounts = await this.getObservedSchemaValueCounts(
       query,
-      variableCombos,
+      scopeEntries,
       schemaCodesByComboKey
     );
 
-    variableCombos.forEach(combo => {
-      const comboKey = `${combo.unitId}:${combo.variableId}`;
-      const schemaCodes = schemaCodesByComboKey.get(comboKey);
+    scopeEntries.forEach(entry => {
+      const combo = entry.combo;
+      const schemaCodes = schemaCodesByComboKey.get(entry.comboKey);
       if (!schemaCodes?.length) {
         return;
       }
 
-      const rows = frequencies[comboKey] || [];
+      const rows = frequencies[entry.comboKey] || [];
       const rowsByValue = new Map(rows.map(row => [row.value, row]));
       const observedCountsForCombo =
-        observedCountsOverrideByComboKey.get(comboKey) ||
-        observedSchemaCounts.get(comboKey) ||
+        observedCountsOverrideByComboKey.get(entry.comboKey) ||
+        observedSchemaCounts.get(entry.comboKey) ||
         new Map<string, number>();
       const totalResponses = combo.totalCount || 0;
 
@@ -913,62 +1161,83 @@ export class VariableAnalysisProcessor {
         });
       });
 
-      frequencies[comboKey] = rows;
+      frequencies[entry.comboKey] = rows;
     });
   }
 
   private async getObservedSchemaValueCounts(
     query: SelectQueryBuilder<ResponseEntity>,
-    variableCombos: VariableCombo[],
+    scopeEntries: AnalyzedVariableScopeEntry[],
     schemaCodesByComboKey: Map<string, SchemaCodeInfo[]>
   ): Promise<Map<string, Map<string, number>>> {
     const countsByComboKey = new Map<string, Map<string, number>>();
-    const combosWithSchemaCodes = variableCombos.filter(combo => {
-      const comboKey = `${combo.unitId}:${combo.variableId}`;
-      return (schemaCodesByComboKey.get(comboKey)?.length || 0) > 0;
-    });
+    const entriesWithSchemaCodes = scopeEntries.filter(entry => (
+      (schemaCodesByComboKey.get(entry.comboKey)?.length || 0) > 0
+    ));
+    const scopeByLogicalKey = new Map(
+      entriesWithSchemaCodes.map(entry => [entry.logicalKey, entry])
+    );
     const chunkSize = 100;
 
-    for (let index = 0; index < combosWithSchemaCodes.length; index += chunkSize) {
-      const comboChunk = combosWithSchemaCodes.slice(index, index + chunkSize);
-      const schemaCountQuery = query.clone()
-        .select('unit.id', 'unitId')
-        .addSelect('response.variableid', 'variableId')
-        .addSelect("COALESCE(response.value, '')", 'value')
-        .addSelect('COUNT(*)', 'count')
-        .andWhere(new Brackets(qb => {
-          comboChunk.forEach((combo, comboIndex) => {
-            const comboKey = `${combo.unitId}:${combo.variableId}`;
-            const schemaValues = (schemaCodesByComboKey.get(comboKey) || [])
-              .map(schemaCode => schemaCode.value);
-            const params = {
-              [`schemaUnitId${comboIndex}`]: combo.unitId,
-              [`schemaVariableId${comboIndex}`]: combo.variableId,
-              [`schemaValues${comboIndex}`]: schemaValues
-            };
-            const condition =
-              `unit.id = :schemaUnitId${comboIndex} ` +
-              `AND response.variableid = :schemaVariableId${comboIndex} ` +
-              `AND COALESCE(response.value, '') IN (:...schemaValues${comboIndex})`;
-
-            if (comboIndex === 0) {
-              qb.where(condition, params);
-            } else {
-              qb.orWhere(condition, params);
-            }
-          });
+    for (let index = 0; index < entriesWithSchemaCodes.length; index += chunkSize) {
+      const entryChunk = entriesWithSchemaCodes.slice(index, index + chunkSize);
+      const analysisSql = this.getDedupedAnalysisSql(
+        query,
+        entryChunk.map(entry => entry.logicalKey)
+      );
+      const schemaValueFilters = entryChunk.flatMap(entry => (
+        (schemaCodesByComboKey.get(entry.comboKey) || []).map(schemaCode => ({
+          logicalKey: entry.logicalKey,
+          value: schemaCode.value
         }))
-        .groupBy('unit.id')
-        .addGroupBy('response.variableid')
-        .addGroupBy("COALESCE(response.value, '')");
-
-      const rows: SchemaValueCountRow[] = await schemaCountQuery.getRawMany();
+      ));
+      const schemaValueFiltersParameter =
+        `$${analysisSql.parameters.length + 1}`;
+      const rows: SchemaValueCountRow[] = await this.responseRepository.query(
+        `
+          SELECT
+            analysis_rows."unitName" AS "unitName",
+            analysis_rows."variableId" AS "variableId",
+            COALESCE(analysis_rows."value", '') AS "value",
+            COUNT(*) AS "count"
+          FROM (${analysisSql.sql}) analysis_rows
+          INNER JOIN jsonb_to_recordset(${schemaValueFiltersParameter}::jsonb)
+            AS schema_filter("logicalKey" text, "value" text)
+            ON schema_filter."logicalKey" = CONCAT(
+              UPPER(analysis_rows."unitName"),
+              CHR(31),
+              analysis_rows."variableId"
+            )
+            AND schema_filter."value" = COALESCE(analysis_rows."value", '')
+          GROUP BY
+            analysis_rows."unitName",
+            analysis_rows."variableId",
+            COALESCE(analysis_rows."value", '')
+        `,
+        [
+          ...analysisSql.parameters,
+          JSON.stringify(schemaValueFilters)
+        ]
+      );
 
       rows.forEach(row => {
-        const comboKey = `${Number(row.unitId)}:${row.variableId}`;
-        const valueCounts = countsByComboKey.get(comboKey) || new Map<string, number>();
-        valueCounts.set(row.value || '', parseInt(String(row.count), 10));
-        countsByComboKey.set(comboKey, valueCounts);
+        const entry = scopeByLogicalKey.get(
+          this.getLogicalKey(row.unitName, row.variableId)
+        );
+        if (!entry) {
+          return;
+        }
+        const schemaValues = new Set(
+          (schemaCodesByComboKey.get(entry.comboKey) || [])
+            .map(schemaCode => schemaCode.value)
+        );
+        const value = row.value || '';
+        if (!schemaValues.has(value)) {
+          return;
+        }
+        const valueCounts = countsByComboKey.get(entry.comboKey) || new Map<string, number>();
+        valueCounts.set(value, parseInt(String(row.count), 10));
+        countsByComboKey.set(entry.comboKey, valueCounts);
       });
     }
 

--- a/apps/backend/src/app/models/unit-variable-details.dto.ts
+++ b/apps/backend/src/app/models/unit-variable-details.dto.ts
@@ -26,6 +26,7 @@ export interface VariableDetailDto {
   nullable?: boolean;
   hasCodingScheme: boolean;
   codingSchemeRef?: string;
+  sourceType?: string;
   codes?: CodeInfo[];
   values?: VariableValueInfo[];
   valuesComplete?: boolean;

--- a/apps/frontend/src/app/models/unit-variable-details.dto.ts
+++ b/apps/frontend/src/app/models/unit-variable-details.dto.ts
@@ -26,6 +26,7 @@ export interface VariableDetailDto {
   nullable?: boolean;
   hasCodingScheme: boolean;
   codingSchemeRef?: string;
+  sourceType?: string;
   codes?: CodeInfo[];
   values?: VariableValueInfo[];
   valuesComplete?: boolean;

--- a/apps/frontend/src/app/shared/services/response/variable-analysis.service.ts
+++ b/apps/frontend/src/app/shared/services/response/variable-analysis.service.ts
@@ -42,6 +42,12 @@ export interface VariableCombo {
   unitId: number;
   unitName: string;
   variableId: string;
+  sourceVariableId?: string;
+  variableAlias?: string;
+  selectionSource?: string;
+  sourceType?: string;
+  isDerived?: boolean;
+  hasCodingScheme?: boolean;
   totalCount?: number;
   emptyCount?: number;
   emptyPercentage?: number;
@@ -65,6 +71,12 @@ export interface VariableAnalysisTableRowDto extends VariableFrequencyDto {
   unitId: number;
   unitName: string;
   variableId: string;
+  sourceVariableId?: string;
+  variableAlias?: string;
+  selectionSource?: string;
+  sourceType?: string;
+  isDerived?: boolean;
+  hasCodingScheme?: boolean;
   totalCount: number;
   emptyCount: number;
   emptyPercentage: number;

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
@@ -66,6 +66,12 @@ export interface VariableAnalysisData {
       unitId: number;
       unitName: string;
       variableId: string;
+      sourceVariableId?: string;
+      variableAlias?: string;
+      selectionSource?: string;
+      sourceType?: string;
+      isDerived?: boolean;
+      hasCodingScheme?: boolean;
       totalCount?: number;
       emptyCount?: number;
       emptyPercentage?: number;
@@ -125,6 +131,12 @@ export interface VariableCombo {
   unitId: number;
   unitName: string;
   variableId: string;
+  sourceVariableId?: string;
+  variableAlias?: string;
+  selectionSource?: string;
+  sourceType?: string;
+  isDerived?: boolean;
+  hasCodingScheme?: boolean;
   totalCount?: number;
   emptyCount?: number;
   emptyPercentage?: number;
@@ -1196,10 +1208,28 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
         distinctValueCount - displayedObservedValueCount
       );
 
-      return frequencies.map(frequency => ({
+      const visibleFrequencies: VariableFrequency[] = frequencies.length > 0 ?
+        frequencies :
+        [{
+          unitId: combo.unitId,
+          unitName: combo.unitName,
+          variableid: combo.variableId,
+          value: '',
+          count: 0,
+          percentage: 0,
+          isSchemaOnly: true
+        }];
+
+      return visibleFrequencies.map(frequency => ({
         unitId: combo.unitId,
         unitName: combo.unitName,
         variableId: combo.variableId,
+        sourceVariableId: combo.sourceVariableId,
+        variableAlias: combo.variableAlias,
+        selectionSource: combo.selectionSource,
+        sourceType: combo.sourceType,
+        isDerived: combo.isDerived,
+        hasCodingScheme: combo.hasCodingScheme,
         value: frequency.value,
         label: frequency.label,
         score: frequency.score,


### PR DESCRIPTION
## Summary

Implements the variable analysis changes for issue #556.

- derives the analysis scope from unit metadata and coding schemes instead of only observed response rows
- keeps expected schema variables and schema values visible with zero counts
- restricts workspace-wide metadata scope to units that actually occur in the response basis
- deduplicates response rows per person/booklet/unit/variable/subform for stable counts
- supports multiple-response variables, including boolean arrays with position labels
- adds provenance fields for variable source, alias, source type, derived state, and coding-scheme state
- keeps zero-count variables visible in paginated results, exports, and the frontend dialog fallback
- filters schema-code count queries directly in SQL to avoid grouping unrelated off-schema values

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/job-queue/processors/variable-analysis.processor.spec.ts --runInBand`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/variable-analysis.service.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.spec.ts --runInBand`
- `npx nx lint backend`
- `npx nx lint frontend`
- `git diff --check`
- `git diff --cached --check`
