### PR TITLE
Clarify aggregation progress wording

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -316,10 +316,14 @@
                   {{ aggregation.aggregationActive ? 'Aggregation aktiv' : 'Aggregation nicht aktiv' }}
                 </strong>
                 <span>
-                  Antwort-Analyse: {{ aggregation.rawCases }} Rohantworten ergeben {{ aggregation.effectiveCases }}
-                  effektive Kodierfälle.
+                  {{ 'coding-management-manual.coding-progress.analysis-aggregation-note' | translate:{
+                    rawCases: aggregation.rawCases,
+                    effectiveCases: aggregation.effectiveCases
+                  } }}
                   <ng-container *ngIf="aggregation.collapsedCases > 0">
-                    Einsparung in dieser Analyse: {{ aggregation.collapsedCases }} Kodierungen.
+                    {{ 'coding-management-manual.coding-progress.analysis-aggregation-savings' | translate:{
+                      collapsedCases: aggregation.collapsedCases
+                    } }}
                   </ng-container>
                 </span>
               </div>
@@ -568,7 +572,9 @@
                 <strong>{{ 'coding-management-manual.coding-progress.info-total-title' | translate }}</strong>
                 <span class="info-alert-text-spaced">{{ 'coding-management-manual.coding-progress.info-total-desc' | translate }}</span>
                 <strong>{{ 'coding-management-manual.coding-progress.info-completed-title' | translate }}</strong>
-                <span>{{ 'coding-management-manual.coding-progress.info-completed-desc' | translate }}</span>
+                <span class="info-alert-text-spaced">{{ 'coding-management-manual.coding-progress.info-completed-desc' | translate }}</span>
+                <strong>{{ 'coding-management-manual.coding-progress.info-aggregation-title' | translate }}</strong>
+                <span>{{ 'coding-management-manual.coding-progress.info-aggregation-desc' | translate }}</span>
               </div>
             </div>
 
@@ -639,10 +645,12 @@
             <div *ngIf="codingProgressOverview.aggregationActive" class="aggregation-note">
               <mat-icon>filter_alt</mat-icon>
               <span>
-                Aggregation ist aktiv: {{codingProgressOverview.rawTotalCasesToCode}} Rohantworten ergeben
-                {{codingProgressOverview.totalCasesToCode}} effektive Kodierfälle. Dadurch werden bei Schwelle
-                {{codingProgressOverview.aggregationThreshold}} {{codingProgressOverview.aggregatedDuplicateCases}}
-                Kodierungen eingespart.
+                {{ 'coding-management-manual.coding-progress.aggregation-note' | translate:{
+                  rawCases: codingProgressOverview.rawTotalCasesToCode,
+                  effectiveCases: codingProgressOverview.totalCasesToCode,
+                  threshold: codingProgressOverview.aggregationThreshold,
+                  collapsedCases: codingProgressOverview.aggregatedDuplicateCases
+                } }}
               </span>
             </div>
 
@@ -876,10 +884,12 @@
             <div *ngIf="caseCoverageOverview.aggregationActive" class="aggregation-note">
               <mat-icon>filter_alt</mat-icon>
               <span>
-                Aggregation ist aktiv: {{caseCoverageOverview.totalCasesToCode}} Rohantworten ergeben
-                {{caseCoverageOverview.effectiveTotalCasesToCode}} effektive Kodierfälle. Dadurch werden bei Schwelle
-                {{caseCoverageOverview.aggregationThreshold}} {{caseCoverageOverview.aggregatedDuplicateCases}}
-                Kodierungen eingespart.
+                {{ 'coding-management-manual.coding-progress.aggregation-note' | translate:{
+                  rawCases: caseCoverageOverview.totalCasesToCode,
+                  effectiveCases: caseCoverageOverview.effectiveTotalCasesToCode,
+                  threshold: caseCoverageOverview.aggregationThreshold,
+                  collapsedCases: caseCoverageOverview.aggregatedDuplicateCases
+                } }}
               </span>
             </div>
             <div class="coverage-bar">
@@ -946,10 +956,12 @@
               <div *ngIf="appliedResultsOverview.aggregationActive" class="aggregation-note">
                 <mat-icon>filter_alt</mat-icon>
                 <span>
