### PR TITLE
Show stored distribution summaries for job definitions

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.html
@@ -144,6 +144,15 @@
               <button
                 mat-menu-item
                 type="button"
+                *ngIf="canViewDistributionSummary(definition)"
+                (click)="viewDistributionSummary(definition)"
+                [attr.aria-label]="getActionAriaLabel('distribution-summary', definition)">
+                <mat-icon>table_chart</mat-icon>
+                <span>{{ 'coding-job-definitions.actions.distribution-summary' | translate }}</span>
+              </button>
+              <button
+                mat-menu-item
+                type="button"
                 *ngIf="canRefreshDefinition(definition)"
                 [disabled]="isRefreshingDefinition(definition)"
                 (click)="refreshDefinition(definition)"

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
@@ -17,6 +17,9 @@ import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
 import { JobDefinitionRefreshPreviewDto } from '../../../../../../../api-dto/coding/job-refresh.dto';
 import { JobDefinitionRefreshDialogComponent } from './job-definition-refresh-dialog.component';
+import {
+  JobDefinitionDistributionSummaryDialogComponent
+} from './job-definition-distribution-summary-dialog.component';
 
 describe('CodingJobDefinitionsComponent', () => {
   let component: CodingJobDefinitionsComponent;
@@ -244,6 +247,99 @@ describe('CodingJobDefinitionsComponent', () => {
     expect(component.getCreatedJobsCount(component.jobDefinitions[0])).toBeUndefined();
     expect(component.canCreateCodingJobs(component.jobDefinitions[0])).toBe(false);
     expect(component.getDefinitionsReadyForJobsCount()).toBe(0);
+  });
+
+  it('opens the latest stored distribution snapshot read-only', () => {
+    const matDialog = TestBed.inject(MatDialog);
+    const dialogRefMock = { afterClosed: () => of(false) };
+    jest.spyOn(matDialog, 'open').mockReturnValue(dialogRefMock as never);
+    component.coders = [
+      { id: 1, name: 'Ada' },
+      { id: 2, name: 'Bea' }
+    ];
+    const firstSnapshot = {
+      version: 1 as const,
+      source: 'initial_creation' as const,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      distributionSeed: 'seed-1',
+      selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      selectedVariableBundles: [],
+      selectedCoders: [{ coderId: 1, capacityPercent: 100 }],
+      settings: { caseOrderingMode: 'continuous' as const },
+      distributionByCoderId: { 'Unit 1::Var 1': { 1: 3 } },
+      doubleCodingInfo: {
+        'Unit 1::Var 1': {
+          totalCases: 3,
+          distinctCases: 3,
+          codingTasksTotal: 3,
+          doubleCodedCases: 0,
+          singleCodedCasesAssigned: 3,
+          doubleCodedCasesPerCoderId: { 1: 0 }
+        }
+      },
+      aggregationInfo: {},
+      matchingFlags: [],
+      pairDistribution: {},
+      tasksPerCoder: { 1: 3 },
+      coderWeights: { 1: 1 },
+      jobs: []
+    };
+    const latestSnapshot = {
+      ...firstSnapshot,
+      source: 'refresh' as const,
+      createdAt: '2026-01-02T00:00:00.000Z',
+      distributionByCoderId: { 'Unit 1::Var 1': { 1: 2, 2: 1 } },
+      selectedCoders: [
+        { coderId: 1, capacityPercent: 100 },
+        { coderId: 2, capacityPercent: 100 }
+      ]
+    };
+
+    component.viewDistributionSummary({
+      id: 42,
+      status: 'approved',
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedCoders: [1, 2],
+      createdJobsCount: 2,
+      distributionSnapshots: [firstSnapshot, latestSnapshot]
+    });
+
+    expect(matDialog.open).toHaveBeenCalledWith(
+      JobDefinitionDistributionSummaryDialogComponent,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          definitionId: 42,
+          snapshot: latestSnapshot,
+          coders: component.coders,
+          createdJobsCount: 2
+        })
+      })
+    );
+  });
+
+  it('opens a clear missing-history dialog for old definitions without snapshots', () => {
+    const matDialog = TestBed.inject(MatDialog);
+    const dialogRefMock = { afterClosed: () => of(false) };
+    jest.spyOn(matDialog, 'open').mockReturnValue(dialogRefMock as never);
+
+    component.viewDistributionSummary({
+      id: 43,
+      status: 'approved',
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedCoders: [1],
+      createdJobsCount: 1
+    });
+
+    expect(matDialog.open).toHaveBeenCalledWith(
+      JobDefinitionDistributionSummaryDialogComponent,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          definitionId: 43,
+          snapshot: undefined,
+          createdJobsCount: 1
+        })
+      })
+    );
   });
 
   it('opens a redistribution preview and applies it after confirmation', async () => {

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
@@ -21,7 +21,10 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Subject, firstValueFrom, takeUntil } from 'rxjs';
-import { CodingJobBackendService } from '../../services/coding-job-backend.service';
+import {
+  CodingJobBackendService,
+  JobDefinitionDistributionSnapshot
+} from '../../services/coding-job-backend.service';
 import type { JobDefinitionDistributionPreviewResponse } from '../../services/distributed-coding.service';
 import { AppService } from '../../../core/services/app.service';
 import { Variable, VariableBundle } from '../../models/coding-job.model';
@@ -38,6 +41,9 @@ import {
   CodingJobBulkCreationDialogComponent,
   BulkCreationData
 } from '../coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component';
+import {
+  JobDefinitionDistributionSummaryDialogComponent
+} from './job-definition-distribution-summary-dialog.component';
 
 interface JobDefinition {
   id?: number;
@@ -46,6 +52,7 @@ interface JobDefinition {
   assignedVariableBundles?: VariableBundle[];
   assignedCoders?: number[];
   assignedCoderConfigs?: { coderId: number; capacityPercent: number }[];
+  distributionSnapshots?: JobDefinitionDistributionSnapshot[];
   missingsProfileId?: number | null;
   distributionSeed?: string;
   plannedVariableUsage?: Record<string, number>;
@@ -409,6 +416,27 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
     return definition.status === 'approved' && createdJobsCount !== undefined && createdJobsCount > 0;
   }
 
+  canViewDistributionSummary(definition: JobDefinition): boolean {
+    const createdJobsCount = this.getCreatedJobsCount(definition);
+    return this.hasDistributionSnapshots(definition) ||
+      (createdJobsCount !== undefined && createdJobsCount > 0);
+  }
+
+  hasDistributionSnapshots(definition: JobDefinition): boolean {
+    return Array.isArray(definition.distributionSnapshots) &&
+      definition.distributionSnapshots.length > 0;
+  }
+
+  getLatestDistributionSnapshot(
+    definition: JobDefinition
+  ): JobDefinitionDistributionSnapshot | undefined {
+    if (!this.hasDistributionSnapshots(definition)) {
+      return undefined;
+    }
+
+    return definition.distributionSnapshots![definition.distributionSnapshots!.length - 1];
+  }
+
   isRefreshingDefinition(definition: JobDefinition): boolean {
     return !!definition.id && this.refreshingDefinitionIds.has(definition.id);
   }
@@ -765,6 +793,24 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
     } finally {
       this.refreshingDefinitionIds.delete(definition.id);
     }
+  }
+
+  viewDistributionSummary(definition: JobDefinition): void {
+    if (!definition.id || !this.canViewDistributionSummary(definition)) {
+      return;
+    }
+
+    this.dialog.open(JobDefinitionDistributionSummaryDialogComponent, {
+      width: '1120px',
+      maxWidth: '95vw',
+      data: {
+        definitionId: definition.id,
+        snapshot: this.getLatestDistributionSnapshot(definition),
+        coders: this.coders,
+        createdJobsCount: this.getCreatedJobsCount(definition)
+      },
+      autoFocus: false
+    });
   }
 
   private async applyDefinitionRefresh(

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.html
@@ -1,0 +1,78 @@
+<h2 mat-dialog-title class="distribution-title">
+  <mat-icon>table_chart</mat-icon>
+  {{ 'coding-job-definitions.distribution-summary.title' | translate }}
+</h2>
+
+<mat-dialog-content class="distribution-content">
+  <div class="definition-meta">
+    <span>{{ 'coding-job-definitions.distribution-summary.definition-label' | translate:{id: data.definitionId} }}</span>
+    @if (snapshot) {
+      <span>{{ getSourceLabelKey() | translate }}</span>
+      <span>{{ getSnapshotDate() }}</span>
+    }
+  </div>
+
+  @if (!snapshot) {
+    <div class="missing-history">
+      <mat-icon>info</mat-icon>
+      <p>{{ 'coding-job-definitions.distribution-summary.missing-history' | translate }}</p>
+    </div>
+  } @else {
+    <div class="snapshot-summary">
+      <div class="summary-stat">
+        <span>{{ 'coding-job-definitions.distribution-summary.coders' | translate }}</span>
+        <strong>{{ coderColumns.length }}</strong>
+      </div>
+      <div class="summary-stat">
+        <span>{{ 'coding-job-definitions.distribution-summary.jobs' | translate }}</span>
+        <strong>{{ snapshot.jobs.length }}</strong>
+      </div>
+      <div class="summary-stat">
+        <span>{{ 'coding-job-definitions.distribution-summary.total-cases' | translate }}</span>
+        <strong>{{ getGrandTotal() }}</strong>
+      </div>
+    </div>
+
+    <mat-divider></mat-divider>
+
+    <div class="distribution-matrix" [style.--distribution-columns]="getGridTemplate()">
+      <div class="matrix-row matrix-header">
+        <div class="matrix-cell item-cell">{{ 'coding-job-definitions.distribution-summary.item' | translate }}</div>
+        @for (coder of coderColumns; track coder.id) {
+          <div class="matrix-cell coder-cell">
+            <mat-icon>person</mat-icon>
+            <span>{{ coder.name }}</span>
+          </div>
+        }
+        <div class="matrix-cell">{{ 'coding-job-definitions.distribution-summary.total' | translate }}</div>
+        <div class="matrix-cell">{{ 'coding-job-definitions.distribution-summary.double-coded' | translate }}</div>
+      </div>
+
+      @for (row of rows; track row.itemKey) {
+        <div class="matrix-row">
+          <div class="matrix-cell item-cell">{{ row.label }}</div>
+          @for (coder of coderColumns; track coder.id) {
+            <div class="matrix-cell">{{ row.coderCases[coder.id] || 0 }}</div>
+          }
+          <div class="matrix-cell total-cell">{{ row.totalCases }}</div>
+          <div class="matrix-cell">{{ row.doubleCodedCases }}</div>
+        </div>
+      }
+
+      <div class="matrix-row total-row">
+        <div class="matrix-cell item-cell">{{ 'coding-job-definitions.distribution-summary.grand-total' | translate }}</div>
+        @for (coder of coderColumns; track coder.id) {
+          <div class="matrix-cell">{{ getCoderTotal(coder.id) }}</div>
+        }
+        <div class="matrix-cell total-cell">{{ getGrandTotal() }}</div>
+        <div class="matrix-cell"></div>
+      </div>
+    </div>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-raised-button color="primary" type="button" (click)="dialogRef.close()">
+    {{ 'common.close' | translate }}
+  </button>
+</mat-dialog-actions>

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.scss
@@ -1,0 +1,119 @@
+.distribution-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+
+.distribution-content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: min(980px, 82vw);
+  max-width: 100%;
+}
+
+.definition-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  color: rgba(0, 0, 0, 0.62);
+  font-size: 0.9rem;
+}
+
+.missing-history {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  background: #eef6ff;
+  border: 1px solid rgba(25, 118, 210, 0.18);
+  border-radius: 6px;
+  color: rgba(0, 0, 0, 0.78);
+}
+
+.missing-history p {
+  margin: 0;
+}
+
+.snapshot-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.summary-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  background: #fafafa;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 6px;
+}
+
+.summary-stat span {
+  color: rgba(0, 0, 0, 0.62);
+  font-size: 0.82rem;
+}
+
+.summary-stat strong {
+  color: #1976d2;
+  font-size: 1.2rem;
+}
+
+.distribution-matrix {
+  overflow-x: auto;
+}
+
+.matrix-row {
+  display: grid;
+  grid-template-columns: var(--distribution-columns);
+  min-width: max-content;
+}
+
+.matrix-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 8px 10px;
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  text-align: center;
+}
+
+.matrix-header .matrix-cell,
+.total-row .matrix-cell {
+  font-weight: 600;
+  background: #f5f5f5;
+}
+
+.item-cell {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.coder-cell {
+  gap: 6px;
+}
+
+.coder-cell mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.total-cell {
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .distribution-content {
+    min-width: 0;
+  }
+
+  .snapshot-summary {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+import {
+  JobDefinitionDistributionSummaryDialogComponent,
+  JobDefinitionDistributionSummaryDialogData
+} from './job-definition-distribution-summary-dialog.component';
+
+describe('JobDefinitionDistributionSummaryDialogComponent', () => {
+  let fixture: ComponentFixture<JobDefinitionDistributionSummaryDialogComponent>;
+  let component: JobDefinitionDistributionSummaryDialogComponent;
+
+  const createComponent = (data: JobDefinitionDistributionSummaryDialogData): void => {
+    TestBed.overrideProvider(MAT_DIALOG_DATA, { useValue: data });
+    fixture = TestBed.createComponent(JobDefinitionDistributionSummaryDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        JobDefinitionDistributionSummaryDialogComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: jest.fn() } },
+        { provide: MAT_DIALOG_DATA, useValue: { definitionId: 1, coders: [] } }
+      ]
+    }).compileComponents();
+  });
+
+  it('renders a stored distribution snapshot with coder totals', () => {
+    createComponent({
+      definitionId: 42,
+      coders: [
+        { id: 1, name: 'Ada' },
+        { id: 2, name: 'Bea' }
+      ],
+      snapshot: {
+        version: 1,
+        source: 'initial_creation',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        distributionSeed: 'seed-42',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        selectedVariableBundles: [],
+        selectedCoders: [
+          { coderId: 1, capacityPercent: 100 },
+          { coderId: 2, capacityPercent: 100 }
+        ],
+        settings: { caseOrderingMode: 'continuous' },
+        distributionByCoderId: {
+          'Unit 1::Var 1': { 1: 3, 2: 2 }
+        },
+        doubleCodingInfo: {
+          'Unit 1::Var 1': {
+            totalCases: 5,
+            distinctCases: 4,
+            codingTasksTotal: 5,
+            doubleCodedCases: 1,
+            singleCodedCasesAssigned: 3,
+            doubleCodedCasesPerCoderId: { 1: 1, 2: 1 }
+          }
+        },
+        aggregationInfo: {},
+        matchingFlags: [],
+        pairDistribution: {},
+        tasksPerCoder: { 1: 3, 2: 2 },
+        coderWeights: { 1: 1, 2: 1 },
+        jobs: []
+      }
+    });
+
+    expect(component.rows).toHaveLength(1);
+    expect(component.getCoderTotal(1)).toBe(3);
+    expect(component.getCoderTotal(2)).toBe(2);
+    expect(component.getGrandTotal()).toBe(5);
+    expect(fixture.nativeElement.textContent).toContain('Ada');
+    expect(fixture.nativeElement.textContent).toContain('Unit 1 -> Var 1');
+  });
+
+  it('renders a missing-history message when no snapshot exists', () => {
+    createComponent({
+      definitionId: 43,
+      coders: [],
+      createdJobsCount: 1
+    });
+
+    expect(component.rows).toEqual([]);
+    expect(fixture.nativeElement.querySelector('.missing-history')).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.ts
@@ -1,0 +1,131 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { TranslateModule } from '@ngx-translate/core';
+import type {
+  JobDefinitionDistributionSnapshot
+} from '../../services/coding-job-backend.service';
+
+interface DialogCoder {
+  id: number;
+  name: string;
+}
+
+interface DistributionSummaryRow {
+  itemKey: string;
+  label: string;
+  coderCases: Record<string, number>;
+  totalCases: number;
+  doubleCodedCases: number;
+  singleCodedCasesAssigned: number;
+}
+
+export interface JobDefinitionDistributionSummaryDialogData {
+  definitionId: number;
+  snapshot?: JobDefinitionDistributionSnapshot;
+  coders: DialogCoder[];
+  createdJobsCount?: number;
+}
+
+@Component({
+  selector: 'coding-box-job-definition-distribution-summary-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatDividerModule,
+    MatIconModule,
+    TranslateModule
+  ],
+  templateUrl: './job-definition-distribution-summary-dialog.component.html',
+  styleUrls: ['./job-definition-distribution-summary-dialog.component.scss']
+})
+export class JobDefinitionDistributionSummaryDialogComponent {
+  readonly snapshot = this.data.snapshot;
+  readonly coderColumns = this.getCoderColumns();
+  readonly rows = this.getRows();
+
+  constructor(
+    public dialogRef: MatDialogRef<JobDefinitionDistributionSummaryDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: JobDefinitionDistributionSummaryDialogData
+  ) {}
+
+  getSnapshotDate(): string {
+    if (!this.snapshot?.createdAt) {
+      return '';
+    }
+
+    return new Date(this.snapshot.createdAt).toLocaleString('de-DE');
+  }
+
+  getSourceLabelKey(): string {
+    return this.snapshot?.source === 'refresh' ?
+      'coding-job-definitions.distribution-summary.source.refresh' :
+      'coding-job-definitions.distribution-summary.source.initial';
+  }
+
+  getCoderTotal(coderId: number): number {
+    return this.rows.reduce(
+      (total, row) => total + (row.coderCases[String(coderId)] || 0),
+      0
+    );
+  }
+
+  getGrandTotal(): number {
+    return this.rows.reduce((total, row) => total + row.totalCases, 0);
+  }
+
+  getGridTemplate(): string {
+    const coderColumns = 'minmax(88px, 1fr) '.repeat(this.coderColumns.length);
+    return `minmax(180px, 1.7fr) ${coderColumns}minmax(80px, .8fr) minmax(110px, .9fr)`.trim();
+  }
+
+  private getCoderColumns(): DialogCoder[] {
+    const snapshotCoders = this.snapshot?.selectedCoders || [];
+    const coderNameById = new Map(this.data.coders.map(coder => [coder.id, coder.name]));
+
+    return snapshotCoders.map(coder => ({
+      id: coder.coderId,
+      name: coderNameById.get(coder.coderId) || `Coder ${coder.coderId}`
+    }));
+  }
+
+  private getRows(): DistributionSummaryRow[] {
+    if (!this.snapshot) {
+      return [];
+    }
+
+    return Object.entries(this.snapshot.distributionByCoderId || {})
+      .map(([itemKey, coderCases]) => {
+        const doubleCodingInfo = this.snapshot?.doubleCodingInfo?.[itemKey];
+        return {
+          itemKey,
+          label: this.getItemLabel(itemKey),
+          coderCases,
+          totalCases: Object.values(coderCases).reduce((sum, count) => sum + count, 0),
+          doubleCodedCases: doubleCodingInfo?.doubleCodedCases || 0,
+          singleCodedCasesAssigned: doubleCodingInfo?.singleCodedCasesAssigned || 0
+        };
+      })
+      .filter(row => row.totalCases > 0 || row.doubleCodedCases > 0);
+  }
+
+  private getItemLabel(itemKey: string): string {
+    if (itemKey.startsWith('bundle:')) {
+      const bundleId = Number(itemKey.slice('bundle:'.length));
+      const bundle = this.snapshot?.selectedVariableBundles.find(selectedBundle => selectedBundle.id === bundleId);
+      return bundle?.name || itemKey;
+    }
+
+    const parts = itemKey.split('::');
+    if (parts.length === 2) {
+      return `${parts[0]} -> ${parts[1]}`;
+    }
+
+    return itemKey;
+  }
+}

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2146,6 +2146,7 @@
       "jobs-created-short": "{{count}} erstellt",
       "jobs-count-unavailable": "Der Status erzeugter Kodier-Jobs konnte nicht geladen werden.",
       "jobs-count-unavailable-short": "Status unklar",
+      "distribution-summary": "Verteilungsübersicht anzeigen",
       "refresh": "Kodierjobs neu verteilen",
       "refresh-tooltip": "Prüfen, welche bestehenden Kodierjobs ersetzt und anhand der aktuellen Definition neu erzeugt werden können.",
       "more": "Weitere Aktionen",
@@ -2190,6 +2191,22 @@
         "removed-tasks": "Aufgaben entfernt"
       },
       "confirm": "Jobs neu verteilen"
+    },
+    "distribution-summary": {
+      "title": "Verteilungsübersicht",
+      "definition-label": "Definition #{{id}}",
+      "source": {
+        "initial": "Ersterstellung",
+        "refresh": "Neuverteilung"
+      },
+      "missing-history": "Für diese Job-Definition liegt keine gespeicherte Verteilungsübersicht vor. Vermutlich wurden die Kodierjobs vor Einführung der Snapshot-Speicherung erstellt.",
+      "coders": "Kodierer",
+      "jobs": "Kodierjobs",
+      "total-cases": "Kodieraufgaben",
+      "item": "Variable / Bündel",
+      "total": "Gesamt",
+      "double-coded": "Doppelt kodiert",
+      "grand-total": "Gesamt"
     },
     "summary": {
       "total": "Gesamt",


### PR DESCRIPTION
Refs #542

## What changed
- Added a read-only distribution summary action for job definitions with stored snapshots.
- Added a dialog that shows coders, coding-task totals, double-coded counts, snapshot source and timestamp.
- Added a clear missing-history message for old job definitions without stored snapshots.

## Validation
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts --skip-nx-cache
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.spec.ts --skip-nx-cache
- npx nx lint frontend --skip-nx-cache
- git diff --check