### PR TITLE
Implement item matrix export

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
@@ -184,6 +184,32 @@ describe('WorkspaceCodingExportController', () => {
     expect(jobQueueService.addExportJob).not.toHaveBeenCalled();
   });
 
+  it('rejects invalid item matrix versions before starting a background export job', async () => {
+    const jobQueueService = {
+      addExportJob: jest.fn()
+    };
+    const controller = new WorkspaceCodingExportController(
+      {} as CodingListExportService,
+      {} as CodingResultsExportService,
+      {} as CodingExportService,
+      {} as CodingTimesExportService,
+      {} as CodingExportOrchestratorService,
+      jobQueueService as unknown as JobQueueService,
+      {} as CacheService
+    );
+
+    await expect(controller.startExportJob(
+      5,
+      { user: { id: 2 } } as never,
+      {
+        exportType: 'item-matrix',
+        version: 'v4' as never
+      }
+    )).rejects.toThrow(BadRequestException);
+
+    expect(jobQueueService.addExportJob).not.toHaveBeenCalled();
+  });
+
   it('normalizes authenticated user IDs before starting background export jobs', async () => {
     const jobQueueService = {
       addExportJob: jest.fn().mockResolvedValue({ id: 'job-1' })

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
@@ -108,6 +108,40 @@ export class WorkspaceCodingExportController {
         'GeoGebra file packages require response values because links are written to the value column'
       );
     }
+
+    if (
+      body.exportType === 'item-matrix' &&
+      body.format !== undefined &&
+      body.format !== 'csv' &&
+      body.format !== 'excel'
+    ) {
+      throw new BadRequestException(
+        'item-matrix exports support only "csv" or "excel" format'
+      );
+    }
+
+    if (
+      body.exportType === 'item-matrix' &&
+      body.matrixValue !== undefined &&
+      body.matrixValue !== 'code' &&
+      body.matrixValue !== 'score'
+    ) {
+      throw new BadRequestException(
+        'item-matrix exports support only "code" or "score" matrix values'
+      );
+    }
+
+    if (
+      body.exportType === 'item-matrix' &&
+      body.version !== undefined &&
+      body.version !== 'v1' &&
+      body.version !== 'v2' &&
+      body.version !== 'v3'
+    ) {
+      throw new BadRequestException(
+        'item-matrix exports support only "v1", "v2" or "v3" versions'
+      );
+    }
   }
 
   private getRequestUserId(req: Request): number {
@@ -1122,7 +1156,8 @@ export class WorkspaceCodingExportController {
             'detailed',
             'coding-times',
             'coding-list',
-            'results-by-version'
+            'results-by-version',
+            'item-matrix'
           ],
           description: 'Type of export to generate'
         },
@@ -1136,6 +1171,11 @@ export class WorkspaceCodingExportController {
           enum: ['csv', 'excel', 'json'],
           description:
             'File format for exports that support multiple formats. results-by-version supports csv and excel; coding-list supports csv, excel and json.'
+        },
+        matrixValue: {
+          type: 'string',
+          enum: ['code', 'score'],
+          description: 'Cell value for item-matrix exports'
         },
         outputCommentsInsteadOfCodes: { type: 'boolean' },
         includeReplayUrl: { type: 'boolean' },

--- a/apps/backend/src/app/coding/coding.module.ts
+++ b/apps/backend/src/app/coding/coding.module.ts
@@ -42,7 +42,8 @@ import {
   CodingValidationService,
   CodingAnalysisService,
   CodingFreshnessService,
-  CodingReadinessService
+  CodingReadinessService,
+  CodingItemMatrixExportService
 } from '../database/services/coding';
 import { JobDefinitionService } from '../database/services/jobs';
 // eslint-disable-next-line import/no-cycle
@@ -104,7 +105,8 @@ import { UserModule } from '../user/user.module';
     CodingValidationService,
     CodingAnalysisService,
     CodingFreshnessService,
-    CodingReadinessService
+    CodingReadinessService,
+    CodingItemMatrixExportService
   ],
   exports: [
     CodingJobService,
@@ -126,7 +128,8 @@ import { UserModule } from '../user/user.module';
     CodingValidationService,
     CodingAnalysisService,
     CodingFreshnessService,
-    CodingReadinessService
+    CodingReadinessService,
+    CodingItemMatrixExportService
   ]
 })
 export class CodingModule { }

--- a/apps/backend/src/app/database/services/coding/coding-export-orchestrator.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export-orchestrator.service.spec.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'stream';
 import type { CodingExportService } from './coding-export.service';
 import { CodingExportOrchestratorService } from './coding-export-orchestrator.service';
