### PR TITLE
Kodierergebnisse vergleichen: Kodierungshinweise und Notizen anzeigen

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
@@ -715,9 +715,9 @@
             <td mat-cell *matCellDef="let element">
               <div class="code-cell">
                 <ng-container *ngIf="comparisonMode === 'between-trainings'">
-                  <span
+                  <ng-container
                     *ngIf="
-                      hasCoderFromTrainingCodeOrScore(
+                      hasCoderFromTrainingDisplayData(
                         element,
                         col.substring(6)
                       );
@@ -729,34 +729,53 @@
                         getCoderFromTraining(element, col.substring(6)) as coder
                       "
                     >
-                      Code:
-                      <strong>{{
-                        getDisplayCodeAndIssueText(
-                          coder.code,
-                          coder.codingIssueOption
-                        )
-                      }}</strong>
-                      <mat-icon
-                        *ngIf="coder.notes"
-                        class="note-icon"
-                        [matTooltip]="coder.notes"
-                        >comment</mat-icon
-                      ><br />
-                      <ng-container
-                        *ngIf="coder.code !== '-1' && coder.code !== '-2'"
-                      >
-                        Score: {{ coder.score ?? '-' }}
-                      </ng-container>
+                      <div class="coder-result">
+                        <div class="code-line">
+                          <span class="code-label">Code:</span>
+                          <strong class="code-value">{{
+                            getDisplayCodeText(
+                              coder.code,
+                              coder.codingIssueOption
+                            )
+                          }}</strong>
+                          <span
+                            *ngIf="hasCodingIssue(coder)"
+                            class="coding-issue-badge"
+                            [ngClass]="getCodingIssueClass(coder)"
+                            [matTooltip]="getCodingIssueTooltip(coder)"
+                          >
+                            <mat-icon
+                              class="coding-issue-icon"
+                              [ngClass]="getCodingIssueClass(coder)"
+                              aria-hidden="true"
+                            >
+                              flag
+                            </mat-icon>
+                            {{ getCodingIssueShortLabel(coder.codingIssueOption) }}
+                          </span>
+                          <mat-icon
+                            *ngIf="hasCoderNote(coder)"
+                            class="note-icon"
+                            [matTooltip]="getCoderNoteTooltip(coder)"
+                            aria-label="Kodierer-Notiz"
+                          >
+                            comment
+                          </mat-icon>
+                        </div>
+                        <div class="score-line" *ngIf="shouldShowScore(coder)">
+                          Score: {{ coder.score ?? '-' }}
+                        </div>
+                      </div>
                     </ng-container>
-                  </span>
+                  </ng-container>
                   <ng-template #noBetweenCoderData
                     ><span class="no-data">-</span></ng-template
                   >
                 </ng-container>
                 <ng-container *ngIf="comparisonMode === 'within-training'">
-                  <span
+                  <ng-container
                     *ngIf="
-                      hasCoderCodeOrScore(element, +col.substring(6));
+                      hasCoderDisplayDataForWithin(element, +col.substring(6));
                       else noWithinCoderData
                     "
                   >
@@ -765,26 +784,45 @@
                         getCoderForWithin(element, +col.substring(6)) as coder
                       "
                     >
-                      Code:
-                      <strong>{{
-                        getDisplayCodeAndIssueText(
-                          coder.code,
-                          coder.codingIssueOption
-                        )
-                      }}</strong>
-                      <mat-icon
-                        *ngIf="coder.notes"
-                        class="note-icon"
-                        [matTooltip]="coder.notes"
-                        >comment</mat-icon
-                      ><br />
-                      <ng-container
-                        *ngIf="coder.code !== '-1' && coder.code !== '-2'"
-                      >
-                        Score: {{ coder.score ?? '-' }}
-                      </ng-container>
+                      <div class="coder-result">
+                        <div class="code-line">
+                          <span class="code-label">Code:</span>
+                          <strong class="code-value">{{
+                            getDisplayCodeText(
+                              coder.code,
+                              coder.codingIssueOption
+                            )
+                          }}</strong>
+                          <span
+                            *ngIf="hasCodingIssue(coder)"
+                            class="coding-issue-badge"
+                            [ngClass]="getCodingIssueClass(coder)"
+                            [matTooltip]="getCodingIssueTooltip(coder)"
+                          >
+                            <mat-icon
+                              class="coding-issue-icon"
+                              [ngClass]="getCodingIssueClass(coder)"
+                              aria-hidden="true"
+                            >
+                              flag
+                            </mat-icon>
+                            {{ getCodingIssueShortLabel(coder.codingIssueOption) }}
+                          </span>
+                          <mat-icon
+                            *ngIf="hasCoderNote(coder)"
+                            class="note-icon"
+                            [matTooltip]="getCoderNoteTooltip(coder)"
+                            aria-label="Kodierer-Notiz"
+                          >
+                            comment
+                          </mat-icon>
+                        </div>
+                        <div class="score-line" *ngIf="shouldShowScore(coder)">
+                          Score: {{ coder.score ?? '-' }}
+                        </div>
+                      </div>
                     </ng-container>
-                  </span>
+                  </ng-container>
                   <ng-template #noWithinCoderData
                     ><span class="no-data">-</span></ng-template
                   >

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
@@ -714,13 +714,83 @@
             color: #999;
           }
 
