### PR TITLE
Show applied review results

### DIFF
--- a/apps/backend/src/app/admin/workspace/dto/workspace-coding.interfaces.ts
+++ b/apps/backend/src/app/admin/workspace/dto/workspace-coding.interfaces.ts
@@ -28,6 +28,9 @@ export interface DoubleCodedReviewItem {
   bookletName: string;
   givenAnswer: string;
   isResolved: boolean;
+  appliedCode: number | null;
+  appliedScore: number | null;
+  appliedComment: string | null;
   coderResults: Array<{
     coderId: number;
     coderName: string;

--- a/apps/backend/src/app/admin/workspace/workspace-coding-review.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-review.controller.ts
@@ -108,6 +108,21 @@ export class WorkspaceCodingReviewController {
                 description: 'The given answer by the test person'
               },
               isResolved: { type: 'boolean', description: 'Whether the variable is already resolved' },
+              appliedCode: {
+                type: 'number',
+                nullable: true,
+                description: 'Code that has been applied to the response'
+              },
+              appliedScore: {
+                type: 'number',
+                nullable: true,
+                description: 'Score that has been applied to the response'
+              },
+              appliedComment: {
+                type: 'string',
+                nullable: true,
+                description: 'Optional supervisor comment saved with the applied decision'
+              },
               coderResults: {
                 type: 'array',
                 items: {

--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -84,6 +84,8 @@ describe('CodingReviewService', () => {
     },
     response: {
       value: 'answer',
+      code_v2: null,
+      score_v2: null,
       unit: {
         name: 'UNIT_1',
         booklet: {
@@ -478,9 +480,12 @@ describe('CodingReviewService', () => {
         coding_job_id: 110,
         code: 3,
         score: 1,
+        supervisor_comment: 'Reviewed by manager',
         variable_id: 'VAR_2',
         response: {
           value: 'matching answer',
+          code_v2: 3,
+          score_v2: 1,
           unit: {
             name: 'UNIT_2',
             booklet: {
@@ -511,6 +516,8 @@ describe('CodingReviewService', () => {
         variable_id: 'VAR_2',
         response: {
           value: 'matching answer',
+          code_v2: 3,
+          score_v2: 1,
           unit: {
             name: 'UNIT_2',
             booklet: {
@@ -551,11 +558,137 @@ describe('CodingReviewService', () => {
       responseId: 11,
       variableId: 'VAR_2',
       isResolved: true,
+      appliedCode: 3,
+      appliedScore: 1,
+      appliedComment: 'Reviewed by manager',
       coderResults: [
         { coderId: 3, code: 3, score: 1 },
         { coderId: 4, code: 3, score: 1 }
       ]
     });
+  });
+
+  it('uses matching coding issue review notes as the applied comment', async () => {
+    queryBuilder.getRawMany.mockResolvedValueOnce([
+      { responseId: 11, responseStatus: 5 }
+    ]);
+    codingJobUnitRepository.query.mockResolvedValueOnce([{ total: '1' }]);
+    codingJobUnitRepository.find.mockResolvedValueOnce([
+      makeCodingJobUnit({
+        response_id: 11,
+        coding_job_id: 110,
+        code: -2,
+        score: null,
+        variable_id: 'VAR_2',
+        response: {
+          value: 'answer requiring review',
+          code_v2: 7,
+          score_v2: 2,
+          unit: {
+            name: 'UNIT_2',
+            booklet: {
+              bookletinfo: { name: 'BOOKLET_2' },
+              person: {
+                login: 'person-2',
+                code: 'P002'
+              }
+            }
+          }
+        },
+        coding_job: {
+          workspace_id: workspaceId,
+          job_definition_id: 11,
+          training_id: null,
+          name: 'Issue Source Job',
+          codingJobCoders: [{
+            user_id: 3,
+            user: { username: 'Coder 3' }
+          }]
+        }
+      }),
+      makeCodingJobUnit({
+        response_id: 11,
+        coding_job_id: 111,
+        code: 7,
+        score: 2,
+        variable_id: 'VAR_2',
+        response: {
+          value: 'answer requiring review',
+          code_v2: 7,
+          score_v2: 2,
+          unit: {
+            name: 'UNIT_2',
+            booklet: {
+              bookletinfo: { name: 'BOOKLET_2' },
+              person: {
+                login: 'person-2',
+                code: 'P002'
+              }
+            }
+          }
+        },
+        coding_job: {
+          workspace_id: workspaceId,
+          job_definition_id: 11,
+          training_id: null,
+          name: 'Second Job',
+          codingJobCoders: [{
+            user_id: 4,
+            user: { username: 'Coder 4' }
+          }]
+        }
+      }),
+      makeCodingJobUnit({
+        response_id: 11,
+        coding_job_id: 112,
+        code: 7,
+        score: 2,
+        notes: 'Manager review note',
+        variable_id: 'VAR_2',
+        response: {
+          value: 'answer requiring review',
+          code_v2: 7,
+          score_v2: 2,
+          unit: {
+            name: 'UNIT_2',
+            booklet: {
+              bookletinfo: { name: 'BOOKLET_2' },
+              person: {
+                login: 'person-2',
+                code: 'P002'
+              }
+            }
+          }
+        },
+        coding_job: {
+          workspace_id: workspaceId,
+          job_definition_id: 11,
+          training_id: null,
+          job_type: 'coding_issue_review',
+          name: 'Issue Review Job',
+          codingJobCoders: [{
+            user_id: 5,
+            user: { username: 'Manager' }
+          }]
+        }
+      })
+    ]);
+
+    const result = await service.getDoubleCodedVariablesForReview(workspaceId);
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toMatchObject({
+      responseId: 11,
+      isResolved: true,
+      appliedCode: 7,
+      appliedScore: 2,
+      appliedComment: 'Manager review note',
+      coderResults: [
+        { coderId: 3, code: -2, score: null },
+        { coderId: 4, code: 7, score: 2 }
+      ]
+    });
+    expect(result.data[0].coderResults).toHaveLength(2);
   });
 
   it('applies resolved and coding-status filters independently', async () => {
@@ -794,6 +927,9 @@ describe('CodingReviewService', () => {
   });
 
   it('keeps legacy bundle jobs in job-definition scoped double-coding review rows', async () => {
+    queryBuilder.getRawMany.mockResolvedValueOnce([
+      { responseId: 10, responseStatus: 5 }
+    ]);
     jobDefinitionRepository.find.mockResolvedValueOnce([{
       assigned_variable_bundles: [{
         id: 9,
@@ -807,6 +943,21 @@ describe('CodingReviewService', () => {
     codingJobUnitRepository.find.mockResolvedValueOnce([
       makeCodingJobUnit({
         coding_job_id: 100,
+        response: {
+          value: 'answer',
+          code_v2: 1,
+          score_v2: 1,
+          unit: {
+            name: 'UNIT_1',
+            booklet: {
+              bookletinfo: { name: 'BOOKLET_1' },
+              person: {
+                login: 'person-1',
+                code: 'P001'
+              }
+            }
+          }
+        },
         coding_job: {
           workspace_id: workspaceId,
           job_definition_id: null,
@@ -822,6 +973,21 @@ describe('CodingReviewService', () => {
       makeCodingJobUnit({
         coding_job_id: 101,
         code: 2,
+        response: {
+          value: 'answer',
+          code_v2: 1,
+          score_v2: 1,
+          unit: {
+            name: 'UNIT_1',
+            booklet: {
+              bookletinfo: { name: 'BOOKLET_1' },
+              person: {
+                login: 'person-1',
+                code: 'P001'
+              }
+            }
+          }
+        },
         coding_job: {
           workspace_id: workspaceId,
           job_definition_id: null,
@@ -847,6 +1013,40 @@ describe('CodingReviewService', () => {
           codingJobCoders: [{
             user_id: 4,
             user: { username: 'Coder 4' }
+          }]
+        }
+      }),
+      makeCodingJobUnit({
+        coding_job_id: 105,
+        code: 1,
+        score: 1,
+        notes: 'Legacy bundle review note',
+        variable_bundle_id: 9,
+        response: {
+          value: 'answer',
+          code_v2: 1,
+          score_v2: 1,
+          unit: {
+            name: 'UNIT_1',
+            booklet: {
+              bookletinfo: { name: 'BOOKLET_1' },
+              person: {
+                login: 'person-1',
+                code: 'P001'
+              }
+            }
+          }
+        },
+        coding_job: {
+          workspace_id: workspaceId,
+          job_definition_id: null,
+          training_id: null,
+          job_type: 'coding_issue_review',
+          name: 'Legacy Bundle Issue Review',
+          codingJobVariableBundles: [],
+          codingJobCoders: [{
+            user_id: 5,
+            user: { username: 'Manager' }
           }]
         }
       }),
@@ -899,6 +1099,7 @@ describe('CodingReviewService', () => {
       expect.objectContaining({ coderId: 1, jobId: 100 }),
       expect.objectContaining({ coderId: 2, jobId: 101 })
     ]);
+    expect(result.data[0].appliedComment).toBe('Legacy bundle review note');
   });
 
   it('returns an empty page without loading relations when no double-coded rows match', async () => {
@@ -1153,6 +1354,9 @@ describe('CodingReviewService', () => {
             bookletName: 'BOOKLET_1',
             givenAnswer: 'answer',
             isResolved: false,
+            appliedCode: null,
+            appliedScore: null,
+            appliedComment: null,
             coderResults: [
               {
                 coderId: 31,

--- a/apps/backend/src/app/database/services/coding/coding-review.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.ts
@@ -39,6 +39,12 @@ type ReviewCoderResult = {
   codedAt: Date;
 };
 
+type AppliedReviewResult = {
+  appliedCode: number | null;
+  appliedScore: number | null;
+  appliedComment: string | null;
+};
+
 type KappaCodedVariableRow = {
   responseId: number | string;
   unitName: string;
@@ -140,6 +146,9 @@ export class CodingReviewService {
         bookletName: string;
         givenAnswer: string;
         isResolved: boolean;
+        appliedCode: number | null;
+        appliedScore: number | null;
+        appliedComment: string | null;
         coderResults: Array<{
           coderId: number;
           coderName: string;
@@ -376,7 +385,7 @@ export class CodingReviewService {
         relations
       });
 
-      const finalCodingJobUnits = codingJobUnits.filter(unit => {
+      const isIncludedReviewUnit = (unit: CodingJobUnit) => {
         // Ignore orphaned coding_job_unit rows from deleted jobs.
         if (!unit.coding_job) {
           return false;
@@ -384,10 +393,6 @@ export class CodingReviewService {
 
         // Keep result assembly aligned with the workspace-scoped base query.
         if (unit.coding_job.workspace_id !== workspaceId) {
-          return false;
-        }
-
-        if (isCodingIssueReviewJobType(unit.coding_job.job_type)) {
           return false;
         }
 
@@ -399,14 +404,20 @@ export class CodingReviewService {
           return false;
         }
 
-        const codingJobBundleIds = unit.coding_job.codingJobVariableBundles
-          ?.map(bundle => bundle.variable_bundle_id) || [];
+        const codingJobBundleIds = new Set(
+          (unit.coding_job.codingJobVariableBundles || [])
+            .map(bundle => Number(bundle.variable_bundle_id))
+            .filter(bundleId => Number.isFinite(bundleId))
+        );
+        if (unit.variable_bundle_id !== null && unit.variable_bundle_id !== undefined) {
+          codingJobBundleIds.add(unit.variable_bundle_id);
+        }
         if (!this.isIncludedByScope(
           unit.coding_job.job_definition_id,
           unit.coding_job.training_id,
           jobDefinitionIds,
           coderTrainingIds,
-          codingJobBundleIds,
+          Array.from(codingJobBundleIds),
           scopedJobDefinitionBundleScope,
           unit.unit_name,
           unit.variable_id
@@ -419,7 +430,14 @@ export class CodingReviewService {
         }
 
         return true;
-      });
+      };
+      const scopedCodingJobUnits = codingJobUnits.filter(isIncludedReviewUnit);
+      const finalCodingJobUnits = scopedCodingJobUnits.filter(unit => (
+        !isCodingIssueReviewJobType(unit.coding_job?.job_type)
+      ));
+      const codingIssueReviewUnits = scopedCodingJobUnits.filter(unit => (
+        isCodingIssueReviewJobType(unit.coding_job?.job_type)
+      ));
 
       const responseGroups = new Map<
       number,
@@ -433,6 +451,9 @@ export class CodingReviewService {
         bookletName: string;
         givenAnswer: string;
         isResolved: boolean;
+        appliedCode: number | null;
+        appliedScore: number | null;
+        appliedComment: string | null;
         coderResults: Array<{
           coderId: number;
           coderName: string;
@@ -457,6 +478,11 @@ export class CodingReviewService {
 
         if (!responseGroups.has(responseId)) {
           const responseStatus = statusMap.get(responseId);
+          const isResolved = responseStatus === completeStatus;
+          const appliedResult = this.getAppliedReviewResult(
+            isResolved,
+            unit.response
+          );
           responseGroups.set(responseId, {
             responseId: responseId,
             unitName: unit.unit_name || unit.response?.unit?.name || '',
@@ -466,12 +492,16 @@ export class CodingReviewService {
             personGroup: unit.person_group || unit.response?.unit?.booklet?.person?.group || '',
             bookletName: unit.booklet_name || unit.response?.unit?.booklet?.bookletinfo?.name || '',
             givenAnswer: unit.response?.value || '',
-            isResolved: responseStatus === completeStatus,
+            isResolved,
+            ...appliedResult,
             coderResults: []
           });
         }
 
         const group = responseGroups.get(responseId)!;
+        if (group.isResolved && unit.supervisor_comment && !group.appliedComment) {
+          group.appliedComment = unit.supervisor_comment;
+        }
 
         const coder = this.getDistinctCodingJobCoders(unit.coding_job?.codingJobCoders || [])[0];
         if (coder) {
@@ -480,6 +510,10 @@ export class CodingReviewService {
             unit,
             manualMissingCache
           );
+          if (group.isResolved && this.isAppliedRawResult(group, unit)) {
+            group.appliedCode = resolvedCodeAndScore.code;
+            group.appliedScore = resolvedCodeAndScore.score;
+          }
           const coderResult = {
             coderId: coder.user_id,
             coderName: coder.user?.username || `Coder ${coder.user_id}`,
@@ -506,6 +540,22 @@ export class CodingReviewService {
           } else if (this.shouldReplaceCoderResult(group.coderResults[existingResultIndex], coderResult)) {
             group.coderResults[existingResultIndex] = coderResult;
           }
+        }
+      }
+
+      for (const unit of codingIssueReviewUnits) {
+        const group = responseGroups.get(unit.response_id);
+        if (!group?.isResolved || group.appliedComment || !unit.notes?.trim()) {
+          continue;
+        }
+
+        const resolvedCodeAndScore = await this.resolveManualMissingForReview(
+          workspaceId,
+          unit,
+          manualMissingCache
+        );
+        if (this.isAppliedResolvedResult(group, resolvedCodeAndScore)) {
+          group.appliedComment = unit.notes.trim();
         }
       }
 
@@ -998,6 +1048,52 @@ export class CodingReviewService {
     }
 
     return candidate.codedAt.getTime() > existing.codedAt.getTime();
+  }
+
+  private getAppliedReviewResult(
+    isResolved: boolean,
+    response?: Pick<ResponseEntity, 'code_v2' | 'score_v2'> | null
+  ): AppliedReviewResult {
+    if (!isResolved) {
+      return {
+        appliedCode: null,
+        appliedScore: null,
+        appliedComment: null
+      };
+    }
+
+    return {
+      appliedCode: this.toNullableNumber(response?.code_v2),
+      appliedScore: this.toNullableNumber(response?.score_v2),
+      appliedComment: null
+    };
+  }
+
+  private toNullableNumber(value: number | string | null | undefined): number | null {
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+
+    const parsedValue = Number(value);
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+  }
+
+  private isAppliedRawResult(
+    appliedResult: AppliedReviewResult,
+    unit: Pick<CodingJobUnit, 'code' | 'score'>
+  ): boolean {
+    return appliedResult.appliedCode !== null &&
+      appliedResult.appliedCode === this.toNullableNumber(unit.code) &&
+      appliedResult.appliedScore === this.toNullableNumber(unit.score);
+  }
+
+  private isAppliedResolvedResult(
+    appliedResult: AppliedReviewResult,
+    resolvedResult: { code: number | null; score: number | null }
+  ): boolean {
+    return appliedResult.appliedCode !== null &&
+      appliedResult.appliedCode === resolvedResult.code &&
+      appliedResult.appliedScore === resolvedResult.score;
   }
 
   async applyDoubleCodedResolutions(

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.html
@@ -22,7 +22,39 @@
       }
     </div>
 
-    @if (!element.isResolved) {
+    @if (element.isResolved) {
+      @if (getAppliedReviewResult(element); as appliedResult) {
+        <div class="applied-result" [matTooltip]="getAppliedResultTooltip(element)">
+          <div class="applied-result-header">
+            <span class="applied-result-label">
+              {{ 'double-coded-review.applied-result.label' | translate }}
+            </span>
+            <span class="applied-result-source">
+              {{ getAppliedResultSourceLabel(element) }}
+            </span>
+          </div>
+          <div class="applied-code-row">
+            <span
+              class="applied-code-value"
+              [matTooltip]="getCodeLabel(appliedResult.code)"
+            >
+              {{ getCodeDisplay(appliedResult.code) || 'N/A' }}
+            </span>
+            @if (appliedResult.score !== null) {
+              <span class="applied-score-value"
+                >({{ appliedResult.score }})</span
+              >
+            }
+          </div>
+          @if (appliedResult.comment) {
+            <div class="applied-comment">
+              <mat-icon>rate_review</mat-icon>
+              <span>{{ appliedResult.comment }}</span>
+            </div>
+          }
+        </div>
+      }
+    } @else {
       <mat-form-field class="decision-select-field" appearance="outline">
         <mat-label>{{
           'double-coded-review.decision.select-label' | translate
@@ -477,7 +509,9 @@
                                   <div
                                     class="coder-column-cell"
                                     [ngClass]="{
-                                      pending: result.code === null
+                                      pending: result.code === null,
+                                      'applied-code-match':
+                                        isAppliedCodeMatch(element, result)
                                     }"
                                   >
                                     @if (results.length > 1) {
@@ -504,6 +538,16 @@
                                         @if (result.score !== null) {
                                           <span class="coder-score-value"
                                             >({{ result.score }})</span
+                                          >
+                                        }
+                                        @if (isAppliedCodeMatch(element, result)) {
+                                          <mat-icon
+                                            class="applied-match-icon"
+                                            [matTooltip]="
+                                              'double-coded-review.applied-result.match-tooltip'
+                                                | translate
+                                            "
+                                            >done</mat-icon
                                           >
                                         }
                                       </div>
@@ -936,7 +980,11 @@
                               @for (result of results; track result.jobId) {
                                 <div
                                   class="coder-column-cell"
-                                  [ngClass]="{ pending: result.code === null }"
+                                  [ngClass]="{
+                                    pending: result.code === null,
+                                    'applied-code-match':
+                                      isAppliedCodeMatch(element, result)
+                                  }"
                                 >
                                   @if (results.length > 1) {
                                     <div
@@ -960,6 +1008,16 @@
                                       @if (result.score !== null) {
                                         <span class="coder-score-value"
                                           >({{ result.score }})</span
+                                        >
+                                      }
+                                      @if (isAppliedCodeMatch(element, result)) {
+                                        <mat-icon
+                                          class="applied-match-icon"
+                                          [matTooltip]="
+                                            'double-coded-review.applied-result.match-tooltip'
+                                              | translate
+                                          "
+                                          >done</mat-icon
                                         >
                                       }
                                     </div>

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.scss
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.scss
@@ -360,6 +360,12 @@
             background-color: #fafbfc;
           }
 
+          &.applied-code-match {
+            border-color: #2e7d32;
+            background-color: #eef8f0;
+            box-shadow: inset 3px 0 0 #2e7d32;
+          }
+
           .coder-result-source {
             min-width: 0;
             overflow: hidden;
@@ -391,6 +397,14 @@
             .coder-score-value {
               color: #64748b;
               font-size: 12px;
+            }
+
+            .applied-match-icon {
+              color: #2e7d32;
+              flex-shrink: 0;
+              font-size: 16px;
+              height: 16px;
+              width: 16px;
             }
           }
 
@@ -493,6 +507,84 @@
             min-height: 56px;
             font-size: 13px;
             line-height: 1.4;
+          }
+        }
+
+        .applied-result {
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+          padding: 10px;
+          border: 1px solid #bbd7f5;
+          border-radius: 8px;
+          background-color: #f4f9ff;
+
+          .applied-result-header {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            min-width: 0;
+          }
+
+          .applied-result-label {
+            color: #1565c0;
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+          }
+
+          .applied-result-source {
+            min-width: 0;
+            overflow: hidden;
+            color: #64748b;
+            font-size: 12px;
+            line-height: 1.3;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+
+          .applied-code-row {
+            display: flex;
+            align-items: baseline;
+            gap: 5px;
+          }
+
+          .applied-code-value {
+            color: #0f172a;
+            font-size: 18px;
+            font-weight: 700;
+            line-height: 1.2;
+          }
+
+          .applied-score-value {
+            color: #64748b;
+            font-size: 13px;
+          }
+
+          .applied-comment {
+            display: flex;
+            align-items: flex-start;
+            gap: 5px;
+            color: #475569;
+            font-size: 12px;
+            line-height: 1.35;
+            min-width: 0;
+
+            mat-icon {
+              color: #1976d2;
+              flex-shrink: 0;
+              font-size: 16px;
+              height: 16px;
+              width: 16px;
+            }
+
+            span {
+              min-width: 0;
+              overflow: hidden;
+              display: -webkit-box;
+              -webkit-box-orient: vertical;
+              -webkit-line-clamp: 3;
+            }
           }
         }
       }

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
@@ -68,6 +68,9 @@ describe('DoubleCodedReviewComponent', () => {
                   bookletName: 'Booklet 1',
                   givenAnswer: 'answer',
                   isResolved: false,
+                  appliedCode: null,
+                  appliedScore: null,
+                  appliedComment: null,
                   coderResults: [
                     {
                       coderId: 10,
@@ -102,6 +105,9 @@ describe('DoubleCodedReviewComponent', () => {
                   bookletName: 'Booklet 1',
                   givenAnswer: 'second answer',
                   isResolved: false,
+                  appliedCode: null,
+                  appliedScore: null,
+                  appliedComment: null,
                   coderResults: [
                     {
                       coderId: 10,
@@ -136,6 +142,9 @@ describe('DoubleCodedReviewComponent', () => {
                   bookletName: 'Booklet 2',
                   givenAnswer: 'third answer',
                   isResolved: false,
+                  appliedCode: null,
+                  appliedScore: null,
+                  appliedComment: null,
                   coderResults: [
                     {
                       coderId: 10,
@@ -160,9 +169,46 @@ describe('DoubleCodedReviewComponent', () => {
                       codedAt: '2026-05-20T11:10:00.000Z'
                     }
                   ]
+                },
+                {
+                  responseId: 504,
+                  unitName: 'Unit D',
+                  variableId: 'VAR_4',
+                  personLogin: 'person-4',
+                  personCode: 'P004',
+                  bookletName: 'Booklet 2',
+                  givenAnswer: 'fourth answer',
+                  isResolved: true,
+                  appliedCode: 2,
+                  appliedScore: 1,
+                  appliedComment: 'Final decision note',
+                  coderResults: [
+                    {
+                      coderId: 10,
+                      coderName: 'Coder A',
+                      jobId: 4001,
+                      jobName: 'Definition 103 / A',
+                      code: 1,
+                      score: 0,
+                      notes: null,
+                      supervisorComment: null,
+                      codedAt: '2026-05-20T12:00:00.000Z'
+                    },
+                    {
+                      coderId: 20,
+                      coderName: 'Coder B',
+                      jobId: 4002,
+                      jobName: 'Definition 103 / B',
+                      code: 2,
+                      score: 1,
+                      notes: null,
+                      supervisorComment: 'Final decision note',
+                      codedAt: '2026-05-20T12:10:00.000Z'
+                    }
+                  ]
                 }
               ],
-              total: 3,
+              total: 4,
               page: 1,
               limit: 50
             })),
@@ -275,6 +321,28 @@ describe('DoubleCodedReviewComponent', () => {
     expect(coderACell.textContent).toContain('Definition 102 / A');
     expect(coderACell.textContent).toContain('#3002');
     expect(coderBCell.textContent).toContain('-');
+  });
+
+  it('shows applied decisions and marks matching original codes for resolved rows', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const rows = Array.from(nativeElement.querySelectorAll('tbody tr')) as HTMLElement[];
+    const resolvedRow = rows[3];
+
+    expect(resolvedRow.querySelector('.applied-result')?.textContent).toContain('2');
+    expect(resolvedRow.querySelector('.applied-result')?.textContent).toContain('Final decision note');
+    expect(resolvedRow.querySelector('.decision-status.resolved')?.textContent)
+      .toContain('double-coded-review.applied');
+
+    const coderACell = resolvedRow.querySelector('td.mat-column-coder_10') as HTMLElement;
+    const coderBCell = resolvedRow.querySelector('td.mat-column-coder_20') as HTMLElement;
+
+    expect(coderACell.querySelector('.applied-code-match')).toBeNull();
+    expect(coderBCell.querySelector('.applied-code-match')).toBeTruthy();
+    expect(coderBCell.querySelector('.applied-match-icon')).toBeTruthy();
   });
 
   it('labels duplicate coder decisions with job source and counts progress by unique coders', async () => {

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -54,8 +54,17 @@ interface DoubleCodedItem {
   bookletName: string;
   givenAnswer: string;
   isResolved: boolean;
+  appliedCode: number | null;
+  appliedScore: number | null;
+  appliedComment: string | null;
   coderResults: CoderResult[];
   selectedCoderResult?: CoderResult;
+}
+
+interface AppliedReviewResult {
+  code: number | null;
+  score: number | null;
+  comment: string | null;
 }
 
 interface CoderColumnMeta {
@@ -375,7 +384,8 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     currentItems.forEach(item => {
       const controlName = this.getItemControlName(item);
 
-      const resolvedResult = item.coderResults.find(cr => !!cr.supervisorComment);
+      const resolvedResult = this.getAppliedMatchingCoderResult(item) ||
+        item.coderResults.find(cr => !!cr.supervisorComment);
       const firstCodedResult = item.coderResults.find(cr => cr.code !== null);
 
       let defaultValue = '';
@@ -509,6 +519,68 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       item.selectedCoderResult;
 
     return selectedResult && selectedResult.code !== null ? selectedResult : undefined;
+  }
+
+  getAppliedReviewResult(item: DoubleCodedItem): AppliedReviewResult | null {
+    if (!item.isResolved) {
+      return null;
+    }
+
+    const code = item.appliedCode ?? null;
+    const score = item.appliedScore ?? null;
+    const comment = item.appliedComment?.trim() ||
+      item.coderResults.find(result => !!result.supervisorComment)?.supervisorComment?.trim() ||
+      null;
+
+    if (code === null && score === null && !comment) {
+      return null;
+    }
+
+    return {
+      code,
+      score,
+      comment
+    };
+  }
+
+  getAppliedMatchingCoderResult(item: DoubleCodedItem): CoderResult | undefined {
+    const appliedResult = this.getAppliedReviewResult(item);
+    if (!appliedResult || appliedResult.code === null) {
+      return undefined;
+    }
+
+    return item.coderResults.find(result => (
+      result.code === appliedResult.code &&
+      (result.score ?? null) === (appliedResult.score ?? null)
+    )) || item.coderResults.find(result => result.code === appliedResult.code);
+  }
+
+  getAppliedResultSourceLabel(item: DoubleCodedItem): string {
+    const matchingResult = this.getAppliedMatchingCoderResult(item);
+    if (matchingResult) {
+      return this.getDecisionResultSourceLabel(item, matchingResult);
+    }
+
+    return this.translateService.instant('double-coded-review.applied-result.final-source');
+  }
+
+  getAppliedResultTooltip(item: DoubleCodedItem): string {
+    const appliedResult = this.getAppliedReviewResult(item);
+    if (!appliedResult) {
+      return '';
+    }
+
+    const codeDisplay = this.getCodeDisplay(appliedResult.code) || this.getCodeLabel(appliedResult.code) || 'N/A';
+    const scoreDisplay = appliedResult.score !== null ? ` (${appliedResult.score})` : '';
+
+    return `${this.translateService.instant('double-coded-review.applied-result.label')}: ${codeDisplay}${scoreDisplay}`;
+  }
+
+  isAppliedCodeMatch(item: DoubleCodedItem, result: CoderResult): boolean {
+    const appliedResult = this.getAppliedReviewResult(item);
+    return !!appliedResult &&
+      appliedResult.code !== null &&
+      result.code === appliedResult.code;
   }
 
   getDecisionStatusClass(item: DoubleCodedItem): string {
@@ -787,7 +859,8 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       next: response => {
         this.allData = response.data.map(item => ({
           ...item,
-          selectedCoderResult: item.coderResults.find(result => result.code !== null)
+          selectedCoderResult: this.getAppliedMatchingCoderResult(item) ||
+            item.coderResults.find(result => result.code !== null)
         }));
         this.updateDisplayedColumns(this.allData);
         this.dataSource.data = this.allData;

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -532,6 +532,9 @@ describe('TestPersonCodingService', () => {
           bookletName: 'BOOKLET_1',
           givenAnswer: 'answer',
           isResolved: false,
+          appliedCode: null,
+          appliedScore: null,
+          appliedComment: null,
           coderResults: [{
             coderId: 1,
             coderName: 'Coder 1',

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -1066,6 +1066,9 @@ export class TestPersonCodingService {
         bookletName: string;
         givenAnswer: string;
         isResolved: boolean;
+        appliedCode: number | null;
+        appliedScore: number | null;
+        appliedComment: string | null;
         coderResults: Array<{
           coderId: number;
           coderName: string;
@@ -1127,6 +1130,9 @@ export class TestPersonCodingService {
         bookletName: string;
         givenAnswer: string;
         isResolved: boolean;
+        appliedCode: number | null;
+        appliedScore: number | null;
+        appliedComment: string | null;
         coderResults: Array<{
           coderId: number;
           coderName: string;

--- a/apps/frontend/src/app/high-coverage-component-methods.spec.ts
+++ b/apps/frontend/src/app/high-coverage-component-methods.spec.ts
@@ -97,6 +97,9 @@ const sampleReviewItem = {
   bookletName: 'booklet',
   givenAnswer: 'answer',
   isResolved: false,
+  appliedCode: null,
+  appliedScore: null,
+  appliedComment: null,
   coderResults: [
     sampleCoderResult,
     {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2467,6 +2467,11 @@
     "coders-done": "Kodierer fertig",
     "pending": "Ausstehend",
     "applied": "Angewandt",
+    "applied-result": {
+      "label": "Angewendeter Code",
+      "final-source": "Endgültige Entscheidung",
+      "match-tooltip": "Entspricht dem angewendeten Code"
+    },
     "decision": {
       "select-label": "Endgültiger Code",
       "no-selection": "Kein Code gewählt",


### PR DESCRIPTION
## Summary

- include applied code, score, and review comment in double-coded review rows
- show resolved rows with the applied decision and mark matching coder results in the review table
- keep coding issue review notes visible when they match the final applied result

## Details

The review endpoint now reads the applied v2 result for resolved responses and enriches double-coded review rows with the saved code, score, and comment. Coding issue review units are considered separately so their notes can be surfaced without adding them as regular coder results.

The Angular review view displays the applied result instead of a decision selector for resolved rows and highlights the original coder result that matches the final code.

Refs #702, #704

## Validation

- npx nx lint backend
- npx nx test backend
- npx nx lint frontend
- npx nx test frontend
- git diff --check