### PR TITLE
[codex] Handle skip imports without merging existing units

### DIFF
--- a/api-dto/files/test-results-upload-result.dto.ts
+++ b/api-dto/files/test-results-upload-result.dto.ts
@@ -44,10 +44,18 @@ export type TestResultsUploadIssueDto = {
 
 export type TestResultsUploadSummaryDto = {
   totalRows: number;
+  overwriteMode?: 'skip' | 'merge' | 'replace';
+  scope?: 'person' | 'workspace' | 'group' | 'booklet' | 'unit' | 'response';
   responseRows?: number;
   logRows?: number;
   bookletLogRows?: number;
   unitLogRows?: number;
+  savedResponses?: number;
+  deletedResponses?: number;
+  skippedExistingUnits?: number;
+  skippedExistingResponses?: number;
+  addedUnits?: number;
+  changedUnits?: number;
   savedLogs?: number;
   skippedRows?: number;
   skippedLogs?: number;

--- a/apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts
@@ -559,7 +559,9 @@ describe('PersonPersistenceService', () => {
       addedUnitIds: [99],
       changedUnitIds: [],
       addedResponseCount: 1,
-      changedResponseCount: 0
+      changedResponseCount: 0,
+      savedResponseCount: 1,
+      skippedExistingResponseCount: 0
     });
   });
 
@@ -626,7 +628,9 @@ describe('PersonPersistenceService', () => {
       addedUnitIds: [],
       changedUnitIds: [40],
       addedResponseCount: 0,
-      changedResponseCount: 1
+      changedResponseCount: 1,
+      savedResponseCount: 1,
+      skippedExistingResponseCount: 1
     });
   });
 
@@ -638,6 +642,8 @@ describe('PersonPersistenceService', () => {
     } as Unit);
     const responseSaveSpy = jest.spyOn(responseRepository, 'save');
     const chunkDeleteSpy = jest.spyOn(chunkRepository, 'delete');
+    const lastStateSpy = jest.spyOn(service, 'saveUnitLastState');
+    const processSubformsSpy = jest.spyOn(service, 'processSubforms');
 
     const result = await service.processBookletWithTransaction(
       {
@@ -674,11 +680,16 @@ describe('PersonPersistenceService', () => {
 
     expect(responseSaveSpy).not.toHaveBeenCalled();
     expect(chunkDeleteSpy).not.toHaveBeenCalled();
+    expect(lastStateSpy).not.toHaveBeenCalled();
+    expect(processSubformsSpy).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       addedUnitIds: [],
       changedUnitIds: [],
+      skippedExistingUnitIds: [40],
       addedResponseCount: 0,
-      changedResponseCount: 0
+      changedResponseCount: 0,
+      savedResponseCount: 0,
+      skippedExistingResponseCount: 1
     });
   });
 });

