### PR TITLE
DERIVE_ERROR-Fälle für Schulungen auswählbar machen

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
@@ -92,7 +92,8 @@ export class WorkspaceCoderTrainingController {
             properties: {
               variableId: { type: 'string' },
               unitId: { type: 'string' },
-              sampleCount: { type: 'number' }
+              sampleCount: { type: 'number' },
+              includeDeriveError: { type: 'boolean' }
             }
           }
         }
@@ -139,6 +140,7 @@ export class WorkspaceCoderTrainingController {
                        variableId: string;
                        unitId: string;
                        sampleCount: number;
+                       includeDeriveError?: boolean;
                      }[];
                    }
   ): Promise<
@@ -291,7 +293,8 @@ export class WorkspaceCoderTrainingController {
             properties: {
               variableId: { type: 'string' },
               unitId: { type: 'string' },
-              sampleCount: { type: 'number' }
+              sampleCount: { type: 'number' },
+              includeDeriveError: { type: 'boolean' }
             }
           }
         },
@@ -302,7 +305,8 @@ export class WorkspaceCoderTrainingController {
             properties: {
               unitName: { type: 'string' },
               variableId: { type: 'string' },
-              sampleCount: { type: 'number' }
+              sampleCount: { type: 'number' },
+              includeDeriveError: { type: 'boolean' }
             }
           }
         },
@@ -362,6 +366,7 @@ export class WorkspaceCoderTrainingController {
                        variableId: string;
                        unitId: string;
                        sampleCount: number;
+                       includeDeriveError?: boolean;
                      }[];
                      assignedVariables?: JobDefinitionVariable[];
                      assignedVariableBundles?: JobDefinitionVariableBundle[];
@@ -666,7 +671,8 @@ export class WorkspaceCoderTrainingController {
             properties: {
               variableId: { type: 'string' },
               unitId: { type: 'string' },
-              sampleCount: { type: 'number' }
+              sampleCount: { type: 'number' },
+              includeDeriveError: { type: 'boolean' }
             }
           }
         },
@@ -677,7 +683,8 @@ export class WorkspaceCoderTrainingController {
             properties: {
               unitName: { type: 'string' },
               variableId: { type: 'string' },
-              sampleCount: { type: 'number' }
+              sampleCount: { type: 'number' },
+              includeDeriveError: { type: 'boolean' }
             }
           }
         },
@@ -725,6 +732,7 @@ export class WorkspaceCoderTrainingController {
           variableId: string;
           unitId: string;
           sampleCount: number;
+          includeDeriveError?: boolean;
         }[];
         assignedVariables?: JobDefinitionVariable[];
         assignedVariableBundles?: JobDefinitionVariableBundle[];

--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
@@ -200,6 +200,12 @@ export class WorkspaceCodingAnalysisController {
     description: 'Filter variables by coder training requirement',
     type: Boolean
   })
