### PR TITLE
Invalidate coding caches after response imports

### DIFF
--- a/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
@@ -13,6 +13,7 @@ import { Person, Response, Log } from '../shared';
 import { CacheService } from '../../../cache/cache.service';
 import { WorkspaceTestResultsService } from './workspace-test-results.service';
 import { CodingFreshnessService } from '../coding/coding-freshness.service';
+import { CodingAnalysisService } from '../coding/coding-analysis.service';
 
 describe('TestCenterService', () => {
   let service: TestcenterService;
@@ -20,6 +21,7 @@ describe('TestCenterService', () => {
   let personService: DeepMocked<PersonService>;
   let workspaceTestResultsService: DeepMocked<WorkspaceTestResultsService>;
   let codingFreshnessService: DeepMocked<CodingFreshnessService>;
+  let codingAnalysisService: DeepMocked<CodingAnalysisService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -52,7 +54,9 @@ describe('TestCenterService', () => {
         {
           provide: WorkspaceTestResultsService,
           useValue: createMock<WorkspaceTestResultsService>({
-            invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined)
+            invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined),
+            invalidateCodingStatisticsCache: jest.fn().mockResolvedValue(undefined),
+            invalidateCodingAvailabilityCache: jest.fn().mockResolvedValue(undefined)
           })
         },
         {
@@ -77,6 +81,12 @@ describe('TestCenterService', () => {
               items: []
             })
           })
+        },
+        {
+          provide: CodingAnalysisService,
+          useValue: createMock<CodingAnalysisService>({
+            invalidateCache: jest.fn().mockResolvedValue(undefined)
+          })
         }
       ]
     }).compile();
@@ -86,6 +96,7 @@ describe('TestCenterService', () => {
     personService = module.get(PersonService);
     workspaceTestResultsService = module.get(WorkspaceTestResultsService);
     codingFreshnessService = module.get(CodingFreshnessService);
+    codingAnalysisService = module.get(CodingAnalysisService);
     personService.filterLogRowsForPerson.mockImplementation((rows, person) => (
       (rows || []).filter(row => row.groupname === person.group &&
         row.loginname === person.login &&
@@ -316,6 +327,13 @@ describe('TestCenterService', () => {
       expect(
         workspaceTestResultsService.invalidateWorkspaceStatsCache
       ).toHaveBeenCalledWith(123);
+      expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(123);
+      expect(
+        workspaceTestResultsService.invalidateCodingStatisticsCache
+      ).toHaveBeenCalledWith(123);
+      expect(
+        workspaceTestResultsService.invalidateCodingAvailabilityCache
+      ).toHaveBeenCalledWith(123);
       expect(
         codingFreshnessService.markUnitsPendingAfterImport
       ).toHaveBeenCalledWith(123, [10], 2);
@@ -328,6 +346,70 @@ describe('TestCenterService', () => {
         currentRevision: 1,
         items: []
       });
+    });
+
+    it('should keep Testcenter response imports successful when coding cache invalidation fails', async () => {
+      const mockResponses: Response[] = [
+        {
+          groupname: 'group1',
+          loginname: 'user1',
+          code: 'code1',
+          bookletname: 'booklet1',
+          unitname: 'unit1',
+          originalUnitId: 'unit-1-id',
+          responses: '[]',
+          laststate: '{}'
+        }
+      ];
+      httpService.axiosRef.get.mockResolvedValue({
+        data: mockResponses
+      } as AxiosResponse);
+      const mockPersons: Person[] = [
+        {
+          workspace_id: 123,
+          group: 'group1',
+          login: 'user1',
+          code: 'code1',
+          booklets: []
+        }
+      ];
+      personService.createPersonList.mockResolvedValue(mockPersons);
+      personService.assignBookletsToPerson.mockResolvedValue(mockPersons[0]);
+      personService.assignUnitsToBookletAndPerson.mockResolvedValue(
+        mockPersons[0]
+      );
+      personService.processPersonBooklets.mockResolvedValue({
+        addedUnitIds: [10],
+        changedUnitIds: [],
+        addedResponseCount: 1,
+        changedResponseCount: 0
+      });
+      personService.getImportStatistics.mockResolvedValue({
+        persons: 1,
+        booklets: 1,
+        units: 1
+      });
+      workspaceTestResultsService.invalidateCodingStatisticsCache
+        .mockRejectedValueOnce(new Error('statistics cache failed'));
+
+      const result = await service.importWorkspaceFiles(
+        '123',
+        'ws-456',
+        'demo',
+        '',
+        'token',
+        mockImportOptions,
+        'group1'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          level: 'warning',
+          category: 'other',
+          message: expect.stringContaining('Kodierstatistiken')
+        })
+      ]);
     });
   });
 