+import type { CodingItemMatrixExportService } from './coding-item-matrix-export.service';
 import type { CodingResultsExportService } from './coding-results-export.service';
 
 jest.mock('./coding-export.service', () => ({
@@ -21,13 +22,23 @@ describe('CodingExportOrchestratorService', () => {
       exportCodingResultsByVersionAsGeoGebraZip: jest.fn(),
       exportCodingResultsDetailed: jest.fn()
     };
+    const codingItemMatrixExportService = {
+      exportItemMatrixAsCsvStream: jest.fn(),
+      exportItemMatrixAsExcel: jest.fn()
+    };
 
     const service = new CodingExportOrchestratorService(
       codingExportService as unknown as CodingExportService,
-      codingResultsExportService as unknown as CodingResultsExportService
+      codingResultsExportService as unknown as CodingResultsExportService,
+      codingItemMatrixExportService as unknown as CodingItemMatrixExportService
     );
 
-    return { service, codingExportService, codingResultsExportService };
+    return {
+      service,
+      codingExportService,
+      codingResultsExportService,
+      codingItemMatrixExportService
+    };
   };
 
   it('routes versioned CSV exports to the specialized results export service', async () => {
@@ -107,6 +118,50 @@ describe('CodingExportOrchestratorService', () => {
       onProgress
     );
     expect(codingResultsExportService.exportCodingResultsByVersionAsExcel).not.toHaveBeenCalled();
+  });
+
+  it('routes item matrix CSV exports to the item matrix export service', async () => {
+    const { service, codingItemMatrixExportService } = createService();
+    const csvStream = Readable.from(['csv']);
+    const onProgress = jest.fn();
+    const checkCancellation = jest.fn();
+    codingItemMatrixExportService.exportItemMatrixAsCsvStream.mockReturnValue(csvStream);
+
+    await expect(service.exportItemMatrixAsCsv({
+      workspaceId: 7,
+      matrixValue: 'code',
+      version: 'v1',
+      onProgress,
+      checkCancellation
+    })).resolves.toBe(csvStream);
+
+    expect(codingItemMatrixExportService.exportItemMatrixAsCsvStream).toHaveBeenCalledWith(
+      7,
+      'code',
+      'v1',
+      onProgress,
+      checkCancellation
+    );
+  });
+
+  it('routes item matrix Excel exports to the item matrix export service', async () => {
+    const { service, codingItemMatrixExportService } = createService();
+    const buffer = Buffer.from('xlsx');
+    codingItemMatrixExportService.exportItemMatrixAsExcel.mockResolvedValue(buffer);
+
+    await expect(service.exportItemMatrixAsExcel({
+      workspaceId: 7,
+      matrixValue: 'score',
+      version: 'v2'
+    })).resolves.toBe(buffer);
+
+    expect(codingItemMatrixExportService.exportItemMatrixAsExcel).toHaveBeenCalledWith(
+      7,
+      'score',
+      'v2',
+      undefined,
+      undefined
+    );
   });
 
   it('routes unscoped detailed exports to the specialized batched results export service', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-export-orchestrator.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export-orchestrator.service.ts
@@ -2,6 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
 import { Readable } from 'stream';
 import { CodingExportService } from './coding-export.service';
+import {
+  CodingItemMatrixExportService,
+  ItemMatrixValue,
+  ItemMatrixVersion
+} from './coding-item-matrix-export.service';
 import { CodingResultsExportService } from './coding-results-export.service';
 
 type CodingVersion = 'v1' | 'v2' | 'v3';
@@ -34,11 +39,20 @@ export interface DetailedCodingResultsExportOptions {
   serverUrl?: string;
 }
 
+export interface ItemMatrixExportOptions {
+  workspaceId: number;
+  matrixValue?: ItemMatrixValue;
+  version?: ItemMatrixVersion;
+  onProgress?: (percentage: number) => Promise<void>;
+  checkCancellation?: () => Promise<void>;
+}
+
 @Injectable()
 export class CodingExportOrchestratorService {
   constructor(
     private readonly codingExportService: CodingExportService,
-    private readonly codingResultsExportService: CodingResultsExportService
+    private readonly codingResultsExportService: CodingResultsExportService,
+    private readonly codingItemMatrixExportService: CodingItemMatrixExportService
   ) { }
 
   exportResultsByVersionAsCsv(
@@ -111,6 +125,26 @@ export class CodingExportOrchestratorService {
       options.coderTrainingIds,
       options.coderIds,
       options.serverUrl || ''
+    );
+  }
+
+  exportItemMatrixAsCsv(options: ItemMatrixExportOptions): Promise<Readable> {
+    return Promise.resolve(this.codingItemMatrixExportService.exportItemMatrixAsCsvStream(
+      options.workspaceId,
+      options.matrixValue || 'score',
+      options.version || 'v2',
+      options.onProgress,
+      options.checkCancellation
+    ) as Readable);
+  }
+
+  exportItemMatrixAsExcel(options: ItemMatrixExportOptions): Promise<Buffer> {
+    return this.codingItemMatrixExportService.exportItemMatrixAsExcel(
+      options.workspaceId,
+      options.matrixValue || 'score',
+      options.version || 'v2',
+      options.onProgress,
+      options.checkCancellation
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.spec.ts
@@ -1,0 +1,226 @@
+import { CodingItemMatrixExportService } from './coding-item-matrix-export.service';
+
+const collectStream = (stream: NodeJS.ReadableStream): Promise<string> => (
+  new Promise((resolve, reject) => {
+    let output = '';
+    stream.on('data', chunk => {
+      output += chunk.toString();
+    });
+    stream.on('end', () => resolve(output));
+    stream.on('error', reject);
+  })
+);
+
+describe('CodingItemMatrixExportService', () => {
+  const createService = (
+    missingsProfilesService: {
+      getMissingByIdForProfileOrDefault?: jest.Mock;
+      getMissingByCodeForProfileOrDefault?: jest.Mock;
+    } = {}
+  ) => new CodingItemMatrixExportService(
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    missingsProfilesService as never
+  );
+
+  it('streams score matrix rows with stable metadata and item columns', async () => {
+    const service = createService();
+    (service as never as {
+      buildMatrixContext: jest.Mock;
+      getResponseValuesForRows: jest.Mock;
+    }).buildMatrixContext = jest.fn().mockResolvedValue({
+      rows: [{
+        bookletId: 10,
+        bookletName: 'BOOKLET-1',
+        personLogin: 'login-1',
+        personCode: 'code-1',
+        personGroup: 'group-1'
+      }],
+      columns: [{
+        key: 'UNIT1\u001FVAR1',
+        header: 'Alias1__VAR1',
+        unitName: 'UNIT1',
+        variableId: 'VAR1'
+      }]
+    });
+    (service as never as { getResponseValuesForRows: jest.Mock }).getResponseValuesForRows =
+      jest.fn().mockResolvedValue(new Map([
+        [10, new Map([['UNIT1\u001FVAR1', { code: 3, score: 2 }]])]
+      ]));
+
+    const output = await collectStream(service.exportItemMatrixAsCsvStream(7, 'score', 'v2'));
+
+    expect(output).toContain('person_login;person_code;person_group;booklet_name;Alias1__VAR1');
+    expect(output).toContain('login-1;code-1;group-1;BOOKLET-1;2');
+  });
+
+  it('maps internal manual missing codes through the missing profile', async () => {
+    const missingsProfilesService = {
+      getMissingByIdForProfileOrDefault: jest.fn().mockResolvedValue({
+        id: 'mir',
+        label: 'missing invalid response',
+        code: -98,
+        score: 0
+      })
+    };
+    const service = createService(missingsProfilesService);
+    (service as never as {
+      buildMatrixContext: jest.Mock;
+      getResponseValuesForRows: jest.Mock;
+    }).buildMatrixContext = jest.fn().mockResolvedValue({
+      rows: [{
+        bookletId: 11,
+        bookletName: 'BOOKLET-1',
+        personLogin: 'login-1',
+        personCode: 'code-1',
+        personGroup: 'group-1'
+      }],
+      columns: [{
+        key: 'UNIT1\u001FVAR1',
+        header: 'UNIT1__VAR1',
+        unitName: 'UNIT1',
+        variableId: 'VAR1'
+      }]
+    });
+    (service as never as { getResponseValuesForRows: jest.Mock }).getResponseValuesForRows =
+      jest.fn().mockResolvedValue(new Map([
+        [11, new Map([['UNIT1\u001FVAR1', { code: -3, score: null }]])]
+      ]));
+
+    const output = await collectStream(service.exportItemMatrixAsCsvStream(7, 'code', 'v2'));
+
+    expect(output).toContain('login-1;code-1;group-1;BOOKLET-1;-98');
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault)
+      .toHaveBeenCalledWith(7, null, 'mir');
+  });
+
+  it('exports existing concrete missing codes without resolving them through the default profile', async () => {
+    const missingsProfilesService = {
+      getMissingByIdForProfileOrDefault: jest.fn(),
+      getMissingByCodeForProfileOrDefault: jest.fn()
+    };
+    const service = createService(missingsProfilesService);
+    (service as never as {
+      buildMatrixContext: jest.Mock;
+      getResponseValuesForRows: jest.Mock;
+    }).buildMatrixContext = jest.fn().mockResolvedValue({
+      rows: [{
+        bookletId: 12,
+        bookletName: 'BOOKLET-1',
+        personLogin: 'login-1',
+        personCode: 'code-1',
+        personGroup: 'group-1'
+      }],
+      columns: [{
+        key: 'UNIT1\u001FVAR1',
+        header: 'UNIT1__VAR1',
+        unitName: 'UNIT1',
+        variableId: 'VAR1'
+      }]
+    });
+    (service as never as { getResponseValuesForRows: jest.Mock }).getResponseValuesForRows =
+      jest.fn().mockResolvedValue(new Map([
+        [12, new Map([['UNIT1\u001FVAR1', { code: -96, score: 0 }]])]
+      ]));
+
+    const codeOutput = await collectStream(service.exportItemMatrixAsCsvStream(7, 'code', 'v2'));
+    const scoreOutput = await collectStream(service.exportItemMatrixAsCsvStream(7, 'score', 'v2'));
+
+    expect(codeOutput).toContain('login-1;code-1;group-1;BOOKLET-1;-96');
+    expect(scoreOutput).toContain('login-1;code-1;group-1;BOOKLET-1;0');
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault).not.toHaveBeenCalled();
+    expect(missingsProfilesService.getMissingByCodeForProfileOrDefault).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the unit key when aliases differ for the same unit', async () => {
+    const queryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      distinct: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        { unitName: 'UNIT1', unitAlias: 'AliasA' },
+        { unitName: 'UNIT1', unitAlias: 'AliasB' },
+        { unitName: 'UNIT2', unitAlias: 'AliasC' }
+      ])
+    };
+    const unitRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder)
+    };
+    const workspaceFilesService = {
+      getUnitVariableMap: jest.fn().mockResolvedValue(new Map([
+        ['UNIT1', new Set(['VAR1'])],
+        ['UNIT2', new Set(['VAR1'])]
+      ]))
+    };
+    const workspaceExclusionService = {
+      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+        globalIgnoredUnits: [],
+        ignoredBooklets: [],
+        testletIgnoredUnits: []
+      })
+    };
+    const service = new CodingItemMatrixExportService(
+      {} as never,
+      {} as never,
+      unitRepository as never,
+      workspaceFilesService as never,
+      workspaceExclusionService as never
+    );
+
+    const columns = await (service as never as {
+      getColumns: (workspaceId: number) => Promise<Array<{ header: string }>>;
+    }).getColumns(7);
+
+    expect(columns.map(column => column.header)).toEqual([
+      'UNIT1__VAR1',
+      'AliasC__VAR1'
+    ]);
+  });
+
+  it('does not create matrix columns for globally excluded units', async () => {
+    const queryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      distinct: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([])
+    };
+    const unitRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder)
+    };
+    const workspaceFilesService = {
+      getUnitVariableMap: jest.fn().mockResolvedValue(new Map([
+        ['UNIT1', new Set(['VAR1'])],
+        ['UNIT2', new Set(['VAR2'])]
+      ]))
+    };
+    const workspaceExclusionService = {
+      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+        globalIgnoredUnits: ['UNIT1'],
+        ignoredBooklets: [],
+        testletIgnoredUnits: []
+      })
+    };
+    const service = new CodingItemMatrixExportService(
+      {} as never,
+      {} as never,
+      unitRepository as never,
+      workspaceFilesService as never,
+      workspaceExclusionService as never
+    );
+
+    const columns = await (service as never as {
+      getColumns: (workspaceId: number) => Promise<Array<{ header: string }>>;
+    }).getColumns(7);
+
+    expect(columns.map(column => column.header)).toEqual(['UNIT2__VAR2']);
+  });
+});

