### PR TITLE
Add display options to coder trainings

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
@@ -201,6 +201,14 @@ export class WorkspaceCoderTrainingController {
             enum: ['continuous', 'alternating'],
             description: 'Global case ordering mode for this training'
           },
+          show_score: {
+            type: 'boolean',
+            description: 'Whether score values are shown in coding jobs created for this training'
+          },
+          allow_comments: {
+            type: 'boolean',
+            description: 'Whether comments are allowed in coding jobs created for this training'
+          },
           suppress_general_instructions: {
             type: 'boolean',
             description: 'Whether general variable instructions are hidden in coding jobs created for this training'
@@ -221,6 +229,8 @@ export class WorkspaceCoderTrainingController {
     case_selection_mode?: string;
     reference_training_ids?: number[];
     reference_mode?: string | null;
+    show_score?: boolean;
+    allow_comments?: boolean;
     suppress_general_instructions?: boolean;
   }[]
   > {
@@ -320,6 +330,14 @@ export class WorkspaceCoderTrainingController {
             }
           }
         },
+        showScore: {
+          type: 'boolean',
+          description: 'Whether score values are shown in coding jobs created for this training'
+        },
+        allowComments: {
+          type: 'boolean',
+          description: 'Whether comments are allowed in coding jobs created for this training'
+        },
         suppressGeneralInstructions: {
           type: 'boolean',
           description: 'Whether general variable instructions are hidden in coding jobs created for this training'
@@ -374,6 +392,8 @@ export class WorkspaceCoderTrainingController {
                      caseSelectionMode?: 'oldest_first' | 'newest_first' | 'random' | 'random_per_testgroup' | 'random_testgroups';
                      referenceTrainingIds?: number[];
                      referenceMode?: 'same' | 'different';
+                     showScore?: boolean;
+                     allowComments?: boolean;
                      suppressGeneralInstructions?: boolean;
                    }
   ): Promise<{
@@ -400,6 +420,8 @@ export class WorkspaceCoderTrainingController {
       body.caseSelectionMode,
       body.referenceTrainingIds,
       body.referenceMode,
+      body.showScore,
+      body.allowComments,
       body.suppressGeneralInstructions
     );
   }
@@ -702,6 +724,14 @@ export class WorkspaceCoderTrainingController {
         caseSelectionMode: { type: 'string', enum: ['oldest_first', 'newest_first', 'random', 'random_per_testgroup', 'random_testgroups'] },
         referenceTrainingIds: { type: 'array', items: { type: 'number' } },
         referenceMode: { type: 'string', enum: ['same', 'different'] },
+        showScore: {
+          type: 'boolean',
+          description: 'Whether score values are shown in coding jobs created for this training'
+        },
+        allowComments: {
+          type: 'boolean',
+          description: 'Whether comments are allowed in coding jobs created for this training'
+        },
         suppressGeneralInstructions: {
           type: 'boolean',
           description: 'Whether general variable instructions are hidden in coding jobs created for this training'
@@ -740,6 +770,8 @@ export class WorkspaceCoderTrainingController {
         caseSelectionMode?: 'oldest_first' | 'newest_first' | 'random' | 'random_per_testgroup' | 'random_testgroups';
         referenceTrainingIds?: number[];
         referenceMode?: 'same' | 'different';
+        showScore?: boolean;
+        allowComments?: boolean;
         suppressGeneralInstructions?: boolean;
       }
   ): Promise<{ success: boolean; message: string; jobsCreated?: number }> {
@@ -760,6 +792,8 @@ export class WorkspaceCoderTrainingController {
       body.caseSelectionMode,
       body.referenceTrainingIds,
       body.referenceMode,
+      body.showScore,
+      body.allowComments,
       body.suppressGeneralInstructions
     );
   }

--- a/apps/backend/src/app/database/entities/coder-training.entity.ts
+++ b/apps/backend/src/app/database/entities/coder-training.entity.ts
@@ -61,6 +61,12 @@ export class CoderTraining {
     reference_mode: ReferenceMode | null;
 
   @Column({ type: 'boolean', default: false })
+    show_score: boolean;
+
+  @Column({ type: 'boolean', default: true })
+    allow_comments: boolean;
+
+  @Column({ type: 'boolean', default: false })
     suppress_general_instructions: boolean;
 
   @OneToMany(() => CodingJob, codingJob => codingJob.training, { cascade: true })

--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -238,13 +238,19 @@ describe('CoderTrainingService', () => {
         undefined,
         undefined,
         undefined,
+        true,
+        false,
         true
       );
 
       expect(coderTrainingRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+        show_score: true,
+        allow_comments: false,
         suppress_general_instructions: true
       }));
       expect(codingJobRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+        showScore: true,
+        allowComments: false,
         suppressGeneralInstructions: true
       }));
 
