### PR TITLE
Show new cases in job definition refresh preview

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -306,6 +306,70 @@ describe('CodingJobService distribution from job definitions', () => {
     expect(createdJobCalls[0].subset.map(response => response.id)).toEqual([6, 7, 8, 9, 10]);
   });
 
+  it('shows newly imported available cases in a job definition refresh preview', async () => {
+    const responses = Array.from({ length: 8 }, (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1'));
+    const variable = { unitName: 'Unit 1', variableId: 'Var 1' };
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+    jest.spyOn(
+      service as unknown as {
+        getJobDefinitionExistingTaskRows: (
+          workspaceId: number,
+          jobDefinitionId: number
+        ) => Promise<Array<{ responseId: number; taskCount: number }>>;
+      },
+      'getJobDefinitionExistingTaskRows'
+    ).mockResolvedValue(
+      [1, 2, 3, 4, 5].map(responseId => ({ responseId, taskCount: 1 }))
+    );
+    jest.spyOn(
+      service as unknown as {
+        getJobDefinitionJobCounts: (
+          workspaceId: number,
+          jobDefinitionId: number
+        ) => Promise<{ existingJobsCount: number; staleJobsCount: number }>;
+      },
+      'getJobDefinitionJobCounts'
+    ).mockResolvedValue({ existingJobsCount: 1, staleJobsCount: 1 });
+    jest.spyOn(
+      service as unknown as {
+        jobDefinitionHasAnyCodingWork: (
+          workspaceId: number,
+          jobDefinitionId: number
+        ) => Promise<boolean>;
+      },
+      'jobDefinitionHasAnyCodingWork'
+    ).mockResolvedValue(false);
+
+    const preview = await service.previewJobDefinitionRefresh(5, {
+      selectedVariables: [variable],
+      selectedCoders: [{ id: 1, name: 'Ada', username: 'ada' }],
+      caseOrderingMode: 'continuous',
+      jobDefinitionId: 80
+    });
+
+    expect(preview).toMatchObject({
+      jobDefinitionId: 80,
+      existingJobsCount: 1,
+      staleJobsCount: 1,
+      existingCases: 5,
+      plannedCases: 8,
+      retainedCases: 5,
+      addedCases: 3,
+      removedCases: 0,
+      addedCodingTasks: 3,
+      removedCodingTasks: 0,
+      canApply: true
+    });
+    expect(
+      (
+        service as unknown as { getAssignedResponseIdsForVariables: jest.Mock }
+      ).getAssignedResponseIdsForVariables
+    ).toHaveBeenCalledWith(5, [variable], 80, undefined);
+  });
+
   it('assigns double-coded cases to exactly two coders when more coders are selected', async () => {
     const responses = Array.from({ length: 6 }, (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1'));
     const createdJobCalls: Array<{ subset: SlimResponseForTest[] }> = [];

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
@@ -65,7 +65,8 @@ describe('UploadResultsService', () => {
           provide: WorkspaceTestResultsService,
           useValue: createMock<WorkspaceTestResultsService>({
             invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined),
-            invalidateCodingStatisticsCache: jest.fn().mockResolvedValue(undefined)
+            invalidateCodingStatisticsCache: jest.fn().mockResolvedValue(undefined),
+            invalidateCodingAvailabilityCache: jest.fn().mockResolvedValue(undefined)
           })
         },
         {
@@ -835,6 +836,7 @@ existing-group;new-login;new-code;booklet1;unit1;"[{""subForm"":"""",""content""
       );
       expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(1);
       expect(workspaceTestResultsService.invalidateCodingStatisticsCache).toHaveBeenCalledWith(1);
+      expect(workspaceTestResultsService.invalidateCodingAvailabilityCache).toHaveBeenCalledWith(1);
       expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
     });
 
@@ -955,6 +957,7 @@ existing-group;existing-login;existing-code;booklet1;unit2;"[{""subForm"":"""","
       );
       expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(1);
       expect(workspaceTestResultsService.invalidateCodingStatisticsCache).toHaveBeenCalledWith(1);
+      expect(workspaceTestResultsService.invalidateCodingAvailabilityCache).toHaveBeenCalledWith(1);
       expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
     });
 
@@ -971,7 +974,8 @@ existing-group;existing-login;existing-code;booklet1;unit2;"[{""subForm"":"""","
       const unitLogRepository = createMock<Repository<UnitLog>>();
       const realWorkspaceService = createMock<WorkspaceTestResultsService>({
         invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined),
-        invalidateCodingStatisticsCache: jest.fn().mockResolvedValue(undefined)
+        invalidateCodingStatisticsCache: jest.fn().mockResolvedValue(undefined),
+        invalidateCodingAvailabilityCache: jest.fn().mockResolvedValue(undefined)
       });
       const realCodingFreshnessService = createMock<CodingFreshnessService>({
         markUnitsPendingAfterImport: jest.fn().mockResolvedValue(undefined),
@@ -1165,9 +1169,10 @@ existing-group;existing-login;existing-code;booklet1;unit2;"[{""subForm"":"""","
       );
       expect(realCodingAnalysisService.invalidateCache).toHaveBeenCalledWith(1);
       expect(realWorkspaceService.invalidateCodingStatisticsCache).toHaveBeenCalledWith(1);
+      expect(realWorkspaceService.invalidateCodingAvailabilityCache).toHaveBeenCalledWith(1);
     });
 
-    it('should mark freshness and invalidate response-analysis and coding-statistics caches after importing responses', async () => {
+    it('should mark freshness and invalidate response-analysis, coding-statistics, and availability caches after importing responses', async () => {
       const fileContent = `groupname;loginname;code;bookletname;unitname;responses;laststate
 test-group;test-user;code;booklet1;unit1;[];""`;
 
@@ -1252,6 +1257,7 @@ test-group;test-user;code;booklet1;unit1;[];""`;
       );
       expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(1);
       expect(workspaceTestResultsService.invalidateCodingStatisticsCache).toHaveBeenCalledWith(1);
+      expect(workspaceTestResultsService.invalidateCodingAvailabilityCache).toHaveBeenCalledWith(1);
       expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
     });
 
@@ -1352,9 +1358,10 @@ test-group;test-user;code;booklet1;unit1;[];""`;
       });
       expect(codingAnalysisService.invalidateCache).not.toHaveBeenCalled();
       expect(workspaceTestResultsService.invalidateCodingStatisticsCache).not.toHaveBeenCalled();
+      expect(workspaceTestResultsService.invalidateCodingAvailabilityCache).not.toHaveBeenCalled();
     });
 
-    it('should invalidate response-analysis and coding-statistics caches after a post-write freshness failure', async () => {
+    it('should invalidate response-analysis, coding-statistics, and availability caches after a post-write freshness failure', async () => {
       const fileContent = `groupname;loginname;code;bookletname;unitname;responses;laststate
 test-group;test-user;code;booklet1;unit1;[];""`;
 
@@ -1434,6 +1441,7 @@ test-group;test-user;code;booklet1;unit1;[];""`;
       expect(codingFreshnessService.markUnitsPendingAfterImport).toHaveBeenCalledWith(1, [101], 1);
       expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(1);
       expect(workspaceTestResultsService.invalidateCodingStatisticsCache).toHaveBeenCalledWith(1);
+      expect(workspaceTestResultsService.invalidateCodingAvailabilityCache).toHaveBeenCalledWith(1);
       expect(result.issues?.some(issue => issue.message.includes('freshness failed'))).toBe(true);
     });
   });

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.ts
@@ -131,7 +131,8 @@ export class UploadResultsService {
     try {
       await Promise.all([
         this.codingAnalysisService?.invalidateCache(workspaceId),
-        this.workspaceTestResultsService.invalidateCodingStatisticsCache(workspaceId)
+        this.workspaceTestResultsService.invalidateCodingStatisticsCache(workspaceId),
+        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId)
       ]);
     } catch (error) {
       const detail = error instanceof Error ? error.message : 'Unknown error';
@@ -140,7 +141,7 @@ export class UploadResultsService {
         level: 'warning',
         category: 'other',
         message:
-          'Die Ergebnisdaten wurden verarbeitet, aber Kodierstatistiken oder Antwort-Analyse konnten nicht zuverlässig aktualisiert werden. Die Werte können sich nach Aktualisierung noch ändern.'
+          'Die Ergebnisdaten wurden verarbeitet, aber Kodierstatistiken, Antwort-Analyse oder verfügbare Fälle konnten nicht zuverlässig aktualisiert werden. Die Werte können sich nach Aktualisierung noch ändern.'
       });
     }
   }

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -1563,9 +1563,13 @@ export class WorkspaceTestResultsService {
     await this.codingStatisticsService?.invalidateCache(workspaceId);
   }
 
+  async invalidateCodingAvailabilityCache(workspaceId: number): Promise<void> {
+    await this.codingValidationService.invalidateIncompleteVariablesCache(workspaceId);
+  }
+
   private async invalidateCachesAfterTestResultDeletion(workspaceId: number): Promise<void> {
     await Promise.all([
-      this.codingValidationService.invalidateIncompleteVariablesCache(workspaceId),
+      this.invalidateCodingAvailabilityCache(workspaceId),
       this.invalidateWorkspaceStatsCache(workspaceId),
       this.invalidateCodingStatisticsCache(workspaceId)
     ]);

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.spec.ts
@@ -49,4 +49,16 @@ describe('JobDefinitionRefreshDialogComponent', () => {
       }
     ]);
   });
+
+  it('exposes newly available cases as a positive refresh preview stat', () => {
+    const component = createComponent({ addedCases: 3 });
+
+    expect(component.getCaseStats()).toEqual(expect.arrayContaining([
+      {
+        labelKey: 'coding-job-definitions.refresh-dialog.stats.added-cases',
+        value: 3,
+        tone: 'positive'
+      }
+    ]));
+  });
 });

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2148,7 +2148,7 @@
         "existing-cases": "Bisherige Fälle",
         "planned-cases": "Geplante Fälle",
         "retained-cases": "Bleiben erhalten",
-        "added-cases": "Neue Fälle",
+        "added-cases": "Neue verfügbare Fälle",
         "removed-cases": "Entfernte Fälle",
         "added-tasks": "Aufgaben hinzugefügt",
         "removed-tasks": "Aufgaben entfernt"


### PR DESCRIPTION
## Summary

Closes #540.

- invalidate manual-coding availability caches after response imports so refreshed job definitions see newly imported cases
- show the refresh-preview case delta as "Neue verfügbare Fälle"
- add coverage for an existing job definition receiving newly available cases after later imports

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts --runInBand`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts --runInBand`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.spec.ts --runInBand`
- `npx nx lint backend`
- `npx nx lint frontend`