### PR TITLE
Fix coding job pause status actions

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -1889,6 +1889,67 @@ describe('CodingJobService', () => {
     }
   );
 
+  it('pauses active coding jobs through the coder action', async () => {
+    const codingJob = {
+      id: 1,
+      workspace_id: 3,
+      status: 'active'
+    };
+    codingJobRepository.findOne.mockResolvedValue(codingJob);
+
+    await expect(service.pauseCodingJob(1, 3)).resolves.toMatchObject({
+      status: 'paused'
+    });
+
+    expect(codingJobRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 1, workspace_id: 3 }
+    });
+    expect(codingJobRepository.save).toHaveBeenCalledWith({
+      ...codingJob,
+      status: 'paused'
+    });
+  });
+
+  it('leaves completed coding jobs unchanged when a pause arrives late', async () => {
+    const codingJob = {
+      id: 1,
+      workspace_id: 3,
+      status: 'completed'
+    };
+    codingJobRepository.findOne.mockResolvedValue(codingJob);
+
+    await expect(service.pauseCodingJob(1, 3)).resolves.toBe(codingJob);
+
+    expect(codingJobRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('resumes paused coding jobs through the coder action', async () => {
+    const codingJob = {
+      id: 1,
+      workspace_id: 3,
+      status: 'paused'
+    };
+    codingJobRepository.findOne.mockResolvedValue(codingJob);
+
+    await expect(service.resumeCodingJob(1, 3)).resolves.toMatchObject({
+      status: 'active'
+    });
+
+    expect(codingJobRepository.save).toHaveBeenCalledWith({
+      ...codingJob,
+      status: 'active'
+    });
+  });
+
+  it('rejects coder status actions for unknown coding jobs', async () => {
+    codingJobRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.pauseCodingJob(1, 3)).rejects.toBeInstanceOf(
+      NotFoundException
+    );
+    expect(codingJobRepository.save).not.toHaveBeenCalled();
+  });
+
   it('validates updated coders before saving job fields or deleting existing assignments', async () => {
     codingJobRepository.findOne.mockResolvedValue({
       id: 1,

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -2705,6 +2705,47 @@ export class CodingJobService {
     return savedCodingJob;
   }
 
+  async pauseCodingJob(id: number, workspaceId: number): Promise<CodingJob> {
+    return this.setOwnCodingJobStatus(id, workspaceId, 'paused');
+  }
+
+  async resumeCodingJob(id: number, workspaceId: number): Promise<CodingJob> {
+    return this.setOwnCodingJobStatus(id, workspaceId, 'active');
+  }
+
+  async submitCodingJob(id: number, workspaceId: number): Promise<CodingJob> {
+    return this.updateCodingJob(id, workspaceId, { status: 'completed' });
+  }
+
+  private async setOwnCodingJobStatus(
+    id: number,
+    workspaceId: number,
+    status: 'active' | 'paused'
+  ): Promise<CodingJob> {
+    const codingJob = await this.codingJobRepository.findOne({
+      where: { id, workspace_id: workspaceId }
+    });
+
+    if (!codingJob) {
+      throw new NotFoundException(`Coding job with ID ${id} not found`);
+    }
+
+    if (['review', 'results_applied'].includes(codingJob.status)) {
+      return codingJob;
+    }
+
+    if (codingJob.status === 'completed' && status === 'paused') {
+      return codingJob;
+    }
+
+    if (codingJob.status === status) {
+      return codingJob;
+    }
+
+    codingJob.status = status;
+    return this.codingJobRepository.save(codingJob);
+  }
+
   async markCodingJobResultsApplied(
     id: number,
     workspaceId: number,

--- a/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.spec.ts
+++ b/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.spec.ts
@@ -20,6 +20,9 @@ describe('WsgCodingJobController', () => {
     getBulkCodingProgress: jest.Mock;
     createCodingJob: jest.Mock;
     updateCodingJob: jest.Mock;
+    pauseCodingJob: jest.Mock;
+    resumeCodingJob: jest.Mock;
+    submitCodingJob: jest.Mock;
     saveCodingProgress: jest.Mock;
     saveCodingIssueReviewProgress: jest.Mock;
     saveCodingNotes: jest.Mock;
@@ -54,6 +57,9 @@ describe('WsgCodingJobController', () => {
       getBulkCodingProgress: jest.fn().mockResolvedValue({}),
       createCodingJob: jest.fn().mockResolvedValue({ id: 124 }),
       updateCodingJob: jest.fn(),
+      pauseCodingJob: jest.fn().mockResolvedValue({ id: 123, status: 'paused' }),
+      resumeCodingJob: jest.fn().mockResolvedValue({ id: 123, status: 'active' }),
+      submitCodingJob: jest.fn().mockResolvedValue({ id: 123, status: 'completed' }),
       saveCodingProgress: jest.fn().mockResolvedValue({ id: 123 }),
       saveCodingIssueReviewProgress: jest.fn().mockResolvedValue({ id: 123 }),
       saveCodingNotes: jest.fn().mockResolvedValue({ id: 123 }),
@@ -93,6 +99,20 @@ describe('WsgCodingJobController', () => {
       AccessLevelGuard
     ]);
     expect(Reflect.getMetadata('accessLevel', handler)).toBe(2);
+  });
+
+  it.each([
+    'pauseCodingJob',
+    'resumeCodingJob',
+    'submitCodingJob'
+  ] as const)('uses coder access guards for %s', methodName => {
+    const handler = WsgCodingJobController.prototype[methodName];
+
+    expect(Reflect.getMetadata(GUARDS_METADATA, handler)).toEqual([
+      JwtAuthGuard,
+      WorkspaceGuard
+    ]);
+    expect(Reflect.getMetadata('accessLevel', handler)).toBeUndefined();
   });
 
   it('passes onlyOpen=true to the coding job service when requested', async () => {
@@ -170,6 +190,24 @@ describe('WsgCodingJobController', () => {
     expect(codingJobService.updateCodingJob).toHaveBeenCalledWith(123, 47, {
       status: 'review'
     });
+  });
+
+  it.each([
+    ['pauseCodingJob', 'pauseCodingJob'],
+    ['resumeCodingJob', 'resumeCodingJob'],
+    ['submitCodingJob', 'submitCodingJob']
+  ] as const)('uses coding access for %s', async (controllerMethod, serviceMethod) => {
+    await controller[controllerMethod](47, 123, req);
+
+    expect(codingJobService.assertUserCanCodeCodingJob).toHaveBeenCalledWith(
+      123,
+      47,
+      5
+    );
+    expect(
+      codingJobService.assertUserCanAccessCodingJob
+    ).not.toHaveBeenCalled();
+    expect(codingJobService[serviceMethod]).toHaveBeenCalledWith(123, 47);
   });
 
   it('prepares read-only reviews with management access and without changing job state', async () => {

--- a/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
+++ b/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
@@ -678,6 +678,117 @@ export class WsgCodingJobController {
     return this.prepareCodingJobReplay(workspaceId, id, req, onlyOpen);
   }
 
+  @Post(':id/pause')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Pause an assigned coding job',
+    description: 'Pauses a coding job assigned to the current coder'
+  })
+  @ApiParam({
+    name: 'workspace_id',
+    type: Number,
+    required: true,
+    description: 'The ID of the workspace'
+  })
+  @ApiParam({
+    name: 'id',
+    type: Number,
+    required: true,
+    description: 'The ID of the coding job'
+  })
+  @ApiOkResponse({
+    description: 'The coding job has been paused.',
+    type: CodingJobDto
+  })
+  async pauseCodingJob(
+    @WorkspaceId() workspaceId: number,
+      @Param('id', ParseIntPipe) id: number,
+      @Req() req: Request
+  ): Promise<CodingJobDto> {
+    await this.assertCodingJobCodingAccess(workspaceId, id, req);
+    const codingJob = await this.codingJobService.pauseCodingJob(
+      id,
+      workspaceId
+    );
+    return CodingJobDto.fromEntity(codingJob);
+  }
+
+  @Post(':id/resume')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Resume an assigned coding job',
+    description: 'Marks a coding job assigned to the current coder as active'
+  })
+  @ApiParam({
+    name: 'workspace_id',
+    type: Number,
+    required: true,
+    description: 'The ID of the workspace'
+  })
+  @ApiParam({
+    name: 'id',
+    type: Number,
+    required: true,
+    description: 'The ID of the coding job'
+  })
+  @ApiOkResponse({
+    description: 'The coding job has been resumed.',
+    type: CodingJobDto
+  })
+  async resumeCodingJob(
+    @WorkspaceId() workspaceId: number,
+      @Param('id', ParseIntPipe) id: number,
+      @Req() req: Request
+  ): Promise<CodingJobDto> {
+    await this.assertCodingJobCodingAccess(workspaceId, id, req);
+    const codingJob = await this.codingJobService.resumeCodingJob(
+      id,
+      workspaceId
+    );
+    return CodingJobDto.fromEntity(codingJob);
+  }
+
+  @Post(':id/submit')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Submit an assigned coding job',
+    description: 'Completes a coding job assigned to the current coder'
+  })
+  @ApiParam({
+    name: 'workspace_id',
+    type: Number,
+    required: true,
+    description: 'The ID of the workspace'
+  })
+  @ApiParam({
+    name: 'id',
+    type: Number,
+    required: true,
+    description: 'The ID of the coding job'
+  })
+  @ApiOkResponse({
+    description: 'The coding job has been submitted.',
+    type: CodingJobDto
+  })
+  @ApiBadRequestResponse({
+    description: 'The coding job cannot be completed yet.'
+  })
+  async submitCodingJob(
+    @WorkspaceId() workspaceId: number,
+      @Param('id', ParseIntPipe) id: number,
+      @Req() req: Request
+  ): Promise<CodingJobDto> {
+    await this.assertCodingJobCodingAccess(workspaceId, id, req);
+    const codingJob = await this.codingJobService.submitCodingJob(
+      id,
+      workspaceId
+    );
+    return CodingJobDto.fromEntity(codingJob);
+  }
+
   @Get(':id/review')
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   @ApiBearerAuth()

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -432,6 +432,22 @@ describe('CodingJobBackendService', () => {
       });
     });
 
+    it.each([
+      ['pauseCodingJob', 'pause'],
+      ['resumeCodingJob', 'resume'],
+      ['submitCodingJob', 'submit']
+    ] as const)('should use the %s endpoint with auth token override', (methodName, path) => {
+      service[methodName](47, 123, 'url-token').subscribe();
+
+      const req = httpMock.expectOne(
+        `${mockServerUrl}wsg-admin/workspace/47/coding-job/123/${path}`
+      );
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({});
+      expect(req.request.headers.get('Authorization')).toBe('Bearer url-token');
+      req.flush({});
+    });
+
     it('should use the supplied auth token when saving coding progress', () => {
       service
         .saveCodingProgress(

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -507,6 +507,39 @@ export class CodingJobBackendService {
     );
   }
 
+  pauseCodingJob(
+    workspaceId: number,
+    codingJobId: number,
+    authToken?: string
+  ): Observable<CodingJob> {
+    const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/${codingJobId}/pause`;
+    return this.http.post<CodingJob>(url, {}, {
+      headers: this.getAuthHeader(authToken)
+    });
+  }
+
+  resumeCodingJob(
+    workspaceId: number,
+    codingJobId: number,
+    authToken?: string
+  ): Observable<CodingJob> {
+    const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/${codingJobId}/resume`;
+    return this.http.post<CodingJob>(url, {}, {
+      headers: this.getAuthHeader(authToken)
+    });
+  }
+
+  submitCodingJob(
+    workspaceId: number,
+    codingJobId: number,
+    authToken?: string
+  ): Observable<CodingJob> {
+    const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/${codingJobId}/submit`;
+    return this.http.post<CodingJob>(url, {}, {
+      headers: this.getAuthHeader(authToken)
+    });
+  }
+
   prepareCodingJobReview(
     workspaceId: number,
     codingJobId: number
@@ -682,6 +715,19 @@ export class CodingJobBackendService {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(codingJob)
+    }).catch(() => undefined);
+  }
+
+  pauseCodingJobKeepalive(
+    workspaceId: number,
+    codingJobId: number,
+    authToken?: string
+  ): void {
+    const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/${codingJobId}/pause`;
+    fetch(url, {
+      method: 'POST',
+      keepalive: true,
+      headers: this.getAuthHeader(authToken)
     }).catch(() => undefined);
   }
 

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -137,12 +137,16 @@ describe('ReplayComponent', () => {
     getCodingJobs: jest.Mock;
     getCodingJobUnits: jest.Mock;
     updateCodingJob: jest.Mock;
+    pauseCodingJob: jest.Mock;
+    resumeCodingJob: jest.Mock;
+    submitCodingJob: jest.Mock;
     getCodingProgress: jest.Mock;
     getCodingNotes: jest.Mock;
     getCodingJob: jest.Mock;
     saveCodingProgress: jest.Mock;
     saveCodingNotes: jest.Mock;
     updateCodingJobKeepalive: jest.Mock;
+    pauseCodingJobKeepalive: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -169,12 +173,16 @@ describe('ReplayComponent', () => {
       })),
       getCodingJobUnits: jest.fn().mockReturnValue(of([])),
       updateCodingJob: jest.fn().mockReturnValue(of({})),
+      pauseCodingJob: jest.fn().mockReturnValue(of({})),
+      resumeCodingJob: jest.fn().mockReturnValue(of({})),
+      submitCodingJob: jest.fn().mockReturnValue(of({})),
       getCodingProgress: jest.fn().mockReturnValue(of({})),
       getCodingNotes: jest.fn().mockReturnValue(of({})),
       getCodingJob: jest.fn().mockReturnValue(of({})),
       saveCodingProgress: jest.fn().mockReturnValue(of({})),
       saveCodingNotes: jest.fn().mockReturnValue(of({})),
-      updateCodingJobKeepalive: jest.fn()
+      updateCodingJobKeepalive: jest.fn(),
+      pauseCodingJobKeepalive: jest.fn()
     };
 
     await TestBed.configureTestingModule({
@@ -1037,6 +1045,7 @@ describe('ReplayComponent', () => {
       otherCoders: []
     }]));
     codingJobBackendServiceMock.updateCodingJob.mockClear();
+    codingJobBackendServiceMock.resumeCodingJob.mockClear();
 
     fixture.destroy();
     fixture = TestBed.createComponent(ReplayComponent);
@@ -1053,6 +1062,7 @@ describe('ReplayComponent', () => {
     expect(component.isCodingReadOnly()).toBe(true);
     expect(codingJobBackendServiceMock.getCodingJobUnits).toHaveBeenCalledWith(47, 77, 'valid-token', false);
     expect(codingJobBackendServiceMock.updateCodingJob).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.resumeCodingJob).not.toHaveBeenCalled();
   });
 
   it('should load coding-issue-review mode as editable without coding job status side effects', async () => {
@@ -1083,6 +1093,7 @@ describe('ReplayComponent', () => {
     }]));
     codingJobBackendServiceMock.getCodingJob.mockReturnValue(of({ status: 'completed' }));
     codingJobBackendServiceMock.updateCodingJob.mockClear();
+    codingJobBackendServiceMock.resumeCodingJob.mockClear();
 
     fixture.destroy();
     fixture = TestBed.createComponent(ReplayComponent);
@@ -1101,6 +1112,7 @@ describe('ReplayComponent', () => {
     expect(component.isCodingReadOnly()).toBe(false);
     expect(codingJobBackendServiceMock.getCodingJobUnits).toHaveBeenCalledWith(47, 77, 'valid-token', false);
     expect(codingJobBackendServiceMock.updateCodingJob).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.resumeCodingJob).not.toHaveBeenCalled();
   });
 
   it('should reuse coding job units loaded from query params during replay navigation', async () => {
@@ -1677,6 +1689,7 @@ describe('ReplayComponent', () => {
       appService.createOwnToken.mockReturnValueOnce(of('workspace-token'));
       codingJobBackendServiceMock.getCodingProgress.mockReturnValueOnce(throwError(() => new Error('Progress error')));
       codingJobBackendServiceMock.updateCodingJob.mockClear();
+      codingJobBackendServiceMock.resumeCodingJob.mockClear();
       codingJobBackendServiceMock.getCodingJobUnits.mockReturnValueOnce(of([{
         responseId: 1,
         unitName: 'UNIT_COMPLETED',
@@ -1698,10 +1711,10 @@ describe('ReplayComponent', () => {
       expect(saveAllSpy).toHaveBeenCalledWith(47, 77);
       expect(component.codingService.isCompletedJobReview).toBe(false);
       expect(component.isCodingReadOnly()).toBe(false);
-      expect(codingJobBackendServiceMock.updateCodingJob).toHaveBeenCalledWith(
+      expect(codingJobBackendServiceMock.updateCodingJob).not.toHaveBeenCalled();
+      expect(codingJobBackendServiceMock.resumeCodingJob).toHaveBeenCalledWith(
         48,
         88,
-        { status: 'active' },
         'workspace-token'
       );
 
@@ -1797,7 +1810,7 @@ describe('ReplayComponent', () => {
       expect(component.codingService.currentVariableId).toBe('VAR_CURRENT');
       expect(component.codingService.selectedCodes.get('current-key')).toEqual({ id: 1, code: '1', label: 'Current Code' });
       expect(component.codingService.notes.get('current-note-key')).toBe('Current Note');
-      expect(codingJobBackendServiceMock.updateCodingJob).not.toHaveBeenCalledWith(48, 88, { status: 'active' }, targetToken);
+      expect(codingJobBackendServiceMock.resumeCodingJob).not.toHaveBeenCalledWith(48, 88, targetToken);
       expect(snackBar.open).toHaveBeenCalledWith(
         'replay.job-switcher.switch-error',
         'close',

--- a/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
@@ -15,12 +15,16 @@ describe('ReplayCodingService', () => {
   beforeEach(() => {
     codingJobBackendServiceMock = {
       updateCodingJob: jest.fn(),
+      pauseCodingJob: jest.fn(),
+      resumeCodingJob: jest.fn(),
+      submitCodingJob: jest.fn(),
       getCodingProgress: jest.fn(),
       getCodingNotes: jest.fn(),
       getCodingJob: jest.fn(),
       saveCodingProgress: jest.fn(),
       saveCodingNotes: jest.fn(),
-      updateCodingJobKeepalive: jest.fn()
+      updateCodingJobKeepalive: jest.fn(),
+      pauseCodingJobKeepalive: jest.fn()
     } as unknown as jest.Mocked<CodingJobBackendService>;
 
     translateServiceMock = {
@@ -48,24 +52,34 @@ describe('ReplayCodingService', () => {
   });
 
   describe('updateCodingJobStatus', () => {
-    it('should update status via backend', async () => {
-      codingJobBackendServiceMock.updateCodingJob.mockReturnValue(of({} as CodingJob));
+    it('should resume active status via dedicated backend endpoint', async () => {
+      codingJobBackendServiceMock.resumeCodingJob.mockReturnValue(of({} as CodingJob));
       await service.updateCodingJobStatus(1, 100, 'active');
-      expect(codingJobBackendServiceMock.updateCodingJob).toHaveBeenCalledWith(1, 100, { status: 'active' });
+      expect(codingJobBackendServiceMock.resumeCodingJob).toHaveBeenCalledWith(1, 100);
     });
 
     it('should pass the replay auth token to backend status updates', async () => {
-      codingJobBackendServiceMock.updateCodingJob.mockReturnValue(of({} as CodingJob));
+      codingJobBackendServiceMock.resumeCodingJob.mockReturnValue(of({} as CodingJob));
       service.setAuthToken('replay-token');
 
       await service.updateCodingJobStatus(1, 100, 'active');
 
-      expect(codingJobBackendServiceMock.updateCodingJob).toHaveBeenCalledWith(
+      expect(codingJobBackendServiceMock.resumeCodingJob).toHaveBeenCalledWith(
         1,
         100,
-        { status: 'active' },
         'replay-token'
       );
+    });
+
+    it('should pause and submit via dedicated backend endpoints', async () => {
+      codingJobBackendServiceMock.pauseCodingJob.mockReturnValue(of({} as CodingJob));
+      codingJobBackendServiceMock.submitCodingJob.mockReturnValue(of({} as CodingJob));
+
+      await service.updateCodingJobStatus(1, 100, 'paused');
+      await service.updateCodingJobStatus(1, 100, 'completed');
+
+      expect(codingJobBackendServiceMock.pauseCodingJob).toHaveBeenCalledWith(1, 100);
+      expect(codingJobBackendServiceMock.submitCodingJob).toHaveBeenCalledWith(1, 100);
     });
   });
 
@@ -512,10 +526,9 @@ describe('ReplayCodingService', () => {
 
       service.pauseCodingJobOnUnload(1, 100);
 
-      expect(codingJobBackendServiceMock.updateCodingJobKeepalive).toHaveBeenCalledWith(
+      expect(codingJobBackendServiceMock.pauseCodingJobKeepalive).toHaveBeenCalledWith(
         1,
         100,
-        { status: 'paused' },
         'replay-token'
       );
     });
@@ -664,9 +677,12 @@ describe('ReplayCodingService', () => {
       await service.submitCodingJob(1, 100);
 
       expect(codingJobBackendServiceMock.updateCodingJob).not.toHaveBeenCalled();
+      expect(codingJobBackendServiceMock.pauseCodingJob).not.toHaveBeenCalled();
+      expect(codingJobBackendServiceMock.resumeCodingJob).not.toHaveBeenCalled();
+      expect(codingJobBackendServiceMock.submitCodingJob).not.toHaveBeenCalled();
       expect(codingJobBackendServiceMock.saveCodingProgress).not.toHaveBeenCalled();
       expect(codingJobBackendServiceMock.saveCodingNotes).not.toHaveBeenCalled();
-      expect(codingJobBackendServiceMock.updateCodingJobKeepalive).not.toHaveBeenCalled();
+      expect(codingJobBackendServiceMock.pauseCodingJobKeepalive).not.toHaveBeenCalled();
     });
 
     it('ignores code selections without changing local progress', async () => {

--- a/apps/frontend/src/app/replay/services/replay-coding.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.ts
@@ -104,6 +104,21 @@ export class ReplayCodingService {
 
   async updateCodingJobStatus(workspaceId: number, jobId: number, status: 'active' | 'paused' | 'completed' | 'open') {
     if (this.isReviewMode) return Promise.resolve(undefined);
+    if (status === 'active') {
+      return firstValueFrom(
+        this.codingJobBackendService.resumeCodingJob(workspaceId, jobId, ...this.authTokenArg)
+      );
+    }
+    if (status === 'paused') {
+      return firstValueFrom(
+        this.codingJobBackendService.pauseCodingJob(workspaceId, jobId, ...this.authTokenArg)
+      );
+    }
+    if (status === 'completed') {
+      return firstValueFrom(
+        this.codingJobBackendService.submitCodingJob(workspaceId, jobId, ...this.authTokenArg)
+      );
+    }
     return firstValueFrom(
       this.codingJobBackendService.updateCodingJob(workspaceId, jobId, { status }, ...this.authTokenArg)
     );
@@ -557,10 +572,9 @@ export class ReplayCodingService {
     if (!jobId || !workspaceId) return;
     if (this.isReviewMode) return;
     if (this.isCodingJobCompleted || this.isCompletedJobReview || this.isCodingJobFinalized) return;
-    this.codingJobBackendService.updateCodingJobKeepalive(
+    this.codingJobBackendService.pauseCodingJobKeepalive(
       workspaceId,
       jobId,
-      { status: 'paused' },
       ...this.authTokenArg
     );
   }


### PR DESCRIPTION
## Summary

- add dedicated coder-access endpoints for pausing, resuming, and submitting assigned coding jobs
- route replay status changes and unload pause handling through those endpoints instead of the admin update endpoint
- make late pause/resume markers idempotent for finalized coding jobs so completed jobs are not moved away from their final state

## Context

Related to #685. Follow-up heartbeat/timeout tracking is captured in #723.

## Validation

- npx nx test backend --runTestsByPath apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.spec.ts apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
- npx nx test backend --runTestsByPath src/app/wsg-admin/coding-job/coding-job.controller.spec.ts
- npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts apps/frontend/src/app/replay/services/replay-coding.service.spec.ts apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
- npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
- npx nx lint backend
- npx nx lint frontend

Note: one broad backend run triggered by Jest path handling failed once in unrelated services-read-methods.spec.ts with a timeout; a subsequent backend run completed successfully.