### PR TITLE
Bump version to 1.16.0

### DIFF
--- a/apps/frontend/src/app/components/home/home.component.html
+++ b/apps/frontend/src/app/components/home/home.component.html
@@ -11,7 +11,7 @@
     [appTitle]="'Web application for coding'"
     [introHtml]="'appService.appConfig.introHtml'"
     [appName]="'IQB-Kodierbox'"
-    [appVersion]="'1.15.1'"
+    [appVersion]="'1.16.0'"
     [userName]="authData.userName"
     [userLongName]="appService.userProfile.firstName + ' ' + appService.userProfile.lastName"
     [isUserLoggedIn]="Number(authData.userId) > 0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coding-box",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coding-box",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "20.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-box",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary

- Update the package metadata version to 1.16.0.
- Update the home page app version display to 1.16.0.
- Keep package-lock metadata aligned with package.json.

## Validation

- Not run; this is a metadata and static display-only change.
