### PR TITLE
Fix per-variable double coding distribution

### DIFF
--- a/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.spec.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.spec.ts
@@ -1,0 +1,29 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateJobDefinitionDto } from './create-job-definition.dto';
+
+describe('CreateJobDefinitionDto', () => {
+  it('accepts a bounded distribution seed', async () => {
+    const dto = plainToInstance(CreateJobDefinitionDto, {
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedCoders: [1],
+      distributionSeed: `job-definition:7:${'a'.repeat(32)}`
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some(error => error.property === 'distributionSeed')).toBe(false);
+  });
+
+  it('rejects oversized distribution seeds', async () => {
+    const dto = plainToInstance(CreateJobDefinitionDto, {
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedCoders: [1],
+      distributionSeed: 'x'.repeat(129)
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some(error => error.property === 'distributionSeed')).toBe(true);
+  });
+});

--- a/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.ts
@@ -5,6 +5,8 @@ import {
   IsArray,
   IsBoolean,
   IsNumber,
+  IsString,
+  MaxLength,
   Max,
   Min,
   ValidateNested
@@ -110,7 +112,7 @@ export class CreateJobDefinitionDto {
     maxCodingCases?: number;
 
   @ApiProperty({
-    description: 'Absolute number of cases that should be double coded',
+    description: 'Absolute number of cases per variable that should be double coded',
     example: 10,
     required: false
   })
@@ -121,7 +123,7 @@ export class CreateJobDefinitionDto {
     doubleCodingAbsolute?: number;
 
   @ApiProperty({
-    description: 'Percentage (0-100) of cases that should be double coded',
+    description: 'Percentage (0-100) of cases per variable that should be double coded',
     example: 25.5,
     required: false
   })
@@ -141,6 +143,17 @@ export class CreateJobDefinitionDto {
   @IsEnum(['continuous', 'alternating'])
   @IsOptional()
     caseOrderingMode?: CaseOrderingMode;
+
+  @ApiProperty({
+    description: 'Seed used for deterministic distribution planning',
+    example: 'job-definition:7:550e8400-e29b-41d4-a716-446655440000',
+    maxLength: 128,
+    required: false
+  })
+  @IsString()
+  @MaxLength(128)
+  @IsOptional()
+    distributionSeed?: string;
 
   @ApiProperty({
     description: 'Whether to show scores in generated coding jobs',

--- a/apps/backend/src/app/admin/coding-job/dto/update-job-definition.dto.spec.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/update-job-definition.dto.spec.ts
@@ -1,0 +1,16 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateJobDefinitionDto } from './update-job-definition.dto';
+
+describe('UpdateJobDefinitionDto', () => {
+  it('does not expose distributionSeed as an updatable field', async () => {
+    const dto = plainToInstance(UpdateJobDefinitionDto, {
+      maxCodingCases: 10,
+      distributionSeed: 'frontend-seed'
+    });
+
+    const errors = await validate(dto, { whitelist: true, forbidNonWhitelisted: true });
+
+    expect(errors.some(error => error.property === 'distributionSeed')).toBe(true);
+  });
+});

--- a/apps/backend/src/app/admin/coding-job/dto/update-job-definition.dto.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/update-job-definition.dto.ts
@@ -1,7 +1,9 @@
-import { PartialType } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateJobDefinitionDto } from './create-job-definition.dto';
 
 /**
  * DTO for updating a job definition
  */
-export class UpdateJobDefinitionDto extends PartialType(CreateJobDefinitionDto) {}
+export class UpdateJobDefinitionDto extends PartialType(
+  OmitType(CreateJobDefinitionDto, ['distributionSeed'] as const)
+) {}

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -235,9 +235,9 @@ describe('CodingJobService distribution from job definitions', () => {
 
     const doubleCodingSummary = Object.values(result.doubleCodingInfo);
     expect(doubleCodingSummary.reduce((sum, item) => sum + item.distinctCases, 0)).toBe(7);
-    expect(doubleCodingSummary.reduce((sum, item) => sum + item.codingTasksTotal, 0)).toBe(8);
-    expect(doubleCodingSummary.reduce((sum, item) => sum + item.doubleCodedCases, 0)).toBe(1);
-    expect(doubleCodingSummary.reduce((sum, item) => sum + item.singleCodedCasesAssigned, 0)).toBe(6);
+    expect(doubleCodingSummary.reduce((sum, item) => sum + item.codingTasksTotal, 0)).toBe(10);
+    expect(doubleCodingSummary.reduce((sum, item) => sum + item.doubleCodedCases, 0)).toBe(3);
+    expect(doubleCodingSummary.reduce((sum, item) => sum + item.singleCodedCasesAssigned, 0)).toBe(4);
 
     expect(createdJobCalls.every(call => call.dto.jobDefinitionId === 77)).toBe(true);
     expect(createdJobCalls.every(call => call.subset.length > 0)).toBe(true);
@@ -257,7 +257,7 @@ describe('CodingJobService distribution from job definitions', () => {
     createdJobCalls.flatMap(call => call.subset).forEach(response => {
       assignedResponseCounts.set(response.id, (assignedResponseCounts.get(response.id) || 0) + 1);
     });
-    expect([...assignedResponseCounts.values()].filter(count => count === 2)).toHaveLength(1);
+    expect([...assignedResponseCounts.values()].filter(count => count === 2)).toHaveLength(3);
     expect(Math.max(...assignedResponseCounts.values())).toBe(2);
   });
 
@@ -435,6 +435,83 @@ describe('CodingJobService distribution from job definitions', () => {
     expect([...assignedResponseCounts.values()].filter(count => count === 2)).toHaveLength(2);
     expect(Math.max(...assignedResponseCounts.values())).toBe(2);
     expect(Object.values(result.pairDistribution).reduce((sum, count) => sum + count, 0)).toBe(2);
+  });
+
+  it('applies the absolute double-coding count to each selected variable', async () => {
+    const responses = [
+      ...Array.from({ length: 3 }, (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1')),
+      makeResponse(10, 'Unit 2', 'Var 2')
+    ];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+
+    const preview = await service.calculateDistribution(5, {
+      selectedVariables: [
+        { unitName: 'Unit 1', variableId: 'Var 1' },
+        { unitName: 'Unit 2', variableId: 'Var 2' }
+      ],
+      selectedCoders: [
+        { id: 1, name: 'Ada', username: 'ada' },
+        { id: 2, name: 'Bea', username: 'bea' }
+      ],
+      doubleCodingAbsolute: 2,
+      caseOrderingMode: 'continuous',
+      distributionSeed: 'double-coding-absolute-per-variable'
+    });
+
+    expect(preview.doubleCodingInfo['Unit 1::Var 1']).toMatchObject({
+      distinctCases: 3,
+      codingTasksTotal: 5,
+      doubleCodedCases: 2,
+      singleCodedCasesAssigned: 1
+    });
+    expect(preview.doubleCodingInfo['Unit 2::Var 2']).toMatchObject({
+      distinctCases: 1,
+      codingTasksTotal: 2,
+      doubleCodedCases: 1,
+      singleCodedCasesAssigned: 0
+    });
+    expect(
+      Object.values(preview.doubleCodingInfo)
+        .reduce((sum, item) => sum + item.doubleCodedCases, 0)
+    ).toBe(3);
+  });
+
+  it('applies the percentage double-coding count per variable and rounds up', async () => {
+    const responses = [
+      ...Array.from({ length: 277 }, (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1')),
+      ...Array.from({ length: 51 }, (_, index) => makeResponse(index + 1000, 'Unit 2', 'Var 2')),
+      ...Array.from({ length: 5 }, (_, index) => makeResponse(index + 2000, 'Unit 3', 'Var 3'))
+    ];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+
+    const preview = await service.calculateDistribution(5, {
+      selectedVariables: [
+        { unitName: 'Unit 1', variableId: 'Var 1' },
+        { unitName: 'Unit 2', variableId: 'Var 2' },
+        { unitName: 'Unit 3', variableId: 'Var 3' }
+      ],
+      selectedCoders: [
+        { id: 1, name: 'Ada', username: 'ada' },
+        { id: 2, name: 'Bea', username: 'bea' }
+      ],
+      doubleCodingPercentage: 10,
+      caseOrderingMode: 'continuous',
+      distributionSeed: 'double-coding-percentage-per-variable'
+    });
+
+    expect(preview.doubleCodingInfo['Unit 1::Var 1'].doubleCodedCases).toBe(28);
+    expect(preview.doubleCodingInfo['Unit 2::Var 2'].doubleCodedCases).toBe(6);
+    expect(preview.doubleCodingInfo['Unit 3::Var 3'].doubleCodedCases).toBe(1);
+    expect(
+      Object.values(preview.doubleCodingInfo)
+        .reduce((sum, item) => sum + item.doubleCodedCases, 0)
+    ).toBe(35);
   });
 
   it('ignores unsupported requests for more than two coders per double-coded case', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -5787,6 +5787,29 @@ export class CodingJobService {
     request: DistributionPlanRequest,
     totalCases: number
   ): number {
+    const { doubleCodingAbsolute, doubleCodingPercentage } =
+      this.getDoubleCodingSettings(request);
+
+    if (doubleCodingAbsolute > 0) {
+      return Math.min(doubleCodingAbsolute, totalCases);
+    }
+
+    if (doubleCodingPercentage > 0) {
+      return Math.min(
+        Math.ceil((doubleCodingPercentage / 100) * totalCases),
+        totalCases
+      );
+    }
+
+    return 0;
+  }
+
+  private getDoubleCodingSettings(
+    request: Pick<
+    DistributionPlanRequest,
+    'doubleCodingAbsolute' | 'doubleCodingPercentage'
+    >
+  ): { doubleCodingAbsolute: number; doubleCodingPercentage: number } {
     const doubleCodingAbsolute = Number(request.doubleCodingAbsolute || 0);
     const doubleCodingPercentage = Number(request.doubleCodingPercentage || 0);
 
@@ -5796,18 +5819,11 @@ export class CodingJobService {
       );
     }
 
-    if (doubleCodingAbsolute > 0) {
-      return Math.min(doubleCodingAbsolute, totalCases);
-    }
+    return { doubleCodingAbsolute, doubleCodingPercentage };
+  }
 
-    if (doubleCodingPercentage > 0) {
-      return Math.min(
-        Math.floor((doubleCodingPercentage / 100) * totalCases),
-        totalCases
-      );
-    }
-
-    return 0;
+  private getResponseVariableKey(response: SlimResponse): string {
+    return `${response.unitName}::${response.variableid}`;
   }
 
   private getCoderLoadRatio(
@@ -6094,12 +6110,30 @@ export class CodingJobService {
       planItems,
       request.maxCodingCases
     );
-    const doubleCodingCount = this.getDoubleCodingCount(
-      request,
-      selectedCases.length
-    );
+    this.getDoubleCodingSettings(request);
+    const selectedCaseCountsByVariableKey = new Map<string, number>();
+    selectedCases.forEach(selectedCase => {
+      const variableKey = this.getResponseVariableKey(selectedCase.response);
+      selectedCaseCountsByVariableKey.set(
+        variableKey,
+        (selectedCaseCountsByVariableKey.get(variableKey) || 0) + 1
+      );
+    });
+    const doubleCodingCountsByVariableKey = new Map<string, number>();
+    selectedCaseCountsByVariableKey.forEach((caseCount, variableKey) => {
+      doubleCodingCountsByVariableKey.set(
+        variableKey,
+        this.getDoubleCodingCount(request, caseCount)
+      );
+    });
+    const totalDoubleCodingCount = Array.from(
+      doubleCodingCountsByVariableKey.values()
+    ).reduce((sum, count) => sum + count, 0);
 
-    if (doubleCodingCount > 0 && coders.length < codersPerDoubleCodedCase) {
+    if (
+      totalDoubleCodingCount > 0 &&
+      coders.length < codersPerDoubleCodedCase
+    ) {
       throw new BadRequestException(
         `Double coding requires at least ${codersPerDoubleCodedCase} selected coders.`
       );
@@ -6113,12 +6147,18 @@ export class CodingJobService {
     const jobsByItemAndCoder = new Map<string, Map<number, SlimResponse[]>>();
     const plannedCases: DistributionPlanCase[] = [];
     const doubleCodingCoderCombinations =
-      doubleCodingCount > 0 ?
+      totalDoubleCodingCount > 0 ?
         this.getCoderCombinations(coders, codersPerDoubleCodedCase) :
         [];
+    const assignedDoubleCodingCountsByVariableKey = new Map<string, number>();
 
-    selectedCases.forEach((selectedCase, index) => {
-      const isDoubleCoded = index < doubleCodingCount;
+    selectedCases.forEach(selectedCase => {
+      const variableKey = this.getResponseVariableKey(selectedCase.response);
+      const assignedDoubleCodingCount =
+        assignedDoubleCodingCountsByVariableKey.get(variableKey) || 0;
+      const isDoubleCoded =
+        assignedDoubleCodingCount <
+        (doubleCodingCountsByVariableKey.get(variableKey) || 0);
       const assignedCoders = isDoubleCoded ?
         this.chooseDoubleCodingCoders(
           doubleCodingCoderCombinations,
@@ -6138,6 +6178,10 @@ export class CodingJobService {
       const assignedCoderIds = assignedCoders.map(coder => coder.id);
 
       if (isDoubleCoded) {
+        assignedDoubleCodingCountsByVariableKey.set(
+          variableKey,
+          assignedDoubleCodingCount + 1
+        );
         const pairKey = [...assignedCoderIds].sort((a, b) => a - b).join('-');
         pairCounts.set(pairKey, (pairCounts.get(pairKey) || 0) + 1);
       }

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -269,6 +269,23 @@ describe('JobDefinitionService', () => {
     ]);
   });
 
+  it('uses a provided distribution seed when creating a definition', async () => {
+    const result = await service.createJobDefinition({
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedCoders: [1],
+      maxCodingCases: 2,
+      distributionSeed: 'frontend-seed'
+    }, 7);
+
+    expect(result.distribution_seed).toBe('frontend-seed');
+    expect(codingJobService.calculateDistributionVariableUsageBatch).toHaveBeenCalledWith(7, [
+      expect.objectContaining({
+        key: 'requested',
+        distributionSeed: 'frontend-seed'
+      })
+    ]);
+  });
+
   it('merges DERIVE_ERROR opt-in into bundled variables when planning usage', async () => {
     variableBundleRepository.find.mockResolvedValue([
       {

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -742,7 +742,7 @@ export class JobDefinitionService {
 
   async createJobDefinition(createDto: CreateJobDefinitionDto, workspaceId: number): Promise<JobDefinition> {
     const coderAssignments = this.resolveCoderAssignments(createDto);
-    const distributionSeed = this.createDistributionSeed(workspaceId);
+    const distributionSeed = createDto.distributionSeed || this.createDistributionSeed(workspaceId);
     const missingsProfileId = await this.missingsProfilesService.resolveMissingsProfileId(
       workspaceId,
       createDto.missingsProfileId

--- a/apps/frontend/src/app/coding/components/coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component.ts
@@ -387,13 +387,16 @@ export class CodingJobBulkCreationDialogComponent {
   private getCaseCountForCoder(item: Variable | PreviewVariableBundle, coder: Coder): number {
     let itemKey;
     let totalCases;
+    let variableCaseCounts: number[];
 
     if ('variables' in item) { // bundle
       itemKey = this.getBundleItemKey(item);
-      totalCases = item.variables.reduce((sum, v) => sum + (v.responseCount || 0), 0);
+      variableCaseCounts = item.variables.map(variable => variable.responseCount || 0);
+      totalCases = variableCaseCounts.reduce((sum, count) => sum + count, 0);
     } else { // variable
       itemKey = `${item.unitName}::${item.variableId}`;
       totalCases = item.responseCount || 0;
+      variableCaseCounts = [totalCases];
     }
 
     if (this.data.distribution && this.data.doubleCodingInfo) {
@@ -416,13 +419,8 @@ export class CodingJobBulkCreationDialogComponent {
 
     if (coderIndex === -1) return 0;
 
-    // Calculate double coding requirements
-    let doubleCodingCount = 0;
-    if (this.data.doubleCodingAbsolute && this.data.doubleCodingAbsolute > 0) {
-      doubleCodingCount = Math.min(this.data.doubleCodingAbsolute, totalCases);
-    } else if (this.data.doubleCodingPercentage && this.data.doubleCodingPercentage > 0) {
-      doubleCodingCount = Math.floor((this.data.doubleCodingPercentage / 100) * totalCases);
-    }
+    const doubleCodingCount = variableCaseCounts
+      .reduce((sum, count) => sum + this.getDoubleCodingCountForVariable(count), 0);
 
     const singleCodingCases = totalCases - doubleCodingCount;
     const baseCasesPerCoder = Math.floor(singleCodingCases / sortedCoders.length);
@@ -430,6 +428,19 @@ export class CodingJobBulkCreationDialogComponent {
 
     const singleCases = baseCasesPerCoder + (coderIndex < remainder ? 1 : 0);
     return singleCases + doubleCodingCount;
+  }
+
+  private getDoubleCodingCountForVariable(totalCases: number): number {
+    if (this.data.doubleCodingAbsolute && this.data.doubleCodingAbsolute > 0) {
+      return Math.min(this.data.doubleCodingAbsolute, totalCases);
+    }
+    if (this.data.doubleCodingPercentage && this.data.doubleCodingPercentage > 0) {
+      return Math.min(
+        Math.ceil((this.data.doubleCodingPercentage / 100) * totalCases),
+        totalCases
+      );
+    }
+    return 0;
   }
 
   private initForm(): void {

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
@@ -78,6 +78,15 @@ describe('CodingJobDefinitionDialogComponent', () => {
     ...bundle,
     variables: bundle.variables.map(variable => ({ ...variable }))
   }));
+  const emptyDistributionPreview = {
+    distribution: {},
+    distributionByCoderId: {},
+    doubleCodingInfo: {},
+    aggregationInfo: {},
+    matchingFlags: [],
+    warnings: [],
+    tasksPerCoder: {}
+  };
 
   beforeEach(async () => {
     mockCodingJobBackendService = {
@@ -111,7 +120,8 @@ describe('CodingJobDefinitionDialogComponent', () => {
     } as unknown as Partial<CodingJobBackendService>;
 
     mockDistributedCodingService = {
-      createDistributedCodingJobs: jest.fn()
+      createDistributedCodingJobs: jest.fn(),
+      calculateDistribution: jest.fn().mockReturnValue(of(emptyDistributionPreview))
     } as unknown as Partial<DistributedCodingService>;
 
     mockAppService = {
@@ -478,6 +488,7 @@ describe('CodingJobDefinitionDialogComponent', () => {
 
     expect(mockCodingJobBackendService.createJobDefinition).toHaveBeenCalledTimes(1);
     expect(mockCodingJobBackendService.createJobDefinition).toHaveBeenCalledWith(1, expect.objectContaining({
+      distributionSeed: expect.stringMatching(/^job-definition:1:/),
       showScore: false,
       allowComments: true,
       suppressGeneralInstructions: false
@@ -638,12 +649,14 @@ describe('CodingJobDefinitionDialogComponent', () => {
       component.onSubmit();
       tick();
 
+      const updatePayload = (mockCodingJobBackendService.updateJobDefinition as jest.Mock).mock.calls[0][2];
       expect(mockCodingJobBackendService.updateJobDefinition).toHaveBeenCalledWith(1, 555, expect.objectContaining({
         showScore: true,
         allowComments: false,
         suppressGeneralInstructions: true,
         missingsProfileId: 7
       }));
+      expect(updatePayload).not.toHaveProperty('distributionSeed');
       expect(mockDialogRef.close).toHaveBeenCalled();
     }));
   });
@@ -922,6 +935,116 @@ describe('CodingJobDefinitionDialogComponent', () => {
     expect(component.getTotalCodingCases()).toBe(14);
   });
 
+  it('should calculate double coding totals per selected variable', () => {
+    createComponent();
+
+    component.selectedVariables.select(component.variables[0]);
+    component.selectedVariables.select(component.variables[2]);
+
+    component.doubleCodingMode = 'absolute';
+    component.codingJobForm.patchValue({ doubleCodingAbsolute: 2 });
+
+    expect(component.getTotalCodingCases()).toBe(14);
+    expect(component.getTotalDoubleCodedCases()).toBe(4);
+    expect(component.getTotalCodingTasks()).toBe(18);
+
+    component.doubleCodingMode = 'percentage';
+    component.codingJobForm.patchValue({ doubleCodingPercentage: 10 });
+
+    expect(component.getTotalDoubleCodedCases()).toBe(2);
+    expect(component.getTotalCodingTasks()).toBe(16);
+  });
+
+  it('should apply max coding cases by distribution item before estimating per-variable double coding', () => {
+    (mockCodingJobBackendService.getJobDefinitions as jest.Mock).mockReturnValue(of([]));
+    createComponent();
+
+    const bundle = component.variableBundles.find(b => b.name === 'Bundle 1');
+    expect(bundle).toBeDefined();
+
+    component.selectedVariableBundles.select(bundle!);
+    component.selectedVariables.select(component.variables[1]);
+    component.doubleCodingMode = 'absolute';
+    component.codingJobForm.patchValue({
+      maxCodingCases: 6,
+      doubleCodingAbsolute: 2
+    });
+
+    expect(component.getTotalCodingCases()).toBe(6);
+    expect(component.getTotalDoubleCodedCases()).toBe(5);
+    expect(component.getTotalCodingTasks()).toBe(11);
+  });
+
+  it('should use the backend distribution preview for definition estimates', fakeAsync(() => {
+    (mockCodingJobBackendService.getJobDefinitions as jest.Mock).mockReturnValue(of([]));
+    (mockDistributedCodingService.calculateDistribution as jest.Mock).mockReturnValue(of({
+      ...emptyDistributionPreview,
+      doubleCodingInfo: {
+        'bundle:1': {
+          totalCases: 10,
+          distinctCases: 6,
+          doubleCodedCases: 4,
+          singleCodedCasesAssigned: 2,
+          codingTasksTotal: 10,
+          doubleCodedCasesPerCoder: {}
+        }
+      },
+      tasksPerCoder: {
+        1: 7,
+        2: 3
+      }
+    }));
+    createComponent();
+    (mockDistributedCodingService.calculateDistribution as jest.Mock).mockClear();
+
+    const bundle = component.variableBundles.find(b => b.name === 'Bundle 1');
+    expect(bundle).toBeDefined();
+
+    component.selectedCoders.select(component.availableCoders[0], component.availableCoders[1]);
+    component.selectedVariableBundles.select(bundle!);
+    component.codingJobForm.patchValue({
+      maxCodingCases: 6,
+      doubleCodingAbsolute: 2,
+      durationSeconds: 60
+    });
+
+    tick(300);
+
+    expect(mockDistributedCodingService.calculateDistribution).toHaveBeenCalledWith(
+      1,
+      [],
+      [
+        expect.objectContaining({ id: 1, capacityPercent: 100 }),
+        expect.objectContaining({ id: 2, capacityPercent: 100 })
+      ],
+      2,
+      0,
+      [expect.objectContaining({ id: 1, name: 'Bundle 1' })],
+      'continuous',
+      6,
+      expect.stringMatching(/^job-definition:1:/)
+    );
+    expect(component.getTotalCodingCases()).toBe(6);
+    expect(component.getTotalDoubleCodedCases()).toBe(4);
+    expect(component.getTotalCodingTasks()).toBe(10);
+    expect(component.getTimePerCoderInSeconds()).toBe(420);
+  }));
+
+  it('should send a stable distribution seed when submitting a new definition for review', () => {
+    createComponent();
+    (mockCodingJobBackendService.createJobDefinition as jest.Mock).mockReturnValue(of({ id: 123 }));
+
+    component.selectedCoders.select(mockCoders[0]);
+    component.selectedVariables.select(mockVariables[0]);
+
+    component.onSubmitForReview();
+
+    expect(mockCodingJobBackendService.createJobDefinition).toHaveBeenCalledWith(1, expect.objectContaining({
+      status: 'pending_review',
+      distributionSeed: expect.stringMatching(/^job-definition:1:/)
+    }));
+  });
+
   it('should calculate "Time per coder" correctly with double coding', () => {
     createComponent();
 
@@ -958,7 +1081,7 @@ describe('CodingJobDefinitionDialogComponent', () => {
     component.doubleCodingMode = 'percentage';
     component.codingJobForm.patchValue({ doubleCodingPercentage: 50 });
 
-    // Total tasks: 10 + floor(0.5 * 10) = 15
+    // Total tasks: 10 + ceil(0.5 * 10) = 15
     // Total time: 15 * 60 = 900s (15 min)
     // Time per coder: 900 / 2 = 450s (7 min 30 sec)
     expect(component.getTotalCodingTasks()).toBe(15);

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
@@ -29,7 +29,7 @@ import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { SelectionModel } from '@angular/cdk/collections';
 import { MatTooltip } from '@angular/material/tooltip';
 import {
-  forkJoin, Subject, takeUntil, firstValueFrom
+  debounceTime, forkJoin, Subject, Subscription, takeUntil, firstValueFrom
 } from 'rxjs';
 import {
   CodingJob,
@@ -42,7 +42,10 @@ import {
   CodingJobBackendService,
   ManualCodingScopeSummary
 } from '../../services/coding-job-backend.service';
-import { DistributedCodingService } from '../../services/distributed-coding.service';
+import {
+  DistributedCodingService,
+  DistributionCalculationResponse
+} from '../../services/distributed-coding.service';
 import { AppService } from '../../../core/services/app.service';
 import { CoderService } from '../../services/coder.service';
 import { CodingJobService } from '../../services/coding-job.service';
@@ -102,6 +105,24 @@ interface CreationResults {
     jobName: string;
     caseCount: number;
   }[];
+}
+
+interface EstimatedDistributionGroup {
+  variableKey: string;
+  remaining: number;
+}
+
+interface EstimatedDistributionItem {
+  groups: EstimatedDistributionGroup[];
+  nextGroupIndex: number;
+  remaining: number;
+}
+
+interface DistributionPreviewSummary {
+  totalCases: number;
+  doubleCodedCases: number;
+  totalCodingTasks: number;
+  tasksPerCoder?: Record<string, number>;
 }
 
 @Component({
@@ -199,6 +220,11 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
 
   private disabledVariableKeys = new Set<string>();
   private baseAvailableCasesByVariable = new Map<string, number>();
+  private definitionDistributionSeed?: string;
+  private distributionPreviewSummary: DistributionPreviewSummary | null = null;
+  private readonly distributionPreviewRefresh$ = new Subject<void>();
+  private distributionPreviewRequestId = 0;
+  private selectionPreviewSubscription = new Subscription();
   existingJobDefinitions: JobDefinition[] = [];
   manualCodingScopeSummary: ManualCodingScopeSummary | null = null;
   includeDeriveErrorInManualCoding = false;
@@ -218,6 +244,13 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     }
 
     this.initForm();
+    this.bindSelectionPreviewRefresh();
+    this.codingJobForm.valueChanges
+      .pipe(debounceTime(150), takeUntil(this.destroy$))
+      .subscribe(() => this.queueDistributionPreviewRefresh());
+    this.distributionPreviewRefresh$
+      .pipe(debounceTime(150), takeUntil(this.destroy$))
+      .subscribe(() => this.loadDistributionPreview());
     this.loadIncludeDeriveErrorSetting();
     this.loadVariableBundles();
     this.loadAvailableCoders();
@@ -257,8 +290,122 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.selectionPreviewSubscription.unsubscribe();
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  private bindSelectionPreviewRefresh(): void {
+    this.selectionPreviewSubscription.unsubscribe();
+    this.selectionPreviewSubscription = new Subscription();
+
+    this.selectionPreviewSubscription.add(
+      this.selectedVariables.changed.subscribe(() => this.queueDistributionPreviewRefresh())
+    );
+    this.selectionPreviewSubscription.add(
+      this.selectedVariableBundles.changed.subscribe(() => this.queueDistributionPreviewRefresh())
+    );
+    this.selectionPreviewSubscription.add(
+      this.selectedCoders.changed.subscribe(() => this.queueDistributionPreviewRefresh())
+    );
+  }
+
+  private queueDistributionPreviewRefresh(): void {
+    if (this.data.mode !== 'definition' || this.isReadOnly) {
+      return;
+    }
+
+    this.distributionPreviewSummary = null;
+    this.distributionPreviewRefresh$.next();
+  }
+
+  private loadDistributionPreview(): void {
+    if (
+      this.data.mode !== 'definition' ||
+      this.codingJobForm.invalid ||
+      this.selectedCoders.selected.length === 0 ||
+      (
+        this.selectedVariables.selected.length === 0 &&
+        this.selectedVariableBundles.selected.length === 0
+      )
+    ) {
+      this.distributionPreviewSummary = null;
+      return;
+    }
+
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      this.distributionPreviewSummary = null;
+      return;
+    }
+
+    const requestId = this.distributionPreviewRequestId + 1;
+    this.distributionPreviewRequestId = requestId;
+
+    this.distributedCodingService.calculateDistribution(
+      workspaceId,
+      this.getSelectedDefinitionVariables(),
+      this.mapCodersForDistribution(this.getSelectedCodersForDistribution()),
+      this.sanitizeNumber(this.codingJobForm.value.doubleCodingAbsolute),
+      this.sanitizeNumber(this.codingJobForm.value.doubleCodingPercentage),
+      this.selectedVariableBundles.selected.map(bundle => ({
+        id: bundle.id,
+        name: bundle.name,
+        caseOrderingMode: bundle.caseOrderingMode,
+        variables: bundle.variables.map(variable => ({
+          unitName: variable.unitName,
+          variableId: variable.variableId
+        }))
+      })),
+      this.codingJobForm.value.caseOrderingMode,
+      this.sanitizeNumber(this.codingJobForm.value.maxCodingCases),
+      this.getDistributionSeed()
+    )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: preview => {
+          if (requestId !== this.distributionPreviewRequestId) {
+            return;
+          }
+
+          this.distributionPreviewSummary = this.buildDistributionPreviewSummary(preview);
+        },
+        error: () => {
+          if (requestId === this.distributionPreviewRequestId) {
+            this.distributionPreviewSummary = null;
+          }
+        }
+      });
+  }
+
+  private buildDistributionPreviewSummary(
+    preview: DistributionCalculationResponse
+  ): DistributionPreviewSummary {
+    return Object.values(preview.doubleCodingInfo || {}).reduce(
+      (summary, info) => {
+        const distinctCases = Number(info.distinctCases);
+        const doubleCodedCases = Number(info.doubleCodedCases || 0);
+        const singleCodedCasesAssigned = Number(info.singleCodedCasesAssigned);
+        const totalCases = Number.isFinite(distinctCases) ?
+          distinctCases :
+          doubleCodedCases + (Number.isFinite(singleCodedCasesAssigned) ? singleCodedCasesAssigned : 0);
+        const codingTasksTotal = Number(info.codingTasksTotal);
+
+        summary.totalCases += totalCases;
+        summary.doubleCodedCases += doubleCodedCases;
+        summary.totalCodingTasks += Number.isFinite(codingTasksTotal) ?
+          codingTasksTotal :
+          totalCases + doubleCodedCases;
+
+        return summary;
+      },
+      {
+        totalCases: 0,
+        doubleCodedCases: 0,
+        totalCodingTasks: 0,
+        tasksPerCoder: preview.tasksPerCoder
+      } as DistributionPreviewSummary
+    );
   }
 
   private loadIncludeDeriveErrorSetting(): void {
@@ -307,6 +454,8 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
         } else {
           this.selectedCoders = new SelectionModel<Coder>(true, []);
         }
+        this.bindSelectionPreviewRefresh();
+        this.queueDistributionPreviewRefresh();
       },
       error: () => {
         this.isLoadingAvailableCoders = false;
@@ -345,6 +494,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     }
 
     coder.capacityPercent = this.normalizeCoderCapacityPercent(value);
+    this.queueDistributionPreviewRefresh();
   }
 
   getSelectedCoderConfigs(): JobDefinitionCoderConfig[] {
@@ -414,6 +564,8 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
         const assignedIds = coders.map(c => c.id);
         const preSelectedCoders = this.availableCoders.filter(c => assignedIds.includes(c.id));
         this.selectedCoders = new SelectionModel<Coder>(true, preSelectedCoders);
+        this.bindSelectionPreviewRefresh();
+        this.queueDistributionPreviewRefresh();
       },
       error: () => {
         this.isLoadingCoders = false;
@@ -459,6 +611,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
 
     if (originallyAssigned && originallyAssigned.length > 0) {
       this.selectedVariables = this.createVariableSelectionModel([...originallyAssigned]);
+      this.bindSelectionPreviewRefresh();
     }
   }
 
@@ -595,7 +748,9 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     });
 
     this.selectedVariables = this.createVariableSelectionModel(nextSelectedVariables);
+    this.bindSelectionPreviewRefresh();
     this.syncSelectionWithAvailability();
+    this.queueDistributionPreviewRefresh();
   }
 
   private createVariableSelectionModel(initiallySelectedValues: Variable[] = []): SelectionModel<Variable> {
@@ -769,6 +924,10 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     );
 
     toDeselect.forEach(v => this.selectedVariables.deselect(v));
+
+    if (toDeselect.length > 0) {
+      this.queueDistributionPreviewRefresh();
+    }
   }
 
   applyFilter(): void {
@@ -968,6 +1127,10 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
   }
 
   getTotalCodingCases(): number {
+    if (this.distributionPreviewSummary) {
+      return this.distributionPreviewSummary.totalCases;
+    }
+
     const maxCases = this.codingJobForm.getRawValue().maxCodingCases;
     const isDefinitionMode = this.data.mode === 'definition';
     let total = this.getDistributableCodingCasesBeforeLimit();
@@ -984,20 +1147,202 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     return total;
   }
 
-  getTotalDoubleCodedCases(): number {
-    const totalCases = this.getTotalCodingCases();
-    if (totalCases === 0) return 0;
+  private getSelectedDistributionVariableCaseCountsAfterLimit(): number[] {
+    const items = this.getSelectedDistributionItems();
+    const maxCases = this.codingJobForm.getRawValue().maxCodingCases;
+    const total = items.reduce((sum, item) => sum + item.remaining, 0);
+    const targetCases =
+      this.data.mode === 'definition' &&
+      typeof maxCases === 'number' &&
+      maxCases > 0 ?
+        Math.min(total, maxCases) :
+        total;
+    const selectedCaseCountsByVariable = new Map<string, number>();
+    let selectedCases = 0;
 
+    while (selectedCases < targetCases) {
+      let progressed = false;
+
+      for (const item of items) {
+        if (selectedCases >= targetCases) {
+          break;
+        }
+
+        const variableKey = this.takeNextEstimatedItemCase(item);
+        if (!variableKey) {
+          continue;
+        }
+
+        selectedCaseCountsByVariable.set(
+          variableKey,
+          (selectedCaseCountsByVariable.get(variableKey) || 0) + 1
+        );
+        selectedCases += 1;
+        progressed = true;
+      }
+
+      if (!progressed) {
+        break;
+      }
+    }
+
+    return Array.from(selectedCaseCountsByVariable.values());
+  }
+
+  private takeNextEstimatedItemCase(item: EstimatedDistributionItem): string | undefined {
+    if (item.remaining <= 0 || item.groups.length === 0) {
+      return undefined;
+    }
+
+    for (let attempts = 0; attempts < item.groups.length; attempts += 1) {
+      const group = item.groups[item.nextGroupIndex % item.groups.length];
+      item.nextGroupIndex = (item.nextGroupIndex + 1) % item.groups.length;
+
+      if (group.remaining <= 0) {
+        continue;
+      }
+
+      group.remaining -= 1;
+      item.remaining -= 1;
+      return group.variableKey;
+    }
+
+    return undefined;
+  }
+
+  private getSelectedDistributionItems(): EstimatedDistributionItem[] {
+    const caseOrderingMode = this.codingJobForm.getRawValue().caseOrderingMode || 'continuous';
+    const items: EstimatedDistributionItem[] = [];
+
+    this.selectedVariableBundles.selected.forEach(bundle => {
+      const itemKey = `bundle:${bundle.id}`;
+      const itemCaseOrderingMode = bundle.caseOrderingMode || caseOrderingMode;
+      const cases = this.getEstimatedItemCases(
+        bundle.variables as Variable[],
+        itemCaseOrderingMode,
+        itemKey
+      );
+
+      if (cases.remaining > 0) {
+        items.push(cases);
+      }
+    });
+
+    this.selectedVariables.selected.forEach(variable => {
+      const itemKey = `${variable.unitName}::${variable.variableId}`;
+      const cases = this.getEstimatedItemCases([variable], caseOrderingMode, itemKey);
+
+      if (cases.remaining > 0) {
+        items.push(cases);
+      }
+    });
+
+    return items;
+  }
+
+  private getEstimatedItemCases(
+    variables: Variable[],
+    mode: 'continuous' | 'alternating',
+    itemKey: string
+  ): EstimatedDistributionItem {
+    const distributionSeed = this.getDistributionSeed();
+    const variableGroups = variables
+      .map(variable => ({
+        variableKey: this.getVariableUsageKey(variable.unitName, variable.variableId),
+        stratumKey: this.getEstimatedResponseStratumKey(variable, mode),
+        remaining: this.getVariableAvailableCases(variable)
+      }))
+      .filter(group => group.remaining > 0)
+      .sort((a, b) => {
+        const hashA = this.stableHash(`${distributionSeed}:${itemKey}:stratum:${a.stratumKey}`);
+        const hashB = this.stableHash(`${distributionSeed}:${itemKey}:stratum:${b.stratumKey}`);
+        return hashA - hashB || a.stratumKey.localeCompare(b.stratumKey);
+      });
+
+    return {
+      groups: variableGroups.map(group => ({
+        variableKey: group.variableKey,
+        remaining: group.remaining
+      })),
+      nextGroupIndex: 0,
+      remaining: variableGroups.reduce((sum, group) => sum + group.remaining, 0)
+    };
+  }
+
+  private getDistributionSeed(): string {
+    const existingSeed = this.data.codingJob?.distributionSeed;
+    if (existingSeed !== undefined && existingSeed !== null && existingSeed !== '') {
+      return String(existingSeed);
+    }
+
+    if (this.data.jobDefinitionId !== undefined && this.data.jobDefinitionId !== null) {
+      return `job-definition:${this.data.jobDefinitionId}`;
+    }
+
+    if (!this.definitionDistributionSeed) {
+      this.definitionDistributionSeed =
+        `job-definition:${this.appService.selectedWorkspaceId}:${this.createDistributionSeedId()}`;
+    }
+
+    return this.definitionDistributionSeed;
+  }
+
+  private createDistributionSeedId(): string {
+    return globalThis.crypto?.randomUUID?.() ||
+      `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  }
+
+  private getEstimatedResponseStratumKey(
+    variable: Pick<Variable, 'unitName' | 'variableId'>,
+    mode: 'continuous' | 'alternating'
+  ): string {
+    if (mode === 'alternating') {
+      return `::::${variable.unitName}::${variable.variableId}`;
+    }
+
+    return `${variable.unitName}::${variable.variableId}::::`;
+  }
+
+  private stableHash(value: string): number {
+    let hash = 0;
+
+    for (let i = 0; i < value.length; i += 1) {
+      hash = (hash * 31 + value.charCodeAt(i)) % 4294967291;
+    }
+
+    return hash;
+  }
+
+  private getDoubleCodedCasesForVariable(totalCases: number): number {
     const { doubleCodingAbsolute, doubleCodingPercentage } = this.codingJobForm.getRawValue();
 
     if (this.doubleCodingMode === 'absolute') {
       return Math.min(doubleCodingAbsolute || 0, totalCases);
     }
 
-    return Math.floor(((doubleCodingPercentage || 0) / 100) * totalCases);
+    return Math.min(
+      Math.ceil(((doubleCodingPercentage || 0) / 100) * totalCases),
+      totalCases
+    );
+  }
+
+  getTotalDoubleCodedCases(): number {
+    if (this.distributionPreviewSummary) {
+      return this.distributionPreviewSummary.doubleCodedCases;
+    }
+
+    return this.getSelectedDistributionVariableCaseCountsAfterLimit()
+      .reduce(
+        (sum, totalCases) => sum + this.getDoubleCodedCasesForVariable(totalCases),
+        0
+      );
   }
 
   getTotalCodingTasks(): number {
+    if (this.distributionPreviewSummary) {
+      return this.distributionPreviewSummary.totalCodingTasks;
+    }
+
     return this.getTotalCodingCases() + this.getTotalDoubleCodedCases();
   }
 
@@ -1007,6 +1352,17 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
   }
 
   getTimePerCoderInSeconds(): number {
+    if (this.distributionPreviewSummary?.tasksPerCoder) {
+      const durationPerCase = this.codingJobForm.getRawValue().durationSeconds || 1;
+      const taskCounts = Object.values(this.distributionPreviewSummary.tasksPerCoder)
+        .map(tasks => Number(tasks))
+        .filter(tasks => Number.isFinite(tasks));
+
+      if (taskCounts.length > 0) {
+        return Math.max(...taskCounts) * durationPerCase;
+      }
+    }
+
     const totalTime = this.getTotalTimeInSeconds();
     const capacityWeights = this.selectedCoders.selected.map(
       coder => this.getCoderCapacityPercent(coder) / 100
@@ -1106,6 +1462,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     if (selectedVariable) {
       selectedVariable.includeDeriveError = includeDeriveError;
     }
+    this.queueDistributionPreviewRefresh();
   }
 
   private getSelectedDefinitionVariables(): Variable[] {
@@ -1447,6 +1804,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     if (selectedBundle && selectedBundle !== bundle) {
       selectedBundle.caseOrderingMode = mode;
     }
+    this.queueDistributionPreviewRefresh();
   }
 
   private removeConflictingIndividualSelections(bundle: VariableBundle): void {
@@ -1478,6 +1836,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
 
     this.codingJobForm.get('doubleCodingAbsolute')?.updateValueAndValidity();
     this.codingJobForm.get('doubleCodingPercentage')?.updateValueAndValidity();
+    this.queueDistributionPreviewRefresh();
   }
 
   toggleDoubleCodingMode(): void {
@@ -1527,6 +1886,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
       doubleCodingAbsolute: this.sanitizeNumber(this.codingJobForm.value.doubleCodingAbsolute),
       doubleCodingPercentage: this.sanitizeNumber(this.codingJobForm.value.doubleCodingPercentage),
       caseOrderingMode: this.codingJobForm.value.caseOrderingMode,
+      distributionSeed: this.getDistributionSeed(),
       missingsProfileId: this.sanitizeNumber(this.codingJobForm.value.missingsProfileId),
       showScore: this.codingJobForm.value.showScore,
       allowComments: this.codingJobForm.value.allowComments,
@@ -1652,6 +2012,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
       doubleCodingAbsolute: this.sanitizeNumber(this.codingJobForm.value.doubleCodingAbsolute),
       doubleCodingPercentage: this.sanitizeNumber(this.codingJobForm.value.doubleCodingPercentage),
       caseOrderingMode: this.codingJobForm.value.caseOrderingMode,
+      distributionSeed: this.getDistributionSeed(),
       missingsProfileId: this.sanitizeNumber(this.codingJobForm.value.missingsProfileId),
       showScore: this.codingJobForm.value.showScore,
       allowComments: this.codingJobForm.value.allowComments,

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2007,7 +2007,7 @@
       "general-info": "Allgemeine Informationen",
       "double-coding": {
         "title": "Doppelkodierung",
-        "description": "Konfiguriere, welche Fälle doppelt kodiert werden sollen."
+        "description": "Konfiguriere, wie viele Fälle für jede Variable doppelt kodiert werden sollen."
       },
       "variable-bundles": {
         "title": "Variablenbündel",


### PR DESCRIPTION
## Summary

- calculate double-coding counts per selected variable instead of across the global case total
- round percentage-based double coding up per variable
- keep definition distribution previews and submitted definitions on the same deterministic seed
- clarify the German double-coding description and cover DTO/preview behavior with tests

## Validation

- npx nx lint backend
- npx nx test backend --runInBand
- npx nx lint frontend
- npx nx test frontend --runInBand

Related to #686.