@@ -629,6 +711,13 @@ describe('TestCenterService', () => {
       );
       expect(result.persons).toBe(1);
       expect(result.units).toBe(2);
+      expect(codingAnalysisService.invalidateCache).not.toHaveBeenCalled();
+      expect(
+        workspaceTestResultsService.invalidateCodingStatisticsCache
+      ).not.toHaveBeenCalled();
+      expect(
+        workspaceTestResultsService.invalidateCodingAvailabilityCache
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.ts
@@ -23,6 +23,7 @@ import {
 import { CacheService } from '../../../cache/cache.service';
 import { WorkspaceTestResultsService } from './workspace-test-results.service';
 import { CodingFreshnessService } from '../coding/coding-freshness.service';
+import { CodingAnalysisService } from '../coding/coding-analysis.service';
 import { TestResultsMutationSummary } from './person-persistence.service';
 import { withWorkspaceTestResultsMutationLock } from '../shared/workspace-test-results-lock.util';
 
@@ -65,7 +66,9 @@ export class TestcenterService {
     private readonly workspaceTestResultsService: WorkspaceTestResultsService,
     private readonly connection: DataSource,
     @Optional()
-    private readonly codingFreshnessService?: CodingFreshnessService
+    private readonly codingFreshnessService?: CodingFreshnessService,
+    @Optional()
+    private readonly codingAnalysisService?: CodingAnalysisService
   ) {}
 
   persons: Person[] = [];
@@ -251,6 +254,7 @@ export class TestcenterService {
 
             if (personBatches.length === 0) continue;
 
+            let responseImportMutatedData = false;
             await withWorkspaceTestResultsMutationLock(this.connection, Number(workspace_id), async () => {
               const mutationSummary = this.createMutationSummary();
               for (const personBatch of personBatches) {
@@ -264,12 +268,21 @@ export class TestcenterService {
                 this.mergeMutationSummary(mutationSummary, batchSummary);
               }
 
+              responseImportMutatedData =
+                this.responseImportMutatedTestResults(mutationSummary);
               await this.updateCodingFreshnessAfterResponseImport(
                 Number(workspace_id),
                 mutationSummary,
                 issues
               );
             });
+
+            if (responseImportMutatedData) {
+              await this.invalidateCodingCachesAfterResponsesImport(
+                Number(workspace_id),
+                issues
+              );
+            }
           }
 
           return { issues };
@@ -958,13 +971,50 @@ export class TestcenterService {
     }
   }
 
+  private async invalidateCodingCachesAfterResponsesImport(
+    workspaceId: number,
+    issues: TestResultsUploadIssueDto[]
+  ): Promise<void> {
+    try {
+      await Promise.all([
+        this.codingAnalysisService?.invalidateCache(workspaceId),
+        this.workspaceTestResultsService.invalidateCodingStatisticsCache(workspaceId),
+        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId)
+      ]);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`Could not invalidate coding caches after Testcenter response import: ${detail}`);
+      issues.push({
+        level: 'warning',
+        category: 'other',
+        message:
+          'Der Testcenter-Import wurde verarbeitet, aber Kodierstatistiken, Antwort-Analyse oder verfügbare Fälle konnten nicht zuverlässig aktualisiert werden. Die Werte können sich nach Aktualisierung noch ändern.'
+      });
+    }
+  }
+
+  private responseImportMutatedTestResults(
+    mutationSummary: Partial<TestResultsMutationSummary>
+  ): boolean {
+    return (mutationSummary.addedUnitIds?.length || 0) > 0 ||
+      (mutationSummary.changedUnitIds?.length || 0) > 0 ||
+      (mutationSummary.addedResponseIds?.length || 0) > 0 ||
+      (mutationSummary.addedResponseCount || 0) > 0 ||
+      (mutationSummary.changedResponseCount || 0) > 0 ||
+      (mutationSummary.savedResponseCount || 0) > 0 ||
+      (mutationSummary.deletedResponseCount || 0) > 0;
+  }
+
   private createMutationSummary(): TestResultsMutationSummary {
     return {
       addedUnitIds: [],
       changedUnitIds: [],
       addedResponseIds: [],
       addedResponseCount: 0,
-      changedResponseCount: 0
+      changedResponseCount: 0,
+      savedResponseCount: 0,
+      deletedResponseCount: 0,
+      skippedExistingResponseCount: 0
     };
   }
 
@@ -980,6 +1030,13 @@ export class TestcenterService {
     target.addedResponseIds?.push(...(source.addedResponseIds || []));
     target.addedResponseCount += source.addedResponseCount || 0;
     target.changedResponseCount += source.changedResponseCount || 0;
+    target.savedResponseCount =
+      (target.savedResponseCount || 0) + (source.savedResponseCount || 0);
+    target.deletedResponseCount =
+      (target.deletedResponseCount || 0) + (source.deletedResponseCount || 0);
+    target.skippedExistingResponseCount =
+      (target.skippedExistingResponseCount || 0) +
+      (source.skippedExistingResponseCount || 0);
   }
 
   private async updateCodingFreshnessAfterResponseImport(

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
@@ -14,6 +14,8 @@ import { FileIo } from '../../../admin/workspace/file-io.interface';
 import { WorkspaceTestResultsService } from './workspace-test-results.service';
 import { CodingFreshnessService } from '../coding/coding-freshness.service';
 import { CodingAnalysisService } from '../coding/coding-analysis.service';
+import { CodingStatisticsService } from '../coding/coding-statistics.service';
+import { getCodingStatisticsCacheKey } from '../coding/coding-statistics-cache-key.util';
 import Persons from '../../entities/persons.entity';
 import { Booklet } from '../../entities/booklet.entity';
 import { Unit } from '../../entities/unit.entity';
@@ -1227,6 +1229,56 @@ test-group;test-user;code;booklet1;unit1;[];""`;
         addedResponseCount: 1,
         changedResponseCount: 1
       });
+      const codingStatisticsCache = new Map<string, unknown>([
+        [getCodingStatisticsCacheKey(1, 'v1'), {
+          totalResponses: 1,
+          baseResponseCount: 1,
+          derivedResponseCount: 0,
+          derivedVariableCount: 0,
+          derivedStatusCounts: {},
+          statusCounts: { 5: 1 }
+        }]
+      ]);
+      const statisticsCacheService = {
+        get: jest.fn(async (key: string) => codingStatisticsCache.get(key)),
+        set: jest.fn(async (key: string, value: unknown) => {
+          codingStatisticsCache.set(key, value);
+          return true;
+        }),
+        delete: jest.fn(async (key: string) => {
+          codingStatisticsCache.delete(key);
+          return true;
+        })
+      };
+      const statisticsRepository = {
+        query: jest.fn().mockResolvedValue([
+          { statusValue: 5, isDerived: false, count: '2' }
+        ])
+      };
+      const codingStatisticsAfterImportService = new CodingStatisticsService(
+        statisticsRepository as never,
+        statisticsCacheService as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {
+          resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+            globalIgnoredUnits: [],
+            ignoredBooklets: [],
+            testletIgnoredUnits: []
+          })
+        } as never,
+        {
+          getUnitVariableMap: jest.fn().mockResolvedValue(
+            new Map([['unit1', new Set(['VAR_1'])]])
+          ),
+          getDerivedVariableMap: jest.fn().mockResolvedValue(new Map())
+        } as never
+      );
+      jest.spyOn(workspaceTestResultsService, 'invalidateCodingStatisticsCache')
+        .mockImplementation(async workspaceId => {
+          await codingStatisticsAfterImportService.invalidateCache(workspaceId);
+        });
 
       const file: FileIo = {
         buffer: Buffer.from(fileContent),
@@ -1247,6 +1299,8 @@ test-group;test-user;code;booklet1;unit1;[];""`;
           overwriteMode: 'merge'
         }
       }));
