### PR TITLE
Fix manual export option labels

### DIFF
--- a/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.html
@@ -23,13 +23,13 @@
     <h3>{{ 'manual-coding-export.double-coding-method' | translate }}</h3>
     <mat-radio-group class="manual-export-radio-group" [(ngModel)]="doubleCodingMethod">
       <mat-radio-button value="most-frequent">
-        {{ 'ws-admin.export-options.double-coding-methods.most-frequent' | translate }}
+        {{ 'ws-admin.export-options.most-frequent-random' | translate }}
       </mat-radio-button>
       <mat-radio-button value="new-column-per-coder">
-        {{ 'ws-admin.export-options.double-coding-methods.new-column-per-coder' | translate }}
+        {{ 'ws-admin.export-options.new-column-per-coder' | translate }}
       </mat-radio-button>
       <mat-radio-button value="new-row-per-variable">
-        {{ 'ws-admin.export-options.double-coding-methods.new-row-per-variable' | translate }}
+        {{ 'ws-admin.export-options.new-row-per-variable' | translate }}
       </mat-radio-button>
     </mat-radio-group>
   </section>

--- a/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.spec.ts
@@ -1,3 +1,7 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ManualCodingExportDialogComponent } from './manual-coding-export-dialog.component';
 
 describe('ManualCodingExportDialogComponent', () => {
@@ -44,5 +48,47 @@ describe('ManualCodingExportDialogComponent', () => {
     component.confirm();
 
     expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  describe('template', () => {
+    let fixture: ComponentFixture<ManualCodingExportDialogComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          ManualCodingExportDialogComponent,
+          NoopAnimationsModule,
+          TranslateModule.forRoot()
+        ],
+        providers: [
+          { provide: MatDialogRef, useValue: { close: jest.fn() } },
+          { provide: MAT_DIALOG_DATA, useValue: { context: 'training', coders: [] } }
+        ]
+      }).compileComponents();
+
+      const translateService = TestBed.inject(TranslateService);
+      translateService.setTranslation('de', {
+        'ws-admin': {
+          'export-options': {
+            'most-frequent-random': 'Kodierer: häufigster Code',
+            'new-column-per-coder': 'pro Kodierer neue Spalte',
+            'new-row-per-variable': 'pro Variable neue Zeile'
+          }
+        }
+      });
+      translateService.use('de');
+
+      fixture = TestBed.createComponent(ManualCodingExportDialogComponent);
+      fixture.detectChanges();
+    });
+
+    it('renders translated double-coding method labels', () => {
+      const textContent = fixture.nativeElement.textContent;
+
+      expect(textContent).toContain('Kodierer: häufigster Code');
+      expect(textContent).toContain('pro Kodierer neue Spalte');
+      expect(textContent).toContain('pro Variable neue Zeile');
+      expect(textContent).not.toContain('ws-admin.export-options.double-coding-methods');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- use the existing export option translation keys in the manual coding export dialog
- add a focused template test for the double-coding method labels

## Context
The manual coding export dialog pointed at missing `double-coding-methods` translation keys. As a result, users saw raw translation keys instead of German labels.

Refs #680

## Validation
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.spec.ts`
- `npx nx lint frontend`