### PR TITLE
Add progress feedback for Testcenter test group loading

### DIFF
--- a/api-dto/files/test-groups-load-progress.dto.ts
+++ b/api-dto/files/test-groups-load-progress.dto.ts
@@ -1,0 +1,24 @@
+export type TestGroupsLoadStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'unknown';
+
+export type TestGroupsLoadPhase =
+  | 'fetching-testcenter-groups'
+  | 'checking-workspace-groups'
+  | 'checking-booklet-logs'
+  | 'annotating-groups';
+
+export interface TestGroupsLoadProgressDto {
+  importRunId: string;
+  status: TestGroupsLoadStatus;
+  phase?: TestGroupsLoadPhase;
+  totalGroups: number;
+  processedGroups: number;
+  existingGroups: number;
+  groupsWithLogs: number;
+  message?: string;
+  error?: string;
+  updatedAt: number;
+}

--- a/apps/backend/src/app/admin/workspace/workspace-test-center.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-test-center.controller.ts
@@ -18,6 +18,7 @@ import { WorkspaceGuard } from './workspace.guard';
 import { TestGroupsInfoDto } from '../../../../../../api-dto/files/test-groups-info.dto';
 import { ImportOptionsDto as ImportOptions } from '../../../../../../api-dto/files/import-options.dto';
 import { ImportWorkspaceFilesProgressDto } from '../../../../../../api-dto/files/import-workspace-progress.dto';
+import { TestGroupsLoadProgressDto } from '../../../../../../api-dto/files/test-groups-load-progress.dto';
 
 import { CacheService } from '../../cache/cache.service';
 import { JobQueueService } from '../../job-queue/job-queue.service';
@@ -238,6 +239,34 @@ export class WorkspaceTestCenterController {
     );
   }
 