+      const statisticsAfterMerge =
+        await codingStatisticsAfterImportService.getCodingStatistics(1);
 
       expect(codingFreshnessService.markUnitsPendingAfterImport).toHaveBeenCalledWith(1, [101], 1);
       expect(codingFreshnessService.markResponsesPendingAfterImport).toHaveBeenCalledWith(1, [303]);
@@ -1259,6 +1313,12 @@ test-group;test-user;code;booklet1;unit1;[];""`;
       expect(workspaceTestResultsService.invalidateCodingStatisticsCache).toHaveBeenCalledWith(1);
       expect(workspaceTestResultsService.invalidateCodingAvailabilityCache).toHaveBeenCalledWith(1);
       expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
+      expect(statisticsAfterMerge.totalResponses).toBe(2);
+      expect(statisticsRepository.query).toHaveBeenCalledTimes(1);
+      expect(
+        (workspaceTestResultsService.invalidateCodingStatisticsCache as jest.Mock)
+          .mock.invocationCallOrder[0]
+      ).toBeLessThan(statisticsRepository.query.mock.invocationCallOrder[0]);
     });
 
     it('should report response skip mode counts without treating skipped units as mutations', async () => {


### PR DESCRIPTION
## Summary
- invalidate coding analysis, coding statistics, and coding availability caches after mutating Testcenter response imports
- keep imports successful when cache invalidation fails and report a warning
- cover merge/statistics and Testcenter mutation/no-op cases

## Validation
- npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts --runInBand
- npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts --runInBand
- npx nx lint backend
- npx nx test backend --runInBand

Fixes #539