### PR TITLE
Resolve manual missing results from profile

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.html
@@ -58,6 +58,9 @@
       @if (isNotesUnavailable) {
       <span class="summary-warning">Notizen nicht geladen</span>
       }
+      @if (isMissingProfileUnavailable) {
+      <span class="summary-warning">Missing-Profil nicht vollständig auflösbar</span>
+      }
       @if (hasActiveFilters()) {
       <button mat-button type="button" (click)="clearAllFilters()">
         <mat-icon>filter_alt_off</mat-icon>

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
@@ -8,6 +8,7 @@ import { CodingJobResultDialogComponent } from './coding-job-result-dialog.compo
 import { CodingJobBackendService } from '../../../services/coding-job-backend.service';
 import { FileService } from '../../../../shared/services/file/file.service';
 import { AppService } from '../../../../core/services/app.service';
+import { MissingsProfileService } from '../../../services/missings-profile.service';
 
 class MatSnackBarMock {
   open = jest.fn(() => ({
@@ -52,11 +53,57 @@ describe('CodingJobResultDialogComponent', () => {
     open: jest.fn()
   };
 
+  const mockMissingsProfileService = {
+    getMissingsProfiles: jest.fn(() => of([{ id: 1, label: 'IQB-Standard' }])) as jest.Mock,
+    getMissingsProfileDetails: jest.fn(() => of({
+      id: 1,
+      label: 'IQB-Standard',
+      missings: JSON.stringify([
+        {
+          id: 'mir',
+          label: 'missing invalid response',
+          description: '',
+          code: -98,
+          score: 0
+        },
+        {
+          id: 'mci',
+          label: 'missing coding impossible',
+          description: '',
+          code: -97,
+          score: 0
+        }
+      ])
+    })) as jest.Mock
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockDialogData.codingJob = { id: 1, name: 'Test Job' };
     mockCodingJobBackendService.getCodingJobUnits.mockReturnValue(of([]));
     mockCodingJobBackendService.getCodingProgress.mockReturnValue(of({}));
     mockCodingJobBackendService.getCodingNotes.mockReturnValue(of({}));
+    mockMissingsProfileService.getMissingsProfiles.mockReturnValue(of([{ id: 1, label: 'IQB-Standard' }]));
+    mockMissingsProfileService.getMissingsProfileDetails.mockReturnValue(of({
+      id: 1,
+      label: 'IQB-Standard',
+      missings: JSON.stringify([
+        {
+          id: 'mir',
+          label: 'missing invalid response',
+          description: '',
+          code: -98,
+          score: 0
+        },
+        {
+          id: 'mci',
+          label: 'missing coding impossible',
+          description: '',
+          code: -97,
+          score: 0
+        }
+      ])
+    }));
 
     await TestBed.configureTestingModule({
       imports: [CodingJobResultDialogComponent, TranslateModule.forRoot()],
@@ -65,6 +112,7 @@ describe('CodingJobResultDialogComponent', () => {
         { provide: MAT_DIALOG_DATA, useValue: mockDialogData },
         { provide: MatSnackBar, useClass: MatSnackBarMock },
         { provide: CodingJobBackendService, useValue: mockCodingJobBackendService },
+        { provide: MissingsProfileService, useValue: mockMissingsProfileService },
         { provide: FileService, useValue: mockFileService },
         { provide: AppService, useValue: mockAppService },
         { provide: Router, useValue: mockRouter },
@@ -143,6 +191,169 @@ describe('CodingJobResultDialogComponent', () => {
     expect(component.dataSource.data).toHaveLength(1);
     expect(component.dataSource.data[0].code).toBe(1);
     expect(component.isNotesUnavailable).toBe(true);
+  });
+
+  it('should resolve manually selected missing codes from the coding job missing profile', () => {
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      missings_profile_id: 77
+    };
+    mockMissingsProfileService.getMissingsProfileDetails.mockReturnValue(of({
+      id: 77,
+      label: 'Custom',
+      missings: JSON.stringify([
+        {
+          id: 'mir',
+          label: 'Custom MIR',
+          description: '',
+          code: -123,
+          score: 7
+        },
+        {
+          id: 'mci',
+          label: 'Custom MCI',
+          description: '',
+          code: -124,
+          score: 8
+        }
+      ])
+    }));
+    mockCodingJobBackendService.getCodingJobUnits.mockReturnValue(of([{
+      responseId: 1,
+      unitName: 'UNIT_1',
+      unitAlias: 'UNIT_1',
+      variableId: 'VAR_1',
+      variableAnchor: 'VAR_1',
+      bookletName: 'BOOKLET_A',
+      personLogin: 'login',
+      personCode: 'code',
+      personGroup: 'group',
+      isDoubleCoded: false,
+      otherCoders: []
+    }]));
+    mockCodingJobBackendService.getCodingProgress.mockReturnValue(of({
+      'login@code@group@BOOKLET_A::BOOKLET_A::UNIT_1::VAR_1': {
+        id: -3,
+        label: 'MIR'
+      }
+    }));
+
+    component.loadCodingResults();
+
+    expect(mockMissingsProfileService.getMissingsProfileDetails).toHaveBeenLastCalledWith(123, 77);
+    expect(component.dataSource.data[0]).toMatchObject({
+      code: -123,
+      score: 7,
+      codeLabel: 'Custom MIR',
+      unresolvedMissing: false
+    });
+    expect(component.getCodedResultCount()).toBe(1);
+  });
+
+  it('should block applying results when a manual missing cannot be resolved from the profile', () => {
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      status: 'completed',
+      missings_profile_id: 77
+    };
+    mockMissingsProfileService.getMissingsProfileDetails.mockReturnValue(of({
+      id: 77,
+      label: 'Incomplete',
+      missings: JSON.stringify([
+        {
+          id: 'mci',
+          label: 'Custom MCI',
+          description: '',
+          code: -124,
+          score: 8
+        }
+      ])
+    }));
+    mockCodingJobBackendService.getCodingJobUnits.mockReturnValue(of([{
+      responseId: 1,
+      unitName: 'UNIT_1',
+      unitAlias: 'UNIT_1',
+      variableId: 'VAR_1',
+      variableAnchor: 'VAR_1',
+      bookletName: 'BOOKLET_A',
+      personLogin: 'login',
+      personCode: 'code',
+      personGroup: 'group',
+      isDoubleCoded: false,
+      otherCoders: []
+    }]));
+    mockCodingJobBackendService.getCodingProgress.mockReturnValue(of({
+      'login@code@group@BOOKLET_A::BOOKLET_A::UNIT_1::VAR_1': {
+        id: -3,
+        label: 'MIR'
+      }
+    }));
+
+    component.loadCodingResults();
+
+    const result = component.dataSource.data[0];
+    expect(result.unresolvedMissing).toBe(true);
+    expect(component.getCodeDisplay(result)).toBe('Missing nicht auflösbar');
+    expect(component.canApplyCodingResults()).toBe(false);
+    expect(component.getApplyButtonTooltip()).toContain('Missing-Kodierung');
+  });
+
+  it.each([
+    ['null', null],
+    ['empty string', ''],
+    ['blank string', '   ']
+  ])('should block applying results when a manual missing score is %s', (_label, score) => {
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      status: 'completed',
+      missings_profile_id: 77
+    };
+    mockMissingsProfileService.getMissingsProfileDetails.mockReturnValue(of({
+      id: 77,
+      label: 'Incomplete',
+      missings: JSON.stringify([
+        {
+          id: 'mir',
+          label: 'Custom MIR',
+          description: '',
+          code: -123,
+          score
+        },
+        {
+          id: 'mci',
+          label: 'Custom MCI',
+          description: '',
+          code: -124,
+          score: 8
+        }
+      ])
+    }));
+    mockCodingJobBackendService.getCodingJobUnits.mockReturnValue(of([{
+      responseId: 1,
+      unitName: 'UNIT_1',
+      unitAlias: 'UNIT_1',
+      variableId: 'VAR_1',
+      variableAnchor: 'VAR_1',
+      bookletName: 'BOOKLET_A',
+      personLogin: 'login',
+      personCode: 'code',
+      personGroup: 'group',
+      isDoubleCoded: false,
+      otherCoders: []
+    }]));
+    mockCodingJobBackendService.getCodingProgress.mockReturnValue(of({
+      'login@code@group@BOOKLET_A::BOOKLET_A::UNIT_1::VAR_1': {
+        id: -3,
+        label: 'MIR'
+      }
+    }));
+
+    component.loadCodingResults();
+
+    const result = component.dataSource.data[0];
+    expect(result.unresolvedMissing).toBe(true);
+    expect(result.score).toBeUndefined();
+    expect(component.canApplyCodingResults()).toBe(false);
   });
 
   it('should identify new-code cases by stable issue option id', () => {

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
@@ -5,7 +5,7 @@ import {
   HostListener
 } from '@angular/core';
 import {
-  Subject, debounceTime, forkJoin, of, catchError, finalize, takeUntil
+  Subject, debounceTime, forkJoin, of, catchError, finalize, takeUntil, map, Observable, switchMap
 } from 'rxjs';
 import {
   MAT_DIALOG_DATA, MatDialogModule, MatDialogRef, MatDialog
@@ -28,10 +28,12 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { Router } from '@angular/router';
 import { FileService } from '../../../../shared/services/file/file.service';
 import { CodingJobBackendService } from '../../../services/coding-job-backend.service';
+import { MissingsProfileService } from '../../../services/missings-profile.service';
 import { AppService } from '../../../../core/services/app.service';
 import { CodingJob } from '../../../models/coding-job.model';
 import { SchemeEditorDialogComponent } from '../../scheme-editor-dialog/scheme-editor-dialog.component';
 import { base64ToUtf8, utf8ToBase64 } from '../../../../shared/utils/common-utils';
+import { MissingDto, MissingsProfilesDto } from '../../../../../../../../api-dto/coding/missings-profiles.dto';
 import {
   ApplyCodingResultsDialogComponent,
   ApplyCodingResultsDialogResult
@@ -61,6 +63,7 @@ interface CodingResult {
   notes?: string;
   isDoubleCoded?: boolean;
   otherCoders?: string[];
+  unresolvedMissing?: boolean;
 }
 
 interface CodingProgressEntry {
@@ -83,6 +86,12 @@ interface CodingJobUnitResult {
   personGroup: string;
   isDoubleCoded: boolean;
   otherCoders: string[];
+}
+
+interface ResolvedMissingPreview {
+  code: number;
+  score: number;
+  label?: string;
 }
 
 @Component({
@@ -112,6 +121,7 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
   @ViewChild(MatPaginator) paginator?: MatPaginator;
 
   private codingJobBackendService = inject(CodingJobBackendService);
+  private missingsProfileService = inject(MissingsProfileService);
   private fileService = inject(FileService);
   private appService = inject(AppService);
   private snackBar = inject(MatSnackBar);
@@ -121,6 +131,7 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
 
   isLoading = true;
   isNotesUnavailable = false;
+  isMissingProfileUnavailable = false;
   dataSource = new MatTableDataSource<CodingResult>([]);
   displayedColumns: string[] = [
     'unitName',
@@ -136,6 +147,11 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
 
   private refreshSubject = new Subject<void>();
   private destroy$ = new Subject<void>();
+  private readonly defaultMissingProfileLabel = 'IQB-Standard';
+  private readonly manualMissingIdsByIssueOptionId = new Map<number, string>([
+    [-3, 'mir'],
+    [-4, 'mci']
+  ]);
 
   readonly pageSize = 50;
   readonly pageSizeOptions = [25, 50, 100];
@@ -184,10 +200,12 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
   loadCodingResults(): void {
     this.isLoading = true;
     this.isNotesUnavailable = false;
+    this.isMissingProfileUnavailable = false;
 
     forkJoin({
       units: this.codingJobBackendService.getCodingJobUnits(this.data.workspaceId, this.data.codingJob.id),
       progress: this.codingJobBackendService.getCodingProgress(this.data.workspaceId, this.data.codingJob.id),
+      missingProfile: this.getMissingProfileForJob(),
       notes: this.codingJobBackendService.getCodingNotes(this.data.workspaceId, this.data.codingJob.id).pipe(
         catchError(() => {
           this.isNotesUnavailable = true;
@@ -201,12 +219,17 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
         this.isLoading = false;
       })
     ).subscribe({
-      next: ({ units, progress, notes }) => {
+      next: ({
+        units, progress, notes, missingProfile
+      }) => {
+        const manualMissingLookup = this.getManualMissingLookup(missingProfile);
         this.dataSource.data = (units || []).map(unit => this.mapCodingResult(
           unit as CodingJobUnitResult,
           progress as Record<string, CodingProgressEntry>,
-          notes as Record<string, string>
+          notes as Record<string, string>,
+          manualMissingLookup
         ));
+        this.isMissingProfileUnavailable = this.getUnresolvedMissingCount() > 0;
         this.applyFilters();
         this.paginator?.firstPage();
       },
@@ -220,16 +243,20 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
   private mapCodingResult(
     unit: CodingJobUnitResult,
     progressResult: Record<string, CodingProgressEntry>,
-    notesResult: Record<string, string>
+    notesResult: Record<string, string>,
+    manualMissingLookup: Map<number, ResolvedMissingPreview>
   ): CodingResult {
     const progressKey = this.getCodingProgressKey(unit);
     const progress = progressResult[progressKey];
     const notes = notesResult ? notesResult[progressKey] : undefined;
-    const mappedCode = this.getMappedResultCode(progress);
-    const mappedScore = this.getMappedResultScore(progress);
+    const mappedCode = this.getMappedResultCode(progress, manualMissingLookup);
+    const mappedScore = this.getMappedResultScore(progress, manualMissingLookup);
     const reviewIssueOption = this.getReviewIssueOption(progress);
     const testPerson = this.getTestPersonLabel(unit);
     const otherCoders = (unit.otherCoders || []).filter(Boolean);
+    const progressCode = this.toNumericCode(progress?.id);
+    const missingPreview = progressCode === null ? undefined : manualMissingLookup.get(progressCode);
+    const unresolvedMissing = this.isManualMissingIssueOption(progressCode) && !missingPreview;
 
     return {
       unitName: unit.unitName,
@@ -250,7 +277,7 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
         unit.bookletName
       ].filter(Boolean).join(' '),
       code: mappedCode,
-      codeLabel: progress?.label,
+      codeLabel: missingPreview?.label ?? progress?.label,
       score: mappedScore,
       codingIssueOption: reviewIssueOption ?? undefined,
       codingIssueOptionLabel: reviewIssueOption !== null ? this.getCodingIssueOption(reviewIssueOption) : undefined,
@@ -258,8 +285,80 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
       givenScore: reviewIssueOption !== null && progress?.score !== undefined && progress?.score !== null ? progress.score : undefined,
       notes: notes,
       isDoubleCoded: otherCoders.length > 0,
-      otherCoders
+      otherCoders,
+      unresolvedMissing
     };
+  }
+
+  private getMissingProfileForJob(): Observable<MissingsProfilesDto | null> {
+    if (this.data.codingJob.missings_profile) {
+      return of(this.toMissingProfileDto(this.data.codingJob.missings_profile));
+    }
+
+    const profileId = this.data.codingJob.missings_profile_id ?? this.data.codingJob.missingsProfileId;
+    if (profileId && profileId > 0) {
+      return this.missingsProfileService.getMissingsProfileDetails(this.data.workspaceId, profileId);
+    }
+
+    return this.missingsProfileService.getMissingsProfiles(this.data.workspaceId).pipe(
+      map(profiles => profiles.find(profile => profile.label === this.defaultMissingProfileLabel)?.id),
+      switchMap(defaultProfileId => this.missingsProfileService.getMissingsProfileDetails(
+        this.data.workspaceId,
+        defaultProfileId || this.defaultMissingProfileLabel
+      ))
+    );
+  }
+
+  private toMissingProfileDto(profile: MissingsProfilesDto): MissingsProfilesDto {
+    return Object.assign(new MissingsProfilesDto(), profile);
+  }
+
+  private getManualMissingLookup(profile: MissingsProfilesDto | null): Map<number, ResolvedMissingPreview> {
+    const lookup = new Map<number, ResolvedMissingPreview>();
+    if (!profile) {
+      return lookup;
+    }
+
+    const missings = this.toMissingProfileDto(profile).parseMissings();
+    this.manualMissingIdsByIssueOptionId.forEach((missingId, issueOptionId) => {
+      const missing = missings.find(entry => entry.id === missingId);
+      const resolved = this.toResolvedMissingPreview(missing);
+      if (resolved) {
+        lookup.set(issueOptionId, resolved);
+      }
+    });
+
+    return lookup;
+  }
+
+  private toResolvedMissingPreview(missing?: MissingDto): ResolvedMissingPreview | null {
+    if (!missing) {
+      return null;
+    }
+
+    const code = Number(missing.code);
+    if (!Number.isInteger(code) || !this.hasExplicitFiniteScore(missing.score)) {
+      return null;
+    }
+
+    return {
+      code,
+      score: Number(missing.score),
+      label: missing.label
+    };
+  }
+
+  private hasExplicitFiniteScore(score: unknown): boolean {
+    if (typeof score === 'number') {
+      return Number.isFinite(score);
+    }
+
+    if (typeof score === 'string') {
+      const trimmedScore = score.trim();
+      return trimmedScore !== '' && Number.isFinite(Number(trimmedScore));
+    }
+
+    return false;
   }
 
   private getCodingProgressKey(unit: CodingJobUnitResult): string {
@@ -432,12 +531,17 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
     return this.dataSource.data.filter(result => this.isCodingIssueOption(result)).length;
   }
 
+  getUnresolvedMissingCount(): number {
+    return this.dataSource.data.filter(result => result.unresolvedMissing).length;
+  }
+
   canApplyCodingResults(): boolean {
     return !this.isLoading &&
       this.data.codingJob.status !== 'results_applied' &&
       this.isCodingJobFreshnessApplyable() &&
       !this.data.codingJob.training?.id &&
       !this.data.codingJob.training_id &&
+      this.getUnresolvedMissingCount() === 0 &&
       this.getCodedResultCount() > 0;
   }
 
@@ -450,6 +554,9 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
     }
     if (this.data.codingJob.training?.id || this.data.codingJob.training_id) {
       return 'Trainingsergebnisse können nicht auf Antwortdaten angewendet werden';
+    }
+    if (this.getUnresolvedMissingCount() > 0) {
+      return `${this.getUnresolvedMissingCount()} Missing-Kodierung(en) können nicht aus dem Missing-Profil aufgelöst werden`;
     }
     if (this.getCodedResultCount() === 0) {
       return 'Keine kodierten Ergebnisse zum Anwenden vorhanden';
@@ -564,6 +671,9 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
   }
 
   getCodeDisplay(result: CodingResult): string {
+    if (result.unresolvedMissing) {
+      return 'Missing nicht auflösbar';
+    }
     if (result.code !== undefined && result.code !== null) {
       if (this.isCodingIssueOption(result)) {
         if (result.givenCode !== undefined && result.givenCode !== null) {
@@ -577,6 +687,9 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
   }
 
   getScoreDisplay(result: CodingResult): string {
+    if (result.unresolvedMissing) {
+      return '';
+    }
     if (this.isCodingIssueOption(result)) {
       if (result.givenScore !== undefined && result.givenScore !== null) {
         return `${result.givenScore} (unsicher)`;
@@ -615,23 +728,36 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
     return Number.isNaN(parsed) ? null : parsed;
   }
 
-  private getMappedResultCode(progress?: CodingProgressEntry): number | null {
+  private getMappedResultCode(
+    progress: CodingProgressEntry | undefined,
+    manualMissingLookup: Map<number, ResolvedMissingPreview>
+  ): number | null {
     const code = this.toNumericCode(progress?.id);
-    if (code === -3) {
-      return -98;
+    if (code !== null && manualMissingLookup.has(code)) {
+      return manualMissingLookup.get(code)?.code ?? null;
     }
-    if (code === -4) {
-      return -97;
+    if (this.isManualMissingIssueOption(code)) {
+      return null;
     }
     return code;
   }
 
-  private getMappedResultScore(progress?: CodingProgressEntry): number | undefined {
+  private getMappedResultScore(
+    progress: CodingProgressEntry | undefined,
+    manualMissingLookup: Map<number, ResolvedMissingPreview>
+  ): number | undefined {
     const code = this.toNumericCode(progress?.id);
-    if (code === -3 || code === -4) {
-      return 0;
+    if (code !== null && manualMissingLookup.has(code)) {
+      return manualMissingLookup.get(code)?.score;
+    }
+    if (this.isManualMissingIssueOption(code)) {
+      return undefined;
     }
     return progress?.score;
+  }
+
+  private isManualMissingIssueOption(code: number | null): boolean {
+    return code !== null && this.manualMissingIdsByIssueOptionId.has(code);
   }
 
   private getReviewIssueOption(progress?: CodingProgressEntry): number | null {


### PR DESCRIPTION
## Summary

Refs #615.

This updates the coding job result dialog so manually selected `mci` and `mir` outcomes are resolved through the coding job's missing profile instead of being hardcoded in the dialog.

## Details

- load the job-specific missing profile, embedded profile, or IQB-Standard fallback while loading result data
- map manual missing issue options to profile-defined code and score values for preview/application checks
- block applying results when a manual missing cannot be resolved or lacks an explicit finite score
- show a warning in the result summary when missing-profile resolution is incomplete
- cover custom profiles, unresolved profile entries, and invalid score values with component tests

## Validation

- `npx nx test frontend --runInBand --testFile=apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts`
- `npx nx lint frontend`
- `git diff --check`
- manual browser check on `http://localhost:4200/#/workspace-admin/47/coding/manual`: temporarily set local dev DB job units to `-3/-4`, verified IQB-Standard mapping to `-98/-97` with score `0`, then restored the local DB rows
