### PR TITLE
Warn about incompatible replay players

### DIFF
--- a/api-dto/files/file-validation-result.dto.ts
+++ b/api-dto/files/file-validation-result.dto.ts
@@ -63,6 +63,14 @@ export type GeoGebraValidationResult = {
   packageStatus: GeoGebraPackageStatus;
 };
 
+export type ReplayCompatibilityWarning = {
+  unit: string;
+  requestedPlayer: string;
+  resolvedPlayer?: string;
+  requiredPlayer: string;
+  message: string;
+};
+
 export class FileValidationResultDto {
   @ApiProperty({ type: Boolean, description: 'Indicates whether test takers were found' })
     testTakersFound!: boolean;
@@ -78,6 +86,9 @@ export class FileValidationResultDto {
 
   @ApiProperty({ type: Object, description: 'GeoGebra usage and package availability' })
     geogebra?: GeoGebraValidationResult;
+
+  @ApiProperty({ type: [Object], description: 'Replay compatibility warnings for referenced players' })
+    replayCompatibilityWarnings?: ReplayCompatibilityWarning[];
 
   @ApiProperty({ type: [Object], description: 'Array of validation results for each test taker' })
     validationResults!: {

--- a/apps/backend/src/app/admin/workspace/github-releases.controller.ts
+++ b/apps/backend/src/app/admin/workspace/github-releases.controller.ts
@@ -34,4 +34,12 @@ export class GithubReleasesController {
   ): Promise<boolean> {
     return this.githubReleasesService.downloadAndInstall(workspaceId, body.url);
   }
+
+  @Post(':workspace_id/github/install-compatible-aspect-player')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  async installCompatibleAspectPlayer(
+    @WorkspaceId() workspaceId: number
+  ): Promise<boolean> {
+    return this.githubReleasesService.installCompatibleAspectPlayer(workspaceId);
+  }
 }

--- a/apps/backend/src/app/admin/workspace/github-releases.service.spec.ts
+++ b/apps/backend/src/app/admin/workspace/github-releases.service.spec.ts
@@ -16,6 +16,8 @@ describe('GithubReleasesService', () => {
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GithubReleasesService,
@@ -102,6 +104,42 @@ describe('GithubReleasesService', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('schemer.html');
+    });
+  });
+
+  describe('installCompatibleAspectPlayer', () => {
+    it('should install the minimal compatible Aspect player release', async () => {
+      mockHttpService.get
+        .mockReturnValueOnce(of({
+          data: [
+            {
+              tag_name: 'editor/2.9.4+player/2.9.4',
+              published_at: '2025-05-07T12:00:00Z',
+              assets: [
+                {
+                  name: 'iqb-player-aspect-2.9.4.html',
+                  browser_download_url: 'http://example.com/iqb-player-aspect-2.9.4.html'
+                }
+              ]
+            }
+          ]
+        }))
+        .mockReturnValueOnce(of({
+          data: Buffer.from('<html></html>')
+        }));
+      mockWorkspaceFilesService.uploadTestFiles.mockResolvedValue([]);
+
+      const result = await service.installCompatibleAspectPlayer(7);
+
+      expect(result).toBe(true);
+      expect(mockWorkspaceFilesService.uploadTestFiles).toHaveBeenCalledWith(
+        7,
+        [expect.objectContaining({
+          originalname: 'iqb-player-aspect-2.9.4.html',
+          mimetype: 'text/html'
+        })],
+        true
+      );
     });
   });
 });

--- a/apps/backend/src/app/admin/workspace/github-releases.service.ts
+++ b/apps/backend/src/app/admin/workspace/github-releases.service.ts
@@ -22,6 +22,10 @@ export interface GithubReleaseShort {
   published_at: string;
 }
 