--- a/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.ts
@@ -1,0 +1,478 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as ExcelJS from 'exceljs';
+import * as fastCsv from 'fast-csv';
+import { PassThrough } from 'stream';
+import { Repository } from 'typeorm';
+import { Booklet } from '../../entities/booklet.entity';
+import { ResponseEntity } from '../../entities/response.entity';
+import { Unit } from '../../entities/unit.entity';
+import {
+  isExcludedByResolvedExclusions,
+  normalizeExclusionUnitId,
+  WorkspaceExclusionService
+} from '../workspace/workspace-exclusion.service';
+import { WorkspaceFilesService } from '../workspace/workspace-files.service';
+import { mapCodeForExport } from '../../../utils/coding-utils';
+import { MissingsProfilesService, ResolvedMissingValue } from './missings-profiles.service';
+
+export type ItemMatrixValue = 'code' | 'score';
+export type ItemMatrixFormat = 'csv' | 'excel';
+export type ItemMatrixVersion = 'v1' | 'v2' | 'v3';
+
+interface MatrixColumn {
+  key: string;
+  header: string;
+  unitName: string;
+  variableId: string;
+}
+
+interface MatrixRow {
+  bookletId: number;
+  bookletName: string;
+  personLogin: string;
+  personCode: string;
+  personGroup: string;
+}
+
+interface RawMatrixRow {
+  bookletId: number;
+  bookletName: string;
+  personLogin: string;
+  personCode: string;
+  personGroup: string;
+}
+
+interface ResponseValue {
+  code: number | null;
+  score: number | null;
+}
+
+@Injectable()
+export class CodingItemMatrixExportService {
+  private readonly logger = new Logger(CodingItemMatrixExportService.name);
+
+  private readonly missingValueCache = new Map<string, ResolvedMissingValue>();
+
+  constructor(
+    @InjectRepository(ResponseEntity)
+    private readonly responseRepository: Repository<ResponseEntity>,
+    @InjectRepository(Booklet)
+    private readonly bookletRepository: Repository<Booklet>,
+    @InjectRepository(Unit)
+    private readonly unitRepository: Repository<Unit>,
+    private readonly workspaceFilesService: WorkspaceFilesService,
+    private readonly workspaceExclusionService: WorkspaceExclusionService,
+    @Optional()
+    private readonly missingsProfilesService?: MissingsProfilesService
+  ) {}
+
+  exportItemMatrixAsCsvStream(
+    workspaceId: number,
+    value: ItemMatrixValue,
+    version: ItemMatrixVersion = 'v2',
+    progressCallback?: (percentage: number) => Promise<void>,
+    checkCancellation?: () => Promise<void>
+  ): NodeJS.ReadableStream {
+    const outputStream = new PassThrough();
+
+    (async () => {
+      try {
+        const context = await this.buildMatrixContext(workspaceId);
+        const headers = this.getHeaders(context.columns);
+        const matrixStream = fastCsv.format({
+          headers,
+          delimiter: ';',
+          alwaysWriteHeaders: true
+        });
+
+        matrixStream.on('error', error => outputStream.emit('error', error));
+        matrixStream.pipe(outputStream);
+
+        await this.writeRows(
+          workspaceId,
+          context.rows,
+          context.columns,
+          value,
+          version,
+          async row => {
+            if (!matrixStream.write(row)) {
+              await new Promise(resolve => {
+                matrixStream.once('drain', resolve);
+              });
+            }
+          },
+          progressCallback,
+          checkCancellation
+        );
+
+        matrixStream.end();
+      } catch (error) {
+        this.logger.error(`Error streaming item matrix export: ${error.message}`, error.stack);
+        outputStream.emit('error', error);
+      }
+    })();
+
+    return outputStream;
+  }
+
+  async exportItemMatrixAsExcel(
+    workspaceId: number,
+    value: ItemMatrixValue,
+    version: ItemMatrixVersion = 'v2',
+    progressCallback?: (percentage: number) => Promise<void>,
+    checkCancellation?: () => Promise<void>
+  ): Promise<Buffer> {
+    const context = await this.buildMatrixContext(workspaceId);
+    const chunks: Buffer[] = [];
+    const stream = new PassThrough();
+
+    stream.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+
+    const workbook = new ExcelJS.stream.xlsx.WorkbookWriter({
+      stream,
+      useStyles: false,
+      useSharedStrings: false
+    });
+    const worksheet = workbook.addWorksheet('Itemmatrix');
+    worksheet.columns = this.getHeaders(context.columns).map(header => ({
+      header,
+      key: header,
+      width: header.length > 24 ? 28 : 18
+    }));
+
+    const streamComplete = new Promise<void>((resolve, reject) => {
+      stream.on('end', resolve);
+      stream.on('error', reject);
+    });
+
+    await this.writeRows(
+      workspaceId,
+      context.rows,
+      context.columns,
+      value,
+      version,
+      async row => {
+        worksheet.addRow(row).commit();
+      },
+      progressCallback,
+      checkCancellation
+    );
+
+    await worksheet.commit();
+    await workbook.commit();
+    await streamComplete;
+
+    return Buffer.concat(chunks);
+  }
+
+  private async buildMatrixContext(workspaceId: number): Promise<{
+    rows: MatrixRow[];
+    columns: MatrixColumn[];
+  }> {
+    this.missingValueCache.clear();
+    const [rows, columns] = await Promise.all([
+      this.getRows(workspaceId),
+      this.getColumns(workspaceId)
+    ]);
+
+    this.logger.log(
+      `Prepared item matrix context for workspace ${workspaceId}: ${rows.length} rows, ${columns.length} columns`
+    );
+
+    return { rows, columns };
+  }
+
+  private getHeaders(columns: MatrixColumn[]): string[] {
+    return [
+      'person_login',
+      'person_code',
+      'person_group',
+      'booklet_name',
+      ...columns.map(column => column.header)
+    ];
+  }
+
+  private async getRows(workspaceId: number): Promise<MatrixRow[]> {
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const rows = await this.bookletRepository
+      .createQueryBuilder('booklet')
+      .innerJoin('booklet.person', 'person')
+      .innerJoin('booklet.bookletinfo', 'bookletinfo')
+      .select('booklet.id', 'bookletId')
+      .addSelect('bookletinfo.name', 'bookletName')
+      .addSelect('person.login', 'personLogin')
+      .addSelect('person.code', 'personCode')
+      .addSelect('person.group', 'personGroup')
+      .where('person.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('person.consider = :consider', { consider: true })
+      .orderBy('person.group', 'ASC')
+      .addOrderBy('person.login', 'ASC')
+      .addOrderBy('person.code', 'ASC')
+      .addOrderBy('bookletinfo.name', 'ASC')
+      .getRawMany<RawMatrixRow>();
+
+    return rows
+      .filter(row => !isExcludedByResolvedExclusions(exclusions, row.bookletName, ''))
+      .map(row => ({
+        bookletId: Number(row.bookletId),
+        bookletName: row.bookletName || '',
+        personLogin: row.personLogin || '',
+        personCode: row.personCode || '',
+        personGroup: row.personGroup || ''
+      }));
+  }
+
+  private async getColumns(workspaceId: number): Promise<MatrixColumn[]> {
+    const [unitVariableMap, unitAliases, exclusions] = await Promise.all([
+      this.workspaceFilesService.getUnitVariableMap(workspaceId),
+      this.getUnitAliases(workspaceId),
+      this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId)
+    ]);
+
+    const preferredHeaders = new Map<string, number>();
+    const columns: MatrixColumn[] = [];
+
+    Array.from(unitVariableMap.entries())
+      .sort(([unitA], [unitB]) => unitA.localeCompare(unitB))
+      .forEach(([unitName, variables]) => {
+        if (isExcludedByResolvedExclusions(exclusions, '', unitName)) {
+          return;
+        }
+
+        Array.from(variables)
+          .sort((a, b) => a.localeCompare(b))
+          .forEach(variableId => {
+            const alias = unitAliases.get(normalizeExclusionUnitId(unitName));
+            const preferredHeader = `${alias || unitName}__${variableId}`;
+            const header = this.createUniqueHeader(
+              preferredHeader,
+              `${unitName}__${variableId}`,
+              preferredHeaders
+            );
+            columns.push({
+              key: `${normalizeExclusionUnitId(unitName)}\u001F${variableId}`,
+              header,
+              unitName,
+              variableId
+            });
+          });
+      });
+
+    return columns;
+  }
+
+  private createUniqueHeader(
+    preferredHeader: string,
+    fallbackHeader: string,
+    seen: Map<string, number>
+  ): string {
+    if (!seen.has(preferredHeader)) {
+      seen.set(preferredHeader, 1);
+      return preferredHeader;
+    }
+
+    if (!seen.has(fallbackHeader)) {
+      seen.set(fallbackHeader, 1);
+      return fallbackHeader;
+    }
+
+    const nextCount = (seen.get(fallbackHeader) || 1) + 1;
+    seen.set(fallbackHeader, nextCount);
+    return `${fallbackHeader}__${nextCount}`;
+  }
+
+  private async getUnitAliases(workspaceId: number): Promise<Map<string, string>> {
+    const rows = await this.unitRepository
+      .createQueryBuilder('unit')
+      .innerJoin('unit.booklet', 'booklet')
+      .innerJoin('booklet.person', 'person')
+      .select('unit.name', 'unitName')
+      .addSelect('unit.alias', 'unitAlias')
+      .where('person.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('unit.alias IS NOT NULL')
+      .andWhere("unit.alias != ''")
+      .distinct(true)
+      .getRawMany<{ unitName: string; unitAlias: string }>();
+
+    const aliasesByUnit = new Map<string, Set<string>>();
+    rows.forEach(row => {
+      const normalizedUnit = normalizeExclusionUnitId(row.unitName);
+      const alias = String(row.unitAlias || '').trim();
+      if (!normalizedUnit || !alias) {
+        return;
+      }
+      const aliases = aliasesByUnit.get(normalizedUnit) || new Set<string>();
+      aliases.add(alias);
+      aliasesByUnit.set(normalizedUnit, aliases);
+    });
+
+    const stableAliases = new Map<string, string>();
+    aliasesByUnit.forEach((aliases, unitName) => {
+      if (aliases.size === 1) {
+        stableAliases.set(unitName, Array.from(aliases)[0]);
+      }
+    });
+    return stableAliases;
+  }
+
+  private async writeRows(
+    workspaceId: number,
+    rows: MatrixRow[],
+    columns: MatrixColumn[],
+    value: ItemMatrixValue,
+    version: ItemMatrixVersion,
+    writeRow: (row: Record<string, string | number>) => Promise<void>,
+    progressCallback?: (percentage: number) => Promise<void>,
+    checkCancellation?: () => Promise<void>
+  ): Promise<void> {
+    const batchSize = 100;
+    let written = 0;
+
+    for (let start = 0; start < rows.length; start += batchSize) {
+      await checkCancellation?.();
+      const batchRows = rows.slice(start, start + batchSize);
+      const responseValues = await this.getResponseValuesForRows(
+        workspaceId,
+        batchRows,
+        version
+      );
+
+      for (const row of batchRows) {
+        const exportRow: Record<string, string | number> = {
+          person_login: row.personLogin,
+          person_code: row.personCode,
+          person_group: row.personGroup,
+          booklet_name: row.bookletName
+        };
+        const rowValues = responseValues.get(row.bookletId) || new Map<string, ResponseValue>();
+
+        for (const column of columns) {
+          const cellValue = rowValues.get(column.key);
+          exportRow[column.header] = cellValue ?
+            await this.resolveExportCellValue(workspaceId, cellValue, value) :
+            '';
+        }
+
+        await writeRow(exportRow);
+        written += 1;
+      }
+
+      if (progressCallback && rows.length > 0) {
+        await progressCallback(Math.min(100, Math.round((written / rows.length) * 100)));
+      }
+
+      await new Promise(resolve => {
+        setImmediate(resolve);
+      });
+    }
+  }
+
+  private async getResponseValuesForRows(
+    workspaceId: number,
+    rows: MatrixRow[],
+    version: ItemMatrixVersion
+  ): Promise<Map<number, Map<string, ResponseValue>>> {
+    if (rows.length === 0) {
+      return new Map();
+    }
+
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const unitVariableMap = await this.workspaceFilesService.getUnitVariableMap(workspaceId);
+    const validPairs = new Set(
+      Array.from(unitVariableMap.entries()).flatMap(([unitName, variables]) => (
+        Array.from(variables).map(variableId => `${normalizeExclusionUnitId(unitName)}\u001F${variableId}`)
+      ))
+    );
+    const bookletIds = rows.map(row => row.bookletId);
+    const responses = await this.responseRepository
+      .createQueryBuilder('response')
+      .innerJoinAndSelect('response.unit', 'unit')
+      .innerJoinAndSelect('unit.booklet', 'booklet')
+      .innerJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
+      .where('booklet.id IN (:...bookletIds)', { bookletIds })
+      .orderBy('response.id', 'ASC')
+      .getMany();
+    const result = new Map<number, Map<string, ResponseValue>>();
+
+    for (const response of responses) {
+      const unitName = response.unit?.name || '';
+      const bookletName = response.unit?.booklet?.bookletinfo?.name || '';
+      if (isExcludedByResolvedExclusions(exclusions, bookletName, unitName)) {
+        continue;
+      }
+
+      const key = `${normalizeExclusionUnitId(unitName)}\u001F${response.variableid}`;
+      if (!validPairs.has(key)) {
+        continue;
+      }
+
+      const bookletId = response.unit.bookletid;
+      if (!result.has(bookletId)) {
+        result.set(bookletId, new Map());
+      }
+      result.get(bookletId)!.set(key, this.getVersionedValue(response, version));
+    }
+
+    return result;
+  }
+
+  private getVersionedValue(
+    response: ResponseEntity,
+    version: ItemMatrixVersion
+  ): ResponseValue {
+    switch (version) {
+      case 'v1':
+        return { code: response.code_v1, score: response.score_v1 };
+      case 'v2':
+        return { code: response.code_v2, score: response.score_v2 };
+      case 'v3':
+        return { code: response.code_v3, score: response.score_v3 };
+      default:
+        throw new Error(`Unsupported item-matrix version: ${version}`);
+    }
+  }
+
+  private async resolveExportCellValue(
+    workspaceId: number,
+    value: ResponseValue,
+    requestedValue: ItemMatrixValue
+  ): Promise<string | number> {
+    const missing = await this.resolveMissingValue(workspaceId, value.code);
+    if (requestedValue === 'score') {
+      return value.score ?? missing?.score ?? '';
+    }
+
+    return missing?.code ?? mapCodeForExport(value.code) ?? '';
+  }
+
+  private async resolveMissingValue(
+    workspaceId: number,
+    code: number | null
+  ): Promise<ResolvedMissingValue | null> {
+    if (code !== -3 && code !== -4) {
+      return null;
+    }
+
+    const cacheKey = `${workspaceId}:id:${code === -3 ? 'mir' : 'mci'}`;
+
+    if (this.missingValueCache.has(cacheKey)) {
+      return this.missingValueCache.get(cacheKey)!;
+    }
+
+    if (!this.missingsProfilesService) {
+      return null;
+    }
+
+    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+      workspaceId,
+      null,
+      code === -3 ? 'mir' : 'mci'
+    );
+
+    this.missingValueCache.set(cacheKey, missing);
+    return missing;
+  }
+}

