### PR TITLE
Resolve IQB missing scores and profile exports

### DIFF
--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -22,7 +22,12 @@ import { ChunkEntity } from '../../entities/chunk.entity';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { CodingJobService } from './coding-job.service';
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
-import { MissingsProfilesService } from './missings-profiles.service';
+import {
+  IQB_STANDARD_MISSING_CODES,
+  IQB_STANDARD_MISSING_SCORES,
+  IqbStandardMissingId,
+  MissingsProfilesService
+} from './missings-profiles.service';
 import {
   applyResolvedExclusionsToQuery,
   isExcludedByResolvedExclusions,
@@ -114,14 +119,13 @@ type MissingCodeDisplayContext = MissingCodePair & {
 };
 
 const DEFAULT_MISSING_CODE_CONTEXT: MissingCodeDisplayContext = {
-  mirCode: -98,
-  mciCode: -97,
-  negativeCodes: new Set([-97, -98, -99]),
-  scoresByCode: new Map([
-    [-97, 0],
-    [-98, 0],
-    [-99, 0]
-  ])
+  mirCode: IQB_STANDARD_MISSING_CODES.mir,
+  mciCode: IQB_STANDARD_MISSING_CODES.mci,
+  negativeCodes: new Set(Object.values(IQB_STANDARD_MISSING_CODES)),
+  scoresByCode: new Map(
+    (Object.entries(IQB_STANDARD_MISSING_SCORES) as Array<[IqbStandardMissingId, number]>)
+      .map(([missingId, score]) => [IQB_STANDARD_MISSING_CODES[missingId], score])
+  )
 };
 
 @Injectable()

--- a/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
@@ -38,7 +38,8 @@ function createServiceWithDetailedMocks(
     unit?: Record<string, unknown>,
     discussionResults?: Record<string, unknown>[],
     users?: Record<string, unknown>[],
-    totalCount?: number
+    totalCount?: number,
+    missingsProfilesService?: { getMissingByIdForProfileOrDefault: jest.Mock }
   } = {}
 ) {
   const totalCountQueryBuilder = {
@@ -121,7 +122,8 @@ function createServiceWithDetailedMocks(
     userRepository as unknown as Repository<User>,
     {} as CodingListService,
     {} as WorkspaceCoreService,
-    workspaceExclusionService
+    workspaceExclusionService,
+    overrides.missingsProfilesService as never
   );
 
   return { service, totalCountQueryBuilder, unitsBatchQueryBuilder };
@@ -145,6 +147,52 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
       '(resp.status_v1 IS NULL OR resp.status_v1 NOT IN (:...excludedStatuses))',
       { excludedStatuses: [0, 1, 2, 10] }
     );
+  });
+
+  it('does not resolve manual missing profiles for regular detailed export codes', async () => {
+    const missingsProfilesService = {
+      getMissingByIdForProfileOrDefault: jest.fn().mockRejectedValue(new Error('unexpected missing lookup'))
+    };
+    const { service } = createServiceWithDetailedMocks(1, {
+      missingsProfilesService,
+      unit: {
+        code: 7,
+        score: 2,
+        coding_issue_option: 1,
+        notes: '',
+        updated_at: new Date('2026-04-14T10:00:00.000Z'),
+        response_id: 123,
+        unit_name: 'U1',
+        variable_id: 'V1',
+        coding_job: {
+          training_id: null,
+          missings_profile_id: 77,
+          codingJobCoders: [{ user: { username: 'coder1' } }]
+        },
+        response: {
+          status_v1: 8,
+          unit: {
+            name: 'U1',
+            booklet: {
+              person: {
+                login: 'p-login',
+                code: 'p-code',
+                group: 'G1'
+              },
+              bookletinfo: {
+                name: 'B1'
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const buffer = await service.exportCodingResultsDetailed(1, false, false, false, false);
+    const csv = buffer.toString('utf-8');
+
+    expect(csv).toContain('"7";"Code-Vergabe unsicher"');
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault).not.toHaveBeenCalled();
   });
 
   it('skips detailed coding rows with excluded response statuses defensively', async () => {
@@ -579,6 +627,122 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
       'cju.coding_issue_option',
       'coding_issue_option'
     );
+  });
+
+  it('exports profile-specific manual missing scores in score-bearing aggregated export', async () => {
+    const createQueryBuilder = (rawRows: unknown[] = []) => {
+      const qb = {
+        innerJoin: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        addGroupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rawRows)
+      };
+      return qb;
+    };
+
+    const variableRecordsQuery = createQueryBuilder([{
+      unitName: 'UNIT',
+      variableId: 'VAR',
+      bookletName: 'BOOKLET-A'
+    }]);
+    const manualCodingQuery = createQueryBuilder([{
+      personId: '10',
+      unitName: 'UNIT',
+      variableId: 'VAR',
+      cju_code: '-3',
+      cju_score: null,
+      coding_issue_option: null,
+      code_v1: null,
+      score_v1: null,
+      code_v2: null,
+      score_v2: null,
+      code_v3: null,
+      score_v3: null,
+      notes: null,
+      username: 'Coder A',
+      jobId: '1',
+      trainingId: null,
+      missingsProfileId: '77',
+      responseId: '100'
+    }]);
+    const coderRecordsQuery = createQueryBuilder([{ userName: 'Coder A' }]);
+    const autoVariablesQuery = createQueryBuilder([]);
+    const personResultsQuery = createQueryBuilder([{
+      id: '10',
+      login: 'login-a',
+      code: 'code-a',
+      group: 'group-a',
+      bookletName: 'BOOKLET-A'
+    }]);
+    const autoCodingQuery = createQueryBuilder([]);
+    const responseRepository = {
+      createQueryBuilder: jest.fn()
+        .mockReturnValueOnce(autoVariablesQuery)
+        .mockReturnValueOnce(personResultsQuery)
+        .mockReturnValueOnce(autoCodingQuery)
+    };
+    const codingJobRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(coderRecordsQuery)
+    };
+    const codingJobUnitRepository = {
+      createQueryBuilder: jest.fn()
+        .mockReturnValueOnce(variableRecordsQuery)
+        .mockReturnValueOnce(manualCodingQuery)
+    };
+    const workspaceExclusionService = {
+      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+        globalIgnoredUnits: [],
+        ignoredBooklets: [],
+        testletIgnoredUnits: []
+      })
+    };
+    const missingsProfilesService = {
+      getMissingByIdForProfileOrDefault: jest.fn().mockResolvedValue({
+        id: 'mir',
+        label: 'MIR',
+        code: -97,
+        score: 0
+      })
+    };
+
+    const service = new CodingExportService(
+      responseRepository as unknown as Repository<ResponseEntity>,
+      codingJobRepository as unknown as Repository<CodingJob>,
+      {} as Repository<CodingJobVariable>,
+      codingJobUnitRepository as unknown as Repository<CodingJobUnit>,
+      { find: jest.fn() } as unknown as Repository<CoderTrainingDiscussionResult>,
+      { findBy: jest.fn() } as unknown as Repository<User>,
+      {} as CodingListService,
+      {} as WorkspaceCoreService,
+      workspaceExclusionService as unknown as WorkspaceExclusionService,
+      missingsProfilesService as never
+    );
+
+    const buffer = await service.exportCodingResultsAggregated(
+      7,
+      false,
+      false,
+      false,
+      false,
+      'new-row-per-variable'
+    );
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer);
+    const worksheet = workbook.getWorksheet('Coding Results')!;
+    const headerValues = worksheet.getRow(1).values as unknown[];
+    const codeColumn = headerValues.findIndex(value => value === 'Coder A Code');
+    const scoreColumn = headerValues.findIndex(value => value === 'Coder A Score');
+
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault).toHaveBeenCalledWith(7, 77, 'mir');
+    expect(worksheet.getRow(2).getCell(codeColumn).value).toBe('-97');
+    expect(worksheet.getRow(2).getCell(scoreColumn).value).toBe(0);
   });
 
   it('keeps stored discussion manager names when manager users cannot be resolved', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Readable, PassThrough } from 'stream';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -25,6 +25,7 @@ import {
   isExcludedByResolvedExclusions,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
+import { MissingsProfilesService, ResolvedMissingValue } from './missings-profiles.service';
 
 interface ByVariableCombination {
   unitName: string;
@@ -58,6 +59,7 @@ interface CompactByVariableRawRow {
   notes: string | null;
   pId: string | number;
   trainingId: string | number | null;
+  missingsProfileId: string | number | null;
   responseId: string | number | null;
 }
 
@@ -108,8 +110,63 @@ export class CodingExportService {
     private userRepository: Repository<User>,
     private codingListService: CodingListService,
     private workspaceCoreService: WorkspaceCoreService,
-    private workspaceExclusionService: WorkspaceExclusionService
+    private workspaceExclusionService: WorkspaceExclusionService,
+    @Optional()
+    private missingsProfilesService?: MissingsProfilesService
   ) { }
+
+  private readonly manualMissingExportValueCache = new Map<string, ResolvedMissingValue>();
+
+  private async getManualMissingExportValue(
+    workspaceId: number,
+    code: number | null | undefined,
+    profileId?: number | null
+  ): Promise<ResolvedMissingValue | null> {
+    let missingId: 'mir' | 'mci' | null = null;
+    if (code === -3) {
+      missingId = 'mir';
+    }
+    if (code === -4) {
+      missingId = 'mci';
+    }
+    if (!missingId || !this.missingsProfilesService) {
+      return null;
+    }
+
+    const cacheKey = `${workspaceId}:${profileId ?? 'default'}:${missingId}`;
+    const cached = this.manualMissingExportValueCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+      workspaceId,
+      profileId,
+      missingId
+    );
+    this.manualMissingExportValueCache.set(cacheKey, missing);
+    return missing;
+  }
+
+  private async mapCodeAndScoreForExport(
+    workspaceId: number,
+    code: number | null | undefined,
+    score: number | null | undefined,
+    profileId?: number | null
+  ): Promise<{ code: number | null; score: number | null }> {
+    const manualMissing = await this.getManualMissingExportValue(workspaceId, code, profileId);
+    if (manualMissing) {
+      return {
+        code: manualMissing.code,
+        score: manualMissing.score
+      };
+    }
+
+    return {
+      code: mapCodeForExport(code),
+      score: score ?? null
+    };
+  }
 
   private async getExclusionChecker(workspaceId: number): Promise<(bookletName: string, unitName: string) => boolean> {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
@@ -821,6 +878,7 @@ export class CodingExportService {
         .addSelect('user.username', 'username')
         .addSelect('cj.id', 'jobId')
         .addSelect('cj.training_id', 'trainingId')
+        .addSelect('cj.missings_profile_id', 'missingsProfileId')
         .addSelect('cju.response_id', 'responseId')
         .where('person.id IN (:...ids)', { ids: batchPersonIds });
 
@@ -891,7 +949,7 @@ export class CodingExportService {
       // Group data by person and variable
       const personData = new Map<number, Map<string, AggregatedMostFrequentVariableData>>();
 
-      manualCoding.forEach(row => {
+      for (const row of manualCoding) {
         const pid = parseInt(row.personId, 10);
         const compositeKey = `${row.unitName}_${row.variableId}`;
         if (!personData.has(pid)) personData.set(pid, new Map());
@@ -899,7 +957,13 @@ export class CodingExportService {
         if (!varData.has(compositeKey)) varData.set(compositeKey, { codings: [], comments: [] });
         const d = varData.get(compositeKey)!;
         const rawCode = row.cju_code ?? row.code_v3 ?? row.code_v2 ?? row.code_v1;
-        const code = mapCodeForExport(rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null);
+        const mapped = await this.mapCodeAndScoreForExport(
+          workspaceId,
+          rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null,
+          null,
+          this.toIntegerOrNull(row.missingsProfileId)
+        );
+        const code = mapped.code;
         if (code !== null) {
           d.codings.push({
             code,
@@ -912,7 +976,7 @@ export class CodingExportService {
           const coderName = row.username || `Job ${row.jobId}`;
           d.comments.push(`${coderName}: ${row.notes}`);
         }
-      });
+      }
 
       autoCoding.forEach(row => {
         const pid = parseInt(row.personId, 10);
@@ -1194,6 +1258,7 @@ export class CodingExportService {
         .addSelect('user.username', 'username')
         .addSelect('cj.id', 'jobId')
         .addSelect('cj.training_id', 'trainingId')
+        .addSelect('cj.missings_profile_id', 'missingsProfileId')
         .addSelect('cju.response_id', 'responseId')
         .where('person.id IN (:...ids)', { ids: batchPersonIds });
 
@@ -1258,7 +1323,7 @@ export class CodingExportService {
         codingIssueOption: number | null
       }>>>();
 
-      manualCoding.forEach(row => {
+      for (const row of manualCoding) {
         const pid = parseInt(row.personId, 10);
         const compositeKey = `${row.unitName}_${row.variableId}`;
         const coderName = row.username || `Job ${row.jobId}`;
@@ -1268,17 +1333,22 @@ export class CodingExportService {
         const coderMap = varMap.get(compositeKey)!;
 
         const rawCode = row.cju_code ?? row.code_v3 ?? row.code_v2 ?? row.code_v1;
-        const code = mapCodeForExport(rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null);
-        const score = row.cju_score ?? row.score_v3 ?? row.score_v2 ?? row.score_v1;
+        const rawScore = row.cju_score ?? row.score_v3 ?? row.score_v2 ?? row.score_v1;
+        const mapped = await this.mapCodeAndScoreForExport(
+          workspaceId,
+          rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null,
+          rawScore !== null && rawScore !== undefined ? parseInt(rawScore, 10) : null,
+          this.toIntegerOrNull(row.missingsProfileId)
+        );
         coderMap.set(coderName, {
-          code,
-          score: score !== null && score !== undefined ? parseInt(score, 10) : null,
+          code: mapped.code,
+          score: mapped.score,
           comment: row.notes,
           codingIssueOption: row.coding_issue_option !== null && row.coding_issue_option !== undefined ?
             parseInt(row.coding_issue_option, 10) :
             null
         });
-      });
+      }
 
       autoCoding.forEach(row => {
         const pid = parseInt(row.personId, 10);
@@ -1323,16 +1393,14 @@ export class CodingExportService {
               this.formatCodeWithIssueSuffix(data?.code ?? null, data?.codingIssueOption ?? null);
             row[`${displayName} Score`] = outputCommentsInsteadOfCodes ? '' : (data?.score ?? '');
             if (includeComments) row[`${displayName} Note`] = data?.comment ?? '';
-            const mappedCode = mapCodeForExport(data?.code ?? null);
-            if (mappedCode !== null && mappedCode !== undefined) codes.push(mappedCode);
+            if (data?.code !== null && data?.code !== undefined) codes.push(data.code);
             if (data?.comment) comments.push(`${displayName}: ${data.comment}`);
           });
 
           // Add AUTO if present
           if (coderDataMap?.has('AUTO')) {
             const data = coderDataMap.get('AUTO')!;
-            const mappedCode = mapCodeForExport(data.code);
-            if (mappedCode !== null && mappedCode !== undefined) codes.push(mappedCode);
+            if (data.code !== null && data.code !== undefined) codes.push(data.code);
           }
 
           if (includeModalValue && codes.length > 0) {
@@ -1603,6 +1671,7 @@ export class CodingExportService {
         .addSelect('user.username', 'username')
         .addSelect('cj.id', 'jobId')
         .addSelect('cj.training_id', 'trainingId')
+        .addSelect('cj.missings_profile_id', 'missingsProfileId')
         .addSelect('cju.response_id', 'responseId')
         .where('person.id IN (:...ids)', { ids: batchPersonIds });
 
@@ -1663,7 +1732,7 @@ export class CodingExportService {
         codingIssueOption: number | null
       }>>();
 
-      manualCoding.forEach(row => {
+      for (const row of manualCoding) {
         const pid = parseInt(row.personId, 10);
         const coderName = row.username || `Job ${row.jobId}`;
         const displayName = anonymizeCoders ? coderMapping.get(coderName)! : coderName;
@@ -1673,15 +1742,20 @@ export class CodingExportService {
         const dataMapForPerson = personData.get(pid)!;
 
         const rawCode = row.cju_code ?? row.code_v3 ?? row.code_v2 ?? row.code_v1;
-        const code = mapCodeForExport(rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null);
+        const mapped = await this.mapCodeAndScoreForExport(
+          workspaceId,
+          rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null,
+          null,
+          this.toIntegerOrNull(row.missingsProfileId)
+        );
         dataMapForPerson.set(columnKey, {
-          code,
+          code: mapped.code,
           comment: row.notes,
           codingIssueOption: row.coding_issue_option !== null && row.coding_issue_option !== undefined ?
             parseInt(row.coding_issue_option, 10) :
             null
         });
-      });
+      }
 
       autoCoding.forEach(row => {
         const pid = parseInt(row.personId, 10);
@@ -1712,8 +1786,7 @@ export class CodingExportService {
           row[col] = outputCommentsInsteadOfCodes ?
             data?.comment || '' :
             this.formatCodeWithIssueSuffix(data?.code ?? null, data?.codingIssueOption ?? null);
-          const mappedCode = mapCodeForExport(data?.code ?? null);
-          if (mappedCode !== null && mappedCode !== undefined) codes.push(mappedCode);
+          if (data?.code !== null && data?.code !== undefined) codes.push(data.code);
           if (data?.comment) {
             const coderName = col.split('_').pop();
             comments.push(`${coderName}: ${data.comment}`);
@@ -2011,6 +2084,7 @@ export class CodingExportService {
             .leftJoin('booklet.bookletinfo', 'bookletinfo')
             .innerJoin('booklet.person', 'person')
             .innerJoin('coding_job_unit', 'cju', 'cju.response_id = resp.id')
+            .innerJoin('cju.coding_job', 'cj')
             .select('resp.variableid', 'variableId')
             .addSelect('unit.name', 'unitName')
             .addSelect('cju.code', 'cju_code')
@@ -2020,6 +2094,7 @@ export class CodingExportService {
             .addSelect('cju.notes', 'notes')
             .addSelect('person.id', 'pId')
             .addSelect('bookletinfo.name', 'bookletName')
+            .addSelect('cj.missings_profile_id', 'missingsProfileId')
             .where('person.id IN (:...ids)', { ids: batchIds })
             .andWhere('cju.coding_job_id IN (:...jobIds)', { jobIds });
           applyResolvedExclusionsToQuery(responses, exclusions, {
@@ -2036,7 +2111,12 @@ export class CodingExportService {
             const pData = personDataMap.get(pid)!;
             const latest = getLatestCode(resp);
             const rawCode = resp.cju_code ?? latest.code;
-            const code = mapCodeForExport(rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null);
+            const mapped = await this.mapCodeAndScoreForExport(
+              workspaceId,
+              rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null,
+              null,
+              this.toIntegerOrNull(resp.missingsProfileId)
+            );
 
             if (!resp.unitName || !resp.variableId) {
               continue;
@@ -2047,7 +2127,7 @@ export class CodingExportService {
             }
 
             const variableKey = JSON.stringify([resp.unitName, resp.variableId]);
-            pData[variableKey] = outputCommentsInsteadOfCodes ? resp.notes || '' : code ?? '';
+            pData[variableKey] = outputCommentsInsteadOfCodes ? resp.notes || '' : mapped.code ?? '';
             pData[`_metadata_${variableKey}`] = {
               unitName: resp.unitName,
               variableId: resp.variableId,
@@ -2311,6 +2391,7 @@ export class CodingExportService {
           .addSelect('cju.notes', 'notes')
           .addSelect('person.id', 'pId')
           .addSelect('cj.training_id', 'trainingId')
+          .addSelect('cj.missings_profile_id', 'missingsProfileId')
           .addSelect('cju.response_id', 'responseId')
           .where('person.id IN (:...batchIds)', { batchIds })
           .andWhere('unit.name = :unitName', { unitName })
@@ -2352,9 +2433,14 @@ export class CodingExportService {
           if (d.username) {
             const latest = getLatestCode(d);
             const rawCode = d.cju_code ?? latest.code;
-            const code = mapCodeForExport(rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null);
+            const mapped = await this.mapCodeAndScoreForExport(
+              workspaceId,
+              rawCode !== null && rawCode !== undefined ? parseInt(rawCode, 10) : null,
+              null,
+              this.toIntegerOrNull(d.missingsProfileId)
+            );
             p.codings[d.username] = {
-              code,
+              code: mapped.code,
               notes: d.notes,
               status: d.status_v1,
               codingIssueOption: d.coding_issue_option !== null && d.coding_issue_option !== undefined ?
@@ -2398,11 +2484,8 @@ export class CodingExportService {
             row[dName] = outputCommentsInsteadOfCodes ?
               cData?.notes || '' :
               this.formatCodeWithIssueSuffix(cData?.code ?? null, cData?.codingIssueOption ?? null);
-            if (cData) {
-              const mappedCode = mapCodeForExport(cData.code);
-              if (mappedCode !== null && mappedCode !== undefined) {
-                codes.push(mappedCode);
-              }
+            if (cData?.code !== null && cData?.code !== undefined) {
+              codes.push(cData.code);
             }
           }
 
@@ -2609,6 +2692,7 @@ export class CodingExportService {
         .addSelect('cju.notes', 'notes')
         .addSelect('person.id', 'pId')
         .addSelect('cj.training_id', 'trainingId')
+        .addSelect('cj.missings_profile_id', 'missingsProfileId')
         .addSelect('cju.response_id', 'responseId')
         .where('person.workspace_id = :workspaceId', { workspaceId })
         .andWhere('person.consider = :consider', { consider: true })
@@ -2689,7 +2773,7 @@ export class CodingExportService {
           currentGroup = this.createCompactByVariableGroup(row, groupKey);
         }
 
-        this.addCompactCodingToGroup(currentGroup, row);
+        await this.addCompactCodingToGroup(currentGroup, row, workspaceId);
         this.addCompactDiscussionToGroup(currentGroup, row, discussionResultMap);
       }
 
@@ -2810,17 +2894,24 @@ export class CodingExportService {
     };
   }
 
-  private addCompactCodingToGroup(
+  private async addCompactCodingToGroup(
     group: CompactByVariableGroup,
-    row: CompactByVariableRawRow
-  ): void {
+    row: CompactByVariableRawRow,
+    workspaceId: number
+  ): Promise<void> {
     if (!row.username) return;
 
     const latest = getLatestCode(row as unknown as ResponseEntity);
     const rawCode = row.cju_code ?? latest.code;
     const parsedCode = this.toIntegerOrNull(rawCode);
+    const mapped = await this.mapCodeAndScoreForExport(
+      workspaceId,
+      parsedCode,
+      null,
+      this.toIntegerOrNull(row.missingsProfileId)
+    );
     const coding = {
-      code: mapCodeForExport(parsedCode),
+      code: mapped.code,
       notes: row.notes || null,
       codingIssueOption: this.toIntegerOrNull(row.coding_issue_option),
       updatedAt: row.updatedAt || null
@@ -2873,7 +2964,7 @@ export class CodingExportService {
     }
 
     const codes = codingEntries
-      .map(([, coding]) => mapCodeForExport(coding.code))
+      .map(([, coding]) => coding.code)
       .filter((code): code is number => code !== null && code !== undefined);
     const modal = includeModalValue ? calculateModalValue(codes) : null;
     const pseudoCoderMapping = anonymizeCoders && usePseudoCoders ?
@@ -3212,8 +3303,13 @@ export class CodingExportService {
           }
 
           const timestamp = unit.updated_at ? new Date(unit.updated_at).toLocaleString('de-DE').replace(',', '') : '';
-          const mappedCode = mapCodeForExport(unit.code);
-          const codeValue = mappedCode === null ? '' : mappedCode.toString();
+          const mapped = await this.mapCodeAndScoreForExport(
+            workspaceId,
+            unit.code,
+            null,
+            unit.coding_job?.missings_profile_id
+          );
+          const codeValue = mapped.code === null ? '' : mapped.code.toString();
 
           let commentValue = unit.notes || '';
           if (!outputCommentsInsteadOfCodes && unit.coding_issue_option) {

--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
@@ -31,6 +31,7 @@ import {
 } from '../../../../../../../api-dto/coding/coding-freshness.dto';
 import { CodingJobFreshnessStatus } from '../../../../../../../api-dto/coding/job-refresh.dto';
 import { statusStringToNumber } from '../../utils/response-status-converter';
+import { IQB_STANDARD_MISSING_CODES, MissingsProfilesService } from './missings-profiles.service';
 
 type UnitCodingPresence = Record<CodingFreshnessVersion, boolean>;
 
@@ -104,8 +105,23 @@ export class CodingFreshnessService {
     private readonly responseRepository: Repository<ResponseEntity>,
     private readonly connection: DataSource,
     @Optional()
-    private readonly workspaceExclusionService?: WorkspaceExclusionService
+    private readonly workspaceExclusionService?: WorkspaceExclusionService,
+    @Optional()
+    private readonly missingsProfilesService?: MissingsProfilesService
   ) { }
+
+  private async getDefaultMirCode(workspaceId: number): Promise<number> {
+    if (!this.missingsProfilesService) {
+      return IQB_STANDARD_MISSING_CODES.mir;
+    }
+
+    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+      workspaceId,
+      null,
+      'mir'
+    );
+    return missing.code;
+  }
 
   async getSummary(workspaceId: number): Promise<CodingFreshnessSummaryDto> {
     const query = this.freshnessRepository
@@ -1788,7 +1804,10 @@ export class CodingFreshnessService {
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
       .andWhere('response.status_v1 IN (:...manualSourceStatuses)', { manualSourceStatuses })
-      .andWhere('(response.code_v2 IS NULL OR (response.code_v2 != -111 AND response.code_v2 != -98))')
+      .andWhere(
+        '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+        { aggregatedCode: -111, defaultMirCode: await this.getDefaultMirCode(workspaceId) }
+      )
       .andWhere(new Brackets(qb => {
         qb.where('response.status_v2 IS NULL')
           .orWhere('response.status_v2 NOT IN (:...appliedStatuses)', { appliedStatuses })

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -45,7 +45,7 @@ import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspa
 import { CodingFreshnessService } from './coding-freshness.service';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
 import { CodingFileCacheService } from './coding-file-cache.service';
-import { MissingsProfilesService } from './missings-profiles.service';
+import { IQB_STANDARD_MISSING_CODES, MissingsProfilesService } from './missings-profiles.service';
 import {
   DERIVE_ERROR_STATUS,
   getDeriveErrorManualCodingPairKeys,
@@ -343,6 +343,19 @@ export class CodingJobService {
     }
 
     return profileId;
+  }
+
+  private async getDefaultMirCode(workspaceId: number): Promise<number> {
+    if (!this.missingsProfilesService) {
+      return IQB_STANDARD_MISSING_CODES.mir;
+    }
+
+    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+      workspaceId,
+      null,
+      'mir'
+    );
+    return missing.code;
   }
 
   private async codingJobHasCodingWork(codingJobId: number): Promise<boolean> {
@@ -2560,7 +2573,10 @@ export class CodingJobService {
     });
 
     queryBuilder.andWhere(`(${conditions.join(' OR ')})`, parameters);
-    queryBuilder.andWhere('(response.code_v2 IS NULL OR (response.code_v2 != -111 AND response.code_v2 != -98))');
+    queryBuilder.andWhere(
+      '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+      { aggregatedCode: -111, defaultMirCode: await this.getDefaultMirCode(workspaceId) }
+    );
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
@@ -3172,7 +3188,10 @@ export class CodingJobService {
       .innerJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('(response.code_v2 IS NULL OR (response.code_v2 != -111 AND response.code_v2 != -98))');
+      .andWhere(
+        '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+        { aggregatedCode: -111, defaultMirCode: await this.getDefaultMirCode(workspaceId) }
+      );
     this.applyManualCodingCandidateStatusFilter(queryBuilder, variables);
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     applyResolvedExclusionsToQuery(queryBuilder, exclusions);

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   Brackets, In, Repository
@@ -18,6 +18,7 @@ import {
   buildAggregationGroups,
   summarizeAggregationGroups
 } from './aggregation-metrics.util';
+import { IQB_STANDARD_MISSING_CODES, MissingsProfilesService } from './missings-profiles.service';
 import {
   getCoveredSourceKeysForManualDerivedVariables,
   isCoveredSourceVariable,
@@ -92,8 +93,23 @@ export class CodingProgressService {
     @InjectRepository(Setting)
     private settingRepository: Repository<Setting>,
     private workspaceFilesService: WorkspaceFilesService,
-    private workspaceExclusionService: WorkspaceExclusionService
+    private workspaceExclusionService: WorkspaceExclusionService,
+    @Optional()
+    private missingsProfilesService?: MissingsProfilesService
   ) { }
+
+  private async getDefaultMirCode(workspaceId: number): Promise<number> {
+    if (!this.missingsProfilesService) {
+      return IQB_STANDARD_MISSING_CODES.mir;
+    }
+
+    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+      workspaceId,
+      null,
+      'mir'
+    );
+    return missing.code;
+  }
 
   async getCodingProgressOverview(workspaceId: number): Promise<{
     totalCasesToCode: number;
@@ -444,7 +460,10 @@ export class CodingProgressService {
           });
       }));
     } else {
-      query.andWhere('(response.code_v2 IS NULL OR (response.code_v2 != -111 AND response.code_v2 != -98))');
+      query.andWhere(
+        '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+        { aggregatedCode: -111, defaultMirCode: await this.getDefaultMirCode(workspaceId) }
+      );
     }
 
     applyResolvedExclusionsToQuery(

--- a/apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts
@@ -32,6 +32,7 @@ type TestCodingJobUnit = {
   person_group?: string;
   coding_job?: {
     training_id?: number | null;
+    missings_profile_id?: number | null;
     codingJobCoders?: Array<{
       user?: {
         id?: number;
@@ -147,6 +148,7 @@ function createService(overrides: {
     ignoredBooklets: string[];
     testletIgnoredUnits: Array<{ bookletId: string; unitId: string }>;
   };
+  missingsProfilesService?: { getMissingByIdForProfileOrDefault: jest.Mock };
 } = {}) {
   const responseRepository: MockedRepo<ResponseEntity> = {
     createQueryBuilder: jest.fn()
@@ -189,7 +191,8 @@ function createService(overrides: {
     codingJobUnitRepository as unknown as Repository<CodingJobUnit>,
     codingListService,
     {} as WorkspaceCoreService,
-    workspaceExclusionService
+    workspaceExclusionService,
+    overrides.missingsProfilesService as never
   );
 
   return {
@@ -245,6 +248,29 @@ describe('CodingResultsExportService', () => {
     expect(csv).toContain('"0";""');
     expect(csv).toContain('"zero-code note"');
     expect(csv).not.toContain('skipped');
+  });
+
+  it('does not resolve manual missing profiles for regular detailed export codes', async () => {
+    const missingsProfilesService = {
+      getMissingByIdForProfileOrDefault: jest.fn().mockRejectedValue(new Error('unexpected missing lookup'))
+    };
+    const { service } = createService({
+      missingsProfilesService,
+      codingJobUnits: [{
+        ...baseUnit,
+        code: 7,
+        score: 2,
+        coding_job: {
+          ...baseUnit.coding_job,
+          missings_profile_id: 77
+        }
+      }]
+    });
+
+    const csv = (await service.exportCodingResultsDetailed(1)).toString('utf-8');
+
+    expect(csv).toContain('"7";"Code-Vergabe unsicher"');
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault).not.toHaveBeenCalled();
   });
 
   it('uses comments, replay URLs and pseudo coder names when requested', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-results-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results-export.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Readable } from 'stream';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
@@ -21,6 +21,7 @@ import {
   isExcludedByResolvedExclusions,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
+import { MissingsProfilesService, ResolvedMissingValue } from './missings-profiles.service';
 
 @Injectable()
 export class CodingResultsExportService {
@@ -40,8 +41,63 @@ export class CodingResultsExportService {
     private codingJobUnitRepository: Repository<CodingJobUnit>,
     private codingListService: CodingListService,
     private workspaceCoreService: WorkspaceCoreService,
-    private workspaceExclusionService: WorkspaceExclusionService
+    private workspaceExclusionService: WorkspaceExclusionService,
+    @Optional()
+    private missingsProfilesService?: MissingsProfilesService
   ) { }
+
+  private readonly manualMissingExportValueCache = new Map<string, ResolvedMissingValue>();
+
+  private async getManualMissingExportValue(
+    workspaceId: number,
+    code: number | null | undefined,
+    profileId?: number | null
+  ): Promise<ResolvedMissingValue | null> {
+    let missingId: 'mir' | 'mci' | null = null;
+    if (code === -3) {
+      missingId = 'mir';
+    }
+    if (code === -4) {
+      missingId = 'mci';
+    }
+    if (!missingId || !this.missingsProfilesService) {
+      return null;
+    }
+
+    const cacheKey = `${workspaceId}:${profileId ?? 'default'}:${missingId}`;
+    const cached = this.manualMissingExportValueCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+      workspaceId,
+      profileId,
+      missingId
+    );
+    this.manualMissingExportValueCache.set(cacheKey, missing);
+    return missing;
+  }
+
+  private async mapCodeAndScoreForExport(
+    workspaceId: number,
+    code: number | null | undefined,
+    score: number | null | undefined,
+    profileId?: number | null
+  ): Promise<{ code: number | null; score: number | null }> {
+    const manualMissing = await this.getManualMissingExportValue(workspaceId, code, profileId);
+    if (manualMissing) {
+      return {
+        code: manualMissing.code,
+        score: manualMissing.score
+      };
+    }
+
+    return {
+      code: mapCodeForExport(code),
+      score: score ?? null
+    };
+  }
 
   private async getExclusionChecker(workspaceId: number): Promise<(bookletName: string, unitName: string) => boolean> {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
@@ -284,7 +340,13 @@ export class CodingResultsExportService {
         const compositeVariableKey = `${unitName}_${variableId}`;
 
         const rawCode = unit.code ?? unit.response?.code_v3 ?? unit.response?.code_v2 ?? unit.response?.code_v1 ?? null;
-        const code = mapCodeForExport(rawCode);
+        const mapped = await this.mapCodeAndScoreForExport(
+          workspaceId,
+          rawCode,
+          null,
+          unit.coding_job?.missings_profile_id
+        );
+        const code = mapped.code;
         const comment = unit.notes || null;
 
         if (!testPersonVariableCodes.has(testPersonKey)) {
@@ -604,13 +666,18 @@ export class CodingResultsExportService {
         }
 
         const rawCode = unit.code ?? unit.response?.code_v3 ?? unit.response?.code_v2 ?? unit.response?.code_v1 ?? null;
-        const code = mapCodeForExport(rawCode);
-        const score = unit.response?.score_v3 ?? unit.response?.score_v2 ?? unit.response?.score_v1 ?? null;
+        const rawScore = unit.score ?? unit.response?.score_v3 ?? unit.response?.score_v2 ?? unit.response?.score_v1 ?? null;
+        const mapped = await this.mapCodeAndScoreForExport(
+          workspaceId,
+          rawCode,
+          rawScore,
+          unit.coding_job?.missings_profile_id
+        );
         const comment = unit.notes || null;
 
         dataMap.get(rowKey)!.set(coderName, {
-          code,
-          score,
+          code: mapped.code,
+          score: mapped.score,
           comment,
           codingIssueOption: unit.coding_issue_option ?? null
         });
@@ -921,13 +988,18 @@ export class CodingResultsExportService {
         }
 
         const rawCode = unit.code ?? unit.response?.code_v3 ?? unit.response?.code_v2 ?? unit.response?.code_v1 ?? null;
-        const code = mapCodeForExport(rawCode);
-        const score = unit.response?.score_v3 ?? unit.response?.score_v2 ?? unit.response?.score_v1 ?? null;
+        const rawScore = unit.score ?? unit.response?.score_v3 ?? unit.response?.score_v2 ?? unit.response?.score_v1 ?? null;
+        const mapped = await this.mapCodeAndScoreForExport(
+          workspaceId,
+          rawCode,
+          rawScore,
+          unit.coding_job?.missings_profile_id
+        );
         const comment = unit.notes || null;
 
         dataMap.get(testPersonKey)!.set(columnKey, {
-          code,
-          score,
+          code: mapped.code,
+          score: mapped.score,
           comment,
           codingIssueOption: unit.coding_issue_option ?? null
         });
@@ -1838,8 +1910,13 @@ export class CodingResultsExportService {
             commentValue = this.getCodingIssueText(unit.coding_issue_option) || commentValue;
           }
 
-          const mappedCode = mapCodeForExport(unit.code);
-          const codeValue = mappedCode === null ? '' : mappedCode.toString();
+          const mapped = await this.mapCodeAndScoreForExport(
+            workspaceId,
+            unit.code,
+            null,
+            unit.coding_job?.missings_profile_id
+          );
+          const codeValue = mapped.code === null ? '' : mapped.code.toString();
           const codeIssueValue = this.getCodingIssueText(unit.coding_issue_option);
 
           const rowFields = [

--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -328,6 +328,75 @@ describe('CodingReviewService', () => {
     expect(singleCoderSubQuery.having).toHaveBeenCalledWith('COUNT(DISTINCT single_cjc.user_id) = 1');
   });
 
+  it('resolves manual missing issue codes through the coding job profile for review results', async () => {
+    const missingsProfilesService = {
+      getMissingByIdForProfileOrDefault: jest.fn()
+        .mockImplementation(async (_workspaceId: number, _profileId: number | null, missingId: string) => (
+          missingId === 'mir' ?
+            {
+              id: 'mir', label: 'Missing interpreted response', code: -123, score: 0
+            } :
+            {
+              id: 'mci', label: 'Missing coding impossible', code: -124, score: 0
+            }
+        ))
+    };
+    service = new CodingReviewService(
+      {} as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      {} as never,
+      {
+        resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
+      } as never,
+      missingsProfilesService as never
+    );
+
+    codingJobUnitRepository.find.mockResolvedValueOnce([
+      makeCodingJobUnit({
+        code: -3,
+        score: null,
+        coding_job: {
+          workspace_id: workspaceId,
+          missings_profile_id: 77,
+          job_definition_id: 11,
+          training_id: null,
+          name: 'Job A',
+          codingJobCoders: [{
+            user_id: 1,
+            user: { username: 'Coder 1' }
+          }]
+        }
+      }),
+      makeCodingJobUnit({
+        coding_job_id: 101,
+        code: -4,
+        score: null,
+        coding_job: {
+          workspace_id: workspaceId,
+          missings_profile_id: 77,
+          job_definition_id: 11,
+          training_id: null,
+          name: 'Job B',
+          codingJobCoders: [{
+            user_id: 2,
+            user: { username: 'Coder 2' }
+          }]
+        }
+      })
+    ]);
+
+    const result = await service.getDoubleCodedVariablesForReview(workspaceId);
+
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault).toHaveBeenCalledWith(workspaceId, 77, 'mir');
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault).toHaveBeenCalledWith(workspaceId, 77, 'mci');
+    expect(result.data[0].coderResults).toMatchObject([
+      { coderId: 1, code: -123, score: 0 },
+      { coderId: 2, code: -124, score: 0 }
+    ]);
+  });
+
   it('applies the match agreement filter', async () => {
     await service.getDoubleCodedVariablesForReview(
       workspaceId,

--- a/apps/backend/src/app/database/services/coding/coding-review.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, In, Repository } from 'typeorm';
 import { statusStringToNumber } from '../../utils/response-status-converter';
@@ -13,6 +13,7 @@ import {
   isExcludedByResolvedExclusions,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
+import { MissingsProfilesService, ResolvedMissingValue } from './missings-profiles.service';
 
 type JobDefinitionBundleScope = {
   bundleIds: number[];
@@ -58,6 +59,10 @@ type KappaCodedVariableRow = {
 @Injectable()
 export class CodingReviewService {
   private readonly logger = new Logger(CodingReviewService.name);
+  private readonly manualMissingIdsByIssueOptionId = new Map<number, string>([
+    [-3, 'mir'],
+    [-4, 'mci']
+  ]);
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -69,8 +74,42 @@ export class CodingReviewService {
     @InjectRepository(VariableBundle)
     private variableBundleRepository: Repository<VariableBundle>,
     private codingStatisticsService: CodingStatisticsService,
-    private workspaceExclusionService: WorkspaceExclusionService
+    private workspaceExclusionService: WorkspaceExclusionService,
+    @Optional()
+    private missingsProfilesService?: MissingsProfilesService
   ) { }
+
+  private async resolveManualMissingForReview(
+    workspaceId: number,
+    unit: CodingJobUnit,
+    cache: Map<string, ResolvedMissingValue>
+  ): Promise<{ code: number | null; score: number | null }> {
+    const missingId = this.manualMissingIdsByIssueOptionId.get(unit.code ?? 0) ??
+      this.manualMissingIdsByIssueOptionId.get(unit.coding_issue_option ?? 0);
+    if (!missingId || !this.missingsProfilesService) {
+      return {
+        code: unit.code,
+        score: unit.score
+      };
+    }
+
+    const profileId = unit.coding_job?.missings_profile_id ?? null;
+    const cacheKey = `${profileId ?? 'default'}:${missingId}`;
+    let missing = cache.get(cacheKey);
+    if (!missing) {
+      missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+        workspaceId,
+        profileId,
+        missingId
+      );
+      cache.set(cacheKey, missing);
+    }
+
+    return {
+      code: missing.code,
+      score: missing.score
+    };
+  }
 
   async getDoubleCodedVariablesForReview(
     workspaceId: number,
@@ -398,6 +437,7 @@ export class CodingReviewService {
       }
       >();
       const coderResultIndexByResponseId = new Map<number, Map<number, number>>();
+      const manualMissingCache = new Map<string, ResolvedMissingValue>();
 
       for (const unit of finalCodingJobUnits) {
         const responseId = unit.response_id;
@@ -422,6 +462,11 @@ export class CodingReviewService {
 
         const coder = this.getDistinctCodingJobCoders(unit.coding_job?.codingJobCoders || [])[0];
         if (coder) {
+          const resolvedCodeAndScore = await this.resolveManualMissingForReview(
+            workspaceId,
+            unit,
+            manualMissingCache
+          );
           const coderResult = {
             coderId: coder.user_id,
             coderName: coder.user?.username || `Coder ${coder.user_id}`,
@@ -430,8 +475,8 @@ export class CodingReviewService {
             jobDefinitionId: unit.coding_job?.job_definition_id ?? null,
             trainingId: unit.coding_job?.training_id ?? null,
             trainingLabel: unit.coding_job?.training?.label ?? null,
-            code: unit.code,
-            score: unit.score,
+            code: resolvedCodeAndScore.code,
+            score: resolvedCodeAndScore.score,
             notes: unit.notes,
             supervisorComment: unit.supervisor_comment || null,
             codedAt: unit.created_at

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -950,7 +950,7 @@ export class CodingValidationService {
         .where('response.status_v1 = :status', { status })
         .andWhere('person.workspace_id = :workspace_id', { workspace_id: workspaceId })
         .andWhere('person.consider = :consider', { consider: true })
-        // Exclude special/auto codes (any negative code_v2, e.g. -111 for duplicates, -98 for empty)
+        // Exclude special/auto codes represented as negative code_v2 values.
         .andWhere('(response.code_v2 IS NULL OR response.code_v2 >= 0)')
         .groupBy('unit.name')
         .addGroupBy('response.variableid');

--- a/apps/backend/src/app/database/services/coding/missings-profiles.service.ts
+++ b/apps/backend/src/app/database/services/coding/missings-profiles.service.ts
@@ -13,16 +13,28 @@ export interface ResolvedMissingValue {
   score: number;
 }
 
+export type IqbStandardMissingId = 'mci' | 'mir' | 'mbi_mbo';
+
+export const IQB_STANDARD_MISSING_CODES: Record<IqbStandardMissingId, number> = {
+  mci: -97,
+  mir: -98,
+  mbi_mbo: -99
+};
+
+export const IQB_STANDARD_MISSING_SCORES: Record<IqbStandardMissingId, number> = {
+  mci: 0,
+  mir: 0,
+  mbi_mbo: 0
+};
+
 @Injectable()
 export class MissingsProfilesService {
   private readonly logger = new Logger(MissingsProfilesService.name);
 
   private readonly defaultProfileLabel = 'IQB-Standard';
-  private readonly iqbStandardMissingScores = new Map<string, number>([
-    ['mci', 0],
-    ['mir', 0],
-    ['mbi_mbo', 0]
-  ]);
+  private readonly iqbStandardMissingScores = new Map<string, number>(
+    Object.entries(IQB_STANDARD_MISSING_SCORES)
+  );
 
   constructor(
     @InjectRepository(MissingsProfile)
@@ -232,22 +244,22 @@ export class MissingsProfilesService {
         id: 'mci',
         label: 'missing coding impossible',
         description: '(1) Item müsste/könnte bearbeitet worden sein, aber (2) Antwort ist aufgrund technischer Probleme (z.B. Scanfehler) nicht auswertbar.',
-        code: -97,
-        score: 0
+        code: IQB_STANDARD_MISSING_CODES.mci,
+        score: IQB_STANDARD_MISSING_SCORES.mci
       },
       {
         id: 'mir',
         label: 'missing invalid response',
         description: '(1) Item wurde bearbeitet, aber (2a) leere Antwort oder (2b) ungültige (Spaß-)Antwort. Das Item wurde zwar bearbeitet, aber es wurde seitens der Testperson kein ernsthafter Lösungsversuch unternommen. Beispiel: Antworten wie "kein Plan", "egal", oder eine gemalte Sonne.',
-        code: -98,
-        score: 0
+        code: IQB_STANDARD_MISSING_CODES.mir,
+        score: IQB_STANDARD_MISSING_SCORES.mir
       },
       {
         id: 'mbi_mbo',
         label: 'mbi / mbo',
         description: 'Item wurde nicht bearbeitet aber gesehen oder Item wurde nicht gesehen, aber es gibt nachfolgend gesehene oder bearbeitete Items.',
-        code: -99,
-        score: 0
+        code: IQB_STANDARD_MISSING_CODES.mbi_mbo,
+        score: IQB_STANDARD_MISSING_SCORES.mbi_mbo
       }
     ]);
 

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
@@ -1,5 +1,5 @@
 import { Processor, Process } from '@nestjs/bull';
-import { Logger } from '@nestjs/common';
+import { Logger, Optional } from '@nestjs/common';
 import { Job } from 'bull';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Brackets } from 'typeorm';
@@ -25,6 +25,10 @@ import {
   normalizeAggregationValue
 } from '../../database/services/coding/aggregation-metrics.util';
 import { getCodingAnalysisRunMarkerKey } from '../../database/services/coding/coding-analysis-cache-key.util';
+import {
+  IQB_STANDARD_MISSING_CODES,
+  MissingsProfilesService
+} from '../../database/services/coding/missings-profiles.service';
 
 @Processor('response-analysis')
 export class CodingAnalysisProcessor {
@@ -35,8 +39,23 @@ export class CodingAnalysisProcessor {
     private responseRepository: Repository<ResponseEntity>,
     private cacheService: CacheService,
     private workspaceExclusionService: WorkspaceExclusionService,
-    private workspaceFilesService: WorkspaceFilesService
+    private workspaceFilesService: WorkspaceFilesService,
+    @Optional()
+    private missingsProfilesService?: MissingsProfilesService
   ) { }
+
+  private async getDefaultMirCode(workspaceId: number): Promise<number> {
+    if (!this.missingsProfilesService) {
+      return IQB_STANDARD_MISSING_CODES.mir;
+    }
+
+    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+      workspaceId,
+      null,
+      'mir'
+    );
+    return missing.code;
+  }
 
   @Process()
   async handleResponseAnalysis(job: Job<CodingAnalysisJobData>) {
@@ -78,6 +97,7 @@ export class CodingAnalysisProcessor {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
     const derivedVariableMap = await this.getDerivedVariableMap(workspaceId);
 
     // 1. Identify relevant Unit+Variable combinations
@@ -139,7 +159,7 @@ export class CodingAnalysisProcessor {
         // Exclude already-aggregated responses (non-master duplicates) so they don't reappear after aggregation
         .andWhere(
           '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :emptyCode))',
-          { aggregatedCode: -111, emptyCode: -98 }
+          { aggregatedCode: -111, emptyCode: defaultMirCode }
         );
       applyResolvedExclusionsToQuery(qb, exclusions);
 

--- a/apps/backend/src/app/utils/coding-utils.spec.ts
+++ b/apps/backend/src/app/utils/coding-utils.spec.ts
@@ -5,9 +5,11 @@ describe('coding utils', () => {
     expect(mapCodeForExport(-111)).toBeNull();
   });
 
-  it('keeps existing special export mappings', () => {
-    expect(mapCodeForExport(-3)).toBe(-98);
-    expect(mapCodeForExport(-4)).toBe(-97);
+  it('maps manual missing issue options only with profile context', () => {
+    expect(mapCodeForExport(-3)).toBeNull();
+    expect(mapCodeForExport(-4)).toBeNull();
+    expect(mapCodeForExport(-3, { mirCode: -123, mciCode: -124 })).toBe(-123);
+    expect(mapCodeForExport(-4, { mirCode: -123, mciCode: -124 })).toBe(-124);
     expect(mapCodeForExport(-1)).toBeNull();
     expect(mapCodeForExport(7)).toBe(7);
   });

--- a/apps/backend/src/app/utils/coding-utils.ts
+++ b/apps/backend/src/app/utils/coding-utils.ts
@@ -102,19 +102,27 @@ export function getLatestCode(response: ResponseEntity): { code: number | null; 
   return { code: response.code_v1, score: response.score_v1, version: 'v1' };
 }
 
+export interface ManualMissingCodeMapping {
+  mirCode?: number | null;
+  mciCode?: number | null;
+}
+
 /**
  * Maps internal code values to export representation.
  *
  * Rules:
- * -3 -> -98
- * -4 -> -97
+ * -3 -> profile-specific MIR code when provided
+ * -4 -> profile-specific MCI code when provided
  * -1/-2 -> empty (null)
  * -111 -> empty (legacy duplicate-aggregation marker)
  */
-export function mapCodeForExport(code: number | null | undefined): number | null {
+export function mapCodeForExport(
+  code: number | null | undefined,
+  manualMissingCodes?: ManualMissingCodeMapping
+): number | null {
   if (code === null || code === undefined) return null;
-  if (code === -3) return -98;
-  if (code === -4) return -97;
+  if (code === -3) return manualMissingCodes?.mirCode ?? null;
+  if (code === -4) return manualMissingCodes?.mciCode ?? null;
   if (code === -1 || code === -2 || code === -111) return null;
   return code;
 }

--- a/apps/frontend/src/app/coding/components/coding-management-manual/apply-empty-coding-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/apply-empty-coding-dialog.component.ts
@@ -7,6 +7,8 @@ import { TranslateModule } from '@ngx-translate/core';
 
 export interface ApplyEmptyCodingDialogData {
   count: number;
+  code: number;
+  score: number;
 }
 
 @Component({
@@ -31,8 +33,8 @@ export interface ApplyEmptyCodingDialogData {
         <p><strong>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.apply-header' | translate }}</strong></p>
         <ul>
           <li>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.status' | translate }}: <strong>CODING_COMPLETE</strong></li>
-          <li>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.code' | translate }}: <strong>-98</strong></li>
-          <li>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.score' | translate }}: <strong>0</strong></li>
+          <li>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.code' | translate }}: <strong>{{ data.code }}</strong></li>
+          <li>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.score' | translate }}: <strong>{{ data.score }}</strong></li>
         </ul>
       </div>
     </mat-dialog-content>

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -428,8 +428,8 @@
                 </mat-paginator>
                 <div class="analysis-actions">
                   <button mat-stroked-button color="primary" (click)="onApplyEmptyResponseCoding()"
-                    [disabled]="isApplyingEmptyCoding || responseAnalysis.isCalculating || !hasUncodedEmptyResponses()"
-                    [matTooltip]="'coding-management-manual.response-analysis.apply-empty-coding-tooltip' | translate">
+                    [disabled]="isApplyingEmptyCoding || responseAnalysis.isCalculating || !hasUncodedEmptyResponses() || !emptyResponseMissing"
+                    [matTooltip]="getApplyEmptyResponseCodingTooltip()">
                     <mat-icon *ngIf="!isApplyingEmptyCoding">flash_on</mat-icon>
                     <mat-spinner *ngIf="isApplyingEmptyCoding" diameter="20"></mat-spinner>
                     {{ 'coding-management-manual.response-analysis.apply-empty-coding-button' | translate }}

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -69,6 +69,7 @@ import {
   CodingJobBackendService,
   ManualCodingScopeSummary
 } from '../../services/coding-job-backend.service';
+import { MissingsProfileService } from '../../services/missings-profile.service';
 import { CodingStatisticsService } from '../../services/coding-statistics.service';
 import {
   ValidationProgress,
@@ -86,6 +87,7 @@ import {
 import type {
   ManualCodeAvailabilityWarningDto
 } from '../../../../../../../api-dto/coding/manual-code-availability.dto';
+import { MissingsProfilesDto } from '../../../../../../../api-dto/coding/missings-profiles.dto';
 import {
   CODING_FRESHNESS_TASK_RESULT_HELP,
   formatCodingFreshnessResponseCount,
@@ -155,6 +157,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private testPersonCodingService = inject(TestPersonCodingService);
   private codingJobBackendService = inject(CodingJobBackendService);
+  private missingsProfileService = inject(MissingsProfileService);
   private statisticsService = inject(CodingStatisticsService);
   private appService = inject(AppService);
   private snackBar = inject(MatSnackBar);
@@ -309,6 +312,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   isApplyingCodingResults = false;
 
   private applyingCodingResultJobIds = new Set<number>();
+  emptyResponseMissing: { code: number; score: number } | null = null;
 
   showCoderTraining = false;
   editTraining: CoderTraining | null = null;
@@ -1684,6 +1688,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
+    this.loadDefaultEmptyResponseMissing(workspaceId);
     this.isLoadingMatchingMode = true;
     this.isLoadingResponseAnalysis = true;
 
@@ -1711,6 +1716,65 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.loadResponseAnalysis();
         }
       });
+  }
+
+  private loadDefaultEmptyResponseMissing(workspaceId: number): void {
+    this.emptyResponseMissing = null;
+    this.missingsProfileService
+      .getMissingsProfileDetails(workspaceId, 'IQB-Standard')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: profile => {
+          if (this.appService.selectedWorkspaceId !== workspaceId) {
+            return;
+          }
+
+          const missing = this.toMissingProfileDto(profile)?.parseMissings()
+            .find(entry => entry.id === 'mir');
+          if (!missing || !Number.isInteger(Number(missing.code)) || !this.hasExplicitFiniteScore(missing.score)) {
+            this.emptyResponseMissing = null;
+            return;
+          }
+
+          this.emptyResponseMissing = {
+            code: Number(missing.code),
+            score: Number(missing.score)
+          };
+        },
+        error: () => {
+          this.emptyResponseMissing = null;
+        }
+      });
+  }
+
+  private toMissingProfileDto(profile: MissingsProfilesDto | null): MissingsProfilesDto | null {
+    return profile ? Object.assign(new MissingsProfilesDto(), profile) : null;
+  }
+
+  private hasExplicitFiniteScore(score: unknown): boolean {
+    if (typeof score === 'number') {
+      return Number.isFinite(score);
+    }
+
+    if (typeof score === 'string') {
+      const trimmedScore = score.trim();
+      return trimmedScore !== '' && Number.isFinite(Number(trimmedScore));
+    }
+
+    return false;
+  }
+
+  getApplyEmptyResponseCodingTooltip(): string {
+    if (!this.emptyResponseMissing) {
+      return this.translateService.instant(
+        'coding-management-manual.response-analysis.apply-empty-coding-tooltip-loading'
+      );
+    }
+
+    return this.translateService.instant(
+      'coding-management-manual.response-analysis.apply-empty-coding-tooltip',
+      this.emptyResponseMissing
+    );
   }
 
   private loadCodingFreshness(): void {
@@ -2577,7 +2641,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   onApplyEmptyResponseCoding(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
-    if (!workspaceId || !this.responseAnalysis) {
+    if (!workspaceId || !this.responseAnalysis || !this.emptyResponseMissing) {
       return;
     }
 
@@ -2586,10 +2650,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
+    const emptyResponseMissing = this.emptyResponseMissing;
+
     // Show Material Dialog confirmation
     const dialogRef = this.dialog.open(ApplyEmptyCodingDialogComponent, {
       width: '550px',
-      data: { count: uncodedCount }
+      data: {
+        count: uncodedCount,
+        code: emptyResponseMissing.code,
+        score: emptyResponseMissing.score
+      }
     });
 
     dialogRef.afterClosed().pipe(takeUntil(this.destroy$)).subscribe((confirmed: unknown) => {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -817,12 +817,6 @@ export class CodingResultsComparisonComponent implements OnInit {
     );
   }
 
-  /**
-   * Maps auto-coder codes for display in the coding manager UI.
-   * - Code -4 (technical problems) → -97
-   * - Code -3 (invalid/fun response) → -98
-   * - Codes -1 and -2 → null (empty)
-   */
   mapCodeForDisplay(code: string | number | null | undefined): string {
     if (code === null || code === undefined || code === '') {
       return '';
@@ -831,12 +825,6 @@ export class CodingResultsComparisonComponent implements OnInit {
     if (Number.isNaN(codeNum)) {
       return String(code);
     }
-    if (codeNum === -4) {
-      return '-97';
-    }
-    if (codeNum === -3) {
-      return '-98';
-    }
     if (codeNum === -1 || codeNum === -2) {
       return '';
     }
@@ -844,11 +832,6 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   private getDiscussionScoreFromKnownCodes(comparison: WithinTrainingComparison, codeAsNumber: number): number | null {
-    // Handle mapped codes: -97 (from -4) and -98 (from -3) should have score 0
-    if (codeAsNumber === -97 || codeAsNumber === -98) {
-      return 0;
-    }
-
     const matchedCoder = comparison.coders.find(c => c.code !== null && parseInt(c.code, 10) === codeAsNumber && c.score !== null);
     if (matchedCoder) {
       return matchedCoder.score;

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -994,10 +994,6 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       case -1:
       case -2:
         return '';
-      case -3:
-        return '-98';
-      case -4:
-        return '-97';
       default:
         return code.toString();
     }

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1810,7 +1810,8 @@
         "status": "Status"
       },
       "apply-empty-coding-button": "Kodierung automatisch anwenden",
-      "apply-empty-coding-tooltip": "Kodiert alle leeren Antworten CODING_COMPLETE, Code -98 und Score 0",
+      "apply-empty-coding-tooltip": "Kodiert alle leeren Antworten CODING_COMPLETE, Code {{code}} und Score {{score}}",
+      "apply-empty-coding-tooltip-loading": "IQB-Standard-Missingwert wird geladen",
       "apply-empty-coding-confirm-message": "Möchten Sie die automatische Kodierung für {{count}} leere Unit-Antworten anwenden?",
       "apply-empty-coding-success": "{{count}} leere Antworten wurden erfolgreich kodiert.",
       "apply-empty-coding-error": "Fehler beim Kodieren der leeren Antworten: {{error}}",


### PR DESCRIPTION
## Summary
- set IQB-Standard scores for `mci`, `mir`, and `mbi_mbo` to `0` and reuse those defaults consistently
- resolve manual missing codes through the active/default missing profile in apply, review, progress, analysis, and export paths
- show the resolved empty-response code/score in the manual coding UI and avoid stale values while loading

## Validation
- `npx nx lint backend`
- `npx nx lint frontend`
- `npx nx test backend --runInBand --testFile=apps/backend/src/app/database/services/coding/coding-export.service.spec.ts`
- `npx nx test backend --runInBand --testFile=apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts`
- `npx nx test backend --runInBand --testFile=apps/backend/src/app/database/services/coding/coding-review.service.spec.ts`
- `npx nx test backend --runInBand --testFile=apps/backend/src/app/utils/coding-utils.spec.ts`

Related to #615.
