### PR TITLE
Test VOCS replay page overrides

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-export.high-coverage.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.high-coverage.spec.ts
@@ -193,7 +193,9 @@ describe('CodingExportService high coverage paths', () => {
       1,
       'token',
       'http://server'
-    )).resolves.toContain('UNIT');
+    )).resolves.toBe(
+      'http://server/#/replay/login@code@group@BOOKLET/UNIT/2/VAR?auth=token'
+    );
   });
 
   it('enters the heavier coding result export variants with cancellable safe repositories', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-file-cache.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-file-cache.service.spec.ts
@@ -100,6 +100,26 @@ describe('CodingFileCacheService', () => {
     expect(pageMap.get('VAR_ALIAS')).toBe('1');
   });
 
+  it('parses VOCS page overrides from already structured file data', async () => {
+    const repository = createRepository({
+      'UNIT.VOCS': {
+        file_id: 'UNIT.VOCS',
+        file_type: 'Resource',
+        workspace_id: 1,
+        data: {
+          variableCodings: [
+            { id: 'STRUCTURED_VAR', page: '3' }
+          ]
+        } as unknown as string
+      }
+    });
+    const service = new CodingFileCacheService(repository);
+
+    const pageMap = await service.loadVoudData('UNIT', 1);
+
+    expect(pageMap.get('STRUCTURED_VAR')).toBe('2');
+  });
+
   it('ignores empty and invalid VOCS pages and keeps VOUD fallback pages', async () => {
     const repository = createRepository({
       'UNIT.VOUD': createFile('UNIT.VOUD', {

--- a/apps/backend/src/app/database/services/coding/coding-file-cache.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-file-cache.service.ts
@@ -5,6 +5,17 @@ import FileUpload from '../../entities/file_upload.entity';
 import { resolveVariablePageMap } from '../../../utils/voud/resolveVariablePageMap';
 import { LRUCache } from '../shared';
 
+interface VocsVariableCoding {
+  id?: unknown;
+  alias?: unknown;
+  page?: unknown;
+  sourceType?: unknown;
+}
+
+interface VocsScheme {
+  variableCodings?: VocsVariableCoding[];
+}
+
 /**
  * Service responsible for loading, parsing, and caching VOUD and VOCS files.
  *
@@ -88,15 +99,7 @@ export class CodingFileCacheService {
     }
 
     try {
-      interface VocsScheme {
-        variableCodings?: {
-          id?: unknown;
-          alias?: unknown;
-          page?: unknown;
-        }[];
-      }
-
-      const scheme = JSON.parse(vocsFile.data) as VocsScheme;
+      const scheme = this.parseVocsScheme(vocsFile.data);
       const vars = Array.isArray(scheme?.variableCodings) ?
         scheme.variableCodings :
         [];
@@ -117,6 +120,10 @@ export class CodingFileCacheService {
     }
 
     return pageOverrides;
+  }
+
+  private parseVocsScheme(data: unknown): VocsScheme {
+    return (typeof data === 'string' ? JSON.parse(data) : data) as VocsScheme;
   }
 
   private toVeronaPageIndex(page: unknown): string | null {
@@ -176,25 +183,15 @@ export class CodingFileCacheService {
 
     if (vocsFile) {
       try {
-        interface VocsScheme {
-          variableCodings?: { id: string; sourceType?: string }[];
-        }
-
-        const data =
-          typeof vocsFile.data === 'string' ?
-            JSON.parse(vocsFile.data) :
-            vocsFile.data;
-        const scheme = data as VocsScheme;
-        const vars = scheme?.variableCodings || [];
+        const scheme = this.parseVocsScheme(vocsFile.data);
+        const vars = Array.isArray(scheme?.variableCodings) ?
+          scheme.variableCodings :
+          [];
 
         for (const vc of vars) {
-          if (
-            vc &&
-            vc.id &&
-            vc.sourceType &&
-            vc.sourceType === 'BASE_NO_VALUE'
-          ) {
-            exclusions.add(`${unitName}||${vc.id}`);
+          const variableId = String(vc?.id || '').trim();
+          if (variableId && vc?.sourceType === 'BASE_NO_VALUE') {
+            exclusions.add(`${unitName}||${variableId}`);
           }
         }
       } catch (error) {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -2302,4 +2302,42 @@ describe('CodingJobService', () => {
     expect(result[0].isDoubleCoded).toBe(true);
     expect(result[0].otherCoders).toEqual(['coder1']);
   });
+
+  it('returns resolved page overrides for coding job units', async () => {
+    codingJobRepository.findOne.mockResolvedValue({
+      id: 10,
+      workspace_id: 3,
+      job_definition_id: 5,
+      training_id: null,
+      case_ordering_mode: 'continuous',
+      codingJobCoders: []
+    });
+    codingJobVariableBundleRepository.find.mockResolvedValue([]);
+    codingJobUnitRepository.find
+      .mockResolvedValueOnce([{
+        response_id: 99,
+        unit_name: 'UNIT',
+        unit_alias: 'UNIT',
+        variable_id: 'VAR_WITH_OVERRIDE',
+        variable_anchor: 'VAR_WITH_OVERRIDE',
+        booklet_name: 'BOOKLET',
+        person_login: 'login',
+        person_code: '',
+        person_group: 'group',
+        notes: null,
+        variable_bundle_id: null
+      }])
+      .mockResolvedValueOnce([]);
+    codingFileCacheService.getVariablePageMap.mockResolvedValue(new Map([
+      ['VAR_WITH_OVERRIDE', '1']
+    ]));
+
+    const result = await service.getCodingJobUnits(10);
+
+    expect(codingFileCacheService.getVariablePageMap).toHaveBeenCalledWith('UNIT', 3);
+    expect(result[0]).toMatchObject({
+      variableId: 'VAR_WITH_OVERRIDE',
+      variablePage: '1'
+    });
+  });
 });

--- a/apps/backend/src/app/database/services/coding/coding-replay.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-replay.service.spec.ts
@@ -583,5 +583,39 @@ describe('CodingReplayService', () => {
         })
       );
     });
+
+    it('should use resolved page overrides for coding job replay URLs', async () => {
+      const items = [
+        {
+          responseId: 1,
+          unitName: 'UNIT',
+          unitAlias: null,
+          variableId: 'VAR_WITH_OVERRIDE',
+          variableAnchor: 'VAR_WITH_OVERRIDE',
+          bookletName: 'BOOKLET',
+          personLogin: 'login',
+          personCode: 'code',
+          personGroup: 'group'
+        }
+      ];
+
+      mockCodingListService.getVariablePageMap.mockResolvedValue(new Map([
+        ['VAR_WITH_OVERRIDE', '1']
+      ]));
+      (replayUrlUtil.generateReplayUrl as jest.Mock).mockImplementation(params => (
+        `${params.serverUrl}/#/replay/${params.loginName}@${params.loginCode}@${params.loginGroup}@${params.bookletId}/${params.unitId}/${params.variablePage}/${params.variableAnchor}?auth=${params.authToken}`
+      ));
+
+      const result = await service.generateReplayUrlsForItemsBulk(
+        7,
+        items,
+        'http://example.com'
+      );
+
+      expect(mockCodingListService.getVariablePageMap).toHaveBeenCalledWith('UNIT', 7);
+      expect(result[0].replayUrl).toBe(
+        'http://example.com/#/replay/login@code@group@BOOKLET/UNIT/1/VAR_WITH_OVERRIDE'
+      );
+    });
   });
 });


### PR DESCRIPTION
Relates to #657.

## What changed
- Centralized VOCS parsing in the coding file cache so VOCS data can be handled whether it is stored as JSON text or already structured data.
- Added regression coverage for VOCS page overrides in the coding file cache.
- Added regression coverage that coding job units and coding-job replay URLs use resolved page overrides.
- Tightened the export replay URL assertion to verify the resolved page value exactly.

## Why
Issue #657 requires VOCS/Studio page values to override VOUD replay pages, including coding-list, export, and coding-job replay flows. The existing hotfix path was present; this PR hardens the parsing path and protects the affected replay consumers with tests.

## Validation
- `npx nx lint backend`
- `npx nx test backend --runInBand`
- Focused Jest specs for the changed coding services