+          .code-cell {
+            min-width: 130px;
+          }
+
+          .coder-result {
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
+          }
+
+          .code-line {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            flex-wrap: wrap;
+            line-height: 1.35;
+          }
+
+          .code-label {
+            color: #424242;
+          }
+
+          .code-value {
+            color: #333;
+            overflow-wrap: anywhere;
+          }
+
+          .score-line {
+            color: #424242;
+          }
+
+          .coding-issue-icon {
+            font-size: 16px;
+            width: 16px;
+            height: 16px;
+            vertical-align: text-bottom;
+          }
+
+          .coding-issue-icon.coding-issue-review {
+            color: #b26a00;
+          }
+
+          .coding-issue-icon.coding-issue-info {
+            color: #5d6f7b;
+          }
+
+          .coding-issue-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 3px;
+            min-height: 20px;
+            padding: 2px 6px 2px 4px;
+            border-radius: 4px;
+            font-size: 11px;
+            font-weight: 600;
+            line-height: 1.2;
+            white-space: nowrap;
+
+            &.coding-issue-review {
+              border: 1px solid #ffe082;
+              background: #fff8e1;
+              color: #7a4d00;
+            }
+
+            &.coding-issue-info {
+              border: 1px solid #cfd8dc;
+              background: #eceff1;
+              color: #455a64;
+            }
+          }
+
           .note-icon {
             font-size: 16px;
             width: 16px;
             height: 16px;
             color: #607d8b;
             vertical-align: text-bottom;
-            margin-left: 4px;
           }
 
           .discussion-cell {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -432,6 +432,106 @@ describe('CodingResultsComparisonComponent', () => {
     expect(component.dataSource.filteredData.map(row => row.responseId)).toEqual([10]);
   });
 
+  it('should render compact coding issue badges and only real note icons in coder cells', () => {
+    component.comparisonMode = 'between-trainings';
+    component.availableCodersFromTrainings = [
+      {
+        trainingId: 1,
+        trainingLabel: 'Training A',
+        coderId: 101,
+        coderName: 'Ada'
+      },
+      {
+        trainingId: 2,
+        trainingLabel: 'Training B',
+        coderId: 201,
+        coderName: 'Ben'
+      }
+    ];
+    component.codersFromTrainingsFormControl.setValue(['1_101', '2_201']);
+    component.selectedCodersFromTrainings = new Set(['1_101', '2_201']);
+    component.comparisonData = [
+      {
+        responseId: 12,
+        unitName: 'Unit A',
+        variableId: 'VAR_1',
+        testPerson: 'Test1',
+        personLogin: 'login-1',
+        personCode: 'Code1',
+        personGroup: 'Group A',
+        coders: [
+          {
+            trainingId: 1,
+            trainingLabel: 'Training A',
+            coderId: 101,
+            coderName: 'Ada',
+            code: '7',
+            score: 2,
+            notes: ' Bitte prüfen ',
+            codingIssueOption: -1
+          },
+          {
+            trainingId: 2,
+            trainingLabel: 'Training B',
+            coderId: 201,
+            coderName: 'Ben',
+            code: '-2',
+            score: null,
+            notes: '   ',
+            codingIssueOption: -2
+          }
+        ]
+      }
+    ];
+    component.dataSource.data = component.comparisonData;
+
+    (component as unknown as { updateDisplayedColumns: () => void }).updateDisplayedColumns();
+    fixture.detectChanges();
+
+    const tableText = ((fixture.nativeElement as HTMLElement).textContent || '').replace(/\s+/g, ' ');
+    const issueIcons = fixture.nativeElement.querySelectorAll('.coding-issue-icon');
+    const issueBadges = fixture.nativeElement.querySelectorAll('.coding-issue-badge');
+    const noteIcons = fixture.nativeElement.querySelectorAll('.note-icon');
+    const adaResult = component.comparisonData[0].coders[0];
+    const benResult = component.comparisonData[0].coders[1];
+
+    expect(tableText).toContain('Code:7');
+    expect(tableText).toContain('Score: 2');
+    expect(tableText).toContain('Code:Neuer Code nötig');
+    expect(tableText).toContain('Unsicher');
+    expect(tableText).toContain('Neuer Code');
+    expect(issueIcons).toHaveLength(2);
+    expect(issueBadges).toHaveLength(2);
+    expect(noteIcons).toHaveLength(1);
+    expect(component.getDisplayCodeText('7', -1)).toBe('7');
+    expect(component.getDisplayCodeText('-2', -2)).toBe('Neuer Code nötig');
+    expect(component.getCodingIssueShortLabel(-1)).toBe('Unsicher');
+    expect(component.getCodingIssueShortLabel(-2)).toBe('Neuer Code');
+    expect(component.getCoderNoteTooltip(adaResult)).toBe('Training A - Ada: Bitte prüfen');
+    expect(component.getCodingIssueTooltip(adaResult)).toBe('Training A - Ada: Code-Vergabe unsicher');
+    expect(component.shouldShowScore(adaResult)).toBe(true);
+    expect(component.shouldShowScore(benResult)).toBe(false);
+  });
+
+  it('should include coder names in note tooltips so multiple notes stay distinguishable', () => {
+    expect(component.getCoderNoteTooltip({
+      jobId: 1,
+      coderName: 'Ada',
+      code: '1',
+      score: 1,
+      notes: 'erste Notiz',
+      codingIssueOption: null
+    })).toBe('Ada: erste Notiz');
+    expect(component.getCoderNoteTooltip({
+      jobId: 2,
+      coderName: 'Ben',
+      code: '2',
+      score: 0,
+      notes: 'zweite Notiz',
+      codingIssueOption: null
+    })).toBe('Ben: zweite Notiz');
+  });
+
   it('should initialize discussion values from automatic agreement but not from replay code fallback', () => {
     (component as unknown as {
       initDiscussionValues: (data: Array<{

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -249,6 +249,13 @@ export class CodingResultsComparisonComponent implements OnInit {
     [-4]: 'Technische Probleme'
   };
 
+  readonly codingIssueShortLabelMap: Record<number, string> = {
+    [-1]: 'Unsicher',
+    [-2]: 'Neuer Code',
+    [-3]: 'Spaßantwort',
+    [-4]: 'Technisch'
+  };
+
   tableFilters: ComparisonFilters = {
     unitName: '',
     variableId: '',
@@ -520,6 +527,45 @@ export class CodingResultsComparisonComponent implements OnInit {
     return this.codingIssueLabelMap[codingIssueOption] || `Hinweis ${codingIssueOption}`;
   }
 
+  getCodingIssueShortLabel(codingIssueOption: number | null | undefined): string {
+    if (codingIssueOption === null || codingIssueOption === undefined) {
+      return '';
+    }
+    return this.codingIssueShortLabelMap[codingIssueOption] || `Hinweis ${codingIssueOption}`;
+  }
+
+  private getCoderSourceLabel(coder: ComparisonCoderResult): string {
+    if ('trainingLabel' in coder) {
+      return `${coder.trainingLabel} - ${coder.coderName}`;
+    }
+
+    return coder.coderName;
+  }
+
+  hasCoderNote(coder: Pick<ComparisonCoderResult, 'notes'> | null | undefined): boolean {
+    return !!coder?.notes?.trim();
+  }
+
+  getCoderNoteTooltip(coder: ComparisonCoderResult): string {
+    const note = coder.notes?.trim() || '';
+    return note ? `${this.getCoderSourceLabel(coder)}: ${note}` : '';
+  }
+
+  hasCodingIssue(coder: Pick<ComparisonCoderResult, 'codingIssueOption'> | null | undefined): boolean {
+    return !!this.getCodingIssueLabel(coder?.codingIssueOption);
+  }
+
+  getCodingIssueTooltip(coder: ComparisonCoderResult): string {
+    const issue = this.getCodingIssueLabel(coder.codingIssueOption);
+    return issue ? `${this.getCoderSourceLabel(coder)}: ${issue}` : '';
+  }
+
+  getCodingIssueClass(coder: Pick<ComparisonCoderResult, 'codingIssueOption'>): string {
+    return coder.codingIssueOption === -1 || coder.codingIssueOption === -2 ?
+      'coding-issue-review' :
+      'coding-issue-info';
+  }
+
   getCoderFromTraining(comparison: TrainingComparison, key: string) {
     const parts = key.split('_');
     if (parts.length !== 2) return undefined;
@@ -618,15 +664,38 @@ export class CodingResultsComparisonComponent implements OnInit {
     }
   }
 
-  getDisplayCodeAndIssueText(code: string | null, issueOption?: number | null): string {
-    if (code === null) {
-      return '-';
-    }
+  getDisplayCodeText(code: string | null, issueOption?: number | null): string {
     const issue = this.getCodingIssueLabel(issueOption);
+    if (code === null) {
+      return issue || '-';
+    }
+
     if (code === '-1' || code === '-2') {
       return issue || code;
     }
-    return issue ? `${code} (${issue})` : code;
+
+    return code;
+  }
+
+  shouldShowScore(coder: Pick<ComparisonCoderResult, 'code' | 'score' | 'codingIssueOption'>): boolean {
+    if (coder.code === '-1' || coder.code === '-2') {
+      return false;
+    }
+
+    if (coder.code === null && (coder.codingIssueOption === -1 || coder.codingIssueOption === -2)) {
+      return false;
+    }
+
+    return coder.code !== null || coder.score !== null;
+  }
+
+  private hasCoderDisplayData(coder: ComparisonCoderResult | undefined): boolean {
+    return !!coder && (
+      coder.code !== null ||
+      coder.score !== null ||
+      this.hasCodingIssue(coder) ||
+      this.hasCoderNote(coder)
+    );
   }
 
   /**
@@ -1014,13 +1083,13 @@ export class CodingResultsComparisonComponent implements OnInit {
     return coder ? coder.score : null;
   }
 
-  hasCoderFromTrainingCodeOrScore(comparison: TrainingComparison, key: string): boolean {
+  hasCoderFromTrainingDisplayData(comparison: TrainingComparison, key: string): boolean {
     const parts = key.split('_');
     if (parts.length !== 2) return false;
     const trainingId = parseInt(parts[0], 10);
     const coderId = parseInt(parts[1], 10);
     const coder = comparison.coders.find(c => c.trainingId === trainingId && c.coderId === coderId);
-    return !!(coder && (coder.code !== null || coder.score !== null));
+    return this.hasCoderDisplayData(coder);
   }
 
   calculateStatistics(): void {
@@ -1199,9 +1268,9 @@ export class CodingResultsComparisonComponent implements OnInit {
     return coder ? coder.score : null;
   }
 
-  hasCoderCodeOrScore(comparison: WithinTrainingComparison, jobId: number): boolean {
+  hasCoderDisplayDataForWithin(comparison: WithinTrainingComparison, jobId: number): boolean {
     const coder = comparison.coders.find(c => c.jobId === jobId);
-    return !!(coder && (coder.code !== null || coder.score !== null));
+    return this.hasCoderDisplayData(coder);
   }
 
   applyFilter(event: Event): void {


### PR DESCRIPTION
## Summary

- Shows coding issue hints as compact, visible badges next to each coder code in the comparison table.
- Shows coder notes as note icons with source-aware tooltips so multiple notes remain distinguishable.
- Keeps existing score behavior for regular codes and pure review hints.

Closes #528.

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts`
- `npx nx lint frontend`