### PR TITLE
Fix replay table cell anchor highlighting

### DIFF
--- a/apps/frontend/src/app/replay/utils/dom-utils.spec.ts
+++ b/apps/frontend/src/app/replay/utils/dom-utils.spec.ts
@@ -99,6 +99,105 @@ describe('replay dom-utils', () => {
     expect(fieldA.style.border).toBe('');
   });
 
+  it('highlights only the requested table cell when table fields share a section', () => {
+    const iframe = createIframe(`
+      <aspect-section id="section">
+        <div id="section-frame">
+          <aspect-table id="table" role="grid">
+            <div id="cell-a" role="gridcell">
+              <span id="field-a" data-element-alias="01a"></span>
+            </div>
+            <div id="cell-b" role="gridcell">
+              <span id="field-b" data-element-alias="01b"></span>
+            </div>
+          </aspect-table>
+        </div>
+      </aspect-section>
+    `);
+
+    const highlighted = highlightAspectSectionWithAnchor(iframe, '01b');
+    const section = iframe.contentDocument?.querySelector('#section') as HTMLElement;
+    const sectionFrame = iframe.contentDocument?.querySelector('#section-frame') as HTMLElement;
+    const cellA = iframe.contentDocument?.querySelector('#cell-a') as HTMLElement;
+    const cellB = iframe.contentDocument?.querySelector('#cell-b') as HTMLElement;
+    const fieldB = iframe.contentDocument?.querySelector('#field-b') as HTMLElement;
+
+    expect(highlighted).toEqual([section]);
+    expect(sectionFrame.style.border).toBe('');
+    expect(cellA.style.outline).toBe('');
+    expect(cellB.style.outline).toBe('3px solid #4285f4');
+    expect(cellB.style.outlineOffset).toBe('-3px');
+    expect(fieldB.style.border).toBe('');
+  });
+
+  it('highlights an aliased table field when no separate cell wrapper exists', () => {
+    const iframe = createIframe(`
+      <aspect-section id="section">
+        <div id="section-frame">
+          <aspect-table id="table" role="grid">
+            <span id="field-a" data-element-alias="01a" style="grid-row: 2; grid-column: 2"></span>
+            <span id="field-b" data-element-alias="01b" style="grid-row: 2; grid-column: 3"></span>
+          </aspect-table>
+        </div>
+      </aspect-section>
+    `);
+
+    const highlighted = highlightAspectSectionWithAnchor(iframe, '01a');
+    const section = iframe.contentDocument?.querySelector('#section') as HTMLElement;
+    const sectionFrame = iframe.contentDocument?.querySelector('#section-frame') as HTMLElement;
+    const fieldA = iframe.contentDocument?.querySelector('#field-a') as HTMLElement;
+    const fieldB = iframe.contentDocument?.querySelector('#field-b') as HTMLElement;
+
+    expect(highlighted).toEqual([section]);
+    expect(sectionFrame.style.border).toBe('');
+    expect(fieldA.style.outline).toBe('3px solid #4285f4');
+    expect(fieldB.style.outline).toBe('');
+  });
+
+  it('highlights the real player table cell container for table text fields', () => {
+    const iframe = createIframe(`
+      <aspect-section id="section">
+        <div id="section-frame">
+          <aspect-table>
+            <div class="grid-container" style="display: grid">
+              <div id="cell-a" class="cell-container" style="grid-row-start: 2; grid-column-start: 4;">
+                <div class="element-container">
+                  <aspect-table-child-overlay>
+                    <div class="wrapper">
+                      <aspect-text-field id="field-a" data-element-alias="01"></aspect-text-field>
+                    </div>
+                  </aspect-table-child-overlay>
+                </div>
+              </div>
+              <div id="cell-b" class="cell-container" style="grid-row-start: 3; grid-column-start: 3;">
+                <div class="element-container">
+                  <aspect-table-child-overlay>
+                    <div class="wrapper">
+                      <aspect-text-field id="field-b" data-element-alias="02"></aspect-text-field>
+                    </div>
+                  </aspect-table-child-overlay>
+                </div>
+              </div>
+            </div>
+          </aspect-table>
+        </div>
+      </aspect-section>
+    `);
+
+    const highlighted = highlightAspectSectionWithAnchor(iframe, '02');
+    const section = iframe.contentDocument?.querySelector('#section') as HTMLElement;
+    const sectionFrame = iframe.contentDocument?.querySelector('#section-frame') as HTMLElement;
+    const cellA = iframe.contentDocument?.querySelector('#cell-a') as HTMLElement;
+    const cellB = iframe.contentDocument?.querySelector('#cell-b') as HTMLElement;
+    const fieldB = iframe.contentDocument?.querySelector('#field-b') as HTMLElement;
+
+    expect(highlighted).toEqual([section]);
+    expect(sectionFrame.style.border).toBe('');
+    expect(cellA.style.outline).toBe('');
+    expect(cellB.style.outline).toBe('3px solid #4285f4');
+    expect(fieldB.style.outline).toBe('');
+  });
+
   it('scrolls to an element by alias when it exists', () => {
     const iframe = createIframe('<span id="target" data-element-alias="VAR1"></span>');
     const target = iframe.contentDocument?.querySelector('#target') as HTMLElement;

--- a/apps/frontend/src/app/replay/utils/dom-utils.ts
+++ b/apps/frontend/src/app/replay/utils/dom-utils.ts
@@ -2,10 +2,79 @@
  * Utility functions for DOM manipulation in the replay module
  */
 
+const HIGHLIGHT_BORDER = '3px solid #4285f4';
+const HIGHLIGHT_ATTR = 'data-coding-box-anchor-highlight';
+
+function clearHighlight(element: HTMLElement): void {
+  element.style.border = '';
+  element.style.outline = '';
+  element.style.outlineOffset = '';
+  element.removeAttribute(HIGHLIGHT_ATTR);
+}
+
+function highlightWithBorder(element: HTMLElement): void {
+  element.style.border = HIGHLIGHT_BORDER;
+  element.setAttribute(HIGHLIGHT_ATTR, 'true');
+}
+
+function highlightWithOutline(element: HTMLElement): void {
+  element.style.outline = HIGHLIGHT_BORDER;
+  element.style.outlineOffset = '-3px';
+  element.setAttribute(HIGHLIGHT_ATTR, 'true');
+}
+
+function getParentSection(element: HTMLElement): HTMLElement | null {
+  return element.closest('aspect-section') as HTMLElement | null;
+}
+
+function getTableHighlightTarget(anchorElement: HTMLElement): HTMLElement | null {
+  const tableElement = anchorElement.closest(
+    'aspect-table, table, [data-element-type="table"], [data-aspect-type="table"]'
+  );
+
+  if (!tableElement) {
+    return null;
+  }
+
+  const explicitCell = anchorElement.closest(
+    'td, th, [role="cell"], [role="gridcell"], aspect-table-cell, [data-table-cell], .cell-container, .table-cell, .cell'
+  );
+
+  if (explicitCell && tableElement.contains(explicitCell)) {
+    return explicitCell as HTMLElement;
+  }
+
+  let current: HTMLElement | null = anchorElement;
+  const view = anchorElement.ownerDocument.defaultView;
+  while (current && current !== tableElement) {
+    const inlineStyle = current.getAttribute('style') || '';
+    const computedStyle = view?.getComputedStyle(current);
+    const hasGridPlacement =
+      inlineStyle.includes('grid-row') ||
+      inlineStyle.includes('grid-column') ||
+      (!!computedStyle &&
+        computedStyle.gridRowStart !== 'auto' &&
+        computedStyle.gridColumnStart !== 'auto');
+
+    if (hasGridPlacement) {
+      return current;
+    }
+
+    if (current.parentElement === tableElement) {
+      return current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return anchorElement;
+}
+
 /**
  * Highlights the direct child div elements of aspect-section tags that contain an element with the specified anchor.
  * If an anchor is provided, finds aspect-section tags that contain the element with that data-element-alias
- * and highlights their direct child div elements with a blue border.
+ * and highlights their direct child div elements with a blue border. Multi-field cloze and table elements
+ * are highlighted directly instead, using a border or outline on the focused field or cell.
  *
  * @param iframe The iframe element containing the player's HTML
  * @param anchor Optional data-element-alias to filter aspect-section tags
@@ -19,17 +88,21 @@ export function highlightAspectSectionWithAnchor(iframe: HTMLIFrameElement, anch
       const allAspectSections = iframe.contentDocument.querySelectorAll('aspect-section');
       const elementsByAlias = findElementsByDataAlias(iframe);
 
-      // Reset borders on all potential highlight targets to clear previous state
-      // 1. Reset all elements with aliases (handles individual highlights like cloze fields)
-      Object.values(elementsByAlias).forEach(el => {
-        el.style.border = '';
+      iframe.contentDocument.querySelectorAll(`[${HIGHLIGHT_ATTR}="true"]`).forEach(el => {
+        clearHighlight(el as HTMLElement);
       });
 
-      // 2. Reset direct child divs of all aspect-sections (handles standard section highlighting)
+      // Reset borders on all potential highlight targets to clear previous state.
+      // 1. Reset all elements with aliases (handles individual highlights like cloze fields).
+      Object.values(elementsByAlias).forEach(el => {
+        clearHighlight(el);
+      });
+
+      // 2. Reset direct child divs of all aspect-sections (handles standard section highlighting).
       Array.from(allAspectSections).forEach(section => {
         const directChildDivs = section.querySelectorAll(':scope > div');
         directChildDivs.forEach(div => {
-          (div as HTMLElement).style.border = '';
+          clearHighlight(div as HTMLElement);
         });
       });
 
@@ -43,6 +116,16 @@ export function highlightAspectSectionWithAnchor(iframe: HTMLIFrameElement, anch
           return result;
         }
 
+        const tableHighlightTarget = getTableHighlightTarget(anchorElement);
+        if (tableHighlightTarget) {
+          highlightWithOutline(tableHighlightTarget);
+          const parentSection = getParentSection(anchorElement);
+          if (parentSection) {
+            result.push(parentSection);
+          }
+          return result;
+        }
+
         // If the element is part of a cloze with multiple fields, only highlight the field itself.
         const clozeElement = anchorElement.closest('aspect-cloze');
         if (clozeElement) {
@@ -50,11 +133,11 @@ export function highlightAspectSectionWithAnchor(iframe: HTMLIFrameElement, anch
           // Exclude the cloze itself if it has an alias
           const variablesInside = Array.from(aliasedInside).filter(el => el !== clozeElement);
           if (variablesInside.length > 1) {
-            anchorElement.style.border = '3px solid #4285f4';
+            highlightWithBorder(anchorElement);
             // Find containing aspect-section to include it in the return value
-            const parentSection = anchorElement.closest('aspect-section');
+            const parentSection = getParentSection(anchorElement);
             if (parentSection) {
-              result.push(parentSection as HTMLElement);
+              result.push(parentSection);
             }
             return result;
           }
@@ -67,7 +150,7 @@ export function highlightAspectSectionWithAnchor(iframe: HTMLIFrameElement, anch
         filteredElements.forEach(element => {
           const directChildDivs = element.querySelectorAll(':scope > div');
           directChildDivs.forEach(div => {
-            (div as HTMLElement).style.border = '3px solid #4285f4'; // Google blue color
+            highlightWithBorder(div as HTMLElement);
           });
         });
       }


### PR DESCRIPTION
## Summary
- highlight replay anchors inside ASPECT tables at the table cell level instead of the whole section
- keep multi-field cloze anchors highlighted at the individual field level
- add DOM utility coverage for synthetic table structures and the observed real player `aspect-table > .cell-container` structure

## Context
Refs #651. The issue remains open for confirmation and follow-up.

## Root cause
The replay anchor highlighter previously treated all anchors as section anchors unless they were multi-field cloze fields. Table variables that share one `aspect-section` therefore highlighted the section frame, making different table variables look identical in replay.

## Validation
- `npx nx test frontend -- --runInBand --testPathPatterns=dom-utils.spec.ts`
- `npx nx lint frontend`
- `git diff --check`
- local browser smoke tests on workspace 2:
  - MGV098 / 01 highlights one `.cell-container`
  - MMV068 / 01a highlights one `.cell-container`
  - MMV086 / 01a highlights one `.cell-container`
  - MGV011 / 01c_1 still highlights the individual cloze field
