### PR TITLE
Store distribution snapshots for job definitions

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.spec.ts
@@ -1,6 +1,75 @@
 import { WorkspaceCodingJobDefinitionController } from './workspace-coding-job-definition.controller';
 
 describe('WorkspaceCodingJobDefinitionController', () => {
+  it('reads job definitions through the workspace-scoped service path', async () => {
+    const jobDefinitionService = {
+      getJobDefinition: jest.fn().mockResolvedValue({
+        id: 42,
+        workspace_id: 5
+      })
+    };
+    const controller = new WorkspaceCodingJobDefinitionController(jobDefinitionService as never);
+
+    await expect(controller.getJobDefinition(5, 42)).resolves.toMatchObject({
+      id: 42,
+      workspace_id: 5
+    });
+
+    expect(jobDefinitionService.getJobDefinition).toHaveBeenCalledWith(42, 5);
+  });
+
+  it('updates job definitions through the workspace-scoped service path', async () => {
+    const jobDefinitionService = {
+      updateJobDefinition: jest.fn().mockResolvedValue({
+        id: 42,
+        workspace_id: 5,
+        status: 'approved'
+      })
+    };
+    const controller = new WorkspaceCodingJobDefinitionController(jobDefinitionService as never);
+
+    await expect(controller.updateJobDefinition(5, 42, { status: 'approved' })).resolves.toMatchObject({
+      id: 42,
+      workspace_id: 5,
+      status: 'approved'
+    });
+
+    expect(jobDefinitionService.updateJobDefinition).toHaveBeenCalledWith(42, 5, { status: 'approved' });
+  });
+
+  it('approves job definitions through the workspace-scoped service path', async () => {
+    const jobDefinitionService = {
+      approveJobDefinition: jest.fn().mockResolvedValue({
+        id: 42,
+        workspace_id: 5,
+        status: 'approved'
+      })
+    };
+    const controller = new WorkspaceCodingJobDefinitionController(jobDefinitionService as never);
+
+    await expect(controller.approveJobDefinition(5, 42, { status: 'approved' })).resolves.toMatchObject({
+      id: 42,
+      workspace_id: 5,
+      status: 'approved'
+    });
+
+    expect(jobDefinitionService.approveJobDefinition).toHaveBeenCalledWith(42, 5, { status: 'approved' });
+  });
+
+  it('deletes job definitions through the workspace-scoped service path', async () => {
+    const jobDefinitionService = {
+      deleteJobDefinition: jest.fn().mockResolvedValue(undefined)
+    };
+    const controller = new WorkspaceCodingJobDefinitionController(jobDefinitionService as never);
+
+    await expect(controller.deleteJobDefinition(5, 42)).resolves.toEqual({
+      success: true,
+      message: 'Job definition deleted successfully'
+    });
+
+    expect(jobDefinitionService.deleteJobDefinition).toHaveBeenCalledWith(42, 5);
+  });
+
   it('creates coding jobs through the job definition service', async () => {
     const jobDefinitionService = {
       createCodingJobFromDefinition: jest.fn().mockResolvedValue({

--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
@@ -30,6 +30,134 @@ import {
   JobDefinitionRefreshPreviewDto
 } from '../../../../../../api-dto/coding/job-refresh.dto';
 
+const NUMBER_RECORD_SCHEMA = {
+  type: 'object',
+  additionalProperties: { type: 'number' }
+};
+
+const DISTRIBUTION_SNAPSHOT_SCHEMA = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      version: { type: 'number', enum: [1] },
+      source: { type: 'string', enum: ['initial_creation', 'refresh'] },
+      createdAt: { type: 'string', format: 'date-time' },
+      distributionSeed: { type: 'string' },
+      selectedVariables: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            unitName: { type: 'string' },
+            variableId: { type: 'string' },
+            includeDeriveError: { type: 'boolean' }
+          }
+        }
+      },
+      selectedVariableBundles: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'number' },
+            name: { type: 'string' },
+            variables: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  unitName: { type: 'string' },
+                  variableId: { type: 'string' },
+                  includeDeriveError: { type: 'boolean' }
+                }
+              }
+            },
+            sampleCount: { type: 'number' },
+            caseOrderingMode: { type: 'string', enum: ['continuous', 'alternating'] }
+          }
+        }
+      },
+      selectedCoders: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            coderId: { type: 'number' },
+            capacityPercent: { type: 'number' }
+          }
+        }
+      },
+      settings: {
+        type: 'object',
+        properties: {
+          maxCodingCases: { type: 'number' },
+          doubleCodingAbsolute: { type: 'number' },
+          doubleCodingPercentage: { type: 'number' },
+          caseOrderingMode: { type: 'string', enum: ['continuous', 'alternating'] }
+        }
+      },
+      distributionByCoderId: {
+        type: 'object',
+        additionalProperties: {
+          type: 'object',
+          additionalProperties: { type: 'number' }
+        }
+      },
+      doubleCodingInfo: {
+        type: 'object',
+        additionalProperties: {
+          type: 'object',
+          properties: {
+            totalCases: { type: 'number' },
+            distinctCases: { type: 'number' },
+            codingTasksTotal: { type: 'number' },
+            doubleCodedCases: { type: 'number' },
+            singleCodedCasesAssigned: { type: 'number' },
+            doubleCodedCasesPerCoderId: NUMBER_RECORD_SCHEMA
+          }
+        }
+      },
+      aggregationInfo: {
+        type: 'object',
+        additionalProperties: {
+          type: 'object',
+          properties: {
+            uniqueCases: { type: 'number' },
+            totalResponses: { type: 'number' }
+          }
+        }
+      },
+      matchingFlags: {
+        type: 'array',
+        items: { type: 'string' }
+      },
+      pairDistribution: NUMBER_RECORD_SCHEMA,
+      tasksPerCoder: NUMBER_RECORD_SCHEMA,
+      coderWeights: NUMBER_RECORD_SCHEMA,
+      jobs: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            itemKey: { type: 'string' },
+            coderId: { type: 'number' },
+            variable: {
+              type: 'object',
+              properties: {
+                unitName: { type: 'string' },
+                variableId: { type: 'string' }
+              }
+            },
+            jobId: { type: 'number' },
+            caseCount: { type: 'number' }
+          }
+        }
+      }
+    }
+  }
+};
+
 @ApiTags('Admin Workspace Job Definition')
 @Controller('admin/workspace')
 export class WorkspaceCodingJobDefinitionController {
@@ -76,6 +204,7 @@ export class WorkspaceCodingJobDefinitionController {
           assigned_variable_bundles: { type: 'array' },
           assigned_coders: { type: 'array' },
           assigned_coder_configs: { type: 'array' },
+          distribution_snapshots: DISTRIBUTION_SNAPSHOT_SCHEMA,
           missings_profile_id: { type: 'number', nullable: true },
           distribution_seed: { type: 'string' },
           duration_seconds: { type: 'number' },
@@ -127,6 +256,7 @@ export class WorkspaceCodingJobDefinitionController {
           assigned_variable_bundles: { type: 'array' },
           assigned_coders: { type: 'array' },
           assigned_coder_configs: { type: 'array' },
+          distribution_snapshots: DISTRIBUTION_SNAPSHOT_SCHEMA,
           missings_profile_id: { type: 'number', nullable: true },
           distribution_seed: { type: 'string' },
           duration_seconds: { type: 'number' },
@@ -160,7 +290,7 @@ export class WorkspaceCodingJobDefinitionController {
     @WorkspaceId() workspace_id: number,
       @Param('id') id: number
   ): Promise<JobDefinition> {
-    return this.jobDefinitionService.getJobDefinition(id);
+    return this.jobDefinitionService.getJobDefinition(id, workspace_id);
   }
 
   @Put(':workspace_id/coding/job-definitions/:id')
@@ -181,7 +311,7 @@ export class WorkspaceCodingJobDefinitionController {
       @Param('id') id: number,
       @Body(new ValidationPipe({ transform: true, whitelist: true })) updateDto: UpdateJobDefinitionDto
   ): Promise<JobDefinition> {
-    return this.jobDefinitionService.updateJobDefinition(id, updateDto);
+    return this.jobDefinitionService.updateJobDefinition(id, workspace_id, updateDto);
   }
 
   @Put(':workspace_id/coding/job-definitions/:id/approve')
@@ -202,7 +332,7 @@ export class WorkspaceCodingJobDefinitionController {
       @Param('id') id: number,
       @Body(new ValidationPipe({ transform: true, whitelist: true })) approveDto: ApproveJobDefinitionDto
   ): Promise<JobDefinition> {
-    return this.jobDefinitionService.approveJobDefinition(id, approveDto);
+    return this.jobDefinitionService.approveJobDefinition(id, workspace_id, approveDto);
   }
 
   @Delete(':workspace_id/coding/job-definitions/:id')
@@ -225,7 +355,7 @@ export class WorkspaceCodingJobDefinitionController {
     @WorkspaceId() workspace_id: number,
       @Param('id') id: number
   ): Promise<{ success: boolean; message: string }> {
-    await this.jobDefinitionService.deleteJobDefinition(id);
+    await this.jobDefinitionService.deleteJobDefinition(id, workspace_id);
     return { success: true, message: 'Job definition deleted successfully' };
   }
 
@@ -284,6 +414,10 @@ export class WorkspaceCodingJobDefinitionController {
               doubleCodedCases: { type: 'number' },
               singleCodedCasesAssigned: { type: 'number' },
               doubleCodedCasesPerCoder: {
+                type: 'object',
+                additionalProperties: { type: 'number' }
+              },
+              doubleCodedCasesPerCoderId: {
                 type: 'object',
                 additionalProperties: { type: 'number' }
               }

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -59,6 +59,7 @@ type DistributionDoubleCodingInfoResponse = {
   doubleCodedCases: number;
   singleCodedCasesAssigned: number;
   doubleCodedCasesPerCoder: Record<string, number>;
+  doubleCodedCasesPerCoderId?: Record<string, number>;
 };
 
 type DistributionCalculationResponse = {
@@ -2300,6 +2301,10 @@ export class WorkspaceCodingStatisticsController {
               doubleCodedCasesPerCoder: {
                 type: 'object',
                 additionalProperties: { type: 'number' }
+              },
+              doubleCodedCasesPerCoderId: {
+                type: 'object',
+                additionalProperties: { type: 'number' }
               }
             }
           }
@@ -2466,6 +2471,10 @@ export class WorkspaceCodingStatisticsController {
               doubleCodedCases: { type: 'number' },
               singleCodedCasesAssigned: { type: 'number' },
               doubleCodedCasesPerCoder: {
+                type: 'object',
+                additionalProperties: { type: 'number' }
+              },
+              doubleCodedCasesPerCoderId: {
                 type: 'object',
                 additionalProperties: { type: 'number' }
               }

--- a/apps/backend/src/app/database/entities/job-definition.entity.ts
+++ b/apps/backend/src/app/database/entities/job-definition.entity.ts
@@ -37,6 +37,57 @@ export interface JobDefinitionCoderConfig {
   capacityPercent: number;
 }
 
+export type JobDefinitionDistributionSnapshotSource = 'initial_creation' | 'refresh';
+
+export interface JobDefinitionDistributionSnapshotCoder {
+  coderId: number;
+  capacityPercent: number;
+}
+
+export interface JobDefinitionDistributionSnapshotJob {
+  itemKey?: string;
+  coderId: number;
+  variable: {
+    unitName: string;
+    variableId: string;
+  };
+  jobId: number;
+  caseCount: number;
+}
+
+export interface JobDefinitionDistributionSnapshotDoubleCodingInfo {
+  totalCases: number;
+  distinctCases?: number;
+  codingTasksTotal?: number;
+  doubleCodedCases: number;
+  singleCodedCasesAssigned: number;
+  doubleCodedCasesPerCoderId: Record<string, number>;
+}
+
+export interface JobDefinitionDistributionSnapshot {
+  version: 1;
+  source: JobDefinitionDistributionSnapshotSource;
+  createdAt: string;
+  distributionSeed: string;
+  selectedVariables: JobDefinitionVariable[];
+  selectedVariableBundles: JobDefinitionVariableBundle[];
+  selectedCoders: JobDefinitionDistributionSnapshotCoder[];
+  settings: {
+    maxCodingCases?: number;
+    doubleCodingAbsolute?: number;
+    doubleCodingPercentage?: number;
+    caseOrderingMode?: CaseOrderingMode;
+  };
+  distributionByCoderId: Record<string, Record<string, number>>;
+  doubleCodingInfo: Record<string, JobDefinitionDistributionSnapshotDoubleCodingInfo>;
+  aggregationInfo: Record<string, { uniqueCases: number; totalResponses: number }>;
+  matchingFlags: string[];
+  pairDistribution: Record<string, number>;
+  tasksPerCoder: Record<string, number>;
+  coderWeights: Record<string, number>;
+  jobs: JobDefinitionDistributionSnapshotJob[];
+}
+
 @Entity({ name: 'job_definitions' })
 export class JobDefinition {
   @PrimaryGeneratedColumn()
@@ -82,6 +133,9 @@ export class JobDefinition {
 
   @Column({ type: 'jsonb', nullable: true })
     assigned_coder_configs?: JobDefinitionCoderConfig[];
+
+  @Column({ type: 'jsonb', nullable: true })
+    distribution_snapshots?: JobDefinitionDistributionSnapshot[];
 
   @Column({ type: 'text' })
     distribution_seed?: string;

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -124,6 +124,7 @@ type DistributionDoubleCodingInfo = {
   doubleCodedCases: number;
   singleCodedCasesAssigned: number;
   doubleCodedCasesPerCoder: Record<string, number>;
+  doubleCodedCasesPerCoderId: Record<string, number>;
 };
 
 type DistributionPlanRequest = {
@@ -228,6 +229,16 @@ type DistributedCodingJobsResult = {
   coderWeights: Record<string, number>;
   jobs: DistributionCreatedJob[];
 };
+
+type DistributedCodingJobsTransactionHook = (
+  manager: EntityManager,
+  result: DistributedCodingJobsResult
+) => Promise<void>;
+
+type RefreshDistributedCodingJobsTransactionHook = (
+  manager: EntityManager,
+  result: JobDefinitionRefreshCodingJobsResult
+) => Promise<void>;
 
 type JobDefinitionRefreshCodingJobsResult = DistributedCodingJobsResult & {
   preview: JobDefinitionRefreshPreviewDto;
@@ -3802,11 +3813,13 @@ export class CodingJobService {
 
   private buildEmptyDoubleCodingInfo(coders: NormalizedDistributionCoder[]): DistributionDoubleCodingInfo {
     const doubleCodedCasesPerCoder: Record<string, number> = {};
+    const doubleCodedCasesPerCoderId: Record<string, number> = {};
 
     coders.forEach(coder => {
       if (isSafeKey(coder.displayKey)) {
         doubleCodedCasesPerCoder[coder.displayKey] = 0;
       }
+      doubleCodedCasesPerCoderId[String(coder.id)] = 0;
     });
 
     return {
@@ -3815,7 +3828,8 @@ export class CodingJobService {
       codingTasksTotal: 0,
       doubleCodedCases: 0,
       singleCodedCasesAssigned: 0,
-      doubleCodedCasesPerCoder
+      doubleCodedCasesPerCoder,
+      doubleCodedCasesPerCoderId
     };
   }
 
@@ -4013,6 +4027,9 @@ export class CodingJobService {
         distributionByCoderId[selectedCase.item.itemKey][String(coder.id)] += 1;
         if (isDoubleCoded && isSafeKey(coder.displayKey)) {
           doubleCodingInfo[selectedCase.item.itemKey].doubleCodedCasesPerCoder[coder.displayKey] += 1;
+        }
+        if (isDoubleCoded) {
+          doubleCodingInfo[selectedCase.item.itemKey].doubleCodedCasesPerCoderId[String(coder.id)] += 1;
         }
 
         const itemJobs = jobsByItemAndCoder.get(selectedCase.item.itemKey) || new Map<number, SlimResponse[]>();
@@ -4269,7 +4286,8 @@ export class CodingJobService {
 
   async refreshDistributedCodingJobs(
     workspaceId: number,
-    request: DistributionPlanRequest
+    request: DistributionPlanRequest,
+    afterRefreshInTransaction?: RefreshDistributedCodingJobsTransactionHook
   ): Promise<JobDefinitionRefreshCodingJobsResult> {
     const jobDefinitionId = Number(request.jobDefinitionId);
     if (!Number.isInteger(jobDefinitionId) || jobDefinitionId < 1) {
@@ -4330,6 +4348,13 @@ export class CodingJobService {
         transactionPlan,
         manager
       ));
+
+      if (afterRefreshInTransaction) {
+        await afterRefreshInTransaction(manager, {
+          ...this.buildDistributedCodingJobsResult(transactionPlan, createdJobs),
+          preview
+        });
+      }
     });
 
     await this.invalidateIncompleteVariablesCache(workspaceId);
@@ -4415,7 +4440,8 @@ export class CodingJobService {
 
   async createDistributedCodingJobs(
     workspaceId: number,
-    request: DistributionPlanRequest
+    request: DistributionPlanRequest,
+    afterCreateInTransaction?: DistributedCodingJobsTransactionHook
   ): Promise<DistributedCodingJobsResult> {
     this.logger.log(`Creating distributed coding jobs for workspace ${workspaceId}`);
 
@@ -4438,6 +4464,13 @@ export class CodingJobService {
             plan,
             manager
           ));
+
+          if (afterCreateInTransaction) {
+            await afterCreateInTransaction(
+              manager,
+              this.buildDistributedCodingJobsResult(plan, createdJobs)
+            );
+          }
         });
       }
 

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -736,6 +736,24 @@ describe('JobDefinitionService', () => {
     expect(missingsProfilesService.resolveMissingsProfileId).toHaveBeenCalledWith(7, 77);
   });
 
+  it('scopes single job definition lookup to the workspace', async () => {
+    const definition = {
+      id: 2,
+      workspace_id: 7,
+      assigned_variable_bundles: []
+    };
+    jobDefinitionRepository.findOne.mockResolvedValue(definition);
+
+    await expect(service.getJobDefinition(2, 7)).resolves.toBe(definition);
+
+    expect(jobDefinitionRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        id: 2,
+        workspace_id: 7
+      }
+    });
+  });
+
   it('persists coder capacity configs and derives assigned coder ids from them', async () => {
     await expect(service.createJobDefinition({
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
@@ -774,7 +792,7 @@ describe('JobDefinitionService', () => {
     jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
     jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
 
-    await expect(service.updateJobDefinition(2, {
+    await expect(service.updateJobDefinition(2, 7, {
       assignedCoders: [2, 3]
     })).resolves.toMatchObject({
       id: 2,
@@ -806,7 +824,7 @@ describe('JobDefinitionService', () => {
     codingJobService.calculateDistributionVariableUsageBatch.mockClear();
     codingJobService.assertCodersCanCodeInWorkspace.mockClear();
 
-    await service.updateJobDefinition(2, {
+    await service.updateJobDefinition(2, 7, {
       caseOrderingMode: 'alternating'
     });
 
@@ -849,7 +867,7 @@ describe('JobDefinitionService', () => {
     jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
     jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
 
-    await expect(service.updateJobDefinition(2, {
+    await expect(service.updateJobDefinition(2, 7, {
       showScore: true,
       allowComments: false,
       suppressGeneralInstructions: true
@@ -877,7 +895,7 @@ describe('JobDefinitionService', () => {
     jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
     jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
 
-    await expect(service.updateJobDefinition(2, {
+    await expect(service.updateJobDefinition(2, 7, {
       maxCodingCases: 5
     })).resolves.toMatchObject({ id: 2, max_coding_cases: 5 });
   });
@@ -904,7 +922,7 @@ describe('JobDefinitionService', () => {
     jobDefinitionRepository.findOne.mockResolvedValue(editedDefinition);
     jobDefinitionRepository.find.mockResolvedValue([editedDefinition, competingDefinition]);
 
-    await expect(service.updateJobDefinition(2, {
+    await expect(service.updateJobDefinition(2, 7, {
       status: 'approved'
     })).rejects.toBeInstanceOf(BadRequestException);
     expect(codingJobService.assertCodersCanCodeInWorkspace).toHaveBeenCalledWith([1], 7);
@@ -928,7 +946,7 @@ describe('JobDefinitionService', () => {
       new BadRequestException('Coder is not enabled')
     );
 
-    await expect(service.updateJobDefinition(2, {
+    await expect(service.updateJobDefinition(2, 7, {
       status: 'approved'
     })).rejects.toBeInstanceOf(BadRequestException);
 
@@ -1129,7 +1147,7 @@ describe('JobDefinitionService', () => {
     });
     codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
 
-    await expect(service.updateJobDefinition(2, {
+    await expect(service.updateJobDefinition(2, 7, {
       assignedVariables: [{ unitName: 'Unit 2', variableId: 'Var 2' }]
     })).rejects.toBeInstanceOf(BadRequestException);
 
@@ -1149,7 +1167,7 @@ describe('JobDefinitionService', () => {
     });
     codingJobService.getBlockingCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
 
-    await expect(service.deleteJobDefinition(2)).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.deleteJobDefinition(2, 7)).rejects.toBeInstanceOf(BadRequestException);
 
     expect(jobDefinitionRepository.remove).not.toHaveBeenCalled();
   });
@@ -1168,7 +1186,7 @@ describe('JobDefinitionService', () => {
     jobDefinitionRepository.findOne.mockResolvedValue(definition);
     codingJobService.getBlockingCodingJobCountsByDefinitionIds.mockResolvedValue(new Map());
 
-    await expect(service.deleteJobDefinition(2)).resolves.toBeUndefined();
+    await expect(service.deleteJobDefinition(2, 7)).resolves.toBeUndefined();
 
     expect(jobDefinitionRepository.remove).toHaveBeenCalledWith(definition);
   });
@@ -1222,7 +1240,7 @@ describe('JobDefinitionService', () => {
       case_ordering_mode: 'continuous'
     });
 
-    await expect(service.approveJobDefinition(4, {
+    await expect(service.approveJobDefinition(4, 7, {
       status: 'pending_review'
     })).rejects.toBeInstanceOf(BadRequestException);
   });
@@ -1243,7 +1261,7 @@ describe('JobDefinitionService', () => {
       new BadRequestException('Coder is not enabled')
     );
 
-    await expect(service.approveJobDefinition(4, {
+    await expect(service.approveJobDefinition(4, 7, {
       status: 'approved'
     })).rejects.toBeInstanceOf(BadRequestException);
 
@@ -1288,11 +1306,74 @@ describe('JobDefinitionService', () => {
       { id: 1, username: 'Ada' },
       { id: 3, username: 'Chris' }
     ]);
-    codingJobService.createDistributedCodingJobs.mockResolvedValue({
+    const creationResult = {
       success: true,
       jobsCreated: 2,
-      jobs: [{ jobId: 100 }, { jobId: 101 }]
-    });
+      distribution: {
+        'Unit 1::Var 1': { Chris: 1, Ada: 0 },
+        'bundle:9': { Chris: 0, Ada: 1 }
+      },
+      distributionByCoderId: {
+        'Unit 1::Var 1': { 3: 1, 1: 0 },
+        'bundle:9': { 3: 0, 1: 1 }
+      },
+      doubleCodingInfo: {
+        'Unit 1::Var 1': {
+          totalCases: 1,
+          distinctCases: 1,
+          codingTasksTotal: 1,
+          doubleCodedCases: 0,
+          singleCodedCasesAssigned: 1,
+          doubleCodedCasesPerCoder: { Chris: 0, Ada: 0 },
+          doubleCodedCasesPerCoderId: { 3: 0, 1: 0 }
+        },
+        'bundle:9': {
+          totalCases: 2,
+          distinctCases: 1,
+          codingTasksTotal: 2,
+          doubleCodedCases: 1,
+          singleCodedCasesAssigned: 0,
+          doubleCodedCasesPerCoder: { Chris: 1, Ada: 1 },
+          doubleCodedCasesPerCoderId: { 3: 1, 1: 1 }
+        }
+      },
+      aggregationInfo: {
+        'Unit 1::Var 1': { uniqueCases: 1, totalResponses: 1 },
+        'bundle:9': { uniqueCases: 1, totalResponses: 1 }
+      },
+      matchingFlags: ['NO_AGGREGATION'],
+      pairDistribution: { '1-3': 1 },
+      tasksPerCoder: { 3: 2, 1: 1 },
+      coderWeights: { 3: 0.5, 1: 1.5 },
+      jobs: [
+        {
+          itemKey: 'Unit 1::Var 1',
+          coderId: 3,
+          variable: { unitName: 'Unit 1', variableId: 'Var 1' },
+          jobId: 100,
+          caseCount: 1
+        },
+        {
+          itemKey: 'bundle:9',
+          coderId: 1,
+          variable: { unitName: 'Hydrated Bundle', variableId: '' },
+          jobId: 101,
+          caseCount: 1
+        }
+      ]
+    };
+    codingJobService.createDistributedCodingJobs.mockImplementation(
+      async (_workspaceId, _request, afterCreateInTransaction) => {
+        if (afterCreateInTransaction) {
+          await afterCreateInTransaction(
+            { getRepository: () => jobDefinitionRepository } as never,
+            creationResult
+          );
+        }
+
+        return creationResult;
+      }
+    );
 
     await expect(service.createCodingJobFromDefinition(12, 7)).resolves.toMatchObject({
       success: true,
@@ -1300,33 +1381,216 @@ describe('JobDefinitionService', () => {
     });
 
     expect(codingJobService.createCodingJob).not.toHaveBeenCalled();
-    expect(codingJobService.createDistributedCodingJobs).toHaveBeenCalledWith(7, {
-      selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }],
-      selectedVariableBundles: [{
-        id: 9,
-        name: 'Hydrated Bundle',
-        variables: [{ unitName: 'Unit 2', variableId: 'Var 2' }],
-        caseOrderingMode: 'alternating'
-      }],
-      selectedCoders: [
-        {
-          id: 3, name: 'Chris', username: 'Chris', capacityPercent: 50
-        },
-        {
-          id: 1, name: 'Ada', username: 'Ada', capacityPercent: 150
-        }
-      ],
-      doubleCodingAbsolute: 2,
-      doubleCodingPercentage: undefined,
-      caseOrderingMode: 'continuous',
-      maxCodingCases: 7,
-      jobDefinitionId: 12,
-      missingsProfileId: 88,
-      distributionSeed: 'seed-12',
-      showScore: true,
-      allowComments: false,
-      suppressGeneralInstructions: true
+    expect(codingJobService.createDistributedCodingJobs).toHaveBeenCalledWith(
+      7,
+      {
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }],
+        selectedVariableBundles: [{
+          id: 9,
+          name: 'Hydrated Bundle',
+          variables: [{ unitName: 'Unit 2', variableId: 'Var 2' }],
+          caseOrderingMode: 'alternating'
+        }],
+        selectedCoders: [
+          {
+            id: 3, name: 'Chris', username: 'Chris', capacityPercent: 50
+          },
+          {
+            id: 1, name: 'Ada', username: 'Ada', capacityPercent: 150
+          }
+        ],
+        doubleCodingAbsolute: 2,
+        doubleCodingPercentage: undefined,
+        caseOrderingMode: 'continuous',
+        maxCodingCases: 7,
+        jobDefinitionId: 12,
+        missingsProfileId: 88,
+        distributionSeed: 'seed-12',
+        showScore: true,
+        allowComments: false,
+        suppressGeneralInstructions: true
+      },
+      expect.any(Function)
+    );
+    expect(jobDefinitionRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+      distribution_snapshots: [
+        expect.objectContaining({
+          version: 1,
+          source: 'initial_creation',
+          distributionSeed: 'seed-12',
+          selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }],
+          selectedVariableBundles: [expect.objectContaining({ id: 9 })],
+          selectedCoders: [
+            { coderId: 3, capacityPercent: 50 },
+            { coderId: 1, capacityPercent: 150 }
+          ],
+          settings: {
+            maxCodingCases: 7,
+            doubleCodingAbsolute: 2,
+            doubleCodingPercentage: undefined,
+            caseOrderingMode: 'continuous'
+          },
+          distributionByCoderId: {
+            'Unit 1::Var 1': { 3: 1, 1: 0 },
+            'bundle:9': { 3: 0, 1: 1 }
+          },
+          doubleCodingInfo: {
+            'Unit 1::Var 1': expect.objectContaining({
+              doubleCodedCases: 0,
+              doubleCodedCasesPerCoderId: { 3: 0, 1: 0 }
+            }),
+            'bundle:9': expect.objectContaining({
+              doubleCodedCases: 1,
+              doubleCodedCasesPerCoderId: { 3: 1, 1: 1 }
+            })
+          },
+          jobs: [
+            {
+              itemKey: 'Unit 1::Var 1',
+              coderId: 3,
+              variable: { unitName: 'Unit 1', variableId: 'Var 1' },
+              jobId: 100,
+              caseCount: 1
+            },
+            {
+              itemKey: 'bundle:9',
+              coderId: 1,
+              variable: { unitName: 'Hydrated Bundle', variableId: '' },
+              jobId: 101,
+              caseCount: 1
+            }
+          ]
+        })
+      ]
+    }));
+  });
+
+  it('does not store a distribution snapshot when distributed job creation fails', async () => {
+    jobDefinitionRepository.findOne.mockResolvedValue({
+      id: 15,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      assigned_coder_configs: [{ coderId: 1, capacityPercent: 100 }],
+      distribution_seed: 'seed-15',
+      case_ordering_mode: 'continuous',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
     });
+    usersRepository.find.mockResolvedValue([{ id: 1, username: 'Ada' }]);
+    codingJobService.createDistributedCodingJobs.mockResolvedValue({
+      success: false,
+      jobsCreated: 0,
+      message: 'Failed',
+      jobs: []
+    });
+
+    await expect(service.createCodingJobFromDefinition(15, 7)).resolves.toMatchObject({
+      success: false,
+      message: 'Failed'
+    });
+
+    expect(jobDefinitionRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('appends a refresh distribution snapshot without replacing earlier snapshots', async () => {
+    const existingSnapshot = {
+      version: 1,
+      source: 'initial_creation',
+      createdAt: '2026-01-01T00:00:00.000Z'
+    };
+    jobDefinitionRepository.findOne.mockResolvedValue({
+      id: 16,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      assigned_coder_configs: [{ coderId: 1, capacityPercent: 100 }],
+      distribution_seed: 'seed-16',
+      distribution_snapshots: [existingSnapshot],
+      case_ordering_mode: 'continuous',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
+    });
+    usersRepository.find.mockResolvedValue([{ id: 1, username: 'Ada' }]);
+    const refreshResult = {
+      success: true,
+      jobsCreated: 1,
+      message: 'Updated',
+      distribution: { 'Unit 1::Var 1': { Ada: 1 } },
+      distributionByCoderId: { 'Unit 1::Var 1': { 1: 1 } },
+      doubleCodingInfo: {
+        'Unit 1::Var 1': {
+          totalCases: 1,
+          distinctCases: 1,
+          codingTasksTotal: 1,
+          doubleCodedCases: 0,
+          singleCodedCasesAssigned: 1,
+          doubleCodedCasesPerCoder: { Ada: 0 },
+          doubleCodedCasesPerCoderId: { 1: 0 }
+        }
+      },
+      aggregationInfo: { 'Unit 1::Var 1': { uniqueCases: 1, totalResponses: 1 } },
+      matchingFlags: [],
+      pairDistribution: {},
+      tasksPerCoder: { 1: 1 },
+      coderWeights: { 1: 1 },
+      jobs: [{
+        itemKey: 'Unit 1::Var 1',
+        coderId: 1,
+        variable: { unitName: 'Unit 1', variableId: 'Var 1' },
+        jobId: 200,
+        caseCount: 1
+      }],
+      preview: {
+        jobDefinitionId: 16,
+        existingJobsCount: 1,
+        staleJobsCount: 1,
+        existingCases: 0,
+        plannedCases: 1,
+        retainedCases: 0,
+        addedCases: 1,
+        removedCases: 0,
+        addedCodingTasks: 1,
+        removedCodingTasks: 0,
+        canApply: true
+      }
+    };
+    codingJobService.refreshDistributedCodingJobs.mockImplementation(
+      async (_workspaceId, _request, afterRefreshInTransaction) => {
+        if (afterRefreshInTransaction) {
+          await afterRefreshInTransaction(
+            { getRepository: () => jobDefinitionRepository } as never,
+            refreshResult
+          );
+        }
+
+        return refreshResult;
+      }
+    );
+
+    await expect(service.refreshCodingJobFromDefinition(16, 7)).resolves.toMatchObject({
+      success: true,
+      jobsCreated: 1
+    });
+
+    expect(jobDefinitionRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+      distribution_snapshots: [
+        existingSnapshot,
+        expect.objectContaining({
+          version: 1,
+          source: 'refresh',
+          distributionSeed: 'seed-16',
+          selectedCoders: [{ coderId: 1, capacityPercent: 100 }],
+          jobs: [expect.objectContaining({ jobId: 200, coderId: 1, caseCount: 1 })]
+        })
+      ]
+    }));
   });
 
   it('does not collide hyphenated variable keys when creating jobs from definitions', async () => {
@@ -1364,15 +1628,19 @@ describe('JobDefinitionService', () => {
       success: true
     });
 
-    expect(codingJobService.createDistributedCodingJobs).toHaveBeenCalledWith(7, expect.objectContaining({
-      selectedVariables: [{ unitName: 'Unit-A', variableId: 'B', includeDeriveError: true }],
-      selectedVariableBundles: [{
-        id: 10,
-        name: 'Hyphen Bundle',
-        variables: [{ unitName: 'Unit', variableId: 'A-B' }],
-        caseOrderingMode: undefined
-      }]
-    }));
+    expect(codingJobService.createDistributedCodingJobs).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        selectedVariables: [{ unitName: 'Unit-A', variableId: 'B', includeDeriveError: true }],
+        selectedVariableBundles: [{
+          id: 10,
+          name: 'Hyphen Bundle',
+          variables: [{ unitName: 'Unit', variableId: 'A-B' }],
+          caseOrderingMode: undefined
+        }]
+      }),
+      expect.any(Function)
+    );
   });
 
   it('previews jobs from definitions with the same normalized variable selection', async () => {

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -3,10 +3,13 @@ import {
   Injectable, NotFoundException, BadRequestException
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { EntityManager, Repository, In } from 'typeorm';
 import {
   JobDefinition,
   JobDefinitionCoderConfig,
+  JobDefinitionDistributionSnapshot,
+  JobDefinitionDistributionSnapshotDoubleCodingInfo,
+  JobDefinitionDistributionSnapshotSource,
   JobDefinitionVariable,
   JobDefinitionVariableBundle,
   CaseOrderingMode
@@ -124,6 +127,35 @@ type DefinitionDistributionRequest = {
   allowComments: boolean;
   suppressGeneralInstructions: boolean;
   missingsProfileId: number;
+};
+
+type DistributionResultDoubleCodingInfo = {
+  totalCases: number;
+  distinctCases?: number;
+  codingTasksTotal?: number;
+  doubleCodedCases: number;
+  singleCodedCasesAssigned: number;
+  doubleCodedCasesPerCoder?: Record<string, number>;
+  doubleCodedCasesPerCoderId?: Record<string, number>;
+};
+
+type DistributionResultForSnapshot = {
+  success: boolean;
+  distribution: Record<string, Record<string, number>>;
+  distributionByCoderId?: Record<string, Record<string, number>>;
+  doubleCodingInfo: Record<string, DistributionResultDoubleCodingInfo>;
+  aggregationInfo: Record<string, { uniqueCases: number; totalResponses: number }>;
+  matchingFlags: string[];
+  pairDistribution?: Record<string, number>;
+  tasksPerCoder?: Record<string, number>;
+  coderWeights?: Record<string, number>;
+  jobs: {
+    itemKey?: string;
+    coderId: number;
+    variable: { unitName: string; variableId: string };
+    jobId: number;
+    caseCount: number;
+  }[];
 };
 
 const DEFAULT_CODER_CAPACITY_PERCENT = 100;
@@ -601,6 +633,90 @@ export class JobDefinitionService {
     return Object.fromEntries(usage.entries());
   }
 
+  private buildSnapshotDoubleCodingInfo(
+    doubleCodingInfo: Record<string, DistributionResultDoubleCodingInfo>
+  ): Record<string, JobDefinitionDistributionSnapshotDoubleCodingInfo> {
+    return Object.fromEntries(
+      Object.entries(doubleCodingInfo).map(([itemKey, info]) => [
+        itemKey,
+        {
+          totalCases: info.totalCases,
+          distinctCases: info.distinctCases,
+          codingTasksTotal: info.codingTasksTotal,
+          doubleCodedCases: info.doubleCodedCases,
+          singleCodedCasesAssigned: info.singleCodedCasesAssigned,
+          doubleCodedCasesPerCoderId: info.doubleCodedCasesPerCoderId || {}
+        }
+      ])
+    );
+  }
+
+  private buildDistributionSnapshot(
+    source: JobDefinitionDistributionSnapshotSource,
+    request: DefinitionDistributionRequest,
+    result: DistributionResultForSnapshot
+  ): JobDefinitionDistributionSnapshot {
+    return {
+      version: 1,
+      source,
+      createdAt: new Date().toISOString(),
+      distributionSeed: request.distributionSeed,
+      selectedVariables: request.selectedVariables,
+      selectedVariableBundles: request.selectedVariableBundles,
+      selectedCoders: request.selectedCoders.map(coder => ({
+        coderId: coder.id,
+        capacityPercent: coder.capacityPercent
+      })),
+      settings: {
+        maxCodingCases: request.maxCodingCases,
+        doubleCodingAbsolute: request.doubleCodingAbsolute,
+        doubleCodingPercentage: request.doubleCodingPercentage,
+        caseOrderingMode: request.caseOrderingMode
+      },
+      distributionByCoderId: result.distributionByCoderId || {},
+      doubleCodingInfo: this.buildSnapshotDoubleCodingInfo(result.doubleCodingInfo || {}),
+      aggregationInfo: result.aggregationInfo || {},
+      matchingFlags: result.matchingFlags || [],
+      pairDistribution: result.pairDistribution || {},
+      tasksPerCoder: result.tasksPerCoder || {},
+      coderWeights: result.coderWeights || {},
+      jobs: (result.jobs || []).map(job => ({
+        itemKey: job.itemKey,
+        coderId: job.coderId,
+        variable: job.variable,
+        jobId: job.jobId,
+        caseCount: job.caseCount
+      }))
+    };
+  }
+
+  private async appendDistributionSnapshot(
+    jobDefinitionId: number,
+    source: JobDefinitionDistributionSnapshotSource,
+    request: DefinitionDistributionRequest,
+    result: DistributionResultForSnapshot,
+    manager?: EntityManager
+  ): Promise<void> {
+    const repository = manager?.getRepository(JobDefinition) || this.jobDefinitionRepository;
+    const jobDefinition = await repository.findOne({
+      where: { id: jobDefinitionId }
+    });
+
+    if (!jobDefinition) {
+      throw new NotFoundException(`Job definition with ID ${jobDefinitionId} not found`);
+    }
+
+    const snapshots = Array.isArray(jobDefinition.distribution_snapshots) ?
+      jobDefinition.distribution_snapshots :
+      [];
+    jobDefinition.distribution_snapshots = [
+      ...snapshots,
+      this.buildDistributionSnapshot(source, request, result)
+    ];
+
+    await repository.save(jobDefinition);
+  }
+
   async createJobDefinition(createDto: CreateJobDefinitionDto, workspaceId: number): Promise<JobDefinition> {
     const coderAssignments = this.resolveCoderAssignments(createDto);
     const distributionSeed = this.createDistributionSeed(workspaceId);
@@ -669,9 +785,12 @@ export class JobDefinitionService {
     return this.jobDefinitionRepository.save(jobDefinition);
   }
 
-  async getJobDefinition(id: number): Promise<JobDefinition> {
+  async getJobDefinition(id: number, workspaceId: number): Promise<JobDefinition> {
     const jobDefinition = await this.jobDefinitionRepository.findOne({
-      where: { id }
+      where: {
+        id,
+        workspace_id: workspaceId
+      }
     });
 
     if (!jobDefinition) {
@@ -852,8 +971,8 @@ export class JobDefinitionService {
     }
   }
 
-  async updateJobDefinition(id: number, updateDto: UpdateJobDefinitionDto): Promise<JobDefinition> {
-    const jobDefinition = await this.getJobDefinition(id);
+  async updateJobDefinition(id: number, workspaceId: number, updateDto: UpdateJobDefinitionDto): Promise<JobDefinition> {
+    const jobDefinition = await this.getJobDefinition(id, workspaceId);
     await this.assertJobDefinitionHasNoCreatedJobs(jobDefinition);
     const existingCoderAssignments = this.getStoredCoderAssignments(jobDefinition);
     const nextCoderAssignments = this.resolveCoderAssignments(updateDto, existingCoderAssignments);
@@ -981,8 +1100,8 @@ export class JobDefinitionService {
     return savedDefinition;
   }
 
-  async approveJobDefinition(id: number, approveDto: ApproveJobDefinitionDto): Promise<JobDefinition> {
-    const jobDefinition = await this.getJobDefinition(id);
+  async approveJobDefinition(id: number, workspaceId: number, approveDto: ApproveJobDefinitionDto): Promise<JobDefinition> {
+    const jobDefinition = await this.getJobDefinition(id, workspaceId);
     const coderAssignments = this.getStoredCoderAssignments(jobDefinition);
 
     this.validateStatusTransition(jobDefinition.status, approveDto.status);
@@ -1049,8 +1168,8 @@ export class JobDefinitionService {
     }
   }
 
-  async deleteJobDefinition(id: number): Promise<void> {
-    const jobDefinition = await this.getJobDefinition(id);
+  async deleteJobDefinition(id: number, workspaceId: number): Promise<void> {
+    const jobDefinition = await this.getJobDefinition(id, workspaceId);
     await this.assertJobDefinitionHasNoBlockingCreatedJobs(jobDefinition);
     await this.jobDefinitionRepository.remove(jobDefinition);
   }
@@ -1086,14 +1205,10 @@ export class JobDefinitionService {
     jobDefinitionId: number,
     workspaceId: number
   ): Promise<DefinitionDistributionRequest> {
-    const jobDefinition = await this.getJobDefinition(jobDefinitionId);
+    const jobDefinition = await this.getJobDefinition(jobDefinitionId, workspaceId);
 
     if (jobDefinition.status !== 'approved') {
       throw new BadRequestException('Only approved job definitions can be used to create coding jobs');
-    }
-
-    if (jobDefinition.workspace_id !== workspaceId) {
-      throw new NotFoundException(`Job definition with ID ${jobDefinitionId} not found`);
     }
 
     const variableBundleIds = jobDefinition.assigned_variable_bundles?.map(bundle => bundle.id) || [];
@@ -1159,7 +1274,19 @@ export class JobDefinitionService {
 
   async createCodingJobFromDefinition(jobDefinitionId: number, workspaceId: number) {
     const request = await this.buildDistributionRequestFromDefinition(jobDefinitionId, workspaceId);
-    return this.codingJobService.createDistributedCodingJobs(workspaceId, request);
+    return this.codingJobService.createDistributedCodingJobs(
+      workspaceId,
+      request,
+      async (manager, result) => {
+        await this.appendDistributionSnapshot(
+          jobDefinitionId,
+          'initial_creation',
+          request,
+          result,
+          manager
+        );
+      }
+    );
   }
 
   async previewCodingJobFromDefinition(jobDefinitionId: number, workspaceId: number) {
@@ -1186,7 +1313,19 @@ export class JobDefinitionService {
     workspaceId: number
   ): Promise<JobDefinitionRefreshApplyResultDto> {
     const request = await this.buildDistributionRequestFromDefinition(jobDefinitionId, workspaceId);
-    const result = await this.codingJobService.refreshDistributedCodingJobs(workspaceId, request);
+    const result = await this.codingJobService.refreshDistributedCodingJobs(
+      workspaceId,
+      request,
+      async (manager, transactionResult) => {
+        await this.appendDistributionSnapshot(
+          jobDefinitionId,
+          'refresh',
+          request,
+          transactionResult,
+          manager
+        );
+      }
+    );
     if (!result.success) {
       throw new BadRequestException(result.message);
     }

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -99,6 +99,13 @@ describe('CodingJobBackendService', () => {
             suppressGeneralInstructions: true,
             assignedCoderConfigs: [{ coderId: 1, capacityPercent: 50 }],
             distributionSeed: 'seed-7',
+            distributionSnapshots: [
+              expect.objectContaining({
+                version: 1,
+                source: 'initial_creation',
+                distributionSeed: 'seed-7'
+              })
+            ],
             plannedVariableUsage: { 'Unit 1::Var 1': 2 }
           }),
           expect.objectContaining({
@@ -122,6 +129,24 @@ describe('CodingJobBackendService', () => {
           blocking_created_jobs_count: 1,
           assigned_coder_configs: [{ coderId: 1, capacityPercent: 50 }],
           distribution_seed: 'seed-7',
+          distribution_snapshots: [{
+            version: 1,
+            source: 'initial_creation',
+            createdAt: '2026-06-01T00:00:00.000Z',
+            distributionSeed: 'seed-7',
+            selectedVariables: [],
+            selectedVariableBundles: [],
+            selectedCoders: [{ coderId: 1, capacityPercent: 50 }],
+            settings: {},
+            distributionByCoderId: {},
+            doubleCodingInfo: {},
+            aggregationInfo: {},
+            matchingFlags: [],
+            pairDistribution: {},
+            tasksPerCoder: {},
+            coderWeights: {},
+            jobs: []
+          }],
           planned_variable_usage: { 'Unit 1::Var 1': 2 },
           show_score: true,
           allow_comments: false,

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -71,6 +71,8 @@ interface JobDefinitionApiResponse {
   assigned_coders?: number[];
   assigned_coder_configs?: JobDefinitionCoderConfig[];
   assignedCoderConfigs?: JobDefinitionCoderConfig[];
+  distribution_snapshots?: JobDefinitionDistributionSnapshot[];
+  distributionSnapshots?: JobDefinitionDistributionSnapshot[];
   missings_profile_id?: number | null;
   missingsProfileId?: number | null;
   distribution_seed?: string;
@@ -98,6 +100,49 @@ interface JobDefinitionApiResponse {
   updated_at?: Date;
 }
 
+export interface JobDefinitionDistributionSnapshot {
+  version: 1;
+  source: 'initial_creation' | 'refresh';
+  createdAt: string;
+  distributionSeed: string;
+  selectedVariables: Variable[];
+  selectedVariableBundles: Array<{
+    id: number;
+    name: string;
+    variables?: Variable[];
+    sampleCount?: number;
+    caseOrderingMode?: 'continuous' | 'alternating';
+  }>;
+  selectedCoders: { coderId: number; capacityPercent: number }[];
+  settings: {
+    maxCodingCases?: number;
+    doubleCodingAbsolute?: number;
+    doubleCodingPercentage?: number;
+    caseOrderingMode?: 'continuous' | 'alternating';
+  };
+  distributionByCoderId: Record<string, Record<string, number>>;
+  doubleCodingInfo: Record<string, {
+    totalCases: number;
+    distinctCases?: number;
+    codingTasksTotal?: number;
+    doubleCodedCases: number;
+    singleCodedCasesAssigned: number;
+    doubleCodedCasesPerCoderId: Record<string, number>;
+  }>;
+  aggregationInfo: Record<string, { uniqueCases: number; totalResponses: number }>;
+  matchingFlags: string[];
+  pairDistribution: Record<string, number>;
+  tasksPerCoder: Record<string, number>;
+  coderWeights: Record<string, number>;
+  jobs: Array<{
+    itemKey?: string;
+    coderId: number;
+    variable: { unitName: string; variableId: string };
+    jobId: number;
+    caseCount: number;
+  }>;
+}
+
 export interface JobDefinition {
   id?: number;
   status?: 'draft' | 'pending_review' | 'approved';
@@ -105,6 +150,7 @@ export interface JobDefinition {
   assignedVariableBundles?: import('../models/coding-job.model').VariableBundle[];
   assignedCoders?: number[];
   assignedCoderConfigs?: JobDefinitionCoderConfig[];
+  distributionSnapshots?: JobDefinitionDistributionSnapshot[];
   missingsProfileId?: number | null;
   distributionSeed?: string;
   plannedVariableUsage?: Record<string, number>;
@@ -685,6 +731,7 @@ export class CodingJobBackendService {
         assignedVariableBundles: def.assigned_variable_bundles,
         assignedCoders: def.assigned_coders,
         assignedCoderConfigs: def.assignedCoderConfigs ?? def.assigned_coder_configs,
+        distributionSnapshots: def.distributionSnapshots ?? def.distribution_snapshots,
         missingsProfileId: def.missingsProfileId ?? def.missings_profile_id,
         distributionSeed: def.distributionSeed ?? def.distribution_seed,
         plannedVariableUsage: def.plannedVariableUsage ?? def.planned_variable_usage,

--- a/apps/frontend/src/app/coding/services/distributed-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/distributed-coding.service.ts
@@ -44,6 +44,7 @@ export interface DistributionCalculationResponse {
     doubleCodedCases: number;
     singleCodedCasesAssigned: number;
     doubleCodedCasesPerCoder: Record<string, number>;
+    doubleCodedCasesPerCoderId?: Record<string, number>;
   }>;
   aggregationInfo: Record<string, { uniqueCases: number; totalResponses: number }>;
   matchingFlags: string[];

--- a/database/changelog/coding-box.changelog-1.16.0.sql
+++ b/database/changelog/coding-box.changelog-1.16.0.sql
@@ -49,3 +49,11 @@ SET "missings_profile_id" = (
 WHERE "missings_profile_id" IS NULL;
 
 -- rollback -- Cannot safely restore implicit default profile references after backfill.
+
+-- changeset jurei733:4
+-- comment: Store stable distribution snapshots on job definitions
+
+ALTER TABLE "public"."job_definitions"
+  ADD COLUMN "distribution_snapshots" JSONB NULL;
+
+-- rollback ALTER TABLE "public"."job_definitions" DROP COLUMN IF EXISTS "distribution_snapshots";


### PR DESCRIPTION
## Summary

- add stable JSONB distribution snapshots to job definitions for initial creation and refresh
- persist coder ids, selected variables/bundles, case counts, double-coding details, and created job ids
- scope single job-definition read/update/approve/delete operations by workspace
- expose snapshot fields through backend/frontend types and Swagger

Refs #541

## Validation

- npx nx test backend --testFile=apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts --skip-nx-cache
- npx nx test backend --testFile=apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.spec.ts --skip-nx-cache
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts --skip-nx-cache
- npx nx test frontend --testFile=apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts --skip-nx-cache
- npx nx lint backend
- npx nx lint frontend
- make dev-db-validate-changelog
- git diff --check
