### PR TITLE
Filter training reliability by selected training

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1039,11 +1039,12 @@ describe('CodingManagementManualComponent', () => {
     expect(refreshSpy).not.toHaveBeenCalled();
   });
 
-  it('should open training reliability with a coder-training kappa scope', () => {
+  it('should open training reliability with available coder trainings', () => {
     const dialog = { open: jest.fn() };
     (component as unknown as { dialog: typeof dialog }).dialog = dialog;
+    const training = { id: 7 };
     component.coderTrainingsListComponent = {
-      originalData: [{ id: 7 }],
+      originalData: [training],
       coderTrainings: [],
       openResultsComparison: jest.fn()
     } as unknown as CodingManagementManualComponent['coderTrainingsListComponent'];
@@ -1055,7 +1056,7 @@ describe('CodingManagementManualComponent', () => {
       expect.objectContaining({
         data: {
           excludeTrainings: false,
-          scope: { coderTrainingIds: [7] }
+          availableCoderTrainings: [training]
         }
       })
     );

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -1032,9 +1032,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   openTrainingReliability(): void {
-    const coderTrainingIds = this.getCoderTrainingIds();
+    const coderTrainings = this.getCoderTrainingsForExport();
 
-    if (coderTrainingIds.length === 0) {
+    if (coderTrainings.length === 0) {
       this.showError('Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.');
       return;
     }
@@ -1045,7 +1045,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       height: '90vh',
       data: {
         excludeTrainings: false,
-        scope: { coderTrainingIds }
+        availableCoderTrainings: coderTrainings
       }
     });
   }

--- a/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.html
+++ b/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.html
@@ -6,6 +6,42 @@
 
   <mat-dialog-content class="cohens-kappa-container">
     <div class="content-section">
+      <mat-card class="training-scope-card" *ngIf="hasCoderTrainingSelection">
+        <mat-card-header>
+          <mat-card-title>
+            <mat-icon>school</mat-icon>
+            {{ 'cohens-kappa-statistics.training-selection-title' | translate }}
+          </mat-card-title>
+          <mat-card-subtitle>
+            {{ 'cohens-kappa-statistics.training-selection-subtitle' | translate }}
+          </mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+          <mat-form-field class="training-select" appearance="outline">
+            <mat-label>{{ 'cohens-kappa-statistics.training-select-label' | translate }}</mat-label>
+            <mat-select
+              [(ngModel)]="selectedCoderTrainingId"
+              (selectionChange)="onCoderTrainingSelectionChange()"
+            >
+              <mat-select-trigger>
+                <ng-container *ngIf="getSelectedCoderTraining() as training">
+                  <span class="selected-training-trigger">
+                    <span class="selected-training-title">{{ getTrainingOptionTitle(training) }}</span>
+                    <span class="selected-training-meta">{{ getTrainingOptionMeta(training) }}</span>
+                  </span>
+                </ng-container>
+              </mat-select-trigger>
+              <mat-option *ngFor="let training of availableCoderTrainings" [value]="training.id">
+                <span class="training-option">
+                  <span class="training-option-title">{{ getTrainingOptionTitle(training) }}</span>
+                  <span class="training-option-meta">{{ getTrainingOptionMeta(training) }}</span>
+                </span>
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+        </mat-card-content>
+      </mat-card>
+
       @if (isLoading) {
       <div class="loading-container">
         <mat-spinner diameter="40"></mat-spinner>
@@ -112,7 +148,7 @@
 
         <div class="kappa-detail-actions">
           <button mat-stroked-button color="primary" (click)="exportKappaWorkbook()"
-            [disabled]="!!exportInProgress || isLoading || kappaStatistics.length === 0"
+            [disabled]="!canLoadKappaStatistics || !!exportInProgress || isLoading || kappaStatistics.length === 0"
             [matTooltip]="'cohens-kappa-statistics.export-xlsx-tooltip' | translate">
             <mat-icon>{{ exportInProgress === 'xlsx' ? 'hourglass_empty' : 'download' }}</mat-icon>
             <span>{{ (exportInProgress === 'xlsx' ?
@@ -120,7 +156,7 @@
               'cohens-kappa-statistics.export-xlsx') | translate }}</span>
           </button>
           <button mat-stroked-button color="primary" (click)="exportKappaSummaryCsv()"
-            [disabled]="!!exportInProgress || isLoading || kappaStatistics.length === 0"
+            [disabled]="!canLoadKappaStatistics || !!exportInProgress || isLoading || kappaStatistics.length === 0"
             [matTooltip]="'cohens-kappa-statistics.export-summary-tooltip' | translate">
             <mat-icon>{{ exportInProgress === 'summary' ? 'hourglass_empty' : 'table_view' }}</mat-icon>
             <span>{{ (exportInProgress === 'summary' ?
@@ -128,7 +164,7 @@
               'cohens-kappa-statistics.export-summary') | translate }}</span>
           </button>
           <button mat-stroked-button (click)="exportKappaDetails()"
-            [disabled]="!!exportInProgress || isLoading || kappaStatistics.length === 0"
+            [disabled]="!canLoadKappaStatistics || !!exportInProgress || isLoading || kappaStatistics.length === 0"
             [matTooltip]="'cohens-kappa-statistics.export-details-tooltip' | translate">
             <mat-icon>{{ exportInProgress === 'details' ? 'hourglass_empty' : 'dataset' }}</mat-icon>
             <span>{{ (exportInProgress === 'details' ?
@@ -183,7 +219,11 @@
           @if (kappaStatistics.length === 0) {
           <div class="no-kappa-data">
             <mat-icon>info</mat-icon>
-            <p>{{ 'cohens-kappa-statistics.no-data' | translate }}</p>
+            <p>{{
+              (canLoadKappaStatistics ?
+                'cohens-kappa-statistics.no-data' :
+                'cohens-kappa-statistics.select-training-hint') | translate
+            }}</p>
           </div>
           } @else {
           <section class="kappa-table-section">

--- a/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.scss
+++ b/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.scss
@@ -20,6 +20,35 @@
       }
     }
 
+    .training-scope-card {
+      .training-select {
+        width: 100%;
+        max-width: 640px;
+      }
+
+      .selected-training-trigger,
+      .training-option {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+        line-height: 1.25;
+      }
+
+      .selected-training-title,
+      .training-option-title {
+        font-weight: 600;
+        overflow-wrap: anywhere;
+      }
+
+      .selected-training-meta,
+      .training-option-meta {
+        color: #666;
+        font-size: 12px;
+        overflow-wrap: anywhere;
+      }
+    }
+
     .workspace-kappa-card {
       margin-bottom: 24px;
 

--- a/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.spec.ts
@@ -1,0 +1,231 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogRef
+} from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { of, Subject } from 'rxjs';
+import { AppService } from '../../../core/services/app.service';
+import { CoderTraining } from '../../models/coder-training.model';
+import {
+  CohensKappaStatisticsResponse,
+  TestPersonCodingService
+} from '../../services/test-person-coding.service';
+import {
+  CohensKappaStatisticsComponent,
+  CohensKappaStatisticsDialogData
+} from './cohens-kappa-statistics.component';
+
+describe('CohensKappaStatisticsComponent', () => {
+  let fixture: ComponentFixture<CohensKappaStatisticsComponent>;
+  let component: CohensKappaStatisticsComponent;
+  let testPersonCodingService: {
+    getCohensKappaStatistics: jest.Mock;
+    exportCohensKappaSummaryAsCsv: jest.Mock;
+    exportCohensKappaStatisticsAsXlsx: jest.Mock;
+    exportCohensKappaStatisticsAsCsv: jest.Mock;
+  };
+
+  const kappaResponse: CohensKappaStatisticsResponse = {
+    variables: [
+      {
+        unitName: 'UNIT',
+        variableId: 'VAR',
+        caseCount: 3,
+        doubleCodedCount: 2,
+        doubleCodedRate: 0.67,
+        validPairCount: 2,
+        coderPairCount: 1,
+        meanKappa: 0.5,
+        meanAgreement: 0.75,
+        coderPairs: []
+      }
+    ],
+    workspaceSummary: {
+      totalCodedResponses: 3,
+      totalDoubleCodedResponses: 2,
+      totalCoderPairs: 1,
+      averageKappa: 0.5,
+      meanAgreement: 0.75,
+      variablesIncluded: 1,
+      codersIncluded: 2,
+      weightingMethod: 'weighted'
+    }
+  };
+
+  const trainings = [
+    createTraining(7, 'Schulung A'),
+    createTraining(9, 'Schulung B')
+  ];
+
+  function createKappaResponse(variableId: string): CohensKappaStatisticsResponse {
+    return {
+      ...kappaResponse,
+      variables: [
+        {
+          ...kappaResponse.variables[0],
+          variableId
+        }
+      ]
+    };
+  }
+
+  function createTraining(id: number, label: string): CoderTraining {
+    return {
+      id,
+      label,
+      workspace_id: 1,
+      created_at: new Date('2026-06-01T08:00:00Z'),
+      updated_at: new Date('2026-06-01T08:00:00Z'),
+      jobsCount: 2
+    };
+  }
+
+  async function createComponent(dialogData: CohensKappaStatisticsDialogData): Promise<void> {
+    testPersonCodingService = {
+      getCohensKappaStatistics: jest.fn().mockReturnValue(of(kappaResponse)),
+      exportCohensKappaSummaryAsCsv: jest.fn().mockReturnValue(of(new Blob(['summary']))),
+      exportCohensKappaStatisticsAsXlsx: jest.fn().mockReturnValue(of(new Blob(['xlsx']))),
+      exportCohensKappaStatisticsAsCsv: jest.fn().mockReturnValue(of(new Blob(['details'])))
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        CohensKappaStatisticsComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: MatDialogRef,
+          useValue: { close: jest.fn() }
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: dialogData
+        },
+        {
+          provide: MatSnackBar,
+          useValue: { open: jest.fn() }
+        },
+        {
+          provide: AppService,
+          useValue: { selectedWorkspaceId: 1 }
+        },
+        {
+          provide: TestPersonCodingService,
+          useValue: testPersonCodingService
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CohensKappaStatisticsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    jest.restoreAllMocks();
+  });
+
+  it('auto-selects a single coder training and loads kappa statistics for it', async () => {
+    await createComponent({
+      excludeTrainings: false,
+      availableCoderTrainings: [trainings[0]]
+    });
+
+    expect(component.selectedCoderTrainingId).toBe(7);
+    expect(testPersonCodingService.getCohensKappaStatistics).toHaveBeenCalledWith(
+      1,
+      true,
+      false,
+      undefined,
+      undefined,
+      { coderTrainingIds: [7] }
+    );
+  });
+
+  it('waits for a selection when multiple coder trainings are available', async () => {
+    await createComponent({
+      excludeTrainings: false,
+      availableCoderTrainings: trainings
+    });
+
+    expect(component.selectedCoderTrainingId).toBeNull();
+    expect(testPersonCodingService.getCohensKappaStatistics).not.toHaveBeenCalled();
+    expect(component.canLoadKappaStatistics).toBe(false);
+  });
+
+  it('reloads kappa statistics with the selected coder training', async () => {
+    await createComponent({
+      excludeTrainings: false,
+      availableCoderTrainings: trainings
+    });
+
+    component.selectedCoderTrainingId = 9;
+    component.onCoderTrainingSelectionChange();
+
+    expect(testPersonCodingService.getCohensKappaStatistics).toHaveBeenCalledWith(
+      1,
+      true,
+      false,
+      undefined,
+      undefined,
+      { coderTrainingIds: [9] }
+    );
+  });
+
+  it('ignores stale kappa statistics responses after changing the coder training', async () => {
+    const firstTrainingResponse$ = new Subject<CohensKappaStatisticsResponse>();
+    const secondTrainingResponse$ = new Subject<CohensKappaStatisticsResponse>();
+
+    await createComponent({
+      excludeTrainings: false,
+      availableCoderTrainings: trainings
+    });
+    testPersonCodingService.getCohensKappaStatistics
+      .mockReturnValueOnce(firstTrainingResponse$.asObservable())
+      .mockReturnValueOnce(secondTrainingResponse$.asObservable());
+
+    component.selectedCoderTrainingId = 7;
+    component.onCoderTrainingSelectionChange();
+    component.selectedCoderTrainingId = 9;
+    component.onCoderTrainingSelectionChange();
+
+    secondTrainingResponse$.next(createKappaResponse('CURRENT'));
+    firstTrainingResponse$.next(createKappaResponse('STALE'));
+
+    expect(component.kappaStatistics[0].variableId).toBe('CURRENT');
+  });
+
+  it('exports with the selected coder training scope', async () => {
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn().mockReturnValue('blob:url')
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn()
+    });
+    jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+
+    await createComponent({
+      excludeTrainings: false,
+      availableCoderTrainings: [trainings[0]]
+    });
+
+    component.exportKappaSummaryCsv();
+
+    expect(testPersonCodingService.exportCohensKappaSummaryAsCsv).toHaveBeenCalledWith(
+      1,
+      true,
+      false,
+      undefined,
+      undefined,
+      { coderTrainingIds: [7] }
+    );
+  });
+});

--- a/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.ts
+++ b/apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.ts
@@ -9,6 +9,8 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -21,10 +23,17 @@ import {
   TestPersonCodingService
 } from '../../services/test-person-coding.service';
 import { AppService } from '../../../core/services/app.service';
+import { CoderTraining } from '../../models/coder-training.model';
+import {
+  getTrainingOptionMeta,
+  getTrainingOptionTitle
+} from '../../utils/coder-training-display';
 
 export interface CohensKappaStatisticsDialogData {
   scope?: CohensKappaScope;
   excludeTrainings?: boolean;
+  availableCoderTrainings?: CoderTraining[];
+  selectedCoderTrainingId?: number;
 }
 
 @Component({
@@ -41,6 +50,8 @@ export interface CohensKappaStatisticsDialogData {
     MatDialogModule,
     MatTooltipModule,
     MatSlideToggleModule,
+    MatFormFieldModule,
+    MatSelectModule,
     MatSnackBarModule,
     FormsModule,
     TranslateModule
@@ -51,14 +62,17 @@ export class CohensKappaStatisticsComponent implements OnInit {
   private appService: AppService = inject(AppService);
   private translateService = inject(TranslateService);
   private snackBar = inject(MatSnackBar);
+  private kappaStatisticsRequestId = 0;
 
   constructor(
     @Optional() public dialogRef: MatDialogRef<CohensKappaStatisticsComponent>,
     @Optional() @Inject(MAT_DIALOG_DATA) public dialogData: CohensKappaStatisticsDialogData | null
   ) {
-    this.kappaScope = dialogData?.scope;
-    this.excludeTrainings = dialogData?.excludeTrainings ?? !dialogData?.scope?.coderTrainingIds?.length;
-    this.excludeTrainingsLocked = !!dialogData?.scope?.coderTrainingIds?.length;
+    this.availableCoderTrainings = dialogData?.availableCoderTrainings ?? [];
+    this.selectedCoderTrainingId = this.getInitialCoderTrainingId();
+    this.excludeTrainings = dialogData?.excludeTrainings ??
+      !(this.hasCoderTrainingSelection || this.getEffectiveKappaScope()?.coderTrainingIds?.length);
+    this.excludeTrainingsLocked = this.hasCoderTrainingSelection || !!dialogData?.scope?.coderTrainingIds?.length;
   }
 
   isLoading = false;
@@ -67,7 +81,8 @@ export class CohensKappaStatisticsComponent implements OnInit {
   useWeightedMean = true; // Default to weighted mean (matching R reference implementation)
   excludeTrainings = true; // Default: exclude trainings
   excludeTrainingsLocked = false;
-  private kappaScope?: CohensKappaScope;
+  availableCoderTrainings: CoderTraining[] = [];
+  selectedCoderTrainingId: number | null = null;
   exportInProgress: 'summary' | 'details' | 'xlsx' | null = null;
 
   workspaceKappaSummary: {
@@ -78,14 +93,44 @@ export class CohensKappaStatisticsComponent implements OnInit {
     this.loadKappaStatistics();
   }
 
-  private loadKappaStatistics(): void {
-    this.isLoading = true;
-    const workspaceId = this.appService.selectedWorkspaceId;
+  get hasCoderTrainingSelection(): boolean {
+    return this.availableCoderTrainings.length > 0;
+  }
 
-    if (!workspaceId) {
+  get canLoadKappaStatistics(): boolean {
+    return !this.hasCoderTrainingSelection || this.selectedCoderTrainingId !== null;
+  }
+
+  getSelectedCoderTraining(): CoderTraining | undefined {
+    return this.availableCoderTrainings.find(training => training.id === this.selectedCoderTrainingId);
+  }
+
+  getTrainingOptionTitle(training: CoderTraining): string {
+    return getTrainingOptionTitle(training);
+  }
+
+  getTrainingOptionMeta(training: CoderTraining): string {
+    return getTrainingOptionMeta(training, 'Kodierer', 'Kodierer');
+  }
+
+  onCoderTrainingSelectionChange(): void {
+    this.loadKappaStatistics();
+  }
+
+  private loadKappaStatistics(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    this.kappaStatisticsRequestId += 1;
+    const requestId = this.kappaStatisticsRequestId;
+
+    if (!workspaceId || !this.canLoadKappaStatistics) {
+      this.kappaStatistics = [];
+      this.workspaceKappaSummary = null;
       this.isLoading = false;
       return;
     }
+
+    this.isLoading = true;
+    const kappaScope = this.getEffectiveKappaScope();
 
     this.testPersonCodingService
       .getCohensKappaStatistics(
@@ -94,10 +139,13 @@ export class CohensKappaStatisticsComponent implements OnInit {
         this.excludeTrainings,
         undefined,
         undefined,
-        this.kappaScope
+        kappaScope
       )
       .subscribe({
         next: response => {
+          if (requestId !== this.kappaStatisticsRequestId) {
+            return;
+          }
           this.kappaStatistics = response.variables;
           this.workspaceKappaSummary = {
             workspaceSummary: response.workspaceSummary
@@ -105,6 +153,9 @@ export class CohensKappaStatisticsComponent implements OnInit {
           this.isLoading = false;
         },
         error: () => {
+          if (requestId !== this.kappaStatisticsRequestId) {
+            return;
+          }
           this.kappaStatistics = [];
           this.workspaceKappaSummary = null;
           this.isLoading = false;
@@ -122,11 +173,12 @@ export class CohensKappaStatisticsComponent implements OnInit {
 
   exportKappaSummaryCsv(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
-    if (!workspaceId || this.exportInProgress || this.kappaStatistics.length === 0) {
+    if (!workspaceId || !this.canLoadKappaStatistics || this.exportInProgress || this.kappaStatistics.length === 0) {
       return;
     }
 
     this.exportInProgress = 'summary';
+    const kappaScope = this.getEffectiveKappaScope();
     this.testPersonCodingService
       .exportCohensKappaSummaryAsCsv(
         workspaceId,
@@ -134,7 +186,7 @@ export class CohensKappaStatisticsComponent implements OnInit {
         this.excludeTrainings,
         undefined,
         undefined,
-        this.kappaScope
+        kappaScope
       )
       .pipe(finalize(() => {
         this.exportInProgress = null;
@@ -155,11 +207,12 @@ export class CohensKappaStatisticsComponent implements OnInit {
 
   exportKappaWorkbook(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
-    if (!workspaceId || this.exportInProgress || this.kappaStatistics.length === 0) {
+    if (!workspaceId || !this.canLoadKappaStatistics || this.exportInProgress || this.kappaStatistics.length === 0) {
       return;
     }
 
     this.exportInProgress = 'xlsx';
+    const kappaScope = this.getEffectiveKappaScope();
     this.testPersonCodingService
       .exportCohensKappaStatisticsAsXlsx(
         workspaceId,
@@ -167,7 +220,7 @@ export class CohensKappaStatisticsComponent implements OnInit {
         this.excludeTrainings,
         undefined,
         undefined,
-        this.kappaScope
+        kappaScope
       )
       .pipe(finalize(() => {
         this.exportInProgress = null;
@@ -188,11 +241,12 @@ export class CohensKappaStatisticsComponent implements OnInit {
 
   exportKappaDetails(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
-    if (!workspaceId || this.exportInProgress || this.kappaStatistics.length === 0) {
+    if (!workspaceId || !this.canLoadKappaStatistics || this.exportInProgress || this.kappaStatistics.length === 0) {
       return;
     }
 
     this.exportInProgress = 'details';
+    const kappaScope = this.getEffectiveKappaScope();
     this.testPersonCodingService
       .exportCohensKappaStatisticsAsCsv(
         workspaceId,
@@ -200,7 +254,7 @@ export class CohensKappaStatisticsComponent implements OnInit {
         this.excludeTrainings,
         undefined,
         undefined,
-        this.kappaScope
+        kappaScope
       )
       .pipe(finalize(() => {
         this.exportInProgress = null;
@@ -217,6 +271,42 @@ export class CohensKappaStatisticsComponent implements OnInit {
           );
         }
       });
+  }
+
+  private getInitialCoderTrainingId(): number | null {
+    if (!this.hasCoderTrainingSelection) {
+      return null;
+    }
+
+    const initialTrainingId =
+      this.dialogData?.selectedCoderTrainingId ??
+      (this.dialogData?.scope?.coderTrainingIds?.length === 1 ?
+        this.dialogData.scope.coderTrainingIds[0] :
+        undefined);
+
+    if (
+      initialTrainingId !== undefined &&
+      this.availableCoderTrainings.some(training => training.id === initialTrainingId)
+    ) {
+      return initialTrainingId;
+    }
+
+    return this.availableCoderTrainings.length === 1 ? this.availableCoderTrainings[0].id : null;
+  }
+
+  private getEffectiveKappaScope(): CohensKappaScope | undefined {
+    if (!this.hasCoderTrainingSelection) {
+      return this.dialogData?.scope;
+    }
+
+    if (this.selectedCoderTrainingId === null) {
+      return undefined;
+    }
+
+    return {
+      ...this.dialogData?.scope,
+      coderTrainingIds: [this.selectedCoderTrainingId]
+    };
   }
 
   private saveBlob(blob: Blob, filename: string): void {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2368,6 +2368,10 @@
   "cohens-kappa-statistics": {
     "dialog-title": "Interrater-Reliabilität",
     "loading": "Statistiken werden geladen...",
+    "training-selection-title": "Schulung auswählen",
+    "training-selection-subtitle": "Die Interrater-Reliabilität wird für die ausgewählte Kodierer-Schulung berechnet.",
+    "training-select-label": "Schulung",
+    "select-training-hint": "Bitte wählen Sie eine Schulung aus.",
     "workspace-title": "Inter-Rater Zuverlässigkeit (Cohen's Kappa)",
     "workspace-subtitle": "Arbeitsbereichsübergreifende Analyse der Übereinstimmung zwischen Kodierern bei doppelt kodierten Variablen.",
     "exclude-trainings": "Kodierer-Trainings ausschließen",


### PR DESCRIPTION
## Summary
- Add a training selector to the Cohen's Kappa dialog when it is opened from manual coding trainings.
- Scope reliability statistics and exports to the selected coder training.
- Ignore stale statistics responses after quick training changes and cover the behavior with component tests.

## Validation
- `npx nx test frontend --runTestsByPath=apps/frontend/src/app/coding/components/cohens-kappa-statistics/cohens-kappa-statistics.component.spec.ts`
- `npx nx lint frontend`

Refs #678
