### PR TITLE
Fix double-coded review coder columns

### DIFF
--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
@@ -3,13 +3,13 @@
     <div
       class="decision-status"
       [ngClass]="getDecisionStatusClass(element)"
-      [matTooltip]="element.isResolved ? ('double-coded-review.applied' | translate) : (getCodedCount(element) + '/' + element.coderResults.length + ' ' + ('double-coded-review.coders-done' | translate))">
+      [matTooltip]="getDecisionStatusTooltip(element)">
       <mat-icon>{{ getDecisionStatusIcon(element) }}</mat-icon>
       <span class="status-label">{{ getDecisionStatusLabel(element) }}</span>
       @if (!element.isResolved) {
         <span class="progress-dots">
-          @for (result of element.coderResults; track result.coderId + '-' + result.jobId) {
-            <span class="dot" [ngClass]="result.code !== null ? 'filled' : 'empty'"></span>
+          @for (isCoderDone of getCoderCompletionStates(element); track $index) {
+            <span class="dot" [ngClass]="isCoderDone ? 'filled' : 'empty'"></span>
           }
         </span>
       }
@@ -30,7 +30,9 @@
                 @if (selectedResult.score !== null) {
                   <span class="decision-score-value">({{ selectedResult.score }})</span>
                 }
-                <span class="decision-source">{{ selectedResult.coderName }}</span>
+                <span class="decision-source">
+                  {{ getDecisionResultSourceLabel(element, selectedResult) }}
+                </span>
               </span>
             } @else {
               <span class="pending-coder">{{ 'double-coded-review.decision.no-selection' | translate }}</span>
@@ -40,7 +42,9 @@
           @for (result of element.coderResults; track result.coderId + '-' + result.jobId) {
             <mat-option [value]="result.jobId.toString()" [disabled]="result.code === null">
               <span class="decision-option" [matTooltip]="result.jobName || ''">
-                <span class="decision-option-source">{{ result.coderName }}</span>
+                <span class="decision-option-source">
+                  {{ getDecisionResultSourceLabel(element, result) }}
+                </span>
                 <span class="decision-option-code">{{ getCodeDisplay(result.code) || 'N/A' }}</span>
                 @if (result.score !== null) {
                   <span class="decision-option-score">({{ result.score }})</span>
@@ -268,23 +272,36 @@
                         {{ getCoderColumnHeader(columnId) }}
                       </th>
                       <td mat-cell *matCellDef="let element">
-                        @if (getCoderResultForColumn(element, columnId); as result) {
-                          <div class="coder-column-cell" [ngClass]="{'pending': result.code === null}">
-                            <div class="coder-code-row">
-                              <span class="coder-code-value" [matTooltip]="getCodeLabel(result.code)">{{ getCodeDisplay(result.code) || 'N/A' }}</span>
-                              @if (result.score !== null) {
-                                <span class="coder-score-value">({{ result.score }})</span>
+                        @if (getCoderResultsForColumn(element, columnId); as results) {
+                          @if (results.length > 0) {
+                            <div class="coder-column-results" [class.multiple]="results.length > 1">
+                              @for (result of results; track result.jobId) {
+                                <div class="coder-column-cell" [ngClass]="{'pending': result.code === null}">
+                                  @if (results.length > 1) {
+                                    <div class="coder-result-source" [matTooltip]="getCoderResultSourceLabel(result)">
+                                      {{ getCoderResultSourceLabel(result) }}
+                                    </div>
+                                  }
+                                  <div class="coder-result-content">
+                                    <div class="coder-code-row">
+                                      <span class="coder-code-value" [matTooltip]="getCodeLabel(result.code)">{{ getCodeDisplay(result.code) || 'N/A' }}</span>
+                                      @if (result.score !== null) {
+                                        <span class="coder-score-value">({{ result.score }})</span>
+                                      }
+                                    </div>
+                                    @if (result.notes) {
+                                      <mat-icon class="note-icon" [matTooltip]="result.notes">comment</mat-icon>
+                                    }
+                                    @if (result.supervisorComment) {
+                                      <mat-icon class="supervisor-comment-icon" color="primary" [matTooltip]="result.supervisorComment">rate_review</mat-icon>
+                                    }
+                                  </div>
+                                </div>
                               }
                             </div>
-                            @if (result.notes) {
-                              <mat-icon class="note-icon" [matTooltip]="result.notes">comment</mat-icon>
-                            }
-                            @if (result.supervisorComment) {
-                              <mat-icon class="supervisor-comment-icon" color="primary" [matTooltip]="result.supervisorComment">rate_review</mat-icon>
-                            }
-                          </div>
-                        } @else {
-                          <span class="missing-value">-</span>
+                          } @else {
+                            <span class="missing-value">-</span>
+                          }
                         }
                       </td>
                     </ng-container>
@@ -519,23 +536,36 @@
                       {{ getCoderColumnHeader(columnId) }}
                     </th>
                     <td mat-cell *matCellDef="let element">
-                      @if (getCoderResultForColumn(element, columnId); as result) {
-                        <div class="coder-column-cell" [ngClass]="{'pending': result.code === null}">
-                          <div class="coder-code-row">
-                            <span class="coder-code-value" [matTooltip]="getCodeLabel(result.code)">{{ getCodeDisplay(result.code) || 'N/A' }}</span>
-                            @if (result.score !== null) {
-                              <span class="coder-score-value">({{ result.score }})</span>
+                      @if (getCoderResultsForColumn(element, columnId); as results) {
+                        @if (results.length > 0) {
+                          <div class="coder-column-results" [class.multiple]="results.length > 1">
+                            @for (result of results; track result.jobId) {
+                              <div class="coder-column-cell" [ngClass]="{'pending': result.code === null}">
+                                @if (results.length > 1) {
+                                  <div class="coder-result-source" [matTooltip]="getCoderResultSourceLabel(result)">
+                                    {{ getCoderResultSourceLabel(result) }}
+                                  </div>
+                                }
+                                <div class="coder-result-content">
+                                  <div class="coder-code-row">
+                                    <span class="coder-code-value" [matTooltip]="getCodeLabel(result.code)">{{ getCodeDisplay(result.code) || 'N/A' }}</span>
+                                    @if (result.score !== null) {
+                                      <span class="coder-score-value">({{ result.score }})</span>
+                                    }
+                                  </div>
+                                  @if (result.notes) {
+                                    <mat-icon class="note-icon" [matTooltip]="result.notes">comment</mat-icon>
+                                  }
+                                  @if (result.supervisorComment) {
+                                    <mat-icon class="supervisor-comment-icon" color="primary" [matTooltip]="result.supervisorComment">rate_review</mat-icon>
+                                  }
+                                </div>
+                              </div>
                             }
                           </div>
-                          @if (result.notes) {
-                            <mat-icon class="note-icon" [matTooltip]="result.notes">comment</mat-icon>
-                          }
-                          @if (result.supervisorComment) {
-                            <mat-icon class="supervisor-comment-icon" color="primary" [matTooltip]="result.supervisorComment">rate_review</mat-icon>
-                          }
-                        </div>
-                      } @else {
-                        <span class="missing-value">-</span>
+                        } @else {
+                          <span class="missing-value">-</span>
+                        }
                       }
                     </td>
                   </ng-container>

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.scss
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.scss
@@ -339,50 +339,73 @@
         }
       }
 
-      .coder-column-cell {
+      .coder-column-results {
         display: flex;
-        align-items: center;
+        flex-direction: column;
         gap: 6px;
-        padding: 8px;
-        border: 1px solid #e0e4e8;
-        border-radius: 8px;
-        background-color: #fff;
-        min-height: 40px;
 
-        &.pending {
-          opacity: 0.75;
-          border-style: dashed;
-          background-color: #fafbfc;
-        }
-
-        .coder-code-row {
+        .coder-column-cell {
           display: flex;
-          align-items: baseline;
+          flex-direction: column;
           gap: 4px;
-          min-width: 0;
+          padding: 8px;
+          border: 1px solid #e0e4e8;
+          border-radius: 8px;
+          background-color: #fff;
+          min-height: 40px;
 
-          .coder-code-value {
-            font-weight: 700;
-            color: #1e293b;
+          &.pending {
+            opacity: 0.75;
+            border-style: dashed;
+            background-color: #fafbfc;
           }
 
-          .coder-score-value {
+          .coder-result-source {
+            min-width: 0;
+            overflow: hidden;
             color: #64748b;
-            font-size: 12px;
+            font-size: 11px;
+            line-height: 1.2;
+            text-overflow: ellipsis;
+            white-space: nowrap;
           }
-        }
 
-        .note-icon,
-        .supervisor-comment-icon {
-          font-size: 16px;
-          width: 16px;
-          height: 16px;
-          cursor: help;
-          flex-shrink: 0;
-        }
+          .coder-result-content {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            min-width: 0;
+          }
 
-        .note-icon {
-          color: #f59e0b;
+          .coder-code-row {
+            display: flex;
+            align-items: baseline;
+            gap: 4px;
+            min-width: 0;
+
+            .coder-code-value {
+              font-weight: 700;
+              color: #1e293b;
+            }
+
+            .coder-score-value {
+              color: #64748b;
+              font-size: 12px;
+            }
+          }
+
+          .note-icon,
+          .supervisor-comment-icon {
+            font-size: 16px;
+            width: 16px;
+            height: 16px;
+            cursor: help;
+            flex-shrink: 0;
+          }
+
+          .note-icon {
+            color: #f59e0b;
+          }
         }
       }
 

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
@@ -92,9 +92,77 @@ describe('DoubleCodedReviewComponent', () => {
                       codedAt: '2026-05-20T09:10:00.000Z'
                     }
                   ]
+                },
+                {
+                  responseId: 502,
+                  unitName: 'Unit B',
+                  variableId: 'VAR_2',
+                  personLogin: 'person-2',
+                  personCode: 'P002',
+                  bookletName: 'Booklet 1',
+                  givenAnswer: 'second answer',
+                  isResolved: false,
+                  coderResults: [
+                    {
+                      coderId: 10,
+                      coderName: 'Coder A',
+                      jobId: 2001,
+                      jobName: 'Definition 100 / A',
+                      code: 1,
+                      score: 0,
+                      notes: null,
+                      supervisorComment: null,
+                      codedAt: '2026-05-20T10:00:00.000Z'
+                    },
+                    {
+                      coderId: 20,
+                      coderName: 'Coder B',
+                      jobId: 2002,
+                      jobName: 'Definition 100 / B',
+                      code: 1,
+                      score: 0,
+                      notes: null,
+                      supervisorComment: null,
+                      codedAt: '2026-05-20T10:10:00.000Z'
+                    }
+                  ]
+                },
+                {
+                  responseId: 503,
+                  unitName: 'Unit C',
+                  variableId: 'VAR_3',
+                  personLogin: 'person-3',
+                  personCode: 'P003',
+                  bookletName: 'Booklet 2',
+                  givenAnswer: 'third answer',
+                  isResolved: false,
+                  coderResults: [
+                    {
+                      coderId: 10,
+                      coderName: 'Coder A',
+                      jobId: 3001,
+                      jobName: 'Definition 101 / A',
+                      code: 1,
+                      score: 0,
+                      notes: null,
+                      supervisorComment: null,
+                      codedAt: '2026-05-20T11:00:00.000Z'
+                    },
+                    {
+                      coderId: 10,
+                      coderName: 'Coder A renamed',
+                      jobId: 3002,
+                      jobName: 'Definition 102 / A',
+                      code: 2,
+                      score: 1,
+                      notes: null,
+                      supervisorComment: null,
+                      codedAt: '2026-05-20T11:10:00.000Z'
+                    }
+                  ]
                 }
               ],
-              total: 1,
+              total: 3,
               page: 1,
               limit: 50
             })),
@@ -145,7 +213,7 @@ describe('DoubleCodedReviewComponent', () => {
 
     expect(selectionCell).toBeTruthy();
     expect(selectionCell.querySelector('.decision-status.conflict')?.textContent)
-      .toContain('double-coded-review.decision.status-conflict');
+      .toContain('double-coded-review.decision.status-inter-coder-conflict');
     expect(selectionCell.querySelector('.decision-code-value')?.textContent?.trim()).toBe('1');
     expect(selectionCell.querySelector('.decision-source')?.textContent).toContain('Coder A');
     expect(selectionCell.querySelector('.comment-field')).toBeTruthy();
@@ -170,5 +238,126 @@ describe('DoubleCodedReviewComponent', () => {
     expect(component.selectionForm.get(component.getItemControlName(reviewItem))?.value).toBe('1002');
     expect(selectionCell.querySelector('.decision-code-value')?.textContent?.trim()).toBe('2');
     expect(selectionCell.querySelector('.decision-source')?.textContent).toContain('Coder B');
+  });
+
+  it('creates one dynamic column per coder and exposes alternate coder names in the tooltip', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.dynamicCoderColumns).toEqual(['coder_10', 'coder_20']);
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const coderHeaders = Array.from(
+      nativeElement.querySelectorAll('th.mat-column-coder_10, th.mat-column-coder_20')
+    ) as HTMLElement[];
+
+    expect(coderHeaders).toHaveLength(2);
+    expect(coderHeaders.map(header => header.textContent?.trim())).toEqual(['Coder A', 'Coder B']);
+    expect(component.coderColumnMeta.coder_10.coderNames).toEqual(['Coder A', 'Coder A renamed']);
+    expect(component.getCoderColumnTooltip('coder_10')).toContain('Weitere Namen: Coder A renamed');
+  });
+
+  it('shows multiple results from the same coder in one coder column cell', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const rows = Array.from(nativeElement.querySelectorAll('tbody tr')) as HTMLElement[];
+    const duplicateCoderRow = rows[2];
+    const coderACell = duplicateCoderRow.querySelector('td.mat-column-coder_10') as HTMLElement;
+    const coderBCell = duplicateCoderRow.querySelector('td.mat-column-coder_20') as HTMLElement;
+
+    expect(coderACell.querySelectorAll('.coder-column-cell')).toHaveLength(2);
+    expect(coderACell.textContent).toContain('Definition 101 / A');
+    expect(coderACell.textContent).toContain('#3001');
+    expect(coderACell.textContent).toContain('Definition 102 / A');
+    expect(coderACell.textContent).toContain('#3002');
+    expect(coderBCell.textContent).toContain('-');
+  });
+
+  it('labels duplicate coder decisions with job source and counts progress by unique coders', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const regularItem = component.dataSource.data[0];
+    const duplicateCoderItem = component.dataSource.data[2];
+
+    expect(component.getDecisionResultSourceLabel(regularItem, regularItem.coderResults[0]))
+      .toBe('Coder A');
+    expect(component.getDecisionResultSourceLabel(duplicateCoderItem, duplicateCoderItem.coderResults[0]))
+      .toBe('Coder A - Definition 101 / A (#3001)');
+    expect(component.getDecisionResultSourceLabel(duplicateCoderItem, duplicateCoderItem.coderResults[1]))
+      .toBe('Coder A renamed - Definition 102 / A (#3002)');
+
+    expect(component.getCoderCount(duplicateCoderItem)).toBe(1);
+    expect(component.getCodedCount(duplicateCoderItem)).toBe(1);
+    expect(component.getCoderCompletionStates(duplicateCoderItem)).toEqual([true]);
+
+    const partiallyPendingDuplicateCoderItem = {
+      ...duplicateCoderItem,
+      coderResults: [
+        duplicateCoderItem.coderResults[0],
+        {
+          ...duplicateCoderItem.coderResults[1],
+          code: null
+        }
+      ]
+    };
+
+    expect(component.getCoderCount(partiallyPendingDuplicateCoderItem)).toBe(1);
+    expect(component.getCodedCount(partiallyPendingDuplicateCoderItem)).toBe(0);
+    expect(component.getCoderCompletionStates(partiallyPendingDuplicateCoderItem)).toEqual([false]);
+  });
+
+  it('keeps same-coder deviations actionable while classifying conflict types', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const interCoderConflictItem = component.dataSource.data[0];
+    const matchItem = component.dataSource.data[1];
+    const sameCoderConflictItem = component.dataSource.data[2];
+    const sameCoderMatchItem = {
+      ...sameCoderConflictItem,
+      coderResults: [
+        sameCoderConflictItem.coderResults[0],
+        {
+          ...sameCoderConflictItem.coderResults[1],
+          code: sameCoderConflictItem.coderResults[0].code,
+          score: sameCoderConflictItem.coderResults[0].score
+        }
+      ]
+    };
+    const mixedConflictItem = {
+      ...sameCoderConflictItem,
+      coderResults: [
+        ...sameCoderConflictItem.coderResults,
+        {
+          ...interCoderConflictItem.coderResults[1],
+          jobId: 3003,
+          jobName: 'Definition 103 / B',
+          code: 3,
+          score: 2
+        }
+      ]
+    };
+
+    expect(component.getConflictType(matchItem)).toBe('none');
+    expect(component.getConflictType(sameCoderMatchItem)).toBe('none');
+    expect(component.getConflictType(sameCoderConflictItem)).toBe('same-coder');
+    expect(component.getConflictType(interCoderConflictItem)).toBe('inter-coder');
+    expect(component.getConflictType(mixedConflictItem)).toBe('mixed');
+    expect(component.hasConflict(sameCoderMatchItem)).toBe(false);
+    expect(component.hasConflict(sameCoderConflictItem)).toBe(true);
+
+    expect(component.getDecisionStatusLabel(sameCoderConflictItem))
+      .toBe('double-coded-review.decision.status-same-coder-conflict');
+    expect(component.getDecisionStatusLabel(interCoderConflictItem))
+      .toBe('double-coded-review.decision.status-inter-coder-conflict');
+    expect(component.getDecisionStatusLabel(mixedConflictItem))
+      .toBe('double-coded-review.decision.status-mixed-conflict');
   });
 });

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -61,10 +61,12 @@ interface DoubleCodedItem {
 interface CoderColumnMeta {
   columnId: string;
   coderId: number;
-  jobId: number;
   label: string;
-  jobName: string;
+  coderNames: string[];
+  jobNames: string[];
 }
+
+type ConflictType = 'none' | 'inter-coder' | 'same-coder' | 'mixed';
 
 @Component({
   selector: 'coding-box-double-coded-review',
@@ -398,22 +400,34 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
 
     items.forEach(item => {
       item.coderResults.forEach(result => {
-        const columnId = `coder_${result.jobId}`;
+        const columnId = `coder_${result.coderId}`;
+        const coderName = this.getCoderDisplayName(result);
         if (!meta[columnId]) {
           meta[columnId] = {
             columnId,
             coderId: result.coderId,
-            jobId: result.jobId,
-            label: result.coderName,
-            jobName: result.jobName
+            label: coderName,
+            coderNames: [],
+            jobNames: []
           };
+        }
+
+        if (!meta[columnId].coderNames.includes(coderName)) {
+          meta[columnId].coderNames.push(coderName);
+        }
+
+        if (result.jobName && !meta[columnId].jobNames.includes(result.jobName)) {
+          meta[columnId].jobNames.push(result.jobName);
         }
       });
     });
 
     this.coderColumnMeta = meta;
     this.dynamicCoderColumns = Object.values(meta)
-      .sort((a, b) => a.label.localeCompare(b.label, 'de', { sensitivity: 'base' }))
+      .sort((a, b) => {
+        const labelComparison = a.label.localeCompare(b.label, 'de', { sensitivity: 'base' });
+        return labelComparison || a.coderId - b.coderId;
+      })
       .map(column => column.columnId);
 
     this.displayedColumns = [...this.staticColumns, ...this.dynamicCoderColumns, 'selection'];
@@ -432,13 +446,60 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
   getCoderColumnTooltip(columnId: string): string {
     const meta = this.coderColumnMeta[columnId];
     if (!meta) return '';
-    return meta.jobName ? `${meta.label} (${meta.jobName})` : meta.label;
+
+    const details: string[] = [];
+    const alternativeCoderNames = meta.coderNames.filter(name => name !== meta.label);
+
+    if (alternativeCoderNames.length > 0) {
+      const namesSummary = this.getVisibleValueSummary(alternativeCoderNames);
+      const translatedAlternativeNames = this.translateService.instant(
+        'double-coded-review.columns.alternative-coder-names',
+        { names: namesSummary }
+      );
+      details.push(
+        translatedAlternativeNames === 'double-coded-review.columns.alternative-coder-names' ?
+          `Weitere Namen: ${namesSummary}` :
+          translatedAlternativeNames
+      );
+    }
+
+    if (meta.jobNames.length > 0) {
+      details.push(this.getVisibleValueSummary(meta.jobNames));
+    }
+
+    if (details.length === 0) {
+      return meta.label;
+    }
+
+    return `${meta.label} (${details.join('; ')})`;
   }
 
-  getCoderResultForColumn(item: DoubleCodedItem, columnId: string): CoderResult | undefined {
+  getCoderResultsForColumn(item: DoubleCodedItem, columnId: string): CoderResult[] {
     const meta = this.coderColumnMeta[columnId];
-    if (!meta) return undefined;
-    return item.coderResults.find(result => result.jobId === meta.jobId);
+    if (!meta) return [];
+
+    return item.coderResults
+      .filter(result => result.coderId === meta.coderId)
+      .sort((a, b) => {
+        const jobNameComparison = a.jobName.localeCompare(b.jobName, 'de', { sensitivity: 'base' });
+        return jobNameComparison || a.jobId - b.jobId;
+      });
+  }
+
+  getCoderResultSourceLabel(result: CoderResult): string {
+    return result.jobName ? `${result.jobName} (#${result.jobId})` : `#${result.jobId}`;
+  }
+
+  hasMultipleResultsForCoder(item: DoubleCodedItem, result: Pick<CoderResult, 'coderId'>): boolean {
+    return item.coderResults.filter(coderResult => coderResult.coderId === result.coderId).length > 1;
+  }
+
+  getDecisionResultSourceLabel(item: DoubleCodedItem, result: CoderResult): string {
+    if (!this.hasMultipleResultsForCoder(item, result)) {
+      return this.getCoderDisplayName(result);
+    }
+
+    return `${this.getCoderDisplayName(result)} - ${this.getCoderResultSourceLabel(result)}`;
   }
 
   getSelectedDecisionResult(item: DoubleCodedItem): CoderResult | undefined {
@@ -455,7 +516,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       return 'resolved';
     }
 
-    if (this.hasConflict(item)) {
+    if (this.getConflictType(item) !== 'none') {
       return 'conflict';
     }
 
@@ -484,7 +545,29 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       return this.translateService.instant('double-coded-review.applied');
     }
 
+    const conflictType = this.getConflictType(item);
+    if (conflictType !== 'none') {
+      return this.translateService.instant(`double-coded-review.decision.status-${conflictType}-conflict`);
+    }
+
     return this.translateService.instant(`double-coded-review.decision.status-${statusClass}`);
+  }
+
+  getDecisionStatusTooltip(item: DoubleCodedItem): string {
+    if (item.isResolved) {
+      return this.translateService.instant('double-coded-review.applied');
+    }
+
+    const progressText = `${this.getCodedCount(item)}/${this.getCoderCount(item)} ${
+      this.translateService.instant('double-coded-review.coders-done')
+    }`;
+    const conflictType = this.getConflictType(item);
+
+    if (conflictType === 'none') {
+      return progressText;
+    }
+
+    return `${this.translateService.instant(`double-coded-review.decision.tooltip-${conflictType}-conflict`)} - ${progressText}`;
   }
 
   shouldShowDecisionComment(item: DoubleCodedItem): boolean {
@@ -558,16 +641,47 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
   }
 
   hasConflict(item: DoubleCodedItem): boolean {
-    const validResultSignatures = item.coderResults
-      .map(result => this.getCoderResultSignature(result))
-      .filter((signature): signature is string => signature !== null);
+    // Keep same-coder deviations actionable; the detailed conflict type decides how they are labelled.
+    return this.getConflictType(item) !== 'none';
+  }
 
-    if (validResultSignatures.length < 2) {
-      return false;
+  getConflictType(item: DoubleCodedItem): ConflictType {
+    const validResults = item.coderResults
+      .map(result => ({
+        coderId: result.coderId,
+        signature: this.getCoderResultSignature(result)
+      }))
+      .filter((result): result is { coderId: number; signature: string } => result.signature !== null);
+
+    if (validResults.length < 2) {
+      return 'none';
     }
 
-    const firstSignature = validResultSignatures[0];
-    return validResultSignatures.some(signature => signature !== firstSignature);
+    const signaturesByCoderId = new Map<number, Set<string>>();
+    validResults.forEach(result => {
+      const signatures = signaturesByCoderId.get(result.coderId) || new Set<string>();
+      signatures.add(result.signature);
+      signaturesByCoderId.set(result.coderId, signatures);
+    });
+
+    const hasSameCoderConflict = Array.from(signaturesByCoderId.values())
+      .some(signatures => signatures.size > 1);
+    const hasInterCoderConflict = validResults.some((result, index) => (
+      validResults.slice(index + 1).some(otherResult => (
+        otherResult.coderId !== result.coderId &&
+        otherResult.signature !== result.signature
+      ))
+    ));
+
+    if (hasSameCoderConflict && hasInterCoderConflict) {
+      return 'mixed';
+    }
+
+    if (hasSameCoderConflict) {
+      return 'same-coder';
+    }
+
+    return hasInterCoderConflict ? 'inter-coder' : 'none';
   }
 
   private getCoderResultSignature(result: Pick<CoderResult, 'code' | 'score'>): string | null {
@@ -578,12 +692,42 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     return `${result.code}:${result.score ?? 'NULL'}`;
   }
 
+  private getCoderDisplayName(result: Pick<CoderResult, 'coderId' | 'coderName'>): string {
+    return result.coderName?.trim() || `Coder ${result.coderId}`;
+  }
+
+  private getVisibleValueSummary(values: string[], visibleCount = 3): string {
+    const visibleValues = values.slice(0, visibleCount);
+    const remainingValueCount = values.length - visibleValues.length;
+
+    return remainingValueCount > 0 ?
+      `${visibleValues.join(', ')} (+${remainingValueCount})` :
+      visibleValues.join(', ');
+  }
+
   isAllCodersDone(item: DoubleCodedItem): boolean {
     return item.coderResults.every(cr => cr.code !== null);
   }
 
+  getCoderCount(item: DoubleCodedItem): number {
+    return this.getCoderCompletionStates(item).length;
+  }
+
   getCodedCount(item: DoubleCodedItem): number {
-    return item.coderResults.filter(cr => cr.code !== null).length;
+    return this.getCoderCompletionStates(item).filter(isDone => isDone).length;
+  }
+
+  getCoderCompletionStates(item: DoubleCodedItem): boolean[] {
+    const resultsByCoderId = new Map<number, CoderResult[]>();
+
+    item.coderResults.forEach(result => {
+      const results = resultsByCoderId.get(result.coderId) || [];
+      results.push(result);
+      resultsByCoderId.set(result.coderId, results);
+    });
+
+    return Array.from(resultsByCoderId.values())
+      .map(results => results.every(result => result.code !== null));
   }
 
   onFilterChange(): void {

--- a/apps/frontend/src/app/high-coverage-component-methods.spec.ts
+++ b/apps/frontend/src/app/high-coverage-component-methods.spec.ts
@@ -503,7 +503,7 @@ describe('high coverage component method smoke tests', () => {
     expect(instance.getSelectedDecisionResult(sampleReviewItem)?.coderName).toBe('Coder B');
     expect(instance.getDecisionStatusClass(sampleReviewItem)).toBe('conflict');
     expect(instance.getDecisionStatusIcon(sampleReviewItem)).toBe('warning');
-    expect(instance.getDecisionStatusLabel(sampleReviewItem)).toBe('double-coded-review.decision.status-conflict');
+    expect(instance.getDecisionStatusLabel(sampleReviewItem)).toBe('double-coded-review.decision.status-inter-coder-conflict');
     expect(instance.getDecisionStatusClass({
       ...sampleReviewItem,
       coderResults: [

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2272,7 +2272,8 @@
       "person-info": "Personeninformationen",
       "given-answer": "Gegebene Antwort",
       "coder-results": "Kodierergebnisse",
-      "selection": "Auswahl"
+      "selection": "Auswahl",
+      "alternative-coder-names": "Weitere Namen: {{names}}"
     },
     "code-label": "Code",
     "score-label": "Bewertung",
@@ -2287,8 +2288,14 @@
       "select-label": "Endgültiger Code",
       "no-selection": "Kein Code gewählt",
       "status-conflict": "Abweichung",
+      "status-inter-coder-conflict": "Kodierer-Abweichung",
+      "status-same-coder-conflict": "Mehrfach-Abweichung",
+      "status-mixed-conflict": "Mehrere Abweichungen",
       "status-match": "Übereinstimmung",
-      "status-incomplete": "Unvollständig"
+      "status-incomplete": "Unvollständig",
+      "tooltip-inter-coder-conflict": "Unterschiedliche Kodierer haben abweichende Ergebnisse",
+      "tooltip-same-coder-conflict": "Derselbe Kodierer hat mehrere abweichende Ergebnisse",
+      "tooltip-mixed-conflict": "Es gibt Abweichungen innerhalb eines Kodierers und zwischen Kodierern"
     },
     "filter": {
       "show-only-conflicts": "Nur Konflikte anzeigen",


### PR DESCRIPTION
## Summary

- Fixes the double-coded review table so dynamic coder columns are keyed by `coderId` instead of `jobId`.
- Shows multiple results from the same coder in one column cell with job/source labels.
- Keeps same-coder deviations visible and labels conflict types as same-coder, inter-coder, or mixed.
- Surfaces alternate coder names for the same `coderId` in the column tooltip.

## Root Cause

The review table built its dynamic columns from job ids while displaying coder names as headers. When the same coder had multiple jobs for the same reviewed row, the UI created duplicate columns with the same coder label and made the decision context ambiguous.

## Validation

- `git diff --check --cached`
- `npx nx lint frontend`
- `npx nx test frontend`

Fixes #617
