### PR TITLE
Fix coder training edit population

### DIFF
--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
@@ -26,6 +26,7 @@ describe('CoderTrainingComponent', () => {
   let fixture: ComponentFixture<CoderTrainingComponent>;
   let component: CoderTrainingComponent;
   let coderService: Record<string, jest.Mock>;
+  let variableBundleService: Record<string, jest.Mock>;
   let codingJobBackendService: Record<string, jest.Mock>;
   let codingTrainingBackendService: Record<string, jest.Mock>;
 
@@ -33,7 +34,7 @@ describe('CoderTrainingComponent', () => {
     coderService = createDependencyMock();
     codingJobBackendService = createDependencyMock();
     codingTrainingBackendService = createDependencyMock();
-    const variableBundleService = createDependencyMock();
+    variableBundleService = createDependencyMock();
 
     coderService.getCoders.mockReturnValue(of([
       { id: 1, name: 'Coder 1', username: 'coder1' },
@@ -401,6 +402,67 @@ describe('CoderTrainingComponent', () => {
     component.isLoading = true;
 
     expect(component.getPrimaryActionLabel()).toBe('Schulung wird aktualisiert...');
+  });
+
+  it('populates saved edit settings even when no variables or bundles are available', () => {
+    codingJobBackendService.getCodingIncompleteVariables.mockReturnValueOnce(of([]));
+    variableBundleService.getBundles.mockReturnValueOnce(of({ bundles: [], total: 0 }));
+    component.editTraining = {
+      id: 80,
+      workspace_id: 1,
+      label: 'Saved empty training',
+      case_ordering_mode: 'alternating',
+      case_selection_mode: 'random',
+      reference_training_ids: [99],
+      reference_mode: 'same',
+      suppress_general_instructions: true,
+      assigned_coders: [2],
+      assigned_variables: [],
+      assigned_variable_bundles: [],
+      jobsCount: 1,
+      created_at: new Date(),
+      updated_at: new Date()
+    };
+
+    component.ngOnInit();
+
+    expect(component.trainingForm.get('trainingLabel')?.value).toBe('Saved empty training');
+    expect(component.trainingForm.get('caseOrderingMode')?.value).toBe('alternating');
+    expect(component.trainingForm.get('caseSelectionMode')?.value).toBe('random');
+    expect(component.trainingForm.get('referenceTrainingIds')?.value).toEqual([99]);
+    expect(component.trainingForm.get('referenceMode')?.value).toBe('same');
+    expect(component.trainingForm.get('suppressGeneralInstructions')?.value).toBe(true);
+    expect(component.isCoderSelected(component.coders[1])).toBe(true);
+  });
+
+  it('keeps saved manual variables when bundle loading fails while editing', () => {
+    variableBundleService.getBundles.mockReturnValueOnce(throwError(() => new Error('bundle load failed')));
+    component.editTraining = {
+      id: 81,
+      workspace_id: 1,
+      label: 'Manual variables only',
+      case_ordering_mode: 'continuous',
+      assigned_coders: [1],
+      assigned_variables: [
+        {
+          unitName: 'UNIT',
+          variableId: 'VAR',
+          sampleCount: 3
+        }
+      ],
+      assigned_variable_bundles: [],
+      jobsCount: 1,
+      created_at: new Date(),
+      updated_at: new Date()
+    };
+
+    component.ngOnInit();
+
+    expect(component.trainingForm.get('trainingLabel')?.value).toBe('Manual variables only');
+    expect(component.variablesFormArray.length).toBe(1);
+    expect(component.variablesFormArray.at(0).get('unitId')?.value).toBe('UNIT');
+    expect(component.variablesFormArray.at(0).get('variableId')?.value).toBe('VAR');
+    expect(component.variablesFormArray.at(0).get('sampleCount')?.value).toBe(3);
   });
 
   it('preserves saved bundle ordering when editing and updating a training', () => {

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.ts
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.ts
@@ -33,7 +33,7 @@ import {
   FormControl
 } from '@angular/forms';
 import {
-  Subject, takeUntil, map, startWith, Observable, combineLatest, BehaviorSubject
+  Subject, takeUntil, map, startWith, Observable, combineLatest, BehaviorSubject, tap, catchError, of
 } from 'rxjs';
 import { JobDefinitionSelectionDialogComponent } from './job-definition-selection-dialog.component';
 import { CoderService } from '../../services/coder.service';
@@ -148,6 +148,10 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
   bundleSelection$ = new BehaviorSubject<number[]>([]);
   manualVariablesSelectControl = new FormControl<string[]>([]); // Stable control for mat-select
   private isSyncing = false;
+  private hasPopulatedTrainingSettings = false;
+  private hasPopulatedTrainingSelections = false;
+  private availableVariablesLoaded = false;
+  private availableBundlesLoaded = false;
 
   filteredVariables$!: Observable<Variable[]>;
   filteredBundles$!: Observable<VariableBundle[]>;
@@ -269,13 +273,20 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
     this.loadCoders();
     this.loadAvailableVariables();
     this.loadAvailableTrainings();
+    this.populateTrainingSettingsFromTraining();
 
-    // Population logic: wait for variables and bundles if in edit mode
+    // Variable and bundle selections depend on the loaded option lists.
     combineLatest([
-      this._availableVariables$.pipe(startWith([])),
+      this._availableVariables$,
       this.variableBundleService.getBundles(1, 100).pipe(
         map(({ bundles }: { bundles: VariableBundle[] }) => bundles),
-        startWith([])
+        tap(() => {
+          this.availableBundlesLoaded = true;
+        }),
+        catchError(() => {
+          this.availableBundlesLoaded = true;
+          return of([] as VariableBundle[]);
+        })
       )
     ]).pipe(
       takeUntil(this.destroy$)
@@ -283,8 +294,13 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       this.availableVariables = variables;
       this.availableBundles = bundles;
 
-      if ((variables.length > 0 || bundles.length > 0) && this.editTraining && this.trainingForm.get('variables')?.value.length === 0) {
-        this.populateFormFromTraining();
+      if (
+        this.editTraining &&
+        this.availableVariablesLoaded &&
+        this.availableBundlesLoaded &&
+        !this.hasPopulatedTrainingSelections
+      ) {
+        this.populateTrainingSelectionsFromTraining();
       }
 
       this.isLoadingVariables = false;
@@ -294,7 +310,13 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
   }
 
   private populateFormFromTraining(): void {
+    this.populateTrainingSettingsFromTraining();
+    this.populateTrainingSelectionsFromTraining();
+  }
+
+  private populateTrainingSettingsFromTraining(): void {
     if (!this.editTraining) return;
+    if (this.hasPopulatedTrainingSettings) return;
 
     this.trainingForm.get('trainingLabel')?.setValue(this.editTraining.label);
     if (this.editTraining.case_ordering_mode) {
@@ -316,6 +338,13 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
     if (this.editTraining.assigned_coders) {
       this.selectedCoders = new Set(this.editTraining.assigned_coders);
     }
+
+    this.hasPopulatedTrainingSettings = true;
+  }
+
+  private populateTrainingSelectionsFromTraining(): void {
+    if (!this.editTraining) return;
+    if (this.hasPopulatedTrainingSelections) return;
 
     if (this.editTraining.assigned_variables) {
       this.editTraining.assigned_variables.forEach(v => {
@@ -356,6 +385,7 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
     }
 
     this.updateGroupedVariables();
+    this.hasPopulatedTrainingSelections = true;
   }
 
   ngOnDestroy(): void {
@@ -383,12 +413,15 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       .subscribe({
         next: variables => {
           this.availableVariables = variables;
+          this.availableVariablesLoaded = true;
           this._availableVariables$.next(variables);
           this.isLoadingVariables = false;
           this.changeDetectorRef.markForCheck();
         },
         error: () => {
           this.showError('Fehler beim Laden der verfügbaren Variablen');
+          this.availableVariablesLoaded = true;
+          this._availableVariables$.next([]);
           this.isLoadingVariables = false;
           this.changeDetectorRef.markForCheck();
         }


### PR DESCRIPTION
## Summary
- Populate saved coder-training edit settings as soon as the training input is available.
- Defer variable and bundle selections until their option data has loaded.
- Keep manual variable selections restorable when bundle loading fails.

## Context
Related to #696. This PR intentionally does not close the issue yet.

## Validation
- npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts --runInBand
- npx nx lint frontend
- git diff --check