-                  Aggregation ist aktiv: {{appliedResultsOverview.rawTotalIncompleteResponses}} Rohantworten ergeben
-                  {{appliedResultsOverview.totalIncompleteResponses}} effektive Kodierfälle. Dadurch werden bei Schwelle
-                  {{appliedResultsOverview.aggregationThreshold}} {{appliedResultsOverview.aggregatedDuplicateCases}}
-                  Kodierungen eingespart.
+                  {{ 'coding-management-manual.coding-progress.aggregation-note' | translate:{
+                    rawCases: appliedResultsOverview.rawTotalIncompleteResponses,
+                    effectiveCases: appliedResultsOverview.totalIncompleteResponses,
+                    threshold: appliedResultsOverview.aggregationThreshold,
+                    collapsedCases: appliedResultsOverview.aggregatedDuplicateCases
+                  } }}
                 </span>
               </div>
               <div class="coverage-bar">

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -51,6 +51,18 @@ describe('CodingManagementManualComponent', () => {
     const translateService = TestBed.inject(TranslateService);
     translateService.setTranslation('de', {
       'coding-management-manual': {
+        'coding-progress': {
+          'info-tooltip': 'Erklärung zur Berechnung der Fortschrittswerte anzeigen',
+          'info-total-title': 'Gesamt zu kodierende Fälle',
+          'info-total-desc': 'Zählt die Basisanzahl eindeutiger Antworten.',
+          'info-completed-title': 'Abgeschlossene Fälle',
+          'info-completed-desc': 'Zählt die Anzahl der eindeutigen abgeschlossenen Fälle.',
+          'info-aggregation-title': 'Antwortwert-Aggregation, falls aktiv',
+          'info-aggregation-desc': 'Wenn Antwortwert-Aggregation aktiv ist, werden gleiche Antwortwerte pro Aufgabe/Variable gruppiert. Pro Gruppe wird ein Repräsentant in den Kodierjob gegeben; die Kodierung gilt anschließend für die zugehörigen Rohantworten. Abgeleitete Variablen werden nicht aggregiert.',
+          'aggregation-note': 'Antwortwert-Aggregation ist aktiv: {{rawCases}} Rohantworten werden zu {{effectiveCases}} effektiven Kodierfällen zusammengefasst. Dadurch müssen bei Schwelle {{threshold}} {{collapsedCases}} gleichwertige Rohantworten nicht separat manuell kodiert werden.',
+          'analysis-aggregation-note': 'Antwort-Analyse: {{rawCases}} Rohantworten ergeben {{effectiveCases}} effektive Kodierfälle.',
+          'analysis-aggregation-savings': '{{collapsedCases}} gleichwertige Rohantworten werden in dieser Analyse nicht separat als Kodierfälle gezählt.'
+        },
         freshness: {
           'second-autocoding-ready-title': 'Auto-Coding 2 bereit',
           'second-autocoding-ready-summary': 'Die manuelle Kodierung ist abgeschlossen. Auto-Coding 2 kann nun für {{taskResults}} gestartet oder aktualisiert werden. Das betrifft {{responses}}.',
@@ -638,6 +650,31 @@ describe('CodingManagementManualComponent', () => {
 
     expect(component.caseCoverageOverview?.effectiveUnassignedCases).toBe(0);
     expect(component.getAvailableCasesForNewJobs()).toBe(0);
+  });
+
+  it('explains aggregation savings as avoided separate manual coding', () => {
+    setCompletePlanningState();
+    setCodingProgress(16606, 12000);
+    component.codingProgressOverview = {
+      ...component.codingProgressOverview!,
+      rawTotalCasesToCode: 21606,
+      aggregationActive: true,
+      aggregationThreshold: 2,
+      aggregatedDuplicateCases: 5000
+    };
+    component.showProgressInfo = true;
+
+    fixture.detectChanges();
+
+    const pageText = fixture.nativeElement.textContent as string;
+    expect(pageText).toContain(
+      'Antwortwert-Aggregation ist aktiv: 21606 Rohantworten werden zu 16606 effektiven Kodierfällen zusammengefasst.'
+    );
+    expect(pageText).toContain(
+      'Dadurch müssen bei Schwelle 2 5000 gleichwertige Rohantworten nicht separat manuell kodiert werden.'
+    );
+    expect(pageText).toContain('Abgeleitete Variablen werden nicht aggregiert.');
+    expect(pageText).not.toContain('Kodierungen eingespart');
   });
 
   it('should guide users from incomplete planning to job definitions with available-case context', () => {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1635,7 +1635,12 @@
       "info-total-title": "Gesamt zu kodierende Fälle",
       "info-total-desc": "Zählt die Basisanzahl eindeutiger Antworten, die noch der manuellen Kodierung bedürfen. Antworten von ausgeschlossenen Testteilnehmern werden dynamisch abgezogen.",
       "info-completed-title": "Abgeschlossene Fälle",
-      "info-completed-desc": "Zählt die Anzahl der eindeutigen Fälle, für die mindestens eine abschließende Kodierung in den Jobs vorliegt. Doppelkodierungen werden hierbei als ein Fall gezählt, um eine konsistente Fortschrittsanzeige von maximal 100% zu gewährleisten."
+      "info-completed-desc": "Zählt die Anzahl der eindeutigen Fälle, für die mindestens eine abschließende Kodierung in den Jobs vorliegt. Doppelkodierungen werden hierbei als ein Fall gezählt, um eine konsistente Fortschrittsanzeige von maximal 100% zu gewährleisten.",
+      "info-aggregation-title": "Antwortwert-Aggregation, falls aktiv",
+      "info-aggregation-desc": "Wenn Antwortwert-Aggregation aktiv ist, werden gleiche Antwortwerte pro Aufgabe/Variable gruppiert. Pro Gruppe wird ein Repräsentant in den Kodierjob gegeben; die Kodierung gilt anschließend für die zugehörigen Rohantworten. Abgeleitete Variablen werden nicht aggregiert.",
+      "aggregation-note": "Antwortwert-Aggregation ist aktiv: {{rawCases}} Rohantworten werden zu {{effectiveCases}} effektiven Kodierfällen zusammengefasst. Dadurch müssen bei Schwelle {{threshold}} {{collapsedCases}} gleichwertige Rohantworten nicht separat manuell kodiert werden.",
+      "analysis-aggregation-note": "Antwort-Analyse: {{rawCases}} Rohantworten ergeben {{effectiveCases}} effektive Kodierfälle.",
+      "analysis-aggregation-savings": "{{collapsedCases}} gleichwertige Rohantworten werden in dieser Analyse nicht separat als Kodierfälle gezählt."
     },
     "variable-coverage": {
       "info-tooltip": "Erklärung zur Variablenabdeckung anzeigen",


### PR DESCRIPTION
## Summary
- clarify aggregation progress text as avoided separate manual coding work
- add explanatory info text for answer-value aggregation when active
- cover the rendered wording with a focused frontend component test

Refs #648

## Verification
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
- npx nx lint frontend