--- a/apps/backend/src/app/database/services/test-results/person-persistence.service.ts
+++ b/apps/backend/src/app/database/services/test-results/person-persistence.service.ts
@@ -26,8 +26,12 @@ import { TestResultsUploadIssueDto } from '../../../../../../../api-dto/files/te
 export interface TestResultsMutationSummary {
   addedUnitIds: number[];
   changedUnitIds: number[];
+  skippedExistingUnitIds?: number[];
   addedResponseCount: number;
   changedResponseCount: number;
+  savedResponseCount?: number;
+  deletedResponseCount?: number;
+  skippedExistingResponseCount?: number;
 }
 
 /**
@@ -253,8 +257,7 @@ export class PersonPersistenceService {
       this.logger.error(`Failed to process person booklets: ${error.message}`);
     }
 
-    mutationSummary.addedUnitIds = Array.from(new Set(mutationSummary.addedUnitIds));
-    mutationSummary.changedUnitIds = Array.from(new Set(mutationSummary.changedUnitIds));
+    this.dedupeMutationSummaryUnitIds(mutationSummary);
     return mutationSummary;
   }
 
@@ -322,6 +325,10 @@ export class PersonPersistenceService {
               });
 
               if (existingUnit && overwriteMode === 'skip') {
+                mutationSummary.skippedExistingUnitIds?.push(existingUnit.id);
+                mutationSummary.skippedExistingResponseCount =
+                  (mutationSummary.skippedExistingResponseCount || 0) +
+                  this.countUnitResponses(unit);
                 return;
               }
 
@@ -340,6 +347,12 @@ export class PersonPersistenceService {
                   this.processChunks(unit, targetUnit, booklet)
                 ]);
                 const responseResult = await this.processSubforms(unit, targetUnit, overwriteMode);
+                mutationSummary.savedResponseCount =
+                  (mutationSummary.savedResponseCount || 0) + responseResult.saved;
+                mutationSummary.deletedResponseCount =
+                  (mutationSummary.deletedResponseCount || 0) + responseResult.deleted;
+                mutationSummary.skippedExistingResponseCount =
+                  (mutationSummary.skippedExistingResponseCount || 0) + responseResult.skipped;
                 if (isNewUnit) {
                   mutationSummary.addedUnitIds.push(targetUnit.id);
                   mutationSummary.addedResponseCount += responseResult.saved;
@@ -363,8 +376,7 @@ export class PersonPersistenceService {
       }
     }
 
-    mutationSummary.addedUnitIds = Array.from(new Set(mutationSummary.addedUnitIds));
-    mutationSummary.changedUnitIds = Array.from(new Set(mutationSummary.changedUnitIds));
+    this.dedupeMutationSummaryUnitIds(mutationSummary);
     return mutationSummary;
   }
 
@@ -599,8 +611,12 @@ export class PersonPersistenceService {
     return {
       addedUnitIds: [],
       changedUnitIds: [],
+      skippedExistingUnitIds: [],
       addedResponseCount: 0,
-      changedResponseCount: 0
+      changedResponseCount: 0,
+      savedResponseCount: 0,
+      deletedResponseCount: 0,
+      skippedExistingResponseCount: 0
     };
   }
 
@@ -610,8 +626,29 @@ export class PersonPersistenceService {
   ): void {
     target.addedUnitIds.push(...source.addedUnitIds);
     target.changedUnitIds.push(...source.changedUnitIds);
+    target.skippedExistingUnitIds?.push(...(source.skippedExistingUnitIds || []));
     target.addedResponseCount += source.addedResponseCount;
     target.changedResponseCount += source.changedResponseCount;
+    target.savedResponseCount =
+      (target.savedResponseCount || 0) + (source.savedResponseCount || 0);
+    target.deletedResponseCount =
+      (target.deletedResponseCount || 0) + (source.deletedResponseCount || 0);
+    target.skippedExistingResponseCount =
+      (target.skippedExistingResponseCount || 0) +
+      (source.skippedExistingResponseCount || 0);
+  }
+
+  private dedupeMutationSummaryUnitIds(summary: TestResultsMutationSummary): void {
+    summary.addedUnitIds = Array.from(new Set(summary.addedUnitIds));
+    summary.changedUnitIds = Array.from(new Set(summary.changedUnitIds));
+    summary.skippedExistingUnitIds = Array.from(new Set(summary.skippedExistingUnitIds || []));
+  }
+
+  private countUnitResponses(unit: TcMergeUnit): number {
+    return (unit.subforms || []).reduce(
+      (count, subform) => count + (subform.responses?.length || 0),
+      0
+    );
   }
 
   /**

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
@@ -900,6 +900,105 @@ test-group;test-user;code;booklet1;unit1;[];""`;
       expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
     });
 
+    it('should report response skip mode counts without treating skipped units as mutations', async () => {
+      const fileContent = `groupname;loginname;code;bookletname;unitname;responses;laststate
+test-group;test-user;code;booklet1;unit1;[];""`;
+
+      const filePath = path.join(os.tmpdir(), 'test-response-skip-summary.csv');
+      fs.writeFileSync(filePath, fileContent);
+
+      const person = {
+        workspace_id: 1,
+        group: 'test-group',
+        login: 'test-user',
+        code: 'code',
+        booklets: []
+      };
+      const personWithBooklets = {
+        ...person,
+        booklets: [
+          {
+            id: 'booklet1',
+            logs: [],
+            units: [],
+            sessions: []
+          }
+        ]
+      };
+      const personWithUnits = {
+        ...personWithBooklets,
+        booklets: [
+          {
+            id: 'booklet1',
+            logs: [],
+            sessions: [],
+            units: [
+              {
+                id: 'unit1',
+                alias: 'unit1',
+                laststate: [],
+                chunks: [],
+                subforms: [],
+                logs: []
+              }
+            ]
+          }
+        ]
+      };
+      jest.spyOn(personService, 'createPersonList').mockResolvedValue([person]);
+      jest.spyOn(personService, 'assignBookletsToPerson').mockResolvedValue(personWithBooklets);
+      jest.spyOn(personService, 'assignUnitsToBookletAndPerson').mockResolvedValue(personWithUnits);
+      jest.spyOn(personService, 'processPersonBooklets').mockResolvedValue({
+        addedUnitIds: [],
+        changedUnitIds: [],
+        skippedExistingUnitIds: [40],
+        addedResponseCount: 0,
+        changedResponseCount: 0,
+        savedResponseCount: 0,
+        deletedResponseCount: 0,
+        skippedExistingResponseCount: 2
+      });
+
+      const file: FileIo = {
+        buffer: Buffer.from(fileContent),
+        originalname: 'test.csv',
+        mimetype: 'text/csv',
+        size: fileContent.length,
+        fieldname: 'file',
+        encoding: 'utf-8',
+        path: filePath
+      };
+
+      const result = await service.processUpload(createMock<Job<TestResultsUploadJobData>>({
+        id: '1',
+        data: {
+          workspaceId: 1,
+          file,
+          resultType: 'responses',
+          overwriteMode: 'skip',
+          scope: 'person'
+        }
+      }));
+
+      expect(personService.processPersonBooklets).toHaveBeenCalledWith(
+        [personWithUnits],
+        1,
+        'skip',
+        'person'
+      );
+      expect(result.importSummary).toMatchObject({
+        totalRows: 1,
+        responseRows: 1,
+        overwriteMode: 'skip',
+        scope: 'person',
+        savedResponses: 0,
+        skippedExistingUnits: 1,
+        skippedExistingResponses: 2
+      });
+      expect(codingAnalysisService.invalidateCache).not.toHaveBeenCalled();
+      expect(workspaceTestResultsService.invalidateCodingStatisticsCache).not.toHaveBeenCalled();
+    });
+
     it('should invalidate response-analysis and coding-statistics caches after a post-write freshness failure', async () => {
       const fileContent = `groupname;loginname;code;bookletname;unitname;responses;laststate
 test-group;test-user;code;booklet1;unit1;[];""`;

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.ts
@@ -35,6 +35,12 @@ type UploadSummaryAccumulator = {
   logRows: number;
   bookletLogRows: number;
   unitLogRows: number;
+  savedResponses: number;
+  deletedResponses: number;
+  skippedExistingUnitIds: Set<number>;
+  skippedExistingResponses: number;
+  addedUnitIds: Set<number>;
+  changedUnitIds: Set<number>;
   savedLogs: number;
   skippedRows: number;
   skippedLogs: number;
@@ -158,6 +164,12 @@ export class UploadResultsService {
       logRows: 0,
       bookletLogRows: 0,
       unitLogRows: 0,
+      savedResponses: 0,
+      deletedResponses: 0,
+      skippedExistingUnitIds: new Set<number>(),
+      skippedExistingResponses: 0,
+      addedUnitIds: new Set<number>(),
+      changedUnitIds: new Set<number>(),
       savedLogs: 0,
       skippedRows: 0,
       skippedLogs: 0
@@ -315,11 +327,22 @@ export class UploadResultsService {
   private buildImportSummary(
     resultType: 'logs' | 'responses',
     summary: UploadSummaryAccumulator,
-    issues: TestResultsUploadIssueDto[]
+    issues: TestResultsUploadIssueDto[],
+    overwriteMode: 'skip' | 'merge' | 'replace' = 'skip',
+    scope: 'person' | 'workspace' | 'group' | 'booklet' | 'unit' | 'response' = 'person'
   ): TestResultsUploadSummaryDto | undefined {
     const issueCounts = this.countIssues(issues);
+    const hasResponseSummary = resultType === 'responses' && (
+      summary.responseRows > 0 ||
+      summary.savedResponses > 0 ||
+      summary.deletedResponses > 0 ||
+      summary.skippedExistingUnitIds.size > 0 ||
+      summary.skippedExistingResponses > 0 ||
+      summary.addedUnitIds.size > 0 ||
+      summary.changedUnitIds.size > 0
+    );
 
-    if (summary.totalRows === 0 && !issueCounts) {
+    if (summary.totalRows === 0 && !issueCounts && !hasResponseSummary) {
       return undefined;
     }
 
@@ -342,7 +365,17 @@ export class UploadResultsService {
 
     return {
       ...baseSummary,
-      responseRows: summary.responseRows
+      overwriteMode,
+      scope,
+      responseRows: summary.responseRows,
+      savedResponses: summary.savedResponses,
+      deletedResponses: summary.deletedResponses || undefined,
+      skippedExistingUnits: overwriteMode === 'skip' ?
+        summary.skippedExistingUnitIds.size :
+        undefined,
+      skippedExistingResponses: summary.skippedExistingResponses || undefined,
+      addedUnits: summary.addedUnitIds.size || undefined,
+      changedUnits: summary.changedUnitIds.size || undefined
     };
   }
 
@@ -692,9 +725,23 @@ export class UploadResultsService {
                   workspaceId,
                   overwriteMode,
                   scope === 'workspace' ? 'workspace' : 'person'
-                );
+                ) || {
+                  addedUnitIds: [],
+                  changedUnitIds: [],
+                  addedResponseCount: 0,
+                  changedResponseCount: 0
+                };
                 responsesImportMutatedData = responsesImportMutatedData ||
                   this.responseImportMutatedTestResults(mutationSummary);
+                importSummaryAgg.savedResponses += mutationSummary.savedResponseCount || 0;
+                importSummaryAgg.deletedResponses += mutationSummary.deletedResponseCount || 0;
+                importSummaryAgg.skippedExistingResponses += mutationSummary.skippedExistingResponseCount || 0;
+                (mutationSummary.skippedExistingUnitIds || [])
+                  .forEach(unitId => importSummaryAgg.skippedExistingUnitIds.add(unitId));
+                (mutationSummary.addedUnitIds || [])
+                  .forEach(unitId => importSummaryAgg.addedUnitIds.add(unitId));
+                (mutationSummary.changedUnitIds || [])
+                  .forEach(unitId => importSummaryAgg.changedUnitIds.add(unitId));
                 await this.codingFreshnessService?.markUnitsPendingAfterImport(
                   workspaceId,
                   mutationSummary.addedUnitIds,
@@ -792,7 +839,7 @@ export class UploadResultsService {
       delta,
       responseStatusCounts: Object.keys(statusCounts).length ? statusCounts : undefined,
       issues: issues.length ? issues : undefined,
-      importSummary: this.buildImportSummary(resultType, importSummaryAgg, issues),
+      importSummary: this.buildImportSummary(resultType, importSummaryAgg, issues, overwriteMode, scope),
       logMetrics,
       importedLogs: resultType === 'logs',
       importedResponses: resultType === 'responses',

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-upload-options-dialog.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-upload-options-dialog.component.html
@@ -86,7 +86,7 @@
   <div class="help">
     <div class="help-row">
       <div class="mode">skip</div>
-      <div class="desc">Wenn ein Eintrag bereits existiert, wird er nicht verändert und der Upload-Teil wird übersprungen.</div>
+      <div class="desc">Wenn eine Unit bereits existiert, wird diese Unit vollständig übersprungen. Es werden keine neuen Antwortwerte in diese Unit gemerged.</div>
     </div>
     <div class="help-row">
       <div class="mode">merge</div>

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-upload-result-dialog.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-upload-result-dialog.component.html
@@ -74,6 +74,22 @@
         <div class="k">Antwort-Zeilen in der Datei</div>
         <div class="v">{{ result.importSummary.responseRows | number:'1.0-0' }}</div>
         }
+        @if (result.importSummary.savedResponses !== undefined) {
+        <div class="k">Antwortwerte gespeichert</div>
+        <div class="v">{{ result.importSummary.savedResponses | number:'1.0-0' }}</div>
+        }
+        @if (result.importSummary.skippedExistingUnits !== undefined) {
+        <div class="k">Vorhandene Units übersprungen</div>
+        <div class="v">{{ result.importSummary.skippedExistingUnits | number:'1.0-0' }}</div>
+        }
+        @if (result.importSummary.skippedExistingResponses !== undefined) {
+        <div class="k">Antwortwerte wegen bestehender Daten nicht gemerged</div>
+        <div class="v">{{ result.importSummary.skippedExistingResponses | number:'1.0-0' }}</div>
+        }
+        @if (result.importSummary.deletedResponses !== undefined) {
+        <div class="k">Antwortwerte ersetzt/gelöscht</div>
+        <div class="v">{{ result.importSummary.deletedResponses | number:'1.0-0' }}</div>
+        }
         @if (result.importSummary.bookletLogRows !== undefined) {
         <div class="k">Testheft-Log-Zeilen in der Datei</div>
         <div class="v">{{ result.importSummary.bookletLogRows | number:'1.0-0' }}</div>
@@ -99,6 +115,11 @@
       <div class="summary-note">
         Antwort-Zeilen und Antwortwerte zählen unterschiedliche Dinge: Eine Antwort-Zeile kann mehrere
         Antwortwerte enthalten.
+      </div>
+      }
+      @if (responseImportModeSummary) {
+      <div class="summary-note">
+        {{ responseImportModeSummary }}
       </div>
       }
       @if (issueSummaryEntries.length > 0) {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-upload-result-dialog.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-upload-result-dialog.component.spec.ts
@@ -235,6 +235,41 @@ describe('TestResultsUploadResultDialogComponent', () => {
     );
   });
 
+  it('explains response skip mode and exposes skipped unit counts', () => {
+    component.data = {
+      ...data,
+      result: {
+        ...data.result,
+        issues: undefined,
+        codingFreshness: undefined,
+        importSummary: {
+          totalRows: 1,
+          responseRows: 1,
+          overwriteMode: 'skip',
+          scope: 'person',
+          savedResponses: 0,
+          skippedExistingUnits: 1,
+          skippedExistingResponses: 2
+        }
+      } as never
+    };
+
+    expect(component.importOutcomeMetrics).toEqual([
+      { label: 'Testpersonen', value: 1 },
+      { label: 'Testhefte', value: 1 },
+      { label: 'Aufgaben-IDs', value: 1 },
+      { label: 'Antwortwerte', value: 3 },
+      { label: 'gespeicherte Antwortwerte', value: 0 },
+      { label: 'übersprungene vorhandene Units', value: 1 },
+      { label: 'nicht gemergte Antwortwerte', value: 2 }
+    ]);
+    expect(component.responseImportModeSummary).toBe(
+      'Skip-Modus: 1 vorhandene Unit wurde vollständig übersprungen. ' +
+      '2 Antwortwerte daraus wurden nicht in diese Unit gemerged. ' +
+      '0 neue Antwortwerte wurden gespeichert.'
+    );
+  });
+
   it('ignores zero-count coding freshness rows', () => {
     component.data = {
       resultType: 'responses',

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-upload-result-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-upload-result-dialog.component.ts
@@ -261,6 +261,27 @@ export class TestResultsUploadResultDialogComponent {
       );
     }
 
+    if (this.result.importedResponses && this.result.importSummary) {
+      if (this.result.importSummary.savedResponses !== undefined) {
+        metrics.push({
+          label: 'gespeicherte Antwortwerte',
+          value: this.result.importSummary.savedResponses
+        });
+      }
+      if (this.result.importSummary.skippedExistingUnits !== undefined) {
+        metrics.push({
+          label: 'übersprungene vorhandene Units',
+          value: this.result.importSummary.skippedExistingUnits
+        });
+      }
+      if (this.result.importSummary.skippedExistingResponses !== undefined) {
+        metrics.push({
+          label: 'nicht gemergte Antwortwerte',
+          value: this.result.importSummary.skippedExistingResponses
+        });
+      }
+    }
+
     if (this.result.importedLogs && this.result.importSummary) {
       metrics.push(
         { label: 'Log-Zeilen', value: this.result.importSummary.logRows ?? 0 },
@@ -277,6 +298,33 @@ export class TestResultsUploadResultDialogComponent {
     return !!this.result.importedResponses &&
       responseRows !== undefined &&
       responseRows !== this.result.expected.uniqueResponses;
+  }
+
+  get responseImportModeSummary(): string | null {
+    const summary = this.result.importSummary;
+    if (!this.result.importedResponses || !summary?.overwriteMode) {
+      return null;
+    }
+
+    if (summary.overwriteMode === 'skip') {
+      const skippedUnits = summary.skippedExistingUnits ?? 0;
+      const skippedResponses = summary.skippedExistingResponses ?? 0;
+      const savedResponses = summary.savedResponses ?? 0;
+
+      if (skippedUnits > 0 || skippedResponses > 0) {
+        return `Skip-Modus: ${this.formatCount(skippedUnits, 'vorhandene Unit wurde', 'vorhandene Units wurden')} vollständig übersprungen. ` +
+          `${this.formatCount(skippedResponses, 'Antwortwert daraus wurde', 'Antwortwerte daraus wurden')} nicht in diese Unit gemerged. ` +
+          `${this.formatCount(savedResponses, 'neuer Antwortwert wurde', 'neue Antwortwerte wurden')} gespeichert.`;
+      }
+
+      return 'Skip-Modus: Vorhandene Units bleiben vollständig unverändert. In diesem Import wurde keine vorhandene Unit getroffen.';
+    }
+
+    if (summary.overwriteMode === 'merge') {
+      return 'Merge-Modus: Fehlende Antwortwerte wurden ergänzt; vorhandene Antwortwerte blieben unverändert.';
+    }
+
+    return 'Replace-Modus: Bestehende Antwortwerte im betroffenen Bereich wurden ersetzt.';
   }
 
   get statusCounts(): Array<{ status: string; count: number }> {

--- a/apps/frontend/src/app/ws-admin/services/test-results-upload-state.service.spec.ts
+++ b/apps/frontend/src/app/ws-admin/services/test-results-upload-state.service.spec.ts
@@ -767,4 +767,47 @@ describe('TestResultsUploadStateService', () => {
 
     discardPeriodicTasks();
   }));
+
+  it('should merge response import mode counters across completed jobs', () => {
+    service = TestBed.inject(TestResultsUploadStateService);
+
+    const result = (service as unknown as {
+      mergeImportSummaries: (
+        results: Array<{ importSummary?: unknown }>
+      ) => unknown;
+    }).mergeImportSummaries([
+      {
+        importSummary: {
+          totalRows: 1,
+          responseRows: 1,
+          overwriteMode: 'skip',
+          scope: 'person',
+          savedResponses: 0,
+          skippedExistingUnits: 1,
+          skippedExistingResponses: 2
+        }
+      },
+      {
+        importSummary: {
+          totalRows: 2,
+          responseRows: 2,
+          overwriteMode: 'skip',
+          scope: 'person',
+          savedResponses: 1,
+          skippedExistingUnits: 2,
+          skippedExistingResponses: 3
+        }
+      }
+    ]);
+
+    expect(result).toMatchObject({
+      totalRows: 3,
+      responseRows: 3,
+      overwriteMode: 'skip',
+      scope: 'person',
+      savedResponses: 1,
+      skippedExistingUnits: 3,
+      skippedExistingResponses: 5
+    });
+  });
 });

--- a/apps/frontend/src/app/ws-admin/services/test-results-upload-state.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/test-results-upload-state.service.ts
@@ -57,6 +57,12 @@ type ImportSummaryNumberKey =
   | 'logRows'
   | 'bookletLogRows'
   | 'unitLogRows'
+  | 'savedResponses'
+  | 'deletedResponses'
+  | 'skippedExistingUnits'
+  | 'skippedExistingResponses'
+  | 'addedUnits'
+  | 'changedUnits'
   | 'savedLogs'
   | 'skippedRows'
   | 'skippedLogs';
@@ -897,10 +903,18 @@ export class TestResultsUploadStateService {
 
     return {
       totalRows: summaries.reduce((sum, summary) => sum + Number(summary.totalRows || 0), 0),
+      overwriteMode: this.mergeSingleValue(summaries, 'overwriteMode'),
+      scope: this.mergeSingleValue(summaries, 'scope'),
       responseRows: this.sumOptional(summaries, 'responseRows'),
       logRows: this.sumOptional(summaries, 'logRows'),
       bookletLogRows: this.sumOptional(summaries, 'bookletLogRows'),
       unitLogRows: this.sumOptional(summaries, 'unitLogRows'),
+      savedResponses: this.sumOptional(summaries, 'savedResponses'),
+      deletedResponses: this.sumOptional(summaries, 'deletedResponses'),
+      skippedExistingUnits: this.sumOptional(summaries, 'skippedExistingUnits'),
+      skippedExistingResponses: this.sumOptional(summaries, 'skippedExistingResponses'),
+      addedUnits: this.sumOptional(summaries, 'addedUnits'),
+      changedUnits: this.sumOptional(summaries, 'changedUnits'),
       savedLogs: this.sumOptional(summaries, 'savedLogs'),
       skippedRows: this.sumOptional(summaries, 'skippedRows'),
       skippedLogs: this.sumOptional(summaries, 'skippedLogs'),
@@ -917,6 +931,21 @@ export class TestResultsUploadStateService {
     const hasValue = summaries.some(summary => summary[key] !== undefined);
     if (!hasValue) return undefined;
     return summaries.reduce((sum, summary) => sum + Number(summary[key] || 0), 0);
+  }
+
+  private mergeSingleValue<
+    K extends 'overwriteMode' | 'scope'
+  >(
+    summaries: NonNullable<TestResultsUploadResultDto['importSummary']>[],
+    key: K
+  ): NonNullable<TestResultsUploadResultDto['importSummary']>[K] | undefined {
+    const values = Array.from(new Set(
+      summaries
+        .map(summary => summary[key])
+        .filter((value): value is NonNullable<NonNullable<TestResultsUploadResultDto['importSummary']>[K]> => !!value)
+    ));
+
+    return values.length === 1 ? values[0] : undefined;
   }
 
   private mergeLogMetrics(


### PR DESCRIPTION
## Summary

Fixes #538.

- keep existing Units fully unchanged in response import skip mode
- report saved/skipped/deleted response counters in upload summaries
- make the upload options and result dialog explicit about skip-vs-merge behavior
- keep merged multi-job summaries aligned for the new response import counters

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts --runInBand`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/ws-admin/components/test-results/test-results-upload-result-dialog.component.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/ws-admin/services/test-results-upload-state.service.spec.ts --runInBand`
- `npx nx lint backend`
- `npx nx lint frontend`
- Manual DB/browser smoke: chunked response upload against Docker dev stack in workspace 48 confirmed repeat skip import keeps `VAR_SCORE = initial-538` and does not add `VAR_EXTRA`; browser overview still shows 1 response.
