### PR TITLE
[codex] Keep CodeSelector issue options visible

### DIFF
--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
@@ -89,43 +89,41 @@
   }
 
   <div class="codes-section">
-    <div *ngIf="regularCodes.length || legacySelectedCode; else noCodes">
-      <div class="code-list scrollable-codes">
-        <div class="code-row general-instruction-row" *ngIf="!suppressGeneralInstructions && variableManualInstruction">
-          <div class="code-instruction" [innerHTML]="getSafeHtml(variableManualInstruction)"></div>
+    <div class="code-list scrollable-codes" *ngIf="hasVariableManualInstruction || regularCodes.length || legacySelectedCode">
+      <div class="code-row general-instruction-row" *ngIf="hasVariableManualInstruction">
+        <div class="code-instruction" [innerHTML]="getSafeHtml(variableManualInstruction || '')"></div>
+      </div>
+      <div class="code-row selected read-only legacy-code-row" *ngIf="legacySelectedCode">
+        <div class="code-content">
+          <span class="code-info">
+            <span class="legacy-code-prefix">{{ 'code-selector.legacy-code-label' | translate }}</span>
+            <span class="code-id">{{ legacySelectedCode.id }}</span>
+            <span class="code-score" *ngIf="showScore && legacySelectedCode.score !== undefined">{{
+              'code-selector.score-label' | translate }} {{ legacySelectedCode.score }}</span>
+          </span>
         </div>
-        <div class="code-row selected read-only legacy-code-row" *ngIf="legacySelectedCode">
-          <div class="code-content">
-            <span class="code-info">
-              <span class="legacy-code-prefix">{{ 'code-selector.legacy-code-label' | translate }}</span>
-              <span class="code-id">{{ legacySelectedCode.id }}</span>
-              <span class="code-score" *ngIf="showScore && legacySelectedCode.score !== undefined">{{
-                'code-selector.score-label' | translate }} {{ legacySelectedCode.score }}</span>
-            </span>
-          </div>
-          <div class="legacy-code-note">{{ legacyCodeNoteTranslationKey | translate }}</div>
-        </div>
-        <div class="code-row" [class.selected]="item.id === selectedCode"
-          [class.read-only]="isReadOnly || isRegularSelectionDisabled" *ngFor="let item of regularCodes;"
-          [style.cursor]="(isReadOnly || isRegularSelectionDisabled) ? 'not-allowed' : 'pointer'"
-          (click)="(isReadOnly || isRegularSelectionDisabled) ? null : onSelect(item.id)">
+        <div class="legacy-code-note">{{ legacyCodeNoteTranslationKey | translate }}</div>
+      </div>
+      <div class="code-row" [class.selected]="item.id === selectedCode"
+        [class.read-only]="isReadOnly || isRegularSelectionDisabled" *ngFor="let item of regularCodes;"
+        [style.cursor]="(isReadOnly || isRegularSelectionDisabled) ? 'not-allowed' : 'pointer'"
+        (click)="(isReadOnly || isRegularSelectionDisabled) ? null : onSelect(item.id)">
 
-          <div class="code-content">
-            <span class="code-info">
-              <span class="code-id">{{ item.id }}</span>
-              <span class="code-score" *ngIf="showScore && item.score !== undefined">{{ 'code-selector.score-label' |
-                translate }} {{ item.score }}</span>
-            </span>
-          </div>
-          <div class="code-instruction" *ngIf="item.manualInstruction"
-            [innerHTML]="getSafeHtml(item.manualInstruction)"></div>
+        <div class="code-content">
+          <span class="code-info">
+            <span class="code-id">{{ item.id }}</span>
+            <span class="code-score" *ngIf="showScore && item.score !== undefined">{{ 'code-selector.score-label' |
+              translate }} {{ item.score }}</span>
+          </span>
         </div>
+        <div class="code-instruction" *ngIf="item.manualInstruction"
+          [innerHTML]="getSafeHtml(item.manualInstruction)"></div>
       </div>
     </div>
 
