### PR TITLE
Preserve training display options in discussion replay

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -253,6 +253,37 @@ describe('CodingResultsComparisonComponent', () => {
     );
   });
 
+  it('should pass selected training display options to the discussion replay', () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    codingStatisticsService.getReplayUrl.mockReturnValue(of({
+      replayUrl: 'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1'
+    }));
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.availableTrainings = [{
+      id: 5,
+      workspace_id: 1,
+      label: 'Training with hidden instructions',
+      created_at: new Date('2026-06-11T12:00:00Z'),
+      updated_at: new Date('2026-06-11T12:00:00Z'),
+      jobsCount: 2,
+      suppress_general_instructions: true
+    }];
+
+    component.openReplay({
+      responseId: 77,
+      unitName: 'UNIT_1',
+      variableId: 'VAR_1',
+      testperson: 'login@code@booklet',
+      coders: []
+    } as never);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1&mode=coding&originResponseId=77&suppressGeneralInstructions=true',
+      '_blank'
+    );
+  });
+
   it('should show feedback when no replay URL is returned', () => {
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
     codingStatisticsService.getReplayUrl.mockReturnValue(of({ replayUrl: '' }));

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -469,7 +469,8 @@ export class CodingResultsComparisonComponent implements OnInit {
       return undefined;
     }
 
-    return this.availableTrainings.find(training => training.id === this.selectedTrainingForWithin);
+    return this.availableTrainings.find(training => training.id === this.selectedTrainingForWithin) ||
+      (this.data.selectedTraining?.id === this.selectedTrainingForWithin ? this.data.selectedTraining : undefined);
   }
 
   private getSelectedTrainingsWithoutCodes(): CoderTraining[] {
@@ -1044,7 +1045,11 @@ export class CodingResultsComparisonComponent implements OnInit {
     this.codingStatisticsService.getReplayUrl(workspaceId, responseId).subscribe({
       next: result => {
         if (result.replayUrl) {
-          window.open(this.buildReplayUrl(result.replayUrl, responseId), '_blank');
+          window.open(this.buildReplayUrl(
+            result.replayUrl,
+            responseId,
+            this.getReplayDisplayOptions()
+          ), '_blank');
         } else {
           this.snackBar.open('Replay-URL konnte nicht erzeugt werden.', this.translate.instant('common.close'), { duration: 3000 });
         }
@@ -1055,13 +1060,35 @@ export class CodingResultsComparisonComponent implements OnInit {
     });
   }
 
-  private buildReplayUrl(replayUrl: string, responseId: number): string {
+  private getReplayDisplayOptions(): { suppressGeneralInstructions?: boolean } {
+    if (this.comparisonMode !== 'within-training') {
+      return {};
+    }
+
+    const selectedTraining = this.getSelectedWithinTraining();
+    if (!selectedTraining) {
+      return {};
+    }
+
+    return {
+      suppressGeneralInstructions: selectedTraining.suppress_general_instructions ?? false
+    };
+  }
+
+  private buildReplayUrl(
+    replayUrl: string,
+    responseId: number,
+    displayOptions: { suppressGeneralInstructions?: boolean } = {}
+  ): string {
     const [baseUrl, fragment = ''] = replayUrl.split('#', 2);
     const appendParams = (value: string): string => {
       const [path, query = ''] = value.split('?', 2);
       const params = new URLSearchParams(query);
       params.set('mode', 'coding');
       params.set('originResponseId', responseId.toString());
+      if (displayOptions.suppressGeneralInstructions !== undefined) {
+        params.set('suppressGeneralInstructions', String(displayOptions.suppressGeneralInstructions));
+      }
       const serializedParams = params.toString();
       return serializedParams ? `${path}?${serializedParams}` : path;
     };

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -219,6 +219,32 @@ describe('ReplayComponent', () => {
     expect(component.responses).toBeDefined();
   });
 
+  it('should apply suppress general instructions from query params', async () => {
+    routeParams = {
+      page: '0',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-123',
+      anchor: 'VAR1'
+    };
+    routeQueryParams = {
+      auth: 'valid-token',
+      mode: 'coding',
+      workspaceId: '47',
+      suppressGeneralInstructions: 'true'
+    };
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(ReplayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(component.codingService.suppressGeneralInstructions).toBe(true);
+  });
+
   it('should keep server timings from replay payload', () => {
     expect((component as unknown as { serverTimings: Record<string, number> | null }).serverTimings)
       .toEqual({

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -402,6 +402,18 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
+  private getBooleanQueryParam(value: unknown): boolean | null {
+    if (value === true || value === 'true') {
+      return true;
+    }
+
+    if (value === false || value === 'false') {
+      return false;
+    }
+
+    return null;
+  }
+
   subscribeRouter(): void {
     this.routerSubscription = this.route.params
       ?.subscribe(async params => {
@@ -420,6 +432,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         this.isCodingMode = queryParams.mode === 'coding' || this.isReviewMode;
         this.isBookletReplayMode = queryParams.mode === 'booklet-view' || queryParams.mode === 'booklet';
         this.originResponseId = queryParams.originResponseId ? Number(queryParams.originResponseId) : null;
+        const suppressGeneralInstructions = this.getBooleanQueryParam(queryParams.suppressGeneralInstructions);
         if (this.isCodingMode || this.isBookletReplayMode) {
           let deserializedUnits = null as UnitsReplay | null;
 
@@ -521,6 +534,10 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
               }
             }
           }
+        }
+
+        if (suppressGeneralInstructions !== null) {
+          this.codingService.suppressGeneralInstructions = suppressGeneralInstructions;
         }
 
         if (this.authToken) {


### PR DESCRIPTION
## Summary
- pass the selected coder training display option into discussion replay URLs
- let the replay view read `suppressGeneralInstructions` from the query string
- cover both URL generation and replay initialization with focused frontend tests

## Root cause
Discussion replay opened from the training comparison only carried the response replay context. It did not carry the training-level display option, so the replay view kept the default `suppressGeneralInstructions=false` and showed general instructions.

## Validation
- `npx nx test frontend --runInBand --testPathPatterns='coding-results-comparison.component.spec.ts|replay.component.spec.ts'` (ran all frontend tests: 178 suites, 1396 tests)
- `npx nx lint frontend`

Refs #697
