### PR TITLE
fix(frontend): refresh replay anchor after response switch

### DIFF
--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -396,10 +396,12 @@ describe('ReplayComponent', () => {
       alias: null,
       bookletId: 0,
       variableId: 'VAR_2',
+      variableAnchor: 'ANCHOR_2',
       variablePage: '1'
     });
 
     expect(component.page).toBe('1');
+    expect(component.anchor).toBe('ANCHOR_2');
     expect(component.codingService.currentVariableId).toBe('VAR_2');
   });
 

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -698,12 +698,13 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       name: string;
       testPerson?: string;
       variableId?: string;
+      variableAnchor?: string;
       variablePage?: string;
     };
     const incomingTestPerson = unitAny.testPerson;
 
     if (typeof unitAny.variableId === 'string' && unitAny.variableId.length > 0) {
-      this.anchor = unitAny.variableId;
+      this.anchor = unitAny.variableAnchor || unitAny.variableId;
       this.codingService.currentVariableId = unitAny.variableId;
     }
 

--- a/apps/frontend/src/app/replay/components/unit-player/unit-player.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/unit-player/unit-player.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimpleChange } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { HttpClientModule } from '@angular/common/http';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -53,6 +54,32 @@ describe('UnitPlayerComponent', () => {
     }));
 
     expect(emitSpy).toHaveBeenCalled();
+  });
+
+  it('should emit responseVisible again after unit responses change', () => {
+    const emitSpy = jest.spyOn(component.responseVisible, 'emit');
+    const appService = TestBed.inject(AppService);
+    const source = component.hostingIframe.nativeElement.contentWindow;
+    const emitPlayerStateChanged = () => appService.postMessage$.next(new MessageEvent('message', {
+      data: {
+        type: 'vopStateChangedNotification'
+      },
+      source
+    }));
+
+    emitPlayerStateChanged();
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+
+    component.ngOnChanges({
+      unitResponses: new SimpleChange(
+        { responses: [{ id: '1', content: 'old response' }] },
+        { responses: [{ id: '1', content: 'new response' }] },
+        false
+      )
+    });
+    emitPlayerStateChanged();
+
+    expect(emitSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should not emit a page error when requested page 0 is valid and current', () => {

--- a/apps/frontend/src/app/replay/components/unit-player/unit-player.component.ts
+++ b/apps/frontend/src/app/replay/components/unit-player/unit-player.component.ts
@@ -80,6 +80,7 @@ export class UnitPlayerComponent implements AfterViewInit, OnChanges, OnDestroy 
       this.handleUnitDefChange(unitDefChange.currentValue, unitPlayerChange, unitResponsesChange);
     } else if (unitResponsesChange?.currentValue &&
       unitResponsesChange.previousValue !== unitResponsesChange.currentValue) {
+      this.hasEmittedResponseVisible = false;
       this.handleResponsesChange(unitResponsesChange.currentValue);
       this.sendUnitData();
     }


### PR DESCRIPTION
## Summary

- reset the UnitPlayer response-visible emission guard when replay responses change
- use `variableAnchor || variableId` for replay anchor highlighting during coding case navigation
- add focused Jest coverage for response-change visibility and anchor selection

## Root Cause

When navigating between cases in the same loaded replay/coding view, the unit definition and player can stay unchanged while only `unitResponses` change. `UnitPlayerComponent` only reset `hasEmittedResponseVisible` on `unitDef` changes, so later response-visible notifications could be suppressed and the parent would not restart anchor highlighting. The later navigation path also used only `variableId` as the highlight anchor, while initial loading already preferred `variableAnchor`.

Refs #514

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/replay/components/unit-player/unit-player.component.spec.ts`
- `npx nx test frontend --testFile=apps/frontend/src/app/replay/components/replay/replay.component.spec.ts`
- `npx nx lint frontend`
- `npx nx test frontend`
