### PR TITLE
DERIVE_ERROR in Personen- und Response-Abfragen filterbar machen

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding.controller.ts
@@ -119,14 +119,21 @@ export class WorkspaceCodingController {
   @Get(':workspace_id/coding/manual')
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   @ApiParam({ name: 'workspace_id', type: Number })
+  @ApiQuery({
+    name: 'codedStatus',
+    required: false,
+    description: 'Optional response status_v1 filter, e.g. DERIVE_ERROR'
+  })
   async getManualTestPersons(
     @Query('testPersons') testPersons: string,
+      @Query('codedStatus') codedStatus: string,
       @WorkspaceId() /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
                           workspace_id: number
   ): Promise<Array<ResponseEntity & { unitname: string }>> {
     return this.codingResponseQueryService.getManualTestPersons(
       workspace_id,
-      testPersons
+      testPersons,
+      codedStatus
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-response-query.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-query.service.spec.ts
@@ -90,6 +90,8 @@ describe('CodingResponseQueryService', () => {
 
     service = module.get<CodingResponseQueryService>(CodingResponseQueryService);
     jest.clearAllMocks();
+    mockQueryBuilder.getCount.mockResolvedValue(0);
+    mockQueryBuilder.getMany.mockResolvedValue([]);
     mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
       ['Unit1', new Set(['var1', 'var2'])]
     ]));
@@ -171,6 +173,27 @@ describe('CodingResponseQueryService', () => {
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
         `${getEffectiveCodingStatusExpression('v3')} = :status`,
         { status: 9 }
+      );
+    });
+
+    it('should retrieve DERIVE_ERROR responses by status', async () => {
+      const mockResponses = [{ id: 1, variableid: 'var1', status_v1: 4 }];
+
+      (statusConverter.statusStringToNumber as jest.Mock).mockReturnValue(4);
+      mockQueryBuilder.getCount.mockResolvedValue(1);
+      mockQueryBuilder.getMany.mockResolvedValue(mockResponses);
+
+      const result = await service.getResponsesByStatus(1, 'DERIVE_ERROR', 'v1', 1, 100);
+
+      expect(result).toEqual({
+        data: mockResponses,
+        total: 1,
+        page: 1,
+        limit: 100
+      });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'response.status_v1 = :status',
+        { status: 4 }
       );
     });
 
