### PR TITLE
Validierung: manuelle Variablen ohne auswählbare Codes warnen

### DIFF
--- a/api-dto/coding/manual-code-availability.dto.ts
+++ b/api-dto/coding/manual-code-availability.dto.ts
@@ -1,0 +1,18 @@
+export interface ManualCodeAvailabilityWarningDto {
+  unitName: string;
+  variableId: string;
+  responseCount: number;
+  casesInJobs: number;
+  availableCases: number;
+  uniqueCasesAfterAggregation: number;
+  regularCodeCount: number;
+  selectableRegularCodeCount: number;
+  onlySpecialOptionsAvailable: boolean;
+  message: string;
+}
+
+export interface ManualCodeAvailabilityValidationDto {
+  checkedVariables: number;
+  warningCount: number;
+  warnings: ManualCodeAvailabilityWarningDto[];
+}

--- a/apps/backend/src/app/admin/coding-job/dto/job-definition-variable.dto.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/job-definition-variable.dto.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line max-classes-per-file
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsEnum, IsNumber, IsOptional, IsString, Min
+  IsBoolean, IsEnum, IsNumber, IsOptional, IsString, Min
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -19,6 +19,15 @@ export class JobDefinitionVariableDto {
   })
   @IsString()
     variableId: string;
+
+  @ApiProperty({
+    description: 'Whether DERIVE_ERROR responses for this variable should be included in generated manual coding jobs',
+    example: false,
+    required: false
+  })
+  @IsBoolean()
+  @IsOptional()
+    includeDeriveError?: boolean;
 }
 
 export class JobDefinitionVariableBundleDto {

--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
@@ -25,6 +25,7 @@ import { VariableAnalysisItemDto } from '../../../../../../api-dto/coding/variab
 import { ValidateCodingCompletenessRequestDto } from '../../../../../../api-dto/coding/validate-coding-completeness-request.dto';
 import { ValidateCodingCompletenessResponseDto } from '../../../../../../api-dto/coding/validate-coding-completeness-response.dto';
 import { ExportValidationResultsRequestDto } from '../../../../../../api-dto/coding/export-validation-results-request.dto';
+import { ManualCodeAvailabilityValidationDto } from '../../../../../../api-dto/coding/manual-code-availability.dto';
 import { ResponseMatchingFlag } from '../../database/services/coding/coding-job.service';
 
 @ApiTags('Admin Workspace Coding')
@@ -316,6 +317,70 @@ export class WorkspaceCodingAnalysisController {
       trainingRequiredParam = false;
     }
     return this.codingValidationService.getManualCodingScopeSummary(
+      workspace_id,
+      unitName,
+      trainingRequiredParam
+    );
+  }
+
+  @Get(':workspace_id/coding/incomplete-variables/code-availability')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiTags('coding')
+  @ApiParam({ name: 'workspace_id', type: Number })
+  @ApiQuery({
+    name: 'unitName',
+    required: false,
+    description: 'Filter by unit name',
+    type: String
+  })
+  @ApiQuery({
+    name: 'trainingRequired',
+    required: false,
+    description: 'Filter variables by coder training requirement',
+    type: Boolean
+  })
+  @ApiOkResponse({
+    description:
+      'Manual coding variables without selectable regular codes retrieved successfully.',
+    schema: {
+      type: 'object',
+      properties: {
+        checkedVariables: { type: 'number' },
+        warningCount: { type: 'number' },
+        warnings: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              unitName: { type: 'string' },
+              variableId: { type: 'string' },
+              responseCount: { type: 'number' },
+              casesInJobs: { type: 'number' },
+              availableCases: { type: 'number' },
+              uniqueCasesAfterAggregation: { type: 'number' },
+              regularCodeCount: { type: 'number' },
+              selectableRegularCodeCount: { type: 'number' },
+              onlySpecialOptionsAvailable: { type: 'boolean' },
+              message: { type: 'string' }
+            }
+          }
+        }
+      }
+    }
+  })
+  async validateManualCodeAvailability(
+    @WorkspaceId() workspace_id: number,
+      @Query('unitName') unitName?: string,
+      @Query('trainingRequired') trainingRequired?: string
+  ): Promise<ManualCodeAvailabilityValidationDto> {
+    let trainingRequiredParam: boolean | undefined;
+    if (trainingRequired === 'true') {
+      trainingRequiredParam = true;
+    } else if (trainingRequired === 'false') {
+      trainingRequiredParam = false;
+    }
+
+    return this.codingValidationService.validateManualCodeAvailability(
       workspace_id,
       unitName,
       trainingRequiredParam

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -1738,7 +1738,8 @@ export class WorkspaceCodingStatisticsController {
             type: 'object',
             properties: {
               unitName: { type: 'string' },
-              variableId: { type: 'string' }
+              variableId: { type: 'string' },
+              includeDeriveError: { type: 'boolean' }
             }
           }
         },
@@ -1756,7 +1757,8 @@ export class WorkspaceCodingStatisticsController {
                   type: 'object',
                   properties: {
                     unitName: { type: 'string' },
-                    variableId: { type: 'string' }
+                    variableId: { type: 'string' },
+                    includeDeriveError: { type: 'boolean' }
                   }
                 }
               }
