### PR TITLE
Fix merge import for new units

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.spec.ts
@@ -670,6 +670,63 @@ describe('CodingFreshnessService', () => {
     );
   });
 
+  it('marks newly imported responses in existing units as RESULT_ADDED', async () => {
+    (connection.query as jest.Mock)
+      .mockResolvedValueOnce([{ revision: 9 }])
+      .mockResolvedValueOnce({});
+
+    const importedResponsesQb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([
+        { responseId: '100', unitId: '10' },
+        { responseId: '101', unitId: '10' },
+        { responseId: '102', unitId: '20' }
+      ])
+    });
+    const workspacePresenceQb = queryBuilder({
+      getRawOne: jest.fn().mockResolvedValue({ v1: true, v2: false, v3: true })
+    });
+    (responseRepository.createQueryBuilder as jest.Mock)
+      .mockReturnValueOnce(importedResponsesQb)
+      .mockReturnValueOnce(workspacePresenceQb);
+
+    await service.markResponsesPendingAfterImport(1, [100, 101, 102, 100, -1]);
+
+    expect(freshnessRepository.upsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          unit_id: 10,
+          version: 'v1',
+          state: 'PENDING',
+          reason: 'RESULT_ADDED',
+          affected_response_count: 2,
+          source_revision: 9
+        }),
+        expect.objectContaining({
+          unit_id: 10,
+          version: 'v3',
+          state: 'PENDING',
+          reason: 'RESULT_ADDED',
+          affected_response_count: 2,
+          source_revision: 9
+        }),
+        expect.objectContaining({
+          unit_id: 20,
+          version: 'v1',
+          state: 'PENDING',
+          reason: 'RESULT_ADDED',
+          affected_response_count: 1,
+          source_revision: 9
+        })
+      ]),
+      ['workspace_id', 'unit_id', 'version']
+    );
+    expect((freshnessRepository.upsert as jest.Mock).mock.calls[0][0]).toHaveLength(4);
+    expect(connection.query).toHaveBeenCalledWith(
+      expect.stringContaining('response.id = ANY($2::int[])'),
+      [1, [100, 101, 102], 'stale_source', 'RESULT_ADDED']
+    );
+  });
+
   it('blocks the second auto-coding run when auto-coding 1 has not run yet', async () => {
     const workspacePresenceQb = queryBuilder({
       getRawOne: jest.fn().mockResolvedValue({ v1: false, v2: false, v3: false })

--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
@@ -50,6 +50,11 @@ type FreshnessScopeRow = {
   affectedResponseCount: string;
 };
 
+type ImportedResponseScopeRow = {
+  responseId: string;
+  unitId: string;
+};
+
 type DeleteImpactRow = {
   affectedUnits: string;
   autoCodingV1: string;
@@ -338,6 +343,45 @@ export class CodingFreshnessService {
     await this.markCodingJobsStaleForAddedUnitIds(
       workspaceId,
       ids,
+      'RESULT_ADDED',
+      'stale_source'
+    );
+  }
+
+  async markResponsesPendingAfterImport(
+    workspaceId: number,
+    responseIds: number[]
+  ): Promise<void> {
+    const responseIdsByUnit = await this.getImportedResponseIdsByUnit(
+      workspaceId,
+      responseIds
+    );
+    const unitIds = Array.from(responseIdsByUnit.keys());
+    if (unitIds.length === 0) {
+      return;
+    }
+
+    const revision = await this.incrementRevision(workspaceId);
+    const workspacePresence = await this.getWorkspaceCodingPresence(workspaceId);
+    const rows: FreshnessUpsert[] = [];
+
+    this.getAutoCodingVersionsToRefresh(workspacePresence).forEach(version => {
+      unitIds.forEach(unitId => rows.push(this.buildRow(
+        workspaceId,
+        unitId,
+        version,
+        'PENDING',
+        'RESULT_ADDED',
+        responseIdsByUnit.get(unitId)?.length || 0,
+        revision,
+        null
+      )));
+    });
+
+    await this.upsertRows(rows);
+    await this.markCodingJobsStaleForAddedResponseIds(
+      workspaceId,
+      Array.from(responseIdsByUnit.values()).flat(),
       'RESULT_ADDED',
       'stale_source'
     );
@@ -1057,6 +1101,103 @@ export class CodingFreshnessService {
     );
   }
 
+  private async markCodingJobsStaleForAddedResponseIds(
+    workspaceId: number,
+    responseIds: number[],
+    reason: Extract<CodingFreshnessReason, 'RESULT_ADDED'>,
+    status: Exclude<CodingJobFreshnessStatus, 'current'> = 'stale_source'
+  ): Promise<void> {
+    const ids = this.uniquePositiveIds(responseIds);
+    if (ids.length === 0) {
+      return;
+    }
+
+    await this.connection.query(
+      `
+        WITH added_responses AS (
+          SELECT
+            response.id AS response_id,
+            unit.name AS unit_name,
+            response.variableid AS variable_id,
+            CONCAT_WS('|', person.login, COALESCE(bookletinfo.name, ''), unit.name) AS unit_key
+          FROM response
+          INNER JOIN unit ON unit.id = response.unitid
+          INNER JOIN booklet ON booklet.id = unit.bookletid
+          LEFT JOIN bookletinfo ON bookletinfo.id = booklet.infoid
+          INNER JOIN persons person ON person.id = booklet.personid
+          WHERE person.workspace_id = $1
+            AND person.consider = true
+            AND response.id = ANY($2::int[])
+            AND response.is_autocoder_generated IS NOT TRUE
+        ),
+        matched_job_responses AS (
+          SELECT
+            coding_job.id AS coding_job_id,
+            added_responses.unit_key,
+            added_responses.response_id
+          FROM added_responses
+          INNER JOIN coding_job_variable
+            ON coding_job_variable.unit_name = added_responses.unit_name
+            AND coding_job_variable.variable_id = added_responses.variable_id
+          INNER JOIN coding_job
+            ON coding_job.id = coding_job_variable.coding_job_id
+          WHERE coding_job.workspace_id = $1
+            AND coding_job.training_id IS NULL
+          UNION
+          SELECT
+            coding_job.id AS coding_job_id,
+            added_responses.unit_key,
+            added_responses.response_id
+          FROM added_responses
+          INNER JOIN variable_bundle
+            ON variable_bundle.workspace_id = $1
+            AND variable_bundle.variables @> jsonb_build_array(
+              jsonb_build_object(
+                'unitName', added_responses.unit_name,
+                'variableId', added_responses.variable_id
+              )
+            )
+          INNER JOIN coding_job_variable_bundle
+            ON coding_job_variable_bundle.variable_bundle_id = variable_bundle.id
+          INNER JOIN coding_job
+            ON coding_job.id = coding_job_variable_bundle.coding_job_id
+          WHERE coding_job.workspace_id = $1
+            AND coding_job.training_id IS NULL
+        ),
+        affected_jobs AS (
+          SELECT
+            coding_job_id,
+            COUNT(DISTINCT unit_key) AS affected_units,
+            COUNT(DISTINCT response_id) AS affected_responses
+          FROM matched_job_responses
+          GROUP BY coding_job_id
+        )
+        UPDATE coding_job
+        SET freshness_status = CASE
+              WHEN $3 = 'stale_source' OR coding_job.freshness_status = 'stale_source'
+                THEN 'stale_source'
+              WHEN coding_job.freshness_status = 'review_required' OR $3 = 'review_required'
+                THEN 'review_required'
+              ELSE $3
+            END,
+            freshness_reason = $4,
+            freshness_updated_at = now(),
+            freshness_affected_units = GREATEST(
+              COALESCE(coding_job.freshness_affected_units, 0),
+              affected_jobs.affected_units::int
+            ),
+            freshness_affected_responses = GREATEST(
+              COALESCE(coding_job.freshness_affected_responses, 0),
+              affected_jobs.affected_responses::int
+            ),
+            updated_at = now()
+        FROM affected_jobs
+        WHERE coding_job.id = affected_jobs.coding_job_id
+      `,
+      [workspaceId, ids, status, reason]
+    );
+  }
+
   private async getUnitIdsForResponseIds(
     workspaceId: number,
     responseIds: number[],
@@ -1432,6 +1573,50 @@ export class CodingFreshnessService {
     }));
 
     return presenceByUnit;
+  }
+
+  private async getImportedResponseIdsByUnit(
+    workspaceId: number,
+    responseIds: number[]
+  ): Promise<Map<number, number[]>> {
+    const ids = this.uniquePositiveIds(responseIds);
+    const responseIdsByUnit = new Map<number, number[]>();
+    if (ids.length === 0) {
+      return responseIdsByUnit;
+    }
+
+    const query = this.responseRepository
+      .createQueryBuilder('response')
+      .select('response.id', 'responseId')
+      .addSelect('response.unitid', 'unitId')
+      .innerJoin('response.unit', 'unit')
+      .innerJoin('unit.booklet', 'booklet')
+      .innerJoin('booklet.bookletinfo', 'bookletinfo')
+      .innerJoin('booklet.person', 'person')
+      .where('person.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('person.consider = :consider', { consider: true })
+      .andWhere('response.id IN (:...responseIds)', { responseIds: ids })
+      .andWhere('response.is_autocoder_generated IS NOT TRUE');
+
+    await this.applyWorkspaceExclusions(workspaceId, query);
+
+    const rows = await query.getRawMany<ImportedResponseScopeRow>();
+    rows.forEach(row => {
+      const unitId = Number(row.unitId);
+      const responseId = Number(row.responseId);
+      if (!Number.isInteger(unitId) || unitId <= 0 || !Number.isInteger(responseId) || responseId <= 0) {
+        return;
+      }
+      const existing = responseIdsByUnit.get(unitId) || [];
+      existing.push(responseId);
+      responseIdsByUnit.set(unitId, existing);
+    });
+
+    responseIdsByUnit.forEach((unitResponseIds, unitId) => {
+      responseIdsByUnit.set(unitId, this.uniquePositiveIds(unitResponseIds));
+    });
+
+    return responseIdsByUnit;
   }
 
   private async getResponseCountsByUnit(

--- a/apps/backend/src/app/database/services/test-results/person-persistence.postgres.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/person-persistence.postgres.spec.ts
@@ -1,0 +1,236 @@
+import { DataSource, Repository } from 'typeorm';
+import { PersonPersistenceService } from './person-persistence.service';
+import Persons from '../../entities/persons.entity';
+import { Booklet } from '../../entities/booklet.entity';
+import { Unit } from '../../entities/unit.entity';
+import { UnitLastState } from '../../entities/unitLastState.entity';
+import { BookletInfo } from '../../entities/bookletInfo.entity';
+import { ResponseEntity } from '../../entities/response.entity';
+import { ChunkEntity } from '../../entities/chunk.entity';
+import { BookletLog } from '../../entities/bookletLog.entity';
+import { Session } from '../../entities/session.entity';
+import { UnitLog } from '../../entities/unitLog.entity';
+import { UnitTag } from '../../entities/unitTag.entity';
+import { UnitNote } from '../../entities/unitNote.entity';
+import { Person } from '../shared';
+
+// Opt-in: set POSTGRES_INTEGRATION_TESTS=true and POSTGRES_* if the local
+// development defaults below do not match the target database.
+const describePostgres = process.env.POSTGRES_INTEGRATION_TESTS === 'true' ?
+  describe :
+  describe.skip;
+
+const postgresConfig = {
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: Number(process.env.POSTGRES_PORT || 5432),
+  username: process.env.POSTGRES_USER || 'root',
+  password: process.env.POSTGRES_PASSWORD || 'root-password',
+  database: process.env.POSTGRES_DB || 'coding-box'
+};
+
+describePostgres('PersonPersistenceService Postgres integration', () => {
+  let dataSource: DataSource;
+  let service: PersonPersistenceService;
+  let personsRepository: Repository<Persons>;
+  let bookletInfoRepository: Repository<BookletInfo>;
+  let bookletRepository: Repository<Booklet>;
+  let unitRepository: Repository<Unit>;
+  let responseRepository: Repository<ResponseEntity>;
+  let cleanupPersonIds: number[] = [];
+  let cleanupBookletInfoIds: number[] = [];
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'postgres',
+      ...postgresConfig,
+      entities: [
+        Persons,
+        BookletInfo,
+        Booklet,
+        Session,
+        BookletLog,
+        Unit,
+        UnitLog,
+        UnitLastState,
+        ChunkEntity,
+        ResponseEntity,
+        UnitTag,
+        UnitNote
+      ],
+      synchronize: false
+    });
+
+    await dataSource.initialize();
+
+    personsRepository = dataSource.getRepository(Persons);
+    bookletRepository = dataSource.getRepository(Booklet);
+    unitRepository = dataSource.getRepository(Unit);
+    responseRepository = dataSource.getRepository(ResponseEntity);
+    bookletInfoRepository = dataSource.getRepository(BookletInfo);
+
+    service = new PersonPersistenceService(
+      personsRepository,
+      bookletRepository,
+      unitRepository,
+      dataSource.getRepository(UnitLastState),
+      bookletInfoRepository,
+      responseRepository,
+      dataSource.getRepository(ChunkEntity),
+      dataSource.getRepository(BookletLog),
+      dataSource.getRepository(Session),
+      dataSource.getRepository(UnitLog)
+    );
+  }, 30000);
+
+  afterEach(async () => {
+    for (const personId of cleanupPersonIds) {
+      await personsRepository.delete({ id: personId });
+    }
+
+    for (const bookletInfoId of cleanupBookletInfoIds) {
+      await bookletInfoRepository.delete({ id: bookletInfoId });
+    }
+
+    cleanupPersonIds = [];
+    cleanupBookletInfoIds = [];
+  });
+
+  afterAll(async () => {
+    await dataSource?.destroy();
+  });
+
+  it('persists a merge upload with a new unit against the real Postgres schema', async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const workspaceId = 900000000 + Math.floor(Math.random() * 1000000);
+    const bookletName = `booklet-merge-${suffix}`;
+    const group = `group-${suffix}`;
+    const login = `login-${suffix}`;
+    const code = `code-${suffix}`;
+
+    const person = await personsRepository.save({
+      workspace_id: workspaceId,
+      group,
+      login,
+      code,
+      booklets: []
+    } as Persons);
+    cleanupPersonIds.push(person.id);
+
+    const bookletInfo = await bookletInfoRepository.save({
+      name: bookletName,
+      size: 0
+    } as BookletInfo);
+    cleanupBookletInfoIds.push(bookletInfo.id);
+
+    const booklet = await bookletRepository.save({
+      personid: person.id,
+      infoid: bookletInfo.id,
+      firstts: 1,
+      lastts: 1
+    } as Booklet);
+    const existingUnit = await unitRepository.save({
+      bookletid: booklet.id,
+      name: 'UNIT_EXISTING',
+      alias: 'UNIT_EXISTING'
+    } as Unit);
+    const existingResponse = await responseRepository.save({
+      unitid: existingUnit.id,
+      variableid: 'VAR_EXISTING',
+      status: 3,
+      value: 'existing-answer',
+      subform: ''
+    } as ResponseEntity);
+
+    const importedPerson: Person = {
+      workspace_id: workspaceId,
+      group,
+      login,
+      code,
+      booklets: [
+        {
+          id: bookletName,
+          logs: [],
+          sessions: [],
+          units: [
+            {
+              id: 'UNIT_NEW',
+              alias: 'UNIT_NEW_ORIGINAL',
+              laststate: [{ key: 'unitState', value: 'new' }],
+              chunks: [
+                {
+                  id: 'chunk-1',
+                  type: 'state',
+                  ts: 123,
+                  variables: ['VAR_NEW']
+                }
+              ],
+              subforms: [
+                {
+                  id: '',
+                  responses: [
+                    {
+                      id: 'VAR_NEW',
+                      status: 'VALUE_CHANGED',
+                      value: 'new-answer'
+                    }
+                  ]
+                }
+              ],
+              logs: []
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = await service.processPersonBooklets(
+      [importedPerson],
+      workspaceId,
+      'merge',
+      'person'
+    );
+
+    const units = await unitRepository.find({
+      where: { bookletid: booklet.id },
+      order: { id: 'ASC' }
+    });
+    const newUnit = units.find(unit => unit.name === 'UNIT_NEW');
+    const unchangedResponse = await responseRepository.findOneOrFail({
+      where: { id: existingResponse.id }
+    });
+    const newResponses = await responseRepository.find({
+      where: { unitid: newUnit?.id },
+      order: { id: 'ASC' }
+    });
+
+    expect(newUnit).toMatchObject({
+      bookletid: booklet.id,
+      name: 'UNIT_NEW',
+      alias: 'UNIT_NEW_ORIGINAL'
+    });
+    expect(unchangedResponse).toMatchObject({
+      unitid: existingUnit.id,
+      variableid: 'VAR_EXISTING',
+      value: 'existing-answer'
+    });
+    expect(newResponses).toEqual([
+      expect.objectContaining({
+        unitid: newUnit?.id,
+        variableid: 'VAR_NEW',
+        status: 3,
+        value: 'new-answer',
+        subform: ''
+      })
+    ]);
+    expect(result).toMatchObject({
+      addedUnitIds: [newUnit?.id],
+      changedUnitIds: [],
+      skippedExistingUnitIds: [],
+      addedResponseCount: 1,
+      changedResponseCount: 0,
+      savedResponseCount: 1,
+      deletedResponseCount: 0,
+      skippedExistingResponseCount: 0
+    });
+  }, 30000);
+});

--- a/apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts
@@ -565,6 +565,78 @@ describe('PersonPersistenceService', () => {
     });
   });
 
+  it('adds a new unit for an existing person/booklet in merge mode without replacing existing data', async () => {
+    jest.spyOn(bookletInfoRepository, 'findOne').mockResolvedValue({ id: 20, name: 'BOOKLET_1' } as BookletInfo);
+    jest.spyOn(bookletRepository, 'findOne').mockResolvedValue({ id: 30, personid: 10, infoid: 20 } as Booklet);
+    const unitFindSpy = jest.spyOn(unitRepository, 'findOne').mockResolvedValue(null);
+    jest.spyOn(unitRepository, 'save').mockResolvedValue({
+      id: 99, name: 'UNIT_NEW', alias: 'UNIT_NEW', bookletid: 30
+    } as Unit);
+    jest.spyOn(responseRepository, 'find').mockResolvedValue([]);
+    jest.spyOn(responseRepository, 'save').mockResolvedValue([] as never);
+
+    const result = await service.processBookletWithTransaction(
+      {
+        id: 'BOOKLET_1',
+        logs: [],
+        sessions: [],
+        units: [
+          {
+            id: 'UNIT_NEW',
+            alias: 'UNIT_NEW',
+            laststate: [],
+            chunks: [],
+            subforms: [
+              {
+                id: '',
+                responses: [
+                  {
+                    id: 'VAR_1',
+                    status: 'VALUE_CHANGED',
+                    value: 'answer'
+                  }
+                ]
+              }
+            ],
+            logs: []
+          }
+        ]
+      },
+      {
+        id: 10, group: 'G', login: 'L', code: 'C', workspace_id: 1
+      } as Persons,
+      'merge'
+    );
+
+    expect(unitFindSpy).toHaveBeenCalledWith({
+      where: { alias: 'UNIT_NEW', name: 'UNIT_NEW', bookletid: 30 }
+    });
+    expect(unitRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+      alias: 'UNIT_NEW',
+      name: 'UNIT_NEW',
+      bookletid: 30
+    }));
+    expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
+    expect(responseRepository.save).toHaveBeenCalledWith([
+      expect.objectContaining({
+        unitid: 99,
+        variableid: 'VAR_1',
+        value: 'answer',
+        subform: ''
+      })
+    ]);
+    expect(result).toMatchObject({
+      addedUnitIds: [99],
+      changedUnitIds: [],
+      skippedExistingUnitIds: [],
+      addedResponseCount: 1,
+      changedResponseCount: 0,
+      savedResponseCount: 1,
+      deletedResponseCount: 0,
+      skippedExistingResponseCount: 0
+    });
+  });
+
   it('adds a new variable in an existing unit when upload mode is merge', async () => {
     jest.spyOn(bookletInfoRepository, 'findOne').mockResolvedValue({ id: 20, name: 'BOOKLET_1' } as BookletInfo);
     jest.spyOn(bookletRepository, 'findOne').mockResolvedValue({ id: 30, personid: 10, infoid: 20 } as Booklet);
@@ -574,7 +646,16 @@ describe('PersonPersistenceService', () => {
     jest.spyOn(responseRepository, 'find').mockResolvedValue([
       { variableid: 'VAR_OLD', subform: '' } as ResponseEntity
     ]);
-    jest.spyOn(responseRepository, 'save').mockResolvedValue([] as never);
+    jest.spyOn(responseRepository, 'save').mockResolvedValue([
+      {
+        id: 501,
+        unitid: 40,
+        variableid: 'VAR_NEW',
+        status: 3,
+        value: 'new',
+        subform: ''
+      } as ResponseEntity
+    ] as never);
 
     const result = await service.processBookletWithTransaction(
       {
@@ -626,9 +707,92 @@ describe('PersonPersistenceService', () => {
     ]);
     expect(result).toMatchObject({
       addedUnitIds: [],
-      changedUnitIds: [40],
+      changedUnitIds: [],
+      addedResponseIds: [501],
       addedResponseCount: 0,
-      changedResponseCount: 1,
+      changedResponseCount: 0,
+      savedResponseCount: 1,
+      deletedResponseCount: 0,
+      skippedExistingResponseCount: 1
+    });
+  });
+
+  it('resolves added response ids from the repository when save omits generated ids', async () => {
+    jest.spyOn(bookletInfoRepository, 'findOne').mockResolvedValue({ id: 20, name: 'BOOKLET_1' } as BookletInfo);
+    jest.spyOn(bookletRepository, 'findOne').mockResolvedValue({ id: 30, personid: 10, infoid: 20 } as Booklet);
+    jest.spyOn(unitRepository, 'findOne').mockResolvedValue({
+      id: 40, name: 'UNIT_1', alias: 'UNIT_1', bookletid: 30
+    } as Unit);
+    const responseFindSpy = jest.spyOn(responseRepository, 'find')
+      .mockResolvedValueOnce([
+        { variableid: 'VAR_OLD', subform: '' } as ResponseEntity
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 502,
+          unitid: 40,
+          variableid: 'VAR_NEW',
+          subform: ''
+        } as ResponseEntity
+      ]);
+    jest.spyOn(responseRepository, 'save').mockResolvedValue([
+      {
+        unitid: 40,
+        variableid: 'VAR_NEW',
+        status: 3,
+        value: 'new',
+        subform: ''
+      } as unknown as ResponseEntity
+    ] as never);
+
+    const result = await service.processBookletWithTransaction(
+      {
+        id: 'BOOKLET_1',
+        logs: [],
+        sessions: [],
+        units: [
+          {
+            id: 'UNIT_1',
+            alias: 'UNIT_1',
+            laststate: [],
+            chunks: [],
+            subforms: [
+              {
+                id: '',
+                responses: [
+                  {
+                    id: 'VAR_OLD',
+                    status: 'VALUE_CHANGED',
+                    value: 'old'
+                  },
+                  {
+                    id: 'VAR_NEW',
+                    status: 'VALUE_CHANGED',
+                    value: 'new'
+                  }
+                ]
+              }
+            ],
+            logs: []
+          }
+        ]
+      },
+      {
+        id: 10, group: 'G', login: 'L', code: 'C', workspace_id: 1
+      } as Persons,
+      'merge'
+    );
+
+    expect(responseFindSpy).toHaveBeenCalledTimes(2);
+    expect(responseFindSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      select: ['id', 'unitid', 'variableid', 'subform']
+    }));
+    expect(result).toMatchObject({
+      addedUnitIds: [],
+      changedUnitIds: [],
+      addedResponseIds: [502],
+      addedResponseCount: 0,
+      changedResponseCount: 0,
       savedResponseCount: 1,
       skippedExistingResponseCount: 1
     });

--- a/apps/backend/src/app/database/services/test-results/person-persistence.service.ts
+++ b/apps/backend/src/app/database/services/test-results/person-persistence.service.ts
@@ -27,12 +27,29 @@ export interface TestResultsMutationSummary {
   addedUnitIds: number[];
   changedUnitIds: number[];
   skippedExistingUnitIds?: number[];
+  addedResponseIds?: number[];
   addedResponseCount: number;
   changedResponseCount: number;
   savedResponseCount?: number;
   deletedResponseCount?: number;
   skippedExistingResponseCount?: number;
 }
+
+type ResponseProcessingResult = {
+  success: boolean;
+  saved: number;
+  skipped: number;
+  deleted: number;
+  addedResponseIds: number[];
+};
+
+type ResponseInsertEntry = {
+  unitid: number;
+  variableid: string;
+  status: number;
+  value: string | null;
+  subform: string;
+};
 
 /**
  * PersonPersistenceService
@@ -356,6 +373,8 @@ export class PersonPersistenceService {
                 if (isNewUnit) {
                   mutationSummary.addedUnitIds.push(targetUnit.id);
                   mutationSummary.addedResponseCount += responseResult.saved;
+                } else if (overwriteMode === 'merge' && responseResult.saved > 0) {
+                  mutationSummary.addedResponseIds?.push(...responseResult.addedResponseIds);
                 } else if (
                   responseResult.saved > 0 ||
                   responseResult.deleted > 0 ||
@@ -423,19 +442,19 @@ export class PersonPersistenceService {
     unit: TcMergeUnit,
     savedUnit: Unit,
     overwriteMode: 'skip' | 'merge' | 'replace' = 'skip'
-  ): Promise<{ success: boolean; saved: number; skipped: number; deleted: number }> {
+  ): Promise<ResponseProcessingResult> {
     try {
       const subforms = unit.subforms;
       if (subforms && subforms.length > 0) {
         return await this.saveSubformResponsesForUnit(savedUnit, subforms, overwriteMode);
       }
       return {
-        success: true, saved: 0, skipped: 0, deleted: 0
+        success: true, saved: 0, skipped: 0, deleted: 0, addedResponseIds: []
       };
     } catch (error) {
       this.logger.error(`Failed to process subform responses for unit: ${unit.id}: ${error.message}`);
       return {
-        success: false, saved: 0, skipped: 0, deleted: 0
+        success: false, saved: 0, skipped: 0, deleted: 0, addedResponseIds: []
       };
     }
   }
@@ -516,14 +535,15 @@ export class PersonPersistenceService {
     savedUnit: Unit,
     subforms: TcMergeSubForms[],
     overwriteMode: 'skip' | 'merge' | 'replace' = 'skip'
-  ): Promise<{ success: boolean; saved: number; skipped: number; deleted: number }> {
+  ): Promise<ResponseProcessingResult> {
     try {
       let totalResponsesSaved = 0;
       let totalResponsesSkipped = 0;
       let totalResponsesDeleted = 0;
+      const addedResponseIds: number[] = [];
       for (const subform of subforms) {
         if (subform.responses && subform.responses.length > 0) {
-          const responseEntries = subform.responses.map(response => {
+          const responseEntries: ResponseInsertEntry[] = subform.responses.map(response => {
             let value: string | null;
             if (response.value === null) {
               value = null;
@@ -583,7 +603,10 @@ export class PersonPersistenceService {
             const BATCH_SIZE = 1000;
             for (let i = 0; i < filteredEntries.length; i += BATCH_SIZE) {
               const batch = filteredEntries.slice(i, i + BATCH_SIZE);
-              await this.responseRepository.save(batch);
+              const savedResponses = await this.responseRepository.save(batch);
+              addedResponseIds.push(
+                ...(await this.collectSavedResponseIds(savedResponses, batch))
+              );
             }
             totalResponsesSaved += filteredEntries.length;
           }
@@ -594,7 +617,8 @@ export class PersonPersistenceService {
         success: true,
         saved: totalResponsesSaved,
         skipped: totalResponsesSkipped,
-        deleted: totalResponsesDeleted
+        deleted: totalResponsesDeleted,
+        addedResponseIds: Array.from(new Set(addedResponseIds))
       };
     } catch (error) {
       this.logger.error(`Failed to save responses for unit: ${savedUnit.id}: ${error.message}`);
@@ -602,9 +626,67 @@ export class PersonPersistenceService {
         success: false,
         saved: 0,
         skipped: 0,
-        deleted: 0
+        deleted: 0,
+        addedResponseIds: []
       };
     }
+  }
+
+  private async collectSavedResponseIds(
+    savedResponses: Array<Partial<ResponseEntity>>,
+    entries: ResponseInsertEntry[]
+  ): Promise<number[]> {
+    const savedIds = this.uniquePositiveIds(
+      (savedResponses || []).map(response => Number(response.id))
+    );
+
+    if (savedIds.length >= entries.length) {
+      return savedIds;
+    }
+
+    try {
+      const fallbackIds = await this.findResponseIdsForEntries(entries);
+      return this.uniquePositiveIds([...savedIds, ...fallbackIds]);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`Could not resolve saved response ids after import: ${detail}`);
+      return savedIds;
+    }
+  }
+
+  private async findResponseIdsForEntries(entries: ResponseInsertEntry[]): Promise<number[]> {
+    const unitIds = this.uniquePositiveIds(entries.map(entry => entry.unitid));
+    const variableIds = Array.from(new Set(
+      entries
+        .map(entry => entry.variableid)
+        .filter((variableId): variableId is string => Boolean(variableId))
+    ));
+    if (unitIds.length === 0 || variableIds.length === 0) {
+      return [];
+    }
+
+    const targetKeys = new Set(entries.map(entry => this.responseEntryKey(entry)));
+    const rows = await this.responseRepository.find({
+      where: {
+        unitid: In(unitIds),
+        variableid: In(variableIds)
+      },
+      select: ['id', 'unitid', 'variableid', 'subform']
+    });
+
+    if (!Array.isArray(rows)) {
+      return [];
+    }
+
+    return this.uniquePositiveIds(
+      rows
+        .filter(row => targetKeys.has(this.responseEntryKey(row)))
+        .map(row => Number(row.id))
+    );
+  }
+
+  private responseEntryKey(entry: Pick<ResponseEntity, 'unitid' | 'variableid' | 'subform'>): string {
+    return `${Number(entry.unitid)}@@${entry.variableid}@@${entry.subform || ''}`;
   }
 
   private createMutationSummary(): TestResultsMutationSummary {
@@ -612,6 +694,7 @@ export class PersonPersistenceService {
       addedUnitIds: [],
       changedUnitIds: [],
       skippedExistingUnitIds: [],
+      addedResponseIds: [],
       addedResponseCount: 0,
       changedResponseCount: 0,
       savedResponseCount: 0,
@@ -627,6 +710,7 @@ export class PersonPersistenceService {
     target.addedUnitIds.push(...source.addedUnitIds);
     target.changedUnitIds.push(...source.changedUnitIds);
     target.skippedExistingUnitIds?.push(...(source.skippedExistingUnitIds || []));
+    target.addedResponseIds?.push(...(source.addedResponseIds || []));
     target.addedResponseCount += source.addedResponseCount;
     target.changedResponseCount += source.changedResponseCount;
     target.savedResponseCount =
@@ -642,6 +726,15 @@ export class PersonPersistenceService {
     summary.addedUnitIds = Array.from(new Set(summary.addedUnitIds));
     summary.changedUnitIds = Array.from(new Set(summary.changedUnitIds));
     summary.skippedExistingUnitIds = Array.from(new Set(summary.skippedExistingUnitIds || []));
+    summary.addedResponseIds = Array.from(new Set(summary.addedResponseIds || []));
+  }
+
+  private uniquePositiveIds(ids: number[]): number[] {
+    return Array.from(new Set(
+      ids
+        .map(id => Number(id))
+        .filter(id => Number.isInteger(id) && id > 0)
+    ));
   }
 
   private countUnitResponses(unit: TcMergeUnit): number {

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
@@ -69,6 +69,7 @@ describe('TestCenterService', () => {
           provide: CodingFreshnessService,
           useValue: createMock<CodingFreshnessService>({
             markUnitsPendingAfterImport: jest.fn().mockResolvedValue(undefined),
+            markResponsesPendingAfterImport: jest.fn().mockResolvedValue(undefined),
             markUnitsStaleAfterResultChange: jest.fn().mockResolvedValue(undefined),
             getSummary: jest.fn().mockResolvedValue({
               workspaceId: 123,

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.ts
@@ -962,6 +962,7 @@ export class TestcenterService {
     return {
       addedUnitIds: [],
       changedUnitIds: [],
+      addedResponseIds: [],
       addedResponseCount: 0,
       changedResponseCount: 0
     };
@@ -976,6 +977,7 @@ export class TestcenterService {
     }
     target.addedUnitIds.push(...(source.addedUnitIds || []));
     target.changedUnitIds.push(...(source.changedUnitIds || []));
+    target.addedResponseIds?.push(...(source.addedResponseIds || []));
     target.addedResponseCount += source.addedResponseCount || 0;
     target.changedResponseCount += source.changedResponseCount || 0;
   }
@@ -991,7 +993,8 @@ export class TestcenterService {
 
     const addedUnitIds = this.uniquePositiveIds(mutationSummary.addedUnitIds);
     const changedUnitIds = this.uniquePositiveIds(mutationSummary.changedUnitIds);
-    if (addedUnitIds.length === 0 && changedUnitIds.length === 0) {
+    const addedResponseIds = this.uniquePositiveIds(mutationSummary.addedResponseIds || []);
+    if (addedUnitIds.length === 0 && changedUnitIds.length === 0 && addedResponseIds.length === 0) {
       return;
     }
 
@@ -1001,6 +1004,12 @@ export class TestcenterService {
         addedUnitIds,
         mutationSummary.addedResponseCount
       );
+      if (addedResponseIds.length > 0) {
+        await this.codingFreshnessService.markResponsesPendingAfterImport(
+          workspaceId,
+          addedResponseIds
+        );
+      }
       await this.codingFreshnessService.markUnitsStaleAfterResultChange(
         workspaceId,
         changedUnitIds,

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
@@ -4,14 +4,27 @@ import { createMock } from '@golevelup/ts-jest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { DataSource } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { UploadResultsService } from './upload-results.service';
 import { PersonService } from './person.service';
+import { PersonQueryService } from './person-query.service';
+import { PersonPersistenceService } from './person-persistence.service';
 import { JobQueueService, TestResultsUploadJobData } from '../../../job-queue/job-queue.service';
 import { FileIo } from '../../../admin/workspace/file-io.interface';
 import { WorkspaceTestResultsService } from './workspace-test-results.service';
 import { CodingFreshnessService } from '../coding/coding-freshness.service';
 import { CodingAnalysisService } from '../coding/coding-analysis.service';
+import Persons from '../../entities/persons.entity';
+import { Booklet } from '../../entities/booklet.entity';
+import { Unit } from '../../entities/unit.entity';
+import { UnitLastState } from '../../entities/unitLastState.entity';
+import { BookletInfo } from '../../entities/bookletInfo.entity';
+import { ResponseEntity } from '../../entities/response.entity';
+import { ChunkEntity } from '../../entities/chunk.entity';
+import { BookletLog } from '../../entities/bookletLog.entity';
+import { Session } from '../../entities/session.entity';
+import { UnitLog } from '../../entities/unitLog.entity';
+import { Person } from '../shared';
 
 describe('UploadResultsService', () => {
   let service: UploadResultsService;
@@ -59,6 +72,7 @@ describe('UploadResultsService', () => {
           provide: CodingFreshnessService,
           useValue: createMock<CodingFreshnessService>({
             markUnitsPendingAfterImport: jest.fn().mockResolvedValue(undefined),
+            markResponsesPendingAfterImport: jest.fn().mockResolvedValue(undefined),
             markUnitsStaleAfterResultChange: jest.fn().mockResolvedValue(undefined)
           })
         },
@@ -92,6 +106,16 @@ describe('UploadResultsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('treats saved responses as response import mutations', () => {
+    const responseImportMutatedTestResults = (
+      service as unknown as {
+        responseImportMutatedTestResults(summary: { savedResponseCount?: number }): boolean;
+      }
+    ).responseImportMutatedTestResults.bind(service);
+
+    expect(responseImportMutatedTestResults({ savedResponseCount: 1 })).toBe(true);
   });
 
   describe('uploadTestResults', () => {
@@ -814,6 +838,335 @@ existing-group;new-login;new-code;booklet1;unit1;"[{""subForm"":"""",""content""
       expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
     });
 
+    it('should merge a new unit for an existing person and refresh coding follow-up state', async () => {
+      const fileContent = `groupname;loginname;code;bookletname;unitname;responses;laststate
+existing-group;existing-login;existing-code;booklet1;unit2;"[{""subForm"":"""",""content"":""[{\\""id\\"":\\""VAR_1\\"",\\""status\\"":\\""VALUE_CHANGED\\""}]""}]";""`;
+
+      const filePath = path.join(os.tmpdir(), 'test-merge-new-unit-existing-person.csv');
+      fs.writeFileSync(filePath, fileContent);
+
+      jest.spyOn(personService, 'getWorkspaceUploadStats')
+        .mockResolvedValueOnce({
+          testPersons: 1,
+          testGroups: 1,
+          uniqueBooklets: 1,
+          uniqueUnits: 1,
+          uniqueResponses: 1
+        })
+        .mockResolvedValueOnce({
+          testPersons: 1,
+          testGroups: 1,
+          uniqueBooklets: 1,
+          uniqueUnits: 2,
+          uniqueResponses: 2
+        });
+
+      const existingPerson = {
+        workspace_id: 1,
+        group: 'existing-group',
+        login: 'existing-login',
+        code: 'existing-code',
+        booklets: []
+      };
+      const existingPersonWithBooklets = {
+        ...existingPerson,
+        booklets: [
+          {
+            id: 'booklet1',
+            logs: [],
+            units: [],
+            sessions: []
+          }
+        ]
+      };
+      const existingPersonWithNewUnit = {
+        ...existingPersonWithBooklets,
+        booklets: [
+          {
+            id: 'booklet1',
+            logs: [],
+            sessions: [],
+            units: [
+              {
+                id: 'unit2',
+                alias: 'unit2',
+                laststate: [],
+                chunks: [],
+                subforms: [],
+                logs: []
+              }
+            ]
+          }
+        ]
+      };
+
+      jest.spyOn(personService, 'createPersonList').mockResolvedValue([existingPerson]);
+      jest.spyOn(personService, 'assignBookletsToPerson').mockResolvedValue(existingPersonWithBooklets);
+      jest.spyOn(personService, 'assignUnitsToBookletAndPerson').mockResolvedValue(existingPersonWithNewUnit);
+      jest.spyOn(personService, 'processPersonBooklets').mockResolvedValue({
+        addedUnitIds: [202],
+        changedUnitIds: [],
+        addedResponseCount: 1,
+        changedResponseCount: 0,
+        savedResponseCount: 1,
+        deletedResponseCount: 0,
+        skippedExistingResponseCount: 0
+      });
+
+      const file: FileIo = {
+        buffer: Buffer.from(fileContent),
+        originalname: 'test.csv',
+        mimetype: 'text/csv',
+        size: fileContent.length,
+        fieldname: 'file',
+        encoding: 'utf-8',
+        path: filePath
+      };
+
+      const result = await service.processUpload(createMock<Job<TestResultsUploadJobData>>({
+        id: '1',
+        data: {
+          workspaceId: 1,
+          file,
+          resultType: 'responses',
+          overwriteMode: 'merge',
+          scope: 'person'
+        }
+      }));
+
+      expect(personService.processPersonBooklets).toHaveBeenCalledWith(
+        [existingPersonWithNewUnit],
+        1,
+        'merge',
+        'person'
+      );
+      expect(result.delta).toEqual({
+        testPersons: 0,
+        testGroups: 0,
+        uniqueBooklets: 0,
+        uniqueUnits: 1,
+        uniqueResponses: 1
+      });
+      expect(codingFreshnessService.markUnitsPendingAfterImport).toHaveBeenCalledWith(1, [202], 1);
+      expect(codingFreshnessService.markUnitsStaleAfterResultChange).toHaveBeenCalledWith(
+        1,
+        [],
+        'RESULT_UPDATED'
+      );
+      expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(1);
+      expect(workspaceTestResultsService.invalidateCodingStatisticsCache).toHaveBeenCalledWith(1);
+      expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
+    });
+
+    it('should parse a merge upload and persist a new unit through the real person services', async () => {
+      const personsRepository = createMock<Repository<Persons>>();
+      const bookletRepository = createMock<Repository<Booklet>>();
+      const unitRepository = createMock<Repository<Unit>>();
+      const unitLastStateRepository = createMock<Repository<UnitLastState>>();
+      const bookletInfoRepository = createMock<Repository<BookletInfo>>();
+      const responseRepository = createMock<Repository<ResponseEntity>>();
+      const chunkRepository = createMock<Repository<ChunkEntity>>();
+      const bookletLogRepository = createMock<Repository<BookletLog>>();
+      const sessionRepository = createMock<Repository<Session>>();
+      const unitLogRepository = createMock<Repository<UnitLog>>();
+      const realWorkspaceService = createMock<WorkspaceTestResultsService>({
+        invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined),
+        invalidateCodingStatisticsCache: jest.fn().mockResolvedValue(undefined)
+      });
+      const realCodingFreshnessService = createMock<CodingFreshnessService>({
+        markUnitsPendingAfterImport: jest.fn().mockResolvedValue(undefined),
+        markResponsesPendingAfterImport: jest.fn().mockResolvedValue(undefined),
+        markUnitsStaleAfterResultChange: jest.fn().mockResolvedValue(undefined)
+      });
+      const realCodingAnalysisService = createMock<CodingAnalysisService>({
+        invalidateCache: jest.fn().mockResolvedValue(undefined)
+      });
+
+      let persistedPersons: Persons[] = [];
+      const personQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockImplementation(async () => persistedPersons)
+      };
+
+      jest.spyOn(personsRepository, 'upsert').mockImplementation(async input => {
+        const batch = (Array.isArray(input) ? input : [input]) as Person[];
+        persistedPersons = batch.map(person => ({
+          ...person,
+          id: 11,
+          workspace_id: 1
+        } as unknown as Persons));
+        return {} as never;
+      });
+      jest.spyOn(personsRepository, 'createQueryBuilder').mockReturnValue(personQueryBuilder as never);
+      jest.spyOn(bookletInfoRepository, 'findOne').mockResolvedValue({
+        id: 101,
+        name: 'booklet1'
+      } as unknown as BookletInfo);
+      jest.spyOn(bookletRepository, 'findOne').mockResolvedValue({
+        id: 201,
+        personid: 11,
+        infoid: 101
+      } as unknown as Booklet);
+      jest.spyOn(unitRepository, 'findOne').mockResolvedValue(null);
+      jest.spyOn(unitRepository, 'create').mockImplementation(entity => entity as Unit);
+      jest.spyOn(unitRepository, 'save').mockResolvedValue({
+        id: 202,
+        alias: 'original-unit2',
+        name: 'unit2',
+        bookletid: 201
+      } as unknown as Unit);
+      jest.spyOn(unitLastStateRepository, 'find').mockResolvedValue([]);
+      jest.spyOn(unitLastStateRepository, 'insert').mockResolvedValue({} as never);
+      jest.spyOn(chunkRepository, 'delete').mockResolvedValue({} as never);
+      jest.spyOn(chunkRepository, 'insert').mockResolvedValue({} as never);
+      jest.spyOn(responseRepository, 'find').mockResolvedValue([]);
+      jest.spyOn(responseRepository, 'save').mockResolvedValue([] as never);
+
+      const realPersonService = new PersonService(
+        createMock<PersonQueryService>({
+          getWorkspaceUploadStats: jest.fn()
+            .mockResolvedValueOnce({
+              testPersons: 1,
+              testGroups: 1,
+              uniqueBooklets: 1,
+              uniqueUnits: 1,
+              uniqueResponses: 1
+            })
+            .mockResolvedValueOnce({
+              testPersons: 1,
+              testGroups: 1,
+              uniqueBooklets: 1,
+              uniqueUnits: 2,
+              uniqueResponses: 2
+            })
+        }),
+        new PersonPersistenceService(
+          personsRepository,
+          bookletRepository,
+          unitRepository,
+          unitLastStateRepository,
+          bookletInfoRepository,
+          responseRepository,
+          chunkRepository,
+          bookletLogRepository,
+          sessionRepository,
+          unitLogRepository
+        )
+      );
+      const realUploadService = new UploadResultsService(
+        realPersonService,
+        createMock<JobQueueService>(),
+        realWorkspaceService,
+        {
+          createQueryRunner: jest.fn().mockReturnValue({
+            connect: jest.fn().mockResolvedValue(undefined),
+            query: jest.fn().mockResolvedValue([]),
+            release: jest.fn().mockResolvedValue(undefined)
+          })
+        } as unknown as DataSource,
+        realCodingFreshnessService,
+        realCodingAnalysisService
+      );
+
+      const csvField = (value: string): string => `"${value.replace(/"/g, '""')}"`;
+      const responses = JSON.stringify([
+        {
+          subForm: '',
+          content: JSON.stringify([
+            {
+              id: 'VAR_1',
+              status: 'VALUE_CHANGED',
+              value: 'answer-new'
+            }
+          ])
+        }
+      ]);
+      const laststate = JSON.stringify({ unitState: 'new' });
+      const fileContent = [
+        'groupname;loginname;code;bookletname;unitname;originalUnitId;responses;laststate',
+        [
+          'existing-group',
+          'existing-login',
+          'existing-code',
+          'booklet1',
+          'unit2',
+          'original-unit2',
+          csvField(responses),
+          csvField(laststate)
+        ].join(';')
+      ].join('\n');
+      const filePath = path.join(os.tmpdir(), 'test-merge-new-unit-real-person-services.csv');
+      fs.writeFileSync(filePath, fileContent);
+
+      const file: FileIo = {
+        buffer: Buffer.from(fileContent),
+        originalname: 'test.csv',
+        mimetype: 'text/csv',
+        size: fileContent.length,
+        fieldname: 'file',
+        encoding: 'utf-8',
+        path: filePath
+      };
+
+      const result = await realUploadService.processUpload(createMock<Job<TestResultsUploadJobData>>({
+        id: '1',
+        data: {
+          workspaceId: 1,
+          file,
+          resultType: 'responses',
+          overwriteMode: 'merge',
+          scope: 'person'
+        }
+      }));
+
+      expect(unitRepository.findOne).toHaveBeenCalledWith({
+        where: { alias: 'original-unit2', name: 'unit2', bookletid: 201 }
+      });
+      expect(unitRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+        alias: 'original-unit2',
+        name: 'unit2',
+        bookletid: 201
+      }));
+      expect(responseRepository.find).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          unitid: 202,
+          subform: '',
+          variableid: expect.anything()
+        })
+      }));
+      expect(responseRepository.save).toHaveBeenCalledWith([
+        expect.objectContaining({
+          unitid: 202,
+          variableid: 'VAR_1',
+          value: 'answer-new',
+          subform: ''
+        })
+      ]);
+      expect(result.delta).toEqual({
+        testPersons: 0,
+        testGroups: 0,
+        uniqueBooklets: 0,
+        uniqueUnits: 1,
+        uniqueResponses: 1
+      });
+      expect(result.importSummary).toMatchObject({
+        overwriteMode: 'merge',
+        scope: 'person',
+        responseRows: 1,
+        savedResponses: 1,
+        addedUnits: 1
+      });
+      expect(realCodingFreshnessService.markUnitsPendingAfterImport).toHaveBeenCalledWith(1, [202], 1);
+      expect(realCodingFreshnessService.markUnitsStaleAfterResultChange).toHaveBeenCalledWith(
+        1,
+        [],
+        'RESULT_UPDATED'
+      );
+      expect(realCodingAnalysisService.invalidateCache).toHaveBeenCalledWith(1);
+      expect(realWorkspaceService.invalidateCodingStatisticsCache).toHaveBeenCalledWith(1);
+    });
+
     it('should mark freshness and invalidate response-analysis and coding-statistics caches after importing responses', async () => {
       const fileContent = `groupname;loginname;code;bookletname;unitname;responses;laststate
 test-group;test-user;code;booklet1;unit1;[];""`;
@@ -865,6 +1218,7 @@ test-group;test-user;code;booklet1;unit1;[];""`;
       jest.spyOn(personService, 'processPersonBooklets').mockResolvedValue({
         addedUnitIds: [101],
         changedUnitIds: [202],
+        addedResponseIds: [303],
         addedResponseCount: 1,
         changedResponseCount: 1
       });
@@ -890,6 +1244,7 @@ test-group;test-user;code;booklet1;unit1;[];""`;
       }));
 
       expect(codingFreshnessService.markUnitsPendingAfterImport).toHaveBeenCalledWith(1, [101], 1);
+      expect(codingFreshnessService.markResponsesPendingAfterImport).toHaveBeenCalledWith(1, [303]);
       expect(codingFreshnessService.markUnitsStaleAfterResultChange).toHaveBeenCalledWith(
         1,
         [202],

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.ts
@@ -148,13 +148,17 @@ export class UploadResultsService {
   private responseImportMutatedTestResults(mutationSummary: {
     addedUnitIds?: number[];
     changedUnitIds?: number[];
+    addedResponseIds?: number[];
     addedResponseCount?: number;
     changedResponseCount?: number;
+    savedResponseCount?: number;
   }): boolean {
     return (mutationSummary.addedUnitIds?.length || 0) > 0 ||
       (mutationSummary.changedUnitIds?.length || 0) > 0 ||
+      (mutationSummary.addedResponseIds?.length || 0) > 0 ||
       (mutationSummary.addedResponseCount || 0) > 0 ||
-      (mutationSummary.changedResponseCount || 0) > 0;
+      (mutationSummary.changedResponseCount || 0) > 0 ||
+      (mutationSummary.savedResponseCount || 0) > 0;
   }
 
   private createUploadSummaryAccumulator(): UploadSummaryAccumulator {
@@ -728,6 +732,7 @@ export class UploadResultsService {
                 ) || {
                   addedUnitIds: [],
                   changedUnitIds: [],
+                  addedResponseIds: [],
                   addedResponseCount: 0,
                   changedResponseCount: 0
                 };
@@ -747,6 +752,12 @@ export class UploadResultsService {
                   mutationSummary.addedUnitIds,
                   mutationSummary.addedResponseCount
                 );
+                if ((mutationSummary.addedResponseIds?.length || 0) > 0) {
+                  await this.codingFreshnessService?.markResponsesPendingAfterImport?.(
+                    workspaceId,
+                    mutationSummary.addedResponseIds || []
+                  );
+                }
                 await this.codingFreshnessService?.markUnitsStaleAfterResultChange(
                   workspaceId,
                   mutationSummary.changedUnitIds,


### PR DESCRIPTION
## Summary

Fixes #536.

This change keeps merge imports from treating a new unit in an existing person's booklet as an already-known unit. It records newly created units and newly added responses separately so coding freshness, stale coding jobs, response analysis, and coding statistics follow-up state are refreshed after the import.

## Validation

- `git diff --check`
- `npx nx lint backend`
- `npx nx test backend --skip-nx-cache`
- `POSTGRES_INTEGRATION_TESTS=true POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=root POSTGRES_PASSWORD=root-password POSTGRES_DB=coding-box npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/person-persistence.postgres.spec.ts --skip-nx-cache`