### PR TITLE
Restore profile-aware discussion results

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
@@ -609,7 +609,14 @@ export class WorkspaceCoderTrainingController {
       @Param('trainingId') trainingId: number,
       @Body() body: { responseId: number; code: number | null; score: number | null },
       @Req() req: Request
-  ): Promise<{ success: boolean; code: number | null; score: number | null; managerUserId: number | null; managerName: string | null }> {
+  ): Promise<{
+        success: boolean;
+        code: number | null;
+        score: number | null;
+        source: 'manual' | 'auto_agreement' | null;
+        managerUserId: number | null;
+        managerName: string | null;
+      }> {
     const reqUser = (req as Request & {
       user?: { id?: string | number; username?: string; preferred_username?: string; name?: string };
     }).user;

--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -1608,6 +1608,7 @@ describe('CoderTrainingService', () => {
         manager_name: 'Manager'
       }));
       expect(result.score).toBe(2);
+      expect(result.source).toBe('manual');
     });
 
     it('should score negative discussion codes as missing results without coding scheme lookup', async () => {
@@ -1626,6 +1627,7 @@ describe('CoderTrainingService', () => {
         score: 0
       }));
       expect(result.score).toBe(0);
+      expect(result.source).toBe('manual');
     });
 
     it('should reject negative discussion codes that are not configured as missings', async () => {
@@ -1658,6 +1660,7 @@ describe('CoderTrainingService', () => {
         score: 0
       }));
       expect(result.score).toBe(0);
+      expect(result.source).toBe('manual');
     });
 
     it('should reject negative codes that are not part of the response job missing profile', async () => {
@@ -1735,6 +1738,45 @@ describe('CoderTrainingService', () => {
         score: 0
       }));
       expect(result.score).toBe(0);
+      expect(result.source).toBe('manual');
+    });
+
+    it('should return authoritative automatic agreement when clearing a manual discussion result', async () => {
+      const { training, unit } = createTrainingWithUnit({
+        code: 7,
+        score: 2
+      });
+      const secondUnit = {
+        ...unit,
+        coding_job_id: 12
+      } as CodingJobUnit;
+      training.codingJobs = [
+        {
+          id: 11,
+          missings_profile_id: null,
+          codingJobUnits: [unit]
+        } as CodingJob,
+        {
+          id: 12,
+          missings_profile_id: null,
+          codingJobUnits: [secondUnit]
+        } as CodingJob
+      ];
+      (coderTrainingRepository.findOne as jest.Mock)
+        .mockResolvedValueOnce(training)
+        .mockResolvedValueOnce({ id: 44 });
+
+      const result = await service.saveDiscussionResult(1, 5, 101, 99, 'Manager', null);
+
+      expect(coderTrainingDiscussionResultRepository.delete).toHaveBeenCalledWith(44);
+      expect(result).toEqual({
+        success: true,
+        code: 7,
+        score: 2,
+        source: 'auto_agreement',
+        managerUserId: null,
+        managerName: null
+      });
     });
 
     it('should reject discussion missing codes when default and explicit missing profiles are mixed', async () => {

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -79,6 +79,15 @@ export type TrainingResponseIdsMap = Record<string, number[]>;
 
 type DiscussionSource = 'manual' | 'auto_agreement' | null;
 
+type SaveDiscussionResultResponse = {
+  success: boolean;
+  code: number | null;
+  score: number | null;
+  source: DiscussionSource;
+  managerUserId: number | null;
+  managerName: string | null;
+};
+
 type WithinTrainingCoderResult = {
   jobId: number;
   coderName: string;
@@ -477,6 +486,54 @@ export class CoderTrainingService {
     });
   }
 
+  private buildCoderResultsForResponse(
+    training: CoderTraining,
+    responseId: number,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>,
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>
+  ): WithinTrainingCoderResult[] {
+    return (training.codingJobs || []).map(job => {
+      let code: number | null = null;
+      let score: number | null = null;
+      let notes: string | null = null;
+      let codingIssueOption: number | null = null;
+
+      const coderName = job.codingJobCoders && job.codingJobCoders.length > 0 && job.codingJobCoders[0].user ?
+        `${job.codingJobCoders[0].user.username || 'Unknown'}` :
+        `Coder ${job.name}`;
+
+      job.codingJobUnits?.forEach(unit => {
+        if (
+          unit.response_id === responseId &&
+          !isExcludedByResolvedExclusions(exclusions, unit.booklet_name, unit.unit_name)
+        ) {
+          code = unit.code;
+          if (unit.score !== null) {
+            score = unit.score;
+          }
+          notes = unit.notes;
+          codingIssueOption = unit.coding_issue_option;
+        }
+      });
+
+      const mappedDisplay = this.mapDisplayCodeAndScore(
+        code,
+        score,
+        codingIssueOption,
+        missingCodesByJobId.get(job.id) ?? DEFAULT_MISSING_CODE_CONTEXT
+      );
+
+      return {
+        jobId: job.id,
+        coderName,
+        code: mappedDisplay.code,
+        score: mappedDisplay.score,
+        notes,
+        codingIssueOption
+      };
+    });
+  }
+
   private toNullableScore(score: number | string | null | undefined): number | null {
     if (score === null || score === undefined) {
       return null;
@@ -616,7 +673,7 @@ export class CoderTrainingService {
     managerUserId: number | null,
     managerName: string | null,
     code: number | null | undefined
-  ): Promise<{ success: boolean; code: number | null; score: number | null; managerUserId: number | null; managerName: string | null }> {
+  ): Promise<SaveDiscussionResultResponse> {
     const training = await this.coderTrainingRepository.findOne({
       where: {
         id: trainingId,
@@ -645,13 +702,29 @@ export class CoderTrainingService {
     });
 
     if (code === null || code === undefined) {
+      const missingCodesByJobId = await this.buildMissingCodesByJobId(workspaceId, training.codingJobs || []);
+      const codersData = this.buildCoderResultsForResponse(
+        training,
+        responseId,
+        exclusions,
+        missingCodesByJobId
+      );
+      const automaticDiscussionResult = await this.deriveAutomaticDiscussionResultForResponse(
+        workspaceId,
+        training,
+        responseId,
+        codersData,
+        exclusions
+      );
+
       if (existing) {
         await this.coderTrainingDiscussionResultRepository.delete(existing.id);
       }
       return {
         success: true,
-        code: null,
-        score: null,
+        code: automaticDiscussionResult?.code ?? null,
+        score: automaticDiscussionResult?.score ?? null,
+        source: automaticDiscussionResult ? 'auto_agreement' : null,
         managerUserId: null,
         managerName: null
       };
@@ -686,6 +759,7 @@ export class CoderTrainingService {
       success: true,
       code: saved.code,
       score: saved.score,
+      source: 'manual',
       managerUserId: saved.manager_user_id,
       managerName: saved.manager_name
     };

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -47,6 +47,7 @@ describe('CodingResultsComparisonComponent', () => {
         success: true,
         code: 7,
         score: 2,
+        source: 'manual',
         managerUserId: 2,
         managerName: 'Test User'
       })),
@@ -610,6 +611,43 @@ describe('CodingResultsComparisonComponent', () => {
     expect(discussionSource?.textContent).toContain('Auto-Konsens');
   });
 
+  it('should not persist an unchanged automatic agreement on blur', () => {
+    const row = {
+      responseId: 1,
+      unitName: 'Unit1',
+      variableId: 'Var1',
+      testperson: 'Test1',
+      discussionCode: 7,
+      discussionScore: 2,
+      discussionSource: 'auto_agreement' as 'manual' | 'auto_agreement' | null,
+      coders: [
+        {
+          jobId: 1,
+          coderName: 'Coder1',
+          code: '7',
+          score: 2
+        },
+        {
+          jobId: 2,
+          coderName: 'Coder2',
+          code: '7',
+          score: 2
+        }
+      ]
+    };
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.discussionCodeByResponseId[1] = '7';
+    component.discussionScoreByResponseId[1] = 2;
+
+    component.onDiscussionCodeBlur(row);
+
+    expect(codingTrainingBackendService.saveDiscussionResult).not.toHaveBeenCalled();
+    expect(component.discussionCodeByResponseId[1]).toBe('7');
+    expect(component.discussionScoreByResponseId[1]).toBe(2);
+    expect(row.discussionSource).toBe('auto_agreement');
+  });
+
   it('should save an active replay selection with its score as manual discussion result', () => {
     const row = {
       responseId: 1,
@@ -934,11 +972,12 @@ describe('CodingResultsComparisonComponent', () => {
     });
   });
 
-  it('should clear manual discussion result without restoring local automatic agreement', () => {
+  it('should restore backend-authoritative automatic agreement when clearing a manual discussion result', () => {
     codingTrainingBackendService.saveDiscussionResult.mockReturnValueOnce(of({
       success: true,
-      code: null,
-      score: null,
+      code: 7,
+      score: 2,
+      source: 'auto_agreement',
       managerUserId: null,
       managerName: null
     }));
@@ -972,11 +1011,11 @@ describe('CodingResultsComparisonComponent', () => {
     component.onDiscussionCodeBlur(row);
 
     expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledWith(1, 5, 1, null, null);
-    expect(component.discussionCodeByResponseId[1]).toBe('');
-    expect(component.discussionScoreByResponseId[1]).toBeNull();
-    expect(row.discussionCode).toBeNull();
-    expect(row.discussionScore).toBeNull();
-    expect(row.discussionSource).toBeNull();
+    expect(component.discussionCodeByResponseId[1]).toBe('7');
+    expect(component.discussionScoreByResponseId[1]).toBe(2);
+    expect(row.discussionCode).toBe(7);
+    expect(row.discussionScore).toBe(2);
+    expect(row.discussionSource).toBe('auto_agreement');
   });
 
   it('should clear stale kappa values when changing comparison mode', () => {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -781,6 +781,20 @@ export class CodingResultsComparisonComponent implements OnInit {
     return parseInt(normalized, 10);
   }
 
+  private isUnchangedDiscussionValue(
+    comparison: WithinTrainingComparison,
+    parsedCode: number | null,
+    score: number | null,
+    scoreOverride?: number | null
+  ): boolean {
+    if (scoreOverride !== undefined) {
+      return false;
+    }
+
+    return parsedCode === (comparison.discussionCode ?? null) &&
+      score === (comparison.discussionScore ?? null);
+  }
+
   onDiscussionCodeBlur(
     comparison: TrainingComparison | WithinTrainingComparison,
     scoreOverride?: number | null
@@ -807,6 +821,13 @@ export class CodingResultsComparisonComponent implements OnInit {
         this.getDiscussionScoreFromKnownCodes(withinComparison, parsedCode);
     }
     this.discussionErrorByResponseId[responseId] = '';
+
+    if (this.isUnchangedDiscussionValue(withinComparison, parsedCode, score, scoreOverride)) {
+      this.discussionCodeByResponseId[responseId] = parsedCode !== null ? parsedCode.toString() : '';
+      this.discussionScoreByResponseId[responseId] = withinComparison.discussionScore ?? null;
+      return;
+    }
+
     this.isSavingDiscussionByResponseId[responseId] = true;
 
     this.codingTrainingBackendService.saveDiscussionResult(
@@ -817,23 +838,13 @@ export class CodingResultsComparisonComponent implements OnInit {
       score
     ).subscribe({
       next: result => {
-        if (result.code === null) {
-          this.discussionCodeByResponseId[responseId] = '';
-          this.discussionScoreByResponseId[responseId] = null;
-          withinComparison.discussionCode = null;
-          withinComparison.discussionScore = null;
-          withinComparison.discussionManagerUserId = null;
-          withinComparison.discussionManagerName = null;
-          withinComparison.discussionSource = null;
-        } else {
-          this.discussionCodeByResponseId[responseId] = result.code.toString();
-          this.discussionScoreByResponseId[responseId] = result.score;
-          withinComparison.discussionCode = result.code;
-          withinComparison.discussionScore = result.score;
-          withinComparison.discussionManagerUserId = result.managerUserId;
-          withinComparison.discussionManagerName = result.managerName;
-          withinComparison.discussionSource = 'manual';
-        }
+        this.discussionCodeByResponseId[responseId] = result.code !== null ? result.code.toString() : '';
+        this.discussionScoreByResponseId[responseId] = result.score;
+        withinComparison.discussionCode = result.code;
+        withinComparison.discussionScore = result.score;
+        withinComparison.discussionManagerUserId = result.managerUserId;
+        withinComparison.discussionManagerName = result.managerName;
+        withinComparison.discussionSource = result.source;
         this.discussionErrorByResponseId[responseId] = '';
         if (result.managerName) {
           this.discussionManagerLabel = result.managerName;

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -203,9 +203,23 @@ export class CodingTrainingBackendService {
     responseId: number,
     code: number | null,
     score: number | null
-  ): Observable<{ success: boolean; code: number | null; score: number | null; managerUserId: number | null; managerName: string | null }> {
+  ): Observable<{
+      success: boolean;
+      code: number | null;
+      score: number | null;
+      source: 'manual' | 'auto_agreement' | null;
+      managerUserId: number | null;
+      managerName: string | null;
+    }> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings/${trainingId}/discussion-result`;
-    return this.http.post<{ success: boolean; code: number | null; score: number | null; managerUserId: number | null; managerName: string | null }>(
+    return this.http.post<{
+      success: boolean;
+      code: number | null;
+      score: number | null;
+      source: 'manual' | 'auto_agreement' | null;
+      managerUserId: number | null;
+      managerName: string | null;
+    }>(
       url,
       { responseId, code, score },
       { headers: this.authHeader }


### PR DESCRIPTION
## Summary

- Coupled missing profiles through job definitions, coding jobs, review/export paths, and coder trainings.
- Made coder-training discussion logic use the job/profile-authoritative missing codes, including default-profile fallback.
- Restored backend-authoritative auto agreement after clearing a manual discussion result and avoided persisting unchanged auto agreement on blur.

## Why

Issue #387 needs missing-code handling to follow the applicable missing profile instead of hard-coded MIR/MCI assumptions. Clearing a manual discussion result should also reveal the effective backend-derived auto agreement immediately, without relying on a reload or frontend-only guessing.

## Impact

Training comparison now exposes whether a discussion result is manual or automatic, negative missing codes are validated against the relevant profile, and legacy/default-profile cases keep a deterministic fallback.

## Validation

- `npx nx test backend --skip-nx-cache --runInBand --testFile=apps/backend/src/app/database/services/coding/coder-training.service.spec.ts`
- `npx nx test frontend --skip-nx-cache --runInBand --testFile=apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts`
- `npx nx lint backend --skip-nx-cache`
- `npx nx lint frontend --skip-nx-cache`
- `git diff --check`
- Browser smoke via Chrome Headless for `/` and unauthenticated `/coding` redirect

Cypress E2E was attempted with `npx nx e2e frontend --skip-nx-cache` and `--browser=chrome`; the app built and the devserver started, but the Cypress 15.13.1 runner exited with `SIGILL` in this local environment. `npx cypress info` fails the same way.

Refs #387
