### PR TITLE
[codex] Centralize DERIVE_ERROR status metadata

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -214,9 +214,16 @@ describe('CodingManagementComponent', () => {
 
     const translateService = TestBed.inject(TranslateService);
     translateService.setTranslation('de', {
+      close: 'Schließen',
       'coding-management': {
         actions: {
           close: 'Schließen'
+        },
+        descriptions: {
+          'no-results': 'Keine Ergebnisse für {{status}}'
+        },
+        statistics: {
+          'uncoded-responses-title': 'Unkodierte Antworten'
         },
         readiness: {
           'title-load-failed': 'Auto-Coding-Prüfung nicht verfügbar',
@@ -895,6 +902,20 @@ describe('CodingManagementComponent', () => {
       const statuses = component.getAvailableStatuses();
 
       expect(statuses).toEqual(['200', '300']);
+    });
+
+    it('should use centralized status labels in empty result snackbars', () => {
+      const componentWithPrivate = component as unknown as {
+        fetchResponsesByStatus(status: string): void;
+      };
+
+      componentWithPrivate.fetchResponsesByStatus('4');
+
+      expect(mockSnackBar.open).toHaveBeenCalledWith(
+        'Keine Ergebnisse für DERIVE_ERROR',
+        'Schließen',
+        { duration: 5000 }
+      );
     });
   });
 

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -24,7 +24,6 @@ import { PageEvent } from '@angular/material/paginator';
 import { Router } from '@angular/router';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { responseStatesNumericMap } from '@iqbspecs/response/response.interface';
 import { AppService } from '../../../core/services/app.service';
 import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
 import { CodingStatistics } from '../../../../../../../api-dto/coding/coding-statistics';
@@ -82,6 +81,7 @@ import {
   isCodingFreshnessOpenWarning,
   isSecondAutocodingWaitingForManualCoding
 } from '../../../shared/utils/coding-freshness-text.util';
+import { getResponseStatusLabel } from '../../../shared/utils/response-status-metadata.util';
 import { extractGeoGebraBase64 } from '../../utils/geogebra-value.util';
 
 @Component({
@@ -1010,7 +1010,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         this.isLoading = false;
 
         if (this.data.length === 0) {
-          const statusName = responseStatesNumericMap.find(entry => entry.key.toString() === status)?.value || status;
+          const statusName = getResponseStatusLabel(status);
           this.snackBar.open(
             this.translateService.instant('coding-management.descriptions.no-results', { status: statusName === 'null' ? this.translateService.instant('coding-management.statistics.uncoded-responses-title') : statusName }),
             this.translateService.instant('close'),

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.spec.ts
@@ -69,6 +69,11 @@ describe('ResponseFiltersComponent', () => {
     expect(component.filterChange.emit).toHaveBeenCalledWith(component.filterParams);
   });
 
+  it('should keep DERIVE_ERROR as the visible status label', () => {
+    expect(component.mapStatusToString('4')).toBe('DERIVE_ERROR');
+    expect(component.mapStatusToString('4abc')).toBe('4abc');
+  });
+
   it('should switch GeoGebra searches from all to base responses', () => {
     jest.spyOn(component.filterChange, 'emit');
 

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.ts
@@ -15,8 +15,8 @@ import { MatButton } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIcon } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
-import { responseStatesNumericMap } from '@iqbspecs/response/response.interface';
 import { FilterParams } from '../../../../services/coding-management.service';
+import { getResponseStatusLabel } from '../../../../../shared/utils/response-status-metadata.util';
 
 @Component({
   selector: 'app-response-filters',
@@ -65,10 +65,6 @@ export class ResponseFiltersComponent implements OnDestroy {
     { value: 'derived' as const, label: 'coding-management.filters.response-source-derived' }
   ];
 
-  private responseStatusMap = new Map(
-    responseStatesNumericMap.map(entry => [entry.key, entry.value])
-  );
-
   ngOnDestroy(): void {
     this.clearFilterTimer();
   }
@@ -105,10 +101,6 @@ export class ResponseFiltersComponent implements OnDestroy {
   }
 
   mapStatusToString(status: string): string {
-    const statusNumber = parseInt(status, 10);
-    if (Number.isNaN(statusNumber)) {
-      return status;
-    }
-    return this.responseStatusMap.get(statusNumber) || status;
+    return getResponseStatusLabel(status) || status;
   }
 }

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.spec.ts
@@ -67,6 +67,8 @@ describe('ResponseTableComponent', () => {
   });
 
   it('should format status string correctly', () => {
+    expect(component.getStatusString('4')).toBe('DERIVE_ERROR');
+    expect(component.getStatusString('4abc')).toBe('4abc');
     expect(component.getStatusString('200')).toBeTruthy();
     expect(component.getStatusString('')).toBe('');
   });
@@ -120,5 +122,8 @@ describe('ResponseTableComponent', () => {
 
     component.currentStatusFilter = 'invalid';
     expect(component.getFilterStatusLabel()).toBe('invalid');
+
+    component.currentStatusFilter = '4abc';
+    expect(component.getFilterStatusLabel()).toBe('4abc');
   });
 });

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.ts
@@ -31,9 +31,9 @@ import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDivider } from '@angular/material/divider';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { responseStatesNumericMap } from '@iqbspecs/response/response.interface';
 import { Success } from '../../../../models/success.model';
 import { extractGeoGebraBase64 } from '../../../../utils/geogebra-value.util';
+import { getResponseStatusLabel } from '../../../../../shared/utils/response-status-metadata.util';
 
 @Component({
   selector: 'app-response-table',
@@ -90,10 +90,6 @@ export class ResponseTableComponent implements AfterViewInit, OnChanges {
 
   dataSource = new MatTableDataSource<Success>([]);
 
-  private responseStatusMap = new Map(
-    responseStatesNumericMap.map(entry => [entry.key, entry.value])
-  );
-
   constructor(private translateService: TranslateService) { }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -135,12 +131,11 @@ export class ResponseTableComponent implements AfterViewInit, OnChanges {
 
   getStatusString(status: string): string {
     if (!status) return '';
-    const num = parseInt(status, 10);
-    return Number.isNaN(num) ? status : this.mapStatusToString(num);
+    return this.mapStatusToString(status);
   }
 
-  mapStatusToString(status: number): string {
-    return this.responseStatusMap.get(status) || 'UNKNOWN';
+  mapStatusToString(status: string | number): string {
+    return getResponseStatusLabel(status) || 'UNKNOWN';
   }
 
   onPageChange(event: PageEvent): void {
@@ -195,8 +190,7 @@ export class ResponseTableComponent implements AfterViewInit, OnChanges {
     if (!this.currentStatusFilter || this.currentStatusFilter === 'null') {
       return '';
     }
-    const num = parseInt(this.currentStatusFilter, 10);
-    return Number.isNaN(num) ? this.currentStatusFilter : this.mapStatusToString(num);
+    return this.mapStatusToString(this.currentStatusFilter);
   }
 
   private toSafeFileName(value: string): string {

--- a/apps/frontend/src/app/coding/components/coding-management/components/statistics-card/statistics-card.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/components/statistics-card/statistics-card.component.html
@@ -112,8 +112,11 @@
         <mat-icon class="warning-icon" color="warn"
           [matTooltip]="'coding-management.statistics.missing-schemas' | translate">warning</mat-icon>
         } @else {
-        {{ 'coding-management.statistics.responses-with-status' | translate:{status: mapStatusToString(Number(status))}
-        }}
+        <span [matTooltip]="getStatusTooltipKey(status) | translate"
+          [matTooltipDisabled]="!getStatusTooltipKey(status)">
+          {{ 'coding-management.statistics.responses-with-status' | translate:{status: mapStatusToString(status)}
+          }}
+        </span>
         }
       </span>
       <span class="statistic-value">

--- a/apps/frontend/src/app/coding/components/coding-management/components/statistics-card/statistics-card.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/statistics-card/statistics-card.component.spec.ts
@@ -174,6 +174,12 @@ describe('StatisticsCardComponent', () => {
     expect(component.statusClick.emit).toHaveBeenCalledWith('200');
   });
 
+  it('should keep DERIVE_ERROR visible and provide the explanatory tooltip key', () => {
+    expect(component.mapStatusToString(4)).toBe('DERIVE_ERROR');
+    expect(component.getStatusTooltipKey('4')).toBe('response-status.tooltips.DERIVE_ERROR');
+    expect(component.getStatusTooltipKey('DERIVE_ERROR')).toBe('response-status.tooltips.DERIVE_ERROR');
+  });
+
   it('should emit derivedClick when derived answers are clicked', () => {
     jest.spyOn(component.derivedClick, 'emit');
     component.onDerivedClick();

--- a/apps/frontend/src/app/coding/components/coding-management/components/statistics-card/statistics-card.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/statistics-card/statistics-card.component.ts
@@ -15,8 +15,11 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule } from '@ngx-translate/core';
-import { responseStatesNumericMap } from '@iqbspecs/response/response.interface';
 import { CodingStatistics } from '../../../../../../../../../api-dto/coding/coding-statistics';
+import {
+  getResponseStatusLabel,
+  getResponseStatusTooltipKey
+} from '../../../../../shared/utils/response-status-metadata.util';
 import { StatisticsVersion } from '../../../../services/coding-management.service';
 
 @Component({
@@ -59,10 +62,6 @@ export class StatisticsCardComponent {
   @Output() statusClick = new EventEmitter<string>();
   @Output() derivedClick = new EventEmitter<void>();
 
-  private responseStatusMap = new Map(
-    responseStatesNumericMap.map(entry => [entry.key, entry.value])
-  );
-
   private readonly ignoredStatuses = [
     '0', '1', '2', '3', '10',
     'UNSET', 'NOT_REACHED', 'DISPLAYED', 'VALUE_CHANGED', 'PARTLY_DISPLAYED'
@@ -74,8 +73,12 @@ export class StatisticsCardComponent {
     { value: 'v3' as const, label: 'coding-management.statistics.second-autocode-run' }
   ];
 
-  mapStatusToString(status: number): string {
-    return this.responseStatusMap.get(status) || 'UNKNOWN';
+  mapStatusToString(status: string | number): string {
+    return getResponseStatusLabel(status) || 'UNKNOWN';
+  }
+
+  getStatusTooltipKey(status: string): string {
+    return getResponseStatusTooltipKey(status);
   }
 
   get effectiveTotalResponses(): number {

--- a/apps/frontend/src/app/shared/utils/response-status-metadata.util.spec.ts
+++ b/apps/frontend/src/app/shared/utils/response-status-metadata.util.spec.ts
@@ -1,0 +1,29 @@
+import {
+  getResponseStatusLabel,
+  getResponseStatusMetadata,
+  getResponseStatusTooltipKey
+} from './response-status-metadata.util';
+
+describe('response-status-metadata util', () => {
+  it('keeps DERIVE_ERROR visible as the technical status label', () => {
+    expect(getResponseStatusLabel(4)).toBe('DERIVE_ERROR');
+    expect(getResponseStatusLabel('DERIVE_ERROR')).toBe('DERIVE_ERROR');
+  });
+
+  it('provides a DERIVE_ERROR tooltip key', () => {
+    expect(getResponseStatusTooltipKey(4)).toBe('response-status.tooltips.DERIVE_ERROR');
+    expect(getResponseStatusMetadata('DERIVE_ERROR')).toMatchObject({
+      numeric: 4,
+      status: 'DERIVE_ERROR',
+      label: 'DERIVE_ERROR'
+    });
+  });
+
+  it('falls back to unknown status values unchanged', () => {
+    expect(getResponseStatusLabel('UNKNOWN_STATUS')).toBe('UNKNOWN_STATUS');
+    expect(getResponseStatusLabel(200)).toBe('200');
+    expect(getResponseStatusLabel('4abc')).toBe('4abc');
+    expect(getResponseStatusTooltipKey('UNKNOWN_STATUS')).toBe('');
+    expect(getResponseStatusTooltipKey('4abc')).toBe('');
+  });
+});

--- a/apps/frontend/src/app/shared/utils/response-status-metadata.util.ts
+++ b/apps/frontend/src/app/shared/utils/response-status-metadata.util.ts
@@ -1,0 +1,71 @@
+import { responseStatesNumericMap } from '@iqbspecs/response/response.interface';
+
+export interface ResponseStatusMetadata {
+  numeric: number;
+  status: string;
+  label: string;
+  tooltipKey?: string;
+}
+
+const metadataOverrides: Record<string, Partial<ResponseStatusMetadata>> = {
+  DERIVE_ERROR: {
+    tooltipKey: 'response-status.tooltips.DERIVE_ERROR'
+  }
+};
+
+const responseStatusMetadata = responseStatesNumericMap.map<ResponseStatusMetadata>(entry => {
+  const override = metadataOverrides[entry.value] || {};
+  return {
+    numeric: entry.key,
+    status: entry.value,
+    label: entry.value,
+    ...override
+  };
+});
+
+const metadataByNumericStatus = new Map(
+  responseStatusMetadata.map(metadata => [metadata.numeric, metadata])
+);
+const metadataByTextStatus = new Map(
+  responseStatusMetadata.map(metadata => [metadata.status, metadata])
+);
+
+export function getResponseStatusMetadata(
+  status: string | number | null | undefined
+): ResponseStatusMetadata | null {
+  if (status === null || status === undefined || status === '') {
+    return null;
+  }
+
+  if (typeof status === 'number') {
+    return metadataByNumericStatus.get(status) || null;
+  }
+
+  const normalizedStatus = status.trim();
+  if (normalizedStatus === '') {
+    return null;
+  }
+
+  if (/^-?\d+$/.test(normalizedStatus)) {
+    const numericStatus = parseInt(normalizedStatus, 10);
+    return metadataByNumericStatus.get(numericStatus) || null;
+  }
+
+  return metadataByTextStatus.get(normalizedStatus) || null;
+}
+
+export function getResponseStatusLabel(
+  status: string | number | null | undefined
+): string {
+  if (status === null || status === undefined || status === '') {
+    return '';
+  }
+
+  return getResponseStatusMetadata(status)?.label || String(status);
+}
+
+export function getResponseStatusTooltipKey(
+  status: string | number | null | undefined
+): string {
+  return getResponseStatusMetadata(status)?.tooltipKey || '';
+}

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
@@ -213,6 +213,11 @@ describe('TestResultsComponent', () => {
           'second-autocoding-waits-help': 'Der Start von Auto-Coding 2 bleibt bis dahin gesperrt. {{taskResultHelp}}',
           'second-autocoding-waits-chip': '{{version}}: {{count}} wartet'
         }
+      },
+      'response-status': {
+        tooltips: {
+          DERIVE_ERROR: 'DERIVE_ERROR bedeutet: Ableitung/Solver fehlgeschlagen, z. B. Typkonflikt im Kodierschema. Keine inhaltlich falsche Antwort.'
+        }
       }
     });
     translateService.use('de');
@@ -240,6 +245,11 @@ describe('TestResultsComponent', () => {
   it('should hide log quality when disabled by workspace setting', () => {
     expect(component.showTestResultsLogAnomalies).toBe(false);
     expect(fixture.nativeElement.textContent).not.toContain('Log-Qualität');
+  });
+
+  it('should use centralized DERIVE_ERROR tooltip text', () => {
+    expect(component.getResponseStatusTooltip('DERIVE_ERROR'))
+      .toBe('DERIVE_ERROR bedeutet: Ableitung/Solver fehlgeschlagen, z. B. Typkonflikt im Kodierschema. Keine inhaltlich falsche Antwort.');
   });
 
   it('should show log quality when enabled by workspace setting', () => {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
@@ -73,6 +73,7 @@ import { ValidationService } from '../../../shared/services/validation/validatio
 import { UnitNoteService } from '../../../shared/services/unit/unit-note.service';
 import { ResponseService } from '../../../shared/services/response/response.service';
 import { UnitService } from '../../../shared/services/unit/unit.service';
+import { getResponseStatusTooltipKey } from '../../../shared/utils/response-status-metadata.util';
 import { CodingStatisticsService } from '../../../coding/services/coding-statistics.service';
 import {
   AppliedResultsOverview,
@@ -290,11 +291,6 @@ string,
     numeric: 3,
     description:
       'Dieser Status zeigt an, dass eine Interaktion stattgefunden hat und also der Wert (Value) auszuwerten ist. Bei abgeleiteten Variablen zeigt dieser Status eine erfolgreiche Ableitung an.'
-  },
-  DERIVE_ERROR: {
-    numeric: 4,
-    description:
-      'Dieser Status zeigt an, dass eine Ableitung fehlgeschlagen ist. Dies kann sich beispielsweise auf einen Typkonflikt (numerisch, Text) beziehen und ist in den meisten Fällen über eine Anpassung des Kodierschemas korrigierbar. Der Status bezieht sich allerdings nicht darauf, ob die zugrundeliegenden Variablen einen unzureichenden Status haben, sondern es geht um technische Fehler beim Ableitungsprozess.'
   },
   CODING_COMPLETE: {
     numeric: 5,
@@ -1827,6 +1823,11 @@ export class TestResultsComponent implements OnInit, OnDestroy {
   }
 
   getResponseStatusTooltip(status: string): string {
+    const sharedTooltipKey = getResponseStatusTooltipKey(status);
+    if (sharedTooltipKey) {
+      return this.translateService.instant(sharedTooltipKey);
+    }
+
     const info = RESPONSE_STATUS_INFO[status];
     if (!info) {
       return status;

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.spec.ts
@@ -301,6 +301,14 @@ describe('VariableAnalysisDialogComponent', () => {
     });
   });
 
+  describe('status labels', () => {
+    it('should use centralized response status labels', () => {
+      expect(component.getStatusLabel(8)).toBe('CODING_INCOMPLETE');
+      expect(component.getStatusLabel('4')).toBe('DERIVE_ERROR');
+      expect(component.getStatusLabel('4abc')).toBe('4abc');
+    });
+  });
+
   describe('refreshJobs', () => {
     it('should load jobs from service', () => {
       component.refreshJobs();

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
@@ -44,6 +44,7 @@ import {
   ConfirmDialogComponent,
   ConfirmDialogData
 } from '../../../shared/dialogs/confirm-dialog.component';
+import { getResponseStatusLabel } from '../../../shared/utils/response-status-metadata.util';
 
 export interface VariableAnalysisData {
   unitId: number;
@@ -180,16 +181,6 @@ type VariableAnalysisExportFormat = 'csv' | 'xlsx';
   ]
 })
 export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
-  private readonly responseStatusLabels: Record<number, string> = {
-    0: 'UNSET',
-    1: 'NOT_REACHED',
-    2: 'DISPLAYED',
-    3: 'VALUE_CHANGED',
-    4: 'DERIVE_ERROR',
-    5: 'CODING_COMPLETE',
-    6: 'NO_CODING'
-  };
-
   isLoading = false;
   variableFrequencies: { [key: string]: VariableFrequency[] } = {};
   displayedColumns: string[] = [
@@ -609,9 +600,7 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
   }
 
   getStatusLabel(status: number | string): string {
-    return typeof status === 'number' ?
-      this.responseStatusLabels[status] || status.toString() :
-      status;
+    return getResponseStatusLabel(status);
   }
 
   getVisibleStatusCounts(combo: VariableCombo): VariableStatusCount[] {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -36,6 +36,11 @@
   "status-processing": "Wird bearbeitet",
   "status-completed": "Abgeschlossen",
   "status-failed": "Fehlgeschlagen",
+  "response-status": {
+    "tooltips": {
+      "DERIVE_ERROR": "DERIVE_ERROR bedeutet: Ableitung/Solver fehlgeschlagen, z. B. Typkonflikt im Kodierschema. Keine inhaltlich falsche Antwort."
+    }
+  },
   "xml-viewer": {
     "format-error": "XML konnte nicht formatiert werden",
     "enable-line-wrap": "Zeilen umbrechen",


### PR DESCRIPTION
## Summary
- add a shared frontend utility for response status labels and tooltip metadata
- keep DERIVE_ERROR visible as the technical status while adding the explanatory DERIVE_ERROR tooltip
- replace local response-status mappings in coding statistics, response filters/tables, test results, and variable analysis

## Why
DERIVE_ERROR is an autocoding/derivation status and should remain visible as DERIVE_ERROR. The user-facing explanation now clarifies that it is a derivation/solver failure, not an inherently wrong answer.

Refs #549

## Validation
- npx nx test frontend --watch=false
- npx nx lint frontend