### PR TITLE
Fix frontend cache headers

### DIFF
--- a/config/frontend/default.conf.http-template
+++ b/config/frontend/default.conf.http-template
@@ -7,6 +7,34 @@ server {
 
     #access_log  /var/log/nginx/host.access.log  main;
 
+    location = / {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+        try_files /index.html =404;
+    }
+
+    location = /index.html {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+    }
+
+    location = /assets/config/runtime-config.js {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+    }
+
+    location ^~ /assets/ {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-cache, must-revalidate, max-age=0" always;
+        try_files $uri =404;
+    }
+
+    location ~* "^/[^/]+\.[0-9a-f]{8,}\.(?:js|css)$" {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;

--- a/config/frontend/default.conf.https-template
+++ b/config/frontend/default.conf.https-template
@@ -21,6 +21,34 @@ server {
 
     #access_log  /var/log/nginx/host.access.log  main;
 
+    location = / {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+        try_files /index.html =404;
+    }
+
+    location = /index.html {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+    }
+
+    location = /assets/config/runtime-config.js {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+    }
+
+    location ^~ /assets/ {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-cache, must-revalidate, max-age=0" always;
+        try_files $uri =404;
+    }
+
+    location ~* "^/[^/]+\.[0-9a-f]{8,}\.(?:js|css)$" {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;

--- a/config/frontend/default.conf.template
+++ b/config/frontend/default.conf.template
@@ -7,6 +7,34 @@ server {
 
     #access_log  /var/log/nginx/host.access.log  main;
 
+    location = / {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+        try_files /index.html =404;
+    }
+
+    location = /index.html {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+    }
+
+    location = /assets/config/runtime-config.js {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+    }
+
+    location ^~ /assets/ {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-cache, must-revalidate, max-age=0" always;
+        try_files $uri =404;
+    }
+
+    location ~* "^/[^/]+\.[0-9a-f]{8,}\.(?:js|css)$" {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;


### PR DESCRIPTION
## Summary

- add explicit no-store/no-cache headers for `/` and `/index.html` so browsers revalidate the Angular app shell after deployments
- keep `assets/config/runtime-config.js` uncached because it is generated from runtime environment variables
- revalidate stable assets under `/assets/` while allowing hashed Angular JS/CSS bundles to be cached immutably

## Why

Users could continue seeing the old Kodierbox frontend after a server update until doing a hard refresh. The likely cause was cached `index.html` or other stable frontend assets pointing at the previous build.

## Validation

- `nginx -t` with `config/frontend/default.conf.http-template`
- `nginx -t` with `config/frontend/default.conf.template`
- `nginx -t` with `config/frontend/default.conf.https-template` using a temporary certificate
- temporary Nginx container header checks for `/`, `/index.html`, `runtime-config.js`, stable assets, hashed JS, missing hashed JS, and missing assets

Closes #626