@@ -261,6 +284,64 @@ describe('CodingResponseQueryService', () => {
       await expect(
         service.getResponsesByStatus(1, 'CODING_COMPLETE', 'v1', 1, 100)
       ).rejects.toThrow('Could not retrieve responses. Please check the database connection or query.');
+    });
+  });
+
+  describe('getManualTestPersons', () => {
+    const statusNumbers: Record<string, number> = {
+      CODING_INCOMPLETE: 8,
+      INTENDED_INCOMPLETE: 12,
+      CODE_SELECTION_PENDING: 13,
+      CODING_ERROR: 9,
+      DERIVE_ERROR: 4
+    };
+
+    beforeEach(() => {
+      (statusConverter.statusStringToNumber as jest.Mock).mockImplementation(
+        (status: string) => statusNumbers[status] ?? null
+      );
+    });
+
+    it('should keep default manual person statuses compatible', async () => {
+      await service.getManualTestPersons(1);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'response.status_v1 IN (:...statuses)',
+        { statuses: [8, 12, 13, 9] }
+      );
+    });
+
+    it('should filter manual persons by DERIVE_ERROR when requested', async () => {
+      const mockResponses = [{
+        id: 1,
+        status_v1: 4,
+        unit: { name: 'Unit1' }
+      }];
+      mockQueryBuilder.getMany.mockResolvedValue(mockResponses);
+
+      const result = await service.getManualTestPersons(1, '1, 2', 'DERIVE_ERROR');
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'response.status_v1 = :codedStatus',
+        { codedStatus: 4 }
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'person.id IN (:...personIdsArray)',
+        { personIdsArray: ['1', '2'] }
+      );
+      expect(result).toEqual([
+        {
+          ...mockResponses[0],
+          unitname: 'Unit1'
+        }
+      ]);
+    });
+
+    it('should return no manual persons for invalid status filters', async () => {
+      const result = await service.getManualTestPersons(1, undefined, 'NOPE');
+
+      expect(result).toEqual([]);
+      expect(mockQueryBuilder.getMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-response-query.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-query.service.ts
@@ -141,7 +141,8 @@ export class CodingResponseQueryService {
 
   async getManualTestPersons(
     workspaceId: number,
-    personIds?: string
+    personIds?: string,
+    codedStatus?: string
   ): Promise<Array<ResponseEntity & { unitname: string }>> {
     this.logger.log(
       `Fetching responses for workspaceId = ${workspaceId} ${personIds ? `and personIds = ${personIds}` : ''
@@ -156,8 +157,20 @@ export class CodingResponseQueryService {
         .leftJoinAndSelect('booklet.person', 'person')
         .leftJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
         .where('person.workspace_id = :workspaceId', { workspaceId })
-        .andWhere('person.consider = :consider', { consider: true })
-        .andWhere('response.status_v1 IN (:...statuses)', {
+        .andWhere('person.consider = :consider', { consider: true });
+
+      if (codedStatus) {
+        const statusNumber = statusStringToNumber(codedStatus);
+        if (statusNumber === null) {
+          this.logger.warn(`Invalid manual coding status filter: ${codedStatus}`);
+          return [];
+        }
+
+        queryBuilder.andWhere('response.status_v1 = :codedStatus', {
+          codedStatus: statusNumber
+        });
+      } else {
+        queryBuilder.andWhere('response.status_v1 IN (:...statuses)', {
           statuses: [
             statusStringToNumber('CODING_INCOMPLETE'),
             statusStringToNumber('INTENDED_INCOMPLETE'),
@@ -165,6 +178,7 @@ export class CodingResponseQueryService {
             statusStringToNumber('CODING_ERROR')
           ]
         });
+      }
 
       if (personIds) {
         const personIdsArray = personIds.split(',').map(id => id.trim()).filter(Boolean);

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -868,13 +868,48 @@ describe('WorkspaceTestResultsService', () => {
 
       await service.searchResponses(
         1,
-        { codedStatus: '5', version: 'v3', responseSource: 'all' },
+        { codedStatus: 'CODING_COMPLETE', version: 'v3', responseSource: 'all' },
         { page: 1, limit: 100 }
       );
 
       expect(qb.andWhere).toHaveBeenCalledWith(
         expect.stringContaining('COALESCE(response.status_v3'),
-        { codedStatus: '5' }
+        { codedStatus: 5 }
+      );
+    });
+
+    it('should apply DERIVE_ERROR codedStatus filters numerically', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(0);
+
+      await service.searchResponses(
+        1,
+        { codedStatus: 'DERIVE_ERROR', version: 'v1', responseSource: 'all' },
+        { page: 1, limit: 100 }
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'response.status_v1 = :codedStatus',
+        { codedStatus: 4 }
+      );
+    });
+
+    it('should return no response search results for invalid codedStatus filters', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(0);
+
+      await service.searchResponses(
+        1,
+        { codedStatus: 'NOPE', responseSource: 'all' },
+        { page: 1, limit: 100 }
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith('1=0');
+      expect(qb.andWhere).not.toHaveBeenCalledWith(
+        expect.stringContaining(' = :codedStatus'),
+        expect.any(Object)
       );
     });
 

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -6548,12 +6548,17 @@ export class WorkspaceTestResultsService {
       }
 
       if (searchParams.codedStatus) {
-        const effectiveStatusExpression = getEffectiveCodingStatusExpression(
-          searchParams.version || 'v1'
-        );
-        query.andWhere(`${effectiveStatusExpression} = :codedStatus`, {
-          codedStatus: searchParams.codedStatus
-        });
+        const codedStatusNumber = statusStringToNumber(searchParams.codedStatus);
+        if (codedStatusNumber === null) {
+          query.andWhere('1=0');
+        } else {
+          const effectiveStatusExpression = getEffectiveCodingStatusExpression(
+            searchParams.version || 'v1'
+          );
+          query.andWhere(`${effectiveStatusExpression} = :codedStatus`, {
+            codedStatus: codedStatusNumber
+          });
+        }
       }
 
       if (searchParams.group) {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -899,9 +899,18 @@ describe('CodingManagementComponent', () => {
 
   describe('Data Fetching', () => {
     it('should get available statuses from coding statistics', () => {
+      component.codingStatistics = {
+        totalResponses: 103,
+        statusCounts: {
+          4: 3,
+          200: 50,
+          300: 50
+        }
+      };
+
       const statuses = component.getAvailableStatuses();
 
-      expect(statuses).toEqual(['200', '300']);
+      expect(statuses).toEqual(['4', '200', '300']);
     });
 
     it('should use centralized status labels in empty result snackbars', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.spec.ts
@@ -71,6 +71,7 @@ describe('ResponseFiltersComponent', () => {
 
   it('should keep DERIVE_ERROR as the visible status label', () => {
     expect(component.mapStatusToString('4')).toBe('DERIVE_ERROR');
+    expect(component.mapStatusToString('DERIVE_ERROR')).toBe('DERIVE_ERROR');
     expect(component.mapStatusToString('4abc')).toBe('4abc');
   });
 

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -129,6 +129,21 @@ describe('TestPersonCodingService', () => {
       req.flush(mockResponse);
     });
 
+    it('should include codedStatus parameter when provided', () => {
+      const mockResponse = [{ id: 1, name: 'Test Person 1' }];
+
+      service.getManualTestPersons(mockWorkspaceId, undefined, 'DERIVE_ERROR').subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/manual` &&
+        request.params.get('codedStatus') === 'DERIVE_ERROR'
+      ));
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+
     it('should handle errors and return empty array', () => {
       service.getManualTestPersons(mockWorkspaceId).subscribe(response => {
         expect(response).toEqual([]);

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -247,14 +247,20 @@ export class TestPersonCodingService {
       );
   }
 
-  getManualTestPersons(workspaceId: number, testPersonIds?: string): Observable<unknown> {
-    let url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/manual`;
+  getManualTestPersons(workspaceId: number, testPersonIds?: string, codedStatus?: string): Observable<unknown> {
+    let params = new HttpParams();
     if (testPersonIds) {
-      url += `?testPersons=${testPersonIds}`;
+      params = params.set('testPersons', testPersonIds);
+    }
+    if (codedStatus) {
+      params = params.set('codedStatus', codedStatus);
     }
 
     return this.http
-      .get<unknown>(url, { headers: this.authHeader })
+      .get<unknown>(
+      `${this.serverUrl}admin/workspace/${workspaceId}/coding/manual`,
+      { headers: this.authHeader, params }
+    )
       .pipe(
         catchError(() => of([]))
       );


### PR DESCRIPTION
## Summary

- Make `DERIVE_ERROR` filterable in manual person/response queries without changing the default manual-coding candidate set.
- Normalize response-search `codedStatus` filters through the existing status converter so both `DERIVE_ERROR` and `4` use the same backend path.
- Add frontend/backend regression coverage for visibility and filtering behavior.

## Validation

- `npx nx lint backend`
- `npx nx lint frontend`
- `npx nx test backend`
- `npx nx test frontend`

Related: #548