+const COMPATIBLE_ASPECT_PLAYER_VERSION = '2.9.4';
+const COMPATIBLE_ASPECT_PLAYER_ASSET_NAME =
+  `iqb-player-aspect-${COMPATIBLE_ASPECT_PLAYER_VERSION}.html`;
+
 @Injectable()
 export class GithubReleasesService {
   private readonly logger = new Logger(GithubReleasesService.name);
@@ -68,6 +72,54 @@ export class GithubReleasesService {
       this.logger.error(`Error fetching releases for ${type}: ${error.message}`);
       throw new InternalServerErrorException('Failed to fetch releases from GitHub');
     }
+  }
+
+  async installCompatibleAspectPlayer(workspaceId: number): Promise<boolean> {
+    const release = await this.findCompatibleAspectPlayerRelease();
+    return this.downloadAndInstall(workspaceId, release.url);
+  }
+
+  private async findCompatibleAspectPlayerRelease(): Promise<GithubReleaseShort> {
+    const repo = this.repositories['aspect-player'];
+    let page = 1;
+
+    while (page <= 10) {
+      const response = await firstValueFrom(
+        this.httpService.get<GithubRelease[]>(
+          `https://api.github.com/repos/${repo}/releases`,
+          { params: { per_page: 100, page } }
+        )
+      );
+
+      const release = response.data
+        .map(item => {
+          const asset = item.assets.find(a => a.name.toLowerCase() ===
+            COMPATIBLE_ASPECT_PLAYER_ASSET_NAME);
+
+          if (!asset) return null;
+
+          return {
+            version: item.tag_name,
+            url: asset.browser_download_url,
+            name: asset.name,
+            published_at: item.published_at
+          };
+        })
+        .find((item): item is GithubReleaseShort => item !== null);
+
+      if (release) {
+        return release;
+      }
+
+      if (response.data.length < 100) {
+        break;
+      }
+      page += 1;
+    }
+
+    throw new InternalServerErrorException(
+      `Compatible Aspect player ${COMPATIBLE_ASPECT_PLAYER_VERSION} was not found on GitHub`
+    );
   }
 
   async downloadAndInstall(

--- a/apps/backend/src/app/database/services/validation/workspace-test-files-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/validation/workspace-test-files-validation.service.spec.ts
@@ -12,6 +12,7 @@ import { WorkspaceXmlSchemaValidationService } from '../workspace/workspace-xml-
 import { WorkspaceCoreService } from '../workspace/workspace-core.service';
 import { WorkspaceExclusionService } from '../workspace/workspace-exclusion.service';
 import { ResourcePackageService } from '../workspace/resource-package.service';
+import { ReplayCompatibilityWarning } from '../../../../../../../api-dto/files/file-validation-result.dto';
 
 describe('WorkspaceTestFilesValidationService', () => {
   let service: WorkspaceTestFilesValidationService;
@@ -105,7 +106,7 @@ describe('WorkspaceTestFilesValidationService', () => {
 
     const expectedHash = crypto.createHash('sha256');
     expectedHash.update(JSON.stringify({
-      cacheVersion: 4,
+      cacheVersion: 5,
       exclusions: {
         ignoredUnits: [],
         ignoredBooklets: [],
@@ -115,8 +116,73 @@ describe('WorkspaceTestFilesValidationService', () => {
     }));
     expectedHash.update('\n');
 
-    expect(TEST_FILES_VALIDATION_CACHE_VERSION).toBe(4);
+    expect(TEST_FILES_VALIDATION_CACHE_VERSION).toBe(5);
     expect(fingerprint).toBe(expectedHash.digest('hex'));
+  });
+
+  describe('replay compatibility warnings', () => {
+    type ReplayCompatibilityDetector = {
+      detectReplayCompatibilityWarnings(
+        validationResults: unknown[],
+        unitMap: Map<string, unknown>,
+        resourceIdsArray: string[]
+      ): ReplayCompatibilityWarning[];
+    };
+
+    const createValidationResults = () => ([{
+      units: {
+        files: [{ filename: 'MV22064', exists: true }]
+      }
+    }]);
+
+    const createUnitMap = (playerRefs: string[]) => new Map<string, unknown>([
+      ['MV22064', { playerRefs }]
+    ]);
+
+    const detectWarnings = (
+      playerRefs: string[],
+      resourceIds: string[]
+    ): ReplayCompatibilityWarning[] => (
+      service as unknown as ReplayCompatibilityDetector
+    ).detectReplayCompatibilityWarnings(
+      createValidationResults(),
+      createUnitMap(playerRefs),
+      resourceIds
+    );
+
+    it('should warn for Aspect players without DOM element aliases', () => {
+      const warnings = detectWarnings(
+        ['IQB-PLAYER-ASPECT-2.9.3'],
+        ['IQB-PLAYER-ASPECT-2.9.3']
+      );
+
+      expect(warnings).toEqual([
+        expect.objectContaining({
+          unit: 'MV22064',
+          requestedPlayer: 'IQB-PLAYER-ASPECT-2.9.3',
+          resolvedPlayer: 'IQB-PLAYER-ASPECT-2.9.3',
+          requiredPlayer: 'IQB-PLAYER-ASPECT-2.9.4'
+        })
+      ]);
+    });
+
+    it('should not warn when a compatible patch version is available', () => {
+      const warnings = detectWarnings(
+        ['IQB-PLAYER-ASPECT-2.9.3'],
+        ['IQB-PLAYER-ASPECT-2.9.3', 'IQB-PLAYER-ASPECT-2.9.4']
+      );
+
+      expect(warnings).toEqual([]);
+    });
+
+    it('should not warn for non-Aspect players', () => {
+      const warnings = detectWarnings(
+        ['OTHER-PLAYER-1.0.0'],
+        ['OTHER-PLAYER-1.0.0']
+      );
+
+      expect(warnings).toEqual([]);
+    });
   });
 
   it('should include ignored test file settings in the validation fingerprint', async () => {

--- a/apps/backend/src/app/database/services/validation/workspace-test-files-validation.service.ts
+++ b/apps/backend/src/app/database/services/validation/workspace-test-files-validation.service.ts
@@ -12,7 +12,8 @@ import Persons from '../../entities/persons.entity';
 import {
   FileValidationResultDto,
   FilteredTestTaker,
-  GeoGebraValidationResult
+  GeoGebraValidationResult,
+  ReplayCompatibilityWarning
 } from '../../../../../../../api-dto/files/file-validation-result.dto';
 import { WorkspaceXmlSchemaValidationService } from '../workspace/workspace-xml-schema-validation.service';
 // eslint-disable-next-line import/no-cycle
@@ -88,7 +89,23 @@ type ValidationProgressReporter = (
 ) => void | Promise<void>;
 
 // Bump this whenever test-file validation semantics or result shape changes.
-export const TEST_FILES_VALIDATION_CACHE_VERSION = 4;
+export const TEST_FILES_VALIDATION_CACHE_VERSION = 5;
+
+type ParsedPlayerVersion = {
+  id: string;
+  module: string;
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+const ASPECT_PLAYER_MODULE = 'IQB-PLAYER-ASPECT';
+const ASPECT_PLAYER_REPLAY_ALIAS_MIN_VERSION = {
+  major: 2,
+  minor: 9,
+  patch: 4
+};
+const ASPECT_PLAYER_REPLAY_ALIAS_REQUIRED_PLAYER = 'IQB-PLAYER-ASPECT-2.9.4';
 
 @Injectable()
 export class WorkspaceTestFilesValidationService {
@@ -570,6 +587,12 @@ export class WorkspaceTestFilesValidationService {
         unitMap,
         onProgress
       );
+      const replayCompatibilityWarnings =
+        this.detectReplayCompatibilityWarnings(
+          validationResults,
+          unitMap,
+          resourceIdsArray
+        );
 
       await this.reportProgress(
         onProgress,
@@ -587,6 +610,10 @@ export class WorkspaceTestFilesValidationService {
           unusedTestFiles:
             unusedTestFiles.length > 0 ? unusedTestFiles : undefined,
           geogebra,
+          replayCompatibilityWarnings:
+            replayCompatibilityWarnings.length > 0 ?
+              replayCompatibilityWarnings :
+              undefined,
           validationResults
         };
       }
@@ -600,6 +627,10 @@ export class WorkspaceTestFilesValidationService {
         unusedTestFiles:
           unusedTestFiles.length > 0 ? unusedTestFiles : undefined,
         geogebra,
+        replayCompatibilityWarnings:
+          replayCompatibilityWarnings.length > 0 ?
+            replayCompatibilityWarnings :
+            undefined,
         validationResults: this.createEmptyValidationData()
       };
     } catch (error) {
@@ -1112,6 +1143,140 @@ export class WorkspaceTestFilesValidationService {
       units,
       packageStatus
     };
+  }
+
+  private detectReplayCompatibilityWarnings(
+    validationResults: ValidationData[],
+    unitMap: Map<string, UnitRefs>,
+    resourceIdsArray: string[]
+  ): ReplayCompatibilityWarning[] {
+    const usedUnits = new Set<string>();
+
+    validationResults.forEach(result => {
+      result.units.files
+        .filter(file => file.exists && !file.ignored)
+        .forEach(file => usedUnits.add(file.filename.toUpperCase()));
+    });
+
+    const warningsByKey = new Map<string, ReplayCompatibilityWarning>();
+
+    usedUnits.forEach(unitId => {
+      const refs = unitMap.get(unitId);
+      refs?.playerRefs.forEach(playerRef => {
+        const resolvedPlayer = WorkspaceTestFilesValidationService.resolvePlayerRef(
+          playerRef,
+          resourceIdsArray
+        );
+
+        if (!resolvedPlayer) {
+          return;
+        }
+
+        const parsed = WorkspaceTestFilesValidationService.parsePlayerVersion(
+          resolvedPlayer
+        );
+
+        if (
+          parsed?.module !== ASPECT_PLAYER_MODULE ||
+          WorkspaceTestFilesValidationService.isVersionAtLeast(
+            parsed,
+            ASPECT_PLAYER_REPLAY_ALIAS_MIN_VERSION
+          )
+        ) {
+          return;
+        }
+
+        const key = `${unitId}|${playerRef}|${resolvedPlayer}`;
+        warningsByKey.set(key, {
+          unit: unitId,
+          requestedPlayer: playerRef,
+          resolvedPlayer,
+          requiredPlayer: ASPECT_PLAYER_REPLAY_ALIAS_REQUIRED_PLAYER,
+          message:
+            'Elementgenaue Replay-Markierungen benötigen data-element-alias; ' +
+            `${resolvedPlayer} stellt dieses DOM-Merkmal noch nicht bereit.`
+        });
+      });
+    });
+
+    return Array.from(warningsByKey.values()).sort((a, b) => {
+      const unitCompare = a.unit.localeCompare(b.unit);
+      if (unitCompare !== 0) return unitCompare;
+      return a.requestedPlayer.localeCompare(b.requestedPlayer);
+    });
+  }
+
+  private static resolvePlayerRef(
+    ref: string,
+    allResourceIds: string[]
+  ): string | null {
+    const parsedRef = WorkspaceTestFilesValidationService.parsePlayerVersion(ref);
+    if (!parsedRef) {
+      return allResourceIds.includes(ref) ? ref : null;
+    }
+
+    const candidates = allResourceIds
+      .map(id => WorkspaceTestFilesValidationService.parsePlayerVersion(id))
+      .filter((candidate): candidate is ParsedPlayerVersion => !!candidate)
+      .filter(candidate => candidate.module === parsedRef.module &&
+        candidate.major === parsedRef.major);
+
+    const sameMinor = candidates
+      .filter(candidate => candidate.minor === parsedRef.minor)
+      .sort(WorkspaceTestFilesValidationService.comparePlayerVersionsDesc);
+
+    if (sameMinor.length > 0) {
+      return sameMinor[0].id;
+    }
+
+    const sameMajor = candidates
+      .sort(WorkspaceTestFilesValidationService.comparePlayerVersionsDesc);
+
+    return sameMajor[0]?.id || null;
+  }
+
+  private static parsePlayerVersion(
+    value: string | undefined | null
+  ): ParsedPlayerVersion | null {
+    const normalized = (value || '').trim().toUpperCase().replace(/\\/g, '/');
+    const basename = normalized.split('/').pop() || normalized;
+    const withoutExtension = basename.replace(/\.(HTML|HTM)$/, '');
+    const match = withoutExtension.match(/^(.+)-(\d+)\.(\d+)(?:\.(\d+))?$/);
+
+    if (!match) {
+      return null;
+    }
+
+    return {
+      id: withoutExtension,
+      module: match[1],
+      major: Number.parseInt(match[2], 10),
+      minor: Number.parseInt(match[3], 10),
+      patch: match[4] ? Number.parseInt(match[4], 10) : 0
+    };
+  }
+
+  private static comparePlayerVersionsDesc(
+    a: ParsedPlayerVersion,
+    b: ParsedPlayerVersion
+  ): number {
+    if (b.minor !== a.minor) {
+      return b.minor - a.minor;
+    }
+    return b.patch - a.patch;
+  }
+
+  private static isVersionAtLeast(
+    version: Pick<ParsedPlayerVersion, 'major' | 'minor' | 'patch'>,
+    minimum: Pick<ParsedPlayerVersion, 'major' | 'minor' | 'patch'>
+  ): boolean {
+    if (version.major !== minimum.major) {
+      return version.major > minimum.major;
+    }
+    if (version.minor !== minimum.minor) {
+      return version.minor > minimum.minor;
+    }
+    return version.patch >= minimum.patch;
   }
 
   private resourceFileMatchesRef(

--- a/apps/backend/src/app/prototype-methods.spec.ts
+++ b/apps/backend/src/app/prototype-methods.spec.ts
@@ -205,5 +205,5 @@ describe('backend controller prototype method smoke coverage', () => {
     }
 
     expect(invoked).toBeGreaterThan(300);
-  }, 20000);
+  }, 60000);
 });

--- a/apps/frontend/src/app/shared/services/file/file.service.ts
+++ b/apps/frontend/src/app/shared/services/file/file.service.ts
@@ -569,4 +569,12 @@ export class FileService {
       { headers: this.authHeader }
     );
   }
+
+  installCompatibleAspectPlayer(workspaceId: number): Observable<boolean> {
+    return this.http.post<boolean>(
+      `${this.serverUrl}admin/workspace/${workspaceId}/github/install-compatible-aspect-player`,
+      {},
+      { headers: this.authHeader }
+    );
+  }
 }

--- a/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.html
+++ b/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.html
@@ -113,6 +113,59 @@
     </div>
     }
 
+    @if (replayCompatibilityWarnings && replayCompatibilityWarnings.length > 0) {
+    <div class="replay-compatibility-panel">
+      <mat-expansion-panel [expanded]="true">
+        <mat-expansion-panel-header>
+          <mat-panel-title>
+            <mat-icon class="replay-compatibility-icon">warning</mat-icon>
+            <span class="replay-compatibility-title">
+              {{ 'files-validation.replay-compatibility.title' | translate }}
+            </span>
+          </mat-panel-title>
+          <mat-panel-description>
+            {{ 'files-validation.replay-compatibility.task-count' | translate: { count: replayCompatibilityWarnings.length } }}
+          </mat-panel-description>
+        </mat-expansion-panel-header>
+
+        <div class="replay-compatibility-content">
+          <p class="replay-compatibility-message">
+            {{ 'files-validation.replay-compatibility.message' | translate }}
+          </p>
+
+          @if (data.workspaceId) {
+          <button mat-raised-button color="primary" class="replay-compatibility-action"
+            [disabled]="isInstallingCompatibleAspectPlayer || isRefreshingValidation"
+            (click)="installCompatibleAspectPlayer()">
+            <mat-icon>{{ isInstallingCompatibleAspectPlayer ? 'hourglass_empty' : 'system_update_alt' }}</mat-icon>
+            @if (isInstallingCompatibleAspectPlayer) {
+            {{ 'files-validation.replay-compatibility.installing' | translate }}
+            } @else {
+            {{ 'files-validation.replay-compatibility.install-action' | translate }}
+            }
+          </button>
+          }
+
+          <div class="replay-compatibility-unit-section">
+            <div class="replay-compatibility-unit-header">
+              <span>{{ 'files-validation.replay-compatibility.affected-units' | translate }}</span>
+              <span class="replay-compatibility-unit-count">{{ replayCompatibilityWarnings.length }}</span>
+            </div>
+            <div class="replay-compatibility-unit-list"
+              [attr.aria-label]="'files-validation.replay-compatibility.affected-units' | translate">
+              @for (warning of replayCompatibilityWarnings; track warning.unit + warning.requestedPlayer) {
+              <span class="replay-compatibility-unit-chip"
+                matTooltip="{{ warning.requestedPlayer }} -> {{ warning.resolvedPlayer || warning.requestedPlayer }}">
+                {{ warning.unit }}
+              </span>
+              }
+            </div>
+          </div>
+        </div>
+      </mat-expansion-panel>
+    </div>
+    }
+
     @if (duplicateTestTakers && duplicateTestTakers.length > 0) {
     <div class="missing-units-warning duplicate-testtakers-warning">
       <mat-expansion-panel>

--- a/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.scss
+++ b/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.scss
@@ -384,6 +384,77 @@ h4 {
   }
 }
 
+.replay-compatibility-panel {
+  background-color: #fff8e1;
+  border: 1px solid rgba(245, 124, 0, 0.28);
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
+  display: block;
+  margin: 0 0 16px 0;
+  padding: 8px 12px;
+
+  mat-expansion-panel {
+    background: transparent;
+    border-radius: 4px;
+    box-shadow: none;
+    width: 100%;
+  }
+
+  .replay-compatibility-icon,
+  .replay-compatibility-title {
+    color: #ef6c00;
+  }
+
+  .replay-compatibility-title {
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  .replay-compatibility-content {
+    color: #5d4037;
+    margin-top: 8px;
+  }
+
+  .replay-compatibility-message {
+    line-height: 1.5;
+    margin: 0 0 12px 0;
+  }
+
+  .replay-compatibility-action {
+    margin: 0 0 16px 0;
+  }
+
+  .replay-compatibility-unit-section {
+    background-color: rgba(255, 255, 255, 0.55);
+    border-radius: 6px;
+    padding: 12px;
+  }
+
+  .replay-compatibility-unit-header {
+    align-items: center;
+    display: flex;
+    font-weight: 600;
+    justify-content: space-between;
+    margin-bottom: 10px;
+  }
+
+  .replay-compatibility-unit-count,
+  .replay-compatibility-unit-chip {
+    background-color: rgba(245, 124, 0, 0.14);
+    border-radius: 12px;
+    color: #e65100;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 4px 8px;
+  }
+
+  .replay-compatibility-unit-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+}
+
 .missing-units-warning {
   background-color: #ffebee;
   border-radius: 8px;

--- a/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.ts
@@ -29,7 +29,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { FormsModule } from '@angular/forms';
 import { SelectionModel } from '@angular/cdk/collections';
 import { ScrollingModule } from '@angular/cdk/scrolling';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -44,6 +44,7 @@ import {
   DuplicateTestTaker,
   FileValidationResultDto,
   GeoGebraValidationResult,
+  ReplayCompatibilityWarning,
   UnusedTestFile
 } from '../../../../../../../api-dto/files/file-validation-result.dto';
 import { ContentDialogComponent } from '../../../shared/dialogs/content-dialog/content-dialog.component';
@@ -189,6 +190,7 @@ export class FilesValidationDialogComponent implements OnInit {
     duplicateTestTakers?: DuplicateTestTaker[];
     unusedTestFiles?: UnusedTestFile[];
     geogebra?: GeoGebraValidationResult;
+    replayCompatibilityWarnings?: ReplayCompatibilityWarning[];
     workspaceId?: number;
   }>(MAT_DIALOG_DATA);
 
@@ -198,6 +200,7 @@ export class FilesValidationDialogComponent implements OnInit {
   duplicateTestTakers: DuplicateTestTaker[] = [];
   unusedTestFiles: UnusedTestFile[] = [];
   geogebra?: GeoGebraValidationResult;
+  replayCompatibilityWarnings: ReplayCompatibilityWarning[] = [];
   validationResults: FilesValidationView[] = [];
 
   selection = new SelectionModel<FilteredTestTaker>(true, []);
@@ -227,6 +230,7 @@ export class FilesValidationDialogComponent implements OnInit {
   private testResultService = inject(TestResultService);
   private snackBar = inject(MatSnackBar);
   private validationService = inject(ValidationService);
+  private translate = inject(TranslateService);
 
   isExcluding = false;
   excludingProgress = 0;
@@ -236,6 +240,7 @@ export class FilesValidationDialogComponent implements OnInit {
   isRefreshingValidation = false;
   refreshValidationProgress = 0;
   refreshValidationProgressMessage = '';
+  isInstallingCompatibleAspectPlayer = false;
 
   summary: ValidationSummary = {
     totalTestTakers: 0,
@@ -433,6 +438,7 @@ export class FilesValidationDialogComponent implements OnInit {
     this.duplicateTestTakers = resultDto.duplicateTestTakers || [];
     this.unusedTestFiles = resultDto.unusedTestFiles || [];
     this.geogebra = resultDto.geogebra;
+    this.replayCompatibilityWarnings = resultDto.replayCompatibilityWarnings || [];
 
     this.selection.clear();
     this.allSelected = false;
@@ -546,6 +552,35 @@ export class FilesValidationDialogComponent implements OnInit {
         this.refreshValidationData('GeoGebra-Ressourcenpakete wurden aktualisiert.');
       }
     });
+  }
+
+  installCompatibleAspectPlayer(): void {
+    if (!this.data.workspaceId || this.isInstallingCompatibleAspectPlayer) {
+      return;
+    }
+
+    this.isInstallingCompatibleAspectPlayer = true;
+    this.cdr.markForCheck();
+
+    this.fileService.installCompatibleAspectPlayer(this.data.workspaceId)
+      .pipe(finalize(() => {
+        this.isInstallingCompatibleAspectPlayer = false;
+        this.cdr.markForCheck();
+      }))
+      .subscribe({
+        next: () => {
+          this.refreshValidationData(
+            this.translate.instant('files-validation.replay-compatibility.install-success')
+          );
+        },
+        error: () => {
+          this.snackBar.open(
+            this.translate.instant('files-validation.replay-compatibility.install-error'),
+            'OK',
+            { duration: 3000 }
+          );
+        }
+      });
   }
 
   private createValidationView(result: FilesValidation): FilesValidationView {
@@ -711,6 +746,10 @@ export class FilesValidationDialogComponent implements OnInit {
 
       if (this.data.geogebra) {
         this.geogebra = this.data.geogebra;
+      }
+
+      if (this.data.replayCompatibilityWarnings) {
+        this.replayCompatibilityWarnings = this.data.replayCompatibilityWarnings;
       }
     }
   }

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2474,6 +2474,18 @@
     "invalid": "INVALID:",
     "coding-error": "CODING_ERROR:"
   },
+  "files-validation": {
+    "replay-compatibility": {
+      "title": "Eingeschränkte Replay-Markierung möglich",
+      "task-count": "{{count}} Aufgabe(n)",
+      "message": "Für einige Aufgaben wird ein Aspect-Player verwendet, der keine stabilen Element-Aliase im DOM bereitstellt. Elementgenaue Markierungen im Replay können dadurch fehlen oder ungenau sein. Bitte mindestens IQB-PLAYER-ASPECT 2.9.4 verwenden.",
+      "install-action": "Kompatiblen Aspect-Player installieren",
+      "installing": "Wird installiert...",
+      "install-success": "Kompatibler Aspect-Player wurde installiert.",
+      "install-error": "Kompatibler Aspect-Player konnte nicht installiert werden",
+      "affected-units": "Betroffene Aufgaben"
+    }
+  },
   "coding-validation-results": {
     "title": "Validierungsergebnisse",
     "download-button": "Als Excel herunterladen",


### PR DESCRIPTION
## Summary

- add test-file validation warnings for Aspect players that cannot provide `data-element-alias`
- expose affected units through the validation result DTO
- add an action in the validation dialog to install `iqb-player-aspect-2.9.4.html`
- keep unit files unchanged and rely on existing server-side player resolution

Refs #514

## Verification

- `npx nx lint backend`
- `npx nx lint frontend`
- `npx nx build backend`
- `npx nx build frontend`
- `npx nx test frontend --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/ws-admin/components/files-validation-result/files-validation.component.spec.ts --runInBand`
- `PATH=/Users/julian/.nvm/versions/node/v22.16.0/bin:$PATH npm ci`
- `PATH=/Users/julian/.nvm/versions/node/v22.16.0/bin:$PATH npx nx test backend --testFile=apps/backend/src/app/database/services/validation/workspace-test-files-validation.service.spec.ts --runInBand`
- `PATH=/Users/julian/.nvm/versions/node/v22.16.0/bin:$PATH npx nx test backend --testFile=apps/backend/src/app/admin/workspace/github-releases.service.spec.ts --runInBand`
- `PATH=/Users/julian/.nvm/versions/node/v22.16.0/bin:$PATH npx nx test backend --runInBand`