### PR TITLE
Export job definition distribution as CSV

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.spec.ts
@@ -130,4 +130,25 @@ describe('WorkspaceCodingJobDefinitionController', () => {
 
     expect(jobDefinitionService.previewCodingJobFromDefinition).toHaveBeenCalledWith(42, 5);
   });
+
+  it('exports job definition distribution snapshots as downloadable CSV', async () => {
+    const jobDefinitionService = {
+      exportDistributionSnapshotAsCsv: jest.fn().mockResolvedValue('header\nrow')
+    };
+    const response = {
+      setHeader: jest.fn(),
+      send: jest.fn()
+    };
+    const controller = new WorkspaceCodingJobDefinitionController(jobDefinitionService as never);
+
+    await controller.exportJobDefinitionDistributionAsCsv(5, 42, response as never);
+
+    expect(jobDefinitionService.exportDistributionSnapshotAsCsv).toHaveBeenCalledWith(42, 5);
+    expect(response.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv; charset=utf-8');
+    expect(response.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      expect.stringMatching(/^attachment; filename="job-definition-distribution-5-42-\d{4}-\d{2}-\d{2}\.csv"$/)
+    );
+    expect(response.send).toHaveBeenCalledWith('\uFEFFheader\nrow');
+  });
 });

--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
@@ -7,14 +7,17 @@ import {
   Delete,
   UseGuards,
   Body,
-  ValidationPipe
+  ValidationPipe,
+  Res
 } from '@nestjs/common';
 import {
   ApiOkResponse,
   ApiParam,
   ApiTags,
-  ApiBody
+  ApiBody,
+  ApiProduces
 } from '@nestjs/swagger';
+import { Response } from 'express';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
 import { WorkspaceId } from './workspace.decorator';