-    <ng-template #noCodes>
+    <div *ngIf="!regularCodes.length && !legacySelectedCode">
       <div class="hint">{{ 'code-selector.no-codes-found' | translate }} {{ variableId }}.</div>
-    </ng-template>
+    </div>
   </div>
 
   <div class="uncertain-codes-section fixed-section">

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -88,6 +88,41 @@ describe('CodeSelectorComponent', () => {
     ]
   };
 
+  const issueOnlyCodingScheme: CodingScheme = {
+    version: '1.0',
+    variableCodings: [
+      {
+        id: 'VAR2',
+        alias: 'VAR2',
+        label: 'Variable 2',
+        sourceType: 'BASE',
+        processing: [],
+        codeModel: 'MANUAL_AND_RULES',
+        manualInstruction: '<p>Only general instruction</p>',
+        codes: [
+          {
+            id: 4,
+            type: 'RESIDUAL',
+            label: 'Auto code',
+            score: 0,
+            ruleSetOperatorAnd: false,
+            ruleSets: [],
+            manualInstruction: ''
+          },
+          {
+            id: 5,
+            type: 'RESIDUAL',
+            label: 'Whitespace code',
+            score: 0,
+            ruleSetOperatorAnd: false,
+            ruleSets: [],
+            manualInstruction: '   '
+          }
+        ]
+      }
+    ]
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [FormsModule, TranslateModule.forRoot(), CodeSelectorComponent]
@@ -114,6 +149,39 @@ describe('CodeSelectorComponent', () => {
 
     expect(component.regularCodes.map(code => code.id)).toEqual([1]);
     expect(component.codingIssueOptionCodes).toHaveLength(4);
+  });
+
+  it('keeps coding issue options and general instructions visible without regular manual codes', () => {
+    component.codingScheme = issueOnlyCodingScheme;
+    component.variableId = 'VAR2';
+    const emitSpy = jest.spyOn(component.codeSelected, 'emit');
+
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, issueOnlyCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR2', false)
+    });
+    fixture.detectChanges();
+
+    expect(component.regularCodes).toEqual([]);
+    expect(component.codingIssueOptionCodes.map(code => code.id)).toEqual([-1, -3, -4, -2]);
+    expect(fixture.nativeElement.querySelector('.general-instruction-row').textContent).toContain(
+      'Only general instruction'
+    );
+    expect(fixture.nativeElement.querySelectorAll('.uncertain-codes-section .code-row')).toHaveLength(4);
+
+    component.onSelect(-1);
+    expect(emitSpy).toHaveBeenLastCalledWith({
+      variableId: 'VAR2',
+      code: null,
+      codingIssueOption: expect.objectContaining({ code: -1 })
+    });
+
+    component.onSelect(-2);
+    expect(emitSpy).toHaveBeenLastCalledWith({
+      variableId: 'VAR2',
+      code: null,
+      codingIssueOption: expect.objectContaining({ code: -2 })
+    });
   });
 
   it('keeps manual codes selectable when mixed with empty manual instructions', () => {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -279,6 +279,10 @@ export class CodeSelectorComponent implements OnChanges {
     return this.selectableItems.filter(item => item.type === 'codingIssueOption');
   }
 
+  get hasVariableManualInstruction(): boolean {
+    return !this.suppressGeneralInstructions && !!this.variableManualInstruction?.trim();
+  }
+
   get isRegularSelectionDisabled(): boolean {
     return this.selectedCodingIssueOption === -3 || this.selectedCodingIssueOption === -4;
   }


### PR DESCRIPTION
## Summary

- Keep variable-level manual coding instructions visible even when the CodeSelector has no regular manually selectable codes.
- Preserve the manual coding issue options for variables whose regular codes are filtered out.
- Add frontend coverage for a variable with only non-manual regular codes.

## Why

Fixes #554. The CodeSelector previously tied variable-level instructions to the regular-code list block, so an empty regular-code list could hide instructions even though issue options still needed to be available.

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts`
- `npx nx lint frontend`
- `npx nx test frontend`