### PR TITLE
Add replay link option to manual exports

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1106,7 +1106,7 @@ describe('CodingManagementManualComponent', () => {
     const exportJobService = TestBed.inject(ExportJobService);
     const dialog = {
       open: jest.fn().mockReturnValue({
-        afterClosed: () => of({ exportType: 'detailed' })
+        afterClosed: () => of({ exportType: 'detailed', includeReplayUrl: true })
       })
     };
     const componentInternals = component as unknown as {
@@ -1163,6 +1163,7 @@ describe('CodingManagementManualComponent', () => {
       expect.objectContaining({
         exportType: 'detailed',
         userId: 9,
+        includeReplayUrl: true,
         excludeAutoCoded: true,
         jobDefinitionIds: [11]
       })

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -1164,7 +1164,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const exportConfig: ExportJobConfig = {
       exportType: result.exportType,
       userId: this.appService.userId,
-      includeReplayUrl: false,
+      includeReplayUrl: result.includeReplayUrl ?? false,
       outputCommentsInsteadOfCodes: result.outputCommentsInsteadOfCodes,
       anonymizeCoders: result.anonymizeCoders,
       usePseudoCoders: result.usePseudoCoders,

--- a/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.html
@@ -98,6 +98,11 @@
     <mat-checkbox [(ngModel)]="outputCommentsInsteadOfCodes">
       {{ 'ws-admin.export-options.output-comments-instead-of-codes' | translate }}
     </mat-checkbox>
+    @if (canIncludeReplayUrl) {
+    <mat-checkbox [(ngModel)]="includeReplayUrl">
+      {{ 'ws-admin.export-options.include-replay-url' | translate }}
+    </mat-checkbox>
+    }
     <mat-checkbox [(ngModel)]="anonymizeCoders">
       {{ 'ws-admin.export-options.anonymize-coders' | translate }}
     </mat-checkbox>

--- a/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.spec.ts
@@ -50,6 +50,66 @@ describe('ManualCodingExportDialogComponent', () => {
     expect(dialogRef.close).not.toHaveBeenCalled();
   });
 
+  it('returns includeReplayUrl for review exports', () => {
+    const { component, dialogRef } = createComponent({
+      context: 'execution',
+      coders: []
+    });
+
+    component.includeReplayUrl = true;
+
+    component.confirm();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(
+      expect.objectContaining({
+        exportType: 'aggregated',
+        includeReplayUrl: true
+      })
+    );
+  });
+
+  it('returns includeReplayUrl for detailed report exports', () => {
+    const { component, dialogRef } = createComponent({
+      context: 'training',
+      coders: []
+    });
+
+    component.exportMode = 'report';
+    component.reportExportType = 'detailed';
+    component.includeReplayUrl = true;
+
+    component.confirm();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(
+      expect.objectContaining({
+        exportType: 'detailed',
+        includeReplayUrl: true
+      })
+    );
+  });
+
+  it('does not return includeReplayUrl for coding-times exports', () => {
+    const { component, dialogRef } = createComponent({
+      context: 'training',
+      coders: []
+    });
+
+    component.exportMode = 'report';
+    component.reportExportType = 'coding-times';
+    component.includeReplayUrl = true;
+
+    expect(component.canIncludeReplayUrl).toBe(false);
+
+    component.confirm();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(
+      expect.objectContaining({
+        exportType: 'coding-times',
+        includeReplayUrl: false
+      })
+    );
+  });
+
   describe('template', () => {
     let fixture: ComponentFixture<ManualCodingExportDialogComponent>;
 

--- a/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.ts
@@ -36,6 +36,7 @@ export interface ManualCodingExportDialogResult {
   doubleCodingMethod?: 'new-row-per-variable' | 'new-column-per-coder' | 'most-frequent';
   includeComments?: boolean;
   includeModalValue?: boolean;
+  includeReplayUrl?: boolean;
   anonymizeCoders?: boolean;
   usePseudoCoders?: boolean;
   jobDefinitionIds?: number[];
@@ -68,6 +69,7 @@ export class ManualCodingExportDialogComponent {
   outputCommentsInsteadOfCodes = false;
   includeComments = true;
   includeModalValue = true;
+  includeReplayUrl = false;
   anonymizeCoders = false;
   usePseudoCoders = false;
   selectedJobDefinitionIds: number[] = [];
@@ -104,6 +106,10 @@ export class ManualCodingExportDialogComponent {
     return true;
   }
 
+  get canIncludeReplayUrl(): boolean {
+    return this.exportMode === 'review' || this.reportExportType === 'detailed';
+  }
+
   confirm(): void {
     if (!this.canConfirm) {
       return;
@@ -120,6 +126,7 @@ export class ManualCodingExportDialogComponent {
         doubleCodingMethod: this.doubleCodingMethod,
         includeComments: this.includeComments,
         includeModalValue: this.includeModalValue,
+        includeReplayUrl: this.canIncludeReplayUrl && this.includeReplayUrl,
         anonymizeCoders: this.anonymizeCoders,
         usePseudoCoders: this.anonymizeCoders && this.usePseudoCoders,
         jobDefinitionIds,
@@ -132,6 +139,7 @@ export class ManualCodingExportDialogComponent {
     this.dialogRef.close({
       exportType: this.reportExportType,
       outputCommentsInsteadOfCodes: this.outputCommentsInsteadOfCodes,
+      includeReplayUrl: this.canIncludeReplayUrl && this.includeReplayUrl,
       anonymizeCoders: this.anonymizeCoders,
       usePseudoCoders: this.anonymizeCoders && this.usePseudoCoders,
       jobDefinitionIds,

--- a/package-lock.json
+++ b/package-lock.json
@@ -34509,9 +34509,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,8 @@
     "serialize-javascript": "7.0.5",
     "picomatch": "4.0.4",
     "vite": "7.3.2",
-    "path-to-regexp": "8.4.2"
+    "path-to-regexp": "8.4.2",
+    "shell-quote": "1.8.4"
   },
   "eslintConfig": {
     "extends": "@iqb/eslint-config",


### PR DESCRIPTION
## Summary
- add a Replay-URL option to the manual coding export dialog
- pass the selected option into the manual export job configuration
- keep the option hidden/false for coding-times reports, which do not support replay links
- add focused unit coverage for supported and unsupported manual export types
- override `shell-quote` to `1.8.4` to clear the critical npm audit finding in CI

## Validation
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/manual-coding-export-dialog/manual-coding-export-dialog.component.spec.ts --runInBand
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts --runInBand
- npx nx lint frontend
- npm audit --audit-level critical

Related: #679
