### PR TITLE
Fix coding overview sorting

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding.controller.ts
@@ -29,6 +29,10 @@ import {
   CodingResponseQueryService,
   CodingResultsService
 } from '../../database/services/coding';
+import {
+  CodingResponseSortBy,
+  CodingResponseSortDirection
+} from '../../database/services/coding/coding-response-query.service';
 import { ResponseEntity } from '../../database/entities/response.entity';
 import { JobQueueService } from '../../job-queue/job-queue.service';
 
@@ -166,6 +170,29 @@ export class WorkspaceCodingController {
     description: 'Number of items per page (default: 100, max: 500)',
     type: Number
   })
+  @ApiQuery({
+    name: 'sortBy',
+    required: false,
+    description: 'Column to sort by',
+    enum: [
+      'unitname',
+      'variableid',
+      'value',
+      'codedstatus',
+      'code',
+      'score',
+      'person_code',
+      'person_login',
+      'person_group',
+      'booklet_id'
+    ]
+  })
+  @ApiQuery({
+    name: 'sortDirection',
+    required: false,
+    description: 'Sort direction',
+    enum: ['asc', 'desc']
+  })
   @ApiOkResponse({
     description: 'Responses retrieved successfully.',
     schema: {
@@ -202,7 +229,9 @@ export class WorkspaceCodingController {
       @Param('status') status: string,
                    @Query('version') version: 'v1' | 'v2' | 'v3' = 'v1',
                    @Query('page') page: number = 1,
-                   @Query('limit') limit: number = 100
+                   @Query('limit') limit: number = 100,
+                   @Query('sortBy') sortBy?: CodingResponseSortBy,
+                   @Query('sortDirection') sortDirection?: CodingResponseSortDirection
   ): Promise<{
         data: ResponseEntity[];
         total: number;
@@ -217,7 +246,9 @@ export class WorkspaceCodingController {
       status,
       version,
       validPage,
-      validLimit
+      validLimit,
+      sortBy,
+      sortDirection
     );
   }
 

--- a/apps/backend/src/app/admin/workspace/workspace-test-results-response.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-test-results-response.controller.ts
@@ -17,6 +17,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags,
   ApiBadRequestResponse
 } from '@nestjs/swagger';
@@ -25,6 +26,10 @@ import { AccessLevelGuard, RequireAccessLevel } from './access-level.guard';
 import { WorkspaceGuard } from './workspace.guard';
 import { WorkspaceId } from './workspace.decorator';
 import { WorkspaceTestResultsService, ResponseManagementService } from '../../database/services/test-results';
+import {
+  ResponseSearchSortBy,
+  ResponseSearchSortDirection
+} from '../../database/services/test-results/workspace-test-results.service';
 import { ResponseEntity } from '../../database/entities/response.entity';
 import { RequestWithUser, ResolveDuplicateResponsesRequest, ResponseSearchResult } from './dto/workspace-test-results.interfaces';
 import { CacheService } from '../../cache/cache.service';
@@ -202,6 +207,29 @@ export class WorkspaceTestResultsResponseController {
   @ApiOkResponse({
     description: 'Responses retrieved successfully.'
   })
+  @ApiQuery({
+    name: 'sortBy',
+    required: false,
+    description: 'Column to sort by',
+    enum: [
+      'unitname',
+      'variableid',
+      'value',
+      'codedstatus',
+      'code',
+      'score',
+      'person_code',
+      'person_login',
+      'person_group',
+      'booklet_id'
+    ]
+  })
+  @ApiQuery({
+    name: 'sortDirection',
+    required: false,
+    description: 'Sort direction',
+    enum: ['asc', 'desc']
+  })
   @ApiBadRequestResponse({ description: 'Failed to search for responses' })
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   async searchResponses(
@@ -219,6 +247,8 @@ export class WorkspaceTestResultsResponseController {
       @Query('derivedOnly') derivedOnly?: string,
       @Query('responseSource') responseSource?: 'base' | 'derived' | 'all',
       @Query('personLogin') personLogin?: string,
+      @Query('sortBy') sortBy?: ResponseSearchSortBy,
+      @Query('sortDirection') sortDirection?: ResponseSearchSortDirection,
                                          @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number = 1,
                                          @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number = 20
   ): Promise<ResponseSearchResult> {
@@ -244,7 +274,12 @@ export class WorkspaceTestResultsResponseController {
           responseSource,
           personLogin
         },
-        { page, limit }
+        {
+          page,
+          limit,
+          sortBy,
+          sortDirection
+        }
       );
     } catch (error) {
       this.logger.error(`Error searching for responses: ${error}`);

--- a/apps/backend/src/app/database/services/coding/coding-response-query.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-query.service.spec.ts
@@ -24,7 +24,9 @@ describe('CodingResponseQueryService', () => {
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     getCount: jest.fn(),
+    addSelect: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
     getMany: jest.fn()
@@ -214,6 +216,52 @@ describe('CodingResponseQueryService', () => {
       });
       expect(mockQueryBuilder.skip).toHaveBeenCalledWith(10); // (page - 1) * limit
       expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
+    });
+
+    it('should sort globally by requested response column before pagination', async () => {
+      (statusConverter.statusStringToNumber as jest.Mock).mockReturnValue(5);
+      mockQueryBuilder.getCount.mockResolvedValue(2);
+
+      await service.getResponsesByStatus(1, 'CODING_COMPLETE', 'v2', 1, 100, 'score', 'desc');
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('response.score_v2', 'DESC');
+      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith('response.id', 'ASC');
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(0);
+    });
+
+    it('should sort codedstatus through a selected alias before pagination', async () => {
+      (statusConverter.statusStringToNumber as jest.Mock).mockReturnValue(5);
+      mockQueryBuilder.getCount.mockResolvedValue(2);
+
+      await service.getResponsesByStatus(1, 'CODING_COMPLETE', 'v3', 1, 100, 'codedstatus', 'asc');
+
+      expect(mockQueryBuilder.addSelect).toHaveBeenCalledWith(
+        getEffectiveCodingStatusExpression('v3'),
+        'effective_coding_status_sort'
+      );
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('effective_coding_status_sort', 'ASC');
+      expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith('response.id', 'ASC');
+    });
+
+    it('should normalize invalid version values before building sort expressions', async () => {
+      (statusConverter.statusStringToNumber as jest.Mock).mockReturnValue(5);
+      mockQueryBuilder.getCount.mockResolvedValue(2);
+
+      await service.getResponsesByStatus(
+        1,
+        'CODING_COMPLETE',
+        'v2); DROP TABLE response; --' as unknown as 'v1',
+        1,
+        100,
+        'score',
+        'desc'
+      );
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'response.status_v1 = :status',
+        { status: 5 }
+      );
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('response.score_v1', 'DESC');
     });
 
     it('should return empty result for invalid status', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-response-query.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-query.service.ts
@@ -2,12 +2,15 @@ import {
   Inject, Injectable, Logger, forwardRef
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import {
   STATISTICS_IGNORED_STATUSES,
   statusStringToNumber
 } from '../../utils/response-status-converter';
-import { getEffectiveCodingStatusExpression } from '../../utils/effective-coding-status-expression.util';
+import {
+  CodingVersion,
+  getEffectiveCodingStatusExpression
+} from '../../utils/effective-coding-status-expression.util';
 import { ResponseEntity } from '../../entities/response.entity';
 import {
   applyResolvedExclusionsToQuery,
@@ -15,6 +18,20 @@ import {
 } from '../workspace/workspace-exclusion.service';
 // eslint-disable-next-line import/no-cycle
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
+
+export type CodingResponseSortBy =
+  'unitname' |
+  'variableid' |
+  'value' |
+  'codedstatus' |
+  'code' |
+  'score' |
+  'person_code' |
+  'person_login' |
+  'person_group' |
+  'booklet_id';
+export type CodingResponseSortDirection = 'asc' | 'desc';
+const EFFECTIVE_CODING_STATUS_SORT_ALIAS = 'effective_coding_status_sort';
 
 @Injectable()
 export class CodingResponseQueryService {
@@ -38,7 +55,9 @@ export class CodingResponseQueryService {
     status: string,
     version: 'v1' | 'v2' | 'v3' = 'v1',
     page: number = 1,
-    limit: number = 100
+    limit: number = 100,
+    sortBy?: CodingResponseSortBy,
+    sortDirection?: CodingResponseSortDirection
   ): Promise<{
       data: ResponseEntity[];
       total: number;
@@ -46,6 +65,7 @@ export class CodingResponseQueryService {
       limit: number;
     }> {
     try {
+      const codingVersion = this.normalizeCodingVersion(version);
       const statusNumber = statusStringToNumber(status);
       if (statusNumber === null) {
         this.logger.warn(`Invalid status string: ${status}`);
@@ -92,7 +112,7 @@ export class CodingResponseQueryService {
       applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
       queryBuilder.andWhere(
-        `${getEffectiveCodingStatusExpression(version)} = :status`,
+        `${getEffectiveCodingStatusExpression(codingVersion)} = :status`,
         { status: statusNumber }
       );
       queryBuilder.andWhere(
@@ -101,14 +121,14 @@ export class CodingResponseQueryService {
       );
 
       const total = await queryBuilder.getCount();
+      this.applySorting(queryBuilder, codingVersion, sortBy, sortDirection);
       const data = await queryBuilder
-        .orderBy('response.id', 'ASC')
         .skip(offset)
         .take(limit)
         .getMany();
 
       this.logger.log(
-        `Retrieved ${data.length} responses with status ${status} for version ${version} in workspace ${workspaceId}`
+        `Retrieved ${data.length} responses with status ${status} for version ${codingVersion} in workspace ${workspaceId}`
       );
 
       return {
@@ -137,6 +157,64 @@ export class CodingResponseQueryService {
 
   private toVariablePairKey(unitName: string, variableId: string): string {
     return `${unitName}\u001F${variableId}`;
+  }
+
+  private applySorting(
+    queryBuilder: SelectQueryBuilder<ResponseEntity>,
+    version: CodingVersion,
+    sortBy?: CodingResponseSortBy,
+    sortDirection?: CodingResponseSortDirection
+  ): void {
+    const direction = sortDirection === 'desc' ? 'DESC' : 'ASC';
+    if (sortBy === 'codedstatus') {
+      queryBuilder.addSelect(
+        getEffectiveCodingStatusExpression(version),
+        EFFECTIVE_CODING_STATUS_SORT_ALIAS
+      );
+      queryBuilder
+        .orderBy(EFFECTIVE_CODING_STATUS_SORT_ALIAS, direction)
+        .addOrderBy('response.id', 'ASC');
+      return;
+    }
+
+    const sortExpression = this.getSortExpression(version, sortBy);
+
+    queryBuilder.orderBy(sortExpression, direction);
+    if (sortExpression !== 'response.id') {
+      queryBuilder.addOrderBy('response.id', 'ASC');
+    }
+  }
+
+  private getSortExpression(
+    version: CodingVersion,
+    sortBy?: CodingResponseSortBy
+  ): string {
+    switch (sortBy) {
+      case 'unitname':
+        return 'unit.name';
+      case 'variableid':
+        return 'response.variableid';
+      case 'value':
+        return 'response.value';
+      case 'code':
+        return `response.code_${version}`;
+      case 'score':
+        return `response.score_${version}`;
+      case 'person_code':
+        return 'person.code';
+      case 'person_login':
+        return 'person.login';
+      case 'person_group':
+        return 'person.group';
+      case 'booklet_id':
+        return 'bookletinfo.name';
+      default:
+        return 'response.id';
+    }
+  }
+
+  private normalizeCodingVersion(version: unknown): CodingVersion {
+    return version === 'v2' || version === 'v3' ? version : 'v1';
   }
 
   async getManualTestPersons(

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -25,6 +25,7 @@ import { CodingValidationService } from '../coding/coding-validation.service';
 import { CodingStatisticsService } from '../coding/coding-statistics.service';
 import { WorkspaceCoreService } from '../workspace/workspace-core.service';
 import { WorkspaceExclusionService } from '../workspace/workspace-exclusion.service';
+import { getEffectiveCodingStatusExpression } from '../../utils/effective-coding-status-expression.util';
 
 const mockQueryBuilder = () => ({
   select: jest.fn().mockReturnThis(),
@@ -817,6 +818,90 @@ describe('WorkspaceTestResultsService', () => {
           ggDataUriPrefix: 'data:%;base64,UEsD%'
         }
       );
+    });
+
+    it('should sort response searches by requested column before pagination', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(0);
+
+      await service.searchResponses(
+        1,
+        { responseSource: 'all', version: 'v3' },
+        {
+          page: 2,
+          limit: 100,
+          sortBy: 'person_login',
+          sortDirection: 'desc'
+        }
+      );
+
+      expect(qb.orderBy).toHaveBeenCalledWith('person.login', 'DESC');
+      expect(qb.addOrderBy).toHaveBeenCalledWith('response.id', 'ASC');
+      expect(qb.skip).not.toHaveBeenCalled();
+    });
+
+    it('should normalize invalid version values before building response search sort expressions', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(0);
+
+      await service.searchResponses(
+        1,
+        {
+          responseSource: 'all',
+          version: 'v2); DROP TABLE response; --' as unknown as 'v1'
+        },
+        {
+          page: 1,
+          limit: 100,
+          sortBy: 'code',
+          sortDirection: 'desc'
+        }
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith('response.status_v1 IS NOT NULL');
+      expect(qb.orderBy).toHaveBeenCalledWith('response.code_v1', 'DESC');
+    });
+
+    it('should sort codedStatus response searches through a selected alias before pagination', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(0);
+
+      await service.searchResponses(
+        1,
+        { responseSource: 'all', version: 'v3' },
+        {
+          page: 1,
+          limit: 100,
+          sortBy: 'codedstatus',
+          sortDirection: 'asc'
+        }
+      );
+
+      expect(qb.addSelect).toHaveBeenCalledWith(
+        getEffectiveCodingStatusExpression('v3'),
+        'effective_coding_status_sort'
+      );
+      expect(qb.orderBy).toHaveBeenCalledWith('effective_coding_status_sort', 'ASC');
+      expect(qb.addOrderBy).toHaveBeenCalledWith('response.id', 'ASC');
+    });
+
+    it('should keep the GeoGebra default ordering when no explicit sort is requested', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(0);
+
+      await service.searchResponses(
+        1,
+        { geogebra: true, version: 'v2' },
+        { page: 1, limit: 100 }
+      );
+
+      expect(qb.orderBy).toHaveBeenCalledWith('response.code_v2', 'ASC');
+      expect(qb.addOrderBy).toHaveBeenCalledWith('person.code', 'ASC');
+      expect(qb.addOrderBy).toHaveBeenCalledWith('response.id', 'ASC');
     });
 
     it('should treat GeoGebra all-source searches as base responses', async () => {

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -21,7 +21,10 @@ import {
   statusNumberToString,
   statusStringToNumber
 } from '../../utils/response-status-converter';
-import { getEffectiveCodingStatusExpression } from '../../utils/effective-coding-status-expression.util';
+import {
+  CodingVersion,
+  getEffectiveCodingStatusExpression
+} from '../../utils/effective-coding-status-expression.util';
 import { Unit } from '../../entities/unit.entity';
 import { Booklet } from '../../entities/booklet.entity';
 import { ResponseEntity } from '../../entities/response.entity';
@@ -79,6 +82,20 @@ interface PersonWhere {
   consider: boolean;
   group?: string;
 }
+
+export type ResponseSearchSortBy =
+  'unitname' |
+  'variableid' |
+  'value' |
+  'codedstatus' |
+  'code' |
+  'score' |
+  'person_code' |
+  'person_login' |
+  'person_group' |
+  'booklet_id';
+export type ResponseSearchSortDirection = 'asc' | 'desc';
+const EFFECTIVE_CODING_STATUS_SORT_ALIAS = 'effective_coding_status_sort';
 
 export type WorkspaceOverviewStats = {
   testPersons: number;
@@ -6465,7 +6482,12 @@ export class WorkspaceTestResultsService {
       responseSource?: 'base' | 'derived' | 'all';
       personLogin?: string;
     },
-    options: { page?: number; limit?: number } = {}
+    options: {
+      page?: number;
+      limit?: number;
+      sortBy?: ResponseSearchSortBy;
+      sortDirection?: ResponseSearchSortDirection;
+    } = {}
   ): Promise<{
       data: {
         responseId: number;
@@ -6495,6 +6517,7 @@ export class WorkspaceTestResultsService {
     const page = options.page || 1;
     const limit = options.limit || 10;
     const skip = (page - 1) * limit;
+    const version = this.normalizeCodingVersion(searchParams.version);
 
     this.logger.log(`Searching for responses in workspace ${workspaceId}`);
 
@@ -6552,9 +6575,7 @@ export class WorkspaceTestResultsService {
         if (codedStatusNumber === null) {
           query.andWhere('1=0');
         } else {
-          const effectiveStatusExpression = getEffectiveCodingStatusExpression(
-            searchParams.version || 'v1'
-          );
+          const effectiveStatusExpression = getEffectiveCodingStatusExpression(version);
           query.andWhere(`${effectiveStatusExpression} = :codedStatus`, {
             codedStatus: codedStatusNumber
           });
@@ -6580,9 +6601,6 @@ export class WorkspaceTestResultsService {
           WorkspaceTestResultsService.createGeoGebraValueCondition('response'),
           WorkspaceTestResultsService.geoGebraValueParams
         );
-        const version = searchParams.version || 'v1';
-        query.addOrderBy(`response.code_${version}`, 'ASC');
-        query.addOrderBy('person.code', 'ASC');
       }
 
       const requestedResponseSource = searchParams.derivedOnly ? 'derived' : searchParams.responseSource || 'base';
@@ -6591,9 +6609,7 @@ export class WorkspaceTestResultsService {
         requestedResponseSource;
 
       if (responseSource === 'derived') {
-        const effectiveStatusExpression = getEffectiveCodingStatusExpression(
-          searchParams.version || 'v1'
-        );
+        const effectiveStatusExpression = getEffectiveCodingStatusExpression(version);
         query.andWhere('response.is_autocoder_generated = :derivedOnly', {
           derivedOnly: true
         });
@@ -6603,9 +6619,7 @@ export class WorkspaceTestResultsService {
         });
         await this.applyValidCodingVariableFilter(query, workspaceId);
       } else if (responseSource === 'all') {
-        const effectiveStatusExpression = getEffectiveCodingStatusExpression(
-          searchParams.version || 'v1'
-        );
+        const effectiveStatusExpression = getEffectiveCodingStatusExpression(version);
         query.andWhere(`${effectiveStatusExpression} IS NOT NULL`);
         query.andWhere(`${effectiveStatusExpression} NOT IN (:...ignoredDerivedCodingStatuses)`, {
           ignoredDerivedCodingStatuses: WorkspaceTestResultsService.ignoredDerivedCodingStatuses
@@ -6616,6 +6630,13 @@ export class WorkspaceTestResultsService {
       }
 
       const total = await query.getCount();
+      this.applyResponseSearchSorting(
+        query,
+        version,
+        searchParams.geogebra === true,
+        options.sortBy,
+        options.sortDirection
+      );
 
       if (total === 0) {
         this.logger.log(
@@ -6643,7 +6664,6 @@ export class WorkspaceTestResultsService {
         variablePageMaps.set(unitName, pageMap);
       }
 
-      const version = searchParams.version || 'v1';
       const data = responses.map(response => {
         const code = response[
           `code_${version}` as keyof ResponseEntity
@@ -6695,6 +6715,73 @@ export class WorkspaceTestResultsService {
         `An error occurred while searching for responses: ${error.message}`
       );
     }
+  }
+
+  private applyResponseSearchSorting(
+    query: SelectQueryBuilder<ResponseEntity>,
+    version: CodingVersion,
+    geogebra: boolean,
+    sortBy?: ResponseSearchSortBy,
+    sortDirection?: ResponseSearchSortDirection
+  ): void {
+    const direction = sortDirection === 'desc' ? 'DESC' : 'ASC';
+    if (!sortBy && geogebra) {
+      query
+        .orderBy(`response.code_${version}`, 'ASC')
+        .addOrderBy('person.code', 'ASC')
+        .addOrderBy('response.id', 'ASC');
+      return;
+    }
+
+    if (sortBy === 'codedstatus') {
+      query.addSelect(
+        getEffectiveCodingStatusExpression(version),
+        EFFECTIVE_CODING_STATUS_SORT_ALIAS
+      );
+      query
+        .orderBy(EFFECTIVE_CODING_STATUS_SORT_ALIAS, direction)
+        .addOrderBy('response.id', 'ASC');
+      return;
+    }
+
+    const sortExpression = this.getResponseSearchSortExpression(version, sortBy);
+
+    query.orderBy(sortExpression, direction);
+    if (sortExpression !== 'response.id') {
+      query.addOrderBy('response.id', 'ASC');
+    }
+  }
+
+  private getResponseSearchSortExpression(
+    version: CodingVersion,
+    sortBy?: ResponseSearchSortBy
+  ): string {
+    switch (sortBy) {
+      case 'unitname':
+        return 'unit.name';
+      case 'variableid':
+        return 'response.variableid';
+      case 'value':
+        return 'response.value';
+      case 'code':
+        return `response.code_${version}`;
+      case 'score':
+        return `response.score_${version}`;
+      case 'person_code':
+        return 'person.code';
+      case 'person_login':
+        return 'person.login';
+      case 'person_group':
+        return 'person.group';
+      case 'booklet_id':
+        return 'bookletinfo.name';
+      default:
+        return 'response.id';
+    }
+  }
+
+  private normalizeCodingVersion(version: unknown): CodingVersion {
+    return version === 'v2' || version === 'v3' ? version : 'v1';
   }
 
   private async applyValidCodingVariableFilter(

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
@@ -192,10 +192,10 @@
           [pageSize]="pageSize" [pageIndex]="pageIndex" [pageSizeOptions]="pageSizeOptions" [isLoading]="isLoading"
           [currentStatusFilter]="filterParams.codedStatus || currentStatusFilter" [selectedVersion]="selectedStatisticsVersion"
           [isGeogebraFilterActive]="filterParams.geogebra" [isDerivedFilterActive]="filterParams.responseSource === 'derived'"
-          [isReviewLoading]="isLoadingReview"
+          [isReviewLoading]="isLoadingReview" [sortBy]="sortBy" [sortDirection]="sortDirection"
           (pageChange)="onPageChange($event)"
           (replayClick)="onReplayClick($event)" (showCodingScheme)="onShowCodingScheme($event)"
-          (showUnitXml)="onShowUnitXml($event)" (reviewClick)="onReviewClick()">
+          (showUnitXml)="onShowUnitXml($event)" (reviewClick)="onReviewClick()" (sortChange)="onSortChange($event)">
         </app-response-table>
       </div>
     </div>

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -550,7 +550,9 @@ describe('CodingManagementComponent', () => {
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
         component.filterParams,
         1,
-        100
+        100,
+        undefined,
+        undefined
       );
     });
   });
@@ -595,7 +597,9 @@ describe('CodingManagementComponent', () => {
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
         component.filterParams,
         1,
-        100
+        100,
+        undefined,
+        undefined
       );
     });
 
@@ -617,7 +621,9 @@ describe('CodingManagementComponent', () => {
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
         component.filterParams,
         1,
-        100
+        100,
+        undefined,
+        undefined
       );
     });
 
@@ -668,7 +674,9 @@ describe('CodingManagementComponent', () => {
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
         component.filterParams,
         1,
-        100
+        100,
+        undefined,
+        undefined
       );
     });
 
@@ -704,7 +712,30 @@ describe('CodingManagementComponent', () => {
         '200',
         'v1',
         2, // pageIndex + 1
-        200
+        200,
+        undefined,
+        undefined
+      );
+    });
+
+    it('should reset to the first page and reload data when sorting changes', () => {
+      component.filterParams = {
+        ...component.filterParams,
+        codedStatus: '200'
+      };
+      component.pageIndex = 2;
+
+      component.onSortChange({ active: 'score', direction: 'desc' });
+
+      expect(component.sortBy).toBe('score');
+      expect(component.sortDirection).toBe('desc');
+      expect(component.pageIndex).toBe(0);
+      expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
+        component.filterParams,
+        1,
+        100,
+        'score',
+        'desc'
       );
     });
 
@@ -777,7 +808,9 @@ describe('CodingManagementComponent', () => {
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
         component.filterParams,
         1,
-        2
+        2,
+        undefined,
+        undefined
       );
       expect(mockDialog.open).toHaveBeenCalledWith(
         expect.any(Function),
@@ -828,19 +861,25 @@ describe('CodingManagementComponent', () => {
         1,
         expect.objectContaining({ geogebra: true }),
         1,
-        500
+        500,
+        undefined,
+        undefined
       );
       expect(mockCodingManagementService.searchResponses).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ geogebra: true }),
         2,
-        500
+        500,
+        undefined,
+        undefined
       );
       expect(mockCodingManagementService.searchResponses).toHaveBeenNthCalledWith(
         3,
         expect.objectContaining({ geogebra: true }),
         3,
-        500
+        500,
+        undefined,
+        undefined
       );
       expect(mockDialog.open).toHaveBeenCalledWith(
         expect.any(Function),

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -21,6 +21,7 @@ import {
 } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { PageEvent } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
 import { Router } from '@angular/router';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -53,7 +54,11 @@ import { CodingManagementUiService } from './services/coding-management-ui.servi
 import { StatisticsCardComponent } from './components/statistics-card/statistics-card.component';
 import { ResponseFiltersComponent } from './components/response-filters/response-filters.component';
 import { ResponseTableComponent } from './components/response-table/response-table.component';
-import { SearchResponseItem } from '../../../models/coding-interfaces';
+import {
+  CodingResponseSortBy,
+  CodingResponseSortDirection,
+  SearchResponseItem
+} from '../../../models/coding-interfaces';
 import { ItemListDialogComponent } from '../../../shared/dialogs/item-list-dialog/item-list-dialog.component';
 import { ReviewListDialogComponent } from './components/review-list-dialog/review-list-dialog.component';
 import {
@@ -153,6 +158,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   pageSize = 100;
   totalRecords = 0;
   pageIndex = 0;
+  sortBy: CodingResponseSortBy | '' = '';
+  sortDirection: CodingResponseSortDirection | '' = '';
 
   selectedStatisticsVersion: 'v1' | 'v2' | 'v3' = 'v1';
   codingFreshnessSummary: CodingFreshnessSummaryDto | null = null;
@@ -528,6 +535,22 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     }
   }
 
+  onSortChange(sort: Sort): void {
+    this.sortBy = this.isSupportedResponseSort(sort.active) && sort.direction ?
+      sort.active :
+      '';
+    this.sortDirection = sort.direction === 'asc' || sort.direction === 'desc' ?
+      sort.direction :
+      '';
+    this.pageIndex = 0;
+
+    if (this.currentStatusFilter) {
+      this.fetchResponsesByStatus(this.currentStatusFilter, 1, this.pageSize);
+    } else if (this.hasActiveFilters()) {
+      this.fetchResponsesWithFilters();
+    }
+  }
+
   onReplayClick(response: Success): void {
     this.uiService.openReplayForResponse(response).subscribe(replayUrl => {
       if (replayUrl) {
@@ -600,7 +623,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       concatMap(batchIndex => this.codingManagementService.searchResponses(
         reviewFilterParams,
         batchIndex + 1,
-        reviewBatchSize
+        reviewBatchSize,
+        this.sortBy || undefined,
+        this.sortDirection || undefined
       )),
       reduce(
         (
@@ -980,7 +1005,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       status,
       this.selectedStatisticsVersion,
       page,
-      limit
+      limit,
+      this.sortBy || undefined,
+      this.sortDirection || undefined
     ).subscribe({
       next: response => {
         this.data = response.data.map((item: ResponseEntity) => {
@@ -1037,7 +1064,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.codingManagementService.searchResponses(
       this.filterParams,
       this.pageIndex + 1,
-      this.pageSize
+      this.pageSize,
+      this.sortBy || undefined,
+      this.sortDirection || undefined
     ).subscribe({
       next: (response: { data: SearchResponseItem[]; total: number }) => {
         this.data = this.mapSearchResponseItemsToSuccess(response.data);
@@ -1092,6 +1121,21 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       status_v2: item.status_v2,
       status_v3: item.status_v3
     };
+  }
+
+  private isSupportedResponseSort(sortBy: string): sortBy is CodingResponseSortBy {
+    return [
+      'unitname',
+      'variableid',
+      'value',
+      'codedstatus',
+      'code',
+      'score',
+      'person_code',
+      'person_login',
+      'person_group',
+      'booklet_id'
+    ].includes(sortBy);
   }
 
   // Dialog Methods

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.html
@@ -46,10 +46,13 @@
     </div>
     <mat-divider></mat-divider>
     <div class="table-container">
-        <table mat-table [dataSource]="dataSource" matSort class="coding-table">
+        <table mat-table [dataSource]="dataSource" matSort [matSortActive]="sortBy"
+            [matSortDirection]="sortDirection" (matSortChange)="onSortChange($event)" class="coding-table">
             @for (column of displayedColumns; track column) {
             <ng-container matColumnDef="{{ column }}">
-                <th mat-header-cell *matHeaderCellDef mat-sort-header> {{ getColumnHeader(column) }} </th>
+                <th mat-header-cell *matHeaderCellDef mat-sort-header [disabled]="column === 'actions'">
+                    {{ getColumnHeader(column) }}
+                </th>
                 <td mat-cell *matCellDef="let element"
                     [attr.colspan]="element.id === 0 ? displayedColumns.length : null">
                     @if (element.id === 0) {

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PageEvent } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
 import { ResponseTableComponent } from './response-table.component';
 import { Success } from '../../../../models/success.model';
 
@@ -40,11 +41,33 @@ describe('ResponseTableComponent', () => {
     expect(component.dataSource.data).toEqual(testData);
   });
 
+  it('should not attach local data-source sorting when the table is rendered', () => {
+    const testData = [
+      { id: 1, unitname: 'Test Unit', variableid: 'b' } as Success,
+      { id: 2, unitname: 'Another Unit', variableid: 'a' } as Success
+    ];
+    fixture.componentRef.setInput('displayedColumns', ['unitname', 'variableid']);
+    fixture.componentRef.setInput('data', testData);
+
+    fixture.detectChanges();
+
+    expect(component.dataSource.sort).toBeUndefined();
+  });
+
   it('should emit pageChange when pagination changes', () => {
     jest.spyOn(component.pageChange, 'emit');
     const event = { pageIndex: 1, pageSize: 100, length: 200 } as PageEvent;
     component.onPageChange(event);
     expect(component.pageChange.emit).toHaveBeenCalledWith(event);
+  });
+
+  it('should emit sortChange when sorting changes', () => {
+    jest.spyOn(component.sortChange, 'emit');
+    const event = { active: 'score', direction: 'desc' } as Sort;
+
+    component.onSortChange(event);
+
+    expect(component.sortChange.emit).toHaveBeenCalledWith(event);
   });
 
   it('should emit replayClick when replay button is clicked', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.ts
@@ -3,8 +3,6 @@ import {
   Input,
   Output,
   EventEmitter,
-  ViewChild,
-  AfterViewInit,
   ChangeDetectionStrategy,
   OnChanges,
   SimpleChanges
@@ -23,8 +21,13 @@ import {
   MatTable,
   MatTableDataSource
 } from '@angular/material/table';
-import { MatSort, MatSortModule, MatSortHeader } from '@angular/material/sort';
-import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import {
+  MatSortModule,
+  MatSortHeader,
+  Sort,
+  SortDirection
+} from '@angular/material/sort';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatIcon } from '@angular/material/icon';
 import { MatButton, MatIconButton } from '@angular/material/button';
@@ -34,6 +37,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Success } from '../../../../models/success.model';
 import { extractGeoGebraBase64 } from '../../../../utils/geogebra-value.util';
 import { getResponseStatusLabel } from '../../../../../shared/utils/response-status-metadata.util';
+import { CodingResponseSortBy } from '../../../../../models/coding-interfaces';
 
 @Component({
   selector: 'app-response-table',
@@ -65,7 +69,7 @@ import { getResponseStatusLabel } from '../../../../../shared/utils/response-sta
     TranslateModule
   ]
 })
-export class ResponseTableComponent implements AfterViewInit, OnChanges {
+export class ResponseTableComponent implements OnChanges {
   @Input() data: Success[] = [];
   @Input() displayedColumns: string[] = [];
   @Input() totalRecords = 0;
@@ -78,15 +82,15 @@ export class ResponseTableComponent implements AfterViewInit, OnChanges {
   @Input() isGeogebraFilterActive = false;
   @Input() isDerivedFilterActive = false;
   @Input() isReviewLoading = false;
+  @Input() sortBy: CodingResponseSortBy | '' = '';
+  @Input() sortDirection: SortDirection = '';
 
   @Output() pageChange = new EventEmitter<PageEvent>();
   @Output() replayClick = new EventEmitter<Success>();
   @Output() showCodingScheme = new EventEmitter<number>();
   @Output() showUnitXml = new EventEmitter<number>();
   @Output() reviewClick = new EventEmitter<void>();
-
-  @ViewChild(MatSort) sort!: MatSort;
-  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @Output() sortChange = new EventEmitter<Sort>();
 
   dataSource = new MatTableDataSource<Success>([]);
 
@@ -96,11 +100,6 @@ export class ResponseTableComponent implements AfterViewInit, OnChanges {
     if (changes.data) {
       this.dataSource.data = this.data;
     }
-  }
-
-  ngAfterViewInit(): void {
-    this.dataSource.sort = this.sort;
-    this.dataSource.paginator = this.paginator;
   }
 
   getColumnHeader(column: string): string {
@@ -140,6 +139,10 @@ export class ResponseTableComponent implements AfterViewInit, OnChanges {
 
   onPageChange(event: PageEvent): void {
     this.pageChange.emit(event);
+  }
+
+  onSortChange(sort: Sort): void {
+    this.sortChange.emit(sort);
   }
 
   onReplayClick(response: Success): void {

--- a/apps/frontend/src/app/coding/services/coding-management.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-management.service.ts
@@ -13,7 +13,11 @@ import { CodingVersionService, ResetVersionJobStatus } from './coding-version.se
 import { CodingExportService } from './coding-export.service';
 import { ResponseService } from '../../shared/services/response/response.service';
 import {
-  SearchResponseItem, SearchResponsesParams, CodingJobStatus
+  SearchResponseItem,
+  SearchResponsesParams,
+  CodingJobStatus,
+  CodingResponseSortBy,
+  CodingResponseSortDirection
 } from '../../models/coding-interfaces';
 import { AppService } from '../../core/services/app.service';
 import { CodingStatistics } from '../../../../../../api-dto/coding/coding-statistics';
@@ -201,12 +205,14 @@ export class CodingManagementService {
     status: string,
     version: StatisticsVersion,
     page: number,
-    limit: number
+    limit: number,
+    sortBy?: CodingResponseSortBy,
+    sortDirection?: CodingResponseSortDirection
   ): Observable<{ data: ResponseEntity[], total: number }> {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) return of({ data: [], total: 0 });
 
-    return this.statisticsService.getResponsesByStatus(workspaceId, status, version, page, limit)
+    return this.statisticsService.getResponsesByStatus(workspaceId, status, version, page, limit, sortBy, sortDirection)
       .pipe(
         catchError(() => {
           this.snackBar.open(`Fehler beim Abrufen der Antworten mit Status ${status}`, 'Schließen', {
@@ -227,7 +233,9 @@ export class CodingManagementService {
   searchResponses(
     filterParams: FilterParams,
     page: number,
-    limit: number
+    limit: number,
+    sortBy?: CodingResponseSortBy,
+    sortDirection?: CodingResponseSortDirection
   ): Observable<{ data: SearchResponseItem[], total: number }> {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) return of({ data: [], total: 0 });
@@ -242,7 +250,9 @@ export class CodingManagementService {
       variableId: filterParams.variableId,
       geogebra: filterParams.geogebra,
       responseSource: filterParams.responseSource,
-      personLogin: filterParams.personLogin
+      personLogin: filterParams.personLogin,
+      sortBy,
+      sortDirection
     };
 
     return this.responseService.searchResponses(workspaceId, backendParams, page, limit)

--- a/apps/frontend/src/app/coding/services/coding-statistics.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-statistics.service.spec.ts
@@ -87,6 +87,25 @@ describe('CodingStatisticsService', () => {
     req.flush(mockRes);
   });
 
+  it('should pass response sort params when getting responses by status', () => {
+    const mockRes = {
+      data: [], total: 0, page: 2, limit: 50
+    };
+    service.getResponsesByStatus(1, 'pending', 'v2', 2, 50, 'score', 'desc').subscribe(res => {
+      expect(res.total).toBe(0);
+    });
+
+    const req = httpMock.expectOne(request => request.url === `${mockServerUrl}admin/workspace/1/coding/responses/pending` &&
+      request.params.get('version') === 'v2' &&
+      request.params.get('page') === '2' &&
+      request.params.get('limit') === '50' &&
+      request.params.get('sortBy') === 'score' &&
+      request.params.get('sortDirection') === 'desc'
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(mockRes);
+  });
+
   it('should get replay URL', () => {
     const mockRes = { replayUrl: 'http://replay' };
     service.getReplayUrl(1, 123).subscribe(res => {

--- a/apps/frontend/src/app/coding/services/coding-statistics.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-statistics.service.ts
@@ -10,6 +10,10 @@ import { suppressGlobalHttpErrorContext } from '../../core/interceptors/http-err
 import { VariableAnalysisItemDto } from '../../../../../../api-dto/coding/variable-analysis-item.dto';
 import { ResponseEntity } from '../../shared/models/response-entity.model';
 import { CodingFreshnessSummaryDto } from '../../../../../../api-dto/coding/coding-freshness.dto';
+import {
+  CodingResponseSortBy,
+  CodingResponseSortDirection
+} from '../../models/coding-interfaces';
 
 interface PaginatedResponse<T> {
   data: T[];
@@ -55,11 +59,27 @@ export class CodingStatisticsService {
       );
   }
 
-  getResponsesByStatus(workspace_id: number, status: string, version: 'v1' | 'v2' | 'v3' = 'v1', page: number = 1, limit: number = 100): Observable<PaginatedResponse<ResponseEntity>> {
-    const params = new HttpParams()
+  getResponsesByStatus(
+    workspace_id: number,
+    status: string,
+    version: 'v1' | 'v2' | 'v3' = 'v1',
+    page: number = 1,
+    limit: number = 100,
+    sortBy?: CodingResponseSortBy,
+    sortDirection?: CodingResponseSortDirection
+  ): Observable<PaginatedResponse<ResponseEntity>> {
+    let params = new HttpParams()
       .set('version', version)
       .set('page', page.toString())
       .set('limit', limit.toString());
+
+    if (sortBy) {
+      params = params.set('sortBy', sortBy);
+    }
+
+    if (sortDirection) {
+      params = params.set('sortDirection', sortDirection);
+    }
 
     return this.http
       .get<PaginatedResponse<ResponseEntity>>(

--- a/apps/frontend/src/app/models/coding-interfaces.ts
+++ b/apps/frontend/src/app/models/coding-interfaces.ts
@@ -123,7 +123,22 @@ export interface SearchResponsesParams {
   derivedOnly?: boolean;
   responseSource?: 'base' | 'derived' | 'all';
   personLogin?: string;
+  sortBy?: CodingResponseSortBy;
+  sortDirection?: CodingResponseSortDirection;
 }
+
+export type CodingResponseSortBy =
+  'unitname' |
+  'variableid' |
+  'value' |
+  'codedstatus' |
+  'code' |
+  'score' |
+  'person_code' |
+  'person_login' |
+  'person_group' |
+  'booklet_id';
+export type CodingResponseSortDirection = 'asc' | 'desc';
 
 export interface SearchResponseItem {
   responseId: number;

--- a/apps/frontend/src/app/shared/services/response/response.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/response/response.service.spec.ts
@@ -92,5 +92,29 @@ describe('ResponseService', () => {
       );
       req.flush(mockResponse);
     });
+
+    it('should include sort params when searching responses', () => {
+      const searchParams = {
+        version: 'v2' as const,
+        responseSource: 'all' as const,
+        sortBy: 'person_login' as const,
+        sortDirection: 'desc' as const
+      };
+      const mockResponse = { data: [], total: 0 };
+
+      service.searchResponses(mockWorkspaceId, searchParams, 2, 50).subscribe(res => {
+        expect(res).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(request => request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/responses/search` &&
+        request.params.get('version') === 'v2' &&
+        request.params.get('responseSource') === 'all' &&
+        request.params.get('sortBy') === 'person_login' &&
+        request.params.get('sortDirection') === 'desc' &&
+        request.params.get('page') === '2' &&
+        request.params.get('limit') === '50'
+      );
+      req.flush(mockResponse);
+    });
   });
 });

--- a/apps/frontend/src/app/shared/services/response/response.service.ts
+++ b/apps/frontend/src/app/shared/services/response/response.service.ts
@@ -13,6 +13,10 @@ import { SERVER_URL } from '../../../injection-tokens';
 import { TestResultService } from '../test-result/test-result.service';
 import { ValidationTaskStateService } from '../validation/validation-task-state.service';
 import { suppressGlobalHttpErrorContext } from '../../../core/interceptors/http-error-context';
+import {
+  CodingResponseSortBy,
+  CodingResponseSortDirection
+} from '../../../models/coding-interfaces';
 
 @Injectable({
   providedIn: 'root'
@@ -151,7 +155,7 @@ export class ResponseService {
 
   searchResponses(
     workspaceId: number,
-    searchParams: { value?: string; variableId?: string; unitName?: string; bookletName?: string; status?: string; codedStatus?: string; group?: string; code?: string; version?: 'v1' | 'v2' | 'v3'; geogebra?: boolean; derivedOnly?: boolean; responseSource?: 'base' | 'derived' | 'all'; personLogin?: string },
+    searchParams: { value?: string; variableId?: string; unitName?: string; bookletName?: string; status?: string; codedStatus?: string; group?: string; code?: string; version?: 'v1' | 'v2' | 'v3'; geogebra?: boolean; derivedOnly?: boolean; responseSource?: 'base' | 'derived' | 'all'; personLogin?: string; sortBy?: CodingResponseSortBy; sortDirection?: CodingResponseSortDirection },
     page?: number,
     limit?: number
   ): Observable<{
@@ -228,6 +232,14 @@ export class ResponseService {
 
     if (searchParams.personLogin) {
       params = params.set('personLogin', searchParams.personLogin);
+    }
+
+    if (searchParams.sortBy) {
+      params = params.set('sortBy', searchParams.sortBy);
+    }
+
+    if (searchParams.sortDirection) {
+      params = params.set('sortDirection', searchParams.sortDirection);
     }
 
     if (page !== undefined) {


### PR DESCRIPTION
## Summary

- Adds server-side sorting for coding overview response lists before pagination.
- Wires Angular Material sort events through the frontend services to the backend.
- Handles effective coded-status sorting through a selected query alias and keeps GeoGebra default ordering when no explicit sort is selected.

## Validation

- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-response-query.service.spec.ts
- npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management/components/response-table/response-table.component.spec.ts
- npx nx lint backend
- npx nx lint frontend
- git diff --check

Refs #708
