### PR TITLE
[codex] Test merge import of new person

### DIFF
--- a/apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts
@@ -395,6 +395,21 @@ describe('PersonPersistenceService', () => {
   });
 
   it('imports a new person in an existing test group by matching the full person key', async () => {
+    const existingPersonInSameGroup = {
+      id: 40,
+      group: 'existing-group',
+      login: 'existing-login',
+      code: 'existing-code',
+      workspace_id: 1,
+      booklets: [
+        {
+          id: 'BOOKLET_OLD',
+          logs: [],
+          sessions: [],
+          units: []
+        }
+      ]
+    } as unknown as Persons;
     const importedPerson = {
       id: 41,
       group: 'existing-group',
@@ -410,8 +425,11 @@ describe('PersonPersistenceService', () => {
         }
       ]
     } as unknown as Persons;
+    const requestedKeys: Array<{ group: string; login: string; code: string }> = [];
     const bracketQb = {
-      where: jest.fn(),
+      where: jest.fn((_clause: string, params: { g0: string; l0: string; c0: string }) => {
+        requestedKeys.push({ group: params.g0, login: params.l0, code: params.c0 });
+      }),
       orWhere: jest.fn()
     };
     const qb = {
@@ -420,7 +438,13 @@ describe('PersonPersistenceService', () => {
         brackets.whereFactory(bracketQb);
         return qb;
       }),
-      getMany: jest.fn().mockResolvedValue([importedPerson])
+      getMany: jest.fn().mockImplementation(async () => (
+        [existingPersonInSameGroup, importedPerson].filter(person => requestedKeys.some(key => (
+          person.group === key.group &&
+          person.login === key.login &&
+          person.code === key.code
+        )))
+      ))
     };
     jest.spyOn(personsRepository, 'upsert').mockResolvedValue({} as never);
     jest.spyOn(personsRepository, 'createQueryBuilder').mockReturnValue(qb as never);
@@ -462,6 +486,13 @@ describe('PersonPersistenceService', () => {
     expect(processBookletSpy).toHaveBeenCalledWith(
       importedPerson.booklets[0],
       importedPerson,
+      'merge',
+      []
+    );
+    expect(processBookletSpy).toHaveBeenCalledTimes(1);
+    expect(processBookletSpy).not.toHaveBeenCalledWith(
+      existingPersonInSameGroup.booklets[0],
+      existingPersonInSameGroup,
       'merge',
       []
     );

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
@@ -690,6 +690,130 @@ test-group;test-user;code;booklet1;unit1;[];""`;
       expect(result.issues?.some(issue => issue.category === 'other')).toBe(true);
     });
 
+    it('should merge a new person into an existing test group and report the follow-up state', async () => {
+      const fileContent = `groupname;loginname;code;bookletname;unitname;responses;laststate
+existing-group;new-login;new-code;booklet1;unit1;"[{""subForm"":"""",""content"":""[{\\""id\\"":\\""VAR_1\\"",\\""status\\"":\\""VALUE_CHANGED\\""}]""}]";""`;
+
+      const filePath = path.join(os.tmpdir(), 'test-merge-new-person-existing-group.csv');
+      fs.writeFileSync(filePath, fileContent);
+
+      jest.spyOn(personService, 'getWorkspaceUploadStats')
+        .mockResolvedValueOnce({
+          testPersons: 1,
+          testGroups: 1,
+          uniqueBooklets: 1,
+          uniqueUnits: 1,
+          uniqueResponses: 1
+        })
+        .mockResolvedValueOnce({
+          testPersons: 2,
+          testGroups: 1,
+          uniqueBooklets: 1,
+          uniqueUnits: 2,
+          uniqueResponses: 2
+        });
+
+      const newPerson = {
+        workspace_id: 1,
+        group: 'existing-group',
+        login: 'new-login',
+        code: 'new-code',
+        booklets: []
+      };
+      const newPersonWithBooklets = {
+        ...newPerson,
+        booklets: [
+          {
+            id: 'booklet1',
+            logs: [],
+            units: [],
+            sessions: []
+          }
+        ]
+      };
+      const newPersonWithUnits = {
+        ...newPersonWithBooklets,
+        booklets: [
+          {
+            id: 'booklet1',
+            logs: [],
+            sessions: [],
+            units: [
+              {
+                id: 'unit1',
+                alias: 'unit1',
+                laststate: [],
+                chunks: [],
+                subforms: [],
+                logs: []
+              }
+            ]
+          }
+        ]
+      };
+
+      jest.spyOn(personService, 'createPersonList').mockResolvedValue([newPerson]);
+      jest.spyOn(personService, 'assignBookletsToPerson').mockResolvedValue(newPersonWithBooklets);
+      jest.spyOn(personService, 'assignUnitsToBookletAndPerson').mockResolvedValue(newPersonWithUnits);
+      jest.spyOn(personService, 'processPersonBooklets').mockResolvedValue({
+        addedUnitIds: [101],
+        changedUnitIds: [],
+        addedResponseCount: 1,
+        changedResponseCount: 0
+      });
+
+      const file: FileIo = {
+        buffer: Buffer.from(fileContent),
+        originalname: 'test.csv',
+        mimetype: 'text/csv',
+        size: fileContent.length,
+        fieldname: 'file',
+        encoding: 'utf-8',
+        path: filePath
+      };
+
+      const result = await service.processUpload(createMock<Job<TestResultsUploadJobData>>({
+        id: '1',
+        data: {
+          workspaceId: 1,
+          file,
+          resultType: 'responses',
+          overwriteMode: 'merge',
+          scope: 'person'
+        }
+      }));
+
+      expect(personService.processPersonBooklets).toHaveBeenCalledWith(
+        [newPersonWithUnits],
+        1,
+        'merge',
+        'person'
+      );
+      expect(result.expected).toMatchObject({
+        testPersons: 1,
+        testGroups: 1,
+        uniqueBooklets: 1,
+        uniqueUnits: 1,
+        uniqueResponses: 1
+      });
+      expect(result.delta).toEqual({
+        testPersons: 1,
+        testGroups: 0,
+        uniqueBooklets: 0,
+        uniqueUnits: 1,
+        uniqueResponses: 1
+      });
+      expect(codingFreshnessService.markUnitsPendingAfterImport).toHaveBeenCalledWith(1, [101], 1);
+      expect(codingFreshnessService.markUnitsStaleAfterResultChange).toHaveBeenCalledWith(
+        1,
+        [],
+        'RESULT_UPDATED'
+      );
+      expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(1);
+      expect(workspaceTestResultsService.invalidateCodingStatisticsCache).toHaveBeenCalledWith(1);
+      expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
+    });
+
     it('should mark freshness and invalidate response-analysis and coding-statistics caches after importing responses', async () => {
       const fileContent = `groupname;loginname;code;bookletname;unitname;responses;laststate
 test-group;test-user;code;booklet1;unit1;[];""`;


### PR DESCRIPTION
## Summary
- add regression coverage for importing a new person into an existing test group via response import merge mode
- assert that an existing person in the same group is not processed when the uploaded person key differs
- cover the upload follow-up state: one additional test person, unchanged group count, freshness marking, and coding cache invalidation

## Context
Closes #535.

## Validation
- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts --runInBand`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts --runInBand`
- `npx nx lint backend`

Note: the final validation run used Nx local cache for these already executed checks.