### PR TITLE
Show new job definition refresh cases in distribution summary

### DIFF
--- a/api-dto/coding/job-refresh.dto.ts
+++ b/api-dto/coding/job-refresh.dto.ts
@@ -15,6 +15,31 @@ export interface CodingJobFreshnessImpactDto {
   openResponses: number;
 }
 
+export interface JobDefinitionRefreshCoderTaskDeltaDto {
+  coderId: number;
+  existingCodingTasks: number;
+  plannedCodingTasks: number;
+  retainedCodingTasks: number;
+  addedCodingTasks: number;
+  removedCodingTasks: number;
+}
+
+export interface JobDefinitionRefreshItemDeltaDto {
+  itemKey: string;
+  itemLabel: string;
+  existingCases: number;
+  plannedCases: number;
+  retainedCases: number;
+  addedCases: number;
+  removedCases: number;
+  existingCodingTasks: number;
+  plannedCodingTasks: number;
+  retainedCodingTasks: number;
+  addedCodingTasks: number;
+  removedCodingTasks: number;
+  codingTasksByCoderId: Record<string, JobDefinitionRefreshCoderTaskDeltaDto>;
+}
+
 export interface JobDefinitionRefreshPreviewDto {
   jobDefinitionId: number;
   existingJobsCount: number;
@@ -26,6 +51,8 @@ export interface JobDefinitionRefreshPreviewDto {
   removedCases: number;
   addedCodingTasks: number;
   removedCodingTasks: number;
+  itemDeltas?: JobDefinitionRefreshItemDeltaDto[];
+  codingTasksByCoderId?: Record<string, JobDefinitionRefreshCoderTaskDeltaDto>;
   canApply: boolean;
   blockingReason?: string;
 }

--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
@@ -156,6 +156,10 @@ const DISTRIBUTION_SNAPSHOT_SCHEMA = {
             caseCount: { type: 'number' }
           }
         }
+      },
+      refreshPreview: {
+        type: 'object',
+        nullable: true
       }
     }
   }