+  @ApiQuery({
+    name: 'includeDeriveErrorOnly',
+    required: false,
+    description: 'Also include variables that only have DERIVE_ERROR responses and expose DERIVE_ERROR-aware case counts',
+    type: Boolean
+  })
   @ApiOkResponse({
     description: 'Manual coding variables retrieved successfully.',
     schema: {
@@ -212,6 +218,10 @@ export class WorkspaceCodingAnalysisController {
           responseCount: {
             type: 'number',
             description: 'Number of responses for this variable'
+          },
+          deriveErrorResponseCount: {
+            type: 'number',
+            description: 'Number of DERIVE_ERROR responses for this variable'
           },
           casesInJobs: {
             type: 'number',
@@ -226,6 +236,14 @@ export class WorkspaceCodingAnalysisController {
             type: 'number',
             description: 'Number of unique coding cases after applying aggregation grouping (1 per duplicate group)'
           },
+          availableCasesWithDeriveError: {
+            type: 'number',
+            description: 'Number of available cases when DERIVE_ERROR is included'
+          },
+          uniqueCasesAfterAggregationWithDeriveError: {
+            type: 'number',
+            description: 'Number of unique coding cases after aggregation when DERIVE_ERROR is included'
+          },
           isDerived: {
             type: 'boolean',
             description: 'Whether this is a derived variable (computed from other variables)'
@@ -237,15 +255,19 @@ export class WorkspaceCodingAnalysisController {
   async getCodingIncompleteVariables(
     @WorkspaceId() workspace_id: number,
       @Query('unitName') unitName?: string,
-      @Query('trainingRequired') trainingRequired?: string
+      @Query('trainingRequired') trainingRequired?: string,
+      @Query('includeDeriveErrorOnly') includeDeriveErrorOnly?: string
   ): Promise<
       {
         unitName: string;
         variableId: string;
         responseCount: number;
+        deriveErrorResponseCount: number;
         casesInJobs: number;
         availableCases: number;
         uniqueCasesAfterAggregation: number;
+        availableCasesWithDeriveError?: number;
+        uniqueCasesAfterAggregationWithDeriveError?: number;
         isDerived: boolean;
       }[]
       > {
@@ -258,7 +280,8 @@ export class WorkspaceCodingAnalysisController {
     return this.codingValidationService.getCodingIncompleteVariables(
       workspace_id,
       unitName,
-      trainingRequiredParam
+      trainingRequiredParam,
+      includeDeriveErrorOnly === 'true'
     );
   }
 

--- a/apps/backend/src/app/database/entities/coder-training-variable.entity.ts
+++ b/apps/backend/src/app/database/entities/coder-training-variable.entity.ts
@@ -27,6 +27,9 @@ export class CoderTrainingVariable {
   @Column({ default: 10 })
     sample_count: number;
 
+  @Column({ type: 'boolean', default: false })
+    include_derive_error: boolean;
+
   @ManyToOne(() => CoderTraining, training => training.variables, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'coder_training_id' })
     training: CoderTraining;

--- a/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
+++ b/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { AggregationSummaryDto } from '../../../../../../../api-dto/coding/response-analysis.dto';
 
 export type AggregationMatchingFlag =
@@ -16,6 +17,12 @@ export interface AggregationSourceResponse {
 export interface AggregationGroup<T extends AggregationSourceResponse> {
   key: string;
   responses: T[];
+}
+
+export interface ManualCodingDeduplicationResponse extends AggregationSourceResponse {
+  personLogin?: string | null;
+  personCode?: string | null;
+  personGroup?: string | null;
 }
 
 export function normalizeAggregationValue(
@@ -50,6 +57,36 @@ export function isDerivedAggregationVariable(
   variableId: string
 ): boolean {
   return derivedVariableMap.get(unitName.toUpperCase())?.has(variableId) ?? false;
+}
+
+export function getManualCodingDeduplicationKey(
+  response: ManualCodingDeduplicationResponse
+): string {
+  const valueHash = createHash('sha1').update(response.value || '').digest('hex');
+  return [
+    response.personLogin || '',
+    response.personCode || '',
+    response.personGroup || '',
+    response.unitName,
+    response.variableId,
+    valueHash
+  ].join('::');
+}
+
+export function deduplicateManualCodingResponses<T extends ManualCodingDeduplicationResponse>(
+  responses: T[]
+): T[] {
+  const dedupedByPersonValue = new Map<string, T>();
+
+  for (const response of responses) {
+    const key = getManualCodingDeduplicationKey(response);
+    const existing = dedupedByPersonValue.get(key);
+    if (!existing || response.responseId < existing.responseId) {
+      dedupedByPersonValue.set(key, response);
+    }
+  }
+
+  return Array.from(dedupedByPersonValue.values());
 }
 
 export function buildAggregationGroups<T extends AggregationSourceResponse>(

--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Brackets, Repository } from 'typeorm';
 import { CoderTrainingService, TrainingResponseIdsMap } from './coder-training.service';
 import { CodingJob } from '../../entities/coding-job.entity';
 import { CodingJobCoder } from '../../entities/coding-job-coder.entity';
@@ -150,10 +150,19 @@ describe('CoderTrainingService', () => {
       const selectedCoders = [{ id: 10, name: 'Coder 1' }];
       const variableConfigs = [];
       const trainingLabel = 'Test Training';
-      const assignedVariables = [{ variableId: 'v1', unitName: 'u1', sampleCount: 5 }];
+      const assignedVariables = [{
+        variableId: 'v1',
+        unitName: 'u1',
+        sampleCount: 5,
+        includeDeriveError: true
+      }];
       const assignedVariableBundles = [{ id: 2, name: 'Bundle 1', sampleCount: 20 }];
 
-      mockRepository.find.mockResolvedValue([]); // For responses query
+      mockRepository.find.mockResolvedValue([{
+        id: 2,
+        workspace_id: workspaceId,
+        variables: []
+      }]);
       mockRepository.save.mockResolvedValue({ id: 1 }); // For all saves
 
       await service.createCoderTrainingJobs(
@@ -177,7 +186,8 @@ describe('CoderTrainingService', () => {
         coder_training_id: 1,
         variable_id: 'v1',
         unit_name: 'u1',
-        sample_count: 5
+        sample_count: 5,
+        include_derive_error: true
       }));
 
       // Verify CoderTrainingBundle save
@@ -347,6 +357,104 @@ describe('CoderTrainingService', () => {
 
       generatePackagesSpy.mockRestore();
     });
+
+    it('should generate packages from normalized selections when variable configs are missing bundle variables', async () => {
+      const generatePackagesSpy = jest.spyOn(service, 'generateCoderTrainingPackages')
+        .mockResolvedValue([]);
+      mockRepository.find.mockResolvedValue([{
+        id: 5,
+        workspace_id: 1,
+        variables: [{ unitName: 'UNIT2', variableId: 'VAR2' }]
+      }]);
+      const assignedVariableBundles = [{
+        id: 5,
+        name: 'Bundle',
+        sampleCount: 4,
+        variables: [{
+          unitName: 'UNIT2',
+          variableId: 'VAR2',
+          includeDeriveError: true
+        }]
+      }];
+
+      await service.createCoderTrainingJobs(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [],
+        'Bundle Training',
+        undefined,
+        [],
+        assignedVariableBundles
+      );
+
+      expect(coderTrainingVariableRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+        variable_id: 'VAR2',
+        unit_name: 'UNIT2',
+        sample_count: 4,
+        include_derive_error: true
+      }));
+      expect(generatePackagesSpy).toHaveBeenCalledWith(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [{
+          variableId: 'VAR2',
+          unitId: 'UNIT2',
+          sampleCount: 4,
+          includeDeriveError: true
+        }],
+        {
+          caseSelectionMode: 'oldest_first',
+          referenceTrainingIds: undefined,
+          referenceMode: undefined
+        }
+      );
+
+      generatePackagesSpy.mockRestore();
+    });
+
+    it('should reject variable bundles outside the workspace before creating the training', async () => {
+      mockRepository.find.mockResolvedValue([]);
+      (coderTrainingRepository.save as jest.Mock).mockClear();
+
+      const result = await service.createCoderTrainingJobs(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [],
+        'Invalid Bundle Training',
+        undefined,
+        [],
+        [{ id: 99, name: 'Foreign Bundle', sampleCount: 4 }]
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Unknown variable bundle IDs for workspace 1: 99');
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        where: {
+          id: expect.any(Object),
+          workspace_id: 1
+        }
+      });
+      expect(coderTrainingRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid variable bundle ids before creating the training', async () => {
+      (coderTrainingRepository.save as jest.Mock).mockClear();
+
+      const result = await service.createCoderTrainingJobs(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [],
+        'Invalid Bundle Training',
+        undefined,
+        [],
+        [{ id: '99' as unknown as number, name: 'Invalid Bundle', sampleCount: 4 }]
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Invalid variable bundle IDs: 99');
+      expect(mockRepository.find).not.toHaveBeenCalled();
+      expect(coderTrainingRepository.save).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateCoderTraining', () => {
@@ -370,6 +478,11 @@ describe('CoderTrainingService', () => {
       };
 
       mockRepository.findOne.mockResolvedValue(existingTraining);
+      mockRepository.find.mockResolvedValue([{
+        id: 3,
+        workspace_id: workspaceId,
+        variables: []
+      }]);
       mockRepository.save.mockResolvedValue({ id: trainingId });
 
       await service.updateCoderTraining(
@@ -750,6 +863,11 @@ describe('CoderTrainingService', () => {
       };
 
       mockRepository.findOne.mockResolvedValue(existingTraining);
+      mockRepository.find.mockResolvedValue([{
+        id: 5,
+        workspace_id: 1,
+        variables: []
+      }]);
       mockRepository.delete.mockClear();
       mockRepository.save.mockClear();
 
@@ -1012,6 +1130,63 @@ describe('CoderTrainingService', () => {
 
       generatePackagesSpy.mockRestore();
     });
+
+    it('should not treat legacy bundle variables as changed when editing without assignment changes', async () => {
+      const existingTraining = {
+        id: 1,
+        workspace_id: 1,
+        label: 'Old Label',
+        case_ordering_mode: 'continuous',
+        case_selection_mode: 'oldest_first',
+        coders: [{ user_id: 10 }],
+        variables: [],
+        bundles: [{
+          variable_bundle_id: 5,
+          sample_count: 4,
+          case_ordering_mode: null,
+          bundle: {
+            id: 5,
+            name: 'Bundle',
+            variables: [{ unitName: 'UNIT2', variableId: 'VAR2' }]
+          }
+        }],
+        codingJobs: [{ id: 100 }]
+      };
+
+      mockRepository.findOne.mockResolvedValue(existingTraining);
+      mockRepository.find.mockResolvedValue([{
+        id: 5,
+        workspace_id: 1,
+        variables: [{ unitName: 'UNIT2', variableId: 'VAR2' }]
+      }]);
+      mockRepository.count.mockRejectedValue(new Error('Unchanged legacy bundle variables must not trigger progress checks'));
+      (coderTrainingRepository.save as jest.Mock).mockClear();
+      (coderTrainingCoderRepository.delete as jest.Mock).mockClear();
+      const generatePackagesSpy = jest.spyOn(service, 'generateCoderTrainingPackages');
+
+      const result = await service.updateCoderTraining(
+        1,
+        1,
+        'Updated Label',
+        [{ id: 10, name: 'Coder 1' }],
+        [{ variableId: 'VAR2', unitId: 'UNIT2', sampleCount: 4 }],
+        undefined,
+        [],
+        [{
+          id: 5,
+          name: 'Bundle',
+          sampleCount: 4,
+          variables: [{ unitName: 'UNIT2', variableId: 'VAR2', sampleCount: 4 }]
+        }]
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockRepository.count).not.toHaveBeenCalled();
+      expect(coderTrainingCoderRepository.delete).not.toHaveBeenCalled();
+      expect(generatePackagesSpy).not.toHaveBeenCalled();
+
+      generatePackagesSpy.mockRestore();
+    });
   });
 
   describe('getCoderTrainings', () => {
@@ -1129,19 +1304,28 @@ describe('CoderTrainingService', () => {
   });
 
   describe('generateCoderTrainingPackages', () => {
-    const makeResponseEntity = (responseId: number) => ({
+    const makeResponseEntity = (
+      responseId: number,
+      overrides: Partial<{
+        value: string | null;
+        unitid: number;
+        personLogin: string;
+        personCode: string;
+        personGroup: string;
+      }> = {}
+    ) => ({
       id: responseId,
       variableid: 'var1',
-      value: `value-${responseId}`,
-      unitid: responseId + 100,
+      value: overrides.value ?? `value-${responseId}`,
+      unitid: overrides.unitid ?? responseId + 100,
       unit: {
         alias: 'Alias Unit',
         name: 'Real Unit',
         booklet: {
           person: {
-            login: `person-${responseId}`,
-            code: `${responseId}`,
-            group: 'Group'
+            login: overrides.personLogin ?? `person-${responseId}`,
+            code: overrides.personCode ?? `${responseId}`,
+            group: overrides.personGroup ?? 'Group'
           },
           bookletinfo: {
             name: 'Booklet'
@@ -1240,6 +1424,109 @@ describe('CoderTrainingService', () => {
         statusStringToNumber('INTENDED_INCOMPLETE')
       ]);
       expect(statuses).not.toContain(statusStringToNumber('DERIVE_ERROR'));
+    });
+
+    it('includes DERIVE_ERROR responses in training package sampling when the variable opts in', async () => {
+      const responseQb = mockResponseRepository([]);
+
+      await service.generateCoderTrainingPackages(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [{
+          unitId: 'Alias Unit',
+          variableId: 'var1',
+          sampleCount: 5,
+          includeDeriveError: true
+        }]
+      );
+
+      const bracketCall = responseQb.andWhere.mock.calls.find(
+        ([condition]) => condition instanceof Brackets
+      );
+      expect(bracketCall).toBeDefined();
+
+      const bracketBuilder: Record<string, jest.Mock> = {
+        where: jest.fn().mockReturnThis(),
+        orWhere: jest.fn().mockReturnThis()
+      };
+      (bracketCall?.[0] as Brackets).whereFactory(bracketBuilder as never);
+
+      expect(bracketBuilder.where).toHaveBeenCalledWith(
+        'response.status_v1 IN (:...statuses)',
+        {
+          statuses: [
+            statusStringToNumber('CODING_INCOMPLETE'),
+            statusStringToNumber('INTENDED_INCOMPLETE')
+          ]
+        }
+      );
+      expect(bracketBuilder.orWhere).toHaveBeenCalledWith(
+        'response.status_v1 = :deriveErrorStatus',
+        { deriveErrorStatus: statusStringToNumber('DERIVE_ERROR') }
+      );
+    });
+
+    it('uses the shared aggregation semantics for empty training responses', async () => {
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
+      mockResponseRepository([
+        makeResponseEntity(1, { value: '' }),
+        makeResponseEntity(2, { value: '' }),
+        makeResponseEntity(3, { value: '[]' }),
+        makeResponseEntity(4, { value: 'same' }),
+        makeResponseEntity(5, { value: 'same' })
+      ]);
+
+      const result = await service.generateCoderTrainingPackages(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [{ unitId: 'Alias Unit', variableId: 'var1', sampleCount: 10 }],
+        { caseSelectionMode: 'random' }
+      );
+
+      expect(result[0].responses.map(response => response.responseId)).toEqual([
+        1,
+        2,
+        3,
+        4
+      ]);
+      expect(mockCodingJobService.aggregateResponsesByValue).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates identical training responses before sampling', async () => {
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockResponseRepository([
+        makeResponseEntity(1, {
+          value: 'same',
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
+        }),
+        makeResponseEntity(2, {
+          value: 'same',
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
+        }),
+        makeResponseEntity(3, {
+          value: 'other',
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
+        })
+      ]);
+
+      const result = await service.generateCoderTrainingPackages(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [{ unitId: 'Alias Unit', variableId: 'var1', sampleCount: 10 }],
+        { caseSelectionMode: 'random' }
+      );
+
+      expect(result[0].responses.map(response => response.responseId)).toEqual([
+        1,
+        3
+      ]);
     });
 
     it('should keep the same referenced cases when the training uses a unit alias', async () => {

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -1,8 +1,7 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
-import { createHash } from 'crypto';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
-  Repository, In, IsNull, Not
+  Repository, In, IsNull, Not, Brackets
 } from 'typeorm';
 import { CodingJob } from '../../entities/coding-job.entity';
 import { CodingJobCoder } from '../../entities/coding-job-coder.entity';
@@ -19,7 +18,6 @@ import User from '../../entities/user.entity';
 import { JobDefinitionVariable, JobDefinitionVariableBundle } from '../../entities/job-definition.entity';
 import { VariableBundle } from '../../entities/variable-bundle.entity';
 import { ChunkEntity } from '../../entities/chunk.entity';
-import { statusStringToNumber } from '../../utils/response-status-converter';
 import { CodingJobService } from './coding-job.service';
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import {
@@ -34,6 +32,14 @@ import {
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
 import type { CaseSelectionMode, ReferenceMode } from '../../entities/coder-training.entity';
+import {
+  DERIVE_ERROR_STATUS,
+  MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+} from '../../utils/manual-coding-candidate.util';
+import {
+  buildAggregationGroups,
+  deduplicateManualCodingResponses
+} from './aggregation-metrics.util';
 
 interface CoderTrainingResponse {
   responseId: number;
@@ -81,6 +87,13 @@ interface CoderTrainingWithJobs {
 }
 
 export type TrainingResponseIdsMap = Record<string, number[]>;
+
+type TrainingVariableConfig = {
+  variableId: string;
+  unitId: string;
+  sampleCount: number;
+  includeDeriveError?: boolean;
+};
 
 type DiscussionSource = 'manual' | 'auto_agreement' | null;
 
@@ -424,6 +437,218 @@ export class CoderTrainingService {
     });
 
     return discussionResults > 0;
+  }
+
+  private makeTrainingVariableKey(unitName: string, variableId: string): string {
+    return `${unitName}::${variableId}`;
+  }
+
+  private getValidatedBundleIds(
+    assignedVariableBundles: JobDefinitionVariableBundle[] = []
+  ): number[] {
+    const invalidBundleIds = assignedVariableBundles
+      .map(bundle => bundle?.id)
+      .filter(id => !Number.isInteger(id));
+
+    if (invalidBundleIds.length > 0) {
+      throw new BadRequestException(
+        `Invalid variable bundle IDs: ${invalidBundleIds.map(id => String(id)).join(', ')}`
+      );
+    }
+
+    return assignedVariableBundles.map(bundle => bundle.id);
+  }
+
+  private async getWorkspaceVariableBundlesById(
+    workspaceId: number,
+    bundleIds: number[]
+  ): Promise<Map<number, VariableBundle>> {
+    const uniqueBundleIds = Array.from(new Set(bundleIds));
+    if (uniqueBundleIds.length === 0) {
+      return new Map();
+    }
+
+    const variableBundles = await this.variableBundleRepository.find({
+      where: {
+        id: In(uniqueBundleIds),
+        workspace_id: workspaceId
+      }
+    });
+    const variableBundlesById = new Map(variableBundles.map(bundle => [bundle.id, bundle]));
+    const missingBundleIds = uniqueBundleIds.filter(id => !variableBundlesById.has(id));
+
+    if (missingBundleIds.length > 0) {
+      throw new BadRequestException(
+        `Unknown variable bundle IDs for workspace ${workspaceId}: ${missingBundleIds.join(', ')}`
+      );
+    }
+
+    return variableBundlesById;
+  }
+
+  private async resolveBundleVariableSelections(
+    workspaceId: number,
+    assignedVariableBundles: JobDefinitionVariableBundle[] = []
+  ): Promise<JobDefinitionVariable[]> {
+    const bundleIds = this.getValidatedBundleIds(assignedVariableBundles);
+    const fetchedBundleById = await this.getWorkspaceVariableBundlesById(workspaceId, bundleIds);
+    const variablesByKey = new Map<string, JobDefinitionVariable>();
+
+    const addBundleVariable = (
+      variable: JobDefinitionVariable,
+      bundleSampleCount?: number
+    ) => {
+      if (!variable.unitName || !variable.variableId) {
+        return;
+      }
+
+      const key = this.makeTrainingVariableKey(variable.unitName, variable.variableId);
+      const existing = variablesByKey.get(key);
+      variablesByKey.set(key, {
+        unitName: variable.unitName,
+        variableId: variable.variableId,
+        sampleCount: existing?.sampleCount || variable.sampleCount || bundleSampleCount || 10,
+        includeDeriveError: existing?.includeDeriveError === true || variable.includeDeriveError === true ?
+          true :
+          undefined
+      });
+    };
+
+    assignedVariableBundles.forEach(bundle => {
+      const configuredBundleVariablesByKey = new Map(
+        (bundle.variables || []).map(variable => [
+          this.makeTrainingVariableKey(variable.unitName, variable.variableId),
+          variable
+        ])
+      );
+      const bundleVariables = fetchedBundleById.get(bundle.id)?.variables || [];
+      bundleVariables.forEach(variable => {
+        const configuredVariable = configuredBundleVariablesByKey.get(
+          this.makeTrainingVariableKey(variable.unitName, variable.variableId)
+        );
+        addBundleVariable({
+          unitName: variable.unitName,
+          variableId: variable.variableId,
+          sampleCount: configuredVariable?.sampleCount,
+          includeDeriveError: configuredVariable?.includeDeriveError
+        }, bundle.sampleCount);
+      });
+    });
+
+    return Array.from(variablesByKey.values());
+  }
+
+  private async buildTrainingVariableSelections(
+    workspaceId: number,
+    variableConfigs: TrainingVariableConfig[] = [],
+    assignedVariables: JobDefinitionVariable[] = [],
+    assignedVariableBundles: JobDefinitionVariableBundle[] = []
+  ): Promise<JobDefinitionVariable[]> {
+    const bundleVariables = await this.resolveBundleVariableSelections(workspaceId, assignedVariableBundles);
+    const fallbackVariables = [...assignedVariables, ...bundleVariables];
+    const assignedVariablesByKey = new Map<string, JobDefinitionVariable>();
+    fallbackVariables.forEach(variable => {
+      assignedVariablesByKey.set(
+        this.makeTrainingVariableKey(variable.unitName, variable.variableId),
+        variable
+      );
+    });
+
+    const selectionsByKey = new Map<string, JobDefinitionVariable>();
+    variableConfigs.forEach(config => {
+      const key = this.makeTrainingVariableKey(config.unitId, config.variableId);
+      const assignedVariable = assignedVariablesByKey.get(key);
+      selectionsByKey.set(key, {
+        unitName: config.unitId,
+        variableId: config.variableId,
+        sampleCount: config.sampleCount || assignedVariable?.sampleCount || 10,
+        includeDeriveError: config.includeDeriveError === true || assignedVariable?.includeDeriveError === true ?
+          true :
+          undefined
+      });
+    });
+
+    fallbackVariables.forEach(variable => {
+      const key = this.makeTrainingVariableKey(variable.unitName, variable.variableId);
+      if (!selectionsByKey.has(key)) {
+        selectionsByKey.set(key, {
+          unitName: variable.unitName,
+          variableId: variable.variableId,
+          sampleCount: variable.sampleCount || 10,
+          includeDeriveError: variable.includeDeriveError === true ? true : undefined
+        });
+      }
+    });
+
+    return Array.from(selectionsByKey.values());
+  }
+
+  private mapTrainingVariableSelectionsToConfigs(
+    variables: JobDefinitionVariable[] = []
+  ): TrainingVariableConfig[] {
+    return variables.map(variable => ({
+      variableId: variable.variableId,
+      unitId: variable.unitName,
+      sampleCount: variable.sampleCount || 10,
+      includeDeriveError: variable.includeDeriveError === true ? true : undefined
+    }));
+  }
+
+  private mapTrainingBundles(
+    bundles: CoderTrainingBundle[] = [],
+    variables: JobDefinitionVariable[] = []
+  ): JobDefinitionVariableBundle[] {
+    const variablesByKey = new Map(
+      variables.map(variable => [
+        this.makeTrainingVariableKey(variable.unitName, variable.variableId),
+        variable
+      ])
+    );
+
+    return bundles.map(bundle => ({
+      id: bundle.variable_bundle_id,
+      name: bundle.bundle?.name || '',
+      sampleCount: bundle.sample_count || 10,
+      caseOrderingMode: bundle.case_ordering_mode ?? undefined,
+      variables: bundle.bundle?.variables?.map(variable => {
+        const savedVariable = variablesByKey.get(
+          this.makeTrainingVariableKey(variable.unitName, variable.variableId)
+        );
+        return {
+          unitName: variable.unitName,
+          variableId: variable.variableId,
+          sampleCount: savedVariable?.sampleCount ?? bundle.sample_count ?? 10,
+          includeDeriveError: savedVariable?.includeDeriveError === true ? true : undefined
+        };
+      })
+    }));
+  }
+
+  private mapTrainingVariables(
+    variables: CoderTrainingVariable[] = []
+  ): JobDefinitionVariable[] {
+    return variables.map(variable => ({
+      variableId: variable.variable_id,
+      unitName: variable.unit_name,
+      sampleCount: variable.sample_count || 10,
+      includeDeriveError: variable.include_derive_error === true ? true : undefined
+    }));
+  }
+
+  private getBundleVariableKeys(bundles: CoderTrainingBundle[] = []): Set<string> {
+    return new Set(
+      bundles.flatMap(bundle => bundle.bundle?.variables || [])
+        .map(variable => this.makeTrainingVariableKey(variable.unitName, variable.variableId))
+    );
+  }
+
+  private getTrainingVariablesByKey(
+    variables: CoderTrainingVariable[] = []
+  ): Map<string, CoderTrainingVariable> {
+    return new Map(variables.map(variable => [
+      this.makeTrainingVariableKey(variable.unit_name, variable.variable_id),
+      variable
+    ]));
   }
 
   private mapDisplayCodeAndScore(
@@ -947,7 +1172,7 @@ export class CoderTrainingService {
   async generateCoderTrainingPackages(
     workspaceId: number,
     selectedCoders: { id: number; name: string }[],
-    variableConfigs: { variableId: string; unitId: string; sampleCount: number }[],
+    variableConfigs: TrainingVariableConfig[],
     options?: {
       caseSelectionMode?: CaseSelectionMode;
       referenceTrainingIds?: number[];
@@ -971,13 +1196,12 @@ export class CoderTrainingService {
     const matchingFlags = await this.codingJobService.getResponseMatchingMode(workspaceId);
     this.logger.log(`Aggregation threshold: ${aggregationThreshold}, matching flags: ${matchingFlags.join(', ')}`);
 
-    // Build derived variable lookup to skip aggregation for derived vars
+    // Build derived variable lookup for the shared aggregation logic.
     const derivedVariableMap = await this.workspaceFilesService.getDerivedVariableMap(workspaceId);
     const derivedVariableSets = new Map<string, Set<string>>();
     derivedVariableMap.forEach((vars, unitNameKey) => {
       derivedVariableSets.set(unitNameKey.toUpperCase(), vars);
     });
-    const isDerivedVariable = (unitName: string, variableId: string): boolean => derivedVariableSets.get(unitName.toUpperCase())?.has(variableId) ?? false;
 
     // Pre-sample responses for each variable configuration to ensure consistency across all coders
     const sampledResponsesByConfig: Map<string, CoderTrainingResponse[]> = new Map();
@@ -987,6 +1211,7 @@ export class CoderTrainingService {
       const unitId = config.unitId;
       const sampleCount = config.sampleCount;
       const configKey = `${unitId}:${variableId}`;
+      const includeDeriveError = config.includeDeriveError === true;
 
       this.logger.log(`Querying incomplete responses for unit ${unitId}, variable ${variableId}`);
 
@@ -999,12 +1224,16 @@ export class CoderTrainingService {
         .leftJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
         .where('person.workspace_id = :workspaceId', { workspaceId })
         .andWhere('person.consider = :consider', { consider: true })
-        .andWhere('response.status_v1 IN (:...statuses)', {
-          statuses: [
-            statusStringToNumber('CODING_INCOMPLETE'),
-            statusStringToNumber('INTENDED_INCOMPLETE')
-          ]
-        })
+        .andWhere(includeDeriveError ?
+          new Brackets(qb => {
+            qb.where('response.status_v1 IN (:...statuses)', {
+              statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+            }).orWhere('response.status_v1 = :deriveErrorStatus', {
+              deriveErrorStatus: DERIVE_ERROR_STATUS
+            });
+          }) :
+          'response.status_v1 IN (:...statuses)',
+        { statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES })
         .andWhere('response.variableid = :variableId', { variableId })
         .andWhere('response.status_v2 IS NULL')
         .andWhere('(unit.alias = :unitId OR unit.name = :unitId)', { unitId })
@@ -1083,52 +1312,30 @@ export class CoderTrainingService {
         }
       }
 
-      // De-duplicate identical responses per person/unit/variable/value (keep lowest responseId).
-      const dedupedByPersonValue = new Map<string, CoderTrainingResponse>();
-      for (const response of transformedResponses) {
-        const valueHash = createHash('sha1').update(response.value || '').digest('hex');
-        const key = `${response.personLogin}::${response.personCode}::${response.personGroup}::${response.unitName}::${response.variableId}::${valueHash}`;
-        const existing = dedupedByPersonValue.get(key);
-        if (!existing || response.responseId < existing.responseId) {
-          dedupedByPersonValue.set(key, response);
-        }
+      const dedupedResponses = deduplicateManualCodingResponses(transformedResponses);
+      if (dedupedResponses.length !== transformedResponses.length) {
+        this.logger.debug(`Removed ${transformedResponses.length - dedupedResponses.length} duplicate responses for unit ${unitId}, variable ${variableId}.`);
       }
-      if (dedupedByPersonValue.size !== transformedResponses.length) {
-        this.logger.debug(`Removed ${transformedResponses.length - dedupedByPersonValue.size} duplicate responses for unit ${unitId}, variable ${variableId}.`);
-      }
-      transformedResponses = Array.from(dedupedByPersonValue.values());
+      transformedResponses = dedupedResponses;
 
-      // Apply aggregation grouping: if threshold is set, keep only 1 representative per value group.
-      // Derived variables have null/empty values — skip aggregation to avoid collapsing all responses into 1 group.
-      const isDerived = isDerivedVariable(unitId, variableId);
+      // Apply the same aggregation grouping used by availability analysis.
       let responsesForSampling: CoderTrainingResponse[];
-      if (!isDerived && aggregationThreshold !== null) {
-        // Build slim-compatible objects for aggregation
-        const slimResponses = transformedResponses.map(r => ({
-          id: r.responseId,
-          variableid: r.variableId,
-          value: r.value,
-          unitName: r.unitName,
-          unitAlias: r.unitAlias,
-          bookletName: r.bookletName,
-          personLogin: r.personLogin,
-          personCode: r.personCode,
-          personGroup: r.personGroup
-        }));
-        const aggregatedGroups = this.codingJobService.aggregateResponsesByValue(slimResponses, matchingFlags);
+      if (aggregationThreshold !== null) {
+        const aggregatedGroups = buildAggregationGroups(
+          transformedResponses,
+          matchingFlags,
+          aggregationThreshold,
+          derivedVariableSets
+        );
         responsesForSampling = [];
         for (const group of aggregatedGroups) {
           if (group.responses.length >= aggregationThreshold) {
-            // Keep only 1 representative (lowest id first)
-            const representative = group.responses.reduce((a, b) => (a.id < b.id ? a : b));
-            const orig = transformedResponses.find(r => r.responseId === representative.id);
-            if (orig) responsesForSampling.push(orig);
+            const representative = group.responses.reduce((a, b) => (
+              a.responseId < b.responseId ? a : b
+            ));
+            responsesForSampling.push(representative);
           } else {
-            // Below threshold — all responses are kept individually
-            for (const slimR of group.responses) {
-              const orig = transformedResponses.find(r => r.responseId === slimR.id);
-              if (orig) responsesForSampling.push(orig);
-            }
+            responsesForSampling.push(...group.responses);
           }
         }
         this.logger.log(
@@ -1183,7 +1390,7 @@ export class CoderTrainingService {
   async createCoderTrainingJobs(
     workspaceId: number,
     selectedCoders: { id: number; name: string }[],
-    variableConfigs: { variableId: string; unitId: string; sampleCount: number }[],
+    variableConfigs: TrainingVariableConfig[],
     trainingLabel: string,
     missingsProfileId?: number,
     assignedVariables?: JobDefinitionVariable[],
@@ -1204,6 +1411,13 @@ export class CoderTrainingService {
         workspaceId,
         missingsProfileId
       );
+      const trainingVariableSelections = await this.buildTrainingVariableSelections(
+        workspaceId,
+        variableConfigs,
+        assignedVariables || [],
+        assignedVariableBundles || []
+      );
+      const trainingVariableConfigs = this.mapTrainingVariableSelectionsToConfigs(trainingVariableSelections);
 
       const coderTraining = new CoderTraining();
       coderTraining.workspace_id = workspaceId;
@@ -1219,16 +1433,15 @@ export class CoderTrainingService {
       const savedTraining = await this.coderTrainingRepository.save(coderTraining);
       const trainingId = savedTraining.id;
 
-      // Save assigned variables
-      if (assignedVariables) {
-        for (const variable of assignedVariables) {
-          const trainingVariable = new CoderTrainingVariable();
-          trainingVariable.coder_training_id = trainingId;
-          trainingVariable.variable_id = variable.variableId;
-          trainingVariable.unit_name = variable.unitName;
-          trainingVariable.sample_count = variable.sampleCount || 10;
-          await this.coderTrainingVariableRepository.save(trainingVariable);
-        }
+      // Save selected variables, including variables that came from bundles.
+      for (const variable of trainingVariableSelections) {
+        const trainingVariable = new CoderTrainingVariable();
+        trainingVariable.coder_training_id = trainingId;
+        trainingVariable.variable_id = variable.variableId;
+        trainingVariable.unit_name = variable.unitName;
+        trainingVariable.sample_count = variable.sampleCount || 10;
+        trainingVariable.include_derive_error = variable.includeDeriveError === true;
+        await this.coderTrainingVariableRepository.save(trainingVariable);
       }
 
       // Save assigned bundles
@@ -1253,7 +1466,7 @@ export class CoderTrainingService {
 
       this.logger.log(`Created coder training ${trainingId} with label '${trainingLabel}' and configuration`);
 
-      const trainingPackages = await this.generateCoderTrainingPackages(workspaceId, selectedCoders, variableConfigs, {
+      const trainingPackages = await this.generateCoderTrainingPackages(workspaceId, selectedCoders, trainingVariableConfigs, {
         caseSelectionMode: caseSelectionMode ?? 'oldest_first',
         referenceTrainingIds,
         referenceMode
@@ -1264,12 +1477,10 @@ export class CoderTrainingService {
       const bundleSortingModeMap = new Map<number, 'continuous' | 'alternating'>();
       this.logger.log(`Building bundle maps for ${assignedVariableBundles?.length || 0} bundles`);
       if (assignedVariableBundles && assignedVariableBundles.length > 0) {
-        const bundleIds = assignedVariableBundles.map(b => b.id);
+        const bundleIds = this.getValidatedBundleIds(assignedVariableBundles);
         if (bundleIds.length > 0) {
-          const fetchedBundles = await this.variableBundleRepository.find({
-            where: { id: In(bundleIds) }
-          });
-          for (const bundle of fetchedBundles) {
+          const fetchedBundlesById = await this.getWorkspaceVariableBundlesById(workspaceId, bundleIds);
+          for (const bundle of fetchedBundlesById.values()) {
             // Store the bundle's sorting mode (if set, otherwise null)
             const bundleConfig = assignedVariableBundles.find(b => b.id === bundle.id);
             const mode = bundleConfig?.caseOrderingMode || null;
@@ -1435,31 +1646,49 @@ export class CoderTrainingService {
       order: { created_at: 'DESC' }
     });
 
-    return trainings.map(training => ({
-      id: training.id,
-      workspace_id: training.workspace_id,
-      label: training.label,
-      created_at: training.created_at,
-      updated_at: training.updated_at,
-      jobsCount: training.codingJobs?.length || 0,
-      case_ordering_mode: training.case_ordering_mode,
-      case_selection_mode: training.case_selection_mode,
-      reference_training_ids: training.reference_training_ids ?? undefined,
-      reference_mode: training.reference_mode ?? undefined,
-      suppress_general_instructions: training.suppress_general_instructions,
-      assigned_variables: training.variables?.map(v => ({
-        variableId: v.variable_id,
-        unitName: v.unit_name,
-        sampleCount: v.sample_count
-      })),
-      assigned_variable_bundles: training.bundles?.map(b => ({
-        id: b.variable_bundle_id,
-        name: b.bundle?.name || 'Unknown Bundle',
-        sampleCount: b.sample_count,
-        caseOrderingMode: b.case_ordering_mode
-      })),
-      assigned_coders: training.coders?.map(c => c.user_id)
-    }));
+    return trainings.map(training => {
+      const bundleVariableKeys = this.getBundleVariableKeys(training.bundles || []);
+      const trainingVariablesByKey = this.getTrainingVariablesByKey(training.variables || []);
+
+      return {
+        id: training.id,
+        workspace_id: training.workspace_id,
+        label: training.label,
+        created_at: training.created_at,
+        updated_at: training.updated_at,
+        jobsCount: training.codingJobs?.length || 0,
+        case_ordering_mode: training.case_ordering_mode,
+        case_selection_mode: training.case_selection_mode,
+        reference_training_ids: training.reference_training_ids ?? undefined,
+        reference_mode: training.reference_mode ?? undefined,
+        suppress_general_instructions: training.suppress_general_instructions,
+        assigned_variables: training.variables
+          ?.filter(v => !bundleVariableKeys.has(this.makeTrainingVariableKey(v.unit_name, v.variable_id)))
+          .map(v => ({
+            variableId: v.variable_id,
+            unitName: v.unit_name,
+            sampleCount: v.sample_count,
+            ...(v.include_derive_error === true ? { includeDeriveError: true } : {})
+          })),
+        assigned_variable_bundles: training.bundles?.map(b => ({
+          id: b.variable_bundle_id,
+          name: b.bundle?.name || 'Unknown Bundle',
+          sampleCount: b.sample_count,
+          caseOrderingMode: b.case_ordering_mode,
+          variables: b.bundle?.variables?.map(variable => {
+            const savedVariable = trainingVariablesByKey.get(
+              this.makeTrainingVariableKey(variable.unitName, variable.variableId)
+            );
+            return {
+              ...variable,
+              sampleCount: savedVariable?.sample_count ?? b.sample_count,
+              ...(savedVariable?.include_derive_error === true ? { includeDeriveError: true } : {})
+            };
+          })
+        })),
+        assigned_coders: training.coders?.map(c => c.user_id)
+      };
+    });
   }
 
   async getTrainingCodingComparison(
@@ -1851,7 +2080,7 @@ export class CoderTrainingService {
     trainingId: number,
     trainingLabel: string,
     selectedCoders: { id: number; name: string }[],
-    variableConfigs: { variableId: string; unitId: string; sampleCount: number }[],
+    variableConfigs: TrainingVariableConfig[],
     missingsProfileId?: number,
     assignedVariables?: JobDefinitionVariable[],
     assignedVariableBundles?: JobDefinitionVariableBundle[],
@@ -1870,7 +2099,7 @@ export class CoderTrainingService {
 
       const training = await this.coderTrainingRepository.findOne({
         where: { id: trainingId, workspace_id: workspaceId },
-        relations: ['codingJobs', 'variables', 'bundles', 'coders']
+        relations: ['codingJobs', 'variables', 'bundles', 'bundles.bundle', 'coders']
       });
 
       if (!training) {
@@ -1903,35 +2132,44 @@ export class CoderTrainingService {
       const newCoderIds = selectedCoders.map(c => c.id).sort();
       const codersChanged = JSON.stringify(currentCoderIds) !== JSON.stringify(newCoderIds);
 
-      const currentAssignedVariables: JobDefinitionVariable[] = training.variables?.map(v => ({
-        variableId: v.variable_id,
-        unitName: v.unit_name,
-        sampleCount: v.sample_count || 10
-      })) || [];
+      const currentAssignedVariables = this.mapTrainingVariables(training.variables || []);
 
       const currentCaseOrderingMode = training.case_ordering_mode || 'continuous';
       const newCaseOrderingMode = caseOrderingMode ?? currentCaseOrderingMode;
 
-      const currentAssignedVariableBundles: JobDefinitionVariableBundle[] = training.bundles?.map(b => ({
-        id: b.variable_bundle_id,
-        name: b.bundle?.name || '',
-        sampleCount: b.sample_count || 10,
-        caseOrderingMode: b.case_ordering_mode ?? undefined
-      })) || [];
+      const currentAssignedVariableBundles = this.mapTrainingBundles(
+        training.bundles || [],
+        currentAssignedVariables
+      );
+      const currentTrainingVariables = await this.buildTrainingVariableSelections(
+        workspaceId,
+        [],
+        currentAssignedVariables,
+        currentAssignedVariableBundles
+      );
 
       const effectiveAssignedVariables = assignedVariables ?? currentAssignedVariables;
       const effectiveAssignedVariableBundles = assignedVariableBundles ?? currentAssignedVariableBundles;
+      const effectiveTrainingVariables = await this.buildTrainingVariableSelections(
+        workspaceId,
+        variableConfigs,
+        effectiveAssignedVariables,
+        effectiveAssignedVariableBundles
+      );
+      const effectiveTrainingVariableConfigs = this.mapTrainingVariableSelectionsToConfigs(effectiveTrainingVariables);
 
-      const currentVariables = currentAssignedVariables.map(v => ({
+      const currentVariables = currentTrainingVariables.map(v => ({
         variableId: v.variableId,
         unitName: v.unitName,
-        sampleCount: v.sampleCount || 10
+        sampleCount: v.sampleCount || 10,
+        includeDeriveError: v.includeDeriveError === true
       })).sort((a, b) => (a.variableId + a.unitName).localeCompare(b.variableId + b.unitName));
 
-      const newVariables = effectiveAssignedVariables.map(v => ({
+      const newVariables = effectiveTrainingVariables.map(v => ({
         variableId: v.variableId,
         unitName: v.unitName,
-        sampleCount: v.sampleCount || 10
+        sampleCount: v.sampleCount || 10,
+        includeDeriveError: v.includeDeriveError === true
       })).sort((a, b) => (a.variableId + a.unitName).localeCompare(b.variableId + b.unitName));
 
       const variablesChanged = JSON.stringify(currentVariables) !== JSON.stringify(newVariables);
@@ -2010,12 +2248,13 @@ export class CoderTrainingService {
         await this.coderTrainingCoderRepository.delete({ coder_training_id: trainingId });
 
         // Save new configuration relations
-        for (const variable of effectiveAssignedVariables) {
+        for (const variable of effectiveTrainingVariables) {
           const trainingVariable = new CoderTrainingVariable();
           trainingVariable.coder_training_id = trainingId;
           trainingVariable.variable_id = variable.variableId;
           trainingVariable.unit_name = variable.unitName;
           trainingVariable.sample_count = variable.sampleCount || 10;
+          trainingVariable.include_derive_error = variable.includeDeriveError === true;
           await this.coderTrainingVariableRepository.save(trainingVariable);
         }
 
@@ -2045,7 +2284,7 @@ export class CoderTrainingService {
         }
 
         // Generate and create new jobs
-        const trainingPackages = await this.generateCoderTrainingPackages(workspaceId, selectedCoders, variableConfigs, {
+        const trainingPackages = await this.generateCoderTrainingPackages(workspaceId, selectedCoders, effectiveTrainingVariableConfigs, {
           caseSelectionMode: newCaseSelectionMode,
           referenceTrainingIds: effectiveReferenceTrainingIds,
           referenceMode: newReferenceMode ?? undefined
@@ -2056,12 +2295,10 @@ export class CoderTrainingService {
         const bundleSortingModeMap = new Map<number, 'continuous' | 'alternating' | null>();
         this.logger.log(`[Update] Building bundle maps for ${effectiveAssignedVariableBundles.length} bundles`);
         if (effectiveAssignedVariableBundles.length > 0) {
-          const bundleIds = effectiveAssignedVariableBundles.map(b => b.id);
+          const bundleIds = this.getValidatedBundleIds(effectiveAssignedVariableBundles);
           if (bundleIds.length > 0) {
-            const fetchedBundles = await this.variableBundleRepository.find({
-              where: { id: In(bundleIds) }
-            });
-            for (const bundle of fetchedBundles) {
+            const fetchedBundlesById = await this.getWorkspaceVariableBundlesById(workspaceId, bundleIds);
+            for (const bundle of fetchedBundlesById.values()) {
               // Store the bundle's sorting mode (if set, otherwise null)
               const bundleConfig = effectiveAssignedVariableBundles.find(b => b.id === bundle.id);
               const mode = bundleConfig?.caseOrderingMode ?? null;

--- a/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
@@ -1,3 +1,3 @@
 export function getCodingIncompleteVariablesCacheKey(workspaceId: number): string {
-  return `coding_incomplete_variables_v6:${workspaceId}`;
+  return `coding_incomplete_variables_v7:${workspaceId}`;
 }

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -221,7 +221,7 @@ describe('CodingJobService distribution from job definitions', () => {
     });
 
     expect(result.success).toBe(true);
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v6:5');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v7:5');
     expect(result.distribution).toEqual(preview.distribution);
     expect(result.doubleCodingInfo).toEqual(preview.doubleCodingInfo);
     expect(result.jobsCreated).toBe(createdJobCalls.length);

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -1142,7 +1142,7 @@ describe('CodingJobService', () => {
       job_definition_id: 42
     }));
     expect(codingJobRepository.create.mock.calls[0][0]).not.toHaveProperty('job_definition_id');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v6:7');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v7:7');
   });
 
   it('loads one coding job and expands bundle variables', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
@@ -338,7 +338,7 @@ describe('CodingStatisticsService', () => {
       await service.invalidateIncompleteVariablesCache(1);
 
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v6:1'
+        'coding_incomplete_variables_v7:1'
       );
     });
 

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -11,6 +11,7 @@ import { WorkspacePlayerService } from '../workspace/workspace-player.service';
 import { WorkspaceExclusionService } from '../workspace/workspace-exclusion.service';
 import { CodingJobService } from './coding-job.service';
 import { getManualCodingScopeKey } from '../../utils/manual-coding-scope.util';
+import { statusStringToNumber } from '../../utils/response-status-converter';
 
 describe('CodingValidationService', () => {
   let service: CodingValidationService;
@@ -87,6 +88,22 @@ describe('CodingValidationService', () => {
     addGroupBy: jest.fn().mockReturnThis(),
     getRawMany: jest.fn().mockResolvedValue(rawResults)
   }) as unknown as jest.Mocked<SelectQueryBuilder<ResponseEntity>>;
+
+  const createSlimResponses = (
+    unitName: string,
+    variableid: string,
+    count: number,
+    overrides: Partial<{ value: string | null; statusV1: number | null }> = {}
+  ) => Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    unitName,
+    variableid,
+    value: overrides.value ?? `value-${index + 1}`,
+    ...(overrides.statusV1 !== undefined ? { statusV1: overrides.statusV1 } : {}),
+    personLogin: `${variableid}-person-${index + 1}`,
+    personCode: `${index + 1}`,
+    personGroup: 'group'
+  }));
 
   beforeEach(async () => {
     mockResponseRepository = {
@@ -520,7 +537,7 @@ describe('CodingValidationService', () => {
 
       expect(result).toEqual(cachedVariables);
       expect(mockCacheService.get).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v6:1'
+        'coding_incomplete_variables_v7:1'
       );
     });
 
@@ -553,6 +570,10 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        ...createSlimResponses('unit1', 'var1', 8),
+        ...createSlimResponses('unit1', 'intended-only', 2)
+      ] as never);
 
       const result = await service.getCodingIncompleteVariables(1);
 
@@ -573,7 +594,7 @@ describe('CodingValidationService', () => {
         })
       ]);
       expect(mockCacheService.set).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v6:1',
+        'coding_incomplete_variables_v7:1',
         result,
         300
       );
@@ -605,6 +626,10 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        ...createSlimResponses('unit1', 'var1', 5),
+        ...createSlimResponses('unit1', 'var2', 2)
+      ] as never);
 
       const result = await service.getCodingIncompleteVariables(1);
 
@@ -616,6 +641,56 @@ describe('CodingValidationService', () => {
         expect.objectContaining({
           variableId: 'var2',
           deriveErrorResponseCount: 0
+        })
+      ]);
+    });
+
+    it('should apply training deduplication to standard case counts without aggregation', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '3' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([]);
+      const assignedResponsesQb = createQueryBuilderMock([]);
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(assignedResponsesQb);
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        {
+          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person', personCode: 'code', personGroup: 'group'
+        },
+        {
+          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person', personCode: 'code', personGroup: 'group'
+        },
+        {
+          id: 3, unitName: 'unit1', variableid: 'var1', value: 'other', personLogin: 'person', personCode: 'code', personGroup: 'group'
+        }
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(1);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 3,
+          availableCases: 2,
+          uniqueCasesAfterAggregation: 2
         })
       ]);
     });
@@ -660,6 +735,10 @@ describe('CodingValidationService', () => {
         ])
       );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        ...createSlimResponses('unit1', 'derived-var', 3),
+        ...createSlimResponses('unit1', 'standalone-var', 2)
+      ] as never);
 
       const result = await service.getCodingIncompleteVariables(1);
       const summary = await service.getManualCodingScopeSummary(1);
@@ -713,25 +792,29 @@ describe('CodingValidationService', () => {
           id: 1,
           unitName: 'unit1',
           variableid: 'var1',
-          value: ''
+          value: '',
+          personLogin: 'person-1'
         },
         {
           id: 2,
           unitName: 'unit1',
           variableid: 'var1',
-          value: ''
+          value: '',
+          personLogin: 'person-2'
         },
         {
           id: 3,
           unitName: 'unit1',
           variableid: 'var1',
-          value: null
+          value: null,
+          personLogin: 'person-3'
         },
         {
           id: 4,
           unitName: 'unit1',
           variableid: 'var1',
-          value: '[]'
+          value: '[]',
+          personLogin: 'person-4'
         }
       ] as never);
 
@@ -774,7 +857,9 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
-      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([]);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
+        createSlimResponses('unit1', 'derived-var', 4) as never
+      );
 
       const result = await service.getCodingIncompleteVariables(1);
 
@@ -790,7 +875,7 @@ describe('CodingValidationService', () => {
       ]);
       expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
         1,
-        []
+        [{ unitName: 'unit1', variableId: 'derived-var' }]
       );
     });
 
@@ -800,15 +885,141 @@ describe('CodingValidationService', () => {
       ]);
       const intendedIncompleteQb = createQueryBuilderMock([]);
       const deriveErrorQb = createQueryBuilderMock([]);
-      const casesInJobsQb = createQueryBuilderMock([
-        { unitName: 'unit1', variableId: 'var1', casesInJobs: '4' }
-      ]);
       const assignedResponsesQb = createQueryBuilderMock([
         { unitName: 'unit1', variableId: 'var1', responseId: '1' },
         { unitName: 'unit1', variableId: 'var1', responseId: '2' },
         { unitName: 'unit1', variableId: 'var1', responseId: '3' },
         { unitName: 'unit1', variableId: 'var1', responseId: '5' }
       ]);
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(assignedResponsesQb);
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(4);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        {
+          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-1'
+        },
+        {
+          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-2'
+        },
+        {
+          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-3'
+        },
+        {
+          id: 4, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-4'
+        },
+        {
+          id: 5, unitName: 'unit1', variableid: 'var1', value: 'single', personLogin: 'person-5'
+        },
+        {
+          id: 6, unitName: 'unit1', variableid: 'var1', value: 'single', personLogin: 'person-6'
+        }
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(1);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 6,
+          casesInJobs: 2,
+          availableCases: 1,
+          uniqueCasesAfterAggregation: 3
+        })
+      ]);
+    });
+
+    it('should expose aggregation-aware case counts when DERIVE_ERROR is included', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '2' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '1' }
+      ]);
+      const casesInJobsQb = createQueryBuilderMock([]);
+      const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+      const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(casesInJobsQb);
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        {
+          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus
+        },
+        {
+          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus
+        },
+        {
+          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: deriveErrorStatus
+        }
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(
+        1,
+        undefined,
+        undefined,
+        true
+      );
+
+      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
+        1,
+        [{ unitName: 'unit1', variableId: 'var1', includeDeriveError: true }]
+      );
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 2,
+          deriveErrorResponseCount: 1,
+          uniqueCasesAfterAggregation: 1,
+          uniqueCasesAfterAggregationWithDeriveError: 1
+        })
+      ]);
+    });
+
+    it('should apply training deduplication when DERIVE_ERROR case counts are requested without aggregation', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '3' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '1' }
+      ]);
+      const casesInJobsQb = createQueryBuilderMock([]);
+      const assignedResponsesQb = createQueryBuilderMock([]);
+      const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+      const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
 
       mockResponseRepository.createQueryBuilder = jest.fn()
         .mockReturnValueOnce(codingIncompleteQb)
@@ -826,39 +1037,38 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
       mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
-      mockCodingJobService.getAggregationThreshold.mockResolvedValue(4);
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same'
+          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same'
+          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same'
+          id: 3, unitName: 'unit1', variableid: 'var1', value: 'other', statusV1: codingIncompleteStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
         },
         {
-          id: 4, unitName: 'unit1', variableid: 'var1', value: 'same'
-        },
-        {
-          id: 5, unitName: 'unit1', variableid: 'var1', value: 'single'
-        },
-        {
-          id: 6, unitName: 'unit1', variableid: 'var1', value: 'single'
+          id: 4, unitName: 'unit1', variableid: 'var1', value: 'other', statusV1: deriveErrorStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
         }
       ] as never);
 
-      const result = await service.getCodingIncompleteVariables(1);
+      const result = await service.getCodingIncompleteVariables(
+        1,
+        undefined,
+        undefined,
+        true
+      );
 
       expect(result).toEqual([
         expect.objectContaining({
           unitName: 'unit1',
           variableId: 'var1',
-          responseCount: 6,
-          casesInJobs: 2,
-          availableCases: 1,
-          uniqueCasesAfterAggregation: 3
+          responseCount: 3,
+          deriveErrorResponseCount: 1,
+          uniqueCasesAfterAggregation: 2,
+          uniqueCasesAfterAggregationWithDeriveError: 2
         })
       ]);
     });
@@ -958,6 +1168,9 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
+        createSlimResponses('unit1', 'var1', 5) as never
+      );
     };
 
     it('should warn when a manual variable has no selectable regular codes', async () => {
@@ -1077,7 +1290,7 @@ describe('CodingValidationService', () => {
     it('should generate correct cache key', () => {
       const cacheKey = service.generateIncompleteVariablesCacheKey(123);
 
-      expect(cacheKey).toBe('coding_incomplete_variables_v6:123');
+      expect(cacheKey).toBe('coding_incomplete_variables_v7:123');
     });
   });
 
@@ -1088,7 +1301,7 @@ describe('CodingValidationService', () => {
       await service.invalidateIncompleteVariablesCache(1);
 
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v6:1'
+        'coding_incomplete_variables_v7:1'
       );
     });
   });

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -25,7 +25,12 @@ import {
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
 import { CodingJobService } from './coding-job.service';
-import { buildAggregationGroups } from './aggregation-metrics.util';
+import {
+  buildAggregationGroups,
+  deduplicateManualCodingResponses,
+  getManualCodingDeduplicationKey,
+  ManualCodingDeduplicationResponse
+} from './aggregation-metrics.util';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
 import {
   getCoveredSourceKeysForManualDerivedVariables,
@@ -33,7 +38,10 @@ import {
   ManualCodingExcludedSourceSummary,
   summarizeCoveredSourceVariables
 } from '../../utils/manual-coding-scope.util';
-import { createManualCodingVariableReferences } from '../../utils/manual-coding-candidate.util';
+import {
+  createManualCodingVariableReferences,
+  DERIVE_ERROR_STATUS
+} from '../../utils/manual-coding-candidate.util';
 
 interface NormalizedExpectedCombination {
   unitKey: string;
@@ -61,12 +69,18 @@ type SlimCodingResponse = {
   unitName: string;
   variableid: string;
   value: string | null;
+  statusV1?: number | null;
+  personLogin?: string | null;
+  personCode?: string | null;
+  personGroup?: string | null;
 };
 
 type VariableCaseInfo = {
   casesInJobs: number;
   availableCases: number;
   uniqueCasesAfterAggregation: number;
+  availableCasesWithDeriveError?: number;
+  uniqueCasesAfterAggregationWithDeriveError?: number;
 };
 
 type ManualCodingScopeFromDb = {
@@ -87,6 +101,8 @@ type ManualCodingVariableWithCaseInfo = {
   casesInJobs: number;
   availableCases: number;
   uniqueCasesAfterAggregation: number;
+  availableCasesWithDeriveError?: number;
+  uniqueCasesAfterAggregationWithDeriveError?: number;
   isDerived: boolean;
   coderTrainingRequired: boolean;
 };
@@ -488,7 +504,8 @@ export class CodingValidationService {
   async getCodingIncompleteVariables(
     workspaceId: number,
     unitName?: string,
-    trainingRequired?: boolean
+    trainingRequired?: boolean,
+    includeDeriveErrorOnly = false
   ): Promise<
     {
       unitName: string;
@@ -498,21 +515,28 @@ export class CodingValidationService {
       casesInJobs: number;
       availableCases: number;
       uniqueCasesAfterAggregation: number;
+      availableCasesWithDeriveError?: number;
+      uniqueCasesAfterAggregationWithDeriveError?: number;
       isDerived: boolean;
       coderTrainingRequired: boolean;
     }[]
     > {
     try {
-      if (unitName || trainingRequired !== undefined) {
+      if (unitName || trainingRequired !== undefined || includeDeriveErrorOnly) {
         this.logger.log(
           `Querying manual coding variables for workspace ${workspaceId}${unitName ? ` and unit ${unitName}` : ''}${trainingRequired !== undefined ? ` (trainingRequired: ${trainingRequired})` : ''} (not cached)`
         );
         const variables = await this.fetchCodingIncompleteVariablesFromDb(
           workspaceId,
           unitName,
-          trainingRequired
+          trainingRequired,
+          includeDeriveErrorOnly
         );
-        return await this.enrichVariablesWithCaseInfo(workspaceId, variables);
+        return await this.enrichVariablesWithCaseInfo(
+          workspaceId,
+          variables,
+          includeDeriveErrorOnly
+        );
       }
       const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
       const cachedResult = await this.cacheService.get<
@@ -524,6 +548,8 @@ export class CodingValidationService {
         casesInJobs: number;
         availableCases: number;
         uniqueCasesAfterAggregation: number;
+        availableCasesWithDeriveError?: number;
+        uniqueCasesAfterAggregationWithDeriveError?: number;
         isDerived: boolean;
         coderTrainingRequired: boolean;
       }[]
@@ -538,7 +564,10 @@ export class CodingValidationService {
         `Cache miss: Querying manual coding variables for workspace ${workspaceId}`
       );
       const variables = await this.fetchCodingIncompleteVariablesFromDb(
-        workspaceId
+        workspaceId,
+        undefined,
+        undefined,
+        includeDeriveErrorOnly
       );
       const result = await this.enrichVariablesWithCaseInfo(
         workspaceId,
@@ -667,9 +696,14 @@ export class CodingValidationService {
      */
   private async enrichVariablesWithCaseInfo(
     workspaceId: number,
-    variables: ManualCodingVariableCaseCounts[]
+    variables: ManualCodingVariableCaseCounts[],
+    includeDeriveErrorInCaseInfo = false
   ): Promise<ManualCodingVariableWithCaseInfo[]> {
-    const caseInfoMap = await this.computeVariableCaseInfo(workspaceId, variables);
+    const caseInfoMap = await this.computeVariableCaseInfo(
+      workspaceId,
+      variables,
+      includeDeriveErrorInCaseInfo
+    );
 
     return variables.map(variable => {
       const key = `${variable.unitName}::${variable.variableId}`;
@@ -693,7 +727,8 @@ export class CodingValidationService {
    */
   private async computeVariableCaseInfo(
     workspaceId: number,
-    variables: ManualCodingVariableCaseCounts[]
+    variables: ManualCodingVariableCaseCounts[],
+    includeDeriveErrorInCaseInfo = false
   ): Promise<Map<string, VariableCaseInfo>> {
     const result = new Map<string, VariableCaseInfo>();
 
@@ -701,34 +736,20 @@ export class CodingValidationService {
       return result;
     }
 
-    const casesInJobsMap = await this.getVariableCasesInJobs(workspaceId);
     const aggregationThreshold = await this.codingJobService.getAggregationThreshold(workspaceId);
 
-    if (aggregationThreshold === null) {
-      variables.forEach(v => {
-        const key = `${v.unitName}::${v.variableId}`;
-        const casesInJobs = casesInJobsMap.get(key) || 0;
-        result.set(key, {
-          casesInJobs,
-          availableCases: Math.max(0, v.responseCount - casesInJobs),
-          uniqueCasesAfterAggregation: v.responseCount
-        });
-      });
-      return result;
-    }
-
     const matchingFlags = await this.codingJobService.getResponseMatchingMode(workspaceId);
-    const baseVariables = variables.filter(v => !v.isDerived);
-    const baseVariableReferences = baseVariables.map(v => ({
+    const variableReferences = variables.map(v => ({
       unitName: v.unitName,
-      variableId: v.variableId
+      variableId: v.variableId,
+      ...(includeDeriveErrorInCaseInfo ? { includeDeriveError: true } : {})
     }));
     const [slimResponses, assignedResponseIdsByVariable] = await Promise.all([
       this.codingJobService.getSlimResponsesForVariables(
         workspaceId,
-        baseVariableReferences
+        variableReferences
       ) as Promise<SlimCodingResponse[]>,
-      this.getAssignedResponseIdsByVariable(workspaceId, baseVariableReferences)
+      this.getAssignedResponseIdsByVariable(workspaceId, variableReferences)
     ]);
 
     const derivedVariableMap = new Map<string, Set<string>>();
@@ -743,54 +764,79 @@ export class CodingValidationService {
 
     for (const variable of variables) {
       const key = `${variable.unitName}::${variable.variableId}`;
-      const rawCasesInJobs = casesInJobsMap.get(key) || 0;
 
-      if (variable.isDerived) {
-        result.set(key, {
-          casesInJobs: rawCasesInJobs,
-          availableCases: Math.max(0, variable.responseCount - rawCasesInJobs),
-          uniqueCasesAfterAggregation: variable.responseCount
-        });
-        continue;
-      }
-
-      const varResponses = slimResponses.filter(
+      const varResponsesWithRequestedStatuses = slimResponses.filter(
         r => r.unitName === variable.unitName && r.variableid === variable.variableId
       );
 
-      const aggregatedGroups = buildAggregationGroups(
-        varResponses.map(response => ({
-          ...response,
-          responseId: response.id,
-          variableId: response.variableid
-        })),
-        matchingFlags,
-        aggregationThreshold,
-        derivedVariableMap
-      );
-
-      let uniqueCases = 0;
-      let casesInJobs = 0;
-      const assignedResponseIds = assignedResponseIdsByVariable.get(key) || new Set<number>();
-
-      for (const group of aggregatedGroups) {
-        if (group.responses.length >= aggregationThreshold) {
-          uniqueCases += 1;
-          if (group.responses.some(response => assignedResponseIds.has(response.responseId))) {
-            casesInJobs += 1;
-          }
-        } else {
-          uniqueCases += group.responses.length;
-          casesInJobs += group.responses
+      const countAggregatedCases = (responses: SlimCodingResponse[]) => {
+        const responsesWithCaseFields: ManualCodingDeduplicationResponse[] =
+          responses.map(response => ({
+            ...response,
+            responseId: response.id,
+            variableId: response.variableid
+          }));
+        const assignedResponseIds = assignedResponseIdsByVariable.get(key) || new Set<number>();
+        const assignedDeduplicationKeys = new Set(
+          responsesWithCaseFields
             .filter(response => assignedResponseIds.has(response.responseId))
-            .length;
+            .map(response => getManualCodingDeduplicationKey(response))
+        );
+        const dedupedResponses = deduplicateManualCodingResponses(responsesWithCaseFields);
+        const assignedDedupedResponseIds = new Set(
+          dedupedResponses
+            .filter(response => (
+              assignedResponseIds.has(response.responseId) ||
+              assignedDeduplicationKeys.has(getManualCodingDeduplicationKey(response))
+            ))
+            .map(response => response.responseId)
+        );
+        const aggregatedGroups = buildAggregationGroups(
+          dedupedResponses,
+          matchingFlags,
+          aggregationThreshold,
+          derivedVariableMap
+        );
+
+        let uniqueCases = 0;
+        let casesInJobs = 0;
+
+        for (const group of aggregatedGroups) {
+          if (aggregationThreshold !== null && group.responses.length >= aggregationThreshold) {
+            uniqueCases += 1;
+            if (group.responses.some(response => assignedDedupedResponseIds.has(response.responseId))) {
+              casesInJobs += 1;
+            }
+          } else {
+            uniqueCases += group.responses.length;
+            casesInJobs += group.responses
+              .filter(response => assignedDedupedResponseIds.has(response.responseId))
+              .length;
+          }
         }
-      }
+
+        return { uniqueCases, casesInJobs };
+      };
+
+      const regularVarResponses = includeDeriveErrorInCaseInfo ?
+        varResponsesWithRequestedStatuses.filter(response => response.statusV1 !== DERIVE_ERROR_STATUS) :
+        varResponsesWithRequestedStatuses;
+      const regularCaseInfo = countAggregatedCases(regularVarResponses);
+      const deriveErrorCaseInfo = includeDeriveErrorInCaseInfo ?
+        countAggregatedCases(varResponsesWithRequestedStatuses) :
+        null;
 
       result.set(key, {
-        casesInJobs,
-        availableCases: Math.max(0, uniqueCases - casesInJobs),
-        uniqueCasesAfterAggregation: uniqueCases
+        casesInJobs: regularCaseInfo.casesInJobs,
+        availableCases: Math.max(0, regularCaseInfo.uniqueCases - regularCaseInfo.casesInJobs),
+        uniqueCasesAfterAggregation: regularCaseInfo.uniqueCases,
+        ...(deriveErrorCaseInfo ? {
+          availableCasesWithDeriveError: Math.max(
+            0,
+            deriveErrorCaseInfo.uniqueCases - deriveErrorCaseInfo.casesInJobs
+          ),
+          uniqueCasesAfterAggregationWithDeriveError: deriveErrorCaseInfo.uniqueCases
+        } : {})
       });
     }
 
@@ -923,14 +969,16 @@ export class CodingValidationService {
   private async fetchCodingIncompleteVariablesFromDb(
     workspaceId: number,
     unitName?: string,
-    trainingRequired?: boolean
+    trainingRequired?: boolean,
+    includeDeriveErrorOnly = false
   ): Promise<
     { unitName: string; variableId: string; responseCount: number; deriveErrorResponseCount: number; isDerived: boolean; coderTrainingRequired: boolean }[]
     > {
     const scope = await this.fetchManualCodingScopeFromDb(
       workspaceId,
       unitName,
-      trainingRequired
+      trainingRequired,
+      includeDeriveErrorOnly
     );
     return scope.variables;
   }
@@ -938,7 +986,8 @@ export class CodingValidationService {
   private async fetchManualCodingScopeFromDb(
     workspaceId: number,
     unitName?: string,
-    trainingRequired?: boolean
+    trainingRequired?: boolean,
+    includeDeriveErrorOnly = false
   ): Promise<ManualCodingScopeFromDb> {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     // Helper to build the base query for a given status
@@ -1081,6 +1130,32 @@ export class CodingValidationService {
           coderTrainingRequired
         });
       }
+    }
+
+    if (includeDeriveErrorOnly) {
+      deriveErrorCountsByKey.forEach((deriveErrorResponseCount, key) => {
+        if (mergedMap.has(key)) {
+          return;
+        }
+
+        const [deriveUnitName, variableId] = key.split('::');
+        if (!filterFn({
+          unitName: deriveUnitName,
+          variableId,
+          responseCount: String(deriveErrorResponseCount)
+        })) {
+          return;
+        }
+
+        mergedMap.set(key, {
+          unitName: deriveUnitName,
+          variableId,
+          responseCount: 0,
+          deriveErrorResponseCount,
+          isDerived: derivedVariableSets.get(deriveUnitName?.toUpperCase())?.has(variableId) ?? false,
+          coderTrainingRequired: trainingRequiredSets.get(deriveUnitName?.toUpperCase())?.has(variableId) ?? false
+        });
+      });
     }
 
     const result = Array.from(mergedMap.values());

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -102,7 +102,7 @@ describe('ExternalCodingImportService', () => {
     expect(queryRunner.commitTransaction).toHaveBeenCalled();
     expect(queryRunner.rollbackTransaction).not.toHaveBeenCalled();
     expect(queryRunner.release).toHaveBeenCalled();
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v6:17');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v7:17');
   });
 
   it('imports DERIVE_ERROR without turning it into completed false coding', async () => {

--- a/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
+++ b/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
@@ -36,11 +36,16 @@ export function createManualCodingVariableReferences(
   const referencesByKey = new Map<string, ManualCodingVariableReference>();
   variables.forEach(variable => {
     if (variable.unitName && variable.variableId) {
+      const key = toManualCodingVariablePairKey(variable.unitName, variable.variableId);
+      const existing = referencesByKey.get(key);
       referencesByKey.set(
-        toManualCodingVariablePairKey(variable.unitName, variable.variableId),
+        key,
         {
           unitName: variable.unitName,
-          variableId: variable.variableId
+          variableId: variable.variableId,
+          includeDeriveError: existing?.includeDeriveError === true || variable.includeDeriveError === true ?
+            true :
+            undefined
         }
       );
     }

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.html
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.html
@@ -275,7 +275,19 @@
                 Reihenfolge: {{getCaseOrderingModeLabel(bundleGroup.bundle.caseOrderingMode || trainingForm.get('caseOrderingMode')?.value)}}
               </span>
             </div>
-            <!-- Individual variable details hidden for bundles as per requirement -->
+            <div class="bundle-derive-error-options"
+              *ngIf="bundleGroup.variables.length && getBundleDeriveErrorControls(bundleGroup).length > 0">
+              <mat-checkbox
+                *ngFor="let variableItem of getBundleDeriveErrorControls(bundleGroup)"
+                [checked]="isDeriveErrorIncludedForControl(variableItem.control)"
+                (change)="setDeriveErrorIncludedForControl(variableItem.control, $event.checked)"
+                matTooltip="DERIVE_ERROR-Fälle dieser Bündelvariable zusätzlich in die Schulungsstichprobe aufnehmen.">
+                {{variableItem.control.get('unitId')?.value}} - {{variableItem.control.get('variableId')?.value}}
+                <span *ngIf="getDeriveErrorResponseCountForControl(variableItem.control) > 0">
+                  ({{getDeriveErrorResponseCountForControl(variableItem.control)}})
+                </span>
+              </mat-checkbox>
+            </div>
           </div>
         </div>
       </div>
@@ -319,6 +331,9 @@
               <mat-option *ngFor="let variable of filteredVariables$ | async"
                 [value]="variable.unitName + '::' + variable.variableId">
                 {{variable.unitName}} - {{variable.variableId}} ({{variable.responseCount}} Fälle)
+                <span *ngIf="(variable.deriveErrorResponseCount || 0) > 0" class="derive-error-chip compact">
+                  +{{variable.deriveErrorResponseCount}} DERIVE_ERROR
+                </span>
                 <span *ngIf="isVariableDerived(variable)" class="derived-chip compact">abgeleitet</span>
               </mat-option>
             </mat-select>
@@ -379,6 +394,18 @@
                 </mat-hint>
               </mat-form-field>
 
+              <mat-checkbox
+                *ngIf="hasDeriveErrorResponsesForControl(item.control)"
+                class="derive-error-checkbox"
+                [checked]="isDeriveErrorIncludedForControl(item.control)"
+                (change)="setDeriveErrorIncludedForControl(item.control, $event.checked)"
+                matTooltip="DERIVE_ERROR-Fälle dieser Variable zusätzlich in die Schulungsstichprobe aufnehmen.">
+                DERIVE_ERROR
+                <span *ngIf="getDeriveErrorResponseCountForControl(item.control) > 0">
+                  ({{getDeriveErrorResponseCountForControl(item.control)}})
+                </span>
+              </mat-checkbox>
+
               <!-- Validation/Overlap Warnings -->
               <div class="warning-container">
                 <div *ngIf="item.control.get('overlapWarning')?.value" class="overlap-warning"
@@ -428,6 +455,10 @@
         <li>
           Abgeleitete Variablen:
           <strong>{{getSelectedDerivedVariablesCount()}}</strong>
+        </li>
+        <li>
+          DERIVE_ERROR einbezogen:
+          <strong>{{getSelectedDeriveErrorOptInCount()}}</strong>
         </li>
         <li>
           Fallauswahl:

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.scss
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.scss
@@ -357,6 +357,16 @@ mat-form-field {
       color: #718096;
     }
   }
+
+  .bundle-derive-error-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    padding: 8px 16px 12px;
+    background: #ffffff;
+    border-top: 1px solid #edf2f7;
+    font-size: 0.8rem;
+  }
 }
 
 // Variables List
@@ -368,7 +378,7 @@ mat-form-field {
 
   .variable-item {
     display: grid;
-    grid-template-columns: 1fr 240px 40px 40px;
+    grid-template-columns: minmax(220px, 1fr) 240px minmax(120px, auto) 40px 40px;
     align-items: start;
     gap: 16px;
     padding: 24px 16px 16px;
@@ -483,6 +493,30 @@ mat-form-field {
     min-height: 18px;
     font-size: 0.68rem;
   }
+}
+
+.derive-error-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+  color: #9a3412;
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+
+  &.compact {
+    margin-left: 8px;
+  }
+}
+
+.derive-error-checkbox {
+  align-self: center;
+  white-space: nowrap;
 }
 
 // Summary

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
@@ -3,6 +3,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { FormGroup } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 import { CoderTrainingComponent } from './coder-training.component';
 import { CoderService } from '../../services/coder.service';
@@ -40,7 +41,12 @@ describe('CoderTrainingComponent', () => {
     ]));
     codingJobBackendService.getCodingIncompleteVariables.mockReturnValue(of([
       {
-        unitName: 'UNIT', variableId: 'VAR', responseCount: 10, uniqueCasesAfterAggregation: 8
+        unitName: 'UNIT',
+        variableId: 'VAR',
+        responseCount: 10,
+        uniqueCasesAfterAggregation: 8,
+        uniqueCasesAfterAggregationWithDeriveError: 9,
+        deriveErrorResponseCount: 2
       },
       { unitName: 'UNIT2', variableId: 'VAR2', responseCount: 4 },
       {
@@ -105,7 +111,12 @@ describe('CoderTrainingComponent', () => {
     component = fixture.componentInstance;
     component.availableVariables = [
       {
-        unitName: 'UNIT', variableId: 'VAR', responseCount: 10, uniqueCasesAfterAggregation: 8
+        unitName: 'UNIT',
+        variableId: 'VAR',
+        responseCount: 10,
+        uniqueCasesAfterAggregation: 8,
+        uniqueCasesAfterAggregationWithDeriveError: 9,
+        deriveErrorResponseCount: 2
       },
       { unitName: 'UNIT2', variableId: 'VAR2', responseCount: 4 },
       {
@@ -431,7 +442,11 @@ describe('CoderTrainingComponent', () => {
         id: 5,
         name: 'Bundle',
         sampleCount: 4,
-        caseOrderingMode: 'alternating'
+        caseOrderingMode: 'alternating',
+        variables: [
+          { unitName: 'UNIT2', variableId: 'VAR2', sampleCount: 4 },
+          { unitName: 'UNIT3', variableId: 'DERIVED', sampleCount: 4 }
+        ]
       }
     ]);
     expect(updateCall[8]).toBe('continuous');
@@ -533,7 +548,10 @@ describe('CoderTrainingComponent', () => {
           id: 5,
           name: 'Bundle',
           sampleCount: 4,
-          caseOrderingMode: 'continuous'
+          caseOrderingMode: 'continuous',
+          variables: [
+            { unitName: 'UNIT2', variableId: 'VAR2', sampleCount: 4 }
+          ]
         }
       ],
       'continuous',
@@ -574,9 +592,48 @@ describe('CoderTrainingComponent', () => {
           id: 5,
           name: 'Bundle',
           sampleCount: 4,
-          caseOrderingMode: 'continuous'
+          caseOrderingMode: 'continuous',
+          variables: [
+            { unitName: 'UNIT2', variableId: 'VAR2', sampleCount: 4 }
+          ]
         }
       ],
+      'continuous',
+      'oldest_first',
+      undefined,
+      undefined,
+      false
+    );
+  });
+
+  it('submits DERIVE_ERROR opt-in for selected training variables', () => {
+    component.onVariablesSelectionChange(['UNIT::VAR']);
+    const variableControl = component.variablesFormArray.at(0) as FormGroup;
+    component.setDeriveErrorIncludedForControl(variableControl, true);
+    expect(component.getAvailableCount({ control: variableControl })).toBe(9);
+    component.toggleCoderSelection(component.coders[0]);
+    component.trainingForm.get('trainingLabel')?.setValue('Derive opt-in');
+
+    component.onStartTraining();
+
+    expect(codingTrainingBackendService.createCoderTrainingJobs).toHaveBeenCalledWith(
+      1,
+      [component.coders[0]],
+      [{
+        variableId: 'VAR',
+        unitId: 'UNIT',
+        sampleCount: 8,
+        includeDeriveError: true
+      }],
+      'Derive opt-in',
+      undefined,
+      [{
+        variableId: 'VAR',
+        unitName: 'UNIT',
+        sampleCount: 8,
+        includeDeriveError: true
+      }],
+      [],
       'continuous',
       'oldest_first',
       undefined,
@@ -603,14 +660,24 @@ describe('CoderTrainingComponent', () => {
       importJobDefinitionSelections: (
         jobDef: {
           assignedVariables?: never[];
-          assignedVariableBundles: Array<{ id: number; name: string; caseOrderingMode: 'continuous' | 'alternating' }>;
+          assignedVariableBundles: Array<{
+            id: number;
+            name: string;
+            caseOrderingMode: 'continuous' | 'alternating';
+            variables?: Array<{ unitName: string; variableId: string; includeDeriveError?: boolean }>;
+          }>;
         },
         defaultSampleCount: number
       ) => void;
     }).importJobDefinitionSelections({
       assignedVariables: [],
       assignedVariableBundles: [
-        { id: 5, name: 'Bundle', caseOrderingMode: 'alternating' }
+        {
+          id: 5,
+          name: 'Bundle',
+          caseOrderingMode: 'alternating',
+          variables: [{ unitName: 'UNIT2', variableId: 'VAR2', includeDeriveError: true }]
+        }
       ]
     }, 2);
 
@@ -619,5 +686,6 @@ describe('CoderTrainingComponent', () => {
       { name: 'Bundle', label: 'Abwechselnd' }
     ]);
     expect(component.variablesFormArray.at(0).get('bundleCaseOrderingMode')?.value).toBe('alternating');
+    expect(component.variablesFormArray.at(0).get('includeDeriveError')?.value).toBe(true);
   });
 });

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.ts
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.ts
@@ -55,6 +55,7 @@ export interface VariableConfig {
   variableId: string;
   unitId: string;
   sampleCount: number;
+  includeDeriveError?: boolean;
 }
 
 export interface VariableGrouping {
@@ -318,7 +319,16 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
 
     if (this.editTraining.assigned_variables) {
       this.editTraining.assigned_variables.forEach(v => {
-        this.addVariable(v.variableId, v.unitName, v.sampleCount || 10, undefined, undefined, true);
+        this.addVariable(
+          v.variableId,
+          v.unitName,
+          v.sampleCount || 10,
+          undefined,
+          undefined,
+          true,
+          undefined,
+          v.includeDeriveError === true
+        );
       });
     }
 
@@ -336,6 +346,7 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
             this.editTraining?.case_ordering_mode ||
             'continuous';
           this.addBundleVariables(b.id, sampleCount, caseOrderingMode, true);
+          this.applyBundleVariableDeriveErrorOptions(b.id, b.variables || []);
           if (this.variablesFormArray.controls.some(control => control.get('bundleId')?.value === b.id)) {
             this.selectedBundleIds.add(b.id);
           }
@@ -367,7 +378,7 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.codingJobBackendService.getCodingIncompleteVariables(workspaceId)
+    this.codingJobBackendService.getCodingIncompleteVariables(workspaceId, undefined, undefined, true)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: variables => {
@@ -671,9 +682,18 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
     }
   }
 
-  addVariable(variableId: string = '', unitId: string = '', sampleCount?: number, bundleId?: number, bundleName?: string, skipUpdate = false, bundleCaseOrderingMode?: 'continuous' | 'alternating'): void {
+  addVariable(
+    variableId: string = '',
+    unitId: string = '',
+    sampleCount?: number,
+    bundleId?: number,
+    bundleName?: string,
+    skipUpdate = false,
+    bundleCaseOrderingMode?: 'continuous' | 'alternating',
+    includeDeriveError = false
+  ): void {
     const variableData = this.getAvailableVariable(unitId, variableId);
-    const maxAvailable = variableData ? this.getEffectiveAvailableCount(unitId, variableId) : 1000;
+    const maxAvailable = variableData ? this.getEffectiveAvailableCount(unitId, variableId, includeDeriveError) : 1000;
     const defaultSampleCount = sampleCount !== undefined ? sampleCount : maxAvailable;
 
     const variableGroup = this.fb.group({
@@ -683,7 +703,8 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       bundleId: [bundleId],
       bundleName: [bundleName],
       overlapWarning: [false],
-      bundleCaseOrderingMode: [bundleCaseOrderingMode || null]
+      bundleCaseOrderingMode: [bundleCaseOrderingMode || null],
+      includeDeriveError: [includeDeriveError]
     });
 
     this.variablesFormArray.push(variableGroup);
@@ -760,7 +781,16 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       if (this.isVariableAlreadyAdded(variable)) {
         duplicateVariables.push(`${variable.unitName} - ${variable.variableId}`);
       } else {
-        this.addVariable(variable.variableId, variable.unitName, sampleCountNum, bundle.id, bundle.name, false, effectiveCaseOrderingMode);
+        this.addVariable(
+          variable.variableId,
+          variable.unitName,
+          sampleCountNum,
+          bundle.id,
+          bundle.name,
+          false,
+          effectiveCaseOrderingMode,
+          variable.includeDeriveError === true
+        );
         addedCount += 1;
       }
     });
@@ -777,6 +807,25 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
     bundle.caseOrderingMode = effectiveCaseOrderingMode;
 
     this.checkForOverlaps();
+  }
+
+  private applyBundleVariableDeriveErrorOptions(
+    bundleId: number,
+    variables: Array<Pick<Variable, 'unitName' | 'variableId' | 'includeDeriveError'>> = []
+  ): void {
+    variables.forEach(variable => {
+      const bundleVariableControl = this.variablesFormArray.controls.find(control => (
+        control.get('bundleId')?.value === bundleId &&
+        control.get('unitId')?.value === variable.unitName &&
+        control.get('variableId')?.value === variable.variableId
+      ));
+      if (bundleVariableControl) {
+        this.setDeriveErrorIncludedForControl(
+          bundleVariableControl as FormGroup,
+          variable.includeDeriveError === true
+        );
+      }
+    });
   }
 
   private isVariableAlreadyAdded(variable: { unitName: string; variableId: string }): boolean {
@@ -953,7 +1002,11 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       const variableId = control.get('variableId')?.value;
       const requestedCount = control.get('sampleCount')?.value || 0;
       const variableData = this.getAvailableVariable(unitId, variableId);
-      const effectiveCount = this.getEffectiveAvailableCount(unitId, variableId);
+      const effectiveCount = this.getEffectiveAvailableCount(
+        unitId,
+        variableId,
+        control.get('includeDeriveError')?.value === true
+      );
       return !!variableData && effectiveCount < requestedCount;
     });
   }
@@ -1121,7 +1174,11 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       const unitId = v.control.get('unitId')?.value;
       const variableId = v.control.get('variableId')?.value;
       const variableData = this.getAvailableVariable(unitId, variableId);
-      const effectiveCount = this.getEffectiveAvailableCount(unitId, variableId);
+      const effectiveCount = this.getEffectiveAvailableCount(
+        unitId,
+        variableId,
+        v.control.get('includeDeriveError')?.value === true
+      );
       return !!variableData && effectiveCount < requestedCount;
     });
   }
@@ -1131,23 +1188,81 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
     const variableId = item.control.get('variableId')?.value;
     const requestedCount = item.control.get('sampleCount')?.value || 0;
     const variableData = this.getAvailableVariable(unitId, variableId);
-    const effectiveCount = this.getEffectiveAvailableCount(unitId, variableId);
+    const effectiveCount = this.getEffectiveAvailableCount(
+      unitId,
+      variableId,
+      item.control.get('includeDeriveError')?.value === true
+    );
     return !!variableData && effectiveCount < requestedCount;
   }
 
   getAvailableCount(item: { control: FormGroup }): number {
     const unitId = item.control.get('unitId')?.value;
     const variableId = item.control.get('variableId')?.value;
-    return this.getEffectiveAvailableCount(unitId, variableId);
+    return this.getEffectiveAvailableCount(
+      unitId,
+      variableId,
+      item.control.get('includeDeriveError')?.value === true
+    );
   }
 
-  private getEffectiveAvailableCount(unitId: string | undefined, variableId: string | undefined): number {
+  private getEffectiveAvailableCount(
+    unitId: string | undefined,
+    variableId: string | undefined,
+    includeDeriveError = false
+  ): number {
     const variableData = this.getAvailableVariable(unitId, variableId);
+    if (includeDeriveError) {
+      return variableData?.uniqueCasesAfterAggregationWithDeriveError ??
+        ((variableData?.uniqueCasesAfterAggregation ?? variableData?.responseCount ?? 0) +
+          (variableData?.deriveErrorResponseCount ?? 0));
+    }
+
     return variableData?.uniqueCasesAfterAggregation ?? variableData?.responseCount ?? 0;
   }
 
   private getAvailableVariable(unitId: string | undefined, variableId: string | undefined): Variable | undefined {
     return this.availableVariables.find(avail => avail.unitName === unitId && avail.variableId === variableId);
+  }
+
+  hasDeriveErrorResponsesForControl(control: FormGroup): boolean {
+    const unitId = control.get('unitId')?.value;
+    const variableId = control.get('variableId')?.value;
+    const variable = this.getAvailableVariable(unitId, variableId);
+    return (variable?.deriveErrorResponseCount ?? 0) > 0 || control.get('includeDeriveError')?.value === true;
+  }
+
+  getDeriveErrorResponseCountForControl(control: FormGroup): number {
+    const unitId = control.get('unitId')?.value;
+    const variableId = control.get('variableId')?.value;
+    return this.getAvailableVariable(unitId, variableId)?.deriveErrorResponseCount ?? 0;
+  }
+
+  isDeriveErrorIncludedForControl(control: FormGroup): boolean {
+    return control.get('includeDeriveError')?.value === true;
+  }
+
+  setDeriveErrorIncludedForControl(control: FormGroup, includeDeriveError: boolean): void {
+    control.get('includeDeriveError')?.setValue(includeDeriveError);
+    const unitId = control.get('unitId')?.value;
+    const variableId = control.get('variableId')?.value;
+    const maxAvailable = this.getEffectiveAvailableCount(unitId, variableId, includeDeriveError);
+    control.get('sampleCount')?.setValidators([
+      Validators.required,
+      Validators.min(1),
+      Validators.max(maxAvailable)
+    ]);
+    if (includeDeriveError && (Number(control.get('sampleCount')?.value) || 0) < 1 && maxAvailable > 0) {
+      control.get('sampleCount')?.setValue(maxAvailable);
+    }
+    control.get('sampleCount')?.updateValueAndValidity();
+    this.updateGroupedVariables();
+  }
+
+  getSelectedDeriveErrorOptInCount(): number {
+    return this.variablesFormArray.controls.filter(control => (
+      control.get('includeDeriveError')?.value === true
+    )).length;
   }
 
   getBundleOrderingOverrides(): BundleOrderingOverride[] {
@@ -1174,6 +1289,10 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       .join(', ');
   }
 
+  getBundleDeriveErrorControls(bundleGroup: { variables: { control: FormGroup; index: number }[] }): { control: FormGroup; index: number }[] {
+    return bundleGroup.variables.filter(item => this.hasDeriveErrorResponsesForControl(item.control));
+  }
+
   trackByCoderId(index: number, coder: Coder): number {
     return coder.id;
   }
@@ -1191,7 +1310,8 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       return {
         variableId,
         unitId: control.get('unitId')?.value || '',
-        sampleCount: control.get('sampleCount')?.value || 10
+        sampleCount: control.get('sampleCount')?.value || 10,
+        ...(control.get('includeDeriveError')?.value === true ? { includeDeriveError: true } : {})
       };
     });
 
@@ -1205,16 +1325,23 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
 
     const trainingLabel = this.trainingForm.get('trainingLabel')?.value || '';
 
-    const assignedVariables: { unitName: string; variableId: string; sampleCount: number }[] =
+    const assignedVariables: { unitName: string; variableId: string; sampleCount: number; includeDeriveError?: boolean }[] =
       this.variablesFormArray.controls
         .filter(c => !c.get('bundleId')?.value)
         .map(c => ({
           variableId: c.get('variableId')?.value,
           unitName: c.get('unitId')?.value,
-          sampleCount: c.get('sampleCount')?.value
+          sampleCount: c.get('sampleCount')?.value,
+          ...(c.get('includeDeriveError')?.value === true ? { includeDeriveError: true } : {})
         }));
 
-    const assignedVariableBundles: { id: number; name: string; sampleCount: number; caseOrderingMode?: 'continuous' | 'alternating' }[] = [];
+    const assignedVariableBundles: {
+      id: number;
+      name: string;
+      sampleCount: number;
+      caseOrderingMode?: 'continuous' | 'alternating';
+      variables?: { unitName: string; variableId: string; sampleCount?: number; includeDeriveError?: boolean }[];
+    }[] = [];
     const seenBundleIds = new Set<number>();
     this.variablesFormArray.controls.forEach(c => {
       const bundleId = c.get('bundleId')?.value;
@@ -1226,7 +1353,15 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
           id: bundleId,
           name: c.get('bundleName')?.value,
           sampleCount: c.get('sampleCount')?.value || 10,
-          caseOrderingMode: bundleCaseOrderingMode || this.trainingForm.get('caseOrderingMode')?.value || 'continuous'
+          caseOrderingMode: bundleCaseOrderingMode || this.trainingForm.get('caseOrderingMode')?.value || 'continuous',
+          variables: this.variablesFormArray.controls
+            .filter(control => control.get('bundleId')?.value === bundleId)
+            .map(control => ({
+              unitName: control.get('unitId')?.value,
+              variableId: control.get('variableId')?.value,
+              sampleCount: control.get('sampleCount')?.value || 10,
+              ...(control.get('includeDeriveError')?.value === true ? { includeDeriveError: true } : {})
+            }))
         });
       }
     });
@@ -1337,7 +1472,16 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
         );
         if (!isAlreadyAdded) {
           const sampleCount = v.casesInJobs ?? defaultSampleCount;
-          this.addVariable(v.variableId, v.unitName, sampleCount, undefined, undefined, true);
+          this.addVariable(
+            v.variableId,
+            v.unitName,
+            sampleCount,
+            undefined,
+            undefined,
+            true,
+            undefined,
+            v.includeDeriveError === true
+          );
           varsAdded += 1;
         }
       });
@@ -1353,6 +1497,7 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
             bundlesAdded += 1;
           }
         }
+        this.applyBundleVariableDeriveErrorOptions(b.id, b.variables || []);
       });
       this.bundleSelection$.next(Array.from(this.selectedBundleIds));
     }

--- a/apps/frontend/src/app/coding/models/coder-training.model.ts
+++ b/apps/frontend/src/app/coding/models/coder-training.model.ts
@@ -14,8 +14,14 @@ export interface CoderTraining {
   created_at: Date;
   updated_at: Date;
   jobsCount: number;
-  assigned_variables?: { unitName: string; variableId: string; sampleCount: number }[];
-  assigned_variable_bundles?: { id: number; name: string; sampleCount?: number; caseOrderingMode?: 'continuous' | 'alternating' }[];
+  assigned_variables?: { unitName: string; variableId: string; sampleCount: number; includeDeriveError?: boolean }[];
+  assigned_variable_bundles?: {
+    id: number;
+    name: string;
+    sampleCount?: number;
+    caseOrderingMode?: 'continuous' | 'alternating';
+    variables?: { unitName: string; variableId: string; sampleCount?: number; includeDeriveError?: boolean }[];
+  }[];
   assigned_coders?: number[];
   case_ordering_mode?: 'continuous' | 'alternating';
   case_selection_mode?: CaseSelectionMode;

--- a/apps/frontend/src/app/coding/models/coding-job.model.ts
+++ b/apps/frontend/src/app/coding/models/coding-job.model.ts
@@ -71,6 +71,8 @@ export interface Variable {
   casesInJobs?: number;
   availableCases?: number;
   uniqueCasesAfterAggregation?: number;
+  availableCasesWithDeriveError?: number;
+  uniqueCasesAfterAggregationWithDeriveError?: number;
   isDerived?: boolean;
   coderTrainingRequired?: boolean;
   includeDeriveError?: boolean;

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -432,7 +432,8 @@ export class CodingJobBackendService {
   getCodingIncompleteVariables(
     workspaceId: number,
     unitName?: string,
-    trainingRequired?: boolean
+    trainingRequired?: boolean,
+    includeDeriveErrorOnly?: boolean
   ): Observable<
     {
       unitName: string;
@@ -442,6 +443,8 @@ export class CodingJobBackendService {
       casesInJobs: number;
       availableCases: number;
       uniqueCasesAfterAggregation: number;
+      availableCasesWithDeriveError?: number;
+      uniqueCasesAfterAggregationWithDeriveError?: number;
       isDerived: boolean;
       coderTrainingRequired?: boolean;
     }[]
@@ -454,6 +457,9 @@ export class CodingJobBackendService {
     if (trainingRequired !== undefined) {
       params = params.set('trainingRequired', trainingRequired.toString());
     }
+    if (includeDeriveErrorOnly !== undefined) {
+      params = params.set('includeDeriveErrorOnly', includeDeriveErrorOnly.toString());
+    }
     params = params.set('_t', Date.now().toString());
     return this.http.get<
     {
@@ -464,6 +470,8 @@ export class CodingJobBackendService {
       casesInJobs: number;
       availableCases: number;
       uniqueCasesAfterAggregation: number;
+      availableCasesWithDeriveError?: number;
+      uniqueCasesAfterAggregationWithDeriveError?: number;
       isDerived: boolean;
       coderTrainingRequired?: boolean;
     }[]

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
@@ -65,11 +65,26 @@ describe('CodingTrainingBackendService', () => {
       service.createCoderTrainingJobs(
         1,
         [{ id: 2, name: 'Coder' }],
-        [{ variableId: 'v1', unitId: 'u1', sampleCount: 3 }],
+        [{
+          variableId: 'v1',
+          unitId: 'u1',
+          sampleCount: 3,
+          includeDeriveError: true
+        }],
         'With Options',
         99,
-        [{ unitName: 'Unit', variableId: 'v1', sampleCount: 5 }],
-        [{ id: 7, name: 'Bundle', caseOrderingMode: 'alternating' }],
+        [{
+          unitName: 'Unit',
+          variableId: 'v1',
+          sampleCount: 5,
+          includeDeriveError: true
+        }],
+        [{
+          id: 7,
+          name: 'Bundle',
+          caseOrderingMode: 'alternating',
+          variables: [{ unitName: 'Unit', variableId: 'v2', includeDeriveError: true }]
+        }],
         'alternating',
         'random',
         [10, 11],
@@ -82,10 +97,25 @@ describe('CodingTrainingBackendService', () => {
       expect(req.request.body).toEqual({
         trainingLabel: 'With Options',
         selectedCoders: [{ id: 2, name: 'Coder' }],
-        variableConfigs: [{ variableId: 'v1', unitId: 'u1', sampleCount: 3 }],
+        variableConfigs: [{
+          variableId: 'v1',
+          unitId: 'u1',
+          sampleCount: 3,
+          includeDeriveError: true
+        }],
         missingsProfileId: 99,
-        assignedVariables: [{ unitName: 'Unit', variableId: 'v1', sampleCount: 5 }],
-        assignedVariableBundles: [{ id: 7, name: 'Bundle', caseOrderingMode: 'alternating' }],
+        assignedVariables: [{
+          unitName: 'Unit',
+          variableId: 'v1',
+          sampleCount: 5,
+          includeDeriveError: true
+        }],
+        assignedVariableBundles: [{
+          id: 7,
+          name: 'Bundle',
+          caseOrderingMode: 'alternating',
+          variables: [{ unitName: 'Unit', variableId: 'v2', includeDeriveError: true }]
+        }],
         caseOrderingMode: 'alternating',
         caseSelectionMode: 'random',
         referenceTrainingIds: [10, 11],

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -96,11 +96,18 @@ export class CodingTrainingBackendService {
       variableId: string;
       unitId: string;
       sampleCount: number;
+      includeDeriveError?: boolean;
     }[],
     trainingLabel: string,
     missingsProfileId?: number,
-    assignedVariables?: { unitName: string; variableId: string; sampleCount: number }[],
-    assignedVariableBundles?: { id: number; name: string; sampleCount?: number; caseOrderingMode?: 'continuous' | 'alternating' }[],
+    assignedVariables?: { unitName: string; variableId: string; sampleCount: number; includeDeriveError?: boolean }[],
+    assignedVariableBundles?: {
+      id: number;
+      name: string;
+      sampleCount?: number;
+      caseOrderingMode?: 'continuous' | 'alternating';
+      variables?: { unitName: string; variableId: string; sampleCount?: number; includeDeriveError?: boolean }[];
+    }[],
     caseOrderingMode?: 'continuous' | 'alternating',
     caseSelectionMode?: 'oldest_first' | 'newest_first' | 'random' | 'random_per_testgroup' | 'random_testgroups',
     referenceTrainingIds?: number[],
@@ -133,10 +140,16 @@ export class CodingTrainingBackendService {
     trainingId: number,
     label: string,
     selectedCoders: { id: number; name: string }[],
-    variableConfigs: { variableId: string; unitId: string; sampleCount: number }[],
+    variableConfigs: { variableId: string; unitId: string; sampleCount: number; includeDeriveError?: boolean }[],
     missingsProfileId?: number,
-    assignedVariables?: { unitName: string; variableId: string; sampleCount: number }[],
-    assignedVariableBundles?: { id: number; name: string; sampleCount?: number; caseOrderingMode?: 'continuous' | 'alternating' }[],
+    assignedVariables?: { unitName: string; variableId: string; sampleCount: number; includeDeriveError?: boolean }[],
+    assignedVariableBundles?: {
+      id: number;
+      name: string;
+      sampleCount?: number;
+      caseOrderingMode?: 'continuous' | 'alternating';
+      variables?: { unitName: string; variableId: string; sampleCount?: number; includeDeriveError?: boolean }[];
+    }[],
     caseOrderingMode?: 'continuous' | 'alternating',
     caseSelectionMode?: 'oldest_first' | 'newest_first' | 'random' | 'random_per_testgroup' | 'random_testgroups',
     referenceTrainingIds?: number[],

--- a/database/changelog/coding-box.changelog-1.16.1.sql
+++ b/database/changelog/coding-box.changelog-1.16.1.sql
@@ -1,0 +1,9 @@
+-- liquibase formatted sql
+
+-- changeset jurei733:1
+-- comment: Persist DERIVE_ERROR opt-in for coder-training variables
+
+ALTER TABLE "public"."coder_training_variable"
+  ADD COLUMN "include_derive_error" BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- rollback ALTER TABLE "public"."coder_training_variable" DROP COLUMN IF EXISTS "include_derive_error";

--- a/database/changelog/coding-box.changelog-root.xml
+++ b/database/changelog/coding-box.changelog-root.xml
@@ -39,4 +39,5 @@
   <include file="coding-box.changelog-1.14.1.sql"/>
   <include file="coding-box.changelog-1.15.0.sql"/>
   <include file="coding-box.changelog-1.16.0.sql"/>
+  <include file="coding-box.changelog-1.16.1.sql"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Überblick

Bezieht sich auf #547, ohne das Issue automatisch zu schließen.

- vereinheitlicht den Fallbegriff von Analyse und Schulung über gemeinsame Dedupe-/Aggregationslogik
- ergänzt DERIVE_ERROR-Zählwerte und DERIVE_ERROR-aware Verfügbarkeitswerte in der Analyse
- speichert DERIVE_ERROR-Opt-ins für Schulungsvariablen dauerhaft in coder_training_variable
- stellt DERIVE_ERROR-Opt-ins im Schulungsdialog dar, sendet sie ans Backend und stellt sie beim Bearbeiten wieder her
- schützt Bundle-Auswahlen gegen workspace-fremde oder ungültige Bundle-IDs

## Validierung

- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts --runInBand
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coder-training.service.spec.ts --runInBand
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts --runInBand
- npx nx test frontend --testFile=apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts --runInBand
- npx nx lint backend
- npx nx lint frontend
- git diff --check develop..HEAD