+  @Get(':workspace_id/importWorkspaceFiles/testGroups/progress')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiOperation({
+    summary: 'Get running test group load progress',
+    description:
+      'Returns live progress for retrieving and annotating test groups from a test center.'
+  })
+  @ApiParam({
+    name: 'workspace_id',
+    required: true,
+    description: 'ID of the workspace'
+  })
+  @ApiQuery({
+    name: 'importRunId',
+    required: true,
+    description: 'Run id used when starting test group retrieval'
+  })
+  @ApiOkResponse({ type: Object })
+  async getImportTestcenterGroupsProgress(
+    @Param('workspace_id') workspace_id: string,
+      @Query('importRunId') importRunId: string
+  ): Promise<TestGroupsLoadProgressDto> {
+    return this.testCenterService.getTestGroupsLoadProgress(
+      workspace_id,
+      importRunId
+    );
+  }
+
   @Get(':workspace_id/importWorkspaceFiles/testGroups')
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   @ApiOperation({
@@ -265,6 +294,11 @@ export class WorkspaceTestCenterController {
     required: true,
     description: 'Authentication token'
   })
+  @ApiQuery({
+    name: 'importRunId',
+    required: false,
+    description: 'Optional run id to provide progress while loading test groups'
+  })
   @ApiOkResponse({
     description: 'Test groups retrieved successfully',
     type: [TestGroupsInfoDto]
@@ -275,7 +309,8 @@ export class WorkspaceTestCenterController {
       @Query('server') server: string,
       @Query('url') url: string,
       @Query('tc_workspace') tc_workspace: string,
-      @Query('token') token: string
+      @Query('token') token: string,
+      @Query('importRunId') importRunId: string
   ): Promise<TestGroupsInfoDto[]> {
     try {
       return await this.testCenterService.getTestgroups(
@@ -283,7 +318,8 @@ export class WorkspaceTestCenterController {
         tc_workspace,
         server,
         decodeURIComponent(url),
-        token
+        token,
+        importRunId
       );
     } catch (error) {
       throw new BadRequestException(

--- a/apps/backend/src/app/database/services/test-results/person-query.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/person-query.service.spec.ts
@@ -259,32 +259,50 @@ describe('PersonQueryService', () => {
         { group: 'Group B' },
         { group: 'Group C' }
       ]);
-
-      (personsRepository.createQueryBuilder as jest.Mock).mockReturnValue(groupsQb);
-
-      const logsQbA = mockQueryBuilder();
-      logsQbA.getCount.mockResolvedValue(2);
-      const logsQbB = mockQueryBuilder();
-      logsQbB.getCount.mockResolvedValue(0);
-      const logsQbC = mockQueryBuilder();
-      logsQbC.getCount.mockResolvedValue(5);
-
+      const logsQb = mockQueryBuilder();
+      logsQb.getRawMany.mockResolvedValue([
+        { group: 'Group A', logCount: '2' },
+        { group: 'Group C', logCount: '5' }
+      ]);
+      (personsRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(groupsQb);
       (bookletLogRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(logsQbA)
-        .mockReturnValueOnce(logsQbB)
-        .mockReturnValueOnce(logsQbC);
+        .mockReturnValue(logsQb);
 
       const result = await service.getGroupsWithBookletLogs(1);
 
       expect(result.get('Group A')).toBe(true);
       expect(result.get('Group B')).toBe(false);
       expect(result.get('Group C')).toBe(true);
+      expect(bookletLogRepository.createQueryBuilder)
+        .toHaveBeenCalledWith('bookletlog');
+      expect(logsQb.groupBy).toHaveBeenCalledWith('person.group');
+    });
+
+    it('should reuse supplied workspace groups when available', async () => {
+      const logsQb = mockQueryBuilder();
+      logsQb.getRawMany.mockResolvedValue([
+        { group: 'Group A', logCount: '1' }
+      ]);
+      (bookletLogRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(logsQb);
+
+      const result = await service.getGroupsWithBookletLogs(1, [
+        'Group A',
+        'Group B'
+      ]);
+
+      expect(result).toEqual(new Map([
+        ['Group A', true],
+        ['Group B', false]
+      ]));
+      expect(personsRepository.createQueryBuilder).not.toHaveBeenCalled();
     });
 
     it('should return empty map when no groups exist', async () => {
       const qb = mockQueryBuilder();
       qb.getRawMany.mockResolvedValue([]);
-      (personsRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      (bookletLogRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
 
       const result = await service.getGroupsWithBookletLogs(1);
 
@@ -292,7 +310,7 @@ describe('PersonQueryService', () => {
     });
 
     it('should handle errors gracefully', async () => {
-      (personsRepository.createQueryBuilder as jest.Mock).mockImplementation(() => {
+      (bookletLogRepository.createQueryBuilder as jest.Mock).mockImplementation(() => {
         throw new Error('Database error');
       });
 

--- a/apps/backend/src/app/database/services/test-results/person-query.service.ts
+++ b/apps/backend/src/app/database/services/test-results/person-query.service.ts
@@ -209,16 +209,36 @@ export class PersonQueryService {
     }
   }
 
-  async getGroupsWithBookletLogs(workspaceId: number): Promise<Map<string, boolean>> {
+  async getGroupsWithBookletLogs(
+    workspaceId: number,
+    workspaceGroups?: string[]
+  ): Promise<Map<string, boolean>> {
     try {
-      const groups = await this.getWorkspaceGroups(workspaceId);
-      const groupsWithLogs = new Map<string, boolean>();
-      for (const group of groups) {
-        const hasLogs = await this.hasBookletLogsForGroup(workspaceId, group);
-        groupsWithLogs.set(group, hasLogs);
-      }
+      const groups = workspaceGroups || await this.getWorkspaceGroups(workspaceId);
+      const groupsWithLogs = await this.bookletLogRepository
+        .createQueryBuilder('bookletlog')
+        .innerJoin('bookletlog.booklet', 'booklet')
+        .innerJoin('booklet.person', 'person')
+        .select('person.group', 'group')
+        .addSelect('COUNT(bookletlog.id)', 'logCount')
+        .where('person.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('person.consider = :consider', { consider: true })
+        .groupBy('person.group')
+        .getRawMany();
 
-      return groupsWithLogs;
+      const groupNamesWithLogs = new Set(
+        groupsWithLogs
+          .filter(item => item.group)
+          .filter(item => Number(item.logCount) > 0)
+          .map(item => item.group)
+      );
+
+      return new Map(
+        groups.map(group => [
+          group,
+          groupNamesWithLogs.has(group)
+        ])
+      );
     } catch (error) {
       this.logger.error(`Error getting groups with booklet logs: ${error.message}`);
       return new Map<string, boolean>();

--- a/apps/backend/src/app/database/services/test-results/person.service.ts
+++ b/apps/backend/src/app/database/services/test-results/person.service.ts
@@ -47,8 +47,14 @@ export class PersonService {
     return this.personQueryService.hasBookletLogsForGroup(workspaceId, groupName);
   }
 
-  async getGroupsWithBookletLogs(workspaceId: number): Promise<Map<string, boolean>> {
-    return this.personQueryService.getGroupsWithBookletLogs(workspaceId);
+  async getGroupsWithBookletLogs(
+    workspaceId: number,
+    workspaceGroups?: string[]
+  ): Promise<Map<string, boolean>> {
+    return this.personQueryService.getGroupsWithBookletLogs(
+      workspaceId,
+      workspaceGroups
+    );
   }
 
   async markPersonsAsNotConsidered(workspaceId: number, logins: string[]): Promise<boolean> {

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
@@ -19,6 +19,7 @@ describe('TestCenterService', () => {
   let service: TestcenterService;
   let httpService: { put: jest.Mock; axiosRef: { get: jest.Mock } };
   let personService: DeepMocked<PersonService>;
+  let cacheService: DeepMocked<CacheService>;
   let workspaceTestResultsService: DeepMocked<WorkspaceTestResultsService>;
   let codingFreshnessService: DeepMocked<CodingFreshnessService>;
   let codingAnalysisService: DeepMocked<CodingAnalysisService>;
@@ -94,6 +95,7 @@ describe('TestCenterService', () => {
     service = module.get<TestcenterService>(TestcenterService);
     httpService = module.get(HttpService);
     personService = module.get(PersonService);
+    cacheService = module.get(CacheService);
     workspaceTestResultsService = module.get(WorkspaceTestResultsService);
     codingFreshnessService = module.get(CodingFreshnessService);
     codingAnalysisService = module.get(CodingAnalysisService);
@@ -211,6 +213,8 @@ describe('TestCenterService', () => {
         expect(result).toHaveLength(1);
         expect(result[0].groupName).toBe('group1');
         expect(result[0].existsInDatabase).toBe(false);
+        expect(personService.getGroupsWithBookletLogs)
+          .toHaveBeenCalledWith(123, []);
       });
 
       it('should mark groups as existing in database', async () => {
@@ -242,6 +246,55 @@ describe('TestCenterService', () => {
         );
 
         expect(result[0].existsInDatabase).toBe(true);
+        expect(personService.getGroupsWithBookletLogs)
+          .toHaveBeenCalledWith(123, ['existing-group']);
+      });
+
+      it('should record progress while fetching and preparing test groups', async () => {
+        const mockGroups: TestGroupsInfoDto[] = [
+          {
+            groupName: 'existing-group',
+            groupLabel: 'Existing Group',
+            bookletsStarted: 5,
+            numUnitsMin: 3,
+            numUnitsMax: 8,
+            numUnitsTotal: 25,
+            numUnitsAvg: 5.5,
+            lastChange: Date.now()
+          }
+        ];
+
+        httpService.axiosRef.get.mockResolvedValue({
+          data: mockGroups
+        } as AxiosResponse);
+        personService.getWorkspaceGroups.mockResolvedValue(['existing-group']);
+        personService.getGroupsWithBookletLogs.mockResolvedValue(
+          new Map([['existing-group', true]])
+        );
+
+        const result = await service.getTestgroups(
+          mockWorkspaceId,
+          mockTcWorkspace,
+          'demo',
+          '',
+          mockAuthToken,
+          'run-1'
+        );
+
+        expect(result[0]).toEqual(expect.objectContaining({
+          existsInDatabase: true,
+          hasBookletLogs: true
+        }));
+        expect(cacheService.set).toHaveBeenCalledWith(
+          'testcenter_test_groups_progress:123:run-1',
+          expect.objectContaining({
+            importRunId: 'run-1',
+            status: 'completed',
+            totalGroups: 1,
+            processedGroups: 1
+          }),
+          3600
+        );
       });
 
       it('should surface API errors when fetching test groups fails', async () => {
@@ -253,6 +306,20 @@ describe('TestCenterService', () => {
           '',
           mockAuthToken
         )).rejects.toThrow('Failed to retrieve test groups from Testcenter');
+      });
+
+      it('should reject malformed test group responses', async () => {
+        httpService.axiosRef.get.mockResolvedValue({
+          data: { groups: [] }
+        } as AxiosResponse);
+
+        await expect(service.getTestgroups(
+          mockWorkspaceId,
+          mockTcWorkspace,
+          'demo',
+          '',
+          mockAuthToken
+        )).rejects.toThrow('Unexpected Testcenter response');
       });
     });
   });

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.ts
@@ -20,6 +20,7 @@ import {
   ImportWorkspaceFilesProgressDto,
   ImportWorkspaceOptionKey
 } from '../../../../../../../api-dto/files/import-workspace-progress.dto';
+import { TestGroupsLoadProgressDto } from '../../../../../../../api-dto/files/test-groups-load-progress.dto';
 import { CacheService } from '../../../cache/cache.service';
 import { WorkspaceTestResultsService } from './workspace-test-results.service';
 import { CodingFreshnessService } from '../coding/coding-freshness.service';
@@ -118,12 +119,23 @@ export class TestcenterService {
     tc_workspace: string,
     server: string,
     url: string,
-    authToken: string
+    authToken: string,
+    importRunId?: string
   ): Promise<TestGroupsInfoDto[]> {
     const headersRequest = {
       Authtoken: authToken
     };
     try {
+      await this.updateTestGroupsLoadProgress(workspace_id, importRunId, {
+        status: 'running',
+        phase: 'fetching-testcenter-groups',
+        totalGroups: 0,
+        processedGroups: 0,
+        existingGroups: 0,
+        groupsWithLogs: 0,
+        message: 'Testgruppen werden vom Testcenter abgerufen.'
+      });
+
       const response = await this.httpService.axiosRef.get<TestGroupsInfoDto[]>(
         url ?
           `${url}/api/workspace/${tc_workspace}/results` :
@@ -133,26 +145,191 @@ export class TestcenterService {
           headers: headersRequest
         }
       );
+      if (!Array.isArray(response.data)) {
+        throw new Error('Unexpected Testcenter response: expected a list of test groups.');
+      }
+      const testGroups = response.data;
+
+      await this.updateTestGroupsLoadProgress(workspace_id, importRunId, {
+        phase: 'checking-workspace-groups',
+        totalGroups: testGroups.length,
+        processedGroups: 0,
+        message: `${testGroups.length} Testgruppen geladen. Vorhandene Gruppen werden geprüft.`
+      });
+
       const existingGroups = await this.personService.getWorkspaceGroups(
         Number(workspace_id)
       );
+
+      await this.updateTestGroupsLoadProgress(workspace_id, importRunId, {
+        phase: 'checking-booklet-logs',
+        existingGroups: existingGroups.length,
+        message: 'Vorhandene Booklet-Logs werden geprüft.'
+      });
+
       const groupsWithLogs = await this.personService.getGroupsWithBookletLogs(
-        Number(workspace_id)
+        Number(workspace_id),
+        existingGroups
+      );
+      const existingGroupsSet = new Set(existingGroups);
+      const groupsWithLogsCount = Array.from(groupsWithLogs.values())
+        .filter(Boolean).length;
+
+      await this.updateTestGroupsLoadProgress(workspace_id, importRunId, {
+        phase: 'annotating-groups',
+        groupsWithLogs: groupsWithLogsCount,
+        message: 'Testgruppen werden für die Auswahl vorbereitet.'
+      });
+
+      const annotatedGroups = await this.annotateTestGroupsWithProgress(
+        workspace_id,
+        importRunId,
+        testGroups,
+        existingGroupsSet,
+        groupsWithLogs
       );
 
-      return response.data.map(group => ({
-        ...group,
-        existsInDatabase: existingGroups.includes(group.groupName),
-        hasBookletLogs: groupsWithLogs.get(group.groupName) || false
-      }));
+      await this.updateTestGroupsLoadProgress(workspace_id, importRunId, {
+        status: 'completed',
+        phase: 'annotating-groups',
+        totalGroups: testGroups.length,
+        processedGroups: testGroups.length,
+        message: `${testGroups.length} Testgruppen wurden abgerufen.`
+      });
+
+      return annotatedGroups;
     } catch (error) {
       this.logger.error(`Error fetching test groups: ${error.message}`);
+      await this.updateTestGroupsLoadProgress(workspace_id, importRunId, {
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Testgruppen konnten nicht abgerufen werden.'
+      });
       throw new Error(
         `Failed to retrieve test groups from Testcenter: ${
           error?.message || 'Unknown error'
         }`
       );
     }
+  }
+
+  private testGroupsLoadProgressKey(
+    workspaceId: string,
+    importRunId: string
+  ): string {
+    return `testcenter_test_groups_progress:${workspaceId}:${importRunId}`;
+  }
+
+  private createInitialTestGroupsLoadProgress(
+    importRunId: string
+  ): TestGroupsLoadProgressDto {
+    return {
+      importRunId,
+      status: 'running',
+      phase: 'fetching-testcenter-groups',
+      totalGroups: 0,
+      processedGroups: 0,
+      existingGroups: 0,
+      groupsWithLogs: 0,
+      message: 'Testgruppen werden vom Testcenter abgerufen.',
+      updatedAt: Date.now()
+    };
+  }
+
+  private async loadTestGroupsLoadProgress(
+    workspaceId: string,
+    importRunId?: string
+  ): Promise<TestGroupsLoadProgressDto | null> {
+    if (!importRunId) return null;
+    return this.cacheService.get<TestGroupsLoadProgressDto>(
+      this.testGroupsLoadProgressKey(workspaceId, importRunId)
+    );
+  }
+
+  private async saveTestGroupsLoadProgress(
+    workspaceId: string,
+    importRunId: string,
+    progress: TestGroupsLoadProgressDto
+  ): Promise<void> {
+    progress.updatedAt = Date.now();
+    await this.cacheService.set(
+      this.testGroupsLoadProgressKey(workspaceId, importRunId),
+      progress,
+      3600
+    );
+  }
+
+  async getTestGroupsLoadProgress(
+    workspaceId: string,
+    importRunId: string
+  ): Promise<TestGroupsLoadProgressDto> {
+    const progress = await this.loadTestGroupsLoadProgress(
+      workspaceId,
+      importRunId
+    );
+    if (progress) return progress;
+
+    return {
+      importRunId,
+      status: 'unknown',
+      totalGroups: 0,
+      processedGroups: 0,
+      existingGroups: 0,
+      groupsWithLogs: 0,
+      updatedAt: Date.now()
+    };
+  }
+
+  private async updateTestGroupsLoadProgress(
+    workspaceId: string,
+    importRunId: string | undefined,
+    patch: Partial<Omit<TestGroupsLoadProgressDto, 'importRunId' | 'updatedAt'>>
+  ): Promise<void> {
+    if (!importRunId) return;
+    const current = await this.loadTestGroupsLoadProgress(
+      workspaceId,
+      importRunId
+    );
+    const progress = {
+      ...this.createInitialTestGroupsLoadProgress(importRunId),
+      ...(current || {}),
+      ...patch,
+      importRunId
+    };
+    await this.saveTestGroupsLoadProgress(workspaceId, importRunId, progress);
+  }
+
+  private async annotateTestGroupsWithProgress(
+    workspaceId: string,
+    importRunId: string | undefined,
+    testGroups: TestGroupsInfoDto[],
+    existingGroups: Set<string>,
+    groupsWithLogs: Map<string, boolean>
+  ): Promise<TestGroupsInfoDto[]> {
+    const annotatedGroups: TestGroupsInfoDto[] = [];
+    const chunkSize = 250;
+
+    for (let index = 0; index < testGroups.length; index += chunkSize) {
+      const chunk = testGroups.slice(index, index + chunkSize);
+      annotatedGroups.push(
+        ...chunk.map(group => ({
+          ...group,
+          existsInDatabase: existingGroups.has(group.groupName),
+          hasBookletLogs: groupsWithLogs.get(group.groupName) || false
+        }))
+      );
+
+      const processedGroups = Math.min(index + chunk.length, testGroups.length);
+      await this.updateTestGroupsLoadProgress(workspaceId, importRunId, {
+        phase: 'annotating-groups',
+        totalGroups: testGroups.length,
+        processedGroups,
+        message:
+          `${processedGroups}/${testGroups.length} Testgruppen vorbereitet.`
+      });
+    }
+
+    return annotatedGroups;
   }
 
   private createChunks<T>(array: T[], size: number): T[][] {

--- a/apps/frontend/src/app/services/facades/workspace-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/workspace-facade.service.ts
@@ -37,6 +37,7 @@ import { BookletInfoDto } from '../../../../../../api-dto/booklet-info/booklet-i
 import { UnitInfoDto } from '../../../../../../api-dto/unit-info/unit-info.dto';
 import { ResourcePackageDto } from '../../../../../../api-dto/resource-package/resource-package-dto';
 import { TestGroupsInfoDto } from '../../../../../../api-dto/files/test-groups-info.dto';
+import { TestGroupsLoadProgressDto } from '../../../../../../api-dto/files/test-groups-load-progress.dto';
 import { UnitVariableDetailsDto } from '../../models/unit-variable-details.dto';
 
 interface PaginatedResponse<T> {
@@ -254,15 +255,24 @@ export class WorkspaceFacadeService {
     testCenterWorkspace: string,
     server: string,
     url: string,
-    authToken: string
+    authToken: string,
+    importRunId?: string
   ): Observable<TestGroupsInfoDto[]> {
     return this.importService.importTestcenterGroups(
       workspaceId,
       testCenterWorkspace,
       server,
       url,
-      authToken
+      authToken,
+      importRunId
     );
+  }
+
+  getTestGroupsLoadProgress(
+    workspaceId: number,
+    importRunId: string
+  ): Observable<TestGroupsLoadProgressDto | null> {
+    return this.importService.getTestGroupsLoadProgress(workspaceId, importRunId);
   }
 
   downloadWorkspaceFilesAsZip(workspaceId: number, fileTypes?: string[]): Observable<Blob> {

--- a/apps/frontend/src/app/shared/services/file/import.service.ts
+++ b/apps/frontend/src/app/shared/services/file/import.service.ts
@@ -5,6 +5,7 @@ import { SERVER_URL } from '../../../injection-tokens';
 import { TestGroupsInfoDto } from '../../../../../../../api-dto/files/test-groups-info.dto';
 import { ImportOptionsDto as ImportOptions, ImportResultDto as Result } from '../../../../../../../api-dto/files/import-options.dto';
 import { ImportWorkspaceFilesProgressDto } from '../../../../../../../api-dto/files/import-workspace-progress.dto';
+import { TestGroupsLoadProgressDto } from '../../../../../../../api-dto/files/test-groups-load-progress.dto';
 
 export { ImportOptions, Result };
 
@@ -83,18 +84,36 @@ export class ImportService {
     testCenterWorkspace: string,
     server: string,
     url: string,
-    authToken: string
+    authToken: string,
+    importRunId?: string
   ): Observable<TestGroupsInfoDto[]> {
-    const params = new HttpParams()
+    let params = new HttpParams()
       .set('tc_workspace', testCenterWorkspace)
       .set('server', server)
       .set('url', encodeURIComponent(url))
       .set('token', authToken);
+
+    if (importRunId) {
+      params = params.set('importRunId', importRunId);
+    }
 
     return this.http
       .get<TestGroupsInfoDto[]>(
       `${this.serverUrl}admin/workspace/${workspace_id}/importWorkspaceFiles/testGroups`,
       { params }
     );
+  }
+
+  getTestGroupsLoadProgress(
+    workspace_id: number,
+    importRunId: string
+  ): Observable<TestGroupsLoadProgressDto | null> {
+    const params = new HttpParams().set('importRunId', importRunId);
+    return this.http
+      .get<TestGroupsLoadProgressDto>(
+      `${this.serverUrl}admin/workspace/${workspace_id}/importWorkspaceFiles/testGroups/progress`,
+      { params }
+    )
+      .pipe(catchError(() => of(null)));
   }
 }

--- a/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.html
@@ -227,10 +227,36 @@
         </div>
       </div>
 
-      @if (isUploadingTestResults || isUploadingTestFiles) {
+      @if (isLoadingTestGroups || isUploadingTestResults || isUploadingTestFiles) {
       <div class="loading-container">
         <mat-spinner diameter="40"></mat-spinner>
-        @if (isUploadingTestResults) {
+        @if (isLoadingTestGroups) {
+        <p class="loading-text">
+          Verfügbare Testgruppen im Arbeitsbereich werden abgerufen...
+        </p>
+        <div class="test-groups-load-progress">
+          <p class="loading-subtext">{{ testGroupsLoadMessage }}</p>
+          @if ((testGroupsLoadProgress?.totalGroups || 0) > 0) {
+          <p class="loading-subtext">
+            Testgruppen verarbeitet:
+            {{ testGroupsLoadProgress?.processedGroups || 0 }} /
+            {{ testGroupsLoadProgress?.totalGroups || 0 }}
+            ({{ testGroupsLoadPercent }}%)
+          </p>
+          <mat-progress-bar
+            mode="determinate"
+            [value]="testGroupsLoadPercent"
+          ></mat-progress-bar>
+          } @else {
+          <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+          }
+          @if (testGroupsLoadElapsedSeconds > 2) {
+          <p class="loading-subtext">
+            Laufzeit: {{ testGroupsLoadElapsedText }}
+          </p>
+          }
+        </div>
+        } @if (isUploadingTestResults) {
         <p class="loading-text">
           Verfügbare Testgruppen im Arbeitsbereich werden abgerufen...
         </p>
@@ -272,7 +298,7 @@
         }
         }
       </div>
-      } @if (!isUploadingTestResults && !isUploadingTestFiles) {
+      } @if (!isLoadingTestGroups && !isUploadingTestResults && !isUploadingTestFiles) {
       <div class="form-actions">
         @if (data.importType === 'testResults') {
         <button

--- a/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.scss
+++ b/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.scss
@@ -505,6 +505,12 @@
     width: min(420px, 90%);
   }
 
+  .test-groups-load-progress {
+    margin-top: 12px;
+    width: min(460px, 90%);
+    text-align: center;
+  }
+
   .option-progress-list {
     margin-top: 12px;
     width: min(620px, 95%);

--- a/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.spec.ts
@@ -10,7 +10,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { TestCenterImportComponent } from './test-center-import.component';
 import { environment } from '../../../../environments/environment';
 import { SERVER_URL } from '../../../injection-tokens';
@@ -43,7 +43,8 @@ describe('TestCenterImportComponent', () => {
     const importMock = {
       importTestcenterGroups: jest.fn(),
       importWorkspaceFiles: jest.fn(),
-      getImportWorkspaceFilesProgress: jest.fn().mockReturnValue(of(null))
+      getImportWorkspaceFilesProgress: jest.fn().mockReturnValue(of(null)),
+      getTestGroupsLoadProgress: jest.fn().mockReturnValue(of(null))
     };
     const workspaceAdminMock = {
       getAuthToken: jest.fn().mockReturnValue(''),
@@ -151,6 +152,14 @@ describe('TestCenterImportComponent', () => {
 
     expect(component.showTestGroups).toBe(true);
     expect(component.testGroups).toEqual(mockGroups);
+    expect(importService.importTestcenterGroups).toHaveBeenCalledWith(
+      1,
+      'tc-ws-1',
+      '1',
+      '',
+      'fake-token',
+      expect.stringMatching(/^tc-import-/)
+    );
 
     // 4. Select group and import
     component.toggleRow(mockGroups[0]);
@@ -205,6 +214,61 @@ describe('TestCenterImportComponent', () => {
 
     expect(component.authenticated).toBe(false);
     expect(component.authenticationError).toBe(true);
+  });
+
+  it('should show progress while loading test groups', () => {
+    component.authToken = 'fake-token';
+    component.loginForm.patchValue({ testCenter: 1 });
+    component.importFilesForm.patchValue({
+      workspace: 'tc-ws-1',
+      responses: true
+    });
+
+    const groups$ = new Subject<TestGroupsInfoDto[]>();
+    importService.importTestcenterGroups.mockReturnValue(groups$.asObservable());
+    importService.getTestGroupsLoadProgress.mockReturnValue(of({
+      importRunId: 'run-1',
+      status: 'running',
+      phase: 'annotating-groups',
+      totalGroups: 1000,
+      processedGroups: 250,
+      existingGroups: 20,
+      groupsWithLogs: 5,
+      message: '250/1000 Testgruppen vorbereitet.',
+      updatedAt: Date.now()
+    }));
+
+    component.getTestGroups();
+
+    expect(component.isLoadingTestGroups).toBe(true);
+    expect(component.testGroupsLoadPercent).toBe(25);
+    expect(component.testGroupsLoadMessage).toBe(
+      '250/1000 Testgruppen vorbereitet.'
+    );
+    expect(importService.getTestGroupsLoadProgress).toHaveBeenCalledWith(
+      1,
+      expect.stringMatching(/^tc-import-/)
+    );
+
+    const mockGroups: TestGroupsInfoDto[] = [{
+      groupName: 'group1',
+      groupLabel: 'Group 1',
+      bookletsStarted: 10,
+      numUnitsTotal: 100,
+      numUnitsMin: 1,
+      numUnitsMax: 10,
+      numUnitsAvg: 5,
+      lastChange: Date.now(),
+      existsInDatabase: false,
+      hasBookletLogs: false
+    }];
+
+    groups$.next(mockGroups);
+    groups$.complete();
+
+    expect(component.isLoadingTestGroups).toBe(false);
+    expect(component.showTestGroups).toBe(true);
+    expect(component.testGroups).toEqual(mockGroups);
   });
 
   it('should logout correctly', () => {

--- a/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.ts
@@ -58,6 +58,7 @@ import {
   ImportWorkspaceFilesProgressDto,
   ImportWorkspaceOptionKey
 } from '../../../../../../../api-dto/files/import-workspace-progress.dto';
+import { TestGroupsLoadProgressDto } from '../../../../../../../api-dto/files/test-groups-load-progress.dto';
 
 export type WorkspaceAdmin = {
   label: string;
@@ -175,6 +176,7 @@ export class TestCenterImportComponent {
   testGroupsLoadError: string | null = null;
   uploadError: string | null = null;
   authenticated: boolean = false;
+  isLoadingTestGroups: boolean = false;
   isUploadingTestFiles: boolean = false;
   isUploadingTestResults: boolean = false;
   uploadData: Result | null = null;
@@ -187,7 +189,11 @@ export class TestCenterImportComponent {
   completedUploads: number = 0;
   importRunId: string | null = null;
   uploadProgressDetails: ImportWorkspaceFilesProgressDto | null = null;
+  testGroupsLoadProgress: TestGroupsLoadProgressDto | null = null;
+  testGroupsLoadElapsedSeconds: number = 0;
   private progressPollingSub?: Subscription;
+  private testGroupsProgressPollingSub?: Subscription;
+  private testGroupsLoadStartedAt: number | null = null;
 
   constructor() {
     this.loginForm = this.fb.group({
@@ -284,6 +290,7 @@ export class TestCenterImportComponent {
 
   ngOnDestroy(): void {
     this.stopUploadProgressPolling();
+    this.stopTestGroupsProgressPolling();
   }
 
   toggleRow(group: TestGroupsInfoDto): void {
@@ -380,28 +387,35 @@ export class TestCenterImportComponent {
       this.workspaceAdminService.getLastUrl() ||
       formValues.testCenterIndividual;
 
-    this.isUploadingTestResults = true;
+    const importRunId = this.createImportRunId();
+    this.isLoadingTestGroups = true;
     this.importProgressPercent = 0;
+    this.testGroupsLoadProgress = null;
+    this.testGroupsLoadElapsedSeconds = 0;
     this.testGroupsLoadError = null;
     this.uploadError = null;
+    this.startTestGroupsProgressPolling(importRunId);
     this.importService
       .importTestcenterGroups(
         this.appService.selectedWorkspaceId,
         formValues.workspace,
         server,
         url,
-        this.authToken
+        this.authToken,
+        importRunId
       )
       .subscribe({
         next: (response: TestGroupsInfoDto[]) => {
-          this.isUploadingTestResults = false;
+          this.isLoadingTestGroups = false;
+          this.stopTestGroupsProgressPolling();
           this.workspaceAdminService.setTestGroups(response);
           this.testGroups = response;
           this.selectedRows = [];
           this.showTestGroups = true;
         },
         error: error => {
-          this.isUploadingTestResults = false;
+          this.isLoadingTestGroups = false;
+          this.stopTestGroupsProgressPolling();
           this.testGroups = [];
           this.selectedRows = [];
           this.showTestGroups = false;
@@ -805,6 +819,32 @@ export class TestCenterImportComponent {
     return Math.round((this.completedUploads / this.totalUploadsExpected) * 100);
   }
 
+  get testGroupsLoadPercent(): number {
+    const totalGroups = this.testGroupsLoadProgress?.totalGroups || 0;
+    if (totalGroups <= 0) return 0;
+    if (this.testGroupsLoadProgress?.status === 'completed') return 100;
+    return Math.round(
+      ((this.testGroupsLoadProgress?.processedGroups || 0) / totalGroups) * 100
+    );
+  }
+
+  get testGroupsLoadMessage(): string {
+    if (this.testGroupsLoadProgress?.status === 'unknown') {
+      return 'Verbindung zum Testcenter wird hergestellt.';
+    }
+    return this.testGroupsLoadProgress?.message ||
+      'Testgruppen werden vom Testcenter abgerufen.';
+  }
+
+  get testGroupsLoadElapsedText(): string {
+    if (this.testGroupsLoadElapsedSeconds < 60) {
+      return `${this.testGroupsLoadElapsedSeconds} s`;
+    }
+    const minutes = Math.floor(this.testGroupsLoadElapsedSeconds / 60);
+    const seconds = this.testGroupsLoadElapsedSeconds % 60;
+    return `${minutes} min ${seconds} s`;
+  }
+
   private initializeUploadProgress(selectedGroupCount: number): void {
     if (this.data.importType === 'testResults') {
       this.totalUploadsExpected = selectedGroupCount;
@@ -836,6 +876,43 @@ export class TestCenterImportComponent {
 
   private createImportRunId(): string {
     return `tc-import-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  }
+
+  private startTestGroupsProgressPolling(importRunId: string): void {
+    this.stopTestGroupsProgressPolling();
+    this.testGroupsLoadStartedAt = Date.now();
+    this.testGroupsProgressPollingSub = interval(700).pipe(
+      startWith(0),
+      switchMap(() => this.importService.getTestGroupsLoadProgress(
+        this.appService.selectedWorkspaceId,
+        importRunId
+      ))
+    ).subscribe(progress => {
+      this.updateTestGroupsLoadElapsedSeconds();
+      if (!progress) return;
+
+      this.testGroupsLoadProgress = progress;
+
+      if (progress.status === 'completed' || progress.status === 'failed') {
+        this.stopTestGroupsProgressPolling();
+      }
+    });
+  }
+
+  private stopTestGroupsProgressPolling(): void {
+    this.testGroupsProgressPollingSub?.unsubscribe();
+    this.testGroupsProgressPollingSub = undefined;
+  }
+
+  private updateTestGroupsLoadElapsedSeconds(): void {
+    if (!this.testGroupsLoadStartedAt) {
+      this.testGroupsLoadElapsedSeconds = 0;
+      return;
+    }
+
+    this.testGroupsLoadElapsedSeconds = Math.floor(
+      (Date.now() - this.testGroupsLoadStartedAt) / 1000
+    );
   }
 
   private startUploadProgressPolling(importRunId: string): void {


### PR DESCRIPTION
## Summary
- Add a shared progress DTO and backend polling endpoint for Testcenter test group retrieval.
- Store live progress in Redis while groups are fetched, checked against workspace data, checked for existing booklet logs, and annotated for selection.
- Show determinate/indeterminate progress, processed group counts, and elapsed time in the Testcenter import dialog.
- Replace the previous per-group booklet-log lookup with one grouped query while preserving a complete group-to-boolean result map.

## Impact
Large Testcenter workspaces now provide visible progress instead of only a spinner while available test groups are loaded.

## Validation
- `npx nx lint backend`
- `npx nx lint frontend`
- `npx nx test backend --testFile=src/app/database/services/test-results/testcenter.service.spec.ts --runInBand`
- `npx nx test backend --testFile=src/app/database/services/test-results/person-query.service.spec.ts --runInBand`
- `npx nx test frontend --runTestsByPath apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.spec.ts`
- `npx nx run-many --target=build --projects=frontend,backend --parallel`

Note: This PR intentionally avoids issue-closing keywords so the linked issue can remain open until reviewed.