--- a/apps/backend/src/app/database/services/coding/index.ts
+++ b/apps/backend/src/app/database/services/coding/index.ts
@@ -21,6 +21,7 @@ export { CodingAnalysisService } from './coding-analysis.service';
 export { CodingExportService } from './coding-export.service';
 export { CodingExportOrchestratorService } from './coding-export-orchestrator.service';
 export { CodingFreshnessService } from './coding-freshness.service';
+export { CodingItemMatrixExportService } from './coding-item-matrix-export.service';
 export { CodingListExportService } from './coding-list-export.service';
 export { CodingResultsExportService } from './coding-results-export.service';
 export { CodingTimesExportService } from './coding-times-export.service';

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -149,9 +149,11 @@ export interface ExportJobData {
   | 'test-results'
   | 'test-logs'
   | 'results-by-version'
-  | 'coding-list';
+  | 'coding-list'
+  | 'item-matrix';
   version?: 'v1' | 'v2' | 'v3';
   format?: 'csv' | 'json' | 'excel';
+  matrixValue?: 'code' | 'score';
   outputCommentsInsteadOfCodes?: boolean;
   includeReplayUrl?: boolean;
   includeResponseValues?: boolean;

--- a/apps/backend/src/app/job-queue/processors/export-job.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/export-job.processor.spec.ts
@@ -36,7 +36,9 @@ describe('ExportJobProcessor', () => {
     const codingExportOrchestratorService = {
       exportResultsByVersionAsCsv: jest.fn(),
       exportResultsByVersionAsExcel: jest.fn(),
-      exportDetailed: jest.fn()
+      exportDetailed: jest.fn(),
+      exportItemMatrixAsCsv: jest.fn(),
+      exportItemMatrixAsExcel: jest.fn()
     };
     const cacheService = {
       set: jest.fn().mockResolvedValue(undefined)
@@ -191,6 +193,76 @@ describe('ExportJobProcessor', () => {
     } finally {
       cleanup(filePath);
     }
+  });
+
+  it('routes item matrix CSV exports through the orchestrator', async () => {
+    const { processor, codingExportOrchestratorService } = createProcessor();
+    codingExportOrchestratorService.exportItemMatrixAsCsv.mockResolvedValue(Readable.from(['matrix']));
+    let filePath: string | undefined;
+
+    try {
+      const result = await processor.process(createJob({
+        exportType: 'item-matrix',
+        version: 'v2',
+        format: 'csv',
+        matrixValue: 'score'
+      }));
+      filePath = result.filePath;
+
+      expect(codingExportOrchestratorService.exportItemMatrixAsCsv).toHaveBeenCalledWith({
+        workspaceId: 7,
+        matrixValue: 'score',
+        version: 'v2',
+        onProgress: expect.any(Function),
+        checkCancellation: expect.any(Function)
+      });
+      expect(result.fileName).toMatch(/\.csv$/);
+      expect(fs.readFileSync(filePath as string).toString('utf-8')).toBe('\uFEFFmatrix');
+    } finally {
+      cleanup(filePath);
+    }
+  });
+
+  it('routes item matrix Excel exports through the orchestrator', async () => {
+    const { processor, codingExportOrchestratorService } = createProcessor();
+    codingExportOrchestratorService.exportItemMatrixAsExcel.mockResolvedValue(Buffer.from('xlsx'));
+    let filePath: string | undefined;
+
+    try {
+      const result = await processor.process(createJob({
+        exportType: 'item-matrix',
+        version: 'v3',
+        format: 'excel',
+        matrixValue: 'code'
+      }));
+      filePath = result.filePath;
+
+      expect(codingExportOrchestratorService.exportItemMatrixAsExcel).toHaveBeenCalledWith({
+        workspaceId: 7,
+        matrixValue: 'code',
+        version: 'v3',
+        onProgress: expect.any(Function),
+        checkCancellation: expect.any(Function)
+      });
+      expect(result.fileName).toMatch(/\.xlsx$/);
+      expect(fs.readFileSync(filePath as string).toString('utf-8')).toBe('xlsx');
+    } finally {
+      cleanup(filePath);
+    }
+  });
+
+  it('rejects invalid item matrix versions before exporting', async () => {
+    const { processor, codingExportOrchestratorService } = createProcessor();
+
+    await expect(processor.process(createJob({
+      exportType: 'item-matrix',
+      version: 'v4' as never,
+      format: 'csv',
+      matrixValue: 'score'
+    }))).rejects.toThrow('item-matrix exports support only "v1", "v2" or "v3" versions');
+
+    expect(codingExportOrchestratorService.exportItemMatrixAsCsv).not.toHaveBeenCalled();
+    expect(codingExportOrchestratorService.exportItemMatrixAsExcel).not.toHaveBeenCalled();
   });
 
   it('rejects GeoGebra package exports without response values', async () => {

--- a/apps/backend/src/app/job-queue/processors/export-job.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/export-job.processor.ts
@@ -62,6 +62,34 @@ export class ExportJobProcessor {
         'GeoGebra file packages require response values because links are written to the value column'
       );
     }
+
+    if (
+      job.data.exportType === 'item-matrix' &&
+      job.data.format !== undefined &&
+      job.data.format !== 'csv' &&
+      job.data.format !== 'excel'
+    ) {
+      throw new Error('item-matrix exports support only "csv" or "excel" format');
+    }
+
+    if (
+      job.data.exportType === 'item-matrix' &&
+      job.data.matrixValue !== undefined &&
+      job.data.matrixValue !== 'code' &&
+      job.data.matrixValue !== 'score'
+    ) {
+      throw new Error('item-matrix exports support only "code" or "score" matrix values');
+    }
+
+    if (
+      job.data.exportType === 'item-matrix' &&
+      job.data.version !== undefined &&
+      job.data.version !== 'v1' &&
+      job.data.version !== 'v2' &&
+      job.data.version !== 'v3'
+    ) {
+      throw new Error('item-matrix exports support only "v1", "v2" or "v3" versions');
+    }
   }
 
   private async checkCancellation(
@@ -122,7 +150,8 @@ export class ExportJobProcessor {
       'test-results',
       'test-logs',
       'results-by-version',
-      'coding-list'
+      'coding-list',
+      'item-matrix'
     ];
     if (!validExportTypes.includes(job.data.exportType)) {
       const errorMessage = `Unknown export type: ${job.data.exportType}`;
@@ -149,6 +178,9 @@ export class ExportJobProcessor {
         (job.data.exportType === 'results-by-version' &&
           job.data.format !== 'excel') ||
         (job.data.exportType === 'coding-list' &&
+          job.data.format !== 'excel' &&
+          job.data.format !== 'json') ||
+        (job.data.exportType === 'item-matrix' &&
           job.data.format !== 'excel');
       let fileExt = isCsv ? 'csv' : 'xlsx';
       if (job.data.exportType === 'coding-list' && job.data.format === 'json') {
@@ -250,6 +282,37 @@ export class ExportJobProcessor {
               onProgress,
               job.data.trainingRequired
             );
+
+            await this.writeStreamToFile(stream, filePath, {
+              prependUtf8Bom: true
+            });
+          }
+          break;
+        }
+
+        case 'item-matrix': {
+          const onProgress = async (percentage: number) => {
+            const jobProgress = 20 + Math.round((percentage / 100) * 70);
+            await job.progress(jobProgress);
+            await checkCancellation();
+          };
+
+          if (job.data.format === 'excel') {
+            buffer = await this.codingExportOrchestratorService.exportItemMatrixAsExcel({
+              workspaceId: job.data.workspaceId,
+              matrixValue: job.data.matrixValue || 'score',
+              version: job.data.version || 'v2',
+              onProgress,
+              checkCancellation
+            });
+          } else {
+            const stream = await this.codingExportOrchestratorService.exportItemMatrixAsCsv({
+              workspaceId: job.data.workspaceId,
+              matrixValue: job.data.matrixValue || 'score',
+              version: job.data.version || 'v2',
+              onProgress,
+              checkCancellation
+            });
 
             await this.writeStreamToFile(stream, filePath, {
               prependUtf8Bom: true

--- a/apps/backend/src/app/workspace/workspace.module.ts
+++ b/apps/backend/src/app/workspace/workspace.module.ts
@@ -83,7 +83,8 @@ import {
   CodingJobOperationsService,
   CodebookGenerationService,
   CodingResponseQueryService,
-  CodingFreshnessService
+  CodingFreshnessService,
+  CodingItemMatrixExportService
 } from '../database/services/coding';
 import {
   JobService,
@@ -183,6 +184,7 @@ import { CodingModule } from '../coding/coding.module';
     CodebookGenerationService,
     CodingResponseQueryService,
     CodingFreshnessService,
+    CodingItemMatrixExportService,
     UnitInfoService,
     BookletInfoService,
     WorkspaceExclusionService
@@ -227,6 +229,7 @@ import { CodingModule } from '../coding/coding.module';
     CodebookGenerationService,
     CodingResponseQueryService,
     CodingFreshnessService,
+    CodingItemMatrixExportService,
     UnitInfoService,
     BookletInfoService,
     WorkspaceExclusionService

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -29,10 +29,12 @@ export interface CodingExportConfig {
   | 'by-variable-compact'
   | 'detailed'
   | 'coding-times'
-  | 'results-by-version';
+  | 'results-by-version'
+  | 'item-matrix';
   userId?: number;
   version?: 'v1' | 'v2' | 'v3';
   format?: 'csv' | 'excel';
+  matrixValue?: 'code' | 'score';
   outputCommentsInsteadOfCodes?: boolean;
   includeReplayUrl?: boolean;
   includeResponseValues?: boolean;

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.spec.ts
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.spec.ts
@@ -61,7 +61,8 @@ describe('ExportToastComponent', () => {
           'by-variable-compact': 'Nach Variable, kompakt',
           detailed: 'Detailliertes Kodierprotokoll',
           'coding-times': 'Kodierzeiten-Bericht',
-          'results-by-version': 'Finale Ergebnisdaten'
+          'results-by-version': 'Finale Ergebnisdaten',
+          'item-matrix': 'Itemmatrix'
         },
         errors: {
           'too-many-worksheets-title': 'Export zu groß',
@@ -93,6 +94,7 @@ describe('ExportToastComponent', () => {
     expect(component.getExportTypeLabel('aggregated')).toBe('Aggregierte Ansicht');
     expect(component.getExportTypeLabel('detailed')).toBe('Detailliertes Kodierprotokoll');
     expect(component.getExportTypeLabel('results-by-version')).toBe('Finale Ergebnisdaten');
+    expect(component.getExportTypeLabel('item-matrix')).toBe('Itemmatrix');
     expect(component.getExportTypeLabel('by-variable-compact')).toBe('Nach Variable, kompakt');
     expect(component.getExportTypeLabel('custom')).toBe('custom');
     expect(component.getErrorTitle(jobs[3])).toBe('Export fehlgeschlagen');

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.ts
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.ts
@@ -38,7 +38,8 @@ export class ExportToastComponent implements OnInit, OnDestroy {
     'by-variable-compact': 'export-toast.types.by-variable-compact',
     detailed: 'export-toast.types.detailed',
     'coding-times': 'export-toast.types.coding-times',
-    'results-by-version': 'export-toast.types.results-by-version'
+    'results-by-version': 'export-toast.types.results-by-version',
+    'item-matrix': 'export-toast.types.item-matrix'
   };
 
   jobs: ExportJob[] = [];

--- a/apps/frontend/src/app/shared/services/file/export-job.service.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.ts
@@ -38,10 +38,12 @@ export interface ExportJobConfig {
   | 'by-variable-compact'
   | 'detailed'
   | 'coding-times'
-  | 'results-by-version';
+  | 'results-by-version'
+  | 'item-matrix';
   userId?: number;
   version?: 'v1' | 'v2' | 'v3';
   format?: 'csv' | 'excel';
+  matrixValue?: 'code' | 'score';
   outputCommentsInsteadOfCodes?: boolean;
   includeReplayUrl?: boolean;
   includeResponseValues?: boolean;

--- a/apps/frontend/src/app/ws-admin/components/export/export.component.html
+++ b/apps/frontend/src/app/ws-admin/components/export/export.component.html
@@ -12,6 +12,14 @@
 
         <div class="results-options">
           <mat-form-field appearance="outline">
+            <mat-label>{{ 'ws-admin.export-options.export-type' | translate }}</mat-label>
+            <mat-select [(ngModel)]="selectedFormat" (ngModelChange)="onSelectedFormatChange()">
+              <mat-option value="results-by-version">{{ 'ws-admin.export-options.export-type-results' | translate }}</mat-option>
+              <mat-option value="item-matrix">{{ 'ws-admin.export-options.export-type-item-matrix' | translate }}</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
             <mat-label>{{ 'ws-admin.export-options.results-version' | translate }}</mat-label>
             <mat-select [(ngModel)]="resultsVersion">
               <mat-option value="v1">{{ 'ws-admin.export-options.results-version-v1' | translate }}</mat-option>
@@ -28,19 +36,27 @@
             </mat-select>
           </mat-form-field>
 
-          <mat-checkbox [(ngModel)]="includeResponseValues" color="primary"
+          <mat-form-field *ngIf="selectedFormat === 'item-matrix'" appearance="outline">
+            <mat-label>{{ 'ws-admin.export-options.matrix-value' | translate }}</mat-label>
+            <mat-select [(ngModel)]="matrixValue">
+              <mat-option value="score">{{ 'ws-admin.export-options.matrix-value-score' | translate }}</mat-option>
+              <mat-option value="code">{{ 'ws-admin.export-options.matrix-value-code' | translate }}</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-checkbox *ngIf="selectedFormat === 'results-by-version'" [(ngModel)]="includeResponseValues" color="primary"
             (ngModelChange)="onIncludeResponseValuesChange()"
             [matTooltip]="'ws-admin.export-options.include-response-values-tooltip' | translate">
             {{ 'ws-admin.export-options.include-response-values' | translate }}
           </mat-checkbox>
 
-          <mat-checkbox *ngIf="hasGeoGebraResponses" [(ngModel)]="includeGeoGebraResponseValues" color="primary"
+          <mat-checkbox *ngIf="selectedFormat === 'results-by-version' && hasGeoGebraResponses" [(ngModel)]="includeGeoGebraResponseValues" color="primary"
             [disabled]="!includeResponseValues || includeGeoGebraFiles"
             [matTooltip]="'ws-admin.export-options.include-geogebra-response-values-tooltip' | translate">
             {{ 'ws-admin.export-options.include-geogebra-response-values' | translate }}
           </mat-checkbox>
 
-          <mat-checkbox *ngIf="hasGeoGebraResponses" [(ngModel)]="includeGeoGebraFiles" color="primary"
+          <mat-checkbox *ngIf="selectedFormat === 'results-by-version' && hasGeoGebraResponses" [(ngModel)]="includeGeoGebraFiles" color="primary"
             [disabled]="resultsFormat !== 'excel' || !includeResponseValues"
             (ngModelChange)="onIncludeGeoGebraFilesChange()"
             [matTooltip]="'ws-admin.export-options.include-geogebra-files-tooltip' | translate">

--- a/apps/frontend/src/app/ws-admin/components/export/export.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/export/export.component.spec.ts
@@ -96,6 +96,33 @@ describe('ExportComponent', () => {
     expect(snackOpen).toHaveBeenCalledWith('Datenexport gestartet', 'Schließen', { duration: 3000 });
   });
 
+  it('starts item matrix exports with matrix options', () => {
+    component.selectedFormat = 'item-matrix';
+    component.resultsVersion = 'v2';
+    component.resultsFormat = 'csv';
+    component.matrixValue = 'score';
+    component.includeResponseValues = true;
+    component.includeGeoGebraResponseValues = true;
+    component.includeGeoGebraFiles = true;
+
+    component.onSelectedFormatChange();
+    component.onExport();
+
+    expect(startJob).toHaveBeenCalledWith(5, expect.objectContaining({
+      exportType: 'item-matrix',
+      userId: 2,
+      version: 'v2',
+      format: 'csv',
+      matrixValue: 'score'
+    }));
+    const config = startJob.mock.calls[0][1];
+    expect(config).not.toHaveProperty('includeResponseValues');
+    expect(config).not.toHaveProperty('includeGeoGebraResponseValues');
+    expect(config).not.toHaveProperty('includeGeoGebraFiles');
+    expect(component.includeGeoGebraResponseValues).toBe(false);
+    expect(component.includeGeoGebraFiles).toBe(false);
+  });
+
   it('includes GeoGebra package option only for Excel result exports', () => {
     component.resultsVersion = 'v2';
     component.resultsFormat = 'excel';

--- a/apps/frontend/src/app/ws-admin/components/export/export.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/export/export.component.ts
@@ -15,9 +15,10 @@ import { AppService } from '../../../core/services/app.service';
 import { ExportJobConfig, ExportJobService } from '../../../shared/services/file/export-job.service';
 import { ResponseService } from '../../../shared/services/response/response.service';
 
-export type ExportFormat = 'results-by-version';
+export type ExportFormat = 'results-by-version' | 'item-matrix';
 type ResultsVersion = 'v1' | 'v2' | 'v3';
 type ResultsExportFormat = 'csv' | 'excel';
+type MatrixValue = 'code' | 'score';
 
 @Component({
   selector: 'coding-box-export',
@@ -54,6 +55,7 @@ export class ExportComponent {
   hasGeoGebraResponses = false;
   resultsVersion: ResultsVersion = 'v2';
   resultsFormat: ResultsExportFormat = 'csv';
+  matrixValue: MatrixValue = 'score';
 
   constructor() {
     this.loadOptions();
@@ -73,6 +75,10 @@ export class ExportComponent {
     this.clearUnsupportedResultsOptions();
   }
 
+  onSelectedFormatChange(): void {
+    this.clearUnsupportedResultsOptions();
+  }
+
   onIncludeResponseValuesChange(): void {
     this.clearUnsupportedResultsOptions();
   }
@@ -83,6 +89,7 @@ export class ExportComponent {
 
   private clearUnsupportedResultsOptions(): void {
     if (
+      this.selectedFormat !== 'results-by-version' ||
       this.resultsFormat !== 'excel' ||
       !this.includeResponseValues ||
       !this.hasGeoGebraResponses
@@ -91,6 +98,7 @@ export class ExportComponent {
     }
 
     if (
+      this.selectedFormat !== 'results-by-version' ||
       !this.includeResponseValues ||
       !this.hasGeoGebraResponses ||
       this.includeGeoGebraFiles
@@ -133,6 +141,16 @@ export class ExportComponent {
   }
 
   private buildExportConfig(): ExportJobConfig {
+    if (this.selectedFormat === 'item-matrix') {
+      return {
+        exportType: 'item-matrix',
+        userId: this.appService.userId,
+        version: this.resultsVersion,
+        format: this.resultsFormat,
+        matrixValue: this.matrixValue
+      };
+    }
+
     return {
       exportType: this.selectedFormat,
       userId: this.appService.userId,

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -69,7 +69,8 @@
       "by-variable-compact": "Nach Variable, kompakt",
       "detailed": "Detailliertes Kodierprotokoll",
       "coding-times": "Kodierzeiten-Bericht",
-      "results-by-version": "Finale Ergebnisdaten"
+      "results-by-version": "Finale Ergebnisdaten",
+      "item-matrix": "Itemmatrix"
     }
   },
   "manual-coding-export": {
@@ -468,6 +469,9 @@
       "include-auto-coded-tooltip": "Erweitert den Export um alle Variablen, die nicht manuell kodiert werden müssen. Standardmäßig werden nur Variablen mit CODING_INCOMPLETE Status exportiert.",
       "only-manual-coding": "Nur manuell zu kodierende Variablen",
       "only-manual-coding-tooltip": "Exportiert nur Variablen, die manuell kodiert werden sollen (CODING_INCOMPLETE Variablen). Diese Option ist standardmäßig aktiviert.",
+      "export-type": "Exporttyp",
+      "export-type-results": "Finale Ergebnisdaten",
+      "export-type-item-matrix": "Itemmatrix",
       "results-version": "Ergebnisversion",
       "results-version-v1": "v1 Autocoding",
       "results-version-v2": "v2 manuelle Kodierung",
@@ -475,6 +479,9 @@
       "results-format": "Dateiformat",
       "results-format-csv": "CSV",
       "results-format-excel": "Excel",
+      "matrix-value": "Zellwert",
+      "matrix-value-score": "Score",
+      "matrix-value-code": "Code",
       "include-response-values": "Antwortwerte einschließen",
       "include-response-values-tooltip": "Fügt die ursprünglichen Antwortwerte in den finalen Ergebnisdaten hinzu.",
       "include-geogebra-response-values": "GeoGebra-Werte als String einschließen",


### PR DESCRIPTION
## Summary

- Add an item matrix export path for CSV and Excel with score/code selection and result version handling.
- Wire the export through the background export job, workspace export controller, orchestrator, and frontend export dialog.
- Use stable item columns based on unit alias fallback plus `variable_id`, while keeping the first step to existing/resolved values only.
- Add backend and frontend coverage for request validation, job processing, export orchestration, matrix generation, and UI controls.

Refs #190

## Validation

- `npx nx lint backend`
- `npx nx test backend --runInBand --testPathPatterns=...`
- `npx nx build backend`
- `npx nx lint frontend`
- `npx nx test frontend`
- `npx nx run-many --target=build --projects=frontend,backend --parallel`

The combined build completed successfully with the existing frontend warnings for the optional chain in `test-results.component.html` and the SCSS budget in `coding-management-manual.component.scss`.
