### PR TITLE
Scope für manuelle Kodierungsexporte

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
@@ -198,7 +198,10 @@ describe('WorkspaceCodingStatisticsController', () => {
       'true',
       undefined,
       undefined,
-      'false'
+      'false',
+      '11,12',
+      '21',
+      ['31', '32']
     );
 
     expect(result.variables[0].meanKappa).toBe(0.667);
@@ -214,7 +217,7 @@ describe('WorkspaceCodingStatisticsController', () => {
     expect(result.workspaceSummary.totalDoubleCodedResponses).toBe(1);
     expect(
       codingReviewService.getCodedVariablesForKappa
-    ).toHaveBeenCalledWith(5, false);
+    ).toHaveBeenCalledWith(5, false, [11, 12], [21], [31, 32]);
   });
 
   it('adds unweighted mean kappa per variable to detailed kappa statistics', async () => {
@@ -356,11 +359,14 @@ describe('WorkspaceCodingStatisticsController', () => {
       'UNIT',
       'VAR',
       'false',
+      undefined,
+      undefined,
+      undefined,
       response as never
     );
 
     expect(codingReviewService.getCodedVariablesForKappa)
-      .toHaveBeenCalledWith(5, false);
+      .toHaveBeenCalledWith(5, false, [], [], []);
     expect(response.setHeader).toHaveBeenCalledWith(
       'Content-Type',
       'text/csv; charset=utf-8'
@@ -437,6 +443,9 @@ describe('WorkspaceCodingStatisticsController', () => {
       '=UNIT',
       '+VAR',
       'true',
+      undefined,
+      undefined,
+      undefined,
       response as never
     );
 
@@ -526,6 +535,9 @@ describe('WorkspaceCodingStatisticsController', () => {
       undefined,
       undefined,
       'true',
+      undefined,
+      undefined,
+      undefined,
       response as never
     );
 
@@ -613,6 +625,9 @@ describe('WorkspaceCodingStatisticsController', () => {
       undefined,
       undefined,
       'true',
+      undefined,
+      undefined,
+      undefined,
       response as never
     );
 
@@ -707,6 +722,9 @@ describe('WorkspaceCodingStatisticsController', () => {
       undefined,
       undefined,
       'true',
+      undefined,
+      undefined,
+      undefined,
       response as never
     );
 
@@ -810,6 +828,9 @@ describe('WorkspaceCodingStatisticsController', () => {
       undefined,
       undefined,
       'true',
+      undefined,
+      undefined,
+      undefined,
       response as never
     );
 

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -152,6 +152,16 @@ type KappaStatisticsBuildResult = KappaStatisticsResponse & {
   sourceItems: KappaSourceItem[];
 };
 
+type KappaStatisticsOptions = {
+  weightedMean: boolean;
+  excludeTrainings: boolean;
+  unitName?: string;
+  variableId?: string;
+  jobDefinitionIds: number[];
+  coderTrainingIds: number[];
+  coderIds: number[];
+};
+
 type KappaSourceItem = {
   unitName: string;
   variableId: string;
@@ -426,12 +436,7 @@ export class WorkspaceCodingStatisticsController {
 
   private createCohensKappaExportRows(
     statistics: KappaStatisticsResponse,
-    options: {
-      weightedMean: boolean;
-      excludeTrainings: boolean;
-      unitName?: string;
-      variableId?: string;
-    }
+    options: Pick<KappaStatisticsOptions, 'weightedMean' | 'excludeTrainings' | 'unitName' | 'variableId'>
   ): Record<string, string | number>[] {
     const exportedAt = new Date().toISOString();
     const weightingMethod = options.weightedMean ?
@@ -663,12 +668,7 @@ export class WorkspaceCodingStatisticsController {
 
   private async buildCohensKappaStatistics(
     workspaceId: number,
-    options: {
-      weightedMean: boolean;
-      excludeTrainings: boolean;
-      unitName?: string;
-      variableId?: string;
-    }
+    options: KappaStatisticsOptions
   ): Promise<KappaStatisticsBuildResult> {
     this.logger.log(
       `Calculating Cohen's Kappa for workspace ${workspaceId}${options.unitName ? `, unit: ${options.unitName}` : ''
@@ -677,7 +677,10 @@ export class WorkspaceCodingStatisticsController {
 
     const allCodedItems = (await this.codingReviewService.getCodedVariablesForKappa(
       workspaceId,
-      options.excludeTrainings
+      options.excludeTrainings,
+      options.jobDefinitionIds,
+      options.coderTrainingIds,
+      options.coderIds
     )).map(item => ({
       unitName: item.unitName,
       variableId: item.variableId,
@@ -1162,6 +1165,38 @@ export class WorkspaceCodingStatisticsController {
       .flatMap(item => String(item).split(','))
       .map(item => item.trim())
       .filter(item => item !== '');
+  }
+
+  private parseIdArrayQuery(value?: string | string[]): number[] {
+    return this.parseArrayQuery(value).map(item => {
+      const parsed = Number(item);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new BadRequestException('ID query values must be positive integers');
+      }
+      return parsed;
+    });
+  }
+
+  private buildKappaOptionsFromQuery(query: {
+    weightedMean?: string;
+    excludeTrainings?: string;
+    unitName?: string;
+    variableId?: string;
+    jobDefinitionIds?: string | string[];
+    coderTrainingIds?: string | string[];
+    coderIds?: string | string[];
+  }): KappaStatisticsOptions {
+    const coderTrainingIds = this.parseIdArrayQuery(query.coderTrainingIds);
+
+    return {
+      weightedMean: query.weightedMean !== 'false',
+      excludeTrainings: coderTrainingIds.length > 0 ? false : query.excludeTrainings !== 'false',
+      unitName: query.unitName,
+      variableId: query.variableId,
+      jobDefinitionIds: this.parseIdArrayQuery(query.jobDefinitionIds),
+      coderTrainingIds,
+      coderIds: this.parseIdArrayQuery(query.coderIds)
+    };
   }
 
   @Get(':workspace_id/coding/groups')
@@ -1719,6 +1754,24 @@ export class WorkspaceCodingStatisticsController {
     description: 'Exclude coder training jobs (default: true)',
     type: Boolean
   })
+  @ApiQuery({
+    name: 'jobDefinitionIds',
+    required: false,
+    description: 'Limit statistics to one or more job definition IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderTrainingIds',
+    required: false,
+    description: 'Limit statistics to one or more coder training IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderIds',
+    required: false,
+    description: 'Limit statistics to one or more coder IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
   @ApiOkResponse({
     description:
       "Cohen's Kappa statistics for double-coded variables with workspace summary.",
@@ -1824,20 +1877,27 @@ export class WorkspaceCodingStatisticsController {
       @Query('weightedMean') weightedMean?: string,
       @Query('unitName') unitName?: string,
       @Query('variableId') variableId?: string,
-      @Query('excludeTrainings') excludeTrainings?: string
+      @Query('excludeTrainings') excludeTrainings?: string,
+      @Query('jobDefinitionIds') jobDefinitionIds?: string | string[],
+      @Query('coderTrainingIds') coderTrainingIds?: string | string[],
+      @Query('coderIds') coderIds?: string | string[]
   ): Promise<KappaStatisticsResponse> {
     try {
-      const useWeightedMean = weightedMean !== 'false'; // Default true
-      const isExcludeTrainings = excludeTrainings !== 'false'; // Default true
-
-      const statistics = await this.buildCohensKappaStatistics(workspace_id, {
-        weightedMean: useWeightedMean,
-        excludeTrainings: isExcludeTrainings,
+      const options = this.buildKappaOptionsFromQuery({
+        weightedMean,
+        excludeTrainings,
         unitName,
-        variableId
+        variableId,
+        jobDefinitionIds,
+        coderTrainingIds,
+        coderIds
       });
+      const statistics = await this.buildCohensKappaStatistics(workspace_id, options);
       return this.toPublicCohensKappaStatistics(statistics);
     } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       this.logger.error(
         `Error calculating Cohen's Kappa: ${error.message}`,
         error.stack
@@ -1876,6 +1936,24 @@ export class WorkspaceCodingStatisticsController {
     description: 'Exclude coder training jobs (default: true)',
     type: Boolean
   })
+  @ApiQuery({
+    name: 'jobDefinitionIds',
+    required: false,
+    description: 'Limit export to one or more job definition IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderTrainingIds',
+    required: false,
+    description: 'Limit export to one or more coder training IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderIds',
+    required: false,
+    description: 'Limit export to one or more coder IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
   @ApiOkResponse({
     description: "Cohen's Kappa coder-pair details exported as CSV.",
     content: {
@@ -1893,23 +1971,23 @@ export class WorkspaceCodingStatisticsController {
       @Query('unitName') unitName: string | undefined,
       @Query('variableId') variableId: string | undefined,
       @Query('excludeTrainings') excludeTrainings: string | undefined,
+      @Query('jobDefinitionIds') jobDefinitionIds: string | string[] | undefined,
+      @Query('coderTrainingIds') coderTrainingIds: string | string[] | undefined,
+      @Query('coderIds') coderIds: string | string[] | undefined,
       @Res() res: Response
   ): Promise<void> {
     try {
-      const useWeightedMean = weightedMean !== 'false';
-      const isExcludeTrainings = excludeTrainings !== 'false';
-      const statistics = await this.buildCohensKappaStatistics(workspace_id, {
-        weightedMean: useWeightedMean,
-        excludeTrainings: isExcludeTrainings,
+      const options = this.buildKappaOptionsFromQuery({
+        weightedMean,
+        excludeTrainings,
         unitName,
-        variableId
+        variableId,
+        jobDefinitionIds,
+        coderTrainingIds,
+        coderIds
       });
-      const rows = this.createCohensKappaExportRows(statistics, {
-        weightedMean: useWeightedMean,
-        excludeTrainings: isExcludeTrainings,
-        unitName,
-        variableId
-      });
+      const statistics = await this.buildCohensKappaStatistics(workspace_id, options);
+      const rows = this.createCohensKappaExportRows(statistics, options);
       const csvContent = await fastCsv.writeToString(rows, {
         headers: [...COHENS_KAPPA_EXPORT_HEADERS],
         alwaysWriteHeaders: true,
@@ -1925,6 +2003,9 @@ export class WorkspaceCodingStatisticsController {
       );
       res.send(`\uFEFF${csvContent}`);
     } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       this.logger.error(
         `Error exporting Cohen's Kappa CSV: ${error.message}`,
         error.stack
@@ -1963,6 +2044,24 @@ export class WorkspaceCodingStatisticsController {
     description: 'Exclude coder training jobs (default: true)',
     type: Boolean
   })
+  @ApiQuery({
+    name: 'jobDefinitionIds',
+    required: false,
+    description: 'Limit export to one or more job definition IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderTrainingIds',
+    required: false,
+    description: 'Limit export to one or more coder training IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderIds',
+    required: false,
+    description: 'Limit export to one or more coder IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
   @ApiOkResponse({
     description: "Cohen's Kappa variable summary exported as CSV.",
     content: {
@@ -1980,15 +2079,22 @@ export class WorkspaceCodingStatisticsController {
       @Query('unitName') unitName: string | undefined,
       @Query('variableId') variableId: string | undefined,
       @Query('excludeTrainings') excludeTrainings: string | undefined,
+      @Query('jobDefinitionIds') jobDefinitionIds: string | string[] | undefined,
+      @Query('coderTrainingIds') coderTrainingIds: string | string[] | undefined,
+      @Query('coderIds') coderIds: string | string[] | undefined,
       @Res() res: Response
   ): Promise<void> {
     try {
-      const statistics = await this.buildCohensKappaStatistics(workspace_id, {
-        weightedMean: weightedMean !== 'false',
-        excludeTrainings: excludeTrainings !== 'false',
+      const options = this.buildKappaOptionsFromQuery({
+        weightedMean,
+        excludeTrainings,
         unitName,
-        variableId
+        variableId,
+        jobDefinitionIds,
+        coderTrainingIds,
+        coderIds
       });
+      const statistics = await this.buildCohensKappaStatistics(workspace_id, options);
       const csvContent = await fastCsv.writeToString(
         this.createCohensKappaSummaryExportRows(statistics),
         {
@@ -2007,6 +2113,9 @@ export class WorkspaceCodingStatisticsController {
       );
       res.send(`\uFEFF${csvContent}`);
     } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       this.logger.error(
         `Error exporting Cohen's Kappa summary CSV: ${error.message}`,
         error.stack
@@ -2045,6 +2154,24 @@ export class WorkspaceCodingStatisticsController {
     description: 'Exclude coder training jobs (default: true)',
     type: Boolean
   })
+  @ApiQuery({
+    name: 'jobDefinitionIds',
+    required: false,
+    description: 'Limit export to one or more job definition IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderTrainingIds',
+    required: false,
+    description: 'Limit export to one or more coder training IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderIds',
+    required: false,
+    description: 'Limit export to one or more coder IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
   @ApiOkResponse({
     description:
       "Cohen's Kappa workbook exported as XLSX with summary, pairwise details and coding results sheets.",
@@ -2063,15 +2190,22 @@ export class WorkspaceCodingStatisticsController {
       @Query('unitName') unitName: string | undefined,
       @Query('variableId') variableId: string | undefined,
       @Query('excludeTrainings') excludeTrainings: string | undefined,
+      @Query('jobDefinitionIds') jobDefinitionIds: string | string[] | undefined,
+      @Query('coderTrainingIds') coderTrainingIds: string | string[] | undefined,
+      @Query('coderIds') coderIds: string | string[] | undefined,
       @Res() res: Response
   ): Promise<void> {
     try {
-      const statistics = await this.buildCohensKappaStatistics(workspace_id, {
-        weightedMean: weightedMean !== 'false',
-        excludeTrainings: excludeTrainings !== 'false',
+      const options = this.buildKappaOptionsFromQuery({
+        weightedMean,
+        excludeTrainings,
         unitName,
-        variableId
+        variableId,
+        jobDefinitionIds,
+        coderTrainingIds,
+        coderIds
       });
+      const statistics = await this.buildCohensKappaStatistics(workspace_id, options);
       const buffer = await this.createCohensKappaWorkbookBuffer(
         statistics,
         statistics.sourceItems
@@ -2088,6 +2222,9 @@ export class WorkspaceCodingStatisticsController {
       );
       res.send(buffer);
     } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       this.logger.error(
         `Error exporting Cohen's Kappa XLSX: ${error.message}`,
         error.stack
@@ -2113,6 +2250,24 @@ export class WorkspaceCodingStatisticsController {
     required: false,
     description: 'Exclude coder training jobs (default: true)',
     type: Boolean
+  })
+  @ApiQuery({
+    name: 'jobDefinitionIds',
+    required: false,
+    description: 'Limit statistics to one or more job definition IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderTrainingIds',
+    required: false,
+    description: 'Limit statistics to one or more coder training IDs (comma-separated or repeated query parameters)',
+    type: String
+  })
+  @ApiQuery({
+    name: 'coderIds',
+    required: false,
+    description: 'Limit statistics to one or more coder IDs (comma-separated or repeated query parameters)',
+    type: String
   })
   @ApiOkResponse({
     description:
@@ -2193,7 +2348,10 @@ export class WorkspaceCodingStatisticsController {
   async getWorkspaceCohensKappaSummary(
     @WorkspaceId() workspace_id: number,
       @Query('weightedMean') weightedMean?: string,
-      @Query('excludeTrainings') excludeTrainings?: string
+      @Query('excludeTrainings') excludeTrainings?: string,
+      @Query('jobDefinitionIds') jobDefinitionIds?: string | string[],
+      @Query('coderTrainingIds') coderTrainingIds?: string | string[],
+      @Query('coderIds') coderIds?: string | string[]
   ): Promise<{
         coderPairs: Array<{
           coder1Id: number;
@@ -2215,12 +2373,20 @@ export class WorkspaceCodingStatisticsController {
           weightingMethod: 'weighted' | 'unweighted';
         };
       }> {
-    const useWeightedMean = weightedMean !== 'false'; // Default true
-    const isExcludeTrainings = excludeTrainings !== 'false'; // Default true
+    const options = this.buildKappaOptionsFromQuery({
+      weightedMean,
+      excludeTrainings,
+      jobDefinitionIds,
+      coderTrainingIds,
+      coderIds
+    });
     return this.codingReviewService.getWorkspaceCohensKappaSummary(
       workspace_id,
-      useWeightedMean,
-      isExcludeTrainings
+      options.weightedMean,
+      options.excludeTrainings,
+      options.jobDefinitionIds,
+      options.coderTrainingIds,
+      options.coderIds
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
@@ -131,6 +131,56 @@ function createServiceWithDetailedMocks(
 }
 
 describe('CodingExportService (WS-Admin export smoke)', () => {
+  it('uses TypeORM distinct flag for manual job variable references', async () => {
+    const manualJobVariablesQuery = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      distinct: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([{ unitName: 'UNIT', variableId: 'VAR' }])
+    };
+    const codingJobUnitRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(manualJobVariablesQuery)
+    };
+    const codingListService = {
+      getCodingListVariables: jest.fn().mockResolvedValue([])
+    };
+    const workspaceExclusionService = {
+      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+        globalIgnoredUnits: [],
+        ignoredBooklets: [],
+        testletIgnoredUnits: []
+      })
+    };
+    const service = new CodingExportService(
+      {} as Repository<ResponseEntity>,
+      {} as Repository<CodingJob>,
+      {} as Repository<CodingJobVariable>,
+      codingJobUnitRepository as unknown as Repository<CodingJobUnit>,
+      {} as Repository<CoderTrainingDiscussionResult>,
+      {} as Repository<User>,
+      codingListService as unknown as CodingListService,
+      {} as WorkspaceCoreService,
+      workspaceExclusionService as unknown as WorkspaceExclusionService
+    );
+
+    const references = await (service as unknown as {
+      getManualCodingVariableReferences: (
+        workspaceId: number
+      ) => Promise<Array<{ unitName: string; variableId: string; includeDeriveError?: boolean }>>
+    }).getManualCodingVariableReferences(13);
+
+    expect(references).toEqual([{ unitName: 'UNIT', variableId: 'VAR', includeDeriveError: undefined }]);
+    expect(manualJobVariablesQuery.select).toHaveBeenCalledWith('coding_job_unit.unit_name', 'unitName');
+    expect(manualJobVariablesQuery.select).not.toHaveBeenCalledWith(
+      expect.stringContaining('DISTINCT'),
+      expect.anything()
+    );
+    expect(manualJobVariablesQuery.distinct).toHaveBeenCalledWith(true);
+  });
+
   it('keeps code value and writes code hint when coding_issue_option is set', async () => {
     const { service, totalCountQueryBuilder, unitsBatchQueryBuilder } = createServiceWithDetailedMocks(1);
 
@@ -506,6 +556,7 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
         leftJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
@@ -637,6 +688,7 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
         leftJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
@@ -799,6 +851,7 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
         leftJoinAndSelect: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
@@ -902,6 +955,7 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
         leftJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
@@ -1010,6 +1064,7 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
         leftJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
@@ -1139,6 +1194,7 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
         leftJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),

--- a/apps/backend/src/app/database/services/coding/coding-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.ts
@@ -183,11 +183,12 @@ export class CodingExportService {
     const codingListVariables = await this.codingListService.getCodingListVariables(workspaceId);
     const manualJobVariables = await this.codingJobUnitRepository
       .createQueryBuilder('coding_job_unit')
-      .select('DISTINCT coding_job_unit.unit_name', 'unitName')
+      .select('coding_job_unit.unit_name', 'unitName')
       .addSelect('coding_job_unit.variable_id', 'variableId')
       .innerJoin('coding_job_unit.coding_job', 'coding_job')
       .where('coding_job.workspace_id = :workspaceId', { workspaceId })
       .andWhere('coding_job.training_id IS NULL')
+      .distinct(true)
       .getRawMany<{ unitName: string; variableId: string }>();
 
     const manualCodingVariables = createManualCodingVariableReferences([

--- a/apps/backend/src/app/database/services/coding/coding-list-stream.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-stream.service.spec.ts
@@ -76,7 +76,21 @@ describe('CodingListStreamService', () => {
     mockItemBuilderService = {
       buildCodingItem: jest.fn(),
       buildCodingItemWithVersions: jest.fn(),
-      getHeadersForVersion: jest.fn()
+      getHeadersForVersion: jest.fn().mockReturnValue([
+        'unit_key',
+        'unit_alias',
+        'person_login',
+        'person_code',
+        'person_group',
+        'booklet_name',
+        'variable_id',
+        'variable_page',
+        'variable_anchor',
+        'value',
+        'status_v1',
+        'code_v1',
+        'score_v1'
+      ])
     } as unknown as jest.Mocked<CodingItemBuilderService>;
 
     mockFileCacheService = {
@@ -152,6 +166,94 @@ describe('CodingListStreamService', () => {
 
       expect(stream).toBeDefined();
       expect(mockFileCacheService.clearCaches).toHaveBeenCalled();
+    });
+
+    it('should write headers for empty versioned CSV exports', async () => {
+      mockResponseFilterService.getResponsesBatch.mockResolvedValueOnce([]);
+
+      const stream = await service.getCodingResultsByVersionCsvStream(
+        1,
+        'v1',
+        'token',
+        'http://server'
+      );
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+
+      await new Promise(resolve => {
+        stream.on('end', resolve);
+      });
+
+      expect(Buffer.concat(chunks).toString()).toBe([
+        'unit_key',
+        'unit_alias',
+        'person_login',
+        'person_code',
+        'person_group',
+        'booklet_name',
+        'variable_id',
+        'variable_page',
+        'variable_anchor',
+        'value',
+        'status_v1',
+        'code_v1',
+        'score_v1'
+      ].join(';'));
+      expect(mockItemBuilderService.getHeadersForVersion).toHaveBeenCalledWith('v1', true);
+    });
+
+    it('should include replay URL column in versioned CSV exports when requested', async () => {
+      const response = createMockResponse(1);
+      mockResponseFilterService.getResponsesBatch
+        .mockResolvedValueOnce([response])
+        .mockResolvedValueOnce([]);
+      mockItemBuilderService.buildCodingItemWithVersions.mockResolvedValue({
+        unit_key: 'unit1',
+        unit_alias: 'Unit 1',
+        person_login: 'user1',
+        person_code: 'code1',
+        person_group: 'group1',
+        booklet_name: 'booklet1',
+        variable_id: 'var1',
+        variable_page: '1',
+        variable_anchor: 'var1',
+        value: 'answer',
+        status_v1: 'VALUE_CHANGED',
+        code_v1: '',
+        score_v1: '',
+        url: 'http://server/#/replay/user1@code1@group1@booklet1/unit1/1/var1?auth=token'
+      } as never);
+
+      const stream = await service.getCodingResultsByVersionCsvStream(
+        1,
+        'v1',
+        'token',
+        'http://server',
+        true
+      );
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+
+      await new Promise(resolve => {
+        stream.on('end', resolve);
+      });
+
+      const [header, row] = Buffer.concat(chunks).toString().split('\n');
+
+      expect(header.split(';')).toContain('url');
+      expect(row).toContain(
+        'http://server/#/replay/user1@code1@group1@booklet1/unit1/1/var1?auth=token'
+      );
+      expect(mockItemBuilderService.buildCodingItemWithVersions).toHaveBeenCalledWith(
+        response,
+        'v1',
+        'token',
+        'http://server',
+        1,
+        true,
+        true,
+        false
+      );
     });
 
     it('should pass response value option to versioned CSV item builder', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-list-stream.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-stream.service.ts
@@ -483,7 +483,12 @@ export class CodingListStreamService {
       `Memory-efficient CSV export for coding results version ${version}, workspace ${workspace_id} (replay URLs: ${includeReplayUrls}, response values: ${includeResponseValues})`
     );
     this.fileCacheService.clearCaches();
-    const csvStream = fastCsv.format({ headers: true, delimiter: ';' });
+    const headers = this.itemBuilderService.getHeadersForVersion(version, includeResponseValues);
+    const csvStream = fastCsv.format({
+      headers: includeReplayUrls ? [...headers, 'url'] : headers,
+      delimiter: ';',
+      alwaysWriteHeaders: true
+    });
 
     (async () => {
       try {

--- a/apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts
@@ -105,6 +105,7 @@ const createCodingJobUnitQueryBuilder = (units: TestCodingJobUnit[]) => {
     leftJoinAndSelect: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
     addSelect: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),

--- a/apps/backend/src/app/database/services/coding/coding-results-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results-export.service.ts
@@ -116,11 +116,12 @@ export class CodingResultsExportService {
     const codingListVariables = await this.codingListService.getCodingListVariables(workspaceId);
     const manualJobVariables = await this.codingJobUnitRepository
       .createQueryBuilder('coding_job_unit')
-      .select('DISTINCT coding_job_unit.unit_name', 'unitName')
+      .select('coding_job_unit.unit_name', 'unitName')
       .addSelect('coding_job_unit.variable_id', 'variableId')
       .innerJoin('coding_job_unit.coding_job', 'coding_job')
       .where('coding_job.workspace_id = :workspaceId', { workspaceId })
       .andWhere('coding_job.training_id IS NULL')
+      .distinct(true)
       .getRawMany<{ unitName: string; variableId: string }>();
 
     const manualCodingVariables = createManualCodingVariableReferences([

--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -33,6 +33,7 @@ describe('CodingReviewService', () => {
     having: jest.Mock;
     andHaving: jest.Mock;
     andWhere: jest.Mock;
+    setParameter: jest.Mock;
     orderBy: jest.Mock;
     addOrderBy: jest.Mock;
     offset: jest.Mock;
@@ -112,6 +113,7 @@ describe('CodingReviewService', () => {
       having: jest.fn().mockReturnThis(),
       andHaving: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
       addOrderBy: jest.fn().mockReturnThis(),
       offset: jest.fn().mockReturnThis(),
@@ -1064,5 +1066,175 @@ describe('CodingReviewService', () => {
 
     expect(queryBuilder.andWhere).toHaveBeenCalledWith('cju.code IS NOT NULL');
     expect(queryBuilder.andWhere).not.toHaveBeenCalledWith('cj.training_id IS NULL');
+  });
+
+  it('applies job definition, coder training and coder scopes to kappa data', async () => {
+    queryBuilder.getRawMany.mockResolvedValueOnce([]);
+
+    await service.getCodedVariablesForKappa(workspaceId, false, [11], [21], [31]);
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      '(cj.job_definition_id IN (:...kappaJobDefinitionIds) OR cj.training_id IN (:...kappaCoderTrainingIds))'
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'cjc.user_id IN (:...kappaCoderIds)',
+      { kappaCoderIds: [31] }
+    );
+    expect(queryBuilder.setParameter).toHaveBeenCalledWith('kappaJobDefinitionIds', [11]);
+    expect(queryBuilder.setParameter).toHaveBeenCalledWith('kappaCoderTrainingIds', [21]);
+  });
+
+  it('returns an empty workspace kappa summary for a single selected coder', async () => {
+    const getDoubleCodedVariablesForReviewSpy = jest.spyOn(
+      service,
+      'getDoubleCodedVariablesForReview'
+    );
+
+    const result = await service.getWorkspaceCohensKappaSummary(
+      workspaceId,
+      true,
+      true,
+      [],
+      [],
+      [31]
+    );
+
+    expect(getDoubleCodedVariablesForReviewSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      coderPairs: [],
+      workspaceSummary: {
+        totalDoubleCodedResponses: 0,
+        totalCoderPairs: 0,
+        averageKappa: null,
+        variablesIncluded: 0,
+        codersIncluded: 0,
+        weightingMethod: 'weighted'
+      }
+    });
+  });
+
+  it('keeps workspace kappa summary pairs within the selected coder scope', async () => {
+    const codingStatisticsService = {
+      calculateCohensKappa: jest.fn().mockReturnValue([
+        {
+          coder1Id: 31,
+          coder1Name: 'Coder 31',
+          coder2Id: 32,
+          coder2Name: 'Coder 32',
+          kappa: 1,
+          agreement: 1,
+          totalSharedResponses: 1,
+          validPairs: 1,
+          interpretation: 'Sehr gut'
+        }
+      ])
+    };
+    service = new CodingReviewService(
+      {} as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      codingStatisticsService as never,
+      {
+        resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
+      } as never
+    );
+    const getDoubleCodedVariablesForReviewSpy = jest
+      .spyOn(service, 'getDoubleCodedVariablesForReview')
+      .mockResolvedValueOnce({
+        data: [
+          {
+            responseId: 10,
+            unitName: 'UNIT_1',
+            variableId: 'VAR_1',
+            personLogin: 'person-1',
+            personCode: 'P001',
+            personGroup: 'GROUP_1',
+            bookletName: 'BOOKLET_1',
+            givenAnswer: 'answer',
+            isResolved: false,
+            coderResults: [
+              {
+                coderId: 31,
+                coderName: 'Coder 31',
+                jobId: 100,
+                jobName: 'Job 31',
+                jobDefinitionId: 11,
+                trainingId: null,
+                trainingLabel: null,
+                code: 1,
+                score: 1,
+                notes: null,
+                supervisorComment: null,
+                codedAt: new Date('2026-05-18T00:00:00.000Z')
+              },
+              {
+                coderId: 32,
+                coderName: 'Coder 32',
+                jobId: 101,
+                jobName: 'Job 32',
+                jobDefinitionId: 11,
+                trainingId: null,
+                trainingLabel: null,
+                code: 1,
+                score: 1,
+                notes: null,
+                supervisorComment: null,
+                codedAt: new Date('2026-05-18T00:00:00.000Z')
+              },
+              {
+                coderId: 33,
+                coderName: 'Coder 33',
+                jobId: 102,
+                jobName: 'Job 33',
+                jobDefinitionId: 11,
+                trainingId: null,
+                trainingLabel: null,
+                code: 2,
+                score: 1,
+                notes: null,
+                supervisorComment: null,
+                codedAt: new Date('2026-05-18T00:00:00.000Z')
+              }
+            ]
+          }
+        ],
+        total: 1,
+        page: 1,
+        limit: 1000
+      });
+
+    const result = await service.getWorkspaceCohensKappaSummary(
+      workspaceId,
+      true,
+      true,
+      [],
+      [],
+      [31, 32]
+    );
+
+    expect(getDoubleCodedVariablesForReviewSpy).toHaveBeenCalledWith(
+      workspaceId,
+      1,
+      1000,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [],
+      [],
+      false
+    );
+    expect(codingStatisticsService.calculateCohensKappa).toHaveBeenCalledWith([
+      expect.objectContaining({
+        coder1Id: 31,
+        coder2Id: 32,
+        codes: [{ code1: 1, code2: 1 }]
+      })
+    ]);
+    expect(result.workspaceSummary.codersIncluded).toBe(2);
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-review.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.ts
@@ -522,7 +522,10 @@ export class CodingReviewService {
 
   async getCodedVariablesForKappa(
     workspaceId: number,
-    excludeTrainings: boolean = true
+    excludeTrainings: boolean = true,
+    jobDefinitionIds: number[] = [],
+    coderTrainingIds: number[] = [],
+    coderIds: number[] = []
   ): Promise<Array<{
       responseId: number;
       unitName: string;
@@ -544,6 +547,7 @@ export class CodingReviewService {
         codedAt: Date;
       }>;
     }>> {
+    const scopedJobDefinitionBundleScope = await this.getJobDefinitionBundleScope(workspaceId, jobDefinitionIds);
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     const batchSize = 5000;
     const query = this.codingJobUnitRepository
@@ -592,6 +596,35 @@ export class CodingReviewService {
 
     if (excludeTrainings) {
       query.andWhere('cj.training_id IS NULL');
+    }
+
+    if (this.hasScopeFilters(jobDefinitionIds, coderTrainingIds)) {
+      const scopeClauses: string[] = [];
+
+      if (jobDefinitionIds.length) {
+        scopeClauses.push(this.getJobDefinitionScopeClause(
+          'cj',
+          'cju',
+          'kappaJobDefinitionIds',
+          'kappaJobDefinitionBundleIds',
+          scopedJobDefinitionBundleScope.bundleIds
+        ));
+        query.setParameter('kappaJobDefinitionIds', jobDefinitionIds);
+        if (scopedJobDefinitionBundleScope.bundleIds.length) {
+          query.setParameter('kappaJobDefinitionBundleIds', scopedJobDefinitionBundleScope.bundleIds);
+        }
+      }
+
+      if (coderTrainingIds.length) {
+        scopeClauses.push('cj.training_id IN (:...kappaCoderTrainingIds)');
+        query.setParameter('kappaCoderTrainingIds', coderTrainingIds);
+      }
+
+      query.andWhere(`(${scopeClauses.join(' OR ')})`);
+    }
+
+    if (coderIds.length) {
+      query.andWhere('cjc.user_id IN (:...kappaCoderIds)', { kappaCoderIds: coderIds });
     }
 
     applyResolvedExclusionsToQuery(query, exclusions, {
@@ -1116,7 +1149,10 @@ export class CodingReviewService {
   async getWorkspaceCohensKappaSummary(
     workspaceId: number,
     weightedMean: boolean = true,
-    excludeTrainings: boolean = true
+    excludeTrainings: boolean = true,
+    jobDefinitionIds: number[] = [],
+    coderTrainingIds: number[] = [],
+    coderIds: number[] = []
   ): Promise<{
       coderPairs: Array<{
         coder1Id: number;
@@ -1143,6 +1179,21 @@ export class CodingReviewService {
         `Calculating workspace-wide Cohen's Kappa for double-coded incomplete variables in workspace ${workspaceId}${excludeTrainings ? ' (excluding trainings)' : ''}`
       );
 
+      if (coderIds.length === 1) {
+        return {
+          coderPairs: [],
+          workspaceSummary: {
+            totalDoubleCodedResponses: 0,
+            totalCoderPairs: 0,
+            averageKappa: null,
+            variablesIncluded: 0,
+            codersIncluded: 0,
+            weightingMethod: weightedMean ? 'weighted' : 'unweighted'
+          }
+        };
+      }
+
+      let totalReviewItems = 0;
       let totalDoubleCodedResponses = 0;
       let currentPage = 1;
       const batchSize = 1000;
@@ -1174,16 +1225,25 @@ export class CodingReviewService {
           undefined, // statusFilter
           undefined, // resolvedFilter
           undefined, // agreementFilter
-          undefined, // jobDefinitionIds
-          undefined, // coderTrainingIds
+          jobDefinitionIds,
+          coderTrainingIds,
           false // includeRelations = false
         );
 
+        if (coderIds.length > 0) {
+          doubleCodedData.data.forEach(item => {
+            item.coderResults = item.coderResults.filter(result => coderIds.includes(result.coderId));
+          });
+        }
+
         if (currentPage === 1) {
-          totalDoubleCodedResponses = doubleCodedData.total;
+          totalReviewItems = doubleCodedData.total;
         }
 
         for (const item of doubleCodedData.data) {
+          if (item.coderResults.length < 2) continue;
+
+          totalDoubleCodedResponses += 1;
           uniqueVariables.add(`${item.unitName}:${item.variableId}`);
 
           const coders = item.coderResults;
@@ -1238,7 +1298,7 @@ export class CodingReviewService {
           }
         }
 
-        if ((currentPage * batchSize) >= totalDoubleCodedResponses || doubleCodedData.data.length === 0) {
+        if ((currentPage * batchSize) >= totalReviewItems || doubleCodedData.data.length === 0) {
           hasMore = false;
         } else {
           currentPage += 1;

--- a/apps/backend/src/app/database/services/coding/coding-times-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-times-export.service.ts
@@ -29,11 +29,12 @@ export class CodingTimesExportService {
     const codingListVariables = await this.codingListService.getCodingListVariables(workspaceId);
     const manualJobVariables = await this.codingJobUnitRepository
       .createQueryBuilder('coding_job_unit')
-      .select('DISTINCT coding_job_unit.unit_name', 'unitName')
+      .select('coding_job_unit.unit_name', 'unitName')
       .addSelect('coding_job_unit.variable_id', 'variableId')
       .innerJoin('coding_job_unit.coding_job', 'coding_job')
       .where('coding_job.workspace_id = :workspaceId', { workspaceId })
       .andWhere('coding_job.training_id IS NULL')
+      .distinct(true)
       .getRawMany<{ unitName: string; variableId: string }>();
 
     const manualCodingVariableSet = createManualCodingVariablePairKeySet([

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -33,6 +33,7 @@ describe('CodingValidationService', () => {
     getOne: jest.fn(),
     select: jest.fn().mockReturnThis(),
     addSelect: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
     groupBy: jest.fn().mockReturnThis(),
     addGroupBy: jest.fn().mockReturnThis(),
     getRawMany: jest.fn()
@@ -84,6 +85,7 @@ describe('CodingValidationService', () => {
     getOne: jest.fn(),
     select: jest.fn().mockReturnThis(),
     addSelect: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
     groupBy: jest.fn().mockReturnThis(),
     addGroupBy: jest.fn().mockReturnThis(),
     getRawMany: jest.fn().mockResolvedValue(rawResults)

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -1273,7 +1273,7 @@ export class CodingValidationService {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     const query = this.codingJobUnitRepository
       .createQueryBuilder('cju')
-      .select('DISTINCT cju.unit_name', 'unitName')
+      .select('cju.unit_name', 'unitName')
       .addSelect('cju.variable_id', 'variableId')
       .innerJoin('cju.coding_job', 'coding_job')
       .innerJoin('cju.response', 'response')
@@ -1281,7 +1281,8 @@ export class CodingValidationService {
       .andWhere('coding_job.training_id IS NULL')
       .andWhere('response.status_v1 = :deriveErrorStatus', {
         deriveErrorStatus: statusStringToNumber('DERIVE_ERROR')
-      });
+      })
+      .distinct(true);
 
     applyResolvedExclusionsToQuery(query, exclusions, {
       unitNameExpression: 'cju.unit_name',

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -1759,6 +1759,26 @@ describe('WorkspaceTestResultsService', () => {
     });
   });
 
+  describe('exportTestLogsToStream', () => {
+    const collectStream = (stream: PassThrough): Promise<string> => new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      stream.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      stream.on('error', reject);
+    });
+
+    it('should write headers when no test logs are available', async () => {
+      const resStream = new PassThrough();
+      const outputPromise = collectStream(resStream);
+
+      await service.exportTestLogsToStream(1, resStream);
+
+      await expect(outputPromise).resolves.toBe(
+        'groupname;loginname;code;bookletname;unitname;originalUnitId;timestamp;logentry'
+      );
+    });
+  });
+
   describe('deletion methods', () => {
     it('deleteTestPersons should invalidate cache', async () => {
       const workspaceId = 1;

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -7369,7 +7369,8 @@ export class WorkspaceTestResultsService {
         'logentry'
       ],
       delimiter: ';',
-      quote: null
+      quote: null,
+      alwaysWriteHeaders: true
     });
 
     csvStream.pipe(stream);

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -1359,6 +1359,16 @@
               mat-stroked-button
               color="primary"
               type="button"
+              [disabled]="isStartingManualExport || isLoadingCodersForExport"
+              (click)="openExecutionExport()"
+            >
+              <mat-icon>download</mat-icon>
+              Export
+            </button>
+            <button
+              mat-stroked-button
+              color="primary"
+              type="button"
               (click)="openExecutionTransferCases()"
             >
               <mat-icon>swap_horiz</mat-icon>
@@ -1833,6 +1843,16 @@
             >
               <mat-icon>add</mat-icon>
               Kodierschulung erstellen
+            </button>
+            <button
+              mat-stroked-button
+              color="primary"
+              type="button"
+              [disabled]="isStartingManualExport || isLoadingCodersForExport"
+              (click)="openTrainingExport()"
+            >
+              <mat-icon>download</mat-icon>
+              Export
             </button>
             <button
               mat-stroked-button

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -4,11 +4,16 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatDialog } from '@angular/material/dialog';
 import { Observable, of, throwError } from 'rxjs';
 import { CodingManagementManualComponent } from './coding-management-manual.component';
 import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
 import { ResponseMatchingFlag } from '../../../ws-admin/services/workspace-settings.service';
+import { CoderService } from '../../services/coder.service';
+import { ExportJobService } from '../../../shared/services/file/export-job.service';
+import { CohensKappaStatisticsComponent } from '../cohens-kappa-statistics/cohens-kappa-statistics.component';
+import { ManualCodingExportDialogComponent } from '../manual-coding-export-dialog/manual-coding-export-dialog.component';
 
 type VariableCoverageOverview = NonNullable<
 CodingManagementManualComponent['variableCoverageOverview']
@@ -46,6 +51,21 @@ describe('CodingManagementManualComponent', () => {
         {
           provide: MatSnackBar,
           useValue: { open: jest.fn() }
+        },
+        {
+          provide: MatDialog,
+          useValue: { open: jest.fn().mockReturnValue({ afterClosed: () => of(undefined) }) }
+        },
+        {
+          provide: CoderService,
+          useValue: {
+            getCoders: jest.fn().mockReturnValue(of([])),
+            getCodersForExport: jest.fn().mockReturnValue(of([]))
+          }
+        },
+        {
+          provide: ExportJobService,
+          useValue: { startJob: jest.fn().mockReturnValue(of({ jobId: 'export-1' })) }
         },
         {
           provide: Router,
@@ -964,22 +984,189 @@ describe('CodingManagementManualComponent', () => {
     expect(refreshSpy).not.toHaveBeenCalled();
   });
 
-  it('should open training reliability and discussion in within-training mode', () => {
-    const openResultsComparison = jest.fn();
+  it('should open training reliability with a coder-training kappa scope', () => {
+    const dialog = { open: jest.fn() };
+    (component as unknown as { dialog: typeof dialog }).dialog = dialog;
     component.coderTrainingsListComponent = {
-      openResultsComparison
+      originalData: [{ id: 7 }],
+      coderTrainings: [],
+      openResultsComparison: jest.fn()
     } as unknown as CodingManagementManualComponent['coderTrainingsListComponent'];
 
     component.openTrainingReliability();
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      CohensKappaStatisticsComponent,
+      expect.objectContaining({
+        data: {
+          excludeTrainings: false,
+          scope: { coderTrainingIds: [7] }
+        }
+      })
+    );
+  });
+
+  it('should open execution reliability with cached job definitions when planning tab is not rendered', () => {
+    const dialog = { open: jest.fn() };
+    const componentInternals = component as unknown as {
+      dialog: typeof dialog;
+      jobDefinitionsForExport: Array<{
+        id: number;
+        status: 'approved';
+        assignedVariables: unknown[];
+        assignedVariableBundles: unknown[];
+      }>;
+      jobDefinitionsForExportWorkspaceId: number;
+      hasLoadedJobDefinitionsForExport: boolean;
+      appService: { selectedWorkspaceId: number };
+    };
+    componentInternals.dialog = dialog;
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.jobDefinitionsForExport = [
+      {
+        id: 11,
+        status: 'approved',
+        assignedVariables: [],
+        assignedVariableBundles: []
+      }
+    ];
+    componentInternals.jobDefinitionsForExportWorkspaceId = 5;
+    componentInternals.hasLoadedJobDefinitionsForExport = true;
+    component.codingJobDefinitionsComponent = undefined;
+
+    component.openExecutionReliability();
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      CohensKappaStatisticsComponent,
+      expect.objectContaining({
+        data: {
+          excludeTrainings: true,
+          scope: { jobDefinitionIds: [11] }
+        }
+      })
+    );
+  });
+
+  it('should start execution exports with cached job definition scope when the dialog keeps defaults', () => {
+    const exportJobService = TestBed.inject(ExportJobService);
+    const dialog = {
+      open: jest.fn().mockReturnValue({
+        afterClosed: () => of({ exportType: 'detailed' })
+      })
+    };
+    const componentInternals = component as unknown as {
+      dialog: typeof dialog;
+      jobDefinitionsForExport: Array<{
+        id: number;
+        status: 'approved';
+        assignedVariables: unknown[];
+        assignedVariableBundles: unknown[];
+      }>;
+      jobDefinitionsForExportWorkspaceId: number;
+      hasLoadedJobDefinitionsForExport: boolean;
+      codersForExportWorkspaceId: number;
+      hasLoadedCodersForExport: boolean;
+      appService: {
+        selectedWorkspaceId: number;
+        updateAuthData(authData: unknown): void;
+      };
+    };
+    componentInternals.dialog = dialog;
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.appService.updateAuthData({ userId: 9 });
+    componentInternals.jobDefinitionsForExport = [
+      {
+        id: 11,
+        status: 'approved',
+        assignedVariables: [],
+        assignedVariableBundles: []
+      }
+    ];
+    componentInternals.jobDefinitionsForExportWorkspaceId = 5;
+    componentInternals.hasLoadedJobDefinitionsForExport = true;
+    componentInternals.codersForExportWorkspaceId = 5;
+    componentInternals.hasLoadedCodersForExport = true;
+    component.codingJobDefinitionsComponent = undefined;
+
+    component.openExecutionExport();
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      ManualCodingExportDialogComponent,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          defaultJobDefinitionIds: [11],
+          jobDefinitions: [
+            expect.objectContaining({
+              id: 11
+            })
+          ]
+        })
+      })
+    );
+    expect(exportJobService.startJob).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({
+        exportType: 'detailed',
+        userId: 9,
+        excludeAutoCoded: true,
+        jobDefinitionIds: [11]
+      })
+    );
+  });
+
+  it('should wait for coder scope before opening execution export dialog', () => {
+    const dialog = { open: jest.fn() };
+    const componentInternals = component as unknown as {
+      dialog: typeof dialog;
+      jobDefinitionsForExport: Array<{
+        id: number;
+        status: 'approved';
+        assignedVariables: unknown[];
+        assignedVariableBundles: unknown[];
+      }>;
+      jobDefinitionsForExportWorkspaceId: number;
+      hasLoadedJobDefinitionsForExport: boolean;
+      codersForExportWorkspaceId?: number;
+      hasLoadedCodersForExport: boolean;
+      isLoadingCodersForExport: boolean;
+      appService: {
+        selectedWorkspaceId: number;
+      };
+    };
+    componentInternals.dialog = dialog;
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.jobDefinitionsForExport = [
+      {
+        id: 11,
+        status: 'approved',
+        assignedVariables: [],
+        assignedVariableBundles: []
+      }
+    ];
+    componentInternals.jobDefinitionsForExportWorkspaceId = 5;
+    componentInternals.hasLoadedJobDefinitionsForExport = true;
+    componentInternals.codersForExportWorkspaceId = 5;
+    componentInternals.hasLoadedCodersForExport = false;
+    componentInternals.isLoadingCodersForExport = false;
+    component.codingJobDefinitionsComponent = undefined;
+
+    component.openExecutionExport();
+
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(componentInternals.hasLoadedCodersForExport).toBe(true);
+  });
+
+  it('should open training discussion in within-training mode', () => {
+    const openResultsComparison = jest.fn();
+    component.coderTrainingsListComponent = {
+      originalData: [],
+      coderTrainings: [],
+      openResultsComparison
+    } as unknown as CodingManagementManualComponent['coderTrainingsListComponent'];
+
     component.openTrainingDiscussion();
 
-    expect(openResultsComparison).toHaveBeenNthCalledWith(
-      1,
-      undefined,
-      'within-training'
-    );
-    expect(openResultsComparison).toHaveBeenNthCalledWith(
-      2,
+    expect(openResultsComparison).toHaveBeenCalledWith(
       undefined,
       'within-training'
     );

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -68,6 +68,7 @@ import {
   ApplyCodingResultsResponse,
   BulkApplyCodingResultsResponse,
   CodingJobBackendService,
+  JobDefinition,
   ManualCodingScopeSummary
 } from '../../services/coding-job-backend.service';
 import { MissingsProfileService } from '../../services/missings-profile.service';
@@ -105,6 +106,13 @@ import {
   isCodingFreshnessOpenWarning
 } from '../../../shared/utils/coding-freshness-text.util';
 import { UserBackendService } from '../../../shared/services/user/user-backend.service';
+import { ExportJobConfig, ExportJobService } from '../../../shared/services/file/export-job.service';
+import { CoderService } from '../../services/coder.service';
+import {
+  ManualCodingExportDialogComponent,
+  ManualCodingExportDialogResult
+} from '../manual-coding-export-dialog/manual-coding-export-dialog.component';
+import { CohensKappaStatisticsComponent } from '../cohens-kappa-statistics/cohens-kappa-statistics.component';
 
 interface SavedCodeProgress {
   id?: number;
@@ -170,6 +178,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private validationStateService = inject(ValidationStateService);
   private workspaceSettingsService = inject(WorkspaceSettingsService);
   private userBackendService = inject(UserBackendService);
+  private coderService = inject(CoderService);
+  private exportJobService = inject(ExportJobService);
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
   private router = inject(Router);
@@ -349,6 +359,15 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   showCoderTraining = false;
   editTraining: CoderTraining | null = null;
+  coders: Coder[] = [];
+  isStartingManualExport = false;
+  isLoadingCodersForExport = false;
+  private codersForExportWorkspaceId?: number;
+  private hasLoadedCodersForExport = false;
+  private jobDefinitionsForExport: JobDefinition[] = [];
+  private jobDefinitionsForExportWorkspaceId?: number;
+  private hasLoadedJobDefinitionsForExport = false;
+  private isLoadingJobDefinitionsForExport = false;
 
   expectedCombinations: ExpectedCombinationDto[] = [];
 
@@ -381,10 +400,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       currentProgress.status === 'loading' ||
       currentProgress.status === 'processing';
 
+    this.loadCodersForExport();
+    this.loadJobDefinitionsForExport();
+
     // Set up debounced statistics refresh
     this.jobDefinitionChangeSubject
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(() => {
+        this.loadJobDefinitionsForExport();
         this.loadManualTabData(this.activeManualTab);
         if (this.coderTrainingsListComponent) {
           this.coderTrainingsListComponent.loadCoderTrainings();
@@ -465,6 +488,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.loadCodingFreshness();
         this.loadResponseAnalysis();
         this.reloadCodingJobsList();
+        this.loadJobDefinitionsForExport();
         if (this.codingJobDefinitionsComponent) {
           this.codingJobDefinitionsComponent.refresh();
         }
@@ -1007,7 +1031,22 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   openTrainingReliability(): void {
-    this.openTrainingWithinComparison();
+    const coderTrainingIds = this.getCoderTrainingIds();
+
+    if (coderTrainingIds.length === 0) {
+      this.showError('Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+      return;
+    }
+
+    this.dialog.open(CohensKappaStatisticsComponent, {
+      width: '95vw',
+      maxWidth: '1200px',
+      height: '90vh',
+      data: {
+        excludeTrainings: false,
+        scope: { coderTrainingIds }
+      }
+    });
   }
 
   private openTrainingWithinComparison(): void {
@@ -1029,12 +1068,21 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   openExecutionReliability(): void {
-    if (this.codingJobsComponent) {
-      this.codingJobsComponent.openCohensKappaStatisticsDialog();
+    if (!this.ensureExecutionJobDefinitionScopeReady()) {
       return;
     }
 
-    this.showError('Die Kodierjobs werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+    const jobDefinitionIds = this.getJobDefinitionIds();
+
+    this.dialog.open(CohensKappaStatisticsComponent, {
+      width: '95vw',
+      maxWidth: '1200px',
+      height: '90vh',
+      data: {
+        excludeTrainings: true,
+        scope: jobDefinitionIds.length ? { jobDefinitionIds } : undefined
+      }
+    });
   }
 
   openExecutionDoubleCodedReview(): void {
@@ -1044,6 +1092,190 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     this.showError('Die Kodierjobs werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+  }
+
+  openTrainingExport(): void {
+    const coderTrainingIds = this.getCoderTrainingIds();
+
+    if (coderTrainingIds.length === 0) {
+      this.showError('Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+      return;
+    }
+
+    if (!this.ensureCoderScopeReady()) {
+      return;
+    }
+
+    this.openManualCodingExportDialog('training');
+  }
+
+  openExecutionExport(): void {
+    if (!this.ensureExecutionJobDefinitionScopeReady()) {
+      return;
+    }
+
+    if (!this.ensureCoderScopeReady()) {
+      return;
+    }
+
+    this.openManualCodingExportDialog('execution');
+  }
+
+  private openManualCodingExportDialog(context: 'training' | 'execution'): void {
+    this.dialog.open(ManualCodingExportDialogComponent, {
+      width: '680px',
+      maxWidth: '95vw',
+      data: {
+        context,
+        coders: this.coders,
+        jobDefinitions: context === 'execution' ? this.getJobDefinitionExportOptions() : undefined,
+        coderTrainings: context === 'training' ? this.getCoderTrainingsForExport() : undefined,
+        defaultJobDefinitionIds: context === 'execution' ? this.getJobDefinitionIds() : undefined,
+        defaultCoderTrainingIds: context === 'training' ? this.getCoderTrainingIds() : undefined
+      }
+    }).afterClosed()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((result?: ManualCodingExportDialogResult) => {
+        if (!result) {
+          return;
+        }
+
+        this.startManualCodingExport(context, result);
+      });
+  }
+
+  private startManualCodingExport(
+    context: 'training' | 'execution',
+    result: ManualCodingExportDialogResult
+  ): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+
+    if (!workspaceId) {
+      this.showError('Kein Arbeitsbereich ausgewählt.');
+      return;
+    }
+
+    const exportConfig: ExportJobConfig = {
+      exportType: result.exportType,
+      userId: this.appService.userId,
+      includeReplayUrl: false,
+      outputCommentsInsteadOfCodes: result.outputCommentsInsteadOfCodes,
+      anonymizeCoders: result.anonymizeCoders,
+      usePseudoCoders: result.usePseudoCoders,
+      doubleCodingMethod: result.doubleCodingMethod,
+      includeComments: result.includeComments,
+      includeModalValue: result.includeModalValue,
+      excludeAutoCoded: true,
+      coderIds: result.coderIds,
+      coderTrainingIds: context === 'training' ?
+        result.coderTrainingIds ?? this.getCoderTrainingIds() :
+        undefined,
+      jobDefinitionIds: context === 'execution' ?
+        result.jobDefinitionIds ?? this.getJobDefinitionIds() :
+        undefined
+    };
+
+    this.isStartingManualExport = true;
+    this.exportJobService.startJob(workspaceId, exportConfig)
+      .pipe(finalize(() => {
+        this.isStartingManualExport = false;
+      }))
+      .subscribe({
+        next: () => {
+          this.showSuccess('Exportjob wurde gestartet.');
+        },
+        error: () => {
+          this.showError('Exportjob konnte nicht gestartet werden.');
+        }
+      });
+  }
+
+  private getCoderTrainingIds(): number[] {
+    return this.getCoderTrainingsForExport()
+      .map(training => training.id)
+      .filter((id): id is number => Number.isFinite(id));
+  }
+
+  private getJobDefinitionIds(): number[] {
+    return this.getJobDefinitionsForManualScope()
+      .map(jobDefinition => jobDefinition.id)
+      .filter((id): id is number => Number.isFinite(id));
+  }
+
+  private getCoderTrainingsForExport(): CoderTraining[] {
+    return this.coderTrainingsListComponent?.originalData.length ?
+      this.coderTrainingsListComponent.originalData :
+      this.coderTrainingsListComponent?.coderTrainings ?? [];
+  }
+
+  private getJobDefinitionExportOptions(): { id: number; label: string }[] {
+    return this.getJobDefinitionsForManualScope()
+      .filter(jobDefinition => Number.isFinite(jobDefinition.id))
+      .map(jobDefinition => {
+        const variableCount = jobDefinition.assignedVariables?.length ?? 0;
+        const bundleCount = jobDefinition.assignedVariableBundles?.length ?? 0;
+        const status = jobDefinition.status ? ` (${jobDefinition.status})` : '';
+        return {
+          id: jobDefinition.id as number,
+          label: `Definition #${jobDefinition.id}${status}: ${variableCount} Variablen, ${bundleCount} Bündel`
+        };
+      });
+  }
+
+  private getJobDefinitionsForManualScope(): JobDefinition[] {
+    const renderedDefinitions = this.codingJobDefinitionsComponent?.jobDefinitions;
+    if (renderedDefinitions?.length) {
+      return renderedDefinitions;
+    }
+
+    return this.jobDefinitionsForExportWorkspaceId === this.appService.selectedWorkspaceId ?
+      this.jobDefinitionsForExport :
+      [];
+  }
+
+  private ensureExecutionJobDefinitionScopeReady(): boolean {
+    const workspaceId = this.appService.selectedWorkspaceId;
+
+    if (!workspaceId) {
+      return true;
+    }
+
+    if (
+      (this.hasLoadedJobDefinitionsForExport &&
+        this.jobDefinitionsForExportWorkspaceId === workspaceId) ||
+      this.codingJobDefinitionsComponent
+    ) {
+      return true;
+    }
+
+    if (!this.isLoadingJobDefinitionsForExport) {
+      this.loadJobDefinitionsForExport();
+    }
+
+    this.showError('Die Jobdefinitionen werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+    return false;
+  }
+
+  private ensureCoderScopeReady(): boolean {
+    const workspaceId = this.appService.selectedWorkspaceId;
+
+    if (!workspaceId) {
+      return true;
+    }
+
+    if (
+      this.hasLoadedCodersForExport &&
+      this.codersForExportWorkspaceId === workspaceId
+    ) {
+      return true;
+    }
+
+    if (!this.isLoadingCodersForExport) {
+      this.loadCodersForExport();
+    }
+
+    this.showError('Die Kodierer werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+    return false;
   }
 
   closeCoderTraining(): void {
@@ -1090,6 +1322,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   refreshManualCodingPlanning(): void {
     const activeTab = this.activeManualTab;
     this.loadManualTabData(activeTab);
+    this.loadJobDefinitionsForExport();
     if (activeTab !== 'planning') {
       this.loadCodingFreshness();
     }
@@ -1111,6 +1344,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private refreshManualStateAfterExternalChange(): void {
     const activeTab = this.activeManualTab;
     this.loadManualTabData(activeTab, { reloadCodingJobs: false });
+    this.loadJobDefinitionsForExport();
     if (activeTab !== 'planning') {
       this.loadCodingFreshness();
     }
@@ -1920,6 +2154,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.loadCodingIncompleteVariables();
     this.loadStatusDistributionV2();
     this.reloadCodingJobsList();
+    this.loadJobDefinitionsForExport();
 
     if (this.codingJobDefinitionsComponent) {
       this.codingJobDefinitionsComponent.refresh();
@@ -2034,6 +2269,105 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.canApplyManualCodingResults = false;
+        }
+      });
+  }
+
+  private loadJobDefinitionsForExport(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+
+    if (!workspaceId) {
+      this.jobDefinitionsForExport = [];
+      this.jobDefinitionsForExportWorkspaceId = undefined;
+      this.hasLoadedJobDefinitionsForExport = false;
+      this.isLoadingJobDefinitionsForExport = false;
+      return;
+    }
+
+    if (this.jobDefinitionsForExportWorkspaceId !== workspaceId) {
+      this.jobDefinitionsForExport = [];
+      this.hasLoadedJobDefinitionsForExport = false;
+      this.jobDefinitionsForExportWorkspaceId = workspaceId;
+    }
+
+    this.isLoadingJobDefinitionsForExport = true;
+    this.codingJobBackendService
+      .getJobDefinitions(workspaceId)
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          if (this.jobDefinitionsForExportWorkspaceId === workspaceId) {
+            this.isLoadingJobDefinitionsForExport = false;
+          }
+        })
+      )
+      .subscribe({
+        next: definitions => {
+          if (this.appService.selectedWorkspaceId !== workspaceId) {
+            return;
+          }
+
+          this.jobDefinitionsForExport = definitions;
+          this.jobDefinitionsForExportWorkspaceId = workspaceId;
+          this.hasLoadedJobDefinitionsForExport = true;
+        },
+        error: () => {
+          if (this.appService.selectedWorkspaceId !== workspaceId) {
+            return;
+          }
+
+          this.jobDefinitionsForExport = [];
+          this.jobDefinitionsForExportWorkspaceId = workspaceId;
+          this.hasLoadedJobDefinitionsForExport = false;
+        }
+      });
+  }
+
+  private loadCodersForExport(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+
+    if (!workspaceId) {
+      this.coders = [];
+      this.codersForExportWorkspaceId = undefined;
+      this.hasLoadedCodersForExport = false;
+      this.isLoadingCodersForExport = false;
+      return;
+    }
+
+    if (this.codersForExportWorkspaceId !== workspaceId) {
+      this.coders = [];
+      this.hasLoadedCodersForExport = false;
+      this.codersForExportWorkspaceId = workspaceId;
+    }
+
+    this.isLoadingCodersForExport = true;
+    this.coderService.getCodersForExport()
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          if (this.codersForExportWorkspaceId === workspaceId) {
+            this.isLoadingCodersForExport = false;
+          }
+        })
+      )
+      .subscribe({
+        next: coders => {
+          if (this.appService.selectedWorkspaceId !== workspaceId) {
+            return;
+          }
+
+          this.coders = coders;
+          this.codersForExportWorkspaceId = workspaceId;
+          this.hasLoadedCodersForExport = true;
+        },
+        error: () => {
+          if (this.appService.selectedWorkspaceId !== workspaceId) {
+            return;
+          }
+
+          this.coders = [];
+          this.codersForExportWorkspaceId = workspaceId;
+          this.hasLoadedCodersForExport = false;
         }
       });
   }

--- a/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.html
+++ b/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.html
@@ -24,7 +24,7 @@
         </mat-card-header>
         <mat-card-content>
           <div class="toggles-container">
-            <div class="toggle-item">
+            <div class="toggle-item" *ngIf="!excludeTrainingsLocked">
               <mat-slide-toggle [(ngModel)]="excludeTrainings" (change)="toggleExcludeTrainings()" color="primary">
                 {{ 'cohens-kappa-statistics.exclude-trainings' | translate }}
               </mat-slide-toggle>

--- a/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.ts
+++ b/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.ts
@@ -14,12 +14,18 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { finalize } from 'rxjs';
 import {
+  CohensKappaScope,
   CohensKappaCoderPair,
   CohensKappaStatisticsResponse,
   CohensKappaVariableSummary,
   TestPersonCodingService
 } from '../../services/test-person-coding.service';
 import { AppService } from '../../../core/services/app.service';
+
+export interface CohensKappaStatisticsDialogData {
+  scope?: CohensKappaScope;
+  excludeTrainings?: boolean;
+}
 
 @Component({
   selector: 'coding-box-cohens-kappa-statistics',
@@ -48,14 +54,20 @@ export class CohensKappaStatisticsComponent implements OnInit {
 
   constructor(
     @Optional() public dialogRef: MatDialogRef<CohensKappaStatisticsComponent>,
-    @Optional() @Inject(MAT_DIALOG_DATA) public dialogData: unknown
-  ) { }
+    @Optional() @Inject(MAT_DIALOG_DATA) public dialogData: CohensKappaStatisticsDialogData | null
+  ) {
+    this.kappaScope = dialogData?.scope;
+    this.excludeTrainings = dialogData?.excludeTrainings ?? !dialogData?.scope?.coderTrainingIds?.length;
+    this.excludeTrainingsLocked = !!dialogData?.scope?.coderTrainingIds?.length;
+  }
 
   isLoading = false;
   kappaStatistics: CohensKappaVariableSummary[] = [];
   showInterpretationScale = false;
   useWeightedMean = true; // Default to weighted mean (matching R reference implementation)
   excludeTrainings = true; // Default: exclude trainings
+  excludeTrainingsLocked = false;
+  private kappaScope?: CohensKappaScope;
   exportInProgress: 'summary' | 'details' | 'xlsx' | null = null;
 
   workspaceKappaSummary: {
@@ -75,20 +87,29 @@ export class CohensKappaStatisticsComponent implements OnInit {
       return;
     }
 
-    this.testPersonCodingService.getCohensKappaStatistics(workspaceId, this.useWeightedMean, this.excludeTrainings).subscribe({
-      next: response => {
-        this.kappaStatistics = response.variables;
-        this.workspaceKappaSummary = {
-          workspaceSummary: response.workspaceSummary
-        };
-        this.isLoading = false;
-      },
-      error: () => {
-        this.kappaStatistics = [];
-        this.workspaceKappaSummary = null;
-        this.isLoading = false;
-      }
-    });
+    this.testPersonCodingService
+      .getCohensKappaStatistics(
+        workspaceId,
+        this.useWeightedMean,
+        this.excludeTrainings,
+        undefined,
+        undefined,
+        this.kappaScope
+      )
+      .subscribe({
+        next: response => {
+          this.kappaStatistics = response.variables;
+          this.workspaceKappaSummary = {
+            workspaceSummary: response.workspaceSummary
+          };
+          this.isLoading = false;
+        },
+        error: () => {
+          this.kappaStatistics = [];
+          this.workspaceKappaSummary = null;
+          this.isLoading = false;
+        }
+      });
   }
 
   toggleWeightingMethod(): void {
@@ -107,7 +128,14 @@ export class CohensKappaStatisticsComponent implements OnInit {
 
     this.exportInProgress = 'summary';
     this.testPersonCodingService
-      .exportCohensKappaSummaryAsCsv(workspaceId, this.useWeightedMean, this.excludeTrainings)
+      .exportCohensKappaSummaryAsCsv(
+        workspaceId,
+        this.useWeightedMean,
+        this.excludeTrainings,
+        undefined,
+        undefined,
+        this.kappaScope
+      )
       .pipe(finalize(() => {
         this.exportInProgress = null;
       }))
@@ -133,7 +161,14 @@ export class CohensKappaStatisticsComponent implements OnInit {
 
     this.exportInProgress = 'xlsx';
     this.testPersonCodingService
-      .exportCohensKappaStatisticsAsXlsx(workspaceId, this.useWeightedMean, this.excludeTrainings)
+      .exportCohensKappaStatisticsAsXlsx(
+        workspaceId,
+        this.useWeightedMean,
+        this.excludeTrainings,
+        undefined,
+        undefined,
+        this.kappaScope
+      )
       .pipe(finalize(() => {
         this.exportInProgress = null;
       }))
@@ -159,7 +194,14 @@ export class CohensKappaStatisticsComponent implements OnInit {
 
     this.exportInProgress = 'details';
     this.testPersonCodingService
-      .exportCohensKappaStatisticsAsCsv(workspaceId, this.useWeightedMean, this.excludeTrainings)
+      .exportCohensKappaStatisticsAsCsv(
+        workspaceId,
+        this.useWeightedMean,
+        this.excludeTrainings,
+        undefined,
+        undefined,
+        this.kappaScope
+      )
       .pipe(finalize(() => {
         this.exportInProgress = null;
       }))

--- a/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.html
@@ -1,0 +1,124 @@
+<h2 mat-dialog-title>
+  <mat-icon>download</mat-icon>
+  {{ 'manual-coding-export.title' | translate }}
+</h2>
+
+<mat-dialog-content class="manual-export-content">
+  <p class="manual-export-subtitle">{{ contextSubtitleKey | translate }}</p>
+
+  <section class="manual-export-section">
+    <h3>{{ 'manual-coding-export.mode-title' | translate }}</h3>
+    <mat-radio-group class="manual-export-radio-group" [(ngModel)]="exportMode">
+      <mat-radio-button value="review">
+        {{ 'manual-coding-export.mode-review' | translate }}
+      </mat-radio-button>
+      <mat-radio-button value="report">
+        {{ 'manual-coding-export.mode-report' | translate }}
+      </mat-radio-button>
+    </mat-radio-group>
+  </section>
+
+  @if (exportMode === 'review') {
+  <section class="manual-export-section">
+    <h3>{{ 'manual-coding-export.double-coding-method' | translate }}</h3>
+    <mat-radio-group class="manual-export-radio-group" [(ngModel)]="doubleCodingMethod">
+      <mat-radio-button value="most-frequent">
+        {{ 'ws-admin.export-options.double-coding-methods.most-frequent' | translate }}
+      </mat-radio-button>
+      <mat-radio-button value="new-column-per-coder">
+        {{ 'ws-admin.export-options.double-coding-methods.new-column-per-coder' | translate }}
+      </mat-radio-button>
+      <mat-radio-button value="new-row-per-variable">
+        {{ 'ws-admin.export-options.double-coding-methods.new-row-per-variable' | translate }}
+      </mat-radio-button>
+    </mat-radio-group>
+  </section>
+  } @else {
+  <section class="manual-export-section">
+    <h3>{{ 'manual-coding-export.report-type' | translate }}</h3>
+    <mat-radio-group class="manual-export-radio-group" [(ngModel)]="reportExportType">
+      <mat-radio-button value="detailed">
+        {{ 'manual-coding-export.report-detailed' | translate }}
+      </mat-radio-button>
+      <mat-radio-button value="coding-times">
+        {{ 'manual-coding-export.report-coding-times' | translate }}
+      </mat-radio-button>
+    </mat-radio-group>
+  </section>
+  }
+
+  @if (data.context === 'execution' && data.jobDefinitions?.length) {
+  <section class="manual-export-section">
+    <mat-form-field appearance="outline" class="manual-export-field">
+      <mat-label>{{ 'manual-coding-export.job-definition-filter' | translate }}</mat-label>
+      <mat-select multiple [(ngModel)]="selectedJobDefinitionIds">
+        @for (jobDefinition of data.jobDefinitions; track jobDefinition.id) {
+        <mat-option [value]="jobDefinition.id">{{ jobDefinition.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </section>
+  }
+
+  @if (data.context === 'training' && data.coderTrainings?.length) {
+  <section class="manual-export-section">
+    <mat-form-field appearance="outline" class="manual-export-field">
+      <mat-label>{{ 'manual-coding-export.training-filter' | translate }}</mat-label>
+      <mat-select multiple [(ngModel)]="selectedCoderTrainingIds">
+        @for (training of data.coderTrainings; track training.id) {
+        <mat-option [value]="training.id">{{ training.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </section>
+  }
+
+  @if (data.coders.length > 0) {
+  <section class="manual-export-section">
+    <mat-form-field appearance="outline" class="manual-export-field">
+      <mat-label>{{ 'manual-coding-export.coder-filter' | translate }}</mat-label>
+      <mat-select multiple [(ngModel)]="selectedCoderIds">
+        @for (coder of data.coders; track coder.id) {
+        <mat-option [value]="coder.id">{{ coder.displayName || coder.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </section>
+  }
+
+  <section class="manual-export-section manual-export-options">
+    @if (exportMode === 'review') {
+    <mat-checkbox [(ngModel)]="includeComments">
+      {{ 'ws-admin.export-options.include-comments' | translate }}
+    </mat-checkbox>
+    <mat-checkbox [(ngModel)]="includeModalValue">
+      {{ 'ws-admin.export-options.include-modal-value' | translate }}
+    </mat-checkbox>
+    }
+    <mat-checkbox [(ngModel)]="outputCommentsInsteadOfCodes">
+      {{ 'ws-admin.export-options.output-comments-instead-of-codes' | translate }}
+    </mat-checkbox>
+    <mat-checkbox [(ngModel)]="anonymizeCoders">
+      {{ 'ws-admin.export-options.anonymize-coders' | translate }}
+    </mat-checkbox>
+    <mat-checkbox [(ngModel)]="usePseudoCoders" [disabled]="!anonymizeCoders">
+      {{ 'ws-admin.export-options.use-pseudo-coders' | translate }}
+    </mat-checkbox>
+  </section>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button type="button" mat-dialog-close>
+    {{ 'close' | translate }}
+  </button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    (click)="confirm()"
+    [disabled]="!canConfirm"
+  >
+    <mat-icon>play_arrow</mat-icon>
+    {{ 'manual-coding-export.start' | translate }}
+  </button>
+</mat-dialog-actions>

--- a/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.scss
+++ b/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.scss
@@ -1,0 +1,49 @@
+:host {
+  display: block;
+  min-width: min(620px, 92vw);
+}
+
+h2[mat-dialog-title] {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
+.manual-export-content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 620px;
+}
+
+.manual-export-subtitle {
+  color: rgba(0, 0, 0, 0.65);
+  margin: 0;
+}
+
+.manual-export-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.manual-export-section h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.manual-export-radio-group,
+.manual-export-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.manual-export-field {
+  width: 100%;
+}
+
+mat-dialog-actions button mat-icon {
+  margin-right: 6px;
+}

--- a/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.spec.ts
@@ -1,0 +1,48 @@
+import { ManualCodingExportDialogComponent } from './manual-coding-export-dialog.component';
+
+describe('ManualCodingExportDialogComponent', () => {
+  const createComponent = (
+    data: ConstructorParameters<typeof ManualCodingExportDialogComponent>[1]
+  ): {
+    component: ManualCodingExportDialogComponent;
+    dialogRef: { close: jest.Mock };
+  } => {
+    const dialogRef = { close: jest.fn() };
+    return {
+      component: new ManualCodingExportDialogComponent(dialogRef as never, data),
+      dialogRef
+    };
+  };
+
+  it('requires at least one job definition when execution options are available', () => {
+    const { component, dialogRef } = createComponent({
+      context: 'execution',
+      coders: [],
+      jobDefinitions: [{ id: 11, label: 'Definition #11' }]
+    });
+
+    component.selectedJobDefinitionIds = [];
+
+    expect(component.canConfirm).toBe(false);
+
+    component.confirm();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('requires at least one coder training when training options are available', () => {
+    const { component, dialogRef } = createComponent({
+      context: 'training',
+      coders: [],
+      coderTrainings: [{ id: 7, label: 'Schulung A' } as never]
+    });
+
+    component.selectedCoderTrainingIds = [];
+
+    expect(component.canConfirm).toBe(false);
+
+    component.confirm();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.ts
@@ -1,0 +1,142 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { TranslateModule } from '@ngx-translate/core';
+import { Coder } from '../../models/coder.model';
+import { CoderTraining } from '../../models/coder-training.model';
+
+export type ManualCodingExportContext = 'training' | 'execution';
+export type ManualCodingExportMode = 'review' | 'report';
+export type ManualCodingExportType = 'aggregated' | 'detailed' | 'coding-times';
+
+export interface ManualCodingJobDefinitionOption {
+  id: number;
+  label: string;
+}
+
+export interface ManualCodingExportDialogData {
+  context: ManualCodingExportContext;
+  coders: Coder[];
+  jobDefinitions?: ManualCodingJobDefinitionOption[];
+  coderTrainings?: CoderTraining[];
+  defaultJobDefinitionIds?: number[];
+  defaultCoderTrainingIds?: number[];
+}
+
+export interface ManualCodingExportDialogResult {
+  exportType: ManualCodingExportType;
+  outputCommentsInsteadOfCodes?: boolean;
+  doubleCodingMethod?: 'new-row-per-variable' | 'new-column-per-coder' | 'most-frequent';
+  includeComments?: boolean;
+  includeModalValue?: boolean;
+  anonymizeCoders?: boolean;
+  usePseudoCoders?: boolean;
+  jobDefinitionIds?: number[];
+  coderTrainingIds?: number[];
+  coderIds?: number[];
+}
+
+@Component({
+  selector: 'coding-box-manual-coding-export-dialog',
+  templateUrl: './manual-coding-export-dialog.component.html',
+  styleUrls: ['./manual-coding-export-dialog.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatRadioModule,
+    MatSelectModule,
+    TranslateModule
+  ]
+})
+export class ManualCodingExportDialogComponent {
+  exportMode: ManualCodingExportMode = 'review';
+  reportExportType: Exclude<ManualCodingExportType, 'aggregated'> = 'detailed';
+  doubleCodingMethod: 'new-row-per-variable' | 'new-column-per-coder' | 'most-frequent' = 'most-frequent';
+  outputCommentsInsteadOfCodes = false;
+  includeComments = true;
+  includeModalValue = true;
+  anonymizeCoders = false;
+  usePseudoCoders = false;
+  selectedJobDefinitionIds: number[] = [];
+  selectedCoderTrainingIds: number[] = [];
+  selectedCoderIds: number[] = [];
+
+  constructor(
+    public dialogRef: MatDialogRef<ManualCodingExportDialogComponent, ManualCodingExportDialogResult>,
+    @Inject(MAT_DIALOG_DATA) public data: ManualCodingExportDialogData
+  ) {
+    this.selectedJobDefinitionIds = data.defaultJobDefinitionIds?.length ?
+      data.defaultJobDefinitionIds :
+      data.jobDefinitions?.map(jobDefinition => jobDefinition.id) ?? [];
+    this.selectedCoderTrainingIds = data.defaultCoderTrainingIds?.length ?
+      data.defaultCoderTrainingIds :
+      data.coderTrainings?.map(training => training.id) ?? [];
+  }
+
+  get contextSubtitleKey(): string {
+    return this.data.context === 'training' ?
+      'manual-coding-export.subtitle-training' :
+      'manual-coding-export.subtitle-execution';
+  }
+
+  get canConfirm(): boolean {
+    if (this.data.context === 'execution' && this.data.jobDefinitions?.length) {
+      return this.selectedJobDefinitionIds.length > 0;
+    }
+
+    if (this.data.context === 'training' && this.data.coderTrainings?.length) {
+      return this.selectedCoderTrainingIds.length > 0;
+    }
+
+    return true;
+  }
+
+  confirm(): void {
+    if (!this.canConfirm) {
+      return;
+    }
+
+    const coderIds = this.selectedCoderIds.length ? this.selectedCoderIds : undefined;
+    const jobDefinitionIds = this.selectedJobDefinitionIds.length ? this.selectedJobDefinitionIds : undefined;
+    const coderTrainingIds = this.selectedCoderTrainingIds.length ? this.selectedCoderTrainingIds : undefined;
+
+    if (this.exportMode === 'review') {
+      this.dialogRef.close({
+        exportType: 'aggregated',
+        outputCommentsInsteadOfCodes: this.outputCommentsInsteadOfCodes,
+        doubleCodingMethod: this.doubleCodingMethod,
+        includeComments: this.includeComments,
+        includeModalValue: this.includeModalValue,
+        anonymizeCoders: this.anonymizeCoders,
+        usePseudoCoders: this.anonymizeCoders && this.usePseudoCoders,
+        jobDefinitionIds,
+        coderTrainingIds,
+        coderIds
+      });
+      return;
+    }
+
+    this.dialogRef.close({
+      exportType: this.reportExportType,
+      outputCommentsInsteadOfCodes: this.outputCommentsInsteadOfCodes,
+      anonymizeCoders: this.anonymizeCoders,
+      usePseudoCoders: this.anonymizeCoders && this.usePseudoCoders,
+      jobDefinitionIds,
+      coderTrainingIds,
+      coderIds
+    });
+  }
+}

--- a/apps/frontend/src/app/coding/services/coder.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coder.service.spec.ts
@@ -53,6 +53,24 @@ describe('CoderService', () => {
     });
   });
 
+  describe('getCodersForExport', () => {
+    it('should propagate loading errors', done => {
+      service.getCodersForExport().subscribe({
+        next: () => {
+          done.fail('Expected getCodersForExport to propagate the error');
+        },
+        error: error => {
+          expect(error.status).toBe(500);
+          done();
+        }
+      });
+
+      const req = httpMock.expectOne(`${mockServerUrl}/admin/workspace/1/coders`);
+      expect(req.request.method).toBe('GET');
+      req.flush('failed', { status: 500, statusText: 'Server Error' });
+    });
+  });
+
   describe('getJobsByCoderId', () => {
     it('should fetch jobs for coder', () => {
       service.getJobsByCoderId(1).subscribe();

--- a/apps/frontend/src/app/coding/services/coder.service.ts
+++ b/apps/frontend/src/app/coding/services/coder.service.ts
@@ -17,6 +17,16 @@ export class CoderService {
   private codersSubject = new BehaviorSubject<Coder[]>([]);
 
   getCoders(): Observable<Coder[]> {
+    return this.fetchWorkspaceCoders().pipe(
+      catchError(() => of([]))
+    );
+  }
+
+  getCodersForExport(): Observable<Coder[]> {
+    return this.fetchWorkspaceCoders();
+  }
+
+  private fetchWorkspaceCoders(): Observable<Coder[]> {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
       return of([]);
@@ -41,8 +51,7 @@ export class CoderService {
         }));
         this.codersSubject.next(coders);
         return coders;
-      }),
-      catchError(() => of([]))
+      })
     );
   }
 

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -641,7 +641,11 @@ describe('TestPersonCodingService', () => {
       };
 
       service
-        .getCohensKappaStatistics(mockWorkspaceId, true, false, 'UNIT', 'VAR')
+        .getCohensKappaStatistics(mockWorkspaceId, true, false, 'UNIT', 'VAR', {
+          jobDefinitionIds: [11, 12],
+          coderTrainingIds: [21],
+          coderIds: [31, 32]
+        })
         .subscribe(response => {
           expect(response).toEqual(mockResponse);
           expect(response.variables[0].meanKappa).toBe(0.667);
@@ -652,7 +656,10 @@ describe('TestPersonCodingService', () => {
         request.params.get('weightedMean') === 'true' &&
         request.params.get('excludeTrainings') === 'false' &&
         request.params.get('unitName') === 'UNIT' &&
-        request.params.get('variableId') === 'VAR'
+        request.params.get('variableId') === 'VAR' &&
+        request.params.get('jobDefinitionIds') === '11,12' &&
+        request.params.get('coderTrainingIds') === '21' &&
+        request.params.get('coderIds') === '31,32'
       ));
       expect(req.request.method).toBe('GET');
       req.flush(mockResponse);
@@ -664,7 +671,11 @@ describe('TestPersonCodingService', () => {
       const mockBlob = new Blob(['subunit;nCases'], { type: 'text/csv' });
 
       service
-        .exportCohensKappaSummaryAsCsv(mockWorkspaceId, false, false, 'UNIT', 'VAR')
+        .exportCohensKappaSummaryAsCsv(mockWorkspaceId, false, false, 'UNIT', 'VAR', {
+          jobDefinitionIds: [11],
+          coderTrainingIds: [21],
+          coderIds: [31]
+        })
         .subscribe(response => {
           expect(response).toEqual(mockBlob);
         });
@@ -674,7 +685,10 @@ describe('TestPersonCodingService', () => {
         request.params.get('weightedMean') === 'false' &&
         request.params.get('excludeTrainings') === 'false' &&
         request.params.get('unitName') === 'UNIT' &&
-        request.params.get('variableId') === 'VAR'
+        request.params.get('variableId') === 'VAR' &&
+        request.params.get('jobDefinitionIds') === '11' &&
+        request.params.get('coderTrainingIds') === '21' &&
+        request.params.get('coderIds') === '31'
       ));
       expect(req.request.method).toBe('GET');
       expect(req.request.responseType).toBe('blob');
@@ -687,7 +701,10 @@ describe('TestPersonCodingService', () => {
       });
 
       service
-        .exportCohensKappaStatisticsAsXlsx(mockWorkspaceId, true, true)
+        .exportCohensKappaStatisticsAsXlsx(mockWorkspaceId, true, true, undefined, undefined, {
+          jobDefinitionIds: [11, 12],
+          coderIds: [31]
+        })
         .subscribe(response => {
           expect(response).toEqual(mockBlob);
         });
@@ -695,7 +712,9 @@ describe('TestPersonCodingService', () => {
       const req = httpMock.expectOne(request => (
         request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/cohens-kappa/export/xlsx` &&
         request.params.get('weightedMean') === 'true' &&
-        request.params.get('excludeTrainings') === 'true'
+        request.params.get('excludeTrainings') === 'true' &&
+        request.params.get('jobDefinitionIds') === '11,12' &&
+        request.params.get('coderIds') === '31'
       ));
       expect(req.request.method).toBe('GET');
       expect(req.request.responseType).toBe('blob');
@@ -706,7 +725,9 @@ describe('TestPersonCodingService', () => {
       const mockBlob = new Blob(['Variable;Kappa-Wert'], { type: 'text/csv' });
 
       service
-        .exportCohensKappaStatisticsAsCsv(mockWorkspaceId, false, false, 'UNIT', 'VAR')
+        .exportCohensKappaStatisticsAsCsv(mockWorkspaceId, false, false, 'UNIT', 'VAR', {
+          coderTrainingIds: [21, 22]
+        })
         .subscribe(response => {
           expect(response).toEqual(mockBlob);
         });
@@ -716,7 +737,8 @@ describe('TestPersonCodingService', () => {
         request.params.get('weightedMean') === 'false' &&
         request.params.get('excludeTrainings') === 'false' &&
         request.params.get('unitName') === 'UNIT' &&
-        request.params.get('variableId') === 'VAR'
+        request.params.get('variableId') === 'VAR' &&
+        request.params.get('coderTrainingIds') === '21,22'
       ));
       expect(req.request.method).toBe('GET');
       expect(req.request.responseType).toBe('blob');

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -90,6 +90,12 @@ export interface CohensKappaStatisticsResponse {
   };
 }
 
+export interface CohensKappaScope {
+  jobDefinitionIds?: number[];
+  coderTrainingIds?: number[];
+  coderIds?: number[];
+}
+
 export interface AggregationSettingsResponse {
   success: boolean;
   threshold: number;
@@ -1180,7 +1186,8 @@ export class TestPersonCodingService {
     weightedMean: boolean = true,
     excludeTrainings: boolean = true,
     unitName?: string,
-    variableId?: string
+    variableId?: string,
+    scope?: CohensKappaScope
   ): Observable<CohensKappaStatisticsResponse> {
     let params = new HttpParams();
 
@@ -1193,6 +1200,7 @@ export class TestPersonCodingService {
     if (variableId) {
       params = params.set('variableId', variableId);
     }
+    params = this.appendCohensKappaScopeParams(params, scope);
 
     return this.http
       .get<CohensKappaStatisticsResponse>(
@@ -1221,13 +1229,15 @@ export class TestPersonCodingService {
     weightedMean: boolean = true,
     excludeTrainings: boolean = true,
     unitName?: string,
-    variableId?: string
+    variableId?: string,
+    scope?: CohensKappaScope
   ): Observable<Blob> {
     const params = this.buildCohensKappaExportParams(
       weightedMean,
       excludeTrainings,
       unitName,
-      variableId
+      variableId,
+      scope
     );
 
     return this.http
@@ -1247,13 +1257,15 @@ export class TestPersonCodingService {
     weightedMean: boolean = true,
     excludeTrainings: boolean = true,
     unitName?: string,
-    variableId?: string
+    variableId?: string,
+    scope?: CohensKappaScope
   ): Observable<Blob> {
     const params = this.buildCohensKappaExportParams(
       weightedMean,
       excludeTrainings,
       unitName,
-      variableId
+      variableId,
+      scope
     );
 
     return this.http
@@ -1273,13 +1285,15 @@ export class TestPersonCodingService {
     weightedMean: boolean = true,
     excludeTrainings: boolean = true,
     unitName?: string,
-    variableId?: string
+    variableId?: string,
+    scope?: CohensKappaScope
   ): Observable<Blob> {
     const params = this.buildCohensKappaExportParams(
       weightedMean,
       excludeTrainings,
       unitName,
-      variableId
+      variableId,
+      scope
     );
 
     return this.http
@@ -1298,7 +1312,8 @@ export class TestPersonCodingService {
     weightedMean: boolean,
     excludeTrainings: boolean,
     unitName?: string,
-    variableId?: string
+    variableId?: string,
+    scope?: CohensKappaScope
   ): HttpParams {
     let params = new HttpParams()
       .set('weightedMean', weightedMean.toString())
@@ -1311,13 +1326,30 @@ export class TestPersonCodingService {
       params = params.set('variableId', variableId);
     }
 
-    return params;
+    return this.appendCohensKappaScopeParams(params, scope);
+  }
+
+  private appendCohensKappaScopeParams(params: HttpParams, scope?: CohensKappaScope): HttpParams {
+    let scopedParams = params;
+
+    if (scope?.jobDefinitionIds?.length) {
+      scopedParams = scopedParams.set('jobDefinitionIds', scope.jobDefinitionIds.join(','));
+    }
+    if (scope?.coderTrainingIds?.length) {
+      scopedParams = scopedParams.set('coderTrainingIds', scope.coderTrainingIds.join(','));
+    }
+    if (scope?.coderIds?.length) {
+      scopedParams = scopedParams.set('coderIds', scope.coderIds.join(','));
+    }
+
+    return scopedParams;
   }
 
   getWorkspaceCohensKappaSummary(
     workspaceId: number,
     weightedMean: boolean = true,
-    excludeTrainings: boolean = true
+    excludeTrainings: boolean = true,
+    scope?: CohensKappaScope
   ): Observable<{
       coderPairs: Array<{
         coder1Id: number;
@@ -1339,9 +1371,9 @@ export class TestPersonCodingService {
         weightingMethod: 'weighted' | 'unweighted';
       };
     }> {
-    const params = new HttpParams()
+    const params = this.appendCohensKappaScopeParams(new HttpParams()
       .set('weightedMean', weightedMean.toString())
-      .set('excludeTrainings', excludeTrainings.toString());
+      .set('excludeTrainings', excludeTrainings.toString()), scope);
     return this.http
       .get<{
       coderPairs: Array<{

--- a/apps/frontend/src/app/ws-admin/components/export/export.component.html
+++ b/apps/frontend/src/app/ws-admin/components/export/export.component.html
@@ -7,71 +7,10 @@
     <mat-card-content>
       <p>{{ 'ws-admin.export-description' | translate }}</p>
 
-      <div class="format-options">
-        <mat-radio-group [(ngModel)]="selectedFormat" (ngModelChange)="onFormatChange()">
-          <div class="format-group" *ngFor="let group of exportFormatGroups">
-            <h3>{{ group.label }}</h3>
-            <div class="format-option" *ngFor="let format of group.formats">
-              <mat-radio-button [value]="format.value">
-                <div class="format-label">{{ format.label }}</div>
-                <div class="format-description">{{ format.description }}</div>
-              </mat-radio-button>
-            </div>
-          </div>
-        </mat-radio-group>
-      </div>
-
-      <div class="export-warning" *ngIf="selectedFormat === 'by-variable' && largeByVariableEstimate">
-        <mat-icon aria-hidden="true">warning</mat-icon>
-        <div>
-          <div class="warning-title">
-            {{ 'ws-admin.export-options.by-variable-too-large-title' | translate }}
-          </div>
-          <p>
-            {{ 'ws-admin.export-options.by-variable-too-large-message' | translate: {
-              actual: largeByVariableEstimate.unitVariableCount,
-              max: largeByVariableEstimate.worksheetLimit
-            } }}
-          </p>
-          <button mat-stroked-button color="primary" type="button" (click)="selectCompactVariableExport()">
-            {{ 'ws-admin.export-options.select-compact-variable-export' | translate }}
-          </button>
-        </div>
-      </div>
-
-      <div class="filter-section" *ngIf="supportsJobFilters()">
-        <h3>{{ 'ws-admin.export-options.filter-jobs-trainings' | translate }}</h3>
-        <div class="filter-fields-container">
-          <div class="selection-trigger">
-            <div class="selection-trigger-header">
-              <div class="selection-trigger-title">
-                {{ 'ws-admin.export-options.job-definitions' | translate }} & {{
-                  'ws-admin.export-options.coder-trainings' | translate }}
-              </div>
-              <div class="selection-trigger-summary">{{ getSelectionSummary() }}</div>
-            </div>
-            <button mat-stroked-button color="primary" type="button" (click)="openSelectionDialog()">
-              Auswahl ändern
-            </button>
-          </div>
-
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'ws-admin.export-options.coders' | translate }}</mat-label>
-            <mat-select [(ngModel)]="selectedCoderIds" multiple (selectionChange)="clearLargeByVariableEstimate()">
-              <mat-select-trigger>{{ getCoderSelectionLabel() }}</mat-select-trigger>
-              <mat-option *ngFor="let coder of coders" [value]="coder.id">
-                {{ coder.name }}
-              </mat-option>
-            </mat-select>
-            <mat-hint>{{ 'ws-admin.export-options.coders-empty-means-all' | translate }}</mat-hint>
-          </mat-form-field>
-        </div>
-      </div>
-
       <div class="export-options-section">
         <h3>{{ 'ws-admin.export-options-title' | translate }}</h3>
 
-        <div *ngIf="selectedFormat === 'results-by-version'" class="results-options">
+        <div class="results-options">
           <mat-form-field appearance="outline">
             <mat-label>{{ 'ws-admin.export-options.results-version' | translate }}</mat-label>
             <mat-select [(ngModel)]="resultsVersion">
@@ -108,81 +47,7 @@
             {{ 'ws-admin.export-options.include-geogebra-files' | translate }}
           </mat-checkbox>
         </div>
-
-        <!-- Double-coding method section for aggregated export -->
-        <div *ngIf="selectedFormat === 'aggregated'" class="double-coding-section">
-          <h4>{{ 'ws-admin.export-options.double-coding-method-title' | translate }}</h4>
-          <mat-radio-group [(ngModel)]="doubleCodingMethod" (ngModelChange)="onDoubleCodingMethodChange()"
-            class="double-coding-radio-group">
-            <mat-radio-button value="most-frequent" color="primary"
-              [matTooltip]="'ws-admin.export-options.most-frequent-random-tooltip' | translate">
-              {{ 'ws-admin.export-options.most-frequent-random' | translate }}
-            </mat-radio-button>
-            <mat-radio-button value="new-row-per-variable" color="primary"
-              [matTooltip]="'ws-admin.export-options.new-row-per-variable-tooltip' | translate">
-              {{ 'ws-admin.export-options.new-row-per-variable' | translate }}
-            </mat-radio-button>
-            <mat-radio-button value="new-column-per-coder" color="primary"
-              [matTooltip]="'ws-admin.export-options.new-column-per-coder-tooltip' | translate">
-              {{ 'ws-admin.export-options.new-column-per-coder' | translate }}
-            </mat-radio-button>
-          </mat-radio-group>
-
-          <!-- Additional options for new-row-per-variable and new-column-per-coder -->
-          <div *ngIf="doubleCodingMethod !== 'most-frequent'" class="sub-option">
-            <mat-checkbox [(ngModel)]="includeModalValue" color="primary"
-              [matTooltip]="'ws-admin.export-options.include-modal-value-tooltip' | translate">
-              {{ 'ws-admin.export-options.include-modal-value' | translate }}
-            </mat-checkbox>
-            <mat-checkbox [(ngModel)]="includeComments" color="primary"
-              [matTooltip]="'ws-admin.export-options.include-comments-tooltip' | translate">
-              {{ 'ws-admin.export-options.include-comments' | translate }}
-            </mat-checkbox>
-          </div>
-        </div>
-
-        <!-- Options specific to by-variable export -->
-        <div *ngIf="selectedFormat === 'by-variable' || selectedFormat === 'by-variable-compact'">
-          <mat-checkbox [(ngModel)]="includeModalValue" color="primary"
-            [matTooltip]="'ws-admin.export-options.include-modal-value-tooltip' | translate">
-            {{ 'ws-admin.export-options.include-modal-value' | translate }}
-          </mat-checkbox>
-          <mat-checkbox [(ngModel)]="includeDoubleCoded" color="primary"
-            [matTooltip]="'ws-admin.export-options.include-double-coded-tooltip' | translate">
-            {{ 'ws-admin.export-options.include-double-coded' | translate }}
-          </mat-checkbox>
-          <mat-checkbox [(ngModel)]="includeComments" color="primary"
-            [matTooltip]="'ws-admin.export-options.include-comments-tooltip' | translate">
-            {{ 'ws-admin.export-options.include-comments' | translate }}
-          </mat-checkbox>
-        </div>
-
-        <!-- General export options -->
-        <mat-checkbox *ngIf="supportsReplayUrl()" [(ngModel)]="includeReplayUrl" color="primary"
-          [matTooltip]="'ws-admin.export-options.include-replay-url-tooltip' | translate">
-          {{ 'ws-admin.export-options.include-replay-url' | translate }}
-        </mat-checkbox>
-        <mat-checkbox *ngIf="supportsCommentsInsteadOfCodes()" [(ngModel)]="outputCommentsInsteadOfCodes" color="primary"
-          [matTooltip]="'ws-admin.export-options.output-comments-instead-of-codes-tooltip' | translate">
-          {{ 'ws-admin.export-options.output-comments-instead-of-codes' | translate }}
-        </mat-checkbox>
-        <mat-checkbox *ngIf="supportsCoderOptions()" [(ngModel)]="anonymizeCoders" color="primary"
-          [matTooltip]="'ws-admin.export-options.anonymize-coders-tooltip' | translate">
-          {{ 'ws-admin.export-options.anonymize-coders' | translate }}
-        </mat-checkbox>
-        <div class="sub-option" *ngIf="anonymizeCoders">
-          <mat-checkbox [(ngModel)]="usePseudoCoders" color="primary"
-            [matTooltip]="'ws-admin.export-options.use-pseudo-coders-tooltip' | translate">
-            {{ 'ws-admin.export-options.use-pseudo-coders' | translate }}
-          </mat-checkbox>
-        </div>
       </div>
-
-      <mat-checkbox *ngIf="supportsManualVariableFilter()" [(ngModel)]="excludeAutoCoded"
-        (ngModelChange)="clearLargeByVariableEstimate()" color="primary"
-        [matTooltip]="'ws-admin.export-options.exclude-auto-coded-tooltip' | translate">
-        {{ 'ws-admin.export-options.exclude-auto-coded' | translate }}
-      </mat-checkbox>
     </mat-card-content>
     <mat-card-actions align="end">
       <button mat-raised-button color="primary" (click)="onExport()" [disabled]="isStartingExport">

--- a/apps/frontend/src/app/ws-admin/components/export/export.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/export/export.component.spec.ts
@@ -3,29 +3,19 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { of, throwError } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatDialog } from '@angular/material/dialog';
 import { ExportComponent } from './export.component';
 import { AppService } from '../../../core/services/app.service';
 import { ExportJobService } from '../../../shared/services/file/export-job.service';
-import { CodingFacadeService } from '../../../services/facades/coding-facade.service';
-import { CoderService } from '../../../coding/services/coder.service';
 import { ResponseService } from '../../../shared/services/response/response.service';
 
 describe('ExportComponent', () => {
   let fixture: ComponentFixture<ExportComponent>;
   let component: ExportComponent;
   let startJob: jest.Mock;
-  let estimateJob: jest.Mock;
   let snackOpen: jest.Mock;
 
   beforeEach(async () => {
     startJob = jest.fn().mockReturnValue(of({ jobId: 'job-1' }));
-    estimateJob = jest.fn().mockReturnValue(of({
-      exportType: 'by-variable',
-      unitVariableCount: 10,
-      worksheetLimit: 1000,
-      exceedsWorksheetLimit: false
-    }));
     snackOpen = jest.fn();
 
     await TestBed.configureTestingModule({
@@ -40,29 +30,12 @@ describe('ExportComponent', () => {
           useValue: {
             selectedWorkspaceId: 5,
             userId: 2,
-            loggedUser: undefined,
-            createOwnToken: jest.fn().mockReturnValue(of('token'))
+            loggedUser: undefined
           }
         },
         {
           provide: ExportJobService,
-          useValue: { startJob, estimateJob }
-        },
-        {
-          provide: CodingFacadeService,
-          useValue: {
-            getJobDefinitions: jest.fn().mockReturnValue(of([])),
-            getCoderTrainings: jest.fn().mockReturnValue(of([]))
-          }
-        },
-        {
-          provide: CoderService,
-          useValue: {
-            getCoders: jest.fn().mockReturnValue(of([
-              { id: 30, name: 'coder1' },
-              { id: 31, name: 'coder2' }
-            ]))
-          }
+          useValue: { startJob }
         },
         {
           provide: ResponseService,
@@ -73,10 +46,6 @@ describe('ExportComponent', () => {
         {
           provide: MatSnackBar,
           useValue: { open: snackOpen }
-        },
-        {
-          provide: MatDialog,
-          useValue: { open: jest.fn() }
         }
       ]
     }).compileComponents();
@@ -88,13 +57,8 @@ describe('ExportComponent', () => {
         export: {
           'job-started': 'Datenexport gestartet',
           errors: {
-            'start-failed': 'Datenexport konnte nicht gestartet werden',
-            'too-many-worksheets-short': 'Der Export ist zu groß für einzelne Tabellenblätter.'
+            'start-failed': 'Datenexport konnte nicht gestartet werden'
           }
-        },
-        'export-options': {
-          'all-coders': 'Alle Kodierer',
-          'selected-coders': '{{count}} Kodierer'
         }
       }
     });
@@ -109,28 +73,10 @@ describe('ExportComponent', () => {
     expect(component.selectedFormat).toBe('results-by-version');
   });
 
-  it('groups final result data separately from audit exports', () => {
-    expect(component.exportFormatGroups[0].formats.map(format => format.value)).toEqual([
-      'results-by-version',
-      'aggregated'
-    ]);
-    expect(component.exportFormatGroups[1].formats.map(format => format.value)).toEqual([
-      'by-coder',
-      'by-variable',
-      'by-variable-compact',
-      'detailed',
-      'coding-times'
-    ]);
-  });
-
-  it('starts final result exports without job, training, coder, or manual-variable filters', () => {
-    component.selectedFormat = 'results-by-version';
+  it('starts final result exports without manual coding filters', () => {
     component.resultsVersion = 'v2';
     component.resultsFormat = 'excel';
     component.includeResponseValues = true;
-    component.selectedCombinedJobIds = ['job_10', 'training_20'];
-    component.selectedCoderIds = [30];
-    component.excludeAutoCoded = true;
 
     component.onExport();
 
@@ -151,7 +97,6 @@ describe('ExportComponent', () => {
   });
 
   it('includes GeoGebra package option only for Excel result exports', () => {
-    component.selectedFormat = 'results-by-version';
     component.resultsVersion = 'v2';
     component.resultsFormat = 'excel';
     component.includeResponseValues = true;
@@ -182,7 +127,6 @@ describe('ExportComponent', () => {
   });
 
   it('includes raw GeoGebra response value option for result exports', () => {
-    component.selectedFormat = 'results-by-version';
     component.resultsFormat = 'csv';
     component.includeResponseValues = true;
     component.hasGeoGebraResponses = true;
@@ -199,50 +143,6 @@ describe('ExportComponent', () => {
     }));
   });
 
-  it('keeps audit export filters for detailed coding protocol exports', () => {
-    component.selectedFormat = 'detailed';
-    component.selectedCombinedJobIds = ['job_10', 'training_20'];
-    component.selectedCoderIds = [30];
-    component.excludeAutoCoded = true;
-
-    component.onExport();
-
-    expect(startJob).toHaveBeenCalledWith(5, expect.objectContaining({
-      exportType: 'detailed',
-      jobDefinitionIds: [10],
-      coderTrainingIds: [20],
-      coderIds: [30],
-      excludeAutoCoded: true
-    }));
-  });
-
-  it('blocks oversized legacy by-variable exports and suggests the compact export', () => {
-    estimateJob.mockReturnValueOnce(of({
-      exportType: 'by-variable',
-      unitVariableCount: 2578,
-      worksheetLimit: 1000,
-      exceedsWorksheetLimit: true
-    }));
-    component.selectedFormat = 'by-variable';
-
-    component.onExport();
-
-    expect(estimateJob).toHaveBeenCalledWith(5, expect.objectContaining({
-      exportType: 'by-variable'
-    }));
-    expect(startJob).not.toHaveBeenCalled();
-    expect(component.largeByVariableEstimate?.unitVariableCount).toBe(2578);
-    expect(snackOpen).toHaveBeenCalledWith(
-      'Der Export ist zu groß für einzelne Tabellenblätter.',
-      'Schließen',
-      { duration: 7000 }
-    );
-
-    component.selectCompactVariableExport();
-    expect(component.selectedFormat).toBe('by-variable-compact');
-    expect(component.largeByVariableEstimate).toBeNull();
-  });
-
   it('shows an error when the export job cannot be started', () => {
     startJob.mockReturnValueOnce(throwError(() => new Error('start failed')));
 
@@ -254,16 +154,5 @@ describe('ExportComponent', () => {
       { duration: 5000 }
     );
     expect(component.isStartingExport).toBe(false);
-  });
-
-  it('labels an empty coder filter as all coders', () => {
-    component.selectedCoderIds = [];
-    expect(component.getCoderSelectionLabel()).toBe('Alle Kodierer');
-
-    component.selectedCoderIds = [30];
-    expect(component.getCoderSelectionLabel()).toBe('coder1');
-
-    component.selectedCoderIds = [30, 31];
-    expect(component.getCoderSelectionLabel()).toBe('2 Kodierer');
   });
 });

--- a/apps/frontend/src/app/ws-admin/components/export/export.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/export/export.component.ts
@@ -2,54 +2,22 @@ import { Component, inject } from '@angular/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
-import { MatRadioModule } from '@angular/material/radio';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { Observable } from 'rxjs';
-import { catchError } from 'rxjs/operators';
 import { AppService } from '../../../core/services/app.service';
 import { ExportJobConfig, ExportJobService } from '../../../shared/services/file/export-job.service';
-import { CodingFacadeService } from '../../../services/facades/coding-facade.service';
-import { CoderService } from '../../../coding/services/coder.service';
-import { CodingExportEstimate, JobDefinition } from '../../../coding/services/coding-job-backend.service';
-import { CoderTraining } from '../../../coding/models/coder-training.model';
-import { Coder } from '../../../coding/models/coder.model';
 import { ResponseService } from '../../../shared/services/response/response.service';
-import {
-  ExportSelectionDialogComponent,
-  ExportSelectionDialogResult
-} from './export-selection-dialog.component';
 
-export type ExportFormat =
-  | 'results-by-version'
-  | 'aggregated'
-  | 'by-coder'
-  | 'by-variable'
-  | 'by-variable-compact'
-  | 'detailed'
-  | 'coding-times';
+export type ExportFormat = 'results-by-version';
 type ResultsVersion = 'v1' | 'v2' | 'v3';
 type ResultsExportFormat = 'csv' | 'excel';
-
-interface ExportFormatOption {
-  value: ExportFormat;
-  label: string;
-  description: string;
-}
-
-interface ExportFormatGroup {
-  label: string;
-  formats: ExportFormatOption[];
-}
 
 @Component({
   selector: 'coding-box-export',
@@ -60,15 +28,12 @@ interface ExportFormatGroup {
     TranslateModule,
     MatCardModule,
     MatButtonModule,
-    MatRadioModule,
     MatProgressSpinnerModule,
-    MatProgressBarModule,
     MatSnackBarModule,
     MatCheckboxModule,
     MatTooltipModule,
     MatSelectModule,
     MatFormFieldModule,
-    MatDialogModule,
     MatIconModule,
     FormsModule,
     CommonModule
@@ -79,172 +44,29 @@ export class ExportComponent {
   private exportJobService = inject(ExportJobService);
   private translateService = inject(TranslateService);
   private snackBar = inject(MatSnackBar);
-  private codingFacadeService = inject(CodingFacadeService);
-  private coderService = inject(CoderService);
   private responseService = inject(ResponseService);
-  private dialog = inject(MatDialog);
 
   selectedFormat: ExportFormat = 'results-by-version';
   isStartingExport = false;
-  includeModalValue = false;
-  includeDoubleCoded = false;
-  includeComments = false;
-  includeReplayUrl = false;
   includeResponseValues = true;
   includeGeoGebraResponseValues = false;
   includeGeoGebraFiles = false;
   hasGeoGebraResponses = false;
-  outputCommentsInsteadOfCodes = false;
-  anonymizeCoders = false;
-  usePseudoCoders = false;
-  doubleCodingMethod: 'new-row-per-variable' | 'new-column-per-coder' | 'most-frequent' = 'most-frequent';
-  excludeAutoCoded = false;
   resultsVersion: ResultsVersion = 'v2';
   resultsFormat: ResultsExportFormat = 'csv';
-  largeByVariableEstimate: CodingExportEstimate | null = null;
-
-  jobDefinitions: JobDefinition[] = [];
-  coderTrainings: CoderTraining[] = [];
-  coders: Coder[] = [];
-
-  selectedJobDefinitionIds: number[] = [];
-  selectedCoderTrainingIds: number[] = [];
-  selectedCoderIds: number[] = [];
-  selectedCombinedJobIds: string[] = [];
-
-  exportFormatGroups: ExportFormatGroup[] = [
-    {
-      label: this.translateService.instant('ws-admin.export-format-groups.result-data'),
-      formats: [
-        {
-          value: 'results-by-version',
-          label: this.translateService.instant('ws-admin.export-formats.final-results'),
-          description: this.translateService.instant('ws-admin.export-formats.final-results-description')
-        },
-        {
-          value: 'aggregated',
-          label: this.translateService.instant('ws-admin.export-formats.aggregated'),
-          description: this.translateService.instant('ws-admin.export-formats.aggregated-description')
-        }
-      ]
-    },
-    {
-      label: this.translateService.instant('ws-admin.export-format-groups.audit-quality'),
-      formats: [
-        {
-          value: 'by-coder',
-          label: this.translateService.instant('ws-admin.export-formats.by-coder'),
-          description: this.translateService.instant('ws-admin.export-formats.by-coder-description')
-        },
-        {
-          value: 'by-variable',
-          label: this.translateService.instant('ws-admin.export-formats.by-variable'),
-          description: this.translateService.instant('ws-admin.export-formats.by-variable-description')
-        },
-        {
-          value: 'by-variable-compact',
-          label: this.translateService.instant('ws-admin.export-formats.by-variable-compact'),
-          description: this.translateService.instant('ws-admin.export-formats.by-variable-compact-description')
-        },
-        {
-          value: 'detailed',
-          label: this.translateService.instant('ws-admin.export-formats.detailed'),
-          description: this.translateService.instant('ws-admin.export-formats.detailed-description')
-        },
-        {
-          value: 'coding-times',
-          label: this.translateService.instant('ws-admin.export-formats.coding-times'),
-          description: this.translateService.instant('ws-admin.export-formats.coding-times-description')
-        }
-      ]
-    }
-  ];
 
   constructor() {
     this.loadOptions();
-  }
-
-  openSelectionDialog(): void {
-    const dialogRef = this.dialog.open(ExportSelectionDialogComponent, {
-      width: '1100px',
-      maxWidth: '92vw',
-      data: {
-        jobDefinitions: this.jobDefinitions,
-        coderTrainings: this.coderTrainings,
-        coders: this.coders,
-        selectedCombinedJobIds: this.selectedCombinedJobIds
-      }
-    });
-
-    dialogRef.afterClosed().subscribe((result: ExportSelectionDialogResult | undefined) => {
-      if (!result) return;
-      this.selectedCombinedJobIds = result.selectedCombinedJobIds;
-      this.clearLargeByVariableEstimate();
-    });
-  }
-
-  getSelectionSummary(): string {
-    const jobCount = this.finalJobDefinitionIds.length;
-    const trainingCount = this.finalCoderTrainingIds.length;
-
-    if (jobCount === 0 && trainingCount === 0) return 'Keine Filter gesetzt';
-
-    const parts: string[] = [];
-    if (jobCount > 0) parts.push(`${jobCount} Definition${jobCount === 1 ? '' : 'en'}`);
-    if (trainingCount > 0) parts.push(`${trainingCount} Training${trainingCount === 1 ? '' : 's'}`);
-    return parts.join(', ');
-  }
-
-  getCoderSelectionLabel(): string {
-    if (this.selectedCoderIds.length === 0) {
-      return this.translateService.instant('ws-admin.export-options.all-coders');
-    }
-
-    if (this.selectedCoderIds.length === 1) {
-      const selectedCoder = this.coders.find(coder => coder.id === this.selectedCoderIds[0]);
-      return selectedCoder?.displayName || selectedCoder?.name || `${this.selectedCoderIds[0]}`;
-    }
-
-    return this.translateService.instant('ws-admin.export-options.selected-coders', {
-      count: this.selectedCoderIds.length
-    });
-  }
-
-  getJobDefinitionLabel(def: JobDefinition): string {
-    const idPart = def.id != null ? `Definition #${def.id}` : 'Definition';
-    const statusPart = def.status ? `(${def.status})` : '';
-    const varsCount = def.assignedVariables?.length ?? 0;
-    const bundlesCount = def.assignedVariableBundles?.length ?? 0;
-    const codersCount = def.assignedCoders?.length ?? 0;
-    return `${idPart} ${statusPart} – ${varsCount} Variablen, ${bundlesCount} Bündel, ${codersCount} Kodierer`;
   }
 
   private loadOptions(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) return;
 
-    this.codingFacadeService.getJobDefinitions(workspaceId).subscribe(defs => {
-      this.jobDefinitions = defs;
-    });
-
-    this.codingFacadeService.getCoderTrainings(workspaceId).subscribe(trainings => {
-      this.coderTrainings = trainings;
-    });
-
-    this.coderService.getCoders().subscribe(coders => {
-      this.coders = coders;
-    });
-
     this.responseService.hasGeogebraResponses(workspaceId).subscribe(hasGeoGebraResponses => {
       this.hasGeoGebraResponses = hasGeoGebraResponses;
       this.clearUnsupportedResultsOptions();
     });
-  }
-
-  onFormatChange(): void {
-    this.clearLargeByVariableEstimate();
-    this.clearUnsupportedOptions();
-    this.clearUnsupportedResultsOptions();
   }
 
   onResultsFormatChange(): void {
@@ -259,63 +81,8 @@ export class ExportComponent {
     this.clearUnsupportedResultsOptions();
   }
 
-  onDoubleCodingMethodChange(): void {
-    this.clearUnsupportedOptions();
-  }
-
-  clearLargeByVariableEstimate(): void {
-    this.largeByVariableEstimate = null;
-  }
-
-  selectCompactVariableExport(): void {
-    this.selectedFormat = 'by-variable-compact';
-    this.clearLargeByVariableEstimate();
-    this.clearUnsupportedOptions();
-  }
-
-  supportsReplayUrl(): boolean {
-    return this.selectedFormat !== 'coding-times' &&
-      (this.selectedFormat !== 'aggregated' || this.doubleCodingMethod === 'new-row-per-variable');
-  }
-
-  supportsCommentsInsteadOfCodes(): boolean {
-    return this.selectedFormat !== 'coding-times' && this.selectedFormat !== 'results-by-version';
-  }
-
-  supportsJobFilters(): boolean {
-    return this.selectedFormat !== 'results-by-version';
-  }
-
-  supportsCoderOptions(): boolean {
-    return this.selectedFormat !== 'results-by-version';
-  }
-
-  supportsManualVariableFilter(): boolean {
-    return this.selectedFormat !== 'results-by-version';
-  }
-
-  private clearUnsupportedOptions(): void {
-    if (!this.supportsReplayUrl()) {
-      this.includeReplayUrl = false;
-    }
-
-    if (!this.supportsCommentsInsteadOfCodes()) {
-      this.outputCommentsInsteadOfCodes = false;
-    }
-
-    if (!this.supportsCoderOptions()) {
-      this.anonymizeCoders = false;
-      this.usePseudoCoders = false;
-    }
-
-    if (!this.supportsManualVariableFilter()) {
-      this.excludeAutoCoded = false;
-    }
-  }
-
   private clearUnsupportedResultsOptions(): void {
     if (
-      this.selectedFormat !== 'results-by-version' ||
       this.resultsFormat !== 'excel' ||
       !this.includeResponseValues ||
       !this.hasGeoGebraResponses
@@ -324,31 +91,12 @@ export class ExportComponent {
     }
 
     if (
-      this.selectedFormat !== 'results-by-version' ||
       !this.includeResponseValues ||
       !this.hasGeoGebraResponses ||
       this.includeGeoGebraFiles
     ) {
       this.includeGeoGebraResponseValues = false;
     }
-  }
-
-  get finalJobDefinitionIds(): number[] {
-    return Array.from(new Set(
-      this.selectedCombinedJobIds
-        .filter(id => id.startsWith('job_'))
-        .map(id => parseInt(id.replace('job_', ''), 10))
-        .filter(id => Number.isInteger(id) && id > 0)
-    ));
-  }
-
-  get finalCoderTrainingIds(): number[] {
-    return Array.from(new Set(
-      this.selectedCombinedJobIds
-        .filter(id => id.startsWith('training_'))
-        .map(id => parseInt(id.replace('training_', ''), 10))
-        .filter(id => Number.isInteger(id) && id > 0)
-    ));
   }
 
   onExport(): void {
@@ -364,108 +112,36 @@ export class ExportComponent {
 
     this.isStartingExport = true;
 
-    if (this.selectedFormat === 'by-variable') {
-      this.exportJobService.estimateJob(workspaceId, this.buildExportConfig('')).subscribe({
-        next: estimate => {
-          if (estimate.exceedsWorksheetLimit) {
-            this.largeByVariableEstimate = estimate;
-            this.snackBar.open(
-              this.translateService.instant('ws-admin.export.errors.too-many-worksheets-short'),
-              this.translateService.instant('close'),
-              { duration: 7000 }
-            );
-            this.isStartingExport = false;
-            return;
-          }
-          this.startExportWithToken(workspaceId);
-        },
-        error: () => {
-          this.startExportWithToken(workspaceId);
-        }
-      });
-      return;
-    }
-
-    this.startExportWithToken(workspaceId);
-  }
-
-  private startExportWithToken(workspaceId: number): void {
-    const tokenObservable = this.includeReplayUrl ?
-      this.appService.createOwnToken(workspaceId, 60).pipe(catchError(() => {
+    this.exportJobService.startJob(workspaceId, this.buildExportConfig()).subscribe({
+      next: () => {
         this.snackBar.open(
-          this.translateService.instant('ws-admin.export.errors.token-failed'),
+          this.translateService.instant('ws-admin.export.job-started'),
+          this.translateService.instant('close'),
+          { duration: 3000 }
+        );
+        this.isStartingExport = false;
+      },
+      error: () => {
+        this.snackBar.open(
+          this.translateService.instant('ws-admin.export.errors.start-failed'),
           this.translateService.instant('close'),
           { duration: 5000 }
         );
-        this.isStartingExport = false;
-        throw new Error('Token generation failed');
-      })) :
-      new Observable<string>(subscriber => {
-        subscriber.next('');
-        subscriber.complete();
-      });
-
-    tokenObservable.subscribe({
-      next: authToken => {
-        const exportConfig = this.buildExportConfig(authToken);
-
-        this.exportJobService.startJob(workspaceId, exportConfig).subscribe({
-          next: () => {
-            this.snackBar.open(
-              this.translateService.instant('ws-admin.export.job-started'),
-              this.translateService.instant('close'),
-              { duration: 3000 }
-            );
-            this.isStartingExport = false;
-          },
-          error: () => {
-            this.snackBar.open(
-              this.translateService.instant('ws-admin.export.errors.start-failed'),
-              this.translateService.instant('close'),
-              { duration: 5000 }
-            );
-            this.isStartingExport = false;
-          }
-        });
-      },
-      error: () => {
         this.isStartingExport = false;
       }
     });
   }
 
-  private buildExportConfig(authToken: string): ExportJobConfig {
-    const exportConfig = {
+  private buildExportConfig(): ExportJobConfig {
+    return {
       exportType: this.selectedFormat,
       userId: this.appService.userId,
-      includeReplayUrl: this.includeReplayUrl,
-      authToken
-    };
-
-    if (this.selectedFormat === 'results-by-version') {
-      return {
-        ...exportConfig,
-        version: this.resultsVersion,
-        format: this.resultsFormat,
-        includeResponseValues: this.includeResponseValues,
-        includeGeoGebraResponseValues: this.includeGeoGebraResponseValues,
-        includeGeoGebraFiles: this.includeGeoGebraFiles
-      };
-    }
-
-    return {
-      ...exportConfig,
-      outputCommentsInsteadOfCodes: this.outputCommentsInsteadOfCodes,
-      anonymizeCoders: this.anonymizeCoders,
-      usePseudoCoders: this.usePseudoCoders,
-      doubleCodingMethod: this.doubleCodingMethod,
-      includeComments: this.includeComments,
-      includeModalValue: this.includeModalValue,
-      includeDoubleCoded: this.includeDoubleCoded,
-      excludeAutoCoded: this.excludeAutoCoded,
-      jobDefinitionIds: this.finalJobDefinitionIds,
-      coderTrainingIds: this.finalCoderTrainingIds,
-      coderIds: this.selectedCoderIds
+      includeReplayUrl: false,
+      version: this.resultsVersion,
+      format: this.resultsFormat,
+      includeResponseValues: this.includeResponseValues,
+      includeGeoGebraResponseValues: this.includeGeoGebraResponseValues,
+      includeGeoGebraFiles: this.includeGeoGebraFiles
     };
   }
 }

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -72,6 +72,22 @@
       "results-by-version": "Finale Ergebnisdaten"
     }
   },
+  "manual-coding-export": {
+    "title": "Manuelle Kodierung exportieren",
+    "subtitle-training": "Exportiert Auswertungen aus Kodierschulungen.",
+    "subtitle-execution": "Exportiert Auswertungen aus produktiven Kodieraufträgen.",
+    "mode-title": "Auswertung",
+    "mode-review": "Review- und Diskussionssicht",
+    "mode-report": "Mehrfach-Job-Bericht",
+    "double-coding-method": "Doppelkodierung darstellen",
+    "report-type": "Berichtstyp",
+    "report-detailed": "Detailliertes Kodierprotokoll",
+    "report-coding-times": "Kodierzeiten",
+    "job-definition-filter": "Jobdefinitionen filtern",
+    "training-filter": "Schulungen filtern",
+    "coder-filter": "Kodierer filtern",
+    "start": "Exportjob starten"
+  },
   "process-overview": {
     "title": "Zentrale Prozess-Übersicht",
     "refresh": "Aktualisieren",
@@ -410,8 +426,8 @@
     "job-definitions": "Jobdefinitionen",
     "coding-statistics": "Kodierstatistiken",
     "manual-coding": "Manuelle Kodierung",
-    "export-subtitle": "Finale Ergebnisdaten und Audit-Sichten exportieren",
-    "export-description": "Exportieren Sie finale Ergebnisdaten oder nachvollziehbare Sichten aus Kodieraufträgen.",
+    "export-subtitle": "Finale Ergebnisdaten exportieren",
+    "export-description": "Exportieren Sie die final angewendeten Ergebnisdaten des Arbeitsbereichs.",
     "export-placeholder": "Die Funktionalität zum Datenexport wird in einer zukünftigen Version implementiert.",
     "export-action-button": "Datenexport starten",
     "no-access": "Sie haben keinen Zugriff auf diesen Arbeitsbereich. Bitte kontaktieren Sie den Studienadministrator für Zugriff.",


### PR DESCRIPTION
## Überblick

Refs #647

Dieser PR ordnet die Export- und Kappa-Flows für die manuelle Kodierung neu:

- Datenexport in der Workspace-Administration zeigt nur noch den finalen `results-by-version`-Export.
- Schulung und Durchführung erhalten eigene Exportaktionen mit fachlichem Scope.
- Manuelle Exporte können nach Jobdefinition, Kodierschulung und Kodierer gefiltert werden.
- Kappa-Endpunkte und Frontend-Komponenten unterstützen explizite Scopes über Jobdefinitionen, Trainings und Kodierer.
- CSV-Exporte sind gegen leere Ergebnismengen und TypeORM-`DISTINCT`-SQL-Probleme abgesichert.

## Ursache und Wirkung

Vorher waren manuelle Kodierungsdaten und finale Ergebnisexporte fachlich vermischt. Außerdem fehlte für Kappa-Auswertungen eine echte Scope-API jenseits von `excludeTrainings`. Dadurch konnten Exporte und Reliabilitätsberichte je nach Tab-Kontext zu breit laufen.

Mit dieser Änderung werden die fachlichen Kontexte getrennt: finale Ergebnisdaten bleiben im allgemeinen Datenexport, manuelle Kodierdaten liegen bei Schulung/Durchführung. Die Kappa-Auswertungen und Exportjobs bekommen denselben Scope, den die UI fachlich signalisiert.

Nach der Live-Prüfung wurden zusätzlich leere CSV-Dateien mit fehlendem Header sowie ungültig erzeugtes `DISTINCT`-SQL in mehreren Exportpfaden korrigiert.

## Validierung

- `npx nx test frontend --runInBand --runTestsByPath apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts`
- `npx nx test frontend --runInBand --runTestsByPath apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.spec.ts`
- `npx nx test frontend --runInBand --runTestsByPath apps/frontend/src/app/coding/services/coder.service.spec.ts`
- `npx nx test backend --runInBand --runTestsByPath apps/backend/src/app/database/services/coding/coding-review.service.spec.ts`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-export.service.spec.ts --runInBand=true`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts --runInBand=true`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-times-export.service.spec.ts --runInBand=true`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts --runInBand=true`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-list-stream.service.spec.ts --runInBand=true`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts --runInBand=true`
- `npx nx lint frontend`
- `npx nx lint backend`
- `git diff --check`

## Live-/UI-Prüfung

Lokal gegen die laufende Anwendung geprüft:

- Testergebnisse → Logs exportieren: `workspace-9-logs-2026-06-05.csv`, Header `groupname;loginname;code;bookletname;unitname;originalUnitId;timestamp;logentry`.
- Kodierübersicht → Ergebnisse v2 + Replay-URLs: `coding-results-v2-2026-06-05.csv`, Header enthält `url`.
- Manuelle Kodierung → Durchführung → Mehrfach-Job-Bericht → Detailliertes Kodierprotokoll: UI sendet `exportType: "detailed"` und `jobDefinitionIds: [118]`, Download `export-detailed-2026-06-05.csv` erfolgreich.