@@ -291,6 +294,39 @@ export class WorkspaceCodingJobDefinitionController {
       @Param('id') id: number
   ): Promise<JobDefinition> {
     return this.jobDefinitionService.getJobDefinition(id, workspace_id);
+  }
+
+  @Get(':workspace_id/coding/job-definitions/:id/distribution/csv')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiTags('coding')
+  @ApiParam({ name: 'workspace_id', type: Number })
+  @ApiParam({ name: 'id', type: Number, description: 'Job definition ID' })
+  @ApiProduces('text/csv')
+  @ApiOkResponse({
+    description: 'Job definition distribution exported as CSV.',
+    content: {
+      'text/csv': {
+        schema: {
+          type: 'string',
+          format: 'binary'
+        }
+      }
+    }
+  })
+  async exportJobDefinitionDistributionAsCsv(
+    @WorkspaceId() workspace_id: number,
+      @Param('id') id: number,
+      @Res() res: Response
+  ): Promise<void> {
+    const csvContent = await this.jobDefinitionService.exportDistributionSnapshotAsCsv(id, workspace_id);
+    const exportDate = new Date().toISOString().slice(0, 10);
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="job-definition-distribution-${workspace_id}-${id}-${exportDate}.csv"`
+    );
+    res.send(`\uFEFF${csvContent}`);
   }
 
   @Put(':workspace_id/coding/job-definitions/:id')

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -44,6 +44,7 @@ import {
 } from '../../../../../../api-dto/coding/coding-freshness.dto';
 import { AutocodingReadinessDto } from '../../../../../../api-dto/coding/autocoding-readiness.dto';
 import { JobQueueService } from '../../job-queue/job-queue.service';
+import { sanitizeCsvText } from '../../utils/csv.util';
 
 type CodingStatisticsJobStatusResponse = {
   status: string;
@@ -423,12 +424,6 @@ export class WorkspaceCodingStatisticsController {
     return parts.length > 0 ? parts.join('; ') : 'Direkte Kodierung';
   }
 
-  private sanitizeCsvText(value: string | null | undefined): string {
-    const text = value ?? '';
-    const normalized = text.replace(/[\r\n\t]+/g, ' ');
-    return /^\s*[=+\-@]/.test(normalized) ? `'${normalized}` : normalized;
-  }
-
   private createCohensKappaExportRows(
     statistics: KappaStatisticsResponse,
     options: {
@@ -444,27 +439,27 @@ export class WorkspaceCodingStatisticsController {
       'ungewichteter Mittelwert';
 
     return statistics.variables.flatMap(variable => variable.coderPairs.map(pair => ({
-      Variable: this.sanitizeCsvText(`${variable.unitName} - ${variable.variableId}`),
-      Unit: this.sanitizeCsvText(variable.unitName),
-      'Variablen-ID': this.sanitizeCsvText(variable.variableId),
-      'Job-Definition / Schulungsbezug': this.sanitizeCsvText(this.formatKappaScope(pair)),
-      'Job-Namen': this.sanitizeCsvText(pair.jobNames.join(', ')),
+      Variable: sanitizeCsvText(`${variable.unitName} - ${variable.variableId}`),
+      Unit: sanitizeCsvText(variable.unitName),
+      'Variablen-ID': sanitizeCsvText(variable.variableId),
+      'Job-Definition / Schulungsbezug': sanitizeCsvText(this.formatKappaScope(pair)),
+      'Job-Namen': sanitizeCsvText(pair.jobNames.join(', ')),
       'Job-Definition-IDs': pair.jobDefinitionIds.join(', '),
       'Training-IDs': pair.trainingIds.join(', '),
-      Trainingslabels: this.sanitizeCsvText(pair.trainingLabels.join(', ')),
+      Trainingslabels: sanitizeCsvText(pair.trainingLabels.join(', ')),
       'Kodierer 1 ID': pair.coder1Id,
-      'Kodierer 1': this.sanitizeCsvText(pair.coder1Name),
+      'Kodierer 1': sanitizeCsvText(pair.coder1Name),
       'Kodierer 2 ID': pair.coder2Id,
-      'Kodierer 2': this.sanitizeCsvText(pair.coder2Name),
+      'Kodierer 2': sanitizeCsvText(pair.coder2Name),
       'Anzahl doppelt kodierter Antworten': pair.totalItems,
       'Gueltige Paare': pair.validPairs,
       'Kappa-Wert': pair.kappa ?? '',
       'Uebereinstimmung in Prozent': Math.round(pair.agreement * 1000) / 10,
-      Interpretation: this.sanitizeCsvText(this.getKappaInterpretationLabel(pair.interpretation)),
+      Interpretation: sanitizeCsvText(this.getKappaInterpretationLabel(pair.interpretation)),
       'Trainings ausgeschlossen': options.excludeTrainings ? 'ja' : 'nein',
-      'Mittelwert-Methode': this.sanitizeCsvText(weightingMethod),
-      'Unit-Filter': this.sanitizeCsvText(options.unitName),
-      'Variablen-Filter': this.sanitizeCsvText(options.variableId),
+      'Mittelwert-Methode': sanitizeCsvText(weightingMethod),
+      'Unit-Filter': sanitizeCsvText(options.unitName),
+      'Variablen-Filter': sanitizeCsvText(options.variableId),
       'Exportiert am': exportedAt
     })));
   }
@@ -473,7 +468,7 @@ export class WorkspaceCodingStatisticsController {
     statistics: KappaStatisticsResponse
   ): Record<string, string | number>[] {
     return statistics.variables.map(variable => ({
-      subunit: this.sanitizeCsvText(this.getSubunit(variable.unitName, variable.variableId)),
+      subunit: sanitizeCsvText(this.getSubunit(variable.unitName, variable.variableId)),
       nCases: variable.caseCount,
       nDop: variable.doubleCodedCount,
       percDop: this.toPercent(variable.doubleCodedRate),
@@ -486,16 +481,16 @@ export class WorkspaceCodingStatisticsController {
     statistics: KappaStatisticsResponse
   ): Record<string, string | number>[] {
     return statistics.variables.flatMap(variable => variable.coderPairs.map(pair => ({
-      subunit: this.sanitizeCsvText(this.getSubunit(variable.unitName, variable.variableId)),
+      subunit: sanitizeCsvText(this.getSubunit(variable.unitName, variable.variableId)),
       nCases: variable.caseCount,
       nDop: variable.doubleCodedCount,
       percDop: this.toPercent(variable.doubleCodedRate),
-      Coder1: this.sanitizeCsvText(pair.coder1Name),
-      Coder2: this.sanitizeCsvText(pair.coder2Name),
+      Coder1: sanitizeCsvText(pair.coder1Name),
+      Coder2: sanitizeCsvText(pair.coder2Name),
       N: pair.validPairs,
       kappa: this.roundDecimal(pair.kappa),
-      'Coder1.1': this.sanitizeCsvText(pair.coder1Name),
-      'Coder2.1': this.sanitizeCsvText(pair.coder2Name),
+      'Coder1.1': sanitizeCsvText(pair.coder1Name),
+      'Coder2.1': sanitizeCsvText(pair.coder2Name),
       'N.1': pair.validPairs,
       agree: this.roundDecimal(pair.agreement)
     })));
@@ -557,11 +552,11 @@ export class WorkspaceCodingStatisticsController {
     ];
     const rows = sourceItems.map(item => {
       const row: Record<string, string | number> = {
-        'Test.Person.Login': this.sanitizeCsvText(item.personLogin),
-        'Test.Person.Group': this.sanitizeCsvText(item.personGroup),
-        Unit: this.sanitizeCsvText(item.unitName),
-        Variable: this.sanitizeCsvText(item.variableId),
-        subunit: this.sanitizeCsvText(this.getSubunit(item.unitName, item.variableId))
+        'Test.Person.Login': sanitizeCsvText(item.personLogin),
+        'Test.Person.Group': sanitizeCsvText(item.personGroup),
+        Unit: sanitizeCsvText(item.unitName),
+        Variable: sanitizeCsvText(item.variableId),
+        subunit: sanitizeCsvText(this.getSubunit(item.unitName, item.variableId))
       };
       const codeCounts = new Map<number, number>();
       const comments: string[] = [];
@@ -593,7 +588,7 @@ export class WorkspaceCodingStatisticsController {
       });
       const codedCount = Array.from(codeCounts.values()).reduce((sum, count) => sum + count, 0);
 
-      row.Kommentare = this.sanitizeCsvText(comments.join(' | '));
+      row.Kommentare = sanitizeCsvText(comments.join(' | '));
       row['Häuf.W'] = modalCode;
       row.Abw = codedCount > 0 ? codedCount - modalCount : '';
 

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import { In } from 'typeorm';
 import { JobDefinitionService } from './job-definition.service';
 
 jest.mock('../coding/coding-job.service', () => ({
@@ -752,6 +753,115 @@ describe('JobDefinitionService', () => {
         workspace_id: 7
       }
     });
+  });
+
+  it('exports the latest distribution snapshot as formula-safe CSV', async () => {
+    jobDefinitionRepository.findOne.mockResolvedValue({
+      id: 42,
+      workspace_id: 7,
+      assigned_variable_bundles: [],
+      distribution_snapshots: [
+        {
+          version: 1,
+          source: 'initial_creation',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          distributionSeed: 'old-seed',
+          selectedVariables: [],
+          selectedVariableBundles: [],
+          selectedCoders: [{ coderId: 1, capacityPercent: 100 }],
+          settings: {},
+          distributionByCoderId: { 'Old::Var': { 1: 1 } },
+          doubleCodingInfo: {},
+          aggregationInfo: {},
+          matchingFlags: [],
+          pairDistribution: {},
+          tasksPerCoder: {},
+          coderWeights: {},
+          jobs: []
+        },
+        {
+          version: 1,
+          source: 'refresh',
+          createdAt: '2026-01-02T00:00:00.000Z',
+          distributionSeed: 'new-seed',
+          selectedVariables: [],
+          selectedVariableBundles: [{ id: 9, name: '@Bundle' }],
+          selectedCoders: [
+            { coderId: 2, capacityPercent: 100 },
+            { coderId: 1, capacityPercent: 100 }
+          ],
+          settings: {},
+          distributionByCoderId: {
+            '=UNIT::+VAR': { 1: 2, 2: 1 },
+            'Legacy::Var': { 1: 2, 2: 1 },
+            'bundle:9': { 1: 0, 2: 3 }
+          },
+          doubleCodingInfo: {
+            '=UNIT::+VAR': {
+              totalCases: 3,
+              distinctCases: 2,
+              codingTasksTotal: 3,
+              doubleCodedCases: 1,
+              singleCodedCasesAssigned: 1,
+              doubleCodedCasesPerCoderId: { 1: 1, 2: 1 }
+            },
+            'Legacy::Var': {
+              totalCases: 3,
+              doubleCodedCases: 1,
+              singleCodedCasesAssigned: 1,
+              doubleCodedCasesPerCoderId: { 1: 1, 2: 1 }
+            },
+            'bundle:9': {
+              totalCases: 3,
+              distinctCases: 3,
+              codingTasksTotal: 3,
+              doubleCodedCases: 0,
+              singleCodedCasesAssigned: 3,
+              doubleCodedCasesPerCoderId: {}
+            }
+          },
+          aggregationInfo: {
+            'Legacy::Var': { uniqueCases: 99, totalResponses: 99 }
+          },
+          matchingFlags: [],
+          pairDistribution: {},
+          tasksPerCoder: {},
+          coderWeights: {},
+          jobs: []
+        }
+      ]
+    });
+    usersRepository.find.mockResolvedValue([
+      { id: 1, username: '=Ada' },
+      { id: 2, username: 'Bob' }
+    ]);
+
+    const csv = await service.exportDistributionSnapshotAsCsv(42, 7);
+
+    expect(jobDefinitionRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        id: 42,
+        workspace_id: 7
+      }
+    });
+    expect(usersRepository.find).toHaveBeenCalledWith({ where: { id: In([1, 2]) } });
+    expect(csv).toContain('Job-Definition-ID;Snapshot-Zeitpunkt;Quelle;Typ;Variable/Buendel;Coder-ID;Coder;Fallzahl');
+    expect(csv).toContain("Neuverteilung;Variable;'=UNIT -> +VAR;1;'=Ada;2;2;1;1;1");
+    expect(csv).toContain("Neuverteilung;Variable;Legacy -> Var;1;'=Ada;2;2;1;1;1");
+    expect(csv).toContain("Neuverteilung;Buendel;'@Bundle;2;Bob;3;3;0;3;0");
+    expect(csv).not.toContain('Old::Var');
+  });
+
+  it('rejects distribution CSV export when no snapshot exists', async () => {
+    jobDefinitionRepository.findOne.mockResolvedValue({
+      id: 42,
+      workspace_id: 7,
+      assigned_variable_bundles: [],
+      distribution_snapshots: []
+    });
+
+    await expect(service.exportDistributionSnapshotAsCsv(42, 7))
+      .rejects.toBeInstanceOf(BadRequestException);
   });
 
   it('persists coder capacity configs and derives assigned coder ids from them', async () => {

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -4,6 +4,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository, In } from 'typeorm';
+import * as fastCsv from 'fast-csv';
 import {
   JobDefinition,
   JobDefinitionCoderConfig,
@@ -26,6 +27,7 @@ import {
   JobDefinitionRefreshApplyResultDto,
   JobDefinitionRefreshPreviewDto
 } from '../../../../../../../api-dto/coding/job-refresh.dto';
+import { sanitizeCsvText } from '../../../utils/csv.util';
 
 type JobDefinitionBundleForUsage = JobDefinitionVariableBundle & {
   variables?: JobDefinitionVariable[];
@@ -161,6 +163,25 @@ type DistributionResultForSnapshot = {
 const DEFAULT_CODER_CAPACITY_PERCENT = 100;
 const MIN_CODER_CAPACITY_PERCENT = 10;
 const MAX_CODER_CAPACITY_PERCENT = 300;
+const JOB_DEFINITION_DISTRIBUTION_CSV_HEADERS = [
+  'Job-Definition-ID',
+  'Snapshot-Zeitpunkt',
+  'Quelle',
+  'Typ',
+  'Variable/Buendel',
+  'Coder-ID',
+  'Coder',
+  'Fallzahl',
+  'Gesamt',
+  'Doppelt kodiert',
+  'Einfach zugewiesen',
+  'Doppelt kodiert fuer Coder'
+] as const;
+
+type JobDefinitionDistributionCsvRow = Record<
+typeof JOB_DEFINITION_DISTRIBUTION_CSV_HEADERS[number],
+string | number
+>;
 
 @Injectable()
 export class JobDefinitionService {
@@ -800,6 +821,149 @@ export class JobDefinitionService {
     await this.hydrateAssignedVariableBundles(jobDefinition);
 
     return jobDefinition;
+  }
+
+  async exportDistributionSnapshotAsCsv(
+    jobDefinitionId: number,
+    workspaceId: number
+  ): Promise<string> {
+    const jobDefinition = await this.getJobDefinition(jobDefinitionId, workspaceId);
+    const snapshots = Array.isArray(jobDefinition.distribution_snapshots) ?
+      jobDefinition.distribution_snapshots :
+      [];
+    const snapshot = snapshots[snapshots.length - 1];
+
+    if (!snapshot) {
+      throw new BadRequestException(
+        'No stored distribution snapshot is available for this job definition'
+      );
+    }
+
+    const coderIds = this.getSnapshotCoderIds(snapshot);
+    const coderNamesById = await this.getCoderNamesById(coderIds);
+    const rows = this.createDistributionCsvRows(
+      jobDefinition.id,
+      snapshot,
+      coderIds,
+      coderNamesById
+    );
+
+    return fastCsv.writeToString(rows, {
+      headers: [...JOB_DEFINITION_DISTRIBUTION_CSV_HEADERS],
+      alwaysWriteHeaders: true,
+      delimiter: ';',
+      quote: '"'
+    });
+  }
+
+  private getSnapshotCoderIds(snapshot: JobDefinitionDistributionSnapshot): number[] {
+    const coderIds = new Set<number>();
+
+    (snapshot.selectedCoders || []).forEach(coder => {
+      coderIds.add(coder.coderId);
+    });
+
+    Object.values(snapshot.distributionByCoderId || {}).forEach(coderCases => {
+      Object.keys(coderCases || {}).forEach(coderId => {
+        const parsedCoderId = Number(coderId);
+        if (Number.isFinite(parsedCoderId)) {
+          coderIds.add(parsedCoderId);
+        }
+      });
+    });
+
+    return Array.from(coderIds).sort((a, b) => a - b);
+  }
+
+  private async getCoderNamesById(coderIds: number[]): Promise<Map<number, string>> {
+    if (coderIds.length === 0) {
+      return new Map();
+    }
+
+    const users = await this.usersRepository.find({ where: { id: In(coderIds) } });
+    return new Map(users.map(user => [user.id, user.username]));
+  }
+
+  private createDistributionCsvRows(
+    jobDefinitionId: number,
+    snapshot: JobDefinitionDistributionSnapshot,
+    coderIds: number[],
+    coderNamesById: Map<number, string>
+  ): JobDefinitionDistributionCsvRow[] {
+    return Object.entries(snapshot.distributionByCoderId || {})
+      .sort(([itemKeyA], [itemKeyB]) => itemKeyA.localeCompare(itemKeyB))
+      .flatMap(([itemKey, coderCases]) => {
+        const doubleCodingInfo = snapshot.doubleCodingInfo?.[itemKey];
+        const fallbackTotalCases = Object.values(coderCases || {}).reduce(
+          (sum, caseCount) => sum + caseCount,
+          0
+        );
+        const totalCases = this.getSnapshotDistinctCaseCount(
+          doubleCodingInfo,
+          snapshot.aggregationInfo?.[itemKey]?.uniqueCases,
+          fallbackTotalCases
+        );
+
+        return coderIds.map(coderId => ({
+          'Job-Definition-ID': jobDefinitionId,
+          'Snapshot-Zeitpunkt': sanitizeCsvText(snapshot.createdAt),
+          Quelle: sanitizeCsvText(this.getSnapshotSourceLabel(snapshot.source)),
+          Typ: sanitizeCsvText(this.getSnapshotItemType(itemKey)),
+          'Variable/Buendel': sanitizeCsvText(this.getSnapshotItemLabel(snapshot, itemKey)),
+          'Coder-ID': coderId,
+          Coder: sanitizeCsvText(coderNamesById.get(coderId) || `Coder ${coderId}`),
+          Fallzahl: coderCases?.[String(coderId)] || 0,
+          Gesamt: totalCases,
+          'Doppelt kodiert': doubleCodingInfo?.doubleCodedCases || 0,
+          'Einfach zugewiesen': doubleCodingInfo?.singleCodedCasesAssigned || 0,
+          'Doppelt kodiert fuer Coder': doubleCodingInfo?.doubleCodedCasesPerCoderId?.[String(coderId)] || 0
+        }));
+      });
+  }
+
+  private getSnapshotDistinctCaseCount(
+    doubleCodingInfo: JobDefinitionDistributionSnapshotDoubleCodingInfo | undefined,
+    aggregationUniqueCases: number | undefined,
+    fallbackTotalCases: number
+  ): number {
+    const legacySelectedCases = doubleCodingInfo ?
+      doubleCodingInfo.doubleCodedCases + doubleCodingInfo.singleCodedCasesAssigned :
+      undefined;
+    const snapshotCaseCount = [
+      doubleCodingInfo?.distinctCases,
+      legacySelectedCases,
+      aggregationUniqueCases,
+      doubleCodingInfo?.totalCases,
+      fallbackTotalCases
+    ].find(caseCount => typeof caseCount === 'number' && Number.isFinite(caseCount));
+
+    return snapshotCaseCount ?? fallbackTotalCases;
+  }
+
+  private getSnapshotSourceLabel(source: JobDefinitionDistributionSnapshotSource): string {
+    return source === 'refresh' ? 'Neuverteilung' : 'Ersterstellung';
+  }
+
+  private getSnapshotItemType(itemKey: string): string {
+    return itemKey.startsWith('bundle:') ? 'Buendel' : 'Variable';
+  }
+
+  private getSnapshotItemLabel(
+    snapshot: JobDefinitionDistributionSnapshot,
+    itemKey: string
+  ): string {
+    if (itemKey.startsWith('bundle:')) {
+      const bundleId = Number(itemKey.slice('bundle:'.length));
+      const bundle = snapshot.selectedVariableBundles.find(selectedBundle => selectedBundle.id === bundleId);
+      return bundle?.name || itemKey;
+    }
+
+    const parts = itemKey.split('::');
+    if (parts.length === 2) {
+      return `${parts[0]} -> ${parts[1]}`;
+    }
+
+    return itemKey;
   }
 
   private async attachCreatedJobsCounts(

--- a/apps/backend/src/app/utils/csv.util.ts
+++ b/apps/backend/src/app/utils/csv.util.ts
@@ -1,0 +1,7 @@
+const CSV_FORMULA_PREFIX_PATTERN = /^\s*[=+\-@]/;
+
+export function sanitizeCsvText(value: string | null | undefined): string {
+  const text = value ?? '';
+  const normalized = text.replace(/[\r\n\t]+/g, ' ');
+  return CSV_FORMULA_PREFIX_PATTERN.test(normalized) ? `'${normalized}` : normalized;
+}

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.html
@@ -153,6 +153,16 @@
               <button
                 mat-menu-item
                 type="button"
+                *ngIf="canExportDistributionCsv(definition)"
+                [disabled]="isExportingDistribution(definition)"
+                (click)="exportDistributionCsv(definition)"
+                [attr.aria-label]="getActionAriaLabel('distribution-export', definition)">
+                <mat-icon>download</mat-icon>
+                <span>{{ 'coding-job-definitions.actions.distribution-export' | translate }}</span>
+              </button>
+              <button
+                mat-menu-item
+                type="button"
                 *ngIf="canRefreshDefinition(definition)"
                 [disabled]="isRefreshingDefinition(definition)"
                 (click)="refreshDefinition(definition)"

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
@@ -54,6 +54,7 @@ describe('CodingJobDefinitionsComponent', () => {
               selectedVariableBundles: [],
               selectedCoders: []
             })),
+            exportJobDefinitionDistributionCsv: jest.fn().mockReturnValue(of(new Blob(['csv'], { type: 'text/csv' }))),
             previewJobDefinitionRefresh: jest.fn().mockReturnValue(of({
               jobDefinitionId: 42,
               existingJobsCount: 1,
@@ -339,6 +340,81 @@ describe('CodingJobDefinitionsComponent', () => {
           createdJobsCount: 1
         })
       })
+    );
+  });
+
+  it('exports the latest distribution snapshot as CSV', () => {
+    const blob = new Blob(['csv'], { type: 'text/csv' });
+    const codingJobBackendService = TestBed.inject(CodingJobBackendService) as unknown as {
+      exportJobDefinitionDistributionCsv: jest.Mock;
+    };
+    const createObjectUrl = jest.fn().mockReturnValue('blob:distribution');
+    const revokeObjectUrl = jest.fn();
+    const click = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      value: createObjectUrl,
+      configurable: true
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      value: revokeObjectUrl,
+      configurable: true
+    });
+    codingJobBackendService.exportJobDefinitionDistributionCsv.mockReturnValue(of(blob));
+
+    component.exportDistributionCsv({
+      id: 42,
+      status: 'approved',
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedCoders: [1],
+      createdJobsCount: 2,
+      distributionSnapshots: [{
+        version: 1,
+        source: 'initial_creation',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        distributionSeed: 'seed',
+        selectedVariables: [],
+        selectedVariableBundles: [],
+        selectedCoders: [{ coderId: 1, capacityPercent: 100 }],
+        settings: {},
+        distributionByCoderId: { 'Unit 1::Var 1': { 1: 2 } },
+        doubleCodingInfo: {},
+        aggregationInfo: {},
+        matchingFlags: [],
+        pairDistribution: {},
+        tasksPerCoder: {},
+        coderWeights: {},
+        jobs: []
+      }]
+    });
+
+    expect(codingJobBackendService.exportJobDefinitionDistributionCsv).toHaveBeenCalledWith(1, 42);
+    expect(createObjectUrl).toHaveBeenCalledWith(blob);
+    expect(click).toHaveBeenCalled();
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:distribution');
+
+    click.mockRestore();
+  });
+
+  it('shows a clear message instead of exporting old definitions without snapshots', () => {
+    const codingJobBackendService = TestBed.inject(CodingJobBackendService) as unknown as {
+      exportJobDefinitionDistributionCsv: jest.Mock;
+    };
+    const snackBar = TestBed.inject(MatSnackBar) as unknown as { open: jest.Mock };
+
+    component.exportDistributionCsv({
+      id: 43,
+      status: 'approved',
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedCoders: [1],
+      createdJobsCount: 1
+    });
+
+    expect(codingJobBackendService.exportJobDefinitionDistributionCsv).not.toHaveBeenCalled();
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'coding-job-definitions.messages.snackbar.distribution-export-missing',
+      'common.close',
+      { duration: 5000 }
     );
   });
 

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
@@ -20,7 +20,9 @@ import { MatCardModule } from '@angular/material/card';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Subject, firstValueFrom, takeUntil } from 'rxjs';
+import {
+  Subject, finalize, firstValueFrom, takeUntil
+} from 'rxjs';
 import {
   CodingJobBackendService,
   JobDefinitionDistributionSnapshot
@@ -109,6 +111,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
   isLoading = false;
   isBulkCreating = false;
   refreshingDefinitionIds = new Set<number>();
+  exportingDistributionDefinitionIds = new Set<number>();
   coders: Coder[] = [];
   showInfo = false;
   private readonly variablePreviewLimit = 12;
@@ -422,6 +425,10 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       (createdJobsCount !== undefined && createdJobsCount > 0);
   }
 
+  canExportDistributionCsv(definition: JobDefinition): boolean {
+    return !!definition.id && this.hasDistributionSnapshots(definition);
+  }
+
   hasDistributionSnapshots(definition: JobDefinition): boolean {
     return Array.isArray(definition.distributionSnapshots) &&
       definition.distributionSnapshots.length > 0;
@@ -439,6 +446,10 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
 
   isRefreshingDefinition(definition: JobDefinition): boolean {
     return !!definition.id && this.refreshingDefinitionIds.has(definition.id);
+  }
+
+  isExportingDistribution(definition: JobDefinition): boolean {
+    return !!definition.id && this.exportingDistributionDefinitionIds.has(definition.id);
   }
 
   getEditDefinitionLabel(definition: JobDefinition): string {
@@ -813,6 +824,57 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
     });
   }
 
+  exportDistributionCsv(definition: JobDefinition): void {
+    if (!definition.id) {
+      return;
+    }
+
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      this.showError(
+        this.translateService.instant(
+          'coding-job-definitions.messages.snackbar.no-workspace'
+        )
+      );
+      return;
+    }
+
+    if (!this.canExportDistributionCsv(definition)) {
+      this.showError(
+        this.translateService.instant(
+          'coding-job-definitions.messages.snackbar.distribution-export-missing'
+        )
+      );
+      return;
+    }
+
+    this.exportingDistributionDefinitionIds.add(definition.id);
+    this.codingJobBackendService
+      .exportJobDefinitionDistributionCsv(workspaceId, definition.id)
+      .pipe(
+        finalize(() => {
+          this.exportingDistributionDefinitionIds.delete(definition.id!);
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe({
+        next: blob => {
+          this.saveBlob(
+            blob,
+            `job-definition-distribution-${definition.id}-${this.getDateString()}.csv`
+          );
+        },
+        error: error => {
+          this.showError(
+            this.translateService.instant(
+              'coding-job-definitions.messages.snackbar.distribution-export-failed',
+              { error: this.getErrorMessage(error) }
+            )
+          );
+        }
+      });
+  }
+
   private async applyDefinitionRefresh(
     workspaceId: number,
     jobDefinitionId: number
@@ -1023,6 +1085,21 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
     this.snackBar.open(message, this.translateService.instant('common.close'), {
       duration: 5000
     });
+  }
+
+  private saveBlob(blob: Blob, filename: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  }
+
+  private getDateString(): string {
+    return new Date().toISOString().slice(0, 10);
   }
 
   private getErrorMessage(error: unknown): string {

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -230,6 +230,20 @@ describe('CodingJobBackendService', () => {
       });
     });
 
+    it('should export a job definition distribution as CSV', () => {
+      const mockBlob = new Blob(['Job-Definition-ID;Coder'], { type: 'text/csv' });
+
+      service.exportJobDefinitionDistributionCsv(1, 42).subscribe(response => {
+        expect(response).toBe(mockBlob);
+      });
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/job-definitions/42/distribution/csv`);
+      expect(req.request.method).toBe('GET');
+      expect(req.request.responseType).toBe('blob');
+      expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token');
+      req.flush(mockBlob);
+    });
+
     it('should preview a job definition refresh', () => {
       service.previewJobDefinitionRefresh(1, 42).subscribe(response => {
         expect(response.addedCases).toBe(2);

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -779,6 +779,17 @@ export class CodingJobBackendService {
     return this.http.get<JobDefinitionDistributionPreviewResponse>(url, { headers: this.authHeader });
   }
 
+  exportJobDefinitionDistributionCsv(
+    workspaceId: number,
+    jobDefinitionId: number
+  ): Observable<Blob> {
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/job-definitions/${jobDefinitionId}/distribution/csv`;
+    return this.http.get(url, {
+      headers: this.authHeader,
+      responseType: 'blob'
+    });
+  }
+
   previewJobDefinitionRefresh(
     workspaceId: number,
     jobDefinitionId: number

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2147,6 +2147,7 @@
       "jobs-count-unavailable": "Der Status erzeugter Kodier-Jobs konnte nicht geladen werden.",
       "jobs-count-unavailable-short": "Status unklar",
       "distribution-summary": "Verteilungsübersicht anzeigen",
+      "distribution-export": "Verteilung als CSV exportieren",
       "refresh": "Kodierjobs neu verteilen",
       "refresh-tooltip": "Prüfen, welche bestehenden Kodierjobs ersetzt und anhand der aktuellen Definition neu erzeugt werden können.",
       "more": "Weitere Aktionen",
@@ -2244,6 +2245,8 @@
         "refresh-preview-failed": "Neuverteilung konnte nicht vorbereitet werden: {{error}}",
         "refresh-applied": "Kodierjobs neu verteilt: {{count}} Kodierjobs erstellt.",
         "refresh-apply-failed": "Neuverteilung fehlgeschlagen: {{error}}",
+        "distribution-export-missing": "Für diese Job-Definition liegt keine gespeicherte Verteilungsübersicht vor.",
+        "distribution-export-failed": "Verteilung konnte nicht exportiert werden: {{error}}",
         "coders-loading-failed": "Fehler beim Laden der Kodierer: {{error}}",
         "no-workspace": "No workspace selected"
       }


### PR DESCRIPTION
## Summary
- add a backend CSV export endpoint for stored job-definition distribution snapshots
- reuse shared CSV text sanitizing to avoid spreadsheet formula injection
- add a frontend menu action that downloads the latest stored distribution snapshot as CSV
- cover current and legacy double-coding case counts in backend tests

## Validation
- npx nx lint backend
- npx nx lint frontend
- npx jest apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts --runInBand --config apps/backend/jest.config.ts
- npx nx test backend --runInBand: relevant job-definition spec passes; full suite still fails on existing libxmljs2 ABI / unrelated test-double issues
- npx nx test frontend --runInBand: relevant new specs passed in the run; full suite still fails on existing keycloak-angular/keycloak-js resolution issues

Refs #543