@@ -1859,12 +1861,12 @@ export class WorkspaceCodingStatisticsController {
     @WorkspaceId() workspace_id: number,
       @Body()
                    body: {
-                     selectedVariables: { unitName: string; variableId: string }[];
+                     selectedVariables: { unitName: string; variableId: string; includeDeriveError?: boolean }[];
                      selectedVariableBundles?: {
                        id: number;
                        name: string;
                        caseOrderingMode?: 'continuous' | 'alternating';
-                       variables: { unitName: string; variableId: string }[];
+                       variables: { unitName: string; variableId: string; includeDeriveError?: boolean }[];
                      }[];
                      selectedCoders: {
                        id: number;
@@ -1898,7 +1900,8 @@ export class WorkspaceCodingStatisticsController {
             type: 'object',
             properties: {
               unitName: { type: 'string' },
-              variableId: { type: 'string' }
+              variableId: { type: 'string' },
+              includeDeriveError: { type: 'boolean' }
             }
           }
         },
@@ -1916,7 +1919,8 @@ export class WorkspaceCodingStatisticsController {
                   type: 'object',
                   properties: {
                     unitName: { type: 'string' },
-                    variableId: { type: 'string' }
+                    variableId: { type: 'string' },
+                    includeDeriveError: { type: 'boolean' }
                   }
                 }
               }
@@ -2046,12 +2050,12 @@ export class WorkspaceCodingStatisticsController {
     @WorkspaceId() workspace_id: number,
       @Body()
                    body: {
-                     selectedVariables: { unitName: string; variableId: string }[];
+                     selectedVariables: { unitName: string; variableId: string; includeDeriveError?: boolean }[];
                      selectedVariableBundles?: {
                        id: number;
                        name: string;
                        caseOrderingMode?: 'continuous' | 'alternating';
-                       variables: { unitName: string; variableId: string }[];
+                       variables: { unitName: string; variableId: string; includeDeriveError?: boolean }[];
                      }[];
                      selectedCoders: {
                        id: number;

--- a/apps/backend/src/app/database/entities/job-definition.entity.ts
+++ b/apps/backend/src/app/database/entities/job-definition.entity.ts
@@ -20,6 +20,7 @@ export interface JobDefinitionVariable {
   unitName: string;
   variableId: string;
   sampleCount?: number;
+  includeDeriveError?: boolean;
 }
 
 export interface JobDefinitionVariableBundle {

--- a/apps/backend/src/app/database/services/coding/coding-item-builder.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-item-builder.service.ts
@@ -17,6 +17,7 @@ export interface CodingItem {
   variable_id: string;
   variable_page: string;
   variable_anchor: string;
+  status_v1?: string;
   value?: string;
   url?: string;
 }
@@ -96,6 +97,7 @@ export class CodingItemBuilderService {
         variable_id: variableId,
         variable_page: variablePage,
         variable_anchor: variableAnchor,
+        status_v1: this.formatStatus(response.status_v1),
         url
       };
     } catch (error) {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Brackets } from 'typeorm';
 import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { CodingJob } from '../../entities/coding-job.entity';
 import { CodingJobCoder } from '../../entities/coding-job-coder.entity';
@@ -84,6 +85,9 @@ describe('CodingJobService', () => {
   let cacheService: { delete: jest.Mock };
   let codingFreshnessService: { reconcileAppliedManualCodingJobs: jest.Mock };
   let codingFileCacheService: { getVariablePageMap: jest.Mock };
+  let workspaceFilesService: {
+    getDerivedVariableMap: jest.Mock;
+  };
   let usersService: {
     getUserIsAdmin: jest.Mock;
     getUserAccessLevel: jest.Mock;
@@ -177,7 +181,7 @@ describe('CodingJobService', () => {
         testletIgnoredUnits: []
       })
     };
-    const workspaceFilesService = {
+    workspaceFilesService = {
       getDerivedVariableMap: jest.fn().mockResolvedValue(new Map())
     };
     usersService = {
@@ -1072,6 +1076,45 @@ describe('CodingJobService', () => {
     expectManualCodingCandidateStatusFilter(qb);
   });
 
+  it('includes DERIVE_ERROR responses for job-definition variables that opt into manual coding', async () => {
+    const qb = createQueryBuilder([]);
+    responseRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await expect(service.getResponsesForVariables(3, [{
+      unitName: 'UNIT',
+      variableId: 'VAR',
+      includeDeriveError: true
+    }])).resolves.toEqual([]);
+
+    const bracketCall = qb.andWhere.mock.calls.find(
+      ([condition]) => condition instanceof Brackets
+    );
+    expect(bracketCall).toBeDefined();
+
+    const bracketBuilder: Record<string, jest.Mock> = {
+      where: jest.fn().mockReturnThis(),
+      orWhere: jest.fn().mockReturnThis()
+    };
+    (bracketCall?.[0] as Brackets).whereFactory(bracketBuilder as never);
+
+    expect(bracketBuilder.where).toHaveBeenCalledWith(
+      'response.status_v1 IN (:...statuses)',
+      {
+        statuses: [
+          statusStringToNumber('CODING_INCOMPLETE'),
+          statusStringToNumber('INTENDED_INCOMPLETE')
+        ]
+      }
+    );
+    expect(bracketBuilder.orWhere).toHaveBeenCalledWith(
+      expect.stringContaining('response.status_v1 = :deriveErrorStatus'),
+      {
+        deriveErrorStatus: statusStringToNumber('DERIVE_ERROR'),
+        deriveErrorManualCodingPairKeys: ['UNIT\u001FVAR']
+      }
+    );
+  });
+
   it('does not include DERIVE_ERROR responses when saving coding-job units', async () => {
     const qb = createQueryBuilder([]);
     responseRepository.createQueryBuilder.mockReturnValue(qb);
@@ -1086,6 +1129,62 @@ describe('CodingJobService', () => {
     } as never);
 
     expectManualCodingCandidateStatusFilter(qb);
+  });
+
+  it('counts DERIVE_ERROR distribution cases only for variables with job-definition opt-in', () => {
+    const calculateFromContext = (
+      service as unknown as {
+        calculateDistributionVariableUsageFromContext: (
+          workspaceId: number,
+          request: {
+            selectedVariables: { unitName: string; variableId: string; includeDeriveError?: boolean }[];
+            selectedVariableBundles?: [];
+          },
+          context: unknown
+        ) => Map<string, number>;
+      }
+    ).calculateDistributionVariableUsageFromContext.bind(service);
+    const context = {
+      matchingFlags: [ResponseMatchingFlag.NO_AGGREGATION],
+      aggregationThreshold: null,
+      derivedVariableSets: new Map(),
+      assignedResponseIds: new Set(),
+      allResponses: [
+        {
+          id: 1,
+          variableid: 'VAR',
+          value: 'A',
+          statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+          unitName: 'UNIT',
+          unitAlias: null,
+          bookletName: 'BOOKLET',
+          personLogin: 'LOGIN',
+          personCode: 'CODE',
+          personGroup: 'GROUP'
+        },
+        {
+          id: 2,
+          variableid: 'VAR',
+          value: 'B',
+          statusV1: statusStringToNumber('DERIVE_ERROR'),
+          unitName: 'UNIT',
+          unitAlias: null,
+          bookletName: 'BOOKLET',
+          personLogin: 'LOGIN2',
+          personCode: 'CODE2',
+          personGroup: 'GROUP'
+        }
+      ]
+    };
+
+    expect(calculateFromContext(3, {
+      selectedVariables: [{ unitName: 'UNIT', variableId: 'VAR' }],
+      selectedVariableBundles: []
+    }, context).get('UNIT::VAR')).toBe(1);
+    expect(calculateFromContext(3, {
+      selectedVariables: [{ unitName: 'UNIT', variableId: 'VAR', includeDeriveError: true }],
+      selectedVariableBundles: []
+    }, context).get('UNIT::VAR')).toBe(2);
   });
 
   it('returns no coding-job responses when no variables are assigned', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -3,10 +3,9 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
-  Repository, In, Not, Connection, EntityManager, SelectQueryBuilder
+  Repository, In, Not, Connection, EntityManager, SelectQueryBuilder, Brackets
 } from 'typeorm';
 import * as cheerio from 'cheerio';
-import { statusStringToNumber } from '../../utils/response-status-converter';
 import { SaveCodingProgressDto } from '../../../admin/coding-job/dto/save-coding-progress.dto';
 import { SaveCodingNotesDto } from '../../../admin/coding-job/dto/save-coding-notes.dto';
 import { sortUnitsContinuous, sortUnitsAlternating } from '../../../utils/coding-utils';
@@ -45,6 +44,12 @@ import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspa
 import { CodingFreshnessService } from './coding-freshness.service';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
 import { CodingFileCacheService } from './coding-file-cache.service';
+import {
+  DERIVE_ERROR_STATUS,
+  getDeriveErrorManualCodingPairKeys,
+  ManualCodingVariableReference,
+  MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+} from '../../utils/manual-coding-candidate.util';
 
 function isSafeKey(key: string): boolean {
   return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
@@ -90,7 +95,7 @@ export interface TransferCodingCasesResult {
   transferredCases: number;
 }
 
-type VariableReference = { unitName: string; variableId: string };
+type VariableReference = ManualCodingVariableReference;
 type BundleItem = { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: VariableReference[] };
 type DistributionItem = { type: 'bundle' | 'variable'; item: BundleItem | VariableReference };
 type DistributionCoderInput = {
@@ -233,6 +238,7 @@ interface SlimResponse {
   id: number;
   variableid: string;
   value: string | null;
+  statusV1?: number | null;
   unitName: string;
   unitAlias: string | null;
   bookletName: string;
@@ -311,6 +317,44 @@ export class CodingJobService {
     @Optional()
     private codingFileCacheService?: CodingFileCacheService
   ) { }
+
+  private applyManualCodingCandidateStatusFilter(
+    queryBuilder: SelectQueryBuilder<ResponseEntity>,
+    variables: VariableReference[] = []
+  ): void {
+    const deriveErrorManualCodingPairKeys = getDeriveErrorManualCodingPairKeys(variables);
+
+    if (deriveErrorManualCodingPairKeys.length === 0) {
+      queryBuilder.andWhere('response.status_v1 IN (:...statuses)', {
+        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+      });
+      return;
+    }
+
+    queryBuilder.andWhere(new Brackets(qb => {
+      qb.where('response.status_v1 IN (:...statuses)', {
+        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+      }).orWhere(
+        `response.status_v1 = :deriveErrorStatus
+          AND CONCAT(unit.name, CHR(31), response.variableid) IN (:...deriveErrorManualCodingPairKeys)`,
+        {
+          deriveErrorStatus: DERIVE_ERROR_STATUS,
+          deriveErrorManualCodingPairKeys
+        }
+      );
+    }));
+  }
+
+  private responseMatchesVariableReference(
+    response: SlimResponse,
+    variable: VariableReference
+  ): boolean {
+    if (response.unitName !== variable.unitName || response.variableid !== variable.variableId) {
+      return false;
+    }
+
+    return response.statusV1 !== DERIVE_ERROR_STATUS || variable.includeDeriveError === true;
+  }
 
   async assertUserCanAccessCodingJob(
     codingJobId: number,
@@ -2359,6 +2403,7 @@ export class CodingJobService {
       .select('response.id', 'id')
       .addSelect('response.variableid', 'variableid')
       .addSelect('response.value', 'value')
+      .addSelect('response.status_v1', 'statusV1')
       .addSelect('unit.name', 'unitName')
       .addSelect('unit.alias', 'unitAlias')
       .addSelect('COALESCE(bookletinfo.name, \'\')', 'bookletName')
@@ -2370,13 +2415,8 @@ export class CodingJobService {
       .leftJoin('booklet.bookletinfo', 'bookletinfo')
       .innerJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('response.status_v1 IN (:...statuses)', {
-        statuses: [
-          statusStringToNumber('CODING_INCOMPLETE'),
-          statusStringToNumber('INTENDED_INCOMPLETE')
-        ]
-      });
+      .andWhere('person.consider = :consider', { consider: true });
+    this.applyManualCodingCandidateStatusFilter(queryBuilder);
 
     const conditions: string[] = [];
     const parameters: Record<string, string> = {};
@@ -2403,6 +2443,7 @@ export class CodingJobService {
         id: Number(r.id),
         variableid: variableid,
         value: r.value ?? null,
+        statusV1: r.statusV1 !== undefined && r.statusV1 !== null ? Number(r.statusV1) : null,
         unitName: unitName,
         unitAlias: r.unitAlias ?? null,
         bookletName: r.bookletName ?? '',
@@ -2858,7 +2899,7 @@ export class CodingJobService {
     return filteredResponses;
   }
 
-  async getResponsesForVariables(workspaceId: number, variables: { unitName: string; variableId: string }[]): Promise<ResponseEntity[]> {
+  async getResponsesForVariables(workspaceId: number, variables: VariableReference[]): Promise<ResponseEntity[]> {
     if (variables.length === 0) {
       return [];
     }
@@ -2870,13 +2911,8 @@ export class CodingJobService {
       .leftJoinAndSelect('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('response.status_v1 IN (:...statuses)', {
-        statuses: [
-          statusStringToNumber('CODING_INCOMPLETE'),
-          statusStringToNumber('INTENDED_INCOMPLETE')
-        ]
-      })
       .andWhere('(response.code_v2 IS NULL OR response.code_v2 != -111)');
+    this.applyManualCodingCandidateStatusFilter(queryBuilder, variables);
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
@@ -2902,7 +2938,7 @@ export class CodingJobService {
 
   async getSlimResponsesForVariables(
     workspaceId: number,
-    variables: { unitName: string; variableId: string }[],
+    variables: VariableReference[],
     manager?: EntityManager
   ): Promise<SlimResponse[]> {
     if (variables.length === 0) {
@@ -2914,6 +2950,7 @@ export class CodingJobService {
       .select('response.id', 'id')
       .addSelect('response.variableid', 'variableid')
       .addSelect('response.value', 'value')
+      .addSelect('response.status_v1', 'statusV1')
       .addSelect('unit.name', 'unitName')
       .addSelect('unit.alias', 'unitAlias')
       .addSelect('COALESCE(bookletinfo.name, \'\')', 'bookletName')
@@ -2926,13 +2963,8 @@ export class CodingJobService {
       .innerJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('response.status_v1 IN (:...statuses)', {
-        statuses: [
-          statusStringToNumber('CODING_INCOMPLETE'),
-          statusStringToNumber('INTENDED_INCOMPLETE')
-        ]
-      })
       .andWhere('(response.code_v2 IS NULL OR (response.code_v2 != -111 AND response.code_v2 != -98))');
+    this.applyManualCodingCandidateStatusFilter(queryBuilder, variables);
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
@@ -2959,6 +2991,7 @@ export class CodingJobService {
       id: Number(r.id),
       variableid: r.variableid,
       value: r.value ?? null,
+      statusV1: r.statusV1 !== undefined && r.statusV1 !== null ? Number(r.statusV1) : null,
       unitName: r.unitName ?? '',
       unitAlias: r.unitAlias ?? null,
       bookletName: r.bookletName ?? '',
@@ -2970,7 +3003,7 @@ export class CodingJobService {
 
   private async getAssignedResponseIdsForVariables(
     workspaceId: number,
-    variables: { unitName: string; variableId: string }[],
+    variables: VariableReference[],
     excludeJobDefinitionId?: number,
     manager?: EntityManager
   ): Promise<Set<number>> {
@@ -3355,7 +3388,14 @@ export class CodingJobService {
     const uniqueVariables = new Map<string, VariableReference>();
 
     variables.forEach(variable => {
-      uniqueVariables.set(`${variable.unitName}::${variable.variableId}`, variable);
+      const key = `${variable.unitName}::${variable.variableId}`;
+      const existing = uniqueVariables.get(key);
+      uniqueVariables.set(key, {
+        ...variable,
+        includeDeriveError: existing?.includeDeriveError === true || variable.includeDeriveError === true ?
+          true :
+          undefined
+      });
     });
 
     return Array.from(uniqueVariables.values());
@@ -3591,8 +3631,10 @@ export class CodingJobService {
       variableId
     );
 
-    const allVariables = items.flatMap(
-      itemObj => this.getItemDetails(itemObj, caseOrderingMode, bundleNameCounts).itemVariables
+    const allVariables = this.deduplicateVariableReferences(
+      items.flatMap(
+        itemObj => this.getItemDetails(itemObj, caseOrderingMode, bundleNameCounts).itemVariables
+      )
     );
     const allResponses = await this.getSlimResponsesForVariables(workspaceId, allVariables, manager);
     const assignedResponseIds = await this.getAssignedResponseIdsForVariables(
@@ -3611,7 +3653,7 @@ export class CodingJobService {
       }
 
       warnedVariables.add(variableKey);
-      const variableResponses = allResponses.filter(r => r.unitName === variable.unitName && r.variableid === variable.variableId);
+      const variableResponses = allResponses.filter(r => this.responseMatchesVariableReference(r, variable));
       const warning = this.buildAvailabilityWarning(
         variable,
         variableResponses,
@@ -3644,7 +3686,9 @@ export class CodingJobService {
         continue;
       }
 
-      const allItemResponses = allResponses.filter(response => itemVariables.some(v => v.unitName === response.unitName && v.variableId === response.variableid)
+      const allItemResponses = allResponses.filter(response => itemVariables.some(
+        variable => this.responseMatchesVariableReference(response, variable)
+      )
       );
       const { filteredResponses, uniqueCases, totalResponses } = this.getDistributableResponses(
         allItemResponses,
@@ -3916,10 +3960,9 @@ export class CodingJobService {
         continue;
       }
 
-      const allItemResponses = context.allResponses.filter(response => itemVariables.some(v => (
-        v.unitName === response.unitName &&
-        v.variableId === response.variableid
-      )));
+      const allItemResponses = context.allResponses.filter(response => itemVariables.some(
+        variable => this.responseMatchesVariableReference(response, variable)
+      ));
       const { filteredResponses, uniqueCases, totalResponses } = this.getDistributableResponses(
         allItemResponses,
         context.assignedResponseIds,
@@ -3962,7 +4005,7 @@ export class CodingJobService {
   async calculateDistribution(
     workspaceId: number,
     request: {
-      selectedVariables: { unitName: string; variableId: string }[];
+      selectedVariables: VariableReference[];
       selectedVariableBundles?: BundleItem[];
       selectedCoders: DistributionCoderInput[];
       doubleCodingAbsolute?: number;

--- a/apps/backend/src/app/database/services/coding/coding-list-query.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-query.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ResponseEntity } from '../../entities/response.entity';
-import { statusStringToNumber } from '../../utils/response-status-converter';
+import { statusNumberToString } from '../../utils/response-status-converter';
 // eslint-disable-next-line import/no-cycle
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import { WorkspaceCoreService } from '../workspace/workspace-core.service';
@@ -16,12 +16,13 @@ import {
   getCoveredSourceKeysForManualDerivedVariables,
   isCoveredSourceVariable
 } from '../../utils/manual-coding-scope.util';
+import {
+  CODING_INCOMPLETE_STATUS,
+  INTENDED_INCOMPLETE_STATUS,
+  MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+} from '../../utils/manual-coding-candidate.util';
 
 const PAGE_MAP_LOOKUP_BATCH_SIZE = 8;
-const MANUAL_CODING_CANDIDATE_STATUSES = [
-  statusStringToNumber('CODING_INCOMPLETE'),
-  statusStringToNumber('INTENDED_INCOMPLETE')
-].filter((status): status is number => status !== null);
 
 /**
  * Service responsible for querying coding lists and variables.
@@ -74,11 +75,11 @@ export class CodingListQueryService {
         .leftJoinAndSelect('unit.booklet', 'booklet')
         .leftJoinAndSelect('booklet.person', 'person')
         .leftJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
-        .where('response.status_v1 IN (:...statuses)', {
-          statuses: MANUAL_CODING_CANDIDATE_STATUSES
-        })
-        .andWhere('person.workspace_id = :workspace_id', { workspace_id })
+        .where('person.workspace_id = :workspace_id', { workspace_id })
         .andWhere('person.consider = :consider', { consider: true })
+        .andWhere('response.status_v1 IN (:...statuses)', {
+          statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+        })
         .orderBy('response.id', 'ASC');
 
       const { globalIgnoredUnits, ignoredBooklets, testletIgnoredUnits } = await this.workspaceExclusionService.resolveExclusionsForQueries(workspace_id);
@@ -105,8 +106,6 @@ export class CodingListQueryService {
         trainingRequiredSets.set(unitNameKey.toUpperCase(), variables);
       });
 
-      const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
-
       // 3) Filter responses:
       //    - Variable must exist in unitVariableMap (valid, non-BASE/BASE_NO_VALUE)
       //    - For INTENDED_INCOMPLETE: exclude source variables already represented by a manual derived variable
@@ -117,7 +116,7 @@ export class CodingListQueryService {
         const variableId = r.variableid || '';
         const hasValue = r.value != null && r.value.trim() !== '';
 
-        if (!this.isManualCodingCandidateStatus(r.status_v1)) return false;
+        if (!MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES.includes(Number(r.status_v1))) return false;
         if (!hasValue) return false;
 
         const hasExcludedSubstring = /image|text|audio|frame|video|_0/i.test(variableId);
@@ -138,7 +137,7 @@ export class CodingListQueryService {
       });
       const coveredSourceKeys = getCoveredSourceKeysForManualDerivedVariables(
         baseFiltered
-          .filter(response => response.status_v1 === codingIncompleteStatus)
+          .filter(response => response.status_v1 === CODING_INCOMPLETE_STATUS)
           .map(response => ({
             unitName: response.unit?.name || '',
             variableId: response.variableid || ''
@@ -146,7 +145,7 @@ export class CodingListQueryService {
         derivedVariablesBySourceMap
       );
       const filtered = baseFiltered.filter(response => (
-        response.status_v1 === codingIncompleteStatus ||
+        response.status_v1 !== INTENDED_INCOMPLETE_STATUS ||
         !isCoveredSourceVariable(
           {
             unitName: response.unit?.name || '',
@@ -196,6 +195,7 @@ export class CodingListQueryService {
           variable_id: variableId,
           variable_page: variablePage,
           variable_anchor: variableAnchor,
+          status_v1: statusNumberToString(Number(response.status_v1)) || '',
           url
         };
       });
@@ -210,7 +210,7 @@ export class CodingListQueryService {
       });
 
       this.logger.log(
-        `Found ${sortedResult.length} coding items (CODING_INCOMPLETE + INTENDED_INCOMPLETE) after filtering, total raw ${total}`
+        `Found ${sortedResult.length} coding items after manual-coding candidate filtering, total raw ${total}`
       );
       return { items: sortedResult, total };
     } catch (error) {
@@ -266,10 +266,10 @@ export class CodingListQueryService {
       .addSelect('response.status_v1', 'statusV1')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
+      .andWhere("(response.value IS NOT NULL AND response.value != '')")
       .andWhere('response.status_v1 IN (:...statuses)', {
-        statuses: MANUAL_CODING_CANDIDATE_STATUSES
-      })
-      .andWhere("(response.value IS NOT NULL AND response.value != '')");
+        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+      });
 
     // Exclude media variables
     queryBuilder.andWhere(
@@ -305,13 +305,11 @@ export class CodingListQueryService {
       trainingRequiredSets.set(unitName.toUpperCase(), variables);
     });
 
-    const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
-
     const baseFilteredResults = rawResults.filter(row => {
       const unitNameUpper = row.unitName?.toUpperCase();
       const variableId: string = row.variableId;
 
-      if (!this.isManualCodingCandidateStatus(row.statusV1)) return false;
+      if (!MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES.includes(Number(row.statusV1))) return false;
 
       const validVars = validVariableSets.get(unitNameUpper);
       if (!validVars?.has(variableId)) return false;
@@ -327,7 +325,7 @@ export class CodingListQueryService {
     });
     const coveredSourceKeys = getCoveredSourceKeysForManualDerivedVariables(
       baseFilteredResults
-        .filter(row => Number(row.statusV1) === codingIncompleteStatus)
+        .filter(row => Number(row.statusV1) === CODING_INCOMPLETE_STATUS)
         .map(row => ({
           unitName: row.unitName,
           variableId: row.variableId
@@ -344,7 +342,7 @@ export class CodingListQueryService {
       const statusV1: number = Number(row.statusV1);
 
       // For INTENDED_INCOMPLETE rows: skip source variables already covered by derived variables
-      if (statusV1 !== codingIncompleteStatus) {
+      if (statusV1 === INTENDED_INCOMPLETE_STATUS) {
         if (isCoveredSourceVariable(row, coveredSourceKeys)) {
           continue;
         }
@@ -358,13 +356,9 @@ export class CodingListQueryService {
     }
 
     this.logger.log(
-      `Found ${rawResults.length} CODING_INCOMPLETE + INTENDED_INCOMPLETE variable rows, filtered to ${filteredResults.length} valid distinct variables`
+      `Found ${rawResults.length} manual-coding candidate variable rows, filtered to ${filteredResults.length} valid distinct variables`
     );
 
     return filteredResults;
-  }
-
-  private isManualCodingCandidateStatus(status: unknown): boolean {
-    return MANUAL_CODING_CANDIDATE_STATUSES.includes(Number(status));
   }
 }

--- a/apps/backend/src/app/database/services/coding/coding-list-stream.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-stream.service.ts
@@ -2,7 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import * as fastCsv from 'fast-csv';
 import * as ExcelJS from 'exceljs';
 // eslint-disable-next-line import/no-cycle
-import { CodingResponseFilterService } from './coding-response-filter.service';
+import {
+  CodingResponseFilterService,
+  ResponseFilterOptions
+} from './coding-response-filter.service';
 import { CodingItemBuilderService, CodingItem } from './coding-item-builder.service';
 import { CodingFileCacheService } from './coding-file-cache.service';
 // eslint-disable-next-line import/no-cycle
@@ -35,6 +38,27 @@ export class CodingListStreamService {
     private readonly workspaceFilesService: WorkspaceFilesService
   ) { }
 
+  private async getCodingListFilterContext(
+    workspaceId: number,
+    trainingRequired?: boolean
+  ): Promise<{
+      filterOptions: ResponseFilterOptions;
+      trainingRequiredMap: Map<string, Set<string>> | null;
+    }> {
+    const trainingRequiredMap = await (
+      trainingRequired !== undefined ?
+        this.workspaceFilesService.getCoderTrainingRequiredVariableMap(workspaceId) :
+        Promise.resolve(null)
+    );
+
+    return {
+      filterOptions: {
+        manualCodingCandidatesOnly: true
+      },
+      trainingRequiredMap
+    };
+  }
+
   /**
    * Stream coding list as CSV with memory-efficient batching.
    */
@@ -53,21 +77,22 @@ export class CodingListStreamService {
 
     (async () => {
       try {
-        const totalRows = await this.responseFilterService.countResponses(workspace_id);
+        const { filterOptions, trainingRequiredMap } =
+          await this.getCodingListFilterContext(workspace_id, trainingRequired);
+        const totalRows = await this.responseFilterService.countResponses(
+          workspace_id,
+          filterOptions
+        );
         const batchSize = 500;
         let lastId = 0;
         let totalWritten = 0;
-
-        // Load training required map if filtering is requested
-        const trainingRequiredMap = trainingRequired !== undefined ?
-          await this.workspaceFilesService.getCoderTrainingRequiredVariableMap(workspace_id) :
-          null;
 
         for (; ;) {
           const responses = await this.responseFilterService.getResponsesBatch(
             workspace_id,
             lastId,
-            batchSize
+            batchSize,
+            filterOptions
           );
 
           if (!responses.length) break;
@@ -184,25 +209,27 @@ export class CodingListStreamService {
       { header: 'variable_id', key: 'variable_id', width: 30 },
       { header: 'variable_page', key: 'variable_page', width: 15 },
       { header: 'variable_anchor', key: 'variable_anchor', width: 30 },
+      { header: 'status_v1', key: 'status_v1', width: 20 },
       { header: 'url', key: 'url', width: 60 }
     ];
 
     try {
-      const totalRows = await this.responseFilterService.countResponses(workspace_id);
+      const { filterOptions, trainingRequiredMap } =
+        await this.getCodingListFilterContext(workspace_id, trainingRequired);
+      const totalRows = await this.responseFilterService.countResponses(
+        workspace_id,
+        filterOptions
+      );
       const batchSize = 1000; // Reduced batch size for streaming
       let lastId = 0;
       let totalWritten = 0;
-
-      // Load training required map if filtering is requested
-      const trainingRequiredMap = trainingRequired !== undefined ?
-        await this.workspaceFilesService.getCoderTrainingRequiredVariableMap(workspace_id) :
-        null;
 
       for (; ;) {
         const responses = await this.responseFilterService.getResponsesBatch(
           workspace_id,
           lastId,
-          batchSize
+          batchSize,
+          filterOptions
         );
 
         if (!responses.length) break;
@@ -332,21 +359,22 @@ export class CodingListStreamService {
     trainingRequired?: boolean
   ) {
     try {
-      const totalRows = await this.responseFilterService.countResponses(workspace_id);
+      const { filterOptions, trainingRequiredMap } =
+        await this.getCodingListFilterContext(workspace_id, trainingRequired);
+      const totalRows = await this.responseFilterService.countResponses(
+        workspace_id,
+        filterOptions
+      );
       const batchSize = 5000;
       let lastId = 0;
-      const totalWritten = 0;
-
-      // Load training required map if filtering is requested
-      const trainingRequiredMap = trainingRequired !== undefined ?
-        await this.workspaceFilesService.getCoderTrainingRequiredVariableMap(workspace_id) :
-        null;
+      let totalWritten = 0;
 
       for (; ;) {
         const responses = await this.responseFilterService.getResponsesBatch(
           workspace_id,
           lastId,
-          batchSize
+          batchSize,
+          filterOptions
         );
 
         if (!responses.length) break;
@@ -370,6 +398,7 @@ export class CodingListStreamService {
           );
           if (item) {
             dataListener(item);
+            totalWritten += 1;
           }
         }
 

--- a/apps/backend/src/app/database/services/coding/coding-list.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list.service.ts
@@ -15,6 +15,7 @@ export interface CodingItem {
   variable_id: string;
   variable_page: string;
   variable_anchor: string;
+  status_v1?: string;
   value?: string;
   url?: string;
 }

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -469,6 +469,45 @@ describe('CodingProgressService variable coverage conflicts', () => {
     expect(result.fullyAbgedeckteVariablen).toBe(1);
   });
 
+  it('classifies fully, partially, and missing variable coverage separately', async () => {
+    responseRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([
+      { unitName: 'FULL_UNIT', variableId: '01', caseCount: '3' },
+      { unitName: 'PARTIAL_UNIT', variableId: '01', caseCount: '3' },
+      { unitName: 'MISSING_UNIT', variableId: '01', caseCount: '2' }
+    ]));
+    jobDefinitionRepository.find.mockResolvedValue([
+      {
+        id: 30,
+        status: 'approved',
+        assigned_variables: [{ unitName: 'FULL_UNIT', variableId: '01' }]
+      },
+      {
+        id: 31,
+        status: 'pending_review',
+        assigned_variables: [{ unitName: 'PARTIAL_UNIT', variableId: '01' }]
+      }
+    ]);
+    codingJobUnitRepository.createQueryBuilder
+      .mockReturnValueOnce(createQueryBuilder([
+        { unitName: 'FULL_UNIT', variableId: '01', casesInJobs: '3' },
+        { unitName: 'PARTIAL_UNIT', variableId: '01', casesInJobs: '1' }
+      ]))
+      .mockReturnValueOnce(createQueryBuilder([]));
+
+    const result = await service.getVariableCoverageOverview(5);
+
+    expect(result.totalVariables).toBe(3);
+    expect(result.coveredVariables).toBe(2);
+    expect(result.missingVariables).toBe(1);
+    expect(result.fullyAbgedeckteVariablen).toBe(1);
+    expect(result.partiallyAbgedeckteVariablen).toBe(1);
+    expect(result.conflictedVariables).toBe(0);
+    expect(result.coveragePercentage).toBeCloseTo(66.67, 2);
+    expect(result.coverageByStatus.approved).toEqual(['FULL_UNIT:01']);
+    expect(result.coverageByStatus.pending_review).toEqual(['PARTIAL_UNIT:01']);
+    expect(result.coverageByStatus.conflicted).toEqual([]);
+  });
+
   it('flags variables when the same response is assigned through multiple job definitions', async () => {
     responseRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([
       { unitName: 'MDB091', variableId: '01', caseCount: '2' }

--- a/apps/backend/src/app/database/services/coding/coding-response-filter.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-filter.service.spec.ts
@@ -113,4 +113,22 @@ describe('CodingResponseFilterService', () => {
       queryBuilder.andWhere.mock.calls.some(([condition]) => String(condition).includes('OR response.is_autocoder_generated'))
     ).toBe(false);
   });
+
+  it('keeps DERIVE_ERROR out of default manual coding candidate filters', async () => {
+    const { service, queryBuilder } = createService();
+
+    await service.countResponses(1, {
+      manualCodingCandidatesOnly: true
+    });
+
+    expect(queryBuilder.where).toHaveBeenCalledWith(
+      'response.status_v1 IN (:...statuses)',
+      {
+        statuses: [
+          8,
+          12
+        ]
+      }
+    );
+  });
 });

--- a/apps/backend/src/app/database/services/coding/coding-response-filter.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-filter.service.ts
@@ -16,13 +16,16 @@ import {
 } from '../workspace/workspace-exclusion.service';
 // eslint-disable-next-line import/no-cycle
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
+import { MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES } from '../../utils/manual-coding-candidate.util';
 
 export interface ResponseFilterOptions {
   status?: string;
+  statuses?: number[];
   version?: 'v1' | 'v2' | 'v3';
   considerOnly?: boolean;
   validCodingVariablesOnly?: boolean;
   givenResponsesOnly?: boolean;
+  manualCodingCandidatesOnly?: boolean;
 }
 
 /**
@@ -124,6 +127,14 @@ export class CodingResponseFilterService {
           `${effectiveStatusExpression} NOT IN (:...statisticsIgnoredStatuses)`,
           { statisticsIgnoredStatuses: STATISTICS_IGNORED_STATUSES }
         );
+    } else if (options.manualCodingCandidatesOnly) {
+      queryBuilder.where('response.status_v1 IN (:...statuses)', {
+        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+      });
+    } else if (options.statuses?.length) {
+      queryBuilder.where('response.status_v1 IN (:...statuses)', {
+        statuses: options.statuses
+      });
     } else {
       queryBuilder.where('response.status_v1 = :status', {
         status: statusStringToNumber(status)

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -110,6 +110,7 @@ describe('CodingValidationService', () => {
     mockWorkspaceFilesService = {
       getUnitVariableMap: jest.fn(),
       getIntendedIncompleteSchemeVariableMap: jest.fn(),
+      getUnitVariableDetails: jest.fn(),
       getDerivedVariableMap: jest.fn(),
       getCoderTrainingRequiredVariableMap: jest.fn(),
       getDerivedVariablesBySourceMap: jest.fn()
@@ -875,6 +876,120 @@ describe('CodingValidationService', () => {
       await expect(service.getCodingIncompleteVariables(1)).rejects.toThrow(
         'Could not get manual coding variables'
       );
+    });
+  });
+
+  describe('validateManualCodeAvailability', () => {
+    const mockManualScopeQueries = (): void => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '5' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const casesInJobsQb = createQueryBuilderMock([]);
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(casesInJobsQb);
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+    };
+
+    it('should warn when a manual variable has no selectable regular codes', async () => {
+      mockManualScopeQueries();
+      mockWorkspaceFilesService.getUnitVariableDetails.mockResolvedValue([
+        {
+          unitName: 'unit1',
+          unitId: 'unit1',
+          variables: [
+            {
+              id: 'var1',
+              alias: 'var1',
+              type: 'string',
+              hasCodingScheme: true,
+              codes: [
+                {
+                  id: 1,
+                  label: 'Auto',
+                  manualInstruction: ''
+                },
+                {
+                  id: 2,
+                  label: 'Whitespace',
+                  manualInstruction: '   '
+                }
+              ]
+            }
+          ]
+        }
+      ]);
+
+      const result = await service.validateManualCodeAvailability(1);
+
+      expect(result).toEqual({
+        checkedVariables: 1,
+        warningCount: 1,
+        warnings: [
+          expect.objectContaining({
+            unitName: 'unit1',
+            variableId: 'var1',
+            responseCount: 5,
+            casesInJobs: 0,
+            availableCases: 5,
+            uniqueCasesAfterAggregation: 5,
+            regularCodeCount: 2,
+            selectableRegularCodeCount: 0,
+            onlySpecialOptionsAvailable: true
+          })
+        ]
+      });
+    });
+
+    it('should not warn when at least one regular code has a manual instruction', async () => {
+      mockManualScopeQueries();
+      mockWorkspaceFilesService.getUnitVariableDetails.mockResolvedValue([
+        {
+          unitName: 'unit1',
+          unitId: 'unit1',
+          variables: [
+            {
+              id: 'coding-var',
+              alias: 'var1',
+              type: 'string',
+              hasCodingScheme: true,
+              codes: [
+                {
+                  id: 1,
+                  label: 'Hidden',
+                  manualInstruction: ''
+                },
+                {
+                  id: 2,
+                  label: 'Manual',
+                  manualInstruction: '<p>Manuell auswählbar</p>'
+                }
+              ]
+            }
+          ]
+        }
+      ]);
+
+      const result = await service.validateManualCodeAvailability(1);
+
+      expect(result).toEqual({
+        checkedVariables: 1,
+        warningCount: 0,
+        warnings: []
+      });
     });
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -11,9 +11,14 @@ import { CodingJobUnit } from '../../entities/coding-job-unit.entity';
 import { ExpectedCombinationDto } from '../../../../../../../api-dto/coding/expected-combination.dto';
 import { ValidationResultDto } from '../../../../../../../api-dto/coding/validation-result.dto';
 import { ValidateCodingCompletenessResponseDto } from '../../../../../../../api-dto/coding/validate-coding-completeness-response.dto';
+import {
+  ManualCodeAvailabilityValidationDto,
+  ManualCodeAvailabilityWarningDto
+} from '../../../../../../../api-dto/coding/manual-code-availability.dto';
 import { generateExpectedCombinationsHash } from '../../../utils/coding-utils';
 // eslint-disable-next-line import/no-cycle
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
+import { VariableDetailDto } from '../../../models/unit-variable-details.dto';
 import { WorkspacePlayerService } from '../workspace/workspace-player.service';
 import {
   applyResolvedExclusionsToQuery,
@@ -70,6 +75,17 @@ type ManualCodingScopeFromDb = {
 export type ManualCodingScopeSummary = ManualCodingExcludedSourceSummary & {
   manualVariableCount: number;
   manualResponseCount: number;
+};
+
+type ManualCodingVariableWithCaseInfo = {
+  unitName: string;
+  variableId: string;
+  responseCount: number;
+  casesInJobs: number;
+  availableCases: number;
+  uniqueCasesAfterAggregation: number;
+  isDerived: boolean;
+  coderTrainingRequired: boolean;
 };
 
 @Injectable()
@@ -577,24 +593,77 @@ export class CodingValidationService {
     }
   }
 
+  async validateManualCodeAvailability(
+    workspaceId: number,
+    unitName?: string,
+    trainingRequired?: boolean
+  ): Promise<ManualCodeAvailabilityValidationDto> {
+    try {
+      const [variables, variableDetailsByKey] = await Promise.all([
+        this.getCodingIncompleteVariables(
+          workspaceId,
+          unitName,
+          trainingRequired
+        ),
+        this.getManualCodeAvailabilityDetailsByKey(workspaceId)
+      ]);
+
+      const warnings = variables.reduce<ManualCodeAvailabilityWarningDto[]>(
+        (items, variable) => {
+          const detail = variableDetailsByKey.get(
+            this.getManualCodeAvailabilityKey(
+              variable.unitName,
+              variable.variableId
+            )
+          );
+          const counts = this.getManualCodeAvailabilityCounts(detail);
+
+          if (counts.selectableRegularCodeCount > 0) {
+            return items;
+          }
+
+          items.push({
+            unitName: variable.unitName,
+            variableId: variable.variableId,
+            responseCount: variable.responseCount,
+            casesInJobs: variable.casesInJobs,
+            availableCases: variable.availableCases,
+            uniqueCasesAfterAggregation:
+              variable.uniqueCasesAfterAggregation,
+            regularCodeCount: counts.regularCodeCount,
+            selectableRegularCodeCount: counts.selectableRegularCodeCount,
+            onlySpecialOptionsAvailable: true,
+            message:
+              'Variable hat keine regulaeren Codes mit manueller Instruktion. In der Kodierung bleiben nur Sonderoptionen wie "Code-Vergabe unsicher" oder "Neuer Code noetig" verfuegbar.'
+          });
+          return items;
+        },
+        []
+      );
+
+      return {
+        checkedVariables: variables.length,
+        warningCount: warnings.length,
+        warnings
+      };
+    } catch (error) {
+      this.logger.error(
+        `Error validating manual code availability: ${error.message}`,
+        error.stack
+      );
+      throw new Error(
+        'Could not validate manual code availability. Please check the coding schemes.'
+      );
+    }
+  }
+
   /**
      * Enrich variables with case information (cases in jobs, available cases, and unique cases after aggregation)
      */
   private async enrichVariablesWithCaseInfo(
     workspaceId: number,
     variables: ManualCodingVariableCaseCounts[]
-  ): Promise<
-    {
-      unitName: string;
-      variableId: string;
-      responseCount: number;
-      casesInJobs: number;
-      availableCases: number;
-      uniqueCasesAfterAggregation: number;
-      isDerived: boolean;
-      coderTrainingRequired: boolean;
-    }[]
-    > {
+  ): Promise<ManualCodingVariableWithCaseInfo[]> {
     const caseInfoMap = await this.computeVariableCaseInfo(workspaceId, variables);
 
     return variables.map(variable => {
@@ -725,6 +794,70 @@ export class CodingValidationService {
     );
 
     return result;
+  }
+
+  private async getManualCodeAvailabilityDetailsByKey(
+    workspaceId: number
+  ): Promise<Map<string, VariableDetailDto>> {
+    const unitVariableDetails =
+      await this.workspaceFilesService.getUnitVariableDetails(workspaceId);
+    const variableDetailsByKey = new Map<string, VariableDetailDto>();
+
+    unitVariableDetails.forEach(unitDetails => {
+      const unitKeys = [
+        unitDetails.unitName,
+        unitDetails.unitId
+      ].filter(Boolean);
+
+      unitDetails.variables.forEach(variable => {
+        const variableIds = [
+          variable.alias,
+          variable.id
+        ].filter(Boolean);
+
+        unitKeys.forEach(unitKey => {
+          variableIds.forEach(variableId => {
+            const key = this.getManualCodeAvailabilityKey(
+              unitKey,
+              variableId
+            );
+            if (!variableDetailsByKey.has(key)) {
+              variableDetailsByKey.set(key, variable);
+            }
+          });
+        });
+      });
+    });
+
+    return variableDetailsByKey;
+  }
+
+  private getManualCodeAvailabilityCounts(
+    variable: VariableDetailDto | undefined
+  ): { regularCodeCount: number; selectableRegularCodeCount: number } {
+    const regularCodes = (variable?.codes || []).filter(
+      code => code.id !== undefined && code.id !== null
+    );
+
+    return {
+      regularCodeCount: regularCodes.length,
+      selectableRegularCodeCount: regularCodes.filter(
+        code => this.hasManualInstruction(code)
+      ).length
+    };
+  }
+
+  private hasManualInstruction(
+    code: { manualInstruction?: string | null }
+  ): boolean {
+    return !!code.manualInstruction?.trim();
+  }
+
+  private getManualCodeAvailabilityKey(
+    unitName: string | null | undefined,
+    variableId: string | null | undefined
+  ): string {
+    return `${String(unitName || '').trim().toUpperCase()}::${String(variableId || '').trim()}`;
   }
 
   private async getAssignedResponseIdsByVariable(

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -188,6 +188,113 @@ describe('ExternalCodingImportService', () => {
     }));
   });
 
+  it('imports unversioned codes from coding-list exports that also contain status_v1', async () => {
+    const selectQuery = createQueryBuilder([{
+      id: 551,
+      status_v1: statusStringToNumber('CODING_INCOMPLETE'),
+      status_v2: null,
+      code_v2: null,
+      score_v2: null,
+      unit: { id: 7, name: 'UNIT', alias: 'UNIT' }
+    }]);
+    const updateQuery = createQueryBuilder();
+    const transactionalResponseRepository = {
+      createQueryBuilder: jest.fn()
+        .mockReturnValueOnce(selectQuery)
+        .mockReturnValueOnce(updateQuery)
+    };
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+      manager: {
+        query: jest.fn().mockResolvedValue([]),
+        getRepository: jest.fn().mockReturnValue(transactionalResponseRepository)
+      }
+    };
+    const responseRepository = {
+      manager: {
+        connection: {
+          createQueryRunner: jest.fn().mockReturnValue(queryRunner)
+        }
+      }
+    };
+    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const codingFreshnessService = {
+      markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
+    };
+    const service = new ExternalCodingImportService(
+      responseRepository as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      cacheService as never,
+      codingFreshnessService as never
+    );
+    jest.spyOn(service as unknown as {
+      validateCodeAgainstScheme: (
+        unit: unknown,
+        variableId: string,
+        code: number | null
+      ) => Promise<unknown>;
+    }, 'validateCodeAgainstScheme')
+      .mockImplementation(async (_unit, _variableId, code) => ({
+        isValid: code === 1,
+        score: code === 1 ? 2 : null,
+        status: code === 1 ? 'CODING_COMPLETE' : 'CODING_INCOMPLETE'
+      }));
+
+    const result = await service.importExternalCoding(17, {
+      file: Buffer.from(
+        'unit_key,variable_id,variable_page,variable_anchor,status_v1,code\n' +
+        'UNIT,VAR,0,VAR,CODING_INCOMPLETE,1\n'
+      ).toString('base64'),
+      fileName: 'coding.csv',
+      previewOnly: false
+    });
+
+    expect(result.updatedRows).toBe(1);
+    expect(updateQuery.set).toHaveBeenCalledWith({
+      status_v2: statusStringToNumber('CODING_COMPLETE'),
+      code_v2: 1,
+      score_v2: 2
+    });
+  });
+
+  it('rejects unchanged coding-list exports with status_v1 as coding lists, not coding-results', async () => {
+    const service = new ExternalCodingImportService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      { delete: jest.fn().mockResolvedValue(undefined) } as never,
+      { markManualCodingCurrent: jest.fn().mockResolvedValue(undefined) } as never
+    );
+
+    const result = await service.importExternalCoding(17, {
+      file: Buffer.from(
+        'unit_key,unit_alias,person_login,person_code,person_group,booklet_name,variable_id,variable_page,variable_anchor,status_v1,url\n' +
+        'UNIT,UNIT,login,code,group,BOOKLET,VAR,0,VAR,CODING_INCOMPLETE,https://example.test/replay\n'
+      ).toString('base64'),
+      fileName: 'coding.csv',
+      previewOnly: false
+    });
+
+    expect(result).toMatchObject({
+      processedRows: 1,
+      updatedRows: 0,
+      affectedRows: []
+    });
+    expect(result.errors).toEqual([
+      'Die Datei wurde als Kodierliste erkannt, enthält aber keine importierbaren Kodierungsspalten.',
+      'Bitte ergänzen Sie mindestens eine der Spalten code, score oder status.'
+    ]);
+  });
+
   it('rolls back and fails the import when manual freshness cannot be finalized', async () => {
     const selectQuery = createQueryBuilder([{
       id: 99,

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
@@ -663,6 +663,22 @@ export class ExternalCodingImportService {
   private detectFormat(headers: string[]): ExternalCodingDetectedFormat {
     const has = (header: string) => headers.includes(header);
     const hasAny = (candidates: string[]) => candidates.some(candidate => has(candidate));
+    const hasCodingListIdentity =
+      has('variable_id') && (has('unit_key') || has('unit_alias'));
+    const hasUnversionedCodingValue = hasAny(['status', 'code', 'score']);
+    const hasVersionedCodeOrScore = hasAny([
+      'code_v1', 'score_v1',
+      'code_v2', 'score_v2',
+      'code_v3', 'score_v3'
+    ]);
+    const hasCodingListContext = hasAny([
+      'person_login',
+      'person_code',
+      'person_group',
+      'booklet_name',
+      'variable_page',
+      'variable_anchor'
+    ]);
 
     if (
       has('groupname') &&
@@ -688,6 +704,14 @@ export class ExternalCodingImportService {
     }
 
     if (
+      hasCodingListIdentity &&
+        (hasUnversionedCodingValue || hasCodingListContext) &&
+        !hasVersionedCodeOrScore
+    ) {
+      return hasCodingListContext ? 'coding-list' : 'external-coding';
+    }
+
+    if (
       has('variable_id') &&
         hasAny([
           'status_v1', 'code_v1', 'score_v1',
@@ -698,12 +722,12 @@ export class ExternalCodingImportService {
       return 'coding-results';
     }
 
-    if (has('variable_id') && (has('unit_key') || has('unit_alias'))) {
+    if (hasCodingListIdentity) {
       if (
-        hasAny(['status', 'code', 'score']) ||
-          hasAny(['person_login', 'person_code', 'person_group', 'booklet_name', 'variable_page', 'variable_anchor'])
+        hasUnversionedCodingValue ||
+          hasCodingListContext
       ) {
-        return hasAny(['variable_page', 'variable_anchor']) ? 'coding-list' : 'external-coding';
+        return hasCodingListContext ? 'coding-list' : 'external-coding';
       }
     }
 

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -77,9 +77,9 @@ describe('JobDefinitionService', () => {
     usersRepository.find.mockResolvedValue([]);
     const calculateUsageForRequest = async (request: {
       selectedVariableBundles?: {
-        variables?: { unitName: string; variableId: string }[];
+        variables?: { unitName: string; variableId: string; includeDeriveError?: boolean }[];
       }[];
-      selectedVariables?: { unitName: string; variableId: string }[];
+      selectedVariables?: { unitName: string; variableId: string; includeDeriveError?: boolean }[];
       maxCodingCases?: number;
     }) => {
       const incompleteVariables = await codingValidationService.getCodingIncompleteVariables() as Array<{
@@ -95,7 +95,7 @@ describe('JobDefinitionService', () => {
       );
       const addUsage = (
         usageByVariable: Map<string, number>,
-        variable: { unitName: string; variableId: string },
+        variable: { unitName: string; variableId: string; includeDeriveError?: boolean },
         usage: number
       ) => {
         const key = `${variable.unitName}::${variable.variableId}`;
@@ -103,7 +103,7 @@ describe('JobDefinitionService', () => {
       };
       const reserveAcrossVariables = (
         usageByVariable: Map<string, number>,
-        variables: { unitName: string; variableId: string }[],
+        variables: { unitName: string; variableId: string; includeDeriveError?: boolean }[],
         selectedCases: number
       ) => {
         const entries = variables
@@ -587,7 +587,7 @@ describe('JobDefinitionService', () => {
       {
         id: 1,
         assigned_variables: [
-          { unitName: 'Unit 1', variableId: 'Var 1' },
+          { unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true },
           { unitName: 'Unit 2', variableId: 'Var 2' }
         ],
         assigned_variable_bundles: [],
@@ -1091,7 +1091,7 @@ describe('JobDefinitionService', () => {
       workspace_id: 7,
       status: 'approved',
       assigned_variables: [
-        { unitName: 'Unit 1', variableId: 'Var 1' },
+        { unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true },
         { unitName: 'Unit 2', variableId: 'Var 2' }
       ],
       assigned_variable_bundles: [{ id: 9, name: 'Saved Bundle', caseOrderingMode: 'alternating' }],
@@ -1134,7 +1134,7 @@ describe('JobDefinitionService', () => {
 
     expect(codingJobService.createCodingJob).not.toHaveBeenCalled();
     expect(codingJobService.createDistributedCodingJobs).toHaveBeenCalledWith(7, {
-      selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }],
       selectedVariableBundles: [{
         id: 9,
         name: 'Hydrated Bundle',

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -1037,22 +1037,32 @@ export class JobDefinitionService {
       }) :
       [];
 
-    const bundleVariables = fullVariableBundles.flatMap(bundle => bundle.variables || []);
-    const bundleVariableKeys = new Set(bundleVariables.map(v => `${v.unitName}-${v.variableId}`));
-
-    const filteredVariables = (jobDefinition.assigned_variables || []).filter(v => !bundleVariableKeys.has(`${v.unitName}-${v.variableId}`)
-    );
-
     const savedBundleModes = new Map(
       (jobDefinition.assigned_variable_bundles || [])
         .map(bundle => [bundle.id, bundle.caseOrderingMode])
     );
+    const assignedVariableOptionsByKey = new Map(
+      (jobDefinition.assigned_variables || []).map(variable => [
+        `${variable.unitName}-${variable.variableId}`,
+        variable
+      ])
+    );
     const selectedVariableBundles = fullVariableBundles.map(bundle => ({
       id: bundle.id,
       name: bundle.name,
-      variables: bundle.variables || [],
+      variables: (bundle.variables || []).map(variable => ({
+        ...variable,
+        ...(assignedVariableOptionsByKey.get(`${variable.unitName}-${variable.variableId}`)?.includeDeriveError === true ?
+          { includeDeriveError: true } :
+          {})
+      })),
       caseOrderingMode: savedBundleModes.get(bundle.id)
     }));
+    const bundleVariables = selectedVariableBundles.flatMap(bundle => bundle.variables || []);
+    const bundleVariableKeys = new Set(bundleVariables.map(v => `${v.unitName}-${v.variableId}`));
+
+    const filteredVariables = (jobDefinition.assigned_variables || []).filter(v => !bundleVariableKeys.has(`${v.unitName}-${v.variableId}`)
+    );
     const coderAssignments = this.getStoredCoderAssignments(jobDefinition);
     const capacityByCoderId = new Map(
       coderAssignments.assignedCoderConfigs.map(config => [config.coderId, config.capacityPercent])

--- a/apps/backend/src/app/database/services/validation/workspace-test-files-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/validation/workspace-test-files-validation.service.spec.ts
@@ -333,7 +333,7 @@ describe('WorkspaceTestFilesValidationService', () => {
     ]));
   });
 
-  it('should validate coding schemes with CODER_TRAINING_REQUIRED processing from the current IQB specification', async () => {
+  it('should validate coding schemes with current IQB processing properties', async () => {
     const scheme = {
       version: '3.4',
       variableCodings: [

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -2987,7 +2987,13 @@ ${bookletRefs}
       string,
       Map<
       string,
-      Array<{ id: string | number; label: string; score?: number }>
+      Array<{
+        id: string | number;
+        label: string;
+        score?: number;
+        manualInstruction?: string;
+        type?: string;
+      }>
       >
       >();
       const codingSchemeManualInstructionsMap = new Map<
@@ -3034,7 +3040,13 @@ ${bookletRefs}
             const variableTypes = new Map<string, UnitVariableType>();
             const variableCodes = new Map<
             string,
-            Array<{ id: string | number; label: string; score?: number }>
+            Array<{
+              id: string | number;
+              label: string;
+              score?: number;
+              manualInstruction?: string;
+              type?: string;
+            }>
             >();
             const variableManualInstructions = new Map<string, boolean>();
             const variableClosedCoding = new Map<string, boolean>();
@@ -3063,7 +3075,9 @@ ${bookletRefs}
                   .map(code => ({
                     id: code.id,
                     label: code.label || String(code.id),
-                    score: code.score
+                    score: code.score,
+                    manualInstruction: code.manualInstruction,
+                    type: code.type
                   }));
                 if (codes.length > 0) {
                   variableCodes.set(vc.id, codes);

--- a/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
+++ b/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
@@ -1,0 +1,44 @@
+import { statusStringToNumber } from './response-status-converter';
+
+function requireStatusNumber(status: string): number {
+  const statusNumber = statusStringToNumber(status);
+  if (statusNumber === null) {
+    throw new Error(`Unknown response status: ${status}`);
+  }
+  return statusNumber;
+}
+
+export const CODING_INCOMPLETE_STATUS = requireStatusNumber('CODING_INCOMPLETE');
+export const INTENDED_INCOMPLETE_STATUS = requireStatusNumber('INTENDED_INCOMPLETE');
+export const DERIVE_ERROR_STATUS = requireStatusNumber('DERIVE_ERROR');
+
+export const MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES = [
+  CODING_INCOMPLETE_STATUS,
+  INTENDED_INCOMPLETE_STATUS
+];
+
+export interface ManualCodingVariableReference {
+  unitName: string;
+  variableId: string;
+  includeDeriveError?: boolean;
+}
+
+export function toManualCodingVariablePairKey(
+  unitName: string,
+  variableId: string
+): string {
+  return `${unitName}\u001F${variableId}`;
+}
+
+export function getDeriveErrorManualCodingPairKeys(
+  variables: ManualCodingVariableReference[]
+): string[] {
+  return Array.from(new Set(
+    variables
+      .filter(variable => variable.includeDeriveError === true)
+      .map(variable => toManualCodingVariablePairKey(
+        variable.unitName,
+        variable.variableId
+      ))
+  ));
+}

--- a/apps/backend/src/app/models/unit-variable-details.dto.ts
+++ b/apps/backend/src/app/models/unit-variable-details.dto.ts
@@ -11,6 +11,8 @@ export interface CodeInfo {
   id: string | number;
   label: string;
   score?: number;
+  manualInstruction?: string;
+  type?: string;
 }
 
 export interface VariableValueInfo {

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.html
@@ -231,6 +231,9 @@
                   variable.variableId) {
                   <span class="selection-chip">
                     {{ variable.unitName }}: {{ variable.variableId }}
+                    @if (variable.includeDeriveError) {
+                    <span class="selection-chip-suffix">DERIVE_ERROR</span>
+                    }
                   </span>
                   }
                   @if (selectedVariables.selected.length > 10) {
@@ -443,8 +446,8 @@
                           matTooltipPosition="above">block</mat-icon>
                         }
                       </div>
-                      @if (variable.coderTrainingRequired || variable.isDerived) {
-                      <div class="variable-badges">
+	                      @if (variable.coderTrainingRequired || variable.isDerived) {
+	                      <div class="variable-badges">
                         @if (variable.coderTrainingRequired) {
                         <mat-chip class="training-required-chip" matTooltip="Erhöhter Schulungsaufwand" matTooltipPosition="above">
                           <mat-icon>school</mat-icon>
@@ -457,10 +460,20 @@
                           Abgeleitet
                         </mat-chip>
                         }
-                      </div>
-                      }
-                    </div>
-                  </div>
+	                      </div>
+	                      }
+                        @if (data.mode === 'definition') {
+                        <div class="derive-error-option" (click)="$event.stopPropagation()">
+                          <mat-checkbox
+                            [checked]="isDeriveErrorIncluded(variable)"
+                            [disabled]="isReadOnly || isVariableDisabled(variable) || !selectedVariables.isSelected(variable)"
+                            (change)="setDeriveErrorIncluded(variable, $event.checked)">
+                            DERIVE_ERROR einbeziehen
+                          </mat-checkbox>
+                        </div>
+                        }
+	                    </div>
+	                  </div>
                 </div>
                 }
               </div>

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.scss
@@ -295,6 +295,17 @@
             border-radius: 16px;
             padding: 4px 12px;
             font-size: 0.9rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+          }
+
+          .selection-chip-suffix {
+            background: rgba(0, 0, 0, 0.12);
+            border-radius: 999px;
+            font-size: 0.72rem;
+            font-weight: 600;
+            padding: 2px 6px;
           }
 
           .more-chip {
@@ -620,6 +631,22 @@
             flex-wrap: wrap;
             gap: 6px;
             min-width: 0;
+          }
+
+          .derive-error-option {
+            align-items: center;
+            display: flex;
+            min-height: 28px;
+
+            ::ng-deep .mat-mdc-checkbox {
+              --mdc-checkbox-state-layer-size: 28px;
+            }
+
+            ::ng-deep .mdc-label {
+              color: rgba(0, 0, 0, 0.7);
+              font-size: 0.78rem;
+              line-height: 1.2;
+            }
           }
 
           .training-required-chip,

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
@@ -427,6 +427,25 @@ describe('CodingJobDefinitionDialogComponent', () => {
     }));
   });
 
+  it('should include DERIVE_ERROR opt-in only for selected definition variables', async () => {
+    createComponent();
+    (mockCodingJobBackendService.createJobDefinition as jest.Mock).mockReturnValue(of({ id: 123 }));
+
+    component.selectedCoders.select(mockCoders[0]);
+    component.selectedVariables.select(mockVariables[0]);
+    component.setDeriveErrorIncluded(mockVariables[0], true);
+
+    await component.onSubmit();
+
+    expect(mockCodingJobBackendService.createJobDefinition).toHaveBeenCalledWith(1, expect.objectContaining({
+      assignedVariables: [{
+        unitName: 'Unit 1',
+        variableId: 'Var 1',
+        includeDeriveError: true
+      }]
+    }));
+  });
+
   describe('Mode: Job (Create/Edit)', () => {
     it('should submit create calling createCodingJob and assignCoder when 1 variable selected', fakeAsync(() => {
       createComponent({ mode: 'job', isEdit: false });
@@ -568,6 +587,30 @@ describe('CodingJobDefinitionDialogComponent', () => {
       assignedCoderConfigs: [{ coderId: 1, capacityPercent: 150 }]
     }));
   }));
+
+  it('should restore the DERIVE_ERROR opt-in when editing a definition', () => {
+    const definitionAsCodingJob = {
+      id: 555,
+      assignedVariables: [{
+        unitName: 'Unit 1',
+        variableId: 'Var 1',
+        includeDeriveError: true
+      }]
+    } as Partial<CodingJob>;
+
+    createComponent({
+      mode: 'definition',
+      isEdit: true,
+      jobDefinitionId: 555,
+      codingJob: definitionAsCodingJob as CodingJob
+    });
+
+    const restoredVariable = component.variables.find(variable => variable.unitName === 'Unit 1' && variable.variableId === 'Var 1');
+
+    expect(restoredVariable).toBeDefined();
+    expect(component.selectedVariables.selected).toContain(restoredVariable);
+    expect(restoredVariable?.includeDeriveError).toBe(true);
+  });
 
   it('should open locked definitions read-only without submitting changes', async () => {
     const definitionAsCodingJob = {

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
@@ -506,13 +506,22 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
       };
 
       const assignedKeySet = new Set(originallyAssigned.map(toKey));
+      const assignedByKey = new Map(originallyAssigned.map(variable => [
+        toKey(variable),
+        variable
+      ]));
 
       this.selectedVariables.clear();
       this.variables.forEach(rowVar => {
         const rowKey = makeKey(rowVar.unitName ?? '', rowVar.variableId ?? '');
+        rowVar.includeDeriveError = assignedByKey.get(rowKey)?.includeDeriveError === true;
         if (assignedKeySet.has(rowKey)) {
           this.selectedVariables.select(rowVar);
         }
+      });
+    } else {
+      this.variables.forEach(rowVar => {
+        rowVar.includeDeriveError = false;
       });
     }
   }
@@ -981,6 +990,32 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     }
   }
 
+  isDeriveErrorIncluded(variable: Variable): boolean {
+    return variable.includeDeriveError === true;
+  }
+
+  setDeriveErrorIncluded(variable: Variable, includeDeriveError: boolean): void {
+    if (this.isReadOnly || this.data.mode !== 'definition') {
+      return;
+    }
+
+    variable.includeDeriveError = includeDeriveError;
+    const selectedVariable = this.selectedVariables.selected.find(
+      selected => selected.unitName === variable.unitName && selected.variableId === variable.variableId
+    );
+    if (selectedVariable) {
+      selectedVariable.includeDeriveError = includeDeriveError;
+    }
+  }
+
+  private getSelectedDefinitionVariables(): Variable[] {
+    return this.selectedVariables.selected.map(variable => ({
+      unitName: variable.unitName,
+      variableId: variable.variableId,
+      ...(variable.includeDeriveError === true ? { includeDeriveError: true } : {})
+    }));
+  }
+
   isAllCodersSelected(): boolean {
     const numSelected = this.selectedCoders.selected.length;
     const numRows = this.availableCoders.length;
@@ -1381,7 +1416,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
 
     const jobDefinition: JobDefinition = {
       status: 'draft',
-      assignedVariables: this.selectedVariables.selected.map(v => ({ unitName: v.unitName, variableId: v.variableId })),
+      assignedVariables: this.getSelectedDefinitionVariables(),
       assignedVariableBundles: this.selectedVariableBundles.selected.map(b => ({ id: b.id, name: b.name, caseOrderingMode: b.caseOrderingMode })) as unknown as VariableBundle[],
       assignedCoders: selectedCoderIds,
       assignedCoderConfigs: selectedCoderConfigs,
@@ -1423,7 +1458,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     const selectedCoderConfigs = this.getSelectedCoderConfigs();
 
     const jobDefinition: Partial<JobDefinition> = {
-      assignedVariables: this.selectedVariables.selected.map(v => ({ unitName: v.unitName, variableId: v.variableId })),
+      assignedVariables: this.getSelectedDefinitionVariables(),
       assignedVariableBundles: this.selectedVariableBundles.selected.map(b => ({ id: b.id, name: b.name, caseOrderingMode: b.caseOrderingMode })) as unknown as VariableBundle[],
       assignedCoders: selectedCoderIds,
       assignedCoderConfigs: selectedCoderConfigs,
@@ -1504,7 +1539,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
 
     const jobDefinition: JobDefinition = {
       status: 'pending_review', // Submit for review
-      assignedVariables: this.selectedVariables.selected.map(v => ({ unitName: v.unitName, variableId: v.variableId })),
+      assignedVariables: this.getSelectedDefinitionVariables(),
       assignedVariableBundles: this.selectedVariableBundles.selected.map(b => ({ id: b.id, name: b.name, caseOrderingMode: b.caseOrderingMode })) as unknown as VariableBundle[],
       assignedCoders: selectedCoderIds,
       assignedCoderConfigs: selectedCoderConfigs,

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
@@ -213,7 +213,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       return '-';
     }
     return definition.assignedVariables
-      .map(variable => `${variable.unitName}.${variable.variableId}`)
+      .map(variable => this.getVariableDisplayName(variable))
       .join(', ');
   }
 
@@ -222,8 +222,13 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       return [];
     }
     return definition.assignedVariables.map(
-      variable => `${variable.unitName}.${variable.variableId}`
+      variable => this.getVariableDisplayName(variable)
     );
+  }
+
+  private getVariableDisplayName(variable: Variable): string {
+    const displayName = `${variable.unitName}.${variable.variableId}`;
+    return variable.includeDeriveError ? `${displayName} (DERIVE_ERROR)` : displayName;
   }
 
   getVisibleVariableItems(definition: JobDefinition): string[] {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -103,6 +103,29 @@
         </div>
       </div>
 
+      <div *ngIf="hasManualCodeAvailabilityWarnings" class="manual-code-availability-banner">
+        <mat-icon>warning</mat-icon>
+        <div class="manual-code-availability-copy">
+          <strong>{{ manualCodeAvailabilityWarningCount }} Variablen ohne reguläre auswählbare Codes</strong>
+          <span>
+            In diesen Variablen bleiben in der Kodierung nur Sonderoptionen wie
+            „Code-Vergabe unsicher“ oder „Neuer Code nötig“ verfügbar.
+          </span>
+          <div class="manual-code-availability-list">
+            <span
+              *ngFor="let warning of getManualCodeAvailabilityPreview()"
+              class="manual-code-availability-chip">
+              {{ warning.unitName }} / {{ warning.variableId }}
+            </span>
+            <span
+              *ngIf="manualCodeAvailabilityWarningCount > getManualCodeAvailabilityPreview().length"
+              class="manual-code-availability-chip">
+              +{{ manualCodeAvailabilityWarningCount - getManualCodeAvailabilityPreview().length }} weitere
+            </span>
+          </div>
+        </div>
+      </div>
+
       <div class="planning-overview-grid" aria-label="Übersicht zur manuellen Kodierungsplanung">
         <div class="overview-metric">
           <span class="metric-label">Offene Arbeitsfälle</span>

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
@@ -684,6 +684,59 @@
     }
   }
 
+  .manual-code-availability-banner {
+    align-items: flex-start;
+    background: rgba(245, 124, 0, 0.08);
+    border: 1px solid rgba(245, 124, 0, 0.28);
+    border-radius: 8px;
+    color: #5f4217;
+    display: flex;
+    gap: 12px;
+    margin-bottom: 16px;
+    padding: 14px 16px;
+
+    > mat-icon {
+      color: #ef6c00;
+      flex: 0 0 auto;
+    }
+
+    .manual-code-availability-copy {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+    }
+
+    strong {
+      font-size: 14px;
+      font-weight: 700;
+    }
+
+    span {
+      font-size: 13px;
+      line-height: 1.4;
+      overflow-wrap: anywhere;
+    }
+
+    .manual-code-availability-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 4px;
+    }
+
+    .manual-code-availability-chip {
+      background: rgba(255, 255, 255, 0.72);
+      border: 1px solid rgba(245, 124, 0, 0.24);
+      border-radius: 999px;
+      color: rgba(0, 0, 0, 0.76);
+      font-size: 12px;
+      font-weight: 650;
+      line-height: 1.2;
+      padding: 5px 8px;
+    }
+  }
+
   .planning-overview-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -422,6 +422,42 @@ describe('CodingManagementManualComponent', () => {
     expect(component.getPlanningStatusTitle()).toBe('Manuelle Kodierung abgeschlossen');
   });
 
+  it('should warn when manual variables have no regular selectable codes', () => {
+    setCompletePlanningState();
+    setCodingProgress(10, 4);
+    setAppliedResults(10, 0, 10);
+    component.manualCodeAvailabilityWarnings = [
+      {
+        unitName: 'UNIT1',
+        variableId: 'VAR1',
+        responseCount: 5,
+        casesInJobs: 0,
+        availableCases: 5,
+        uniqueCasesAfterAggregation: 5,
+        regularCodeCount: 2,
+        selectableRegularCodeCount: 0,
+        onlySpecialOptionsAvailable: true,
+        message: 'Variable hat keine regulären Codes mit manueller Instruktion.'
+      }
+    ];
+
+    expect(component.hasManualCodeAvailabilityWarnings).toBe(true);
+    expect(component.hasPlanningWarnings()).toBe(true);
+    expect(component.getPlanningStatusClass()).toBe('status-warning');
+    expect(component.getPlanningStatusIcon()).toBe('warning');
+    expect(component.getPlanningStatusTitle()).toBe('Codes für manuelle Kodierung prüfen');
+    expect(component.getPlanningNextStepTitle()).toBe('Kodierschema prüfen');
+    expect(component.getPlanningNextStepActionLabel()).toBe('Zur Variablenauswahl');
+
+    fixture.detectChanges();
+
+    const banner = fixture.nativeElement.querySelector(
+      '.manual-code-availability-banner'
+    ) as HTMLElement | null;
+    expect(banner?.textContent).toContain('UNIT1 / VAR1');
+    expect(banner?.textContent).toContain('Variablen ohne reguläre auswählbare Codes');
+  });
+
   it('should hide second auto-coding work while manual coding is still open', () => {
     component.codingFreshnessSummary = {
       workspaceId: 1,

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -83,6 +83,9 @@ import {
   CodingFreshnessSummaryDto,
   CodingFreshnessSummaryItemDto
 } from '../../../../../../../api-dto/coding/coding-freshness.dto';
+import type {
+  ManualCodeAvailabilityWarningDto
+} from '../../../../../../../api-dto/coding/manual-code-availability.dto';
 import {
   CODING_FRESHNESS_TASK_RESULT_HELP,
   formatCodingFreshnessResponseCount,
@@ -169,6 +172,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   isLoadingVariableCoverage = false;
   isLoadingCaseCoverage = false;
   isLoadingCodingProgress = false;
+  isLoadingManualCodeAvailability = false;
   isLoadingKappaSummary = false;
 
   // Response matching mode configuration
@@ -281,6 +285,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }[] = [];
 
   manualCodingScopeSummary: ManualCodingScopeSummary | null = null;
+  manualCodeAvailabilityWarnings: ManualCodeAvailabilityWarningDto[] = [];
 
   statusDistribution: { [status: string]: number } = {};
   statusDistributionV2: { [status: string]: number } = {};
@@ -980,6 +985,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingCodingProgress ||
       this.isLoadingVariableCoverage ||
       this.isLoadingCaseCoverage ||
+      this.isLoadingManualCodeAvailability ||
       this.isLoadingMatchingMode;
   }
 
@@ -1066,7 +1072,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   hasPlanningWarnings(): boolean {
-    return (this.variableCoverageOverview?.conflictedVariables || 0) > 0 ||
+    return this.hasManualCodeAvailabilityWarnings ||
+      (this.variableCoverageOverview?.conflictedVariables || 0) > 0 ||
       (this.variableCoverageOverview?.missingVariables || 0) > 0 ||
       (this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0;
   }
@@ -1308,6 +1315,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return 'loading';
     }
 
+    if (this.hasManualCodeAvailabilityWarnings) {
+      return 'warning';
+    }
+
     if ((this.variableCoverageOverview?.conflictedVariables || 0) > 0) {
       return 'warning';
     }
@@ -1367,7 +1378,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'loading':
         return 'Status wird aktualisiert';
       case 'warning':
-        return 'Konflikte prüfen';
+        return this.hasManualCodeAvailabilityWarnings ?
+          'Codes für manuelle Kodierung prüfen' :
+          'Konflikte prüfen';
       case 'planning-incomplete':
         return 'Planung noch unvollständig';
       case 'execution-ready':
@@ -1392,6 +1405,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
     if (planningStatusState === 'progress-unavailable') {
       return 'Die Planung ist vollständig, der aktuelle Kodierfortschritt konnte aber nicht ermittelt werden. Aktualisieren Sie die Ansicht oder prüfen Sie die Kodierjobs.';
+    }
+
+    if (this.hasManualCodeAvailabilityWarnings) {
+      return `${this.manualCodeAvailabilityWarningCount} Variablen haben keine regulären auswählbaren Codes. In der Kodierung wären dort nur Sonderoptionen verfügbar.`;
     }
 
     if ((this.variableCoverageOverview?.conflictedVariables || 0) > 0) {
@@ -1431,7 +1448,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'loading':
         return 'Planungsstand wird geladen';
       case 'warning':
-        return 'Konflikte zuerst klären';
+        return this.hasManualCodeAvailabilityWarnings ?
+          'Kodierschema prüfen' :
+          'Konflikte zuerst klären';
       case 'planning-incomplete':
         return 'Kodierfälle in Jobs verteilen';
       case 'execution-ready':
@@ -1455,6 +1474,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'loading':
         return 'Warten Sie kurz, bis die Planungsdaten aktualisiert sind.';
       case 'warning':
+        if (this.hasManualCodeAvailabilityWarnings) {
+          return 'Ergänzen Sie bei mindestens einem regulären Code eine manuelle Instruktion oder prüfen Sie, ob die betroffenen Variablen manuell kodiert werden sollen.';
+        }
         return 'Prüfen Sie Variablen, die von mehreren Definitionen mit überlappenden Fällen verwendet werden.';
       case 'planning-incomplete':
         if ((this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0) {
@@ -1479,6 +1501,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   getPlanningNextStepActionLabel(): string {
     switch (this.getPlanningStatusState()) {
+      case 'warning':
+        return this.hasManualCodeAvailabilityWarnings ?
+          'Zur Variablenauswahl' :
+          'Zu den Jobdefinitionen';
       case 'execution-ready':
         return 'Zu den Kodierjobs';
       case 'completion-ready':
@@ -1552,6 +1578,18 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   get hasCodingFreshnessWarnings(): boolean {
     return this.codingFreshnessWarnings.length > 0;
+  }
+
+  get manualCodeAvailabilityWarningCount(): number {
+    return this.manualCodeAvailabilityWarnings.length;
+  }
+
+  get hasManualCodeAvailabilityWarnings(): boolean {
+    return this.manualCodeAvailabilityWarningCount > 0;
+  }
+
+  getManualCodeAvailabilityPreview(): ManualCodeAvailabilityWarningDto[] {
+    return this.manualCodeAvailabilityWarnings.slice(0, 5);
   }
 
   get autoCodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
@@ -1858,6 +1896,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private loadCodingIncompleteVariables(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.codingIncompleteVariables = [];
+      this.manualCodingScopeSummary = null;
+      this.manualCodeAvailabilityWarnings = [];
+      this.isLoadingManualCodeAvailability = false;
       return;
     }
 
@@ -1892,6 +1934,24 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.manualCodingScopeSummary = null;
+        }
+      });
+
+    this.isLoadingManualCodeAvailability = true;
+    this.codingJobBackendService
+      .getManualCodeAvailabilityWarnings(workspaceId)
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.isLoadingManualCodeAvailability = false;
+        })
+      )
+      .subscribe({
+        next: result => {
+          this.manualCodeAvailabilityWarnings = result.warnings || [];
+        },
+        error: () => {
+          this.manualCodeAvailabilityWarnings = [];
         }
       });
   }

--- a/apps/frontend/src/app/coding/models/coding-job.model.ts
+++ b/apps/frontend/src/app/coding/models/coding-job.model.ts
@@ -63,6 +63,7 @@ export interface Variable {
   uniqueCasesAfterAggregation?: number;
   isDerived?: boolean;
   coderTrainingRequired?: boolean;
+  includeDeriveError?: boolean;
 }
 
 export interface VariableBundle {

--- a/apps/frontend/src/app/coding/models/coding-list-item.model.ts
+++ b/apps/frontend/src/app/coding/models/coding-list-item.model.ts
@@ -7,5 +7,6 @@ export interface CodingListItem {
   variable_id: string;
   variable_page: string;
   variable_anchor: string;
+  status_v1?: string;
   url: string;
 }

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -10,6 +10,9 @@ import type {
   JobDefinitionRefreshApplyResultDto,
   JobDefinitionRefreshPreviewDto
 } from '../../../../../../api-dto/coding/job-refresh.dto';
+import type {
+  ManualCodeAvailabilityValidationDto
+} from '../../../../../../api-dto/coding/manual-code-availability.dto';
 import {
   CodingJob,
   JobDefinitionCoderConfig,
@@ -425,6 +428,26 @@ export class CodingJobBackendService {
     }
     params = params.set('_t', Date.now().toString());
     return this.http.get<ManualCodingScopeSummary>(
+      url,
+      { params, headers: this.authHeader }
+    );
+  }
+
+  getManualCodeAvailabilityWarnings(
+    workspaceId: number,
+    unitName?: string,
+    trainingRequired?: boolean
+  ): Observable<ManualCodeAvailabilityValidationDto> {
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/incomplete-variables/code-availability`;
+    let params = new HttpParams();
+    if (unitName) {
+      params = params.set('unitName', unitName);
+    }
+    if (trainingRequired !== undefined) {
+      params = params.set('trainingRequired', trainingRequired.toString());
+    }
+    params = params.set('_t', Date.now().toString());
+    return this.http.get<ManualCodeAvailabilityValidationDto>(
       url,
       { params, headers: this.authHeader }
     );

--- a/apps/frontend/src/app/coding/services/distributed-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/distributed-coding.service.ts
@@ -3,6 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, catchError, throwError } from 'rxjs';
 import { SERVER_URL } from '../../injection-tokens';
 
+type DistributionVariable = { unitName: string; variableId: string; includeDeriveError?: boolean };
+
 export interface DistributedCodingJobsResponse {
   success: boolean;
   jobsCreated: number;
@@ -60,11 +62,11 @@ export class DistributedCodingService {
 
   createDistributedCodingJobs(
     workspaceId: number,
-    selectedVariables: { unitName: string; variableId: string }[],
+    selectedVariables: DistributionVariable[],
     selectedCoders: { id: number; name: string; username: string; weight?: number; capacityPercent?: number }[],
     doubleCodingAbsolute?: number,
     doubleCodingPercentage?: number,
-    selectedVariableBundles?: { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: { unitName: string; variableId: string }[] }[],
+    selectedVariableBundles?: { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: DistributionVariable[] }[],
     caseOrderingMode?: 'continuous' | 'alternating',
     maxCodingCases?: number,
     displayOptions?: {
@@ -99,11 +101,11 @@ export class DistributedCodingService {
 
   calculateDistribution(
     workspaceId: number,
-    selectedVariables: { unitName: string; variableId: string }[],
+    selectedVariables: DistributionVariable[],
     selectedCoders: { id: number; name: string; username: string; weight?: number; capacityPercent?: number }[],
     doubleCodingAbsolute?: number,
     doubleCodingPercentage?: number,
-    selectedVariableBundles?: { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: { unitName: string; variableId: string }[] }[],
+    selectedVariableBundles?: { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: DistributionVariable[] }[],
     caseOrderingMode?: 'continuous' | 'alternating',
     maxCodingCases?: number,
     distributionSeed?: string
@@ -119,8 +121,8 @@ export class DistributedCodingService {
       warnings: Array<{ unitName: string; variableId: string; message: string; casesInJobs: number; availableCases: number }>;
     }> {
     const body: {
-      selectedVariables: { unitName: string; variableId: string }[];
-      selectedVariableBundles?: { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: { unitName: string; variableId: string }[] }[];
+      selectedVariables: DistributionVariable[];
+      selectedVariableBundles?: { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: DistributionVariable[] }[];
       selectedCoders: { id: number; name: string; username: string; weight?: number; capacityPercent?: number }[];
       doubleCodingAbsolute?: number;
       doubleCodingPercentage?: number;

--- a/apps/frontend/src/app/models/unit-variable-details.dto.ts
+++ b/apps/frontend/src/app/models/unit-variable-details.dto.ts
@@ -11,6 +11,8 @@ export interface CodeInfo {
   id: string | number;
   label: string;
   score?: number;
+  manualInstruction?: string;
+  type?: string;
 }
 
 export interface VariableValueInfo {


### PR DESCRIPTION
## Was geändert wurde

- ergänzt eine Backend-Validierung für manuelle Kodierungsvariablen, deren reguläre Codes keine manuelle Instruktion haben
- zeigt die Warnung in der manuellen Kodierungsplanung an
- trägt die für DERIVE_ERROR manuell auswählbaren Variablen durch Jobdefinitionen, Listen und Exporte
- verhindert, dass normale Kodierlisten mit status_v1 beim Re-Import als Ergebnisexport fehlklassifiziert werden

## Warum

Wenn eine Variable zwar manuell kodiert werden soll, aber keine regulären auswählbaren manuellen Codes mehr bietet, bleiben Codierern praktisch nur Sonderoptionen. Das soll vor der Jobplanung sichtbar werden, ohne bestehende Schemata hart zu blockieren.

Root Cause des Import-Fixes: normale Kodierlisten enthalten nun status_v1, wodurch die Auto-Erkennung sie zuvor als coding-results interpretieren konnte.

Closes #555

## Validierung

- npx nx lint frontend --skip-nx-cache
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts --skip-nx-cache
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts --skip-nx-cache
- npx nx lint backend --skip-nx-cache
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts --skip-nx-cache
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts --skip-nx-cache
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job.service.spec.ts --skip-nx-cache
- npx nx test backend --testFile=apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts --skip-nx-cache
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-response-filter.service.spec.ts --skip-nx-cache
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts --skip-nx-cache
- git diff --check