@@ -508,7 +514,12 @@ describe('CoderTrainingService', () => {
     });
 
     it('should update display options on an existing training without recreating jobs', async () => {
-      const existingJob = { id: 100, suppressGeneralInstructions: false };
+      const existingJob = {
+        id: 100,
+        showScore: false,
+        allowComments: true,
+        suppressGeneralInstructions: false
+      };
       const existingTraining = {
         id: 1,
         workspace_id: 1,
@@ -516,6 +527,8 @@ describe('CoderTrainingService', () => {
         case_selection_mode: 'random',
         reference_training_ids: [44],
         reference_mode: 'same',
+        show_score: false,
+        allow_comments: true,
         suppress_general_instructions: false,
         coders: [{ user_id: 10 }],
         variables: [{ variable_id: 'v1', unit_name: 'u1', sample_count: 5 }],
@@ -543,10 +556,14 @@ describe('CoderTrainingService', () => {
         undefined,
         undefined,
         undefined,
+        true,
+        false,
         true
       );
 
       expect(coderTrainingRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+        show_score: true,
+        allow_comments: false,
         suppress_general_instructions: true,
         reference_training_ids: [44],
         reference_mode: 'same'
@@ -555,6 +572,8 @@ describe('CoderTrainingService', () => {
       expect(mockRepository.count).not.toHaveBeenCalled();
       expect(codingJobRepository.save).toHaveBeenCalledWith(expect.objectContaining({
         id: 100,
+        showScore: true,
+        allowComments: false,
         suppressGeneralInstructions: true
       }));
     });
@@ -1198,6 +1217,8 @@ describe('CoderTrainingService', () => {
         label: 'Training 1',
         created_at: new Date(),
         updated_at: new Date(),
+        show_score: true,
+        allow_comments: false,
         suppress_general_instructions: true,
         codingJobs: [],
         variables: [{ variable_id: 'v1', unit_name: 'u1', sample_count: 5 }],
@@ -1223,6 +1244,8 @@ describe('CoderTrainingService', () => {
         sampleCount: 25
       });
       expect(result[0].assigned_coders).toEqual([10]);
+      expect(result[0].show_score).toBe(true);
+      expect(result[0].allow_comments).toBe(false);
       expect(result[0].suppress_general_instructions).toBe(true);
     });
   });

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -83,6 +83,8 @@ interface CoderTrainingWithJobs {
   case_selection_mode?: string;
   reference_training_ids?: number[];
   reference_mode?: string | null;
+  show_score?: boolean;
+  allow_comments?: boolean;
   suppress_general_instructions?: boolean;
 }
 
@@ -1399,6 +1401,8 @@ export class CoderTrainingService {
     caseSelectionMode?: CaseSelectionMode,
     referenceTrainingIds?: number[],
     referenceMode?: ReferenceMode,
+    showScore?: boolean,
+    allowComments?: boolean,
     suppressGeneralInstructions?: boolean
   ): Promise<{ success: boolean; jobsCreated: number; message: string; jobs: TrainingJob[]; trainingId?: number }> {
     try {
@@ -1426,6 +1430,8 @@ export class CoderTrainingService {
       coderTraining.case_selection_mode = caseSelectionMode ?? 'oldest_first';
       coderTraining.reference_training_ids = referenceTrainingIds?.length ? referenceTrainingIds : null;
       coderTraining.reference_mode = referenceMode ?? null;
+      coderTraining.show_score = showScore ?? false;
+      coderTraining.allow_comments = allowComments ?? true;
       coderTraining.suppress_general_instructions = suppressGeneralInstructions ?? false;
       coderTraining.created_at = new Date();
       coderTraining.updated_at = new Date();
@@ -1513,6 +1519,8 @@ export class CoderTrainingService {
         codingJob.training_id = trainingId;
         codingJob.missings_profile_id = resolvedMissingsProfileId;
         codingJob.case_ordering_mode = caseOrderingMode || 'continuous';
+        codingJob.showScore = showScore ?? false;
+        codingJob.allowComments = allowComments ?? true;
         codingJob.suppressGeneralInstructions = suppressGeneralInstructions ?? false;
         codingJob.created_at = new Date();
         codingJob.updated_at = new Date();
@@ -1661,6 +1669,8 @@ export class CoderTrainingService {
         case_selection_mode: training.case_selection_mode,
         reference_training_ids: training.reference_training_ids ?? undefined,
         reference_mode: training.reference_mode ?? undefined,
+        show_score: training.show_score,
+        allow_comments: training.allow_comments,
         suppress_general_instructions: training.suppress_general_instructions,
         assigned_variables: training.variables
           ?.filter(v => !bundleVariableKeys.has(this.makeTrainingVariableKey(v.unit_name, v.variable_id)))
@@ -2088,6 +2098,8 @@ export class CoderTrainingService {
     caseSelectionMode?: CaseSelectionMode,
     referenceTrainingIds?: number[],
     referenceMode?: ReferenceMode,
+    showScore?: boolean,
+    allowComments?: boolean,
     suppressGeneralInstructions?: boolean
   ): Promise<{ success: boolean; message: string; jobsCreated?: number; jobs?: TrainingJob[] }> {
     try {
@@ -2228,12 +2240,20 @@ export class CoderTrainingService {
       const resolvedSuppressGeneralInstructions = suppressGeneralInstructions ??
         training.suppress_general_instructions ??
         false;
+      const resolvedShowScore = showScore ??
+        training.show_score ??
+        false;
+      const resolvedAllowComments = allowComments ??
+        training.allow_comments ??
+        true;
 
       training.label = trainingLabel;
       training.case_ordering_mode = newCaseOrderingMode;
       training.case_selection_mode = newCaseSelectionMode;
       training.reference_training_ids = effectiveReferenceTrainingIds.length ? effectiveReferenceTrainingIds : null;
       training.reference_mode = newReferenceMode;
+      training.show_score = resolvedShowScore;
+      training.allow_comments = resolvedAllowComments;
       training.suppress_general_instructions = resolvedSuppressGeneralInstructions;
       training.updated_at = new Date();
 
@@ -2328,6 +2348,8 @@ export class CoderTrainingService {
           codingJob.training_id = trainingId;
           codingJob.missings_profile_id = resolvedMissingsProfileId;
           codingJob.case_ordering_mode = newCaseOrderingMode;
+          codingJob.showScore = resolvedShowScore;
+          codingJob.allowComments = resolvedAllowComments;
           codingJob.suppressGeneralInstructions = resolvedSuppressGeneralInstructions;
           codingJob.created_at = new Date();
           codingJob.updated_at = new Date();
@@ -2436,6 +2458,8 @@ export class CoderTrainingService {
       }
 
       for (const job of training.codingJobs || []) {
+        job.showScore = resolvedShowScore;
+        job.allowComments = resolvedAllowComments;
         job.suppressGeneralInstructions = resolvedSuppressGeneralInstructions;
         await this.codingJobRepository.save(job);
       }

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.html
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.html
@@ -76,6 +76,12 @@
         <h3 class="section-subtitle">{{ 'coding-job-definition-dialog.coding-display-options.title' | translate }}</h3>
       </div>
       <p class="section-description">{{ 'coding-job-definition-dialog.coding-display-options.description' | translate }}</p>
+      <mat-checkbox formControlName="showScore" class="display-option-checkbox">
+        {{ 'coding-job-definition-dialog.coding-display-options.show-score' | translate }}
+      </mat-checkbox>
+      <mat-checkbox formControlName="allowComments" class="display-option-checkbox">
+        {{ 'coding-job-definition-dialog.coding-display-options.allow-comments' | translate }}
+      </mat-checkbox>
       <mat-checkbox formControlName="suppressGeneralInstructions" class="display-option-checkbox">
         {{ 'coding-job-definition-dialog.coding-display-options.suppress-general-instructions' | translate }}
       </mat-checkbox>

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
@@ -338,6 +338,8 @@ describe('CoderTrainingComponent', () => {
       'oldest_first',
       undefined,
       undefined,
+      false,
+      true,
       false
     );
   });
@@ -620,6 +622,8 @@ describe('CoderTrainingComponent', () => {
       'oldest_first',
       undefined,
       undefined,
+      false,
+      true,
       false
     );
   });
@@ -664,6 +668,8 @@ describe('CoderTrainingComponent', () => {
       'oldest_first',
       undefined,
       undefined,
+      false,
+      true,
       false
     );
   });
@@ -700,6 +706,8 @@ describe('CoderTrainingComponent', () => {
       'oldest_first',
       undefined,
       undefined,
+      false,
+      true,
       false
     );
   });

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.ts
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.ts
@@ -161,6 +161,8 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
       trainingLabel: ['', [Validators.required]],
       caseOrderingMode: ['continuous'],
       caseSelectionMode: ['oldest_first' as CaseSelectionMode],
+      showScore: [false],
+      allowComments: [true],
       suppressGeneralInstructions: [false],
       includeDerivedVariables: [true],
       referenceTrainingIds: [[] as number[]],
@@ -331,6 +333,12 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
     if (this.editTraining.reference_mode) {
       this.trainingForm.get('referenceMode')?.setValue(this.editTraining.reference_mode);
     }
+    this.trainingForm.get('showScore')?.setValue(
+      this.editTraining.show_score ?? false
+    );
+    this.trainingForm.get('allowComments')?.setValue(
+      this.editTraining.allow_comments ?? true
+    );
     this.trainingForm.get('suppressGeneralInstructions')?.setValue(
       this.editTraining.suppress_general_instructions ?? false
     );
@@ -1418,6 +1426,8 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
         caseSelectionMode,
         referenceTrainingIds,
         referenceMode ?? undefined,
+        this.trainingForm.get('showScore')?.value ?? false,
+        this.trainingForm.get('allowComments')?.value ?? true,
         this.trainingForm.get('suppressGeneralInstructions')?.value ?? false
       ) :
       this.codingTrainingBackendService.createCoderTrainingJobs(
@@ -1432,6 +1442,8 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
         caseSelectionMode,
         referenceTrainingIds.length ? referenceTrainingIds : undefined,
         referenceMode ?? undefined,
+        this.trainingForm.get('showScore')?.value ?? false,
+        this.trainingForm.get('allowComments')?.value ?? true,
         this.trainingForm.get('suppressGeneralInstructions')?.value ?? false
       );
 
@@ -1491,6 +1503,12 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
 
     this.trainingForm.get('suppressGeneralInstructions')?.setValue(
       jobDef.suppressGeneralInstructions ?? false
+    );
+    this.trainingForm.get('showScore')?.setValue(
+      jobDef.showScore ?? false
+    );
+    this.trainingForm.get('allowComments')?.setValue(
+      jobDef.allowComments ?? true
     );
 
     if (jobDef.assignedVariables && jobDef.assignedVariables.length > 0) {

--- a/apps/frontend/src/app/coding/models/coder-training.model.ts
+++ b/apps/frontend/src/app/coding/models/coder-training.model.ts
@@ -27,5 +27,7 @@ export interface CoderTraining {
   case_selection_mode?: CaseSelectionMode;
   reference_training_ids?: number[];
   reference_mode?: ReferenceMode | null;
+  show_score?: boolean;
+  allow_comments?: boolean;
   suppress_general_instructions?: boolean;
 }

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
@@ -56,6 +56,8 @@ describe('CodingTrainingBackendService', () => {
         caseSelectionMode: undefined,
         referenceTrainingIds: undefined,
         referenceMode: undefined,
+        showScore: undefined,
+        allowComments: undefined,
         suppressGeneralInstructions: undefined
       });
       req.flush({});
@@ -89,6 +91,8 @@ describe('CodingTrainingBackendService', () => {
         'random',
         [10, 11],
         'same',
+        true,
+        false,
         true
       ).subscribe();
 
@@ -120,6 +124,8 @@ describe('CodingTrainingBackendService', () => {
         caseSelectionMode: 'random',
         referenceTrainingIds: [10, 11],
         referenceMode: 'same',
+        showScore: true,
+        allowComments: false,
         suppressGeneralInstructions: true
       });
       req.flush({});
@@ -150,6 +156,8 @@ describe('CodingTrainingBackendService', () => {
         'newest_first',
         [5],
         'different',
+        true,
+        false,
         true
       ).subscribe();
 
@@ -166,6 +174,8 @@ describe('CodingTrainingBackendService', () => {
         caseSelectionMode: 'newest_first',
         referenceTrainingIds: [5],
         referenceMode: 'different',
+        showScore: true,
+        allowComments: false,
         suppressGeneralInstructions: true
       });
       req.flush({});

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -112,6 +112,8 @@ export class CodingTrainingBackendService {
     caseSelectionMode?: 'oldest_first' | 'newest_first' | 'random' | 'random_per_testgroup' | 'random_testgroups',
     referenceTrainingIds?: number[],
     referenceMode?: 'same' | 'different',
+    showScore?: boolean,
+    allowComments?: boolean,
     suppressGeneralInstructions?: boolean
   ): Observable<CreateCoderTrainingJobsResponse> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-training-jobs`;
@@ -126,6 +128,8 @@ export class CodingTrainingBackendService {
       caseSelectionMode,
       referenceTrainingIds,
       referenceMode,
+      showScore,
+      allowComments,
       suppressGeneralInstructions
     }, { headers: this.authHeader });
   }
@@ -154,6 +158,8 @@ export class CodingTrainingBackendService {
     caseSelectionMode?: 'oldest_first' | 'newest_first' | 'random' | 'random_per_testgroup' | 'random_testgroups',
     referenceTrainingIds?: number[],
     referenceMode?: 'same' | 'different',
+    showScore?: boolean,
+    allowComments?: boolean,
     suppressGeneralInstructions?: boolean
   ): Observable<{ success: boolean; message: string; jobsCreated?: number }> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings/${trainingId}`;
@@ -168,6 +174,8 @@ export class CodingTrainingBackendService {
       caseSelectionMode,
       referenceTrainingIds,
       referenceMode,
+      showScore,
+      allowComments,
       suppressGeneralInstructions
     }, { headers: this.authHeader });
   }

--- a/apps/frontend/src/app/services/facades/coding-facade.service.spec.ts
+++ b/apps/frontend/src/app/services/facades/coding-facade.service.spec.ts
@@ -115,7 +115,7 @@ describe('CodingFacadeService', () => {
       [{ variableId: 'Var', unitId: 'Unit', sampleCount: 3 }],
       'Training',
       undefined,
-      { suppressGeneralInstructions: true }
+      { showScore: true, allowComments: false, suppressGeneralInstructions: true }
     ).subscribe();
 
     expect(dependencies[8].createCoderTrainingJobs).toHaveBeenCalledWith(
@@ -130,6 +130,8 @@ describe('CodingFacadeService', () => {
       undefined,
       undefined,
       undefined,
+      true,
+      false,
       true
     );
   });

--- a/apps/frontend/src/app/services/facades/coding-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/coding-facade.service.ts
@@ -123,6 +123,8 @@ interface DistributedCodingCoderSelection {
 }
 
 interface CoderTrainingDisplayOptions {
+  showScore?: boolean;
+  allowComments?: boolean;
   suppressGeneralInstructions?: boolean;
 }
 
@@ -251,6 +253,8 @@ export class CodingFacadeService {
       undefined,
       undefined,
       undefined,
+      displayOptions?.showScore,
+      displayOptions?.allowComments,
       displayOptions?.suppressGeneralInstructions
     );
   }

--- a/database/changelog/coding-box.changelog-1.16.1.sql
+++ b/database/changelog/coding-box.changelog-1.16.1.sql
@@ -1,0 +1,20 @@
+-- liquibase formatted sql
+
+-- changeset jurei733:1
+--validCheckSum: 9:07488bba2e47a938b6e337fe296cc376
+-- comment: Persist DERIVE_ERROR opt-in for coder-training variables
+
+ALTER TABLE "public"."coder_training_variable"
+  ADD COLUMN IF NOT EXISTS "include_derive_error" BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- rollback ALTER TABLE "public"."coder_training_variable" DROP COLUMN IF EXISTS "include_derive_error";
+
+-- changeset jurei733:2
+-- comment: Persist full display options for coder trainings
+
+ALTER TABLE "public"."coder_training"
+  ADD COLUMN IF NOT EXISTS "show_score" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "allow_comments" BOOLEAN NOT NULL DEFAULT true;
+
+-- rollback ALTER TABLE "public"."coder_training" DROP COLUMN IF EXISTS "allow_comments";
+-- rollback ALTER TABLE "public"."coder_training" DROP COLUMN IF EXISTS "show_score";

--- a/database/changelog/coding-box.changelog-root.xml
+++ b/database/changelog/coding-box.changelog-root.xml
@@ -39,4 +39,5 @@
   <include file="coding-box.changelog-1.14.1.sql"/>
   <include file="coding-box.changelog-1.15.0.sql"/>
   <include file="coding-box.changelog-1.16.0.sql"/>
+  <include file="coding-box.changelog-1.16.1.sql"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- Add score visibility, comments, and general-instructions controls to coder training setup.
- Persist training display options and apply them to generated coding jobs.
- Add database migration coverage in the 1.16.1 changelog.

## Validation
- `npx nx test frontend --runInBand`
- `npx nx test backend --runInBand`
- `npx nx lint frontend`
- `npx nx lint backend`
- `make dev-db-validate-changelog`
- `git diff --check`

Refs #699