--- a/apps/backend/src/app/database/entities/job-definition.entity.ts
+++ b/apps/backend/src/app/database/entities/job-definition.entity.ts
@@ -13,6 +13,7 @@ import {
 import { CodingJob } from './coding-job.entity';
 import Workspace from './workspace.entity';
 import { MissingsProfile } from './missings-profile.entity';
+import type { JobDefinitionRefreshPreviewDto } from '../../../../../../api-dto/coding/job-refresh.dto';
 
 export type JobDefinitionStatus = 'draft' | 'pending_review' | 'approved';
 export type CaseOrderingMode = 'continuous' | 'alternating';
@@ -86,6 +87,7 @@ export interface JobDefinitionDistributionSnapshot {
   tasksPerCoder: Record<string, number>;
   coderWeights: Record<string, number>;
   jobs: JobDefinitionDistributionSnapshotJob[];
+  refreshPreview?: JobDefinitionRefreshPreviewDto;
 }
 
 @Entity({ name: 'job_definitions' })

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -318,11 +318,21 @@ describe('CodingJobService distribution from job definitions', () => {
         getJobDefinitionExistingTaskRows: (
           workspaceId: number,
           jobDefinitionId: number
-        ) => Promise<Array<{ responseId: number; taskCount: number }>>;
+        ) => Promise<Array<{
+          responseId: number;
+          itemKey: string;
+          coderId: number;
+          taskCount: number;
+        }>>;
       },
       'getJobDefinitionExistingTaskRows'
     ).mockResolvedValue(
-      [1, 2, 3, 4, 5].map(responseId => ({ responseId, taskCount: 1 }))
+      [1, 2, 3, 4, 5].map(responseId => ({
+        responseId,
+        itemKey: 'Unit 1::Var 1',
+        coderId: 1,
+        taskCount: 1
+      }))
     );
     jest.spyOn(
       service as unknown as {
@@ -361,6 +371,13 @@ describe('CodingJobService distribution from job definitions', () => {
       removedCases: 0,
       addedCodingTasks: 3,
       removedCodingTasks: 0,
+      itemDeltas: [
+        expect.objectContaining({
+          itemKey: 'Unit 1::Var 1',
+          addedCases: 3,
+          addedCodingTasks: 3
+        })
+      ],
       canApply: true
     });
     expect(

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -85,7 +85,10 @@ describe('CodingJobService', () => {
   let cacheService: { delete: jest.Mock };
   let codingFreshnessService: { reconcileAppliedManualCodingJobs: jest.Mock };
   let codingFileCacheService: { getVariablePageMap: jest.Mock };
-  let missingsProfilesService: { resolveMissingsProfileId: jest.Mock };
+  let missingsProfilesService: {
+    resolveMissingsProfileId: jest.Mock;
+    getMissingByIdForProfileOrDefault: jest.Mock;
+  };
   let coderTrainingDiscussionResultRepository: ReturnType<typeof createRepo>;
   let workspaceFilesService: {
     getDerivedVariableMap: jest.Mock;
@@ -200,7 +203,8 @@ describe('CodingJobService', () => {
       getVariablePageMap: jest.fn().mockResolvedValue(new Map())
     };
     missingsProfilesService = {
-      resolveMissingsProfileId: jest.fn(async (_workspaceId: number, profileId?: number | null) => profileId || 55)
+      resolveMissingsProfileId: jest.fn(async (_workspaceId: number, profileId?: number | null) => profileId || 55),
+      getMissingByIdForProfileOrDefault: jest.fn().mockResolvedValue({ code: 99 })
     };
     coderTrainingDiscussionResultRepository.count.mockResolvedValue(0);
 
@@ -760,8 +764,16 @@ describe('CodingJobService', () => {
       'buildDistributionPlan'
     ).mockResolvedValue({
       plannedCases: [
-        { response: { id: 10 }, assignedCoderIds: [1, 2] },
-        { response: { id: 20 }, assignedCoderIds: [1] }
+        {
+          item: { itemKey: 'Unit 1::Var 1', itemLabel: 'Unit 1::Var 1' },
+          response: { id: 10 },
+          assignedCoderIds: [1, 2]
+        },
+        {
+          item: { itemKey: 'Unit 1::Var 1', itemLabel: 'Unit 1::Var 1' },
+          response: { id: 20 },
+          assignedCoderIds: [1]
+        }
       ],
       jobsToCreate: [],
       distribution: {},
@@ -777,8 +789,12 @@ describe('CodingJobService', () => {
 
     codingJobUnitRepository.createQueryBuilder
       .mockReturnValueOnce(createQueryBuilder([
-        { responseId: 10, taskCount: '1' },
-        { responseId: 30, taskCount: '2' }
+        {
+          responseId: 10, itemKey: 'Unit 1::Var 1', coderId: 1, taskCount: '1'
+        },
+        {
+          responseId: 30, itemKey: 'Unit 1::Var 1', coderId: 2, taskCount: '2'
+        }
       ]))
       .mockReturnValueOnce(createQueryBuilder(0));
     codingJobRepository.createQueryBuilder.mockReturnValueOnce(createQueryBuilder({
@@ -796,6 +812,84 @@ describe('CodingJobService', () => {
       removedCases: 1,
       addedCodingTasks: 2,
       removedCodingTasks: 2,
+      itemDeltas: [
+        expect.objectContaining({
+          itemKey: 'Unit 1::Var 1',
+          retainedCases: 1,
+          addedCases: 1,
+          removedCases: 1,
+          addedCodingTasks: 2,
+          removedCodingTasks: 2,
+          codingTasksByCoderId: {
+            1: expect.objectContaining({ addedCodingTasks: 1 }),
+            2: expect.objectContaining({ addedCodingTasks: 1, removedCodingTasks: 2 })
+          }
+        })
+      ],
+      canApply: true
+    });
+  });
+
+  it('counts task deltas when retained cases are reassigned to another coder', async () => {
+    jest.spyOn(
+      service as unknown as { buildDistributionPlan: jest.Mock },
+      'buildDistributionPlan'
+    ).mockResolvedValue({
+      plannedCases: [
+        {
+          item: { itemKey: 'Unit 1::Var 1', itemLabel: 'Unit 1::Var 1' },
+          response: { id: 10 },
+          assignedCoderIds: [2]
+        }
+      ],
+      jobsToCreate: [],
+      distribution: {},
+      distributionByCoderId: {},
+      doubleCodingInfo: {},
+      aggregationInfo: {},
+      matchingFlags: [],
+      warnings: [],
+      pairDistribution: {},
+      tasksPerCoder: {},
+      coderWeights: {}
+    });
+
+    codingJobUnitRepository.createQueryBuilder
+      .mockReturnValueOnce(createQueryBuilder([
+        {
+          responseId: 10, itemKey: 'Unit 1::Var 1', coderId: 1, taskCount: '1'
+        }
+      ]))
+      .mockReturnValueOnce(createQueryBuilder(0));
+    codingJobRepository.createQueryBuilder.mockReturnValueOnce(createQueryBuilder({
+      existingJobsCount: '1',
+      staleJobsCount: '0'
+    }));
+
+    await expect(service.previewJobDefinitionRefresh(3, {
+      jobDefinitionId: 9,
+      selectedVariables: [],
+      selectedCoders: []
+    })).resolves.toMatchObject({
+      retainedCases: 1,
+      addedCases: 0,
+      removedCases: 0,
+      addedCodingTasks: 1,
+      removedCodingTasks: 1,
+      codingTasksByCoderId: {
+        1: expect.objectContaining({ removedCodingTasks: 1 }),
+        2: expect.objectContaining({ addedCodingTasks: 1 })
+      },
+      itemDeltas: [
+        expect.objectContaining({
+          itemKey: 'Unit 1::Var 1',
+          retainedCases: 1,
+          addedCases: 0,
+          removedCases: 0,
+          addedCodingTasks: 1,
+          removedCodingTasks: 1
+        })
+      ],
       canApply: true
     });
   });
@@ -806,7 +900,11 @@ describe('CodingJobService', () => {
       'buildDistributionPlan'
     ).mockResolvedValue({
       plannedCases: [
-        { response: { id: 10 }, assignedCoderIds: [1] }
+        {
+          item: { itemKey: 'Unit 1::Var 1', itemLabel: 'Unit 1::Var 1' },
+          response: { id: 10 },
+          assignedCoderIds: [1]
+        }
       ],
       jobsToCreate: [],
       distribution: {},
@@ -828,7 +926,9 @@ describe('CodingJobService', () => {
 
     codingJobUnitRepository.createQueryBuilder
       .mockReturnValueOnce(createQueryBuilder([
-        { responseId: 10, taskCount: '1' }
+        {
+          responseId: 10, itemKey: 'Unit 1::Var 1', coderId: 1, taskCount: '1'
+        }
       ]))
       .mockReturnValueOnce(createQueryBuilder(1));
     codingJobRepository.createQueryBuilder.mockReturnValueOnce(createQueryBuilder({

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -39,6 +39,8 @@ import {
 } from './coding-progress-key.util';
 import {
   CodingJobFreshnessImpactDto,
+  JobDefinitionRefreshCoderTaskDeltaDto,
+  JobDefinitionRefreshItemDeltaDto,
   JobDefinitionRefreshPreviewDto
 } from '../../../../../../../api-dto/coding/job-refresh.dto';
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
@@ -202,6 +204,13 @@ type DistributionPlan = {
   pairDistribution: Record<string, number>;
   tasksPerCoder: Record<string, number>;
   coderWeights: Record<string, number>;
+};
+
+type JobDefinitionExistingTaskRow = {
+  responseId: number;
+  itemKey: string;
+  coderId: number;
+  taskCount: number;
 };
 
 type DistributionCreatedJob = {
@@ -846,23 +855,12 @@ export class CodingJobService {
   private buildJobDefinitionRefreshPreview(
     jobDefinitionId: number,
     plan: DistributionPlan,
-    existingRows: Array<{ responseId: number; taskCount: number }>,
+    existingRows: JobDefinitionExistingTaskRow[],
     jobsRow: { existingJobsCount: number; staleJobsCount: number },
     hasCodingWork: boolean
   ): JobDefinitionRefreshPreviewDto {
     const existingResponseIds = new Set(existingRows.map(row => row.responseId));
     const plannedResponseIds = new Set(plan.plannedCases.map(plannedCase => plannedCase.response.id));
-    const existingTaskCountByResponseId = new Map(existingRows.map(row => [row.responseId, row.taskCount]));
-    const plannedTaskCountByResponseId = new Map<number, number>();
-
-    plan.plannedCases.forEach(plannedCase => {
-      plannedTaskCountByResponseId.set(
-        plannedCase.response.id,
-        (plannedTaskCountByResponseId.get(plannedCase.response.id) || 0) +
-        plannedCase.assignedCoderIds.length
-      );
-    });
-
     const retainedCases = [...plannedResponseIds]
       .filter(responseId => existingResponseIds.has(responseId))
       .length;
@@ -872,22 +870,15 @@ export class CodingJobService {
     const removedCases = [...existingResponseIds]
       .filter(responseId => !plannedResponseIds.has(responseId))
       .length;
-    let addedCodingTasks = 0;
-    let removedCodingTasks = 0;
-    const responseIdsForTaskDelta = new Set([
-      ...existingTaskCountByResponseId.keys(),
-      ...plannedTaskCountByResponseId.keys()
-    ]);
-
-    responseIdsForTaskDelta.forEach(responseId => {
-      const taskDelta = (plannedTaskCountByResponseId.get(responseId) || 0) -
-        (existingTaskCountByResponseId.get(responseId) || 0);
-      if (taskDelta > 0) {
-        addedCodingTasks += taskDelta;
-      } else {
-        removedCodingTasks += Math.abs(taskDelta);
-      }
-    });
+    const itemDeltas = this.buildJobDefinitionRefreshItemDeltas(plan, existingRows);
+    const codingTasksByCoderId = this.buildJobDefinitionRefreshCoderDeltas(plan, existingRows);
+    const taskDeltas = Object.values(codingTasksByCoderId).reduce(
+      (totals, delta) => ({
+        addedCodingTasks: totals.addedCodingTasks + delta.addedCodingTasks,
+        removedCodingTasks: totals.removedCodingTasks + delta.removedCodingTasks
+      }),
+      { addedCodingTasks: 0, removedCodingTasks: 0 }
+    );
     const existingJobsCount = Number(jobsRow.existingJobsCount || 0);
     const canApply = existingJobsCount === 0 || !hasCodingWork;
 
@@ -900,13 +891,172 @@ export class CodingJobService {
       retainedCases,
       addedCases,
       removedCases,
-      addedCodingTasks,
-      removedCodingTasks,
+      addedCodingTasks: taskDeltas.addedCodingTasks,
+      removedCodingTasks: taskDeltas.removedCodingTasks,
+      itemDeltas,
+      codingTasksByCoderId,
       canApply,
       ...(canApply ? {} : {
         blockingReason: 'Bestehende Kodierjobs enthalten bereits Kodierarbeit. Bitte pruefen Sie die betroffenen Jobs, bevor die Definition neu verteilt wird.'
       })
     };
+  }
+
+  private createEmptyRefreshCoderTaskDelta(coderId: number): JobDefinitionRefreshCoderTaskDeltaDto {
+    return {
+      coderId,
+      existingCodingTasks: 0,
+      plannedCodingTasks: 0,
+      retainedCodingTasks: 0,
+      addedCodingTasks: 0,
+      removedCodingTasks: 0
+    };
+  }
+
+  private incrementRefreshCoderTaskDelta(
+    deltas: Map<number, JobDefinitionRefreshCoderTaskDeltaDto>,
+    coderId: number,
+    field: 'existingCodingTasks' | 'plannedCodingTasks' | 'retainedCodingTasks' | 'addedCodingTasks' | 'removedCodingTasks',
+    count: number
+  ): void {
+    const delta = deltas.get(coderId) || this.createEmptyRefreshCoderTaskDelta(coderId);
+    delta[field] += count;
+    deltas.set(coderId, delta);
+  }
+
+  private getRefreshTaskKey(itemKey: string, coderId: number, responseId: number): string {
+    return `${itemKey}\u0000${coderId}\u0000${responseId}`;
+  }
+
+  private buildExistingTaskCountByItemCoderAndResponse(
+    existingRows: JobDefinitionExistingTaskRow[]
+  ): Map<string, number> {
+    const existing = new Map<string, number>();
+    existingRows.forEach(row => {
+      const key = this.getRefreshTaskKey(row.itemKey, row.coderId, row.responseId);
+      existing.set(key, (existing.get(key) || 0) + row.taskCount);
+    });
+    return existing;
+  }
+
+  private buildPlannedTaskCountByItemCoderAndResponse(
+    plannedCases: DistributionPlanCase[]
+  ): Map<string, number> {
+    const planned = new Map<string, number>();
+    plannedCases.forEach(plannedCase => {
+      plannedCase.assignedCoderIds.forEach(coderId => {
+        const key = this.getRefreshTaskKey(
+          plannedCase.item.itemKey,
+          coderId,
+          plannedCase.response.id
+        );
+        planned.set(key, (planned.get(key) || 0) + 1);
+      });
+    });
+    return planned;
+  }
+
+  private buildJobDefinitionRefreshCoderDeltas(
+    plan: DistributionPlan,
+    existingRows: JobDefinitionExistingTaskRow[],
+    itemKey?: string
+  ): Record<string, JobDefinitionRefreshCoderTaskDeltaDto> {
+    const existing = this.buildExistingTaskCountByItemCoderAndResponse(
+      itemKey ? existingRows.filter(row => row.itemKey === itemKey) : existingRows
+    );
+    const planned = this.buildPlannedTaskCountByItemCoderAndResponse(
+      itemKey ?
+        plan.plannedCases.filter(plannedCase => plannedCase.item.itemKey === itemKey) :
+        plan.plannedCases
+    );
+    const deltas = new Map<number, JobDefinitionRefreshCoderTaskDeltaDto>();
+    const keys = new Set([...existing.keys(), ...planned.keys()]);
+
+    keys.forEach(key => {
+      const [, coderIdPart] = key.split('\u0000');
+      const coderId = Number(coderIdPart);
+      if (!Number.isFinite(coderId)) {
+        return;
+      }
+      const existingCount = existing.get(key) || 0;
+      const plannedCount = planned.get(key) || 0;
+      const retainedCount = Math.min(existingCount, plannedCount);
+
+      this.incrementRefreshCoderTaskDelta(deltas, coderId, 'existingCodingTasks', existingCount);
+      this.incrementRefreshCoderTaskDelta(deltas, coderId, 'plannedCodingTasks', plannedCount);
+      this.incrementRefreshCoderTaskDelta(deltas, coderId, 'retainedCodingTasks', retainedCount);
+      if (plannedCount > existingCount) {
+        this.incrementRefreshCoderTaskDelta(deltas, coderId, 'addedCodingTasks', plannedCount - existingCount);
+      } else if (existingCount > plannedCount) {
+        this.incrementRefreshCoderTaskDelta(deltas, coderId, 'removedCodingTasks', existingCount - plannedCount);
+      }
+    });
+
+    return Object.fromEntries(
+      [...deltas.entries()]
+        .sort(([a], [b]) => a - b)
+        .map(([coderId, delta]) => [String(coderId), delta])
+    );
+  }
+
+  private buildJobDefinitionRefreshItemDeltas(
+    plan: DistributionPlan,
+    existingRows: JobDefinitionExistingTaskRow[]
+  ): JobDefinitionRefreshItemDeltaDto[] {
+    const itemLabels = new Map<string, string>();
+
+    plan.plannedCases.forEach(plannedCase => {
+      itemLabels.set(plannedCase.item.itemKey, plannedCase.item.itemLabel);
+    });
+    existingRows.forEach(row => {
+      if (!itemLabels.has(row.itemKey)) {
+        itemLabels.set(row.itemKey, row.itemKey.startsWith('bundle:') ? row.itemKey : row.itemKey.replace('::', ' -> '));
+      }
+    });
+
+    return [...itemLabels.keys()]
+      .sort((a, b) => a.localeCompare(b))
+      .map(itemKey => {
+        const existingResponseIds = new Set(
+          existingRows
+            .filter(row => row.itemKey === itemKey)
+            .map(row => row.responseId)
+        );
+        const plannedResponseIds = new Set(
+          plan.plannedCases
+            .filter(plannedCase => plannedCase.item.itemKey === itemKey)
+            .map(plannedCase => plannedCase.response.id)
+        );
+        const codingTasksByCoderId = this.buildJobDefinitionRefreshCoderDeltas(plan, existingRows, itemKey);
+        const taskTotals = Object.values(codingTasksByCoderId).reduce(
+          (totals, delta) => ({
+            existingCodingTasks: totals.existingCodingTasks + delta.existingCodingTasks,
+            plannedCodingTasks: totals.plannedCodingTasks + delta.plannedCodingTasks,
+            retainedCodingTasks: totals.retainedCodingTasks + delta.retainedCodingTasks,
+            addedCodingTasks: totals.addedCodingTasks + delta.addedCodingTasks,
+            removedCodingTasks: totals.removedCodingTasks + delta.removedCodingTasks
+          }),
+          {
+            existingCodingTasks: 0,
+            plannedCodingTasks: 0,
+            retainedCodingTasks: 0,
+            addedCodingTasks: 0,
+            removedCodingTasks: 0
+          }
+        );
+
+        return {
+          itemKey,
+          itemLabel: itemLabels.get(itemKey) || itemKey,
+          existingCases: existingResponseIds.size,
+          plannedCases: plannedResponseIds.size,
+          retainedCases: [...plannedResponseIds].filter(responseId => existingResponseIds.has(responseId)).length,
+          addedCases: [...plannedResponseIds].filter(responseId => !existingResponseIds.has(responseId)).length,
+          removedCases: [...existingResponseIds].filter(responseId => !plannedResponseIds.has(responseId)).length,
+          ...taskTotals,
+          codingTasksByCoderId
+        };
+      });
   }
 
   async deleteCodingJobsByDefinition(
@@ -939,24 +1089,44 @@ export class CodingJobService {
     workspaceId: number,
     jobDefinitionId: number,
     manager?: EntityManager
-  ): Promise<Array<{ responseId: number; taskCount: number }>> {
+  ): Promise<JobDefinitionExistingTaskRow[]> {
     const repository = manager ? manager.getRepository(CodingJobUnit) : this.codingJobUnitRepository;
     const query = repository
       .createQueryBuilder('cju')
       .select('cju.response_id', 'responseId')
+      .addSelect(
+        "CASE WHEN cju.variable_bundle_id IS NOT NULL THEN CONCAT('bundle:', cju.variable_bundle_id) ELSE CONCAT(cju.unit_name, '::', cju.variable_id) END",
+        'itemKey'
+      )
+      .addSelect('coding_job_coder.user_id', 'coderId')
       .addSelect('COUNT(cju.id)', 'taskCount')
       .innerJoin('cju.coding_job', 'coding_job')
+      .innerJoin('coding_job.codingJobCoders', 'coding_job_coder')
       .where('coding_job.workspace_id = :workspaceId', { workspaceId })
       .andWhere('coding_job.job_definition_id = :jobDefinitionId', { jobDefinitionId })
       .andWhere('coding_job.training_id IS NULL')
-      .groupBy('cju.response_id');
+      .groupBy('cju.response_id')
+      .addGroupBy('itemKey')
+      .addGroupBy('coding_job_coder.user_id');
 
     await this.applyCodingJobUnitExclusions(query, workspaceId, 'jobDefinitionExistingTasks');
-    const rows = await query.getRawMany<{ responseId: string | number; taskCount: string | number }>();
+    const rows = await query.getRawMany<{
+      responseId: string | number;
+      itemKey: string;
+      coderId: string | number;
+      taskCount: string | number;
+    }>();
     return rows.map(row => ({
       responseId: Number(row.responseId),
+      itemKey: row.itemKey,
+      coderId: Number(row.coderId),
       taskCount: Number(row.taskCount)
-    })).filter(row => Number.isFinite(row.responseId) && Number.isFinite(row.taskCount));
+    })).filter(row => (
+      Number.isFinite(row.responseId) &&
+      Number.isFinite(row.coderId) &&
+      Number.isFinite(row.taskCount) &&
+      isSafeKey(row.itemKey)
+    ));
   }
 
   private async getJobDefinitionJobCounts(

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -1668,6 +1668,32 @@ describe('JobDefinitionService', () => {
         removedCases: 0,
         addedCodingTasks: 1,
         removedCodingTasks: 0,
+        itemDeltas: [
+          {
+            itemKey: 'Unit 1::Var 1',
+            itemLabel: 'Unit 1::Var 1',
+            existingCases: 0,
+            plannedCases: 1,
+            retainedCases: 0,
+            addedCases: 1,
+            removedCases: 0,
+            existingCodingTasks: 0,
+            plannedCodingTasks: 1,
+            retainedCodingTasks: 0,
+            addedCodingTasks: 1,
+            removedCodingTasks: 0,
+            codingTasksByCoderId: {
+              1: {
+                coderId: 1,
+                existingCodingTasks: 0,
+                plannedCodingTasks: 1,
+                retainedCodingTasks: 0,
+                addedCodingTasks: 1,
+                removedCodingTasks: 0
+              }
+            }
+          }
+        ],
         canApply: true
       }
     };
@@ -1697,6 +1723,15 @@ describe('JobDefinitionService', () => {
           source: 'refresh',
           distributionSeed: 'seed-16',
           selectedCoders: [{ coderId: 1, capacityPercent: 100 }],
+          refreshPreview: expect.objectContaining({
+            addedCases: 1,
+            itemDeltas: [
+              expect.objectContaining({
+                itemKey: 'Unit 1::Var 1',
+                addedCases: 1
+              })
+            ]
+          }),
           jobs: [expect.objectContaining({ jobId: 200, coderId: 1, caseCount: 1 })]
         })
       ]

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -151,6 +151,7 @@ type DistributionResultForSnapshot = {
   pairDistribution?: Record<string, number>;
   tasksPerCoder?: Record<string, number>;
   coderWeights?: Record<string, number>;
+  preview?: JobDefinitionRefreshPreviewDto;
   jobs: {
     itemKey?: string;
     coderId: number;
@@ -707,7 +708,8 @@ export class JobDefinitionService {
         variable: job.variable,
         jobId: job.jobId,
         caseCount: job.caseCount
-      }))
+      })),
+      ...(result.preview ? { refreshPreview: result.preview } : {})
     };
   }
 

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
@@ -817,6 +817,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       data: {
         definitionId: definition.id,
         snapshot: this.getLatestDistributionSnapshot(definition),
+        snapshots: definition.distributionSnapshots || [],
         coders: this.coders,
         createdJobsCount: this.getCreatedJobsCount(definition)
       },

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.html
@@ -18,6 +18,25 @@
       <p>{{ 'coding-job-definitions.distribution-summary.missing-history' | translate }}</p>
     </div>
   } @else {
+    @if (snapshots.length > 1) {
+      <div
+        class="snapshot-switcher"
+        [attr.aria-label]="'coding-job-definitions.distribution-summary.snapshots-label' | translate">
+        @for (snapshotOption of snapshots; track $index; let index = $index) {
+          <button
+            mat-stroked-button
+            type="button"
+            [class.selected]="index === selectedSnapshotIndex"
+            (click)="selectSnapshot(index)">
+            {{ (snapshotOption.source === 'refresh'
+              ? 'coding-job-definitions.distribution-summary.source.refresh'
+              : 'coding-job-definitions.distribution-summary.source.initial') | translate }}
+            <span>{{ snapshotOption.createdAt | date:'short' }}</span>
+          </button>
+        }
+      </div>
+    }
+
     <div class="snapshot-summary">
       <div class="summary-stat">
         <span>{{ 'coding-job-definitions.distribution-summary.coders' | translate }}</span>
@@ -31,6 +50,12 @@
         <span>{{ 'coding-job-definitions.distribution-summary.total-cases' | translate }}</span>
         <strong>{{ getGrandTotal() }}</strong>
       </div>
+      @if (hasAddedCases()) {
+        <div class="summary-stat positive">
+          <span>{{ 'coding-job-definitions.distribution-summary.new-cases' | translate }}</span>
+          <strong>{{ getGrandAddedCases() }}</strong>
+        </div>
+      }
     </div>
 
     <mat-divider></mat-divider>
@@ -45,6 +70,9 @@
           </div>
         }
         <div class="matrix-cell">{{ 'coding-job-definitions.distribution-summary.total' | translate }}</div>
+        @if (hasAddedCases()) {
+        <div class="matrix-cell">{{ 'coding-job-definitions.distribution-summary.new' | translate }}</div>
+        }
         <div class="matrix-cell">{{ 'coding-job-definitions.distribution-summary.double-coded' | translate }}</div>
       </div>
 
@@ -52,9 +80,26 @@
         <div class="matrix-row">
           <div class="matrix-cell item-cell">{{ row.label }}</div>
           @for (coder of coderColumns; track coder.id) {
-            <div class="matrix-cell">{{ row.coderCases[coder.id] || 0 }}</div>
+            <div class="matrix-cell value-cell">
+              <span>{{ row.coderCases[coder.id] || 0 }}</span>
+              @if (row.addedCoderTasks[coder.id]) {
+                <span
+                  class="added-value"
+                  [attr.aria-label]="'coding-job-definitions.distribution-summary.added-tasks-title' | translate: {
+                    tasks: row.addedCoderTasks[coder.id]
+                  }"
+                  [attr.title]="'coding-job-definitions.distribution-summary.added-tasks-title' | translate: {
+                    tasks: row.addedCoderTasks[coder.id]
+                  }">
+                  +{{ row.addedCoderTasks[coder.id] }}
+                </span>
+              }
+            </div>
           }
           <div class="matrix-cell total-cell">{{ row.totalCases }}</div>
+          @if (hasAddedCases()) {
+          <div class="matrix-cell added-total-cell">{{ row.addedCases }}</div>
+          }
           <div class="matrix-cell">{{ row.doubleCodedCases }}</div>
         </div>
       }
@@ -65,6 +110,9 @@
           <div class="matrix-cell">{{ getCoderTotal(coder.id) }}</div>
         }
         <div class="matrix-cell total-cell">{{ getGrandTotal() }}</div>
+        @if (hasAddedCases()) {
+        <div class="matrix-cell added-total-cell">{{ getGrandAddedCases() }}</div>
+        }
         <div class="matrix-cell"></div>
       </div>
     </div>

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.scss
@@ -38,8 +38,30 @@
 
 .snapshot-summary {
   display: grid;
-  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 12px;
+}
+
+.snapshot-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.snapshot-switcher button {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+}
+
+.snapshot-switcher button.selected {
+  border-color: #1976d2;
+  color: #1976d2;
+}
+
+.snapshot-switcher span {
+  color: rgba(0, 0, 0, 0.58);
+  font-size: 0.78rem;
 }
 
 .summary-stat {
@@ -60,6 +82,10 @@
 .summary-stat strong {
   color: #1976d2;
   font-size: 1.2rem;
+}
+
+.summary-stat.positive strong {
+  color: #2e7d32;
 }
 
 .distribution-matrix {
@@ -106,6 +132,22 @@
 
 .total-cell {
   font-weight: 600;
+}
+
+.value-cell {
+  flex-direction: column;
+  gap: 2px;
+}
+
+.added-value,
+.added-total-cell {
+  color: #2e7d32;
+  font-weight: 700;
+}
+
+.added-value {
+  font-size: 0.78rem;
+  line-height: 1;
 }
 
 @media (max-width: 720px) {

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.spec.ts
@@ -75,8 +75,197 @@ describe('JobDefinitionDistributionSummaryDialogComponent', () => {
     expect(component.getCoderTotal(1)).toBe(3);
     expect(component.getCoderTotal(2)).toBe(2);
     expect(component.getGrandTotal()).toBe(5);
+    expect(component.hasAddedCases()).toBe(false);
+    expect(fixture.nativeElement.querySelector('.added-total-cell')).toBeFalsy();
     expect(fixture.nativeElement.textContent).toContain('Ada');
     expect(fixture.nativeElement.textContent).toContain('Unit 1 -> Var 1');
+  });
+
+  it('marks newly added refresh tasks separately from the total distribution', () => {
+    createComponent({
+      definitionId: 42,
+      coders: [
+        { id: 1, name: 'Ada' },
+        { id: 2, name: 'Bea' }
+      ],
+      snapshot: {
+        version: 1,
+        source: 'refresh',
+        createdAt: '2026-01-02T00:00:00.000Z',
+        distributionSeed: 'seed-42',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        selectedVariableBundles: [],
+        selectedCoders: [
+          { coderId: 1, capacityPercent: 100 },
+          { coderId: 2, capacityPercent: 100 }
+        ],
+        settings: { caseOrderingMode: 'continuous' },
+        distributionByCoderId: {
+          'Unit 1::Var 1': { 1: 4, 2: 3 }
+        },
+        doubleCodingInfo: {
+          'Unit 1::Var 1': {
+            totalCases: 7,
+            distinctCases: 5,
+            codingTasksTotal: 7,
+            doubleCodedCases: 2,
+            singleCodedCasesAssigned: 3,
+            doubleCodedCasesPerCoderId: { 1: 2, 2: 2 }
+          }
+        },
+        aggregationInfo: {},
+        matchingFlags: [],
+        pairDistribution: {},
+        tasksPerCoder: { 1: 4, 2: 3 },
+        coderWeights: { 1: 1, 2: 1 },
+        jobs: [],
+        refreshPreview: {
+          jobDefinitionId: 42,
+          existingJobsCount: 2,
+          staleJobsCount: 1,
+          existingCases: 3,
+          plannedCases: 5,
+          retainedCases: 3,
+          addedCases: 2,
+          removedCases: 0,
+          addedCodingTasks: 3,
+          removedCodingTasks: 0,
+          canApply: true,
+          itemDeltas: [{
+            itemKey: 'Unit 1::Var 1',
+            itemLabel: 'Unit 1::Var 1',
+            existingCases: 3,
+            plannedCases: 5,
+            retainedCases: 3,
+            addedCases: 2,
+            removedCases: 0,
+            existingCodingTasks: 4,
+            plannedCodingTasks: 7,
+            retainedCodingTasks: 4,
+            addedCodingTasks: 3,
+            removedCodingTasks: 0,
+            codingTasksByCoderId: {
+              1: {
+                coderId: 1,
+                existingCodingTasks: 3,
+                plannedCodingTasks: 4,
+                retainedCodingTasks: 3,
+                addedCodingTasks: 1,
+                removedCodingTasks: 0
+              },
+              2: {
+                coderId: 2,
+                existingCodingTasks: 1,
+                plannedCodingTasks: 3,
+                retainedCodingTasks: 1,
+                addedCodingTasks: 2,
+                removedCodingTasks: 0
+              }
+            }
+          }]
+        }
+      }
+    });
+
+    expect(component.rows[0].addedCases).toBe(2);
+    expect(component.rows[0].addedCoderTasks).toEqual({ 1: 1, 2: 2 });
+    expect(component.getGrandAddedCases()).toBe(2);
+    expect(component.hasAddedCases()).toBe(true);
+    expect(fixture.nativeElement.querySelector('.added-total-cell')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('+1');
+    expect(fixture.nativeElement.textContent).toContain('+2');
+  });
+
+  it('does not render the new-cases column for refresh deltas without added cases', () => {
+    createComponent({
+      definitionId: 42,
+      coders: [
+        { id: 1, name: 'Ada' },
+        { id: 2, name: 'Bea' }
+      ],
+      snapshot: {
+        version: 1,
+        source: 'refresh',
+        createdAt: '2026-01-02T00:00:00.000Z',
+        distributionSeed: 'seed-42',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        selectedVariableBundles: [],
+        selectedCoders: [
+          { coderId: 1, capacityPercent: 100 },
+          { coderId: 2, capacityPercent: 100 }
+        ],
+        settings: { caseOrderingMode: 'continuous' },
+        distributionByCoderId: {
+          'Unit 1::Var 1': { 1: 0, 2: 1 }
+        },
+        doubleCodingInfo: {
+          'Unit 1::Var 1': {
+            totalCases: 1,
+            distinctCases: 1,
+            codingTasksTotal: 1,
+            doubleCodedCases: 0,
+            singleCodedCasesAssigned: 1,
+            doubleCodedCasesPerCoderId: { 1: 0, 2: 0 }
+          }
+        },
+        aggregationInfo: {},
+        matchingFlags: [],
+        pairDistribution: {},
+        tasksPerCoder: { 1: 0, 2: 1 },
+        coderWeights: { 1: 1, 2: 1 },
+        jobs: [],
+        refreshPreview: {
+          jobDefinitionId: 42,
+          existingJobsCount: 1,
+          staleJobsCount: 1,
+          existingCases: 1,
+          plannedCases: 1,
+          retainedCases: 1,
+          addedCases: 0,
+          removedCases: 0,
+          addedCodingTasks: 1,
+          removedCodingTasks: 1,
+          canApply: true,
+          itemDeltas: [{
+            itemKey: 'Unit 1::Var 1',
+            itemLabel: 'Unit 1::Var 1',
+            existingCases: 1,
+            plannedCases: 1,
+            retainedCases: 1,
+            addedCases: 0,
+            removedCases: 0,
+            existingCodingTasks: 1,
+            plannedCodingTasks: 1,
+            retainedCodingTasks: 0,
+            addedCodingTasks: 1,
+            removedCodingTasks: 1,
+            codingTasksByCoderId: {
+              1: {
+                coderId: 1,
+                existingCodingTasks: 1,
+                plannedCodingTasks: 0,
+                retainedCodingTasks: 0,
+                addedCodingTasks: 0,
+                removedCodingTasks: 1
+              },
+              2: {
+                coderId: 2,
+                existingCodingTasks: 0,
+                plannedCodingTasks: 1,
+                retainedCodingTasks: 0,
+                addedCodingTasks: 1,
+                removedCodingTasks: 0
+              }
+            }
+          }]
+        }
+      }
+    });
+
+    expect(component.hasAddedCases()).toBe(false);
+    expect(component.rows[0].addedCoderTasks).toEqual({ 2: 1 });
+    expect(fixture.nativeElement.querySelector('.added-total-cell')).toBeFalsy();
+    expect(fixture.nativeElement.textContent).toContain('+1');
   });
 
   it('renders a missing-history message when no snapshot exists', () => {

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.ts
@@ -8,6 +8,9 @@ import { TranslateModule } from '@ngx-translate/core';
 import type {
   JobDefinitionDistributionSnapshot
 } from '../../services/coding-job-backend.service';
+import type {
+  JobDefinitionRefreshItemDeltaDto
+} from '../../../../../../../api-dto/coding/job-refresh.dto';
 
 interface DialogCoder {
   id: number;
@@ -18,7 +21,9 @@ interface DistributionSummaryRow {
   itemKey: string;
   label: string;
   coderCases: Record<string, number>;
+  addedCoderTasks: Record<string, number>;
   totalCases: number;
+  addedCases: number;
   doubleCodedCases: number;
   singleCodedCasesAssigned: number;
 }
@@ -26,6 +31,7 @@ interface DistributionSummaryRow {
 export interface JobDefinitionDistributionSummaryDialogData {
   definitionId: number;
   snapshot?: JobDefinitionDistributionSnapshot;
+  snapshots?: JobDefinitionDistributionSnapshot[];
   coders: DialogCoder[];
   createdJobsCount?: number;
 }
@@ -45,14 +51,37 @@ export interface JobDefinitionDistributionSummaryDialogData {
   styleUrls: ['./job-definition-distribution-summary-dialog.component.scss']
 })
 export class JobDefinitionDistributionSummaryDialogComponent {
-  readonly snapshot = this.data.snapshot;
-  readonly coderColumns = this.getCoderColumns();
-  readonly rows = this.getRows();
+  selectedSnapshotIndex = this.getInitialSnapshotIndex();
 
   constructor(
     public dialogRef: MatDialogRef<JobDefinitionDistributionSummaryDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: JobDefinitionDistributionSummaryDialogData
   ) {}
+
+  get snapshots(): JobDefinitionDistributionSnapshot[] {
+    if (this.data.snapshots?.length) {
+      return this.data.snapshots;
+    }
+    return this.data.snapshot ? [this.data.snapshot] : [];
+  }
+
+  get snapshot(): JobDefinitionDistributionSnapshot | undefined {
+    return this.snapshots[this.selectedSnapshotIndex];
+  }
+
+  get coderColumns(): DialogCoder[] {
+    return this.getCoderColumns();
+  }
+
+  get rows(): DistributionSummaryRow[] {
+    return this.getRows();
+  }
+
+  selectSnapshot(index: number): void {
+    if (index >= 0 && index < this.snapshots.length) {
+      this.selectedSnapshotIndex = index;
+    }
+  }
 
   getSnapshotDate(): string {
     if (!this.snapshot?.createdAt) {
@@ -79,9 +108,19 @@ export class JobDefinitionDistributionSummaryDialogComponent {
     return this.rows.reduce((total, row) => total + row.totalCases, 0);
   }
 
+  getGrandAddedCases(): number {
+    return this.rows.reduce((total, row) => total + row.addedCases, 0);
+  }
+
   getGridTemplate(): string {
     const coderColumns = 'minmax(88px, 1fr) '.repeat(this.coderColumns.length);
-    return `minmax(180px, 1.7fr) ${coderColumns}minmax(80px, .8fr) minmax(110px, .9fr)`.trim();
+    const addedCasesColumn = this.hasAddedCases() ? 'minmax(88px, .8fr) ' : '';
+    return `minmax(180px, 1.7fr) ${coderColumns}minmax(80px, .8fr) ${addedCasesColumn}minmax(110px, .9fr)`.trim();
+  }
+
+  hasAddedCases(): boolean {
+    return !!this.snapshot?.refreshPreview?.itemDeltas
+      ?.some(delta => delta.addedCases > 0);
   }
 
   private getCoderColumns(): DialogCoder[] {
@@ -99,14 +138,22 @@ export class JobDefinitionDistributionSummaryDialogComponent {
       return [];
     }
 
+    const deltaByItemKey = new Map(
+      (this.snapshot.refreshPreview?.itemDeltas || [])
+        .map(delta => [delta.itemKey, delta])
+    );
+
     return Object.entries(this.snapshot.distributionByCoderId || {})
       .map(([itemKey, coderCases]) => {
         const doubleCodingInfo = this.snapshot?.doubleCodingInfo?.[itemKey];
+        const delta = deltaByItemKey.get(itemKey);
         return {
           itemKey,
           label: this.getItemLabel(itemKey),
           coderCases,
+          addedCoderTasks: this.getAddedCoderTasks(delta),
           totalCases: Object.values(coderCases).reduce((sum, count) => sum + count, 0),
+          addedCases: delta?.addedCases || 0,
           doubleCodedCases: doubleCodingInfo?.doubleCodedCases || 0,
           singleCodedCasesAssigned: doubleCodingInfo?.singleCodedCasesAssigned || 0
         };
@@ -127,5 +174,29 @@ export class JobDefinitionDistributionSummaryDialogComponent {
     }
 
     return itemKey;
+  }
+
+  private getAddedCoderTasks(
+    delta: JobDefinitionRefreshItemDeltaDto | undefined
+  ): Record<string, number> {
+    if (!delta) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(delta.codingTasksByCoderId || {})
+        .map(([coderId, coderDelta]): [string, number] => [coderId, coderDelta.addedCodingTasks])
+        .filter(([, count]) => count > 0)
+    );
+  }
+
+  private getInitialSnapshotIndex(): number {
+    let snapshots: JobDefinitionDistributionSnapshot[] = [];
+    if (this.data.snapshots?.length) {
+      snapshots = this.data.snapshots;
+    } else if (this.data.snapshot) {
+      snapshots = [this.data.snapshot];
+    }
+    return Math.max(0, snapshots.length - 1);
   }
 }

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.html
@@ -77,6 +77,23 @@
       </div>
       }
     </div>
+
+    @if (getAddedItemDeltas().length > 0) {
+    <h3>{{ 'coding-job-definitions.refresh-dialog.added-items-title' | translate }}</h3>
+    <div class="added-items-list">
+      @for (delta of getAddedItemDeltas(); track delta.itemKey) {
+      <div class="added-item">
+        <span>{{ delta.itemLabel }}</span>
+        <strong>
+          {{ 'coding-job-definitions.refresh-dialog.added-item-counts' | translate: {
+            cases: delta.addedCases,
+            tasks: delta.addedCodingTasks
+          } }}
+        </strong>
+      </div>
+      }
+    </div>
+    }
   </mat-dialog-content>
 
   <mat-dialog-actions align="end">

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.scss
@@ -143,6 +143,35 @@ h3 {
   color: #ef6c00;
 }
 
+.added-items-list {
+  border: 1px solid rgba(46, 125, 50, 0.18);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.added-item {
+  align-items: center;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 40px;
+  padding: 8px 12px;
+}
+
+.added-item + .added-item {
+  border-top: 1px solid rgba(46, 125, 50, 0.12);
+}
+
+.added-item span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.added-item strong {
+  color: #2e7d32;
+  white-space: nowrap;
+}
+
 mat-dialog-actions {
   gap: 8px;
   padding: 16px 24px 20px;

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.spec.ts
@@ -61,4 +61,49 @@ describe('JobDefinitionRefreshDialogComponent', () => {
       }
     ]));
   });
+
+  it('lists item-level deltas for newly added cases', () => {
+    const component = createComponent({
+      itemDeltas: [
+        {
+          itemKey: 'Unit 1::Var 1',
+          itemLabel: 'Unit 1::Var 1',
+          existingCases: 4,
+          plannedCases: 6,
+          retainedCases: 4,
+          addedCases: 2,
+          removedCases: 0,
+          existingCodingTasks: 4,
+          plannedCodingTasks: 7,
+          retainedCodingTasks: 4,
+          addedCodingTasks: 3,
+          removedCodingTasks: 0,
+          codingTasksByCoderId: {}
+        },
+        {
+          itemKey: 'Unit 2::Var 2',
+          itemLabel: 'Unit 2::Var 2',
+          existingCases: 3,
+          plannedCases: 3,
+          retainedCases: 3,
+          addedCases: 0,
+          removedCases: 0,
+          existingCodingTasks: 3,
+          plannedCodingTasks: 3,
+          retainedCodingTasks: 3,
+          addedCodingTasks: 0,
+          removedCodingTasks: 0,
+          codingTasksByCoderId: {}
+        }
+      ]
+    });
+
+    expect(component.getAddedItemDeltas()).toEqual([
+      expect.objectContaining({
+        itemKey: 'Unit 1::Var 1',
+        addedCases: 2,
+        addedCodingTasks: 3
+      })
+    ]);
+  });
 });

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.ts
@@ -9,7 +9,10 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { JobDefinitionRefreshPreviewDto } from '../../../../../../../api-dto/coding/job-refresh.dto';
+import {
+  JobDefinitionRefreshItemDeltaDto,
+  JobDefinitionRefreshPreviewDto
+} from '../../../../../../../api-dto/coding/job-refresh.dto';
 
 export interface JobDefinitionRefreshDialogData {
   definitionId: number;
@@ -114,6 +117,11 @@ export class JobDefinitionRefreshDialogComponent {
         tone: this.preview.removedCodingTasks > 0 ? 'negative' : 'default'
       }
     ];
+  }
+
+  getAddedItemDeltas(): JobDefinitionRefreshItemDeltaDto[] {
+    return (this.preview.itemDeltas || [])
+      .filter(delta => delta.addedCases > 0 || delta.addedCodingTasks > 0);
   }
 
   close(): void {

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -141,6 +141,7 @@ export interface JobDefinitionDistributionSnapshot {
     jobId: number;
     caseCount: number;
   }>;
+  refreshPreview?: JobDefinitionRefreshPreviewDto;
 }
 
 export interface JobDefinition {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2180,6 +2180,8 @@
       "preview-title": "Jobstatus",
       "case-title": "Fälle",
       "task-title": "Kodieraufgaben",
+      "added-items-title": "Neue Fälle nach Variable / Bündel",
+      "added-item-counts": "{{cases}} Fälle · {{tasks}} Aufgaben",
       "stats": {
         "existing-jobs": "Vorhandene Jobs",
         "stale-jobs": "Davon veraltet",
@@ -2200,12 +2202,16 @@
         "initial": "Ersterstellung",
         "refresh": "Neuverteilung"
       },
+      "snapshots-label": "Gespeicherte Verteilungen",
       "missing-history": "Für diese Job-Definition liegt keine gespeicherte Verteilungsübersicht vor. Vermutlich wurden die Kodierjobs vor Einführung der Snapshot-Speicherung erstellt.",
       "coders": "Kodierer",
       "jobs": "Kodierjobs",
       "total-cases": "Kodieraufgaben",
+      "new-cases": "Neue Fälle",
       "item": "Variable / Bündel",
       "total": "Gesamt",
+      "new": "Neue Fälle",
+      "added-tasks-title": "Neue Kodieraufgaben: {{tasks}}",
       "double-coded": "Doppelt kodiert",
       "grand-total": "Gesamt"
     },


### PR DESCRIPTION
## What changed

- Adds item- and coder-level refresh delta data to job-definition refresh previews.
- Stores the refresh preview in distribution snapshots created during refresh.
- Shows newly added cases separately in the refresh dialog and distribution summary, including per-coder added coding-task markers.

## Why

Issue #544 asks for newly imported cases to be visible separately after refreshing a job definition instead of being folded silently into the existing distribution overview.

## Validation

- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job.service.spec.ts --runInBand
- npx nx test backend --testFile=apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts --runInBand
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts --runInBand
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.spec.ts --runInBand
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.spec.ts --runInBand
- npx nx lint backend
- npx nx lint frontend
- npx nx run-many --target=build --projects=frontend,backend --parallel

Note: a full backend test run is currently blocked locally by a libxmljs2 Node ABI mismatch, unrelated to this change.

Issue: #544