### PR TITLE
Normalize job definition create preview

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.spec.ts
@@ -21,4 +21,44 @@ describe('WorkspaceCodingJobDefinitionController', () => {
 
     expect(jobDefinitionService.createCodingJobFromDefinition).toHaveBeenCalledWith(42, 5);
   });
+
+  it('previews coding jobs through the normalized job definition service path', async () => {
+    const jobDefinitionService = {
+      previewCodingJobFromDefinition: jest.fn().mockResolvedValue({
+        distribution: {},
+        distributionByCoderId: {},
+        doubleCodingInfo: {},
+        aggregationInfo: {},
+        matchingFlags: [],
+        warnings: [],
+        selectedVariables: [],
+        selectedVariableBundles: [],
+        selectedCoders: [
+          {
+            id: 1,
+            name: 'Ada',
+            username: 'Ada',
+            capacityPercent: 100
+          }
+        ]
+      })
+    };
+    const controller = new WorkspaceCodingJobDefinitionController(jobDefinitionService as never);
+
+    await expect(controller.previewCodingJobFromDefinition(5, 42)).resolves.toMatchObject({
+      distribution: {},
+      selectedVariables: [],
+      selectedVariableBundles: [],
+      selectedCoders: [
+        {
+          id: 1,
+          name: 'Ada',
+          username: 'Ada',
+          capacityPercent: 100
+        }
+      ]
+    });
+
+    expect(jobDefinitionService.previewCodingJobFromDefinition).toHaveBeenCalledWith(42, 5);
+  });
 });

--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
@@ -246,6 +246,155 @@ export class WorkspaceCodingJobDefinitionController {
     );
   }
 
+  @Get(':workspace_id/coding/job-definitions/:id/create-job-preview')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
+  @RequireAccessLevel(2)
+  @ApiTags('coding')
+  @ApiParam({ name: 'workspace_id', type: Number })
+  @ApiParam({ name: 'id', type: Number, description: 'Job definition ID' })
+  @ApiOkResponse({
+    description: 'Preview distributed coding jobs from a job definition.',
+    schema: {
+      type: 'object',
+      properties: {
+        distribution: {
+          type: 'object',
+          additionalProperties: {
+            type: 'object',
+            additionalProperties: { type: 'number' }
+          }
+        },
+        distributionByCoderId: {
+          type: 'object',
+          additionalProperties: {
+            type: 'object',
+            additionalProperties: { type: 'number' }
+          }
+        },
+        doubleCodingInfo: {
+          type: 'object',
+          additionalProperties: {
+            type: 'object',
+            properties: {
+              totalCases: { type: 'number' },
+              distinctCases: { type: 'number' },
+              codingTasksTotal: { type: 'number' },
+              doubleCodedCases: { type: 'number' },
+              singleCodedCasesAssigned: { type: 'number' },
+              doubleCodedCasesPerCoder: {
+                type: 'object',
+                additionalProperties: { type: 'number' }
+              }
+            }
+          }
+        },
+        aggregationInfo: {
+          type: 'object',
+          additionalProperties: {
+            type: 'object',
+            properties: {
+              uniqueCases: { type: 'number' },
+              totalResponses: { type: 'number' }
+            }
+          }
+        },
+        matchingFlags: {
+          type: 'array',
+          items: { type: 'string' }
+        },
+        warnings: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              unitName: { type: 'string' },
+              variableId: { type: 'string' },
+              message: { type: 'string' },
+              casesInJobs: { type: 'number' },
+              availableCases: { type: 'number' }
+            }
+          }
+        },
+        pairDistribution: {
+          type: 'object',
+          additionalProperties: { type: 'number' }
+        },
+        tasksPerCoder: {
+          type: 'object',
+          additionalProperties: { type: 'number' }
+        },
+        coderWeights: {
+          type: 'object',
+          additionalProperties: { type: 'number' }
+        },
+        selectedVariables: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              unitName: { type: 'string' },
+              variableId: { type: 'string' },
+              includeDeriveError: { type: 'boolean' }
+            }
+          }
+        },
+        selectedVariableBundles: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'number' },
+              name: { type: 'string' },
+              caseOrderingMode: { type: 'string', enum: ['continuous', 'alternating'] },
+              variables: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    unitName: { type: 'string' },
+                    variableId: { type: 'string' },
+                    includeDeriveError: { type: 'boolean' }
+                  }
+                }
+              }
+            }
+          }
+        },
+        selectedCoders: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'number' },
+              name: { type: 'string' },
+              username: { type: 'string' },
+              capacityPercent: { type: 'number' }
+            }
+          }
+        }
+      },
+      required: [
+        'distribution',
+        'doubleCodingInfo',
+        'aggregationInfo',
+        'matchingFlags',
+        'warnings',
+        'selectedVariables',
+        'selectedVariableBundles',
+        'selectedCoders'
+      ]
+    }
+  })
+  async previewCodingJobFromDefinition(
+    @WorkspaceId() workspace_id: number,
+      @Param('id') id: number
+  ): Promise<Awaited<ReturnType<JobDefinitionService['previewCodingJobFromDefinition']>>> {
+    return this.jobDefinitionService.previewCodingJobFromDefinition(
+      id,
+      workspace_id
+    );
+  }
+
   @Get(':workspace_id/coding/job-definitions/:id/refresh-preview')
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   @ApiTags('coding')

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -25,6 +25,7 @@ describe('JobDefinitionService', () => {
     createCodingJob: jest.Mock;
     createDistributedCodingJobs: jest.Mock;
     refreshDistributedCodingJobs: jest.Mock;
+    calculateDistribution: jest.Mock;
     calculateDistributionVariableUsage: jest.Mock;
     calculateDistributionVariableUsageBatch: jest.Mock;
     getCodingJobCountsByDefinitionIds: jest.Mock;
@@ -58,6 +59,17 @@ describe('JobDefinitionService', () => {
           removedCodingTasks: 0,
           canApply: true
         }
+      }),
+      calculateDistribution: jest.fn().mockResolvedValue({
+        distribution: {},
+        distributionByCoderId: {},
+        doubleCodingInfo: {},
+        aggregationInfo: {},
+        matchingFlags: [],
+        warnings: [],
+        pairDistribution: {},
+        tasksPerCoder: {},
+        coderWeights: {}
       }),
       calculateDistributionVariableUsage: jest.fn(),
       calculateDistributionVariableUsageBatch: jest.fn(),
@@ -245,6 +257,88 @@ describe('JobDefinitionService', () => {
         selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
         maxCodingCases: 2,
         distributionSeed: result.distribution_seed
+      })
+    ]);
+  });
+
+  it('merges DERIVE_ERROR opt-in into bundled variables when planning usage', async () => {
+    variableBundleRepository.find.mockResolvedValue([
+      {
+        id: 9,
+        name: 'Bundle',
+        variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }]
+      }
+    ]);
+
+    await expect(service.createJobDefinition({
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }],
+      assignedVariableBundles: [{ id: 9, name: 'Bundle' }],
+      assignedCoders: [1],
+      maxCodingCases: 2
+    }, 7)).resolves.toMatchObject({
+      workspace_id: 7,
+      max_coding_cases: 2
+    });
+
+    expect(codingJobService.calculateDistributionVariableUsageBatch).toHaveBeenCalledWith(7, [
+      expect.objectContaining({
+        key: 'requested',
+        selectedVariables: [],
+        selectedVariableBundles: [expect.objectContaining({
+          id: 9,
+          variables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }]
+        })]
+      })
+    ]);
+  });
+
+  it('preserves DERIVE_ERROR opt-in from duplicate assigned variables when planning usage', async () => {
+    variableBundleRepository.find.mockResolvedValue([
+      {
+        id: 9,
+        name: 'Bundle',
+        variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }]
+      }
+    ]);
+
+    await service.createJobDefinition({
+      assignedVariables: [
+        { unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true },
+        { unitName: 'Unit 1', variableId: 'Var 1' }
+      ],
+      assignedVariableBundles: [{ id: 9, name: 'Bundle' }],
+      assignedCoders: [1],
+      maxCodingCases: 2
+    }, 7);
+
+    expect(codingJobService.calculateDistributionVariableUsageBatch).toHaveBeenCalledWith(7, [
+      expect.objectContaining({
+        key: 'requested',
+        selectedVariables: [],
+        selectedVariableBundles: [expect.objectContaining({
+          id: 9,
+          variables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }]
+        })]
+      })
+    ]);
+  });
+
+  it('deduplicates duplicate unbundled variables when planning usage', async () => {
+    await service.createJobDefinition({
+      assignedVariables: [
+        { unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true },
+        { unitName: 'Unit 1', variableId: 'Var 1' }
+      ],
+      assignedVariableBundles: [],
+      assignedCoders: [1],
+      maxCodingCases: 2
+    }, 7);
+
+    expect(codingJobService.calculateDistributionVariableUsageBatch).toHaveBeenCalledWith(7, [
+      expect.objectContaining({
+        key: 'requested',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }],
+        selectedVariableBundles: []
       })
     ]);
   });
@@ -901,6 +995,53 @@ describe('JobDefinitionService', () => {
     ]);
   });
 
+  it('normalizes bundled variable opt-ins when attaching planned usage to listed definitions', async () => {
+    jobDefinitionRepository.find.mockResolvedValue([
+      {
+        id: 6,
+        workspace_id: 7,
+        status: 'draft',
+        assigned_variables: [
+          { unitName: 'Unit-A', variableId: 'B', includeDeriveError: true },
+          { unitName: 'Unit', variableId: 'A-B', includeDeriveError: true }
+        ],
+        assigned_variable_bundles: [{ id: 10, name: 'Hyphen Bundle' }],
+        max_coding_cases: 2,
+        case_ordering_mode: 'continuous',
+        distribution_seed: 'seed-6'
+      }
+    ]);
+    variableBundleRepository.find.mockResolvedValue([
+      {
+        id: 10,
+        name: 'Hyphen Bundle',
+        variables: [{ unitName: 'Unit', variableId: 'A-B' }]
+      }
+    ]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map());
+    codingJobService.getBlockingCodingJobCountsByDefinitionIds.mockResolvedValue(new Map());
+    codingJobService.calculateDistributionVariableUsageBatch.mockResolvedValueOnce(new Map([
+      [6, new Map([['Unit::A-B', 1], ['Unit-A::B', 1]])]
+    ]));
+
+    await service.getJobDefinitions(7);
+
+    expect(codingJobService.calculateDistributionVariableUsageBatch).toHaveBeenCalledWith(7, [
+      expect.objectContaining({
+        key: 6,
+        selectedVariables: [{ unitName: 'Unit-A', variableId: 'B', includeDeriveError: true }],
+        selectedVariableBundles: [expect.objectContaining({
+          id: 10,
+          variables: [{ unitName: 'Unit', variableId: 'A-B', includeDeriveError: true }]
+        })],
+        maxCodingCases: 2,
+        caseOrderingMode: 'continuous',
+        jobDefinitionId: 6,
+        distributionSeed: 'seed-6'
+      })
+    ]);
+  });
+
   it('batches planned variable usage for listed definitions in the same workspace', async () => {
     jobDefinitionRepository.find.mockResolvedValue([
       {
@@ -1158,6 +1299,111 @@ describe('JobDefinitionService', () => {
       showScore: true,
       allowComments: false,
       suppressGeneralInstructions: true
+    });
+  });
+
+  it('does not collide hyphenated variable keys when creating jobs from definitions', async () => {
+    jobDefinitionRepository.findOne.mockResolvedValue({
+      id: 13,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [
+        { unitName: 'Unit-A', variableId: 'B', includeDeriveError: true },
+        { unitName: 'Unit', variableId: 'A-B' }
+      ],
+      assigned_variable_bundles: [{ id: 10, name: 'Hyphen Bundle' }],
+      assigned_coders: [1],
+      duration_seconds: 30,
+      max_coding_cases: 7,
+      double_coding_absolute: 0,
+      double_coding_percentage: null,
+      case_ordering_mode: 'continuous',
+      assigned_coder_configs: [{ coderId: 1, capacityPercent: 100 }],
+      distribution_seed: 'seed-13',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
+    });
+    variableBundleRepository.find.mockResolvedValue([
+      {
+        id: 10,
+        name: 'Hyphen Bundle',
+        variables: [{ unitName: 'Unit', variableId: 'A-B' }]
+      }
+    ]);
+    usersRepository.find.mockResolvedValue([{ id: 1, username: 'Ada' }]);
+
+    await expect(service.createCodingJobFromDefinition(13, 7)).resolves.toMatchObject({
+      success: true
+    });
+
+    expect(codingJobService.createDistributedCodingJobs).toHaveBeenCalledWith(7, expect.objectContaining({
+      selectedVariables: [{ unitName: 'Unit-A', variableId: 'B', includeDeriveError: true }],
+      selectedVariableBundles: [{
+        id: 10,
+        name: 'Hyphen Bundle',
+        variables: [{ unitName: 'Unit', variableId: 'A-B' }],
+        caseOrderingMode: undefined
+      }]
+    }));
+  });
+
+  it('previews jobs from definitions with the same normalized variable selection', async () => {
+    jobDefinitionRepository.findOne.mockResolvedValue({
+      id: 14,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [
+        { unitName: 'Unit-A', variableId: 'B', includeDeriveError: true },
+        { unitName: 'Unit', variableId: 'A-B', includeDeriveError: true }
+      ],
+      assigned_variable_bundles: [{ id: 10, name: 'Hyphen Bundle' }],
+      assigned_coders: [1],
+      duration_seconds: 30,
+      max_coding_cases: 7,
+      double_coding_absolute: 0,
+      double_coding_percentage: null,
+      case_ordering_mode: 'continuous',
+      assigned_coder_configs: [{ coderId: 1, capacityPercent: 100 }],
+      distribution_seed: 'seed-14',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
+    });
+    variableBundleRepository.find.mockResolvedValue([
+      {
+        id: 10,
+        name: 'Hyphen Bundle',
+        variables: [{ unitName: 'Unit', variableId: 'A-B' }]
+      }
+    ]);
+    usersRepository.find.mockResolvedValue([{ id: 1, username: 'Ada' }]);
+
+    const preview = await service.previewCodingJobFromDefinition(14, 7);
+
+    expect(codingJobService.calculateDistribution).toHaveBeenCalledWith(7, expect.objectContaining({
+      selectedVariables: [{ unitName: 'Unit-A', variableId: 'B', includeDeriveError: true }],
+      selectedVariableBundles: [{
+        id: 10,
+        name: 'Hyphen Bundle',
+        variables: [{ unitName: 'Unit', variableId: 'A-B', includeDeriveError: true }],
+        caseOrderingMode: undefined
+      }]
+    }));
+    expect(preview).toMatchObject({
+      selectedVariables: [{ unitName: 'Unit-A', variableId: 'B', includeDeriveError: true }],
+      selectedVariableBundles: [{
+        id: 10,
+        name: 'Hyphen Bundle',
+        variables: [{ unitName: 'Unit', variableId: 'A-B', includeDeriveError: true }],
+        caseOrderingMode: undefined
+      }],
+      selectedCoders: [{
+        id: 1,
+        name: 'Ada',
+        username: 'Ada',
+        capacityPercent: 100
+      }]
     });
   });
 });

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -90,26 +90,23 @@ interface VariableConflictCheckRequest {
 type PlannedVariableUsageBatchRequest = {
   key: string | number;
   selectedVariables: JobDefinitionVariable[];
-  selectedVariableBundles: {
-    id: number;
-    name: string;
-    caseOrderingMode?: CaseOrderingMode;
-    variables: JobDefinitionVariable[];
-  }[];
+  selectedVariableBundles: JobDefinitionDistributionVariableBundle[];
   maxCodingCases?: number;
   caseOrderingMode?: CaseOrderingMode;
   jobDefinitionId?: number;
   distributionSeed?: string;
 };
 
+type JobDefinitionDistributionVariableBundle = {
+  id: number;
+  name: string;
+  caseOrderingMode?: CaseOrderingMode;
+  variables: JobDefinitionVariable[];
+};
+
 type DefinitionDistributionRequest = {
   selectedVariables: JobDefinitionVariable[];
-  selectedVariableBundles: {
-    id: number;
-    name: string;
-    caseOrderingMode?: CaseOrderingMode;
-    variables: JobDefinitionVariable[];
-  }[];
+  selectedVariableBundles: JobDefinitionDistributionVariableBundle[];
   selectedCoders: {
     id: number;
     name: string;
@@ -235,6 +232,58 @@ export class JobDefinitionService {
     return `${unitName}::${variableId}`;
   }
 
+  private buildDistributionVariableSelection(
+    assignedVariables: JobDefinitionVariable[] = [],
+    assignedVariableBundles: JobDefinitionBundleForUsage[] = []
+  ): {
+      selectedVariables: JobDefinitionVariable[];
+      selectedVariableBundles: JobDefinitionDistributionVariableBundle[];
+    } {
+    const assignedVariableOptionsByKey = assignedVariables.reduce(
+      (variablesByKey, variable) => {
+        const key = this.makeVariableKey(variable.unitName, variable.variableId);
+        const existing = variablesByKey.get(key);
+        variablesByKey.set(key, {
+          ...variable,
+          ...(existing?.includeDeriveError === true || variable.includeDeriveError === true ?
+            { includeDeriveError: true } :
+            {})
+        });
+        return variablesByKey;
+      },
+      new Map<string, JobDefinitionVariable>()
+    );
+    const selectedVariableBundles = assignedVariableBundles.map(bundle => ({
+      id: bundle.id,
+      name: bundle.name,
+      caseOrderingMode: bundle.caseOrderingMode,
+      variables: (bundle.variables || []).map(variable => {
+        const assignedVariable = assignedVariableOptionsByKey.get(
+          this.makeVariableKey(variable.unitName, variable.variableId)
+        );
+
+        return {
+          ...variable,
+          ...(variable.includeDeriveError === true || assignedVariable?.includeDeriveError === true ?
+            { includeDeriveError: true } :
+            {})
+        };
+      })
+    }));
+    const bundleVariableKeys = new Set(
+      selectedVariableBundles
+        .flatMap(bundle => bundle.variables)
+        .map(variable => this.makeVariableKey(variable.unitName, variable.variableId))
+    );
+
+    return {
+      selectedVariables: Array.from(assignedVariableOptionsByKey.values()).filter(
+        variable => !bundleVariableKeys.has(this.makeVariableKey(variable.unitName, variable.variableId))
+      ),
+      selectedVariableBundles
+    };
+  }
+
   private createDistributionSeed(workspaceId: number): string {
     return `job-definition:${workspaceId}:${randomUUID()}`;
   }
@@ -257,15 +306,15 @@ export class JobDefinitionService {
     key: string | number,
     definition: JobDefinitionForUsage
   ): PlannedVariableUsageBatchRequest {
+    const variableSelection = this.buildDistributionVariableSelection(
+      definition.assigned_variables || [],
+      definition.assigned_variable_bundles || []
+    );
+
     return {
       key,
-      selectedVariables: definition.assigned_variables || [],
-      selectedVariableBundles: (definition.assigned_variable_bundles || []).map(bundle => ({
-        id: bundle.id,
-        name: bundle.name,
-        caseOrderingMode: bundle.caseOrderingMode,
-        variables: bundle.variables || []
-      })),
+      selectedVariables: variableSelection.selectedVariables,
+      selectedVariableBundles: variableSelection.selectedVariableBundles,
       caseOrderingMode: definition.case_ordering_mode,
       maxCodingCases: definition.max_coding_cases,
       jobDefinitionId: definition.id,
@@ -679,20 +728,14 @@ export class JobDefinitionService {
               definition.assigned_variable_bundles || []
             );
 
-            return {
-              key: definition.id,
-              selectedVariables: definition.assigned_variables || [],
-              selectedVariableBundles: hydratedBundles.map(bundle => ({
-                id: bundle.id,
-                name: bundle.name,
-                caseOrderingMode: bundle.caseOrderingMode,
-                variables: bundle.variables || []
-              })),
-              maxCodingCases: definition.max_coding_cases,
-              caseOrderingMode: definition.case_ordering_mode,
-              jobDefinitionId: definition.id,
-              distributionSeed: this.getDefinitionDistributionSeed(definition)
-            };
+            return this.buildPlannedVariableUsageBatchRequest(definition.id, {
+              id: definition.id,
+              assigned_variables: definition.assigned_variables || [],
+              assigned_variable_bundles: hydratedBundles,
+              max_coding_cases: definition.max_coding_cases,
+              case_ordering_mode: definition.case_ordering_mode,
+              distribution_seed: this.getDefinitionDistributionSeed(definition)
+            });
           });
         const usageRequests = (await Promise.all(usageRequestPromises))
           .filter((request): request is PlannedVariableUsageBatchRequest => request !== undefined);
@@ -1041,27 +1084,15 @@ export class JobDefinitionService {
       (jobDefinition.assigned_variable_bundles || [])
         .map(bundle => [bundle.id, bundle.caseOrderingMode])
     );
-    const assignedVariableOptionsByKey = new Map(
-      (jobDefinition.assigned_variables || []).map(variable => [
-        `${variable.unitName}-${variable.variableId}`,
-        variable
-      ])
-    );
-    const selectedVariableBundles = fullVariableBundles.map(bundle => ({
+    const hydratedBundles = fullVariableBundles.map(bundle => ({
       id: bundle.id,
       name: bundle.name,
-      variables: (bundle.variables || []).map(variable => ({
-        ...variable,
-        ...(assignedVariableOptionsByKey.get(`${variable.unitName}-${variable.variableId}`)?.includeDeriveError === true ?
-          { includeDeriveError: true } :
-          {})
-      })),
+      variables: bundle.variables || [],
       caseOrderingMode: savedBundleModes.get(bundle.id)
     }));
-    const bundleVariables = selectedVariableBundles.flatMap(bundle => bundle.variables || []);
-    const bundleVariableKeys = new Set(bundleVariables.map(v => `${v.unitName}-${v.variableId}`));
-
-    const filteredVariables = (jobDefinition.assigned_variables || []).filter(v => !bundleVariableKeys.has(`${v.unitName}-${v.variableId}`)
+    const variableSelection = this.buildDistributionVariableSelection(
+      jobDefinition.assigned_variables || [],
+      hydratedBundles
     );
     const coderAssignments = this.getStoredCoderAssignments(jobDefinition);
     const capacityByCoderId = new Map(
@@ -1083,8 +1114,8 @@ export class JobDefinitionService {
     });
 
     return {
-      selectedVariables: filteredVariables,
-      selectedVariableBundles,
+      selectedVariables: variableSelection.selectedVariables,
+      selectedVariableBundles: variableSelection.selectedVariableBundles,
       selectedCoders,
       doubleCodingAbsolute: jobDefinition.double_coding_absolute,
       doubleCodingPercentage: this.toOptionalNumber(jobDefinition.double_coding_percentage),
@@ -1101,6 +1132,17 @@ export class JobDefinitionService {
   async createCodingJobFromDefinition(jobDefinitionId: number, workspaceId: number) {
     const request = await this.buildDistributionRequestFromDefinition(jobDefinitionId, workspaceId);
     return this.codingJobService.createDistributedCodingJobs(workspaceId, request);
+  }
+
+  async previewCodingJobFromDefinition(jobDefinitionId: number, workspaceId: number) {
+    const request = await this.buildDistributionRequestFromDefinition(jobDefinitionId, workspaceId);
+    const preview = await this.codingJobService.calculateDistribution(workspaceId, request);
+    return {
+      ...preview,
+      selectedVariables: request.selectedVariables,
+      selectedVariableBundles: request.selectedVariableBundles,
+      selectedCoders: request.selectedCoders
+    };
   }
 
   async previewJobDefinitionRefresh(

--- a/apps/frontend/src/app/coding/components/coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component.spec.ts
@@ -92,6 +92,88 @@ describe('CodingJobBulkCreationDialogComponent', () => {
     });
   });
 
+  it('uses warnings supplied with a precomputed backend preview', () => {
+    createComponent({
+      selectedVariables: [selectedVariable],
+      selectedVariableBundles: [],
+      selectedCoders,
+      distribution: {
+        'Unit 1::Var 1': { Ada: 4, Bea: 0 }
+      },
+      distributionByCoderId: {
+        'Unit 1::Var 1': { 1: 4, 2: 0 }
+      },
+      doubleCodingInfo: {
+        'Unit 1::Var 1': {
+          totalCases: 4,
+          distinctCases: 4,
+          codingTasksTotal: 4,
+          doubleCodedCases: 0,
+          singleCodedCasesAssigned: 4,
+          doubleCodedCasesPerCoder: { Ada: 0, Bea: 0 }
+        }
+      },
+      warnings: [{
+        unitName: 'Unit 1',
+        variableId: 'Var 1',
+        message: 'Already assigned',
+        casesInJobs: 1,
+        availableCases: 4
+      }]
+    });
+
+    expect(component.warnings).toEqual([expect.objectContaining({
+      unitName: 'Unit 1',
+      variableId: 'Var 1'
+    })]);
+    expect(component.showWarningsPanel).toBe(true);
+    expect(mockDistributedCodingService.calculateDistribution).not.toHaveBeenCalled();
+  });
+
+  it('preserves warnings returned by backend distribution calculation', async () => {
+    (mockDistributedCodingService.calculateDistribution as jest.Mock).mockReturnValue(of({
+      distribution: {
+        'Unit 1::Var 1': { Ada: 4, Bea: 0 }
+      },
+      distributionByCoderId: {
+        'Unit 1::Var 1': { 1: 4, 2: 0 }
+      },
+      doubleCodingInfo: {
+        'Unit 1::Var 1': {
+          totalCases: 4,
+          distinctCases: 4,
+          codingTasksTotal: 4,
+          doubleCodedCases: 0,
+          singleCodedCasesAssigned: 4,
+          doubleCodedCasesPerCoder: { Ada: 0, Bea: 0 }
+        }
+      },
+      aggregationInfo: {},
+      matchingFlags: [],
+      warnings: [{
+        unitName: 'Unit 1',
+        variableId: 'Var 1',
+        message: 'Already assigned',
+        casesInJobs: 1,
+        availableCases: 4
+      }]
+    }));
+
+    createComponent({
+      selectedVariables: [selectedVariable],
+      selectedVariableBundles: [],
+      selectedCoders
+    });
+    await fixture.whenStable();
+
+    expect(component.warnings).toEqual([expect.objectContaining({
+      unitName: 'Unit 1',
+      variableId: 'Var 1'
+    })]);
+    expect(component.showWarningsPanel).toBe(true);
+    expect(component.jobPreviews).toHaveLength(1);
+  });
+
   it('uses backend-created job names and counts in the results view', () => {
     createComponent({
       selectedVariables: [selectedVariable],

--- a/apps/frontend/src/app/coding/components/coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component.ts
@@ -26,9 +26,12 @@ interface JobCreationWarning {
   availableCases: number;
 }
 
+type PreviewVariableBundle = Pick<VariableBundle, 'id' | 'name' | 'variables' | 'caseOrderingMode'> &
+Partial<Pick<VariableBundle, 'description' | 'createdAt' | 'updatedAt'>>;
+
 export interface BulkCreationData {
   selectedVariables: Variable[];
-  selectedVariableBundles: VariableBundle[];
+  selectedVariableBundles: PreviewVariableBundle[];
   selectedCoders: Coder[];
   doubleCodingAbsolute?: number;
   doubleCodingPercentage?: number;
@@ -88,7 +91,7 @@ interface DoubleCodingPreview {
 export interface JobPreview {
   name: string;
   variable?: Variable;
-  bundle?: VariableBundle;
+  bundle?: PreviewVariableBundle;
   caseCount?: number;
   coderName?: string;
   jobId?: number;
@@ -103,7 +106,7 @@ export interface BulkCreationResult {
 
 interface DistributionMatrixRow {
   variable?: { unitName: string; variableId: string };
-  bundle?: VariableBundle;
+  bundle?: PreviewVariableBundle;
   variableKey: string;
   totalCases: number;
   coderCases: Record<string, number>;
@@ -192,8 +195,7 @@ export class CodingJobBulkCreationDialogComponent {
       this.data.distribution = result?.distribution || {};
       this.data.distributionByCoderId = result?.distributionByCoderId || {};
       this.data.doubleCodingInfo = result?.doubleCodingInfo || {};
-      this.warnings = result?.warnings || [];
-      this.showWarningsPanel = this.warnings.length > 0;
+      this.data.warnings = result?.warnings || [];
 
       this.initializeFromData();
 
@@ -225,6 +227,8 @@ export class CodingJobBulkCreationDialogComponent {
   private initializeFromData(): void {
     if (!this.data.distribution || !this.data.doubleCodingInfo) return;
 
+    this.warnings = this.data.warnings || [];
+    this.showWarningsPanel = this.warnings.length > 0;
     this.distributionMatrix = [];
     for (const [variableKey, coderCases] of Object.entries(this.data.distribution)) {
       const coderCasesById = this.data.distributionByCoderId?.[variableKey];
@@ -312,7 +316,7 @@ export class CodingJobBulkCreationDialogComponent {
     // Sort coders alphabetically for deterministic job naming
     const sortedCoders = [...this.data.selectedCoders].sort((a, b) => a.name.localeCompare(b.name));
 
-    const items: (Variable | VariableBundle)[] = [];
+    const items: (Variable | PreviewVariableBundle)[] = [];
     if (this.data.selectedVariableBundles) {
       items.push(...this.data.selectedVariableBundles);
     }
@@ -355,7 +359,7 @@ export class CodingJobBulkCreationDialogComponent {
     return `Job ${unitName} (${coderName})`;
   }
 
-  private getBundleItemKey(bundle: Pick<VariableBundle, 'id'>): string {
+  private getBundleItemKey(bundle: Pick<PreviewVariableBundle, 'id'>): string {
     return `bundle:${bundle.id}`;
   }
 
@@ -363,7 +367,7 @@ export class CodingJobBulkCreationDialogComponent {
     return !itemKey.startsWith('bundle:') && itemKey.includes('::');
   }
 
-  private findBundleForItemKey(itemKey: string): VariableBundle | undefined {
+  private findBundleForItemKey(itemKey: string): PreviewVariableBundle | undefined {
     if (itemKey.startsWith('bundle:')) {
       const bundleId = Number(itemKey.slice('bundle:'.length));
       return this.data.selectedVariableBundles?.find(bundle => bundle.id === bundleId);
@@ -372,7 +376,7 @@ export class CodingJobBulkCreationDialogComponent {
     return this.data.selectedVariableBundles?.find(bundle => bundle.name === itemKey);
   }
 
-  getBundleDisplayName(bundle: VariableBundle): string {
+  getBundleDisplayName(bundle: PreviewVariableBundle): string {
     const sameNameCount = (this.data.selectedVariableBundles || [])
       .filter(selectedBundle => selectedBundle.name === bundle.name)
       .length;
@@ -380,7 +384,7 @@ export class CodingJobBulkCreationDialogComponent {
     return sameNameCount > 1 ? `${bundle.name} (#${bundle.id})` : bundle.name;
   }
 
-  private getCaseCountForCoder(item: Variable | VariableBundle, coder: Coder): number {
+  private getCaseCountForCoder(item: Variable | PreviewVariableBundle, coder: Coder): number {
     let itemKey;
     let totalCases;
 

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
@@ -5,7 +5,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { CodingJobDefinitionsComponent } from './coding-job-definitions.component';
 import { CodingJobBackendService } from '../../services/coding-job-backend.service';
@@ -37,6 +37,20 @@ describe('CodingJobDefinitionsComponent', () => {
             approveJobDefinition: jest.fn().mockReturnValue(of({})),
             deleteJobDefinition: jest.fn().mockReturnValue(of({})),
             createCodingJobFromDefinition: jest.fn().mockReturnValue(of({ success: true, jobsCreated: 1, jobs: [] })),
+            previewCodingJobFromDefinition: jest.fn().mockReturnValue(of({
+              distribution: {},
+              distributionByCoderId: {},
+              doubleCodingInfo: {},
+              aggregationInfo: {},
+              matchingFlags: [],
+              warnings: [],
+              pairDistribution: {},
+              tasksPerCoder: {},
+              coderWeights: {},
+              selectedVariables: [],
+              selectedVariableBundles: [],
+              selectedCoders: []
+            })),
             previewJobDefinitionRefresh: jest.fn().mockReturnValue(of({
               jobDefinitionId: 42,
               existingJobsCount: 1,
@@ -332,10 +346,12 @@ describe('CodingJobDefinitionsComponent', () => {
     const coderService = TestBed.inject(CoderService) as unknown as { getCoders: jest.Mock };
     const codingJobBackendService = TestBed.inject(CodingJobBackendService) as unknown as {
       createCodingJobFromDefinition: jest.Mock;
+      previewCodingJobFromDefinition: jest.Mock;
       updateCodingJob: jest.Mock;
     };
     const matDialog = TestBed.inject(MatDialog);
     const assignedVariables = [{ unitName: 'Unit 1', variableId: 'Var 1' }];
+    const previewVariables = [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }];
     const assignedVariableBundles = [{
       id: 9,
       name: 'Bundle A',
@@ -345,16 +361,54 @@ describe('CodingJobDefinitionsComponent', () => {
       updatedAt: new Date('2026-01-02T00:00:00.000Z')
     }];
 
-    coderService.getCoders.mockReturnValue(of([
-      { id: 1, name: 'Ada' },
-      { id: 2, name: 'Bea' },
-      { id: 3, name: 'Chris' }
-    ]));
+    coderService.getCoders.mockClear();
+    coderService.getCoders.mockReturnValue(throwError(() => new Error('coder loading failed')));
     codingJobBackendService.createCodingJobFromDefinition.mockReturnValue(of({
       success: true,
       jobsCreated: 1,
       message: 'created',
       jobs: [{ jobId: 111 }]
+    }));
+    codingJobBackendService.previewCodingJobFromDefinition.mockReturnValue(of({
+      distribution: { 'bundle:9': { Ada: 4, Bea: 3 } },
+      distributionByCoderId: { 'bundle:9': { 1: 4, 2: 3 } },
+      doubleCodingInfo: {
+        'bundle:9': {
+          totalCases: 7,
+          distinctCases: 7,
+          codingTasksTotal: 7,
+          doubleCodedCases: 0,
+          singleCodedCasesAssigned: 7,
+          doubleCodedCasesPerCoder: { Ada: 0, Bea: 0 }
+        }
+      },
+      aggregationInfo: {},
+      matchingFlags: [],
+      warnings: [],
+      pairDistribution: {},
+      tasksPerCoder: { 1: 4, 2: 3 },
+      coderWeights: { 1: 1.5, 2: 0.5 },
+      selectedVariables: previewVariables,
+      selectedVariableBundles: [{
+        id: 9,
+        name: 'Bundle A',
+        caseOrderingMode: 'alternating' as const,
+        variables: [{ unitName: 'Unit 2', variableId: 'Var 2', includeDeriveError: true }]
+      }],
+      selectedCoders: [
+        {
+          id: 2,
+          name: 'Bea',
+          username: 'Bea',
+          capacityPercent: 50
+        },
+        {
+          id: 1,
+          name: 'Ada',
+          username: 'Ada',
+          capacityPercent: 150
+        }
+      ]
     }));
     const dialogRefMock = {
       afterClosed: () => of({
@@ -388,8 +442,13 @@ describe('CodingJobDefinitionsComponent', () => {
 
     expect(matDialog.open).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({
       data: expect.objectContaining({
-        selectedVariables: assignedVariables,
-        selectedVariableBundles: assignedVariableBundles,
+        selectedVariables: previewVariables,
+        selectedVariableBundles: [{
+          id: 9,
+          name: 'Bundle A',
+          caseOrderingMode: 'alternating',
+          variables: [{ unitName: 'Unit 2', variableId: 'Var 2', includeDeriveError: true }]
+        }],
         selectedCoders: [
           { id: 1, name: 'Ada', capacityPercent: 150 },
           { id: 2, name: 'Bea', capacityPercent: 50 }
@@ -398,6 +457,19 @@ describe('CodingJobDefinitionsComponent', () => {
         caseOrderingMode: 'continuous',
         maxCodingCases: 7,
         distributionSeed: 'seed-42',
+        distribution: { 'bundle:9': { Ada: 4, Bea: 3 } },
+        distributionByCoderId: { 'bundle:9': { 1: 4, 2: 3 } },
+        doubleCodingInfo: {
+          'bundle:9': {
+            totalCases: 7,
+            distinctCases: 7,
+            codingTasksTotal: 7,
+            doubleCodedCases: 0,
+            singleCodedCasesAssigned: 7,
+            doubleCodedCasesPerCoder: { Ada: 0, Bea: 0 }
+          }
+        },
+        warnings: [],
         displayOptions: {
           showScore: false,
           allowComments: false,
@@ -406,11 +478,49 @@ describe('CodingJobDefinitionsComponent', () => {
         displayOptionsLocked: true
       })
     }));
+    expect(codingJobBackendService.previewCodingJobFromDefinition).toHaveBeenCalledWith(
+      1,
+      42
+    );
+    expect(coderService.getCoders).not.toHaveBeenCalled();
     expect(codingJobBackendService.createCodingJobFromDefinition).toHaveBeenCalledWith(
       1,
       42
     );
     expect(codingJobBackendService.updateCodingJob).not.toHaveBeenCalled();
+  });
+
+  it('shows a preview error without opening the bulk creation dialog', async () => {
+    const coderService = TestBed.inject(CoderService) as unknown as { getCoders: jest.Mock };
+    const codingJobBackendService = TestBed.inject(CodingJobBackendService) as unknown as {
+      createCodingJobFromDefinition: jest.Mock;
+      previewCodingJobFromDefinition: jest.Mock;
+    };
+    const matDialog = TestBed.inject(MatDialog);
+    const snackBar = TestBed.inject(MatSnackBar) as unknown as { open: jest.Mock };
+    jest.spyOn(matDialog, 'open');
+
+    coderService.getCoders.mockReturnValue(of([{ id: 1, name: 'Ada' }]));
+    codingJobBackendService.previewCodingJobFromDefinition.mockReturnValue(
+      throwError(() => new Error('preview failed'))
+    );
+
+    await component.createCodingJobFromDefinition({
+      id: 42,
+      status: 'approved',
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedCoders: [1],
+      createdJobsCount: 0
+    });
+
+    expect(codingJobBackendService.previewCodingJobFromDefinition).toHaveBeenCalledWith(1, 42);
+    expect(matDialog.open).not.toHaveBeenCalled();
+    expect(codingJobBackendService.createCodingJobFromDefinition).not.toHaveBeenCalled();
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'coding-job-definitions.messages.snackbar.create-preview-failed',
+      'common.close',
+      { duration: 5000 }
+    );
   });
 
   it('passes saved display options into the edit dialog', () => {

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
@@ -22,6 +22,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Subject, firstValueFrom, takeUntil } from 'rxjs';
 import { CodingJobBackendService } from '../../services/coding-job-backend.service';
+import type { JobDefinitionDistributionPreviewResponse } from '../../services/distributed-coding.service';
 import { AppService } from '../../../core/services/app.service';
 import { Variable, VariableBundle } from '../../models/coding-job.model';
 import { CoderService } from '../../services/coder.service';
@@ -826,57 +827,89 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       return;
     }
 
+    let preview: JobDefinitionDistributionPreviewResponse;
     try {
-      const allCoders = await firstValueFrom(this.coderService.getCoders());
-      const capacityByCoderId = new Map(
-        (definition.assignedCoderConfigs || [])
-          .map(config => [config.coderId, config.capacityPercent])
-      );
-      const selectedCoders =
-        allCoders?.filter(coder => definition.assignedCoders!.includes(coder.id)
-        )
-          .map(coder => ({
-            ...coder,
-            capacityPercent: capacityByCoderId.get(coder.id) ?? 100
-          })) || [];
-
-      const dialogData: BulkCreationData = {
-        selectedVariables: definition.assignedVariables || [],
-        selectedVariableBundles: definition.assignedVariableBundles || [],
-        selectedCoders: selectedCoders,
-        doubleCodingAbsolute: definition.doubleCodingAbsolute,
-        doubleCodingPercentage: definition.doubleCodingPercentage,
-        caseOrderingMode: definition.caseOrderingMode || 'continuous',
-        maxCodingCases: definition.maxCodingCases,
-        distributionSeed: definition.distributionSeed,
-        displayOptions: {
-          showScore: definition.showScore ?? false,
-          allowComments: definition.allowComments ?? true,
-          suppressGeneralInstructions: definition.suppressGeneralInstructions ?? false
-        },
-        displayOptionsLocked: true
-      };
-      const dialogRef = this.dialog.open(CodingJobBulkCreationDialogComponent, {
-        width: '1200px',
-        data: dialogData
-      });
-
-      const result = await firstValueFrom(dialogRef.afterClosed());
-
-      if (result && result.confirmed) {
-        await this.createBulkJobsFromDefinition(
+      preview = await firstValueFrom(
+        this.codingJobBackendService.previewCodingJobFromDefinition(
           workspaceId,
           definition.id
-        );
-      }
+        )
+      );
     } catch (error) {
       this.showError(
         this.translateService.instant(
-          'coding-job-definitions.messages.snackbar.coders-loading-failed',
-          { error: (error as Error).message }
+          'coding-job-definitions.messages.snackbar.create-preview-failed',
+          { error: this.getErrorMessage(error) }
         )
       );
+      return;
     }
+
+    const selectedCoders = this.mapPreviewSelectedCoders(preview.selectedCoders);
+    if (selectedCoders.length === 0) {
+      this.showError(
+        this.translateService.instant(
+          'coding-job-definitions.messages.snackbar.create-preview-failed',
+          {
+            error: this.translateService.instant(
+              'coding-job-definitions.messages.snackbar.create-preview-no-coders'
+            )
+          }
+        )
+      );
+      return;
+    }
+
+    const dialogData: BulkCreationData = {
+      selectedVariables: preview.selectedVariables,
+      selectedVariableBundles: preview.selectedVariableBundles,
+      selectedCoders: selectedCoders,
+      doubleCodingAbsolute: definition.doubleCodingAbsolute,
+      doubleCodingPercentage: definition.doubleCodingPercentage,
+      caseOrderingMode: definition.caseOrderingMode || 'continuous',
+      maxCodingCases: definition.maxCodingCases,
+      distributionSeed: definition.distributionSeed,
+      distribution: preview.distribution,
+      distributionByCoderId: preview.distributionByCoderId,
+      doubleCodingInfo: preview.doubleCodingInfo,
+      warnings: preview.warnings,
+      displayOptions: {
+        showScore: definition.showScore ?? false,
+        allowComments: definition.allowComments ?? true,
+        suppressGeneralInstructions: definition.suppressGeneralInstructions ?? false
+      },
+      displayOptionsLocked: true
+    };
+    const dialogRef = this.dialog.open(CodingJobBulkCreationDialogComponent, {
+      width: '1200px',
+      data: dialogData
+    });
+
+    const result = await firstValueFrom(dialogRef.afterClosed());
+
+    if (result && result.confirmed) {
+      await this.createBulkJobsFromDefinition(
+        workspaceId,
+        definition.id
+      );
+    }
+  }
+
+  private mapPreviewSelectedCoders(
+    previewCoders: Array<{
+      id: number;
+      name?: string;
+      username?: string;
+      capacityPercent?: number;
+    }> = []
+  ): Coder[] {
+    return previewCoders
+      .map(coder => ({
+        id: coder.id,
+        name: coder.name || coder.username || `Coder ${coder.id}`,
+        capacityPercent: coder.capacityPercent
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name) || a.id - b.id);
   }
 
   private async createBulkJobsFromDefinition(

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -161,6 +161,50 @@ describe('CodingJobBackendService', () => {
       });
     });
 
+    it('should preview coding jobs through the dedicated job definition endpoint', () => {
+      service.previewCodingJobFromDefinition(1, 42).subscribe(response => {
+        expect(response.distribution).toEqual({ 'Unit::Var': { Ada: 1 } });
+        expect(response.warnings).toEqual([]);
+        expect(response.selectedVariables).toEqual([
+          { unitName: 'Unit', variableId: 'Var', includeDeriveError: true }
+        ]);
+        expect(response.selectedVariableBundles).toEqual([]);
+        expect(response.selectedCoders).toEqual([
+          {
+            id: 1,
+            name: 'Ada',
+            username: 'Ada',
+            capacityPercent: 100
+          }
+        ]);
+      });
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/job-definitions/42/create-job-preview`);
+      expect(req.request.method).toBe('GET');
+      expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token');
+      req.flush({
+        distribution: { 'Unit::Var': { Ada: 1 } },
+        distributionByCoderId: { 'Unit::Var': { 1: 1 } },
+        doubleCodingInfo: {},
+        aggregationInfo: {},
+        matchingFlags: [],
+        warnings: [],
+        pairDistribution: {},
+        tasksPerCoder: {},
+        coderWeights: {},
+        selectedVariables: [{ unitName: 'Unit', variableId: 'Var', includeDeriveError: true }],
+        selectedVariableBundles: [],
+        selectedCoders: [
+          {
+            id: 1,
+            name: 'Ada',
+            username: 'Ada',
+            capacityPercent: 100
+          }
+        ]
+      });
+    });
+
     it('should preview a job definition refresh', () => {
       service.previewJobDefinitionRefresh(1, 42).subscribe(response => {
         expect(response.addedCases).toBe(2);

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -4,7 +4,10 @@ import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { SERVER_URL } from '../../injection-tokens';
 import { ValidationTaskStateService } from '../../shared/services/validation/validation-task-state.service';
-import type { DistributedCodingJobsResponse } from './distributed-coding.service';
+import type {
+  DistributedCodingJobsResponse,
+  JobDefinitionDistributionPreviewResponse
+} from './distributed-coding.service';
 import type {
   CodingJobFreshnessImpactDto,
   JobDefinitionRefreshApplyResultDto,
@@ -715,6 +718,14 @@ export class CodingJobBackendService {
   ): Observable<DistributedCodingJobsResponse> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/job-definitions/${jobDefinitionId}/create-job`;
     return this.http.post<DistributedCodingJobsResponse>(url, {}, { headers: this.authHeader });
+  }
+
+  previewCodingJobFromDefinition(
+    workspaceId: number,
+    jobDefinitionId: number
+  ): Observable<JobDefinitionDistributionPreviewResponse> {
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/job-definitions/${jobDefinitionId}/create-job-preview`;
+    return this.http.get<JobDefinitionDistributionPreviewResponse>(url, { headers: this.authHeader });
   }
 
   previewJobDefinitionRefresh(

--- a/apps/frontend/src/app/coding/services/distributed-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/distributed-coding.service.ts
@@ -3,12 +3,38 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, catchError, throwError } from 'rxjs';
 import { SERVER_URL } from '../../injection-tokens';
 
-type DistributionVariable = { unitName: string; variableId: string; includeDeriveError?: boolean };
+export type DistributionVariable = { unitName: string; variableId: string; includeDeriveError?: boolean };
 
-export interface DistributedCodingJobsResponse {
+export interface DistributionVariableBundle {
+  id: number;
+  name: string;
+  caseOrderingMode?: 'continuous' | 'alternating';
+  variables: DistributionVariable[];
+}
+
+export interface DistributedCodingJobsResponse extends DistributionCalculationResponse {
   success: boolean;
   jobsCreated: number;
   message: string;
+  jobs: {
+    itemKey?: string;
+    coderId: number;
+    coderName: string;
+    variable: { unitName: string; variableId: string };
+    jobId: number;
+    jobName: string;
+    caseCount: number;
+  }[];
+}
+
+export interface DistributionPreviewCoder {
+  id: number;
+  name: string;
+  username: string;
+  capacityPercent?: number;
+}
+
+export interface DistributionCalculationResponse {
   distribution: Record<string, Record<string, number>>;
   distributionByCoderId?: Record<string, Record<string, number>>;
   doubleCodingInfo: Record<string, {
@@ -21,18 +47,16 @@ export interface DistributedCodingJobsResponse {
   }>;
   aggregationInfo: Record<string, { uniqueCases: number; totalResponses: number }>;
   matchingFlags: string[];
+  warnings: Array<{ unitName: string; variableId: string; message: string; casesInJobs: number; availableCases: number }>;
   pairDistribution?: Record<string, number>;
   tasksPerCoder?: Record<string, number>;
   coderWeights?: Record<string, number>;
-  jobs: {
-    itemKey?: string;
-    coderId: number;
-    coderName: string;
-    variable: { unitName: string; variableId: string };
-    jobId: number;
-    jobName: string;
-    caseCount: number;
-  }[];
+}
+
+export interface JobDefinitionDistributionPreviewResponse extends DistributionCalculationResponse {
+  selectedVariables: DistributionVariable[];
+  selectedVariableBundles: DistributionVariableBundle[];
+  selectedCoders: DistributionPreviewCoder[];
 }
 
 @Injectable({
@@ -66,7 +90,7 @@ export class DistributedCodingService {
     selectedCoders: { id: number; name: string; username: string; weight?: number; capacityPercent?: number }[],
     doubleCodingAbsolute?: number,
     doubleCodingPercentage?: number,
-    selectedVariableBundles?: { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: DistributionVariable[] }[],
+    selectedVariableBundles?: DistributionVariableBundle[],
     caseOrderingMode?: 'continuous' | 'alternating',
     maxCodingCases?: number,
     displayOptions?: {
@@ -105,24 +129,14 @@ export class DistributedCodingService {
     selectedCoders: { id: number; name: string; username: string; weight?: number; capacityPercent?: number }[],
     doubleCodingAbsolute?: number,
     doubleCodingPercentage?: number,
-    selectedVariableBundles?: { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: DistributionVariable[] }[],
+    selectedVariableBundles?: DistributionVariableBundle[],
     caseOrderingMode?: 'continuous' | 'alternating',
     maxCodingCases?: number,
     distributionSeed?: string
-  ): Observable<{
-      distribution: Record<string, Record<string, number>>;
-      distributionByCoderId?: Record<string, Record<string, number>>;
-      doubleCodingInfo: DistributedCodingJobsResponse['doubleCodingInfo'];
-      aggregationInfo: Record<string, { uniqueCases: number; totalResponses: number }>;
-      matchingFlags: string[];
-      pairDistribution?: Record<string, number>;
-      tasksPerCoder?: Record<string, number>;
-      coderWeights?: Record<string, number>;
-      warnings: Array<{ unitName: string; variableId: string; message: string; casesInJobs: number; availableCases: number }>;
-    }> {
+  ): Observable<DistributionCalculationResponse> {
     const body: {
       selectedVariables: DistributionVariable[];
-      selectedVariableBundles?: { id: number; name: string; caseOrderingMode?: 'continuous' | 'alternating'; variables: DistributionVariable[] }[];
+      selectedVariableBundles?: DistributionVariableBundle[];
       selectedCoders: { id: number; name: string; username: string; weight?: number; capacityPercent?: number }[];
       doubleCodingAbsolute?: number;
       doubleCodingPercentage?: number;

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2190,6 +2190,8 @@
         "delete-failed": "Fehler beim Löschen: {{error}}",
         "jobs-created": "{{count}} Kodier-Jobs wurden erfolgreich erstellt",
         "jobs-created-partial": "{{successCount}} Jobs erstellt, {{errorCount}} fehlgeschlagen",
+        "create-preview-failed": "Vorschau konnte nicht berechnet werden: {{error}}",
+        "create-preview-no-coders": "Keine Kodierer in der Vorschau",
         "refresh-preview-failed": "Neuverteilung konnte nicht vorbereitet werden: {{error}}",
         "refresh-applied": "Kodierjobs neu verteilt: {{count}} Kodierjobs erstellt.",
         "refresh-apply-failed": "Neuverteilung fehlgeschlagen: {{error}}",


### PR DESCRIPTION
## Summary

- normalize job definition variable and bundle selections before planning, previewing, and creating distributed coding jobs
- add a backend create-job preview endpoint that returns the normalized selections, selected coders, warnings, and distribution data
- update the frontend bulk creation flow to use the backend-normalized preview instead of rebuilding the selection client-side

## Root Cause

The create-from-definition preview could diverge from the backend creation path because the dialog assembled its selection from stored definition data. Definition-specific rules such as bundled variable normalization and DERIVE_ERROR opt-ins were therefore easy to miss in the preview.

## Impact

Users now see the same normalized variable and bundle selection in the preview that the backend will use when the jobs are actually created. This avoids misleading previews without changing the coding scheme.

Fixes #546.

## Validation

- `npx nx test backend --runInBand --silent --testFile=apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts`
- `npx nx test backend --runInBand --silent --testFile=apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.spec.ts`
- `npx nx lint backend`
- `npx nx build backend`
- `npx nx test frontend --runInBand --silent --testFile=apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts`
- `npx nx test frontend --runInBand --silent --testFile=apps/frontend/src/app/coding/components/coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component.spec.ts`
- `npx nx test frontend --runInBand --silent --testFile=apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts`
- `npx nx lint frontend`
- `npx nx build frontend`
- `git diff --check`

Frontend build completed with existing warnings in unrelated files: optional chaining in `test-results.component.html`, unused `MyCodingJobsComponent` import, and the existing SCSS budget warning for `coding-management-manual.component.scss`.
