### PR TITLE
Fix replay URLs for training comparisons

### DIFF
--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -331,12 +331,14 @@ describe('CoderTrainingService', () => {
       expect(mockRepository.save).toHaveBeenCalledWith(expect.arrayContaining([
         expect.objectContaining({
           response_id: 101,
+          workspace_id: 1,
           variable_id: 'VAR',
           unit_name: 'UNIT',
           variable_bundle_id: null
         }),
         expect.objectContaining({
           response_id: 202,
+          workspace_id: 1,
           variable_id: 'VAR2',
           unit_name: 'UNIT2',
           variable_bundle_id: 5
@@ -1005,6 +1007,7 @@ describe('CoderTrainingService', () => {
         .map(([arg]) => arg)
         .find(arg => Array.isArray(arg) && arg.every(unit => unit instanceof CodingJobUnit)) as CodingJobUnit[];
       expect(savedUnits.map(unit => unit.response_id)).toEqual([1, 2, 4, 3]);
+      expect(savedUnits.map(unit => unit.workspace_id)).toEqual([1, 1, 1, 1]);
       expect(savedUnits.map(unit => unit.person_group)).toEqual(['group-1', 'group-1', 'group-2', 'group-2']);
 
       generatePackagesSpy.mockRestore();

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -1384,6 +1384,7 @@ export class CoderTrainingService {
         const codingJobUnits: CodingJobUnit[] = sortedResponses.map(response => {
           const codingJobUnit = new CodingJobUnit();
           codingJobUnit.coding_job_id = jobId;
+          codingJobUnit.workspace_id = workspaceId;
           codingJobUnit.response_id = response.responseId;
           codingJobUnit.unit_name = response.unitName;
           codingJobUnit.unit_alias = response.unitAlias || null;
@@ -2171,6 +2172,7 @@ export class CoderTrainingService {
           const codingJobUnits: CodingJobUnit[] = sortedResponses.map(response => {
             const codingJobUnit = new CodingJobUnit();
             codingJobUnit.coding_job_id = jobId;
+            codingJobUnit.workspace_id = workspaceId;
             codingJobUnit.response_id = response.responseId;
             codingJobUnit.unit_name = response.unitName;
             codingJobUnit.unit_alias = response.unitAlias || null;

--- a/apps/backend/src/app/database/services/coding/coding-replay.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-replay.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { CodingReplayService } from './coding-replay.service';
 import { ResponseEntity } from '../../entities/response.entity';
+import { CodingJobUnit } from '../../entities/coding-job-unit.entity';
 import { CodingListService } from './coding-list.service';
 import * as replayUrlUtil from '../../../utils/replay-url.util';
 
@@ -12,6 +13,17 @@ describe('CodingReplayService', () => {
 
   const mockResponseRepository = {
     findOne: jest.fn()
+  };
+
+  const mockCodingJobUnitQueryBuilder = {
+    innerJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getOne: jest.fn()
+  };
+
+  const mockCodingJobUnitRepository = {
+    createQueryBuilder: jest.fn(() => mockCodingJobUnitQueryBuilder)
   };
 
   const mockCodingListService = {
@@ -27,6 +39,10 @@ describe('CodingReplayService', () => {
           useValue: mockResponseRepository
         },
         {
+          provide: getRepositoryToken(CodingJobUnit),
+          useValue: mockCodingJobUnitRepository
+        },
+        {
           provide: CodingListService,
           useValue: mockCodingListService
         }
@@ -36,6 +52,7 @@ describe('CodingReplayService', () => {
     service = module.get<CodingReplayService>(CodingReplayService);
 
     jest.clearAllMocks();
+    mockCodingJobUnitQueryBuilder.getOne.mockResolvedValue(null);
   });
 
   it('should be defined', () => {
@@ -99,6 +116,7 @@ describe('CodingReplayService', () => {
         variableAnchor: 'var1',
         authToken: 'token123'
       });
+      expect(mockCodingJobUnitRepository.createQueryBuilder).not.toHaveBeenCalled();
     });
 
     it('should throw error when response not found', async () => {
@@ -126,6 +144,120 @@ describe('CodingReplayService', () => {
       await expect(
         service.generateReplayUrlForResponse(1, 1, 'http://example.com', 'token')
       ).rejects.toThrow('Response 1 does not belong to workspace 1');
+      expect(mockCodingJobUnitRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should use coding job unit metadata when response metadata is incomplete', async () => {
+      const mockResponse = {
+        id: 1,
+        variableid: 'var1',
+        unit: {
+          name: 'unit1',
+          booklet: {
+            person: {
+              workspace_id: 1,
+              login: 'response-user',
+              code: 'response-code',
+              group: 'response-group'
+            },
+            bookletinfo: null
+          }
+        }
+      };
+      const mockCodingJobUnit = {
+        unit_name: 'unit1',
+        variable_id: 'var1',
+        variable_anchor: 'anchor1',
+        booklet_name: 'booklet-from-job-unit',
+        person_login: 'job-user',
+        person_code: 'job-code',
+        person_group: 'job-group'
+      };
+
+      mockResponseRepository.findOne.mockResolvedValue(mockResponse);
+      mockCodingJobUnitQueryBuilder.getOne.mockResolvedValue(mockCodingJobUnit);
+      mockCodingListService.getVariablePageMap.mockResolvedValue(new Map([['var1', '3']]));
+      (replayUrlUtil.generateReplayUrl as jest.Mock).mockReturnValue('http://example.com/replay');
+
+      await service.generateReplayUrlForResponse(1, 1, 'http://example.com', 'token');
+
+      expect(mockCodingJobUnitRepository.createQueryBuilder).toHaveBeenCalledWith('codingJobUnit');
+      expect(mockCodingJobUnitQueryBuilder.innerJoinAndSelect).toHaveBeenCalledWith(
+        'codingJobUnit.coding_job',
+        'codingJob',
+        'codingJob.workspace_id = :workspaceId',
+        { workspaceId: 1 }
+      );
+      expect(mockCodingJobUnitQueryBuilder.where).toHaveBeenCalledWith(
+        'codingJobUnit.response_id = :responseId',
+        { responseId: 1 }
+      );
+      expect(replayUrlUtil.generateReplayUrl).toHaveBeenCalledWith({
+        serverUrl: 'http://example.com',
+        loginName: 'response-user',
+        loginCode: 'response-code',
+        loginGroup: 'response-group',
+        bookletId: 'booklet-from-job-unit',
+        unitId: 'unit1',
+        variablePage: '3',
+        variableAnchor: 'anchor1',
+        authToken: 'token'
+      });
+    });
+
+    it('should use workspace-scoped coding job unit metadata when response has no person relation', async () => {
+      const mockResponse = {
+        id: 1,
+        variableid: 'var1',
+        unit: {
+          name: 'unit1',
+          booklet: {
+            bookletinfo: {
+              name: 'booklet1'
+            }
+          }
+        }
+      };
+      const mockCodingJobUnit = {
+        unit_name: 'unit1',
+        variable_id: 'var1',
+        variable_anchor: 'var1',
+        booklet_name: 'booklet-from-job-unit',
+        person_login: 'job-user',
+        person_code: 'job-code',
+        person_group: 'job-group'
+      };
+
+      mockResponseRepository.findOne.mockResolvedValue(mockResponse);
+      mockCodingJobUnitQueryBuilder.getOne.mockResolvedValue(mockCodingJobUnit);
+      mockCodingListService.getVariablePageMap.mockResolvedValue(new Map());
+      (replayUrlUtil.generateReplayUrl as jest.Mock).mockReturnValue('http://example.com/replay');
+
+      await service.generateReplayUrlForResponse(1, 1, 'http://example.com', 'token');
+
+      expect(replayUrlUtil.generateReplayUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          loginName: 'job-user',
+          loginCode: 'job-code',
+          loginGroup: 'job-group',
+          bookletId: 'booklet1'
+        })
+      );
+    });
+
+    it('should throw when neither response nor coding job unit provide enough replay metadata', async () => {
+      mockResponseRepository.findOne.mockResolvedValue({
+        id: 1,
+        variableid: 'var1',
+        unit: {
+          name: 'unit1'
+        }
+      });
+      mockCodingJobUnitQueryBuilder.getOne.mockResolvedValue(null);
+
+      await expect(
+        service.generateReplayUrlForResponse(1, 1, 'http://example.com', 'token')
+      ).rejects.toThrow('Replay metadata for response 1 in workspace 1 not found');
     });
 
     it('should use default page 0 when variable not found in map', async () => {
@@ -154,6 +286,117 @@ describe('CodingReplayService', () => {
       mockResponseRepository.findOne.mockResolvedValue(mockResponse);
       mockCodingListService.getVariablePageMap.mockResolvedValue(mockVariablePageMap);
       (replayUrlUtil.generateReplayUrl as jest.Mock).mockReturnValue(mockReplayUrl);
+
+      await service.generateReplayUrlForResponse(1, 1, 'http://example.com', 'token');
+
+      expect(replayUrlUtil.generateReplayUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variablePage: '0'
+        })
+      );
+    });
+
+    it('should generate replay URL when person code is empty', async () => {
+      const mockResponse = {
+        id: 1,
+        variableid: 'var1',
+        unit: {
+          name: 'unit1',
+          booklet: {
+            person: {
+              workspace_id: 1,
+              login: 'testuser',
+              code: '',
+              group: 'group1'
+            },
+            bookletinfo: {
+              name: 'booklet1'
+            }
+          }
+        }
+      };
+
+      mockResponseRepository.findOne.mockResolvedValue(mockResponse);
+      mockCodingListService.getVariablePageMap.mockResolvedValue(new Map([['var1', '2']]));
+      (replayUrlUtil.generateReplayUrl as jest.Mock).mockReturnValue('http://example.com/replay');
+
+      await service.generateReplayUrlForResponse(1, 1, 'http://example.com', 'token');
+
+      expect(mockCodingJobUnitRepository.createQueryBuilder).not.toHaveBeenCalled();
+      expect(replayUrlUtil.generateReplayUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          loginCode: ''
+        })
+      );
+    });
+
+    it('should keep empty response person code and group when fallback metadata is needed', async () => {
+      const mockResponse = {
+        id: 1,
+        variableid: 'var1',
+        unit: {
+          name: 'unit1',
+          booklet: {
+            person: {
+              workspace_id: 1,
+              login: 'testuser',
+              code: '',
+              group: ''
+            },
+            bookletinfo: null
+          }
+        }
+      };
+      const mockCodingJobUnit = {
+        unit_name: 'unit1',
+        variable_id: 'var1',
+        variable_anchor: 'anchor1',
+        booklet_name: 'booklet-from-job-unit',
+        person_login: 'job-user',
+        person_code: 'stale-code',
+        person_group: 'stale-group'
+      };
+
+      mockResponseRepository.findOne.mockResolvedValue(mockResponse);
+      mockCodingJobUnitQueryBuilder.getOne.mockResolvedValue(mockCodingJobUnit);
+      mockCodingListService.getVariablePageMap.mockResolvedValue(new Map([['var1', '2']]));
+      (replayUrlUtil.generateReplayUrl as jest.Mock).mockReturnValue('http://example.com/replay');
+
+      await service.generateReplayUrlForResponse(1, 1, 'http://example.com', 'token');
+
+      expect(replayUrlUtil.generateReplayUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          loginName: 'testuser',
+          loginCode: '',
+          loginGroup: '',
+          bookletId: 'booklet-from-job-unit'
+        })
+      );
+    });
+
+    it('should use default page 0 when variable page lookup fails', async () => {
+      const mockResponse = {
+        id: 1,
+        variableid: 'var1',
+        unit: {
+          name: 'unit1',
+          booklet: {
+            person: {
+              workspace_id: 1,
+              login: 'testuser',
+              code: 'code123',
+              group: 'group1'
+            },
+            bookletinfo: {
+              name: 'booklet1'
+            }
+          }
+        }
+      };
+
+      mockResponseRepository.findOne.mockResolvedValue(mockResponse);
+      mockCodingListService.getVariablePageMap.mockRejectedValue(new Error('VOUD unavailable'));
+      (replayUrlUtil.generateReplayUrl as jest.Mock).mockReturnValue('http://example.com/replay');
 
       await service.generateReplayUrlForResponse(1, 1, 'http://example.com', 'token');
 
@@ -304,6 +547,41 @@ describe('CodingReplayService', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].replayUrl).toBe('');
+    });
+  });
+
+  describe('generateReplayUrlsForItemsBulk', () => {
+    it('should use variable anchor when generating replay URLs', async () => {
+      const items = [
+        {
+          responseId: 1,
+          unitName: 'unit1',
+          unitAlias: null,
+          variableId: 'var1',
+          variableAnchor: 'anchor1',
+          bookletName: 'booklet1',
+          personLogin: 'user1',
+          personCode: 'code1',
+          personGroup: 'group1'
+        }
+      ];
+
+      mockCodingListService.getVariablePageMap.mockResolvedValue(new Map([['var1', '4']]));
+      (replayUrlUtil.generateReplayUrl as jest.Mock).mockReturnValue('http://example.com/replay?auth=');
+
+      const result = await service.generateReplayUrlsForItemsBulk(
+        1,
+        items,
+        'http://example.com'
+      );
+
+      expect(result[0].replayUrl).toBe('http://example.com/replay');
+      expect(replayUrlUtil.generateReplayUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variablePage: '4',
+          variableAnchor: 'anchor1'
+        })
+      );
     });
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-replay.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-replay.service.ts
@@ -1,9 +1,26 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  ForbiddenException,
+  HttpException,
+  Injectable,
+  Logger,
+  NotFoundException
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ResponseEntity } from '../../entities/response.entity';
+import { CodingJobUnit } from '../../entities/coding-job-unit.entity';
 import { generateReplayUrl } from '../../../utils/replay-url.util';
 import { CodingListService } from './coding-list.service';
+
+interface ReplayMetadata {
+  unitName: string;
+  variableId: string;
+  variableAnchor: string;
+  bookletName: string;
+  personLogin: string;
+  personCode: string;
+  personGroup: string;
+}
 
 @Injectable()
 export class CodingReplayService {
@@ -12,6 +29,8 @@ export class CodingReplayService {
   constructor(
     @InjectRepository(ResponseEntity)
     private responseRepository: Repository<ResponseEntity>,
+    @InjectRepository(CodingJobUnit)
+    private codingJobUnitRepository: Repository<CodingJobUnit>,
     private codingListService: CodingListService
   ) { }
 
@@ -33,52 +52,29 @@ export class CodingReplayService {
       });
 
       if (!response) {
-        throw new Error(`Response with id ${responseId} not found`);
+        throw new NotFoundException(`Response with id ${responseId} not found`);
       }
 
       const person = response.unit?.booklet?.person;
-      if (!person || Number(person.workspace_id) !== Number(workspaceId)) {
-        throw new Error(
+      if (person && Number(person.workspace_id) !== Number(workspaceId)) {
+        throw new ForbiddenException(
           `Response ${responseId} does not belong to workspace ${workspaceId}`
         );
       }
 
-      const unitName = response.unit?.name || '';
-      const variableId = response.variableid || '';
-      const loginName = person.login || '';
-      const loginCode = person.code || '';
-      const loginGroup = person.group || '';
-      const bookletId = response.unit?.booklet?.bookletinfo?.name || '';
+      const responseMetadata = this.getMetadataFromResponse(response);
+      const codingJobUnit = this.hasRequiredReplayMetadata(responseMetadata) ?
+        null :
+        await this.findCodingJobUnitForResponse(workspaceId, responseId);
+      const metadata = this.mergeReplayMetadata(responseMetadata, codingJobUnit);
 
-      // Get the variable page from VOUD data
-      this.logger.log(
-        `Looking up variablePage for unit '${unitName}', variable '${variableId}' in workspace ${workspaceId}`
-      );
-      const variablePageMap = await this.codingListService.getVariablePageMap(
-        unitName,
-        workspaceId
-      );
-      this.logger.log(
-        `VOUD lookup result: variablePageMap has ${variablePageMap.size} entries for unit '${unitName}'`
-      );
-      const variablePage = variablePageMap.get(variableId) || '0';
-      this.logger.log(
-        `Variable '${variableId}' resolved to page '${variablePage}' (found in map: ${variablePageMap.has(
-          variableId
-        )})`
-      );
+      if (!this.hasRequiredReplayMetadata(metadata)) {
+        throw new NotFoundException(
+          `Replay metadata for response ${responseId} in workspace ${workspaceId} not found`
+        );
+      }
 
-      const replayUrl = generateReplayUrl({
-        serverUrl,
-        loginName,
-        loginCode,
-        loginGroup,
-        bookletId,
-        unitId: unitName,
-        variablePage,
-        variableAnchor: variableId,
-        authToken
-      });
+      const replayUrl = await this.buildReplayUrl(workspaceId, metadata, serverUrl, authToken);
 
       this.logger.log(
         `Generated replay URL for response ${responseId} in workspace ${workspaceId}`
@@ -86,7 +82,7 @@ export class CodingReplayService {
 
       return { replayUrl };
     } catch (error) {
-      if (!(error instanceof Error && (error.message.includes('not found') || error.message.includes('does not belong')))) {
+      if (!(error instanceof HttpException) && error instanceof Error) {
         this.logger.error(
           `Error generating replay URL for response ${responseId}: ${error.message}`,
           error.stack
@@ -197,22 +193,149 @@ export class CodingReplayService {
       try {
         const pageMap = variablePageMaps.get(item.unitName) ?? new Map<string, string>();
         const variablePage = pageMap.get(item.variableId) || '0';
-        const replayUrl = generateReplayUrl({
+        const replayUrl = this.createReplayUrl(
+          {
+            unitName: item.unitName,
+            variableId: item.variableId,
+            variableAnchor: item.variableAnchor,
+            bookletName: item.bookletName,
+            personLogin: item.personLogin,
+            personCode: item.personCode,
+            personGroup: item.personGroup
+          },
           serverUrl,
-          loginName: item.personLogin,
-          loginCode: item.personCode,
-          loginGroup: item.personGroup,
-          bookletId: item.bookletName,
-          unitId: item.unitName,
           variablePage,
-          variableAnchor: item.variableId,
-          authToken: ''
-        }).replace('?auth=', '');
+          ''
+        ).replace('?auth=', '');
         return { ...item, replayUrl };
       } catch (error) {
         this.logger.warn(`Failed to generate replay URL for response ${item.responseId}: ${error.message}`);
         return { ...item, replayUrl: '' };
       }
+    });
+  }
+
+  private getMetadataFromResponse(response: ResponseEntity): ReplayMetadata {
+    const person = response.unit?.booklet?.person;
+    return {
+      unitName: response.unit?.name || '',
+      variableId: response.variableid || '',
+      variableAnchor: response.variableid || '',
+      bookletName: response.unit?.booklet?.bookletinfo?.name || '',
+      personLogin: person?.login || '',
+      personCode: person?.code || '',
+      personGroup: person?.group || ''
+    };
+  }
+
+  private mergeReplayMetadata(
+    responseMetadata: ReplayMetadata,
+    codingJobUnit: CodingJobUnit | null
+  ): ReplayMetadata {
+    if (!codingJobUnit) {
+      return responseMetadata;
+    }
+
+    return {
+      unitName: responseMetadata.unitName || codingJobUnit.unit_name || '',
+      variableId: responseMetadata.variableId || codingJobUnit.variable_id || '',
+      variableAnchor: codingJobUnit.variable_anchor || responseMetadata.variableAnchor || codingJobUnit.variable_id || '',
+      bookletName: responseMetadata.bookletName || codingJobUnit.booklet_name || '',
+      personLogin: responseMetadata.personLogin || codingJobUnit.person_login || '',
+      personCode: responseMetadata.personLogin ? responseMetadata.personCode : codingJobUnit.person_code || '',
+      personGroup: responseMetadata.personLogin ? responseMetadata.personGroup : codingJobUnit.person_group || ''
+    };
+  }
+
+  private hasRequiredReplayMetadata(metadata: ReplayMetadata): boolean {
+    return Boolean(
+      metadata.unitName &&
+      metadata.variableId &&
+      metadata.variableAnchor &&
+      metadata.bookletName &&
+      metadata.personLogin
+    );
+  }
+
+  private async findCodingJobUnitForResponse(
+    workspaceId: number,
+    responseId: number
+  ): Promise<CodingJobUnit | null> {
+    return this.codingJobUnitRepository
+      .createQueryBuilder('codingJobUnit')
+      .innerJoinAndSelect(
+        'codingJobUnit.coding_job',
+        'codingJob',
+        'codingJob.workspace_id = :workspaceId',
+        { workspaceId }
+      )
+      .where('codingJobUnit.response_id = :responseId', { responseId })
+      .orderBy('codingJobUnit.id', 'ASC')
+      .getOne();
+  }
+
+  private async buildReplayUrl(
+    workspaceId: number,
+    metadata: ReplayMetadata,
+    serverUrl: string,
+    authToken: string
+  ): Promise<string> {
+    const variablePage = await this.resolveVariablePage(
+      workspaceId,
+      metadata.unitName,
+      metadata.variableId
+    );
+
+    return this.createReplayUrl(metadata, serverUrl, variablePage, authToken);
+  }
+
+  private async resolveVariablePage(
+    workspaceId: number,
+    unitName: string,
+    variableId: string
+  ): Promise<string> {
+    try {
+      this.logger.log(
+        `Looking up variablePage for unit '${unitName}', variable '${variableId}' in workspace ${workspaceId}`
+      );
+      const variablePageMap = await this.codingListService.getVariablePageMap(
+        unitName,
+        workspaceId
+      );
+      this.logger.log(
+        `VOUD lookup result: variablePageMap has ${variablePageMap.size} entries for unit '${unitName}'`
+      );
+      const variablePage = variablePageMap.get(variableId) || '0';
+      this.logger.log(
+        `Variable '${variableId}' resolved to page '${variablePage}' (found in map: ${variablePageMap.has(
+          variableId
+        )})`
+      );
+      return variablePage;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to resolve variablePage for unit '${unitName}', variable '${variableId}' in workspace ${workspaceId}: ${error.message}`
+      );
+      return '0';
+    }
+  }
+
+  private createReplayUrl(
+    metadata: ReplayMetadata,
+    serverUrl: string,
+    variablePage: string,
+    authToken: string
+  ): string {
+    return generateReplayUrl({
+      serverUrl,
+      loginName: metadata.personLogin,
+      loginCode: metadata.personCode,
+      loginGroup: metadata.personGroup,
+      bookletId: metadata.bookletName,
+      unitId: metadata.unitName,
+      variablePage,
+      variableAnchor: metadata.variableAnchor,
+      authToken
     });
   }
 }

--- a/apps/frontend/src/app/coding/services/coding-statistics.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-statistics.service.spec.ts
@@ -5,6 +5,7 @@ import { of } from 'rxjs';
 import { CodingStatisticsService } from './coding-statistics.service';
 import { AppService } from '../../core/services/app.service';
 import { SERVER_URL } from '../../injection-tokens';
+import { SUPPRESS_GLOBAL_HTTP_ERROR } from '../../core/interceptors/http-error-context';
 
 describe('CodingStatisticsService', () => {
   let service: CodingStatisticsService;
@@ -94,6 +95,7 @@ describe('CodingStatisticsService', () => {
 
     const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/responses/123/replay-url?authToken=token`);
     expect(req.request.method).toBe('GET');
+    expect(req.request.context.get(SUPPRESS_GLOBAL_HTTP_ERROR)).toBe(true);
     req.flush(mockRes);
   });
 

--- a/apps/frontend/src/app/coding/services/coding-statistics.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-statistics.service.ts
@@ -82,7 +82,10 @@ export class CodingStatisticsService {
     return this.http
       .get<{ replayUrl: string }>(
       `${this.serverUrl}admin/workspace/${workspaceId}/coding/responses/${responseId}/replay-url`,
-      { params }
+      {
+        params,
+        context: suppressGlobalHttpErrorContext()
+      }
     )
       .pipe(
         catchError(() => of({ replayUrl: '' }))


### PR DESCRIPTION
## Summary
- add workspace-scoped fallback metadata for response replay URLs via coding job units
- preserve valid empty person code/group values when fallback metadata is needed
- suppress global frontend error handling for replay URL lookups that intentionally fall back to an empty URL

## Root cause
Training comparison replay URLs could fail when the response relation did not provide all metadata needed to build a replay link. Existing coding job unit rows already carry that metadata, but the response replay endpoint did not use them as a workspace-scoped fallback.

## Validation
- npx nx lint backend
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-replay.service.spec.ts
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
- npx nx test backend --runInBand
- npx nx lint frontend
- npx nx test frontend

Refs #656