### PR TITLE
Allow replay decisions without coding permission

### DIFF
--- a/apps/backend/src/app/admin/workspace/dto/workspace-coding.interfaces.ts
+++ b/apps/backend/src/app/admin/workspace/dto/workspace-coding.interfaces.ts
@@ -54,6 +54,14 @@ export interface DoubleCodedReviewResponse {
   limit: number;
 }
 
+export interface DoubleCodedResolutionDecision {
+  responseId: number;
+  selectedJobId?: number | null;
+  code?: number | null;
+  score?: number | null;
+  resolutionComment?: string;
+}
+
 export interface DoubleCodedResolutionResponse {
   success: boolean;
   appliedCount: number;

--- a/apps/backend/src/app/admin/workspace/workspace-coding-review.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-review.controller.ts
@@ -18,6 +18,7 @@ import { WorkspaceGuard } from './workspace.guard';
 import { WorkspaceId } from './workspace.decorator';
 import { CodingReviewService } from '../../database/services/coding';
 import {
+  DoubleCodedResolutionDecision,
   DoubleCodedReviewResponse,
   DoubleCodedResolutionResponse
 } from './dto/workspace-coding.interfaces';
@@ -235,7 +236,18 @@ export class WorkspaceCodingReviewController {
               responseId: { type: 'number', description: 'Response ID' },
               selectedJobId: {
                 type: 'number',
-                description: 'Selected coding job ID'
+                nullable: true,
+                description: 'Selected coding job ID for an existing coder result'
+              },
+              code: {
+                type: 'number',
+                nullable: true,
+                description: 'Explicit final replay code when no coder result is selected'
+              },
+              score: {
+                type: 'number',
+                nullable: true,
+                description: 'Replay score echoed by the client; regular-code scores are validated and derived from the coding scheme'
               },
               resolutionComment: {
                 type: 'string',
@@ -243,7 +255,7 @@ export class WorkspaceCodingReviewController {
                 description: 'Optional resolution comment'
               }
             },
-            required: ['responseId', 'selectedJobId']
+            required: ['responseId']
           }
         }
       },
@@ -279,11 +291,7 @@ export class WorkspaceCodingReviewController {
     @WorkspaceId() workspace_id: number,
       @Body()
                    body: {
-                     decisions: Array<{
-                       responseId: number;
-                       selectedJobId: number;
-                       resolutionComment?: string;
-                     }>;
+                     decisions: DoubleCodedResolutionDecision[];
                    }
   ): Promise<DoubleCodedResolutionResponse> {
     return this.codingReviewService.applyDoubleCodedResolutions(

--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -53,6 +53,9 @@ describe('CodingReviewService', () => {
   let variableBundleRepository: {
     find: jest.Mock;
   };
+  let codingJobService: {
+    getCodingSchemeScoreForUnitCode: jest.Mock;
+  };
   let service: CodingReviewService;
 
   const makeCodingJobUnit = (
@@ -182,6 +185,9 @@ describe('CodingReviewService', () => {
     variableBundleRepository = {
       find: jest.fn().mockResolvedValue([])
     };
+    codingJobService = {
+      getCodingSchemeScoreForUnitCode: jest.fn().mockResolvedValue(1)
+    };
 
     service = new CodingReviewService(
       {} as never,
@@ -191,7 +197,8 @@ describe('CodingReviewService', () => {
       {} as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
-      } as never
+      } as never,
+      codingJobService as never
     );
   });
 
@@ -354,6 +361,7 @@ describe('CodingReviewService', () => {
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
       } as never,
+      codingJobService as never,
       missingsProfilesService as never
     );
 
@@ -1285,6 +1293,199 @@ describe('CodingReviewService', () => {
     expect(queryBuilder.setParameter).toHaveBeenCalledWith('kappaCoderTrainingIds', [21]);
   });
 
+  it('applies an explicit replay code with the score derived from the coding scheme', async () => {
+    codingJobService.getCodingSchemeScoreForUnitCode.mockResolvedValueOnce(7);
+    const response = {
+      value: 'supervisor note\n\n--- ORIGINAL RESPONSE ---\noriginal answer',
+      status_v2: null,
+      code_v2: null,
+      score_v2: null
+    };
+    const sourceUnit = makeCodingJobUnit({
+      id: 77,
+      response_id: 10,
+      coding_job_id: 100,
+      code: 1,
+      score: 0,
+      supervisor_comment: 'old comment',
+      response
+    });
+    const clearCommentsQueryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([{ id: 77 }])
+    };
+    const transactionalEntityManager = {
+      findOne: jest.fn().mockResolvedValue(sourceUnit),
+      save: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      getRepository: jest.fn().mockReturnValue({
+        createQueryBuilder: jest.fn().mockReturnValue(clearCommentsQueryBuilder)
+      })
+    };
+    const responseRepository = {
+      manager: {
+        transaction: jest.fn(async (callback: (manager: typeof transactionalEntityManager) => Promise<void>) => (
+          callback(transactionalEntityManager)
+        ))
+      }
+    };
+    const localService = new CodingReviewService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      {} as never,
+      {
+        resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
+      } as never,
+      codingJobService as never
+    );
+
+    const result = await localService.applyDoubleCodedResolutions(workspaceId, [{
+      responseId: 10,
+      code: 3,
+      score: 999,
+      resolutionComment: 'Replay checked'
+    }]);
+
+    expect(transactionalEntityManager.findOne).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        where: {
+          response_id: 10,
+          coding_job: { workspace_id: workspaceId }
+        },
+        relations: ['response', 'coding_job'],
+        order: {
+          id: 'ASC'
+        }
+      })
+    );
+    expect(codingJobService.getCodingSchemeScoreForUnitCode).toHaveBeenCalledWith(
+      sourceUnit,
+      workspaceId,
+      3
+    );
+    expect(sourceUnit.supervisor_comment).toBe('Replay checked');
+    expect(response.code_v2).toBe(3);
+    expect(response.score_v2).toBe(7);
+    expect(response.value).toBe('original answer');
+    expect(transactionalEntityManager.update).toHaveBeenCalled();
+    expect(transactionalEntityManager.save).toHaveBeenCalledWith(
+      expect.any(Function),
+      sourceUnit
+    );
+    expect(transactionalEntityManager.save).toHaveBeenCalledWith(
+      expect.any(Function),
+      response
+    );
+    expect(result).toMatchObject({
+      success: true,
+      appliedCount: 1,
+      failedCount: 0,
+      skippedCount: 0
+    });
+  });
+
+  it('skips explicit replay decisions with codes unsupported by the coding scheme', async () => {
+    const sourceUnit = makeCodingJobUnit({
+      response_id: 10,
+      coding_job_id: 100
+    });
+    const transactionalEntityManager = {
+      findOne: jest.fn().mockResolvedValue(sourceUnit),
+      save: jest.fn(),
+      update: jest.fn(),
+      getRepository: jest.fn()
+    };
+    const responseRepository = {
+      manager: {
+        transaction: jest.fn(async (callback: (manager: typeof transactionalEntityManager) => Promise<void>) => (
+          callback(transactionalEntityManager)
+        ))
+      }
+    };
+    codingJobService.getCodingSchemeScoreForUnitCode.mockRejectedValueOnce(new Error('Unsupported code'));
+    const localService = new CodingReviewService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      {} as never,
+      {
+        resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
+      } as never,
+      codingJobService as never
+    );
+
+    const result = await localService.applyDoubleCodedResolutions(workspaceId, [{
+      responseId: 10,
+      code: 999,
+      score: 1
+    }]);
+
+    expect(codingJobService.getCodingSchemeScoreForUnitCode).toHaveBeenCalledWith(
+      sourceUnit,
+      workspaceId,
+      999
+    );
+    expect(transactionalEntityManager.save).not.toHaveBeenCalled();
+    expect(transactionalEntityManager.update).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: false,
+      appliedCount: 0,
+      failedCount: 0,
+      skippedCount: 1
+    });
+  });
+
+  it('skips explicit replay decisions with invalid code or score values', async () => {
+    const transactionalEntityManager = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+      getRepository: jest.fn()
+    };
+    const responseRepository = {
+      manager: {
+        transaction: jest.fn(async (callback: (manager: typeof transactionalEntityManager) => Promise<void>) => (
+          callback(transactionalEntityManager)
+        ))
+      }
+    };
+    const localService = new CodingReviewService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      {} as never,
+      {
+        resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
+      } as never,
+      codingJobService as never
+    );
+
+    const result = await localService.applyDoubleCodedResolutions(workspaceId, [
+      { responseId: 10, code: '' },
+      { responseId: 11, code: 1, score: ' ' },
+      { responseId: 12, code: true },
+      { responseId: 13, code: 1, score: [2] },
+      { responseId: 14, selectedJobId: true }
+    ] as never);
+
+    expect(transactionalEntityManager.findOne).not.toHaveBeenCalled();
+    expect(transactionalEntityManager.save).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: false,
+      appliedCount: 0,
+      failedCount: 0,
+      skippedCount: 5
+    });
+  });
+
   it('returns an empty workspace kappa summary for a single selected coder', async () => {
     const getDoubleCodedVariablesForReviewSpy = jest.spyOn(
       service,
@@ -1338,7 +1539,8 @@ describe('CodingReviewService', () => {
       codingStatisticsService as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
-      } as never
+      } as never,
+      codingJobService as never
     );
     const getDoubleCodedVariablesForReviewSpy = jest
       .spyOn(service, 'getDoubleCodedVariablesForReview')

--- a/apps/backend/src/app/database/services/coding/coding-review.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.ts
@@ -18,6 +18,7 @@ import {
   applyNonCodingIssueReviewJobFilter,
   isCodingIssueReviewJobType
 } from './coding-job-type.util';
+import { CodingJobService } from './coding-job.service';
 
 type JobDefinitionBundleScope = {
   bundleIds: number[];
@@ -45,6 +46,21 @@ type AppliedReviewResult = {
   appliedComment: string | null;
 };
 
+type DoubleCodedResolutionDecision = {
+  responseId: number;
+  selectedJobId?: number | null;
+  code?: number | null;
+  score?: number | null;
+  resolutionComment?: string;
+};
+
+type ResolvedDoubleCodedResolution = {
+  response: ResponseEntity;
+  sourceUnit: CodingJobUnit;
+  code: number | null;
+  score: number | null;
+};
+
 type KappaCodedVariableRow = {
   responseId: number | string;
   unitName: string;
@@ -69,6 +85,7 @@ type KappaCodedVariableRow = {
 @Injectable()
 export class CodingReviewService {
   private readonly logger = new Logger(CodingReviewService.name);
+  private readonly allowedCodingIssueCodes = new Set([-1, -2, -3, -4]);
   private readonly manualMissingIdsByIssueOptionId = new Map<number, string>([
     [-3, 'mir'],
     [-4, 'mci']
@@ -85,6 +102,7 @@ export class CodingReviewService {
     private variableBundleRepository: Repository<VariableBundle>,
     private codingStatisticsService: CodingStatisticsService,
     private workspaceExclusionService: WorkspaceExclusionService,
+    private codingJobService: CodingJobService,
     @Optional()
     private missingsProfilesService?: MissingsProfilesService
   ) { }
@@ -1098,11 +1116,7 @@ export class CodingReviewService {
 
   async applyDoubleCodedResolutions(
     workspaceId: number,
-    decisions: Array<{
-      responseId: number;
-      selectedJobId: number;
-      resolutionComment?: string;
-    }>
+    decisions: DoubleCodedResolutionDecision[]
   ): Promise<{
       success: boolean;
       appliedCount: number;
@@ -1122,45 +1136,18 @@ export class CodingReviewService {
       await this.responseRepository.manager.transaction(async transactionalEntityManager => {
         for (const decision of decisions) {
           try {
-            const selectedCodingJobUnit =
-              await transactionalEntityManager.findOne(CodingJobUnit, {
-                where: {
-                  response_id: decision.responseId,
-                  coding_job_id: decision.selectedJobId
-                },
-                relations: ['response', 'coding_job']
-              });
+            const resolvedDecision = await this.resolveDoubleCodedResolution(
+              transactionalEntityManager,
+              workspaceId,
+              decision
+            );
 
-            if (!selectedCodingJobUnit) {
-              this.logger.warn(
-                `Could not find coding_job_unit for responseId ${decision.responseId} and jobId ${decision.selectedJobId}`
-              );
+            if (!resolvedDecision) {
               skippedCount += 1;
               continue;
             }
 
-            if (selectedCodingJobUnit.coding_job?.workspace_id !== workspaceId) {
-              this.logger.warn(
-                `Workspace mismatch for responseId ${decision.responseId}`
-              );
-              skippedCount += 1;
-              continue;
-            }
-
-            const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-            if (isExcludedByResolvedExclusions(
-              exclusions,
-              selectedCodingJobUnit.booklet_name,
-              selectedCodingJobUnit.unit_name
-            )) {
-              this.logger.warn(
-                `Skipped ignored responseId ${decision.responseId} for jobId ${decision.selectedJobId}`
-              );
-              skippedCount += 1;
-              continue;
-            }
-
-            const response = selectedCodingJobUnit.response;
+            const response = resolvedDecision.response;
             if (!response) {
               this.logger.warn(
                 `Could not find response for responseId ${decision.responseId}`
@@ -1169,13 +1156,7 @@ export class CodingReviewService {
               continue;
             }
 
-            let updatedValue = response.value || '';
-            const boundary = '\n\n--- ORIGINAL RESPONSE ---\n';
-
-            if (updatedValue.includes(boundary)) {
-              const parts = updatedValue.split(boundary);
-              updatedValue = parts[parts.length - 1];
-            }
+            const updatedValue = this.getOriginalResponseValue(response.value);
 
             await this.clearWorkspaceSupervisorComments(
               transactionalEntityManager,
@@ -1184,20 +1165,20 @@ export class CodingReviewService {
             );
 
             if (decision.resolutionComment && decision.resolutionComment.trim()) {
-              selectedCodingJobUnit.supervisor_comment = decision.resolutionComment.trim();
-              await transactionalEntityManager.save(CodingJobUnit, selectedCodingJobUnit);
+              resolvedDecision.sourceUnit.supervisor_comment = decision.resolutionComment.trim();
+              await transactionalEntityManager.save(CodingJobUnit, resolvedDecision.sourceUnit);
             }
 
             response.status_v2 = statusStringToNumber('CODING_COMPLETE');
-            response.code_v2 = selectedCodingJobUnit.code;
-            response.score_v2 = selectedCodingJobUnit.score;
+            response.code_v2 = resolvedDecision.code;
+            response.score_v2 = resolvedDecision.score;
             response.value = updatedValue;
 
             await transactionalEntityManager.save(ResponseEntity, response);
             appliedCount += 1;
 
             this.logger.debug(
-              `Applied resolution for responseId ${decision.responseId}: code=${selectedCodingJobUnit.code}, score=${selectedCodingJobUnit.score}`
+              `Applied resolution for responseId ${decision.responseId}: code=${resolvedDecision.code}, score=${resolvedDecision.score}`
             );
           } catch (error) {
             this.logger.error(
@@ -1229,6 +1210,199 @@ export class CodingReviewService {
         'Could not apply double-coded resolutions. Please check the database connection.'
       );
     }
+  }
+
+  private async resolveDoubleCodedResolution(
+    manager: EntityManager,
+    workspaceId: number,
+    decision: DoubleCodedResolutionDecision
+  ): Promise<ResolvedDoubleCodedResolution | null> {
+    if (this.hasSelectedCodingJobDecision(decision)) {
+      return this.resolveSelectedCodingJobResolution(manager, workspaceId, decision);
+    }
+
+    return this.resolveExplicitReplayResolution(manager, workspaceId, decision);
+  }
+
+  private hasSelectedCodingJobDecision(decision: DoubleCodedResolutionDecision): boolean {
+    return this.normalizeExplicitReplayInteger(decision.selectedJobId) !== undefined;
+  }
+
+  private async resolveSelectedCodingJobResolution(
+    manager: EntityManager,
+    workspaceId: number,
+    decision: DoubleCodedResolutionDecision
+  ): Promise<ResolvedDoubleCodedResolution | null> {
+    const selectedJobId = this.normalizeExplicitReplayInteger(decision.selectedJobId);
+    if (selectedJobId === undefined) {
+      this.logger.warn(`Invalid selected job ID for responseId ${decision.responseId}`);
+      return null;
+    }
+
+    const selectedCodingJobUnit = await manager.findOne(CodingJobUnit, {
+      where: {
+        response_id: decision.responseId,
+        coding_job_id: selectedJobId
+      },
+      relations: ['response', 'coding_job']
+    });
+
+    if (!selectedCodingJobUnit) {
+      this.logger.warn(
+        `Could not find coding_job_unit for responseId ${decision.responseId} and jobId ${selectedJobId}`
+      );
+      return null;
+    }
+
+    if (!await this.isResolutionSourceAllowed(workspaceId, selectedCodingJobUnit)) {
+      this.logger.warn(`Skipped unavailable responseId ${decision.responseId} for jobId ${selectedJobId}`);
+      return null;
+    }
+
+    return {
+      response: selectedCodingJobUnit.response,
+      sourceUnit: selectedCodingJobUnit,
+      code: selectedCodingJobUnit.code,
+      score: selectedCodingJobUnit.score
+    };
+  }
+
+  private async resolveExplicitReplayResolution(
+    manager: EntityManager,
+    workspaceId: number,
+    decision: DoubleCodedResolutionDecision
+  ): Promise<ResolvedDoubleCodedResolution | null> {
+    if (decision.code === null || decision.code === undefined) {
+      this.logger.warn(`Missing replay code for responseId ${decision.responseId}`);
+      return null;
+    }
+
+    const code = this.normalizeExplicitReplayInteger(decision.code);
+    if (code === undefined) {
+      this.logger.warn(`Invalid replay code for responseId ${decision.responseId}`);
+      return null;
+    }
+
+    if (!this.isExplicitReplayScorePayloadValid(decision.score)) {
+      this.logger.warn(`Invalid replay score for responseId ${decision.responseId}`);
+      return null;
+    }
+
+    const sourceUnit = await manager.findOne(CodingJobUnit, {
+      where: {
+        response_id: decision.responseId,
+        coding_job: { workspace_id: workspaceId }
+      },
+      relations: ['response', 'coding_job'],
+      order: {
+        id: 'ASC'
+      }
+    });
+
+    if (!sourceUnit) {
+      this.logger.warn(`Could not find workspace coding_job_unit for replay responseId ${decision.responseId}`);
+      return null;
+    }
+
+    if (!await this.isResolutionSourceAllowed(workspaceId, sourceUnit)) {
+      this.logger.warn(`Skipped unavailable replay responseId ${decision.responseId}`);
+      return null;
+    }
+
+    const score = await this.resolveExplicitReplayScore(workspaceId, sourceUnit, code);
+    if (score === undefined) {
+      this.logger.warn(`Unsupported replay code for responseId ${decision.responseId}: ${code}`);
+      return null;
+    }
+
+    return {
+      response: sourceUnit.response,
+      sourceUnit,
+      code,
+      score
+    };
+  }
+
+  private async resolveExplicitReplayScore(
+    workspaceId: number,
+    sourceUnit: CodingJobUnit,
+    code: number
+  ): Promise<number | null | undefined> {
+    if (code < 0) {
+      return this.allowedCodingIssueCodes.has(code) ? null : undefined;
+    }
+
+    try {
+      return await this.codingJobService.getCodingSchemeScoreForUnitCode(
+        sourceUnit,
+        workspaceId,
+        code
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Could not validate replay code ${code} for responseId ${sourceUnit.response_id}: ${error.message}`
+      );
+      return undefined;
+    }
+  }
+
+  private isExplicitReplayScorePayloadValid(score: unknown): boolean {
+    if (score === null || score === undefined) {
+      return true;
+    }
+
+    return this.normalizeExplicitReplayNumber(score) !== undefined;
+  }
+
+  private normalizeExplicitReplayInteger(value: unknown): number | undefined {
+    const normalizedValue = this.normalizeExplicitReplayNumber(value);
+    if (normalizedValue === undefined) {
+      return undefined;
+    }
+
+    return Number.isInteger(normalizedValue) ? normalizedValue : undefined;
+  }
+
+  private normalizeExplicitReplayNumber(value: unknown): number | undefined {
+    if (typeof value !== 'number' && typeof value !== 'string') {
+      return undefined;
+    }
+
+    if (typeof value === 'string' && value.trim() === '') {
+      return undefined;
+    }
+
+    const normalizedValue = Number(value);
+    return Number.isFinite(normalizedValue) ? normalizedValue : undefined;
+  }
+
+  private async isResolutionSourceAllowed(
+    workspaceId: number,
+    sourceUnit: CodingJobUnit
+  ): Promise<boolean> {
+    if (sourceUnit.coding_job?.workspace_id !== workspaceId) {
+      this.logger.warn(`Workspace mismatch for responseId ${sourceUnit.response_id}`);
+      return false;
+    }
+
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    return !isExcludedByResolvedExclusions(
+      exclusions,
+      sourceUnit.booklet_name,
+      sourceUnit.unit_name
+    );
+  }
+
+  private getOriginalResponseValue(value: string | null | undefined): string {
+    let updatedValue = value || '';
+    const boundary = '\n\n--- ORIGINAL RESPONSE ---\n';
+
+    if (updatedValue.includes(boundary)) {
+      const parts = updatedValue.split(boundary);
+      updatedValue = parts[parts.length - 1];
+    }
+
+    return updatedValue;
   }
 
   private async clearWorkspaceSupervisorComments(

--- a/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
@@ -626,7 +626,9 @@ export class WorkspaceCodingService {
     workspaceId: number,
     decisions: Array<{
       responseId: number;
-      selectedJobId: number;
+      selectedJobId?: number | null;
+      code?: number | null;
+      score?: number | null;
       resolutionComment?: string;
     }>
   ): Promise<{

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -228,7 +228,7 @@ describe('CodingResultsComparisonComponent', () => {
     expect(component.withinTrainingData[0].modalValueDisplay?.valueText).toBe('7*');
   });
 
-  it('should open replay for the row response with coding context', () => {
+  it('should open replay for the row response with coding decision context', () => {
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
     codingStatisticsService.getReplayUrl.mockReturnValue(of({
       replayUrl: 'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1'
@@ -248,7 +248,7 @@ describe('CodingResultsComparisonComponent', () => {
     expect(appService.createOwnToken).not.toHaveBeenCalled();
     expect(codingStatisticsService.getReplayUrl).toHaveBeenCalledWith(1, 77);
     expect(openSpy).toHaveBeenCalledWith(
-      'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1&mode=coding&originResponseId=77',
+      'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1&mode=coding-decision&originResponseId=77',
       '_blank'
     );
   });
@@ -279,7 +279,7 @@ describe('CodingResultsComparisonComponent', () => {
     } as never);
 
     expect(openSpy).toHaveBeenCalledWith(
-      'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1&mode=coding&originResponseId=77&suppressGeneralInstructions=true',
+      'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1&mode=coding-decision&originResponseId=77&suppressGeneralInstructions=true',
       '_blank'
     );
   });

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -1084,7 +1084,7 @@ export class CodingResultsComparisonComponent implements OnInit {
     const appendParams = (value: string): string => {
       const [path, query = ''] = value.split('?', 2);
       const params = new URLSearchParams(query);
-      params.set('mode', 'coding');
+      params.set('mode', 'coding-decision');
       params.set('originResponseId', responseId.toString());
       if (displayOptions.suppressGeneralInstructions !== undefined) {
         params.set('suppressGeneralInstructions', String(displayOptions.suppressGeneralInstructions));

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
@@ -17,6 +17,25 @@ describe('DoubleCodedReviewComponent', () => {
   let fixture: ComponentFixture<DoubleCodedReviewComponent>;
   let overlayContainer: OverlayContainer;
 
+  type ReplaySelectionMessage = {
+    type: 'replayCodeSelected';
+    testPerson: string;
+    unitId: string;
+    variableId: unknown;
+    code: unknown;
+    score?: unknown;
+    responseId: number;
+  };
+
+  type ReplaySelectionHarness = {
+    handleReplayCodeSelected: (
+      message: ReplaySelectionMessage,
+      source: MessageEventSource | null,
+      origin?: string
+    ) => void;
+    replayWindowByResponseId: Map<number, MessageEventSource>;
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
@@ -302,6 +321,255 @@ describe('DoubleCodedReviewComponent', () => {
     expect(coderHeaders.map(header => header.textContent?.trim())).toEqual(['Coder A', 'Coder B']);
     expect(component.coderColumnMeta.coder_10.coderNames).toEqual(['Coder A', 'Coder A renamed']);
     expect(component.getCoderColumnTooltip('coder_10')).toContain('Weitere Namen: Coder A renamed');
+  });
+
+  it('opens replay in coding decision mode for double-coded review decisions', async () => {
+    const codingStatisticsService = TestBed.inject(CodingStatisticsService) as unknown as {
+      getReplayUrl: jest.Mock;
+    };
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    codingStatisticsService.getReplayUrl.mockReturnValue(of({
+      replayUrl: 'http://localhost:3333/#/replay/person/unit/0/VAR_1?workspaceId=1'
+    }));
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    component.openReplay(501);
+
+    expect(codingStatisticsService.getReplayUrl).toHaveBeenCalledWith(1, 501);
+    expect(openSpy).toHaveBeenCalledWith(
+      `${window.location.origin}/#/replay/person/unit/0/VAR_1?workspaceId=1&mode=coding-decision&originResponseId=501`,
+      '_blank'
+    );
+  });
+
+  it('selects an available coder result from a replay code selection', async () => {
+    const snackBar = TestBed.inject(MatSnackBar) as unknown as { open: jest.Mock };
+    const replaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    snackBar.open.mockClear();
+    harness.replayWindowByResponseId.set(501, replaySource);
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '2',
+      score: 1,
+      responseId: 501
+    }, replaySource);
+
+    const item = component.dataSource.data.find(row => row.responseId === 501);
+    expect(component.selectionForm.get('item_501')?.value).toBe('1002');
+    expect(item?.selectedCoderResult?.jobId).toBe(1002);
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'double-coded-review.success.replay-code-selected',
+      'close',
+      expect.objectContaining({ panelClass: ['success-snackbar'] })
+    );
+  });
+
+  it('stores and applies a replay code selection that has no coder result', async () => {
+    const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
+      applyDoubleCodedResolutions: jest.Mock;
+    };
+    const replaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    harness.replayWindowByResponseId.set(501, replaySource);
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '3',
+      score: 2,
+      responseId: 501
+    }, replaySource);
+
+    const item = component.dataSource.data.find(row => row.responseId === 501);
+    expect(item).toBeDefined();
+    expect(component.selectionForm.get('item_501')?.value).toBe('replay:501');
+    expect(component.getSelectedDecisionResult(item!)?.code).toBe(3);
+    expect(component.getSelectedDecisionResult(item!)?.score).toBe(2);
+    expect(component.getDecisionResultSourceLabel(item!, component.getSelectedDecisionResult(item!)!))
+      .toBe('double-coded-review.decision.replay-source');
+
+    testPersonCodingService.applyDoubleCodedResolutions.mockClear();
+    component.applySingleDecision(item!);
+
+    expect(testPersonCodingService.applyDoubleCodedResolutions).toHaveBeenCalledWith(1, {
+      decisions: [{ responseId: 501, code: 3, score: 2 }]
+    });
+  });
+
+  it('stores a replay code selection when only the score differs from coder results', async () => {
+    const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
+      applyDoubleCodedResolutions: jest.Mock;
+    };
+    const replaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    harness.replayWindowByResponseId.set(501, replaySource);
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '2',
+      score: 2,
+      responseId: 501
+    }, replaySource);
+
+    const item = component.dataSource.data.find(row => row.responseId === 501);
+    expect(component.selectionForm.get('item_501')?.value).toBe('replay:501');
+
+    testPersonCodingService.applyDoubleCodedResolutions.mockClear();
+    component.applySingleDecision(item!);
+
+    expect(testPersonCodingService.applyDoubleCodedResolutions).toHaveBeenCalledWith(1, {
+      decisions: [{ responseId: 501, code: 2, score: 2 }]
+    });
+  });
+
+  it('stores a replay code selection when the score is explicitly null', async () => {
+    const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
+      applyDoubleCodedResolutions: jest.Mock;
+    };
+    const replaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    harness.replayWindowByResponseId.set(501, replaySource);
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '2',
+      score: null,
+      responseId: 501
+    }, replaySource);
+
+    const item = component.dataSource.data.find(row => row.responseId === 501);
+    expect(component.selectionForm.get('item_501')?.value).toBe('replay:501');
+
+    testPersonCodingService.applyDoubleCodedResolutions.mockClear();
+    component.applySingleDecision(item!);
+
+    expect(testPersonCodingService.applyDoubleCodedResolutions).toHaveBeenCalledWith(1, {
+      decisions: [{ responseId: 501, code: 2, score: null }]
+    });
+  });
+
+  it('ignores malformed replay code selections without crashing', async () => {
+    const snackBar = TestBed.inject(MatSnackBar) as unknown as { open: jest.Mock };
+    const replaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    snackBar.open.mockClear();
+    harness.replayWindowByResponseId.set(501, replaySource);
+    expect(() => harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: { invalid: true },
+      code: { invalid: true },
+      responseId: 501
+    }, replaySource)).not.toThrow();
+
+    expect(component.selectionForm.get('item_501')?.value).toBe('1001');
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'double-coded-review.errors.replay-code-not-in-decisions',
+      'close',
+      expect.objectContaining({ panelClass: ['error-snackbar'] })
+    );
+  });
+
+  it('ignores replay code selections with malformed scores', async () => {
+    const snackBar = TestBed.inject(MatSnackBar) as unknown as { open: jest.Mock };
+    const replaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    snackBar.open.mockClear();
+    harness.replayWindowByResponseId.set(501, replaySource);
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '2',
+      score: { invalid: true },
+      responseId: 501
+    }, replaySource);
+
+    expect(component.selectionForm.get('item_501')?.value).toBe('1001');
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'double-coded-review.errors.replay-code-not-in-decisions',
+      'close',
+      expect.objectContaining({ panelClass: ['error-snackbar'] })
+    );
+  });
+
+  it('ignores replay code selections from stale replay windows', async () => {
+    const snackBar = TestBed.inject(MatSnackBar) as unknown as { open: jest.Mock };
+    const expectedReplaySource = {} as MessageEventSource;
+    const staleReplaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    snackBar.open.mockClear();
+    harness.replayWindowByResponseId.set(501, expectedReplaySource);
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '3',
+      score: 2,
+      responseId: 501
+    }, staleReplaySource);
+
+    expect(component.selectionForm.get('item_501')?.value).toBe('1001');
+    expect(component.getSelectedDecisionResult(component.dataSource.data[0])?.code).toBe(1);
+    expect(snackBar.open).not.toHaveBeenCalled();
+  });
+
+  it('ignores replay code selections from another origin', async () => {
+    const snackBar = TestBed.inject(MatSnackBar) as unknown as { open: jest.Mock };
+    const replaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    snackBar.open.mockClear();
+    harness.replayWindowByResponseId.set(501, replaySource);
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '3',
+      score: 2,
+      responseId: 501
+    }, replaySource, 'https://example.test');
+
+    expect(component.selectionForm.get('item_501')?.value).toBe('1001');
+    expect(component.getSelectedDecisionResult(component.dataSource.data[0])?.code).toBe(1);
+    expect(snackBar.open).not.toHaveBeenCalled();
   });
 
   it('shows multiple results from the same coder in one coder column cell', async () => {

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -32,6 +32,11 @@ import { CodingFacadeService } from '../../../services/facades/coding-facade.ser
 import { JobDefinition } from '../../services/coding-job-backend.service';
 import { CoderTraining } from '../../models/coder-training.model';
 import { CodingStatisticsService } from '../../services/coding-statistics.service';
+import { PostMessage, PostMessageService } from '../../../core/services/post-message.service';
+import {
+  appendReplayUrlParams,
+  normalizeReplayUrlToCurrentOrigin
+} from '../../utils/replay-url.util';
 
 interface CoderResult {
   coderId: number;
@@ -66,6 +71,34 @@ interface AppliedReviewResult {
   score: number | null;
   comment: string | null;
 }
+
+interface ReplayDecisionResult {
+  source: 'replay';
+  code: number;
+  score: number | null;
+}
+
+type DecisionResult = CoderResult | ReplayDecisionResult;
+
+interface ReplayCodeSelectedMessage extends PostMessage {
+  testPerson: string;
+  unitId: string;
+  variableId: unknown;
+  code: unknown;
+  score?: unknown;
+  responseId?: number;
+}
+
+type ValidReplayScore = { isValid: true; hasScore: boolean; value: number | null };
+type ParsedReplayScore = ValidReplayScore | { isValid: false };
+
+type DoubleCodedResolutionDecision = {
+  responseId: number;
+  selectedJobId?: number;
+  code?: number;
+  score?: number | null;
+  resolutionComment?: string;
+};
 
 interface CoderColumnMeta {
   columnId: string;
@@ -112,6 +145,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
   private workspaceService = inject(WorkspaceBackendService);
   private codingFacadeService = inject(CodingFacadeService);
   private codingStatisticsService = inject(CodingStatisticsService);
+  private postMessageService = inject(PostMessageService);
 
   constructor(
     @Optional() public dialogRef: MatDialogRef<DoubleCodedReviewComponent>,
@@ -146,12 +180,18 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
   selectionForm!: FormGroup;
   selectedItem: DoubleCodedItem | null = null;
   replayLoadingByResponseId: Record<number, boolean> = {};
+  private replayDecisionByResponseId = new Map<number, ReplayDecisionResult>();
+  private replayWindowByResponseId = new Map<number, MessageEventSource>();
+  private readonly replayDecisionPrefix = 'replay:';
 
   ngOnInit(): void {
     this.initializeForm();
     this.setupFilters();
     this.loadCoders();
     this.loadFilterOptions();
+    this.postMessageService.getMessages<ReplayCodeSelectedMessage>('replayCodeSelected')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(data => this.handleReplayCodeSelected(data.message, data.source, data.origin));
   }
 
   ngOnDestroy(): void {
@@ -504,7 +544,11 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     return item.coderResults.filter(coderResult => coderResult.coderId === result.coderId).length > 1;
   }
 
-  getDecisionResultSourceLabel(item: DoubleCodedItem, result: CoderResult): string {
+  getDecisionResultSourceLabel(item: DoubleCodedItem, result: DecisionResult): string {
+    if (this.isReplayDecisionResult(result)) {
+      return this.translateService.instant('double-coded-review.decision.replay-source');
+    }
+
     if (!this.hasMultipleResultsForCoder(item, result)) {
       return this.getCoderDisplayName(result);
     }
@@ -512,13 +556,22 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     return `${this.getCoderDisplayName(result)} - ${this.getCoderResultSourceLabel(result)}`;
   }
 
-  getSelectedDecisionResult(item: DoubleCodedItem): CoderResult | undefined {
-    const selectedJobId = this.selectionForm?.get(this.getItemControlName(item))?.value;
-    const selectedResult = selectedJobId ?
-      item.coderResults.find(result => result.jobId.toString() === selectedJobId) :
+  getSelectedDecisionResult(item: DoubleCodedItem): DecisionResult | undefined {
+    const selectedValue = this.selectionForm?.get(this.getItemControlName(item))?.value;
+    const replayDecision = this.getReplayDecisionForControlValue(item, selectedValue);
+    if (replayDecision) {
+      return replayDecision;
+    }
+
+    const selectedResult = selectedValue ?
+      item.coderResults.find(result => result.jobId.toString() === selectedValue) :
       item.selectedCoderResult;
 
     return selectedResult && selectedResult.code !== null ? selectedResult : undefined;
+  }
+
+  private isReplayDecisionResult(result: DecisionResult): result is ReplayDecisionResult {
+    return 'source' in result && result.source === 'replay';
   }
 
   getAppliedReviewResult(item: DoubleCodedItem): AppliedReviewResult | null {
@@ -697,12 +750,166 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
           return;
         }
 
-        window.open(result.replayUrl, '_blank');
+        const replayWindow = window.open(this.buildReplayDecisionUrl(result.replayUrl, responseId), '_blank');
+        if (replayWindow) {
+          this.replayWindowByResponseId.set(responseId, replayWindow);
+        }
       },
       error: () => {
         this.showError(this.translateService.instant('double-coded-review.errors.replay-failed'));
       }
     });
+  }
+
+  private buildReplayDecisionUrl(replayUrl: string, responseId: number): string {
+    return appendReplayUrlParams(
+      normalizeReplayUrlToCurrentOrigin(replayUrl),
+      {
+        mode: 'coding-decision',
+        originResponseId: responseId,
+        workspaceId: this.appService.selectedWorkspaceId
+      }
+    );
+  }
+
+  private handleReplayCodeSelected(
+    data: ReplayCodeSelectedMessage,
+    source: MessageEventSource | null,
+    origin: string = window.location.origin
+  ): void {
+    if (!this.isReplayMessageSourceAllowed(data, source, origin)) {
+      return;
+    }
+
+    const item = this.findReplaySelectedItem(data);
+    const selectedCode = this.parseReplaySelectedCode(data.code);
+
+    if (!item || selectedCode === null) {
+      this.showError(this.translateService.instant('double-coded-review.errors.replay-code-not-in-decisions'));
+      return;
+    }
+
+    const selectedScore = this.parseReplaySelectedScore(
+      data.score,
+      Object.prototype.hasOwnProperty.call(data, 'score')
+    );
+    if (!selectedScore.isValid) {
+      this.showError(this.translateService.instant('double-coded-review.errors.replay-code-not-in-decisions'));
+      return;
+    }
+
+    const selectedResult = this.findReplaySelectedResult(item, selectedCode, selectedScore);
+
+    if (selectedResult) {
+      const selectedJobId = selectedResult.jobId.toString();
+      this.replayDecisionByResponseId.delete(item.responseId);
+      this.getOrCreateFormControl(this.getItemControlName(item)).setValue(selectedJobId);
+      this.onSelectionChange(item, selectedJobId);
+      this.showSuccess(this.translateService.instant('double-coded-review.success.replay-code-selected'));
+      return;
+    }
+
+    const replayDecision: ReplayDecisionResult = {
+      source: 'replay',
+      code: selectedCode,
+      score: selectedScore.value
+    };
+    this.replayDecisionByResponseId.set(item.responseId, replayDecision);
+    item.selectedCoderResult = undefined;
+    this.getOrCreateFormControl(this.getItemControlName(item))
+      .setValue(this.getReplayDecisionControlValue(item));
+    this.showSuccess(this.translateService.instant('double-coded-review.success.replay-code-selected'));
+  }
+
+  private isReplayMessageSourceAllowed(
+    data: ReplayCodeSelectedMessage,
+    source: MessageEventSource | null,
+    origin: string
+  ): boolean {
+    if (!data.responseId || !source || origin !== window.location.origin) {
+      return false;
+    }
+
+    return this.replayWindowByResponseId.get(data.responseId) === source;
+  }
+
+  private findReplaySelectedItem(data: ReplayCodeSelectedMessage): DoubleCodedItem | undefined {
+    const variableId = this.normalizeReplayMessageText(data.variableId).toLowerCase();
+    const candidates = data.responseId ?
+      this.allData.filter(item => item.responseId === data.responseId) :
+      this.allData;
+
+    return candidates.find(item => item.variableId.trim().toLowerCase() === variableId) ||
+      (data.responseId ? candidates[0] : undefined);
+  }
+
+  private parseReplaySelectedCode(code: unknown): number | null {
+    if (typeof code !== 'string' && typeof code !== 'number') {
+      return null;
+    }
+
+    const trimmedCode = String(code).trim();
+    if (trimmedCode === '') {
+      return null;
+    }
+
+    const selectedCode = Number(trimmedCode);
+    return Number.isFinite(selectedCode) ? selectedCode : null;
+  }
+
+  private parseReplaySelectedScore(score: unknown, hasScore: boolean): ParsedReplayScore {
+    if (!hasScore) {
+      return { isValid: true, hasScore: false, value: null };
+    }
+
+    if (score === null) {
+      return { isValid: true, hasScore: true, value: null };
+    }
+
+    if (typeof score !== 'string' && typeof score !== 'number') {
+      return { isValid: false };
+    }
+
+    if (typeof score === 'string' && score.trim() === '') {
+      return { isValid: false };
+    }
+
+    const selectedScore = Number(score);
+    return Number.isFinite(selectedScore) ?
+      { isValid: true, hasScore: true, value: selectedScore } :
+      { isValid: false };
+  }
+
+  private findReplaySelectedResult(
+    item: DoubleCodedItem,
+    selectedCode: number,
+    selectedScore: ValidReplayScore
+  ): CoderResult | undefined {
+    const matchingCodeResults = item.coderResults
+      .filter(result => result.code === selectedCode);
+
+    if (selectedScore.hasScore) {
+      return matchingCodeResults.find(result => result.score === selectedScore.value);
+    }
+
+    return matchingCodeResults[0];
+  }
+
+  private normalizeReplayMessageText(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+  }
+
+  private getReplayDecisionControlValue(item: DoubleCodedItem): string {
+    return `${this.replayDecisionPrefix}${item.responseId}`;
+  }
+
+  private getReplayDecisionForControlValue(
+    item: DoubleCodedItem,
+    controlValue: string | null | undefined
+  ): ReplayDecisionResult | undefined {
+    return controlValue === this.getReplayDecisionControlValue(item) ?
+      this.replayDecisionByResponseId.get(item.responseId) :
+      undefined;
   }
 
   hasConflict(item: DoubleCodedItem): boolean {
@@ -897,6 +1104,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
   }
 
   onSelectionChange(item: DoubleCodedItem, selectedJobId: string): void {
+    this.replayDecisionByResponseId.delete(item.responseId);
     const selectedResult = item.coderResults.find(cr => cr.jobId.toString() === selectedJobId);
     if (selectedResult && selectedResult.code !== null) {
       item.selectedCoderResult = selectedResult;
@@ -912,7 +1120,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const decisions: Array<{ responseId: number; selectedJobId: number; resolutionComment?: string }> = [];
+    const decisions: DoubleCodedResolutionDecision[] = [];
     const currentItems = this.getCurrentItems();
     let hasIncomplete = false;
 
@@ -967,7 +1175,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     }
   }
 
-  private confirmIncompleteResolution(workspaceId: number, decisions: Array<{ responseId: number; selectedJobId: number; resolutionComment?: string }>): void {
+  private confirmIncompleteResolution(workspaceId: number, decisions: DoubleCodedResolutionDecision[]): void {
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
       data: {
         title: this.translateService.instant('double-coded-review.warnings.incomplete-title'),
@@ -984,34 +1192,49 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     });
   }
 
-  private getDecisionForItem(item: DoubleCodedItem): { responseId: number; selectedJobId: number; resolutionComment?: string } | null {
+  private getDecisionForItem(item: DoubleCodedItem): DoubleCodedResolutionDecision | null {
     const controlName = this.getItemControlName(item);
-    const selectedJobId = this.selectionForm.get(controlName)?.value;
+    const selectedValue = this.selectionForm.get(controlName)?.value;
+    const replayDecision = this.getReplayDecisionForControlValue(item, selectedValue);
 
-    if (selectedJobId) {
-      const selectedResult = item.coderResults.find(cr => cr.jobId.toString() === selectedJobId);
+    if (replayDecision) {
+      return this.withResolutionComment(item, {
+        responseId: item.responseId,
+        code: replayDecision.code,
+        score: replayDecision.score
+      });
+    }
+
+    if (selectedValue) {
+      const selectedResult = item.coderResults.find(cr => cr.jobId.toString() === selectedValue);
       if (selectedResult && selectedResult.code !== null) {
-        const decision: { responseId: number; selectedJobId: number; resolutionComment?: string } = {
+        return this.withResolutionComment(item, {
           responseId: item.responseId,
           selectedJobId: selectedResult.jobId
-        };
-
-        if (this.hasConflict(item)) {
-          const commentControlName = this.getCommentControlName(item);
-          const comment = this.selectionForm.get(commentControlName)?.value;
-          if (comment && comment.trim()) {
-            decision.resolutionComment = comment.trim();
-          }
-        }
-        return decision;
+        });
       }
     }
     return null;
   }
 
+  private withResolutionComment(
+    item: DoubleCodedItem,
+    decision: DoubleCodedResolutionDecision
+  ): DoubleCodedResolutionDecision {
+    if (this.hasConflict(item)) {
+      const commentControlName = this.getCommentControlName(item);
+      const comment = this.selectionForm.get(commentControlName)?.value;
+      if (comment && comment.trim()) {
+        decision.resolutionComment = comment.trim();
+      }
+    }
+
+    return decision;
+  }
+
   private sendDecisions(
     workspaceId: number,
-    decisions: Array<{ responseId: number; selectedJobId: number; resolutionComment?: string }>
+    decisions: DoubleCodedResolutionDecision[]
   ): void {
     this.isLoading = true;
     this.testPersonCodingService.applyDoubleCodedResolutions(workspaceId, { decisions }).subscribe({

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -602,6 +602,37 @@ describe('TestPersonCodingService', () => {
     });
   });
 
+  describe('applyDoubleCodedResolutions', () => {
+    it('should post explicit replay code decisions for double-coded review resolutions', () => {
+      const mockResponse = {
+        success: true,
+        appliedCount: 1,
+        failedCount: 0,
+        skippedCount: 0,
+        message: 'ok'
+      };
+      const body = {
+        decisions: [{
+          responseId: 10,
+          code: 3,
+          score: 2,
+          resolutionComment: 'Replay checked'
+        }]
+      };
+
+      service.applyDoubleCodedResolutions(mockWorkspaceId, body).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/double-coded-review/apply-resolutions`
+      );
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(body);
+      req.flush(mockResponse);
+    });
+  });
+
   describe('getCohensKappaStatistics', () => {
     it('should request detailed kappa statistics with filters and return variable mean kappa', () => {
       const mockResponse = {

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -46,6 +46,14 @@ export interface CodingStatistics {
   };
 }
 
+export interface DoubleCodedResolutionDecision {
+  responseId: number;
+  selectedJobId?: number;
+  code?: number;
+  score?: number | null;
+  resolutionComment?: string;
+}
+
 export interface CodingStatisticsWithJob extends CodingStatistics {
   jobId?: string;
   message?: string;
@@ -1156,7 +1164,7 @@ export class TestPersonCodingService {
 
   applyDoubleCodedResolutions(
     workspaceId: number,
-    dto: { decisions: Array<{ responseId: number; selectedJobId: number; resolutionComment?: string }> }
+    dto: { decisions: DoubleCodedResolutionDecision[] }
   ): Observable<{
       success: boolean;
       appliedCount: number;

--- a/apps/frontend/src/app/core/services/post-message.service.spec.ts
+++ b/apps/frontend/src/app/core/services/post-message.service.spec.ts
@@ -27,6 +27,21 @@ describe('PostMessageService', () => {
     });
   });
 
+  describe('getMessages', () => {
+    it('should include the message origin', done => {
+      service.getMessages('test').subscribe(event => {
+        expect(event.message).toEqual({ type: 'test' });
+        expect(event.origin).toBe('https://example.test');
+        done();
+      });
+
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'test' },
+        origin: 'https://example.test'
+      }));
+    });
+  });
+
   describe('generateSessionId', () => {
     it('should generate numeric string', () => {
       const id = service.generateSessionId();

--- a/apps/frontend/src/app/core/services/post-message.service.ts
+++ b/apps/frontend/src/app/core/services/post-message.service.ts
@@ -12,14 +12,20 @@ export interface PostMessage {
   data?: Record<string, unknown>;
 }
 
+export type PostMessageEvent<T extends PostMessage = PostMessage> = {
+  message: T;
+  source: MessageEventSource | null;
+  origin: string;
+};
+
 @Injectable({
   providedIn: 'root'
 })
 export class PostMessageService {
-  private readonly messageSubject: Subject<{ message: PostMessage, source: MessageEventSource | null }> =
-    new Subject<{ message: PostMessage, source: MessageEventSource | null }>();
+  private readonly messageSubject: Subject<PostMessageEvent> =
+    new Subject<PostMessageEvent>();
 
-  readonly messages$: Observable<{ message: PostMessage, source: MessageEventSource | null }> =
+  readonly messages$: Observable<PostMessageEvent> =
     this.messageSubject.asObservable();
 
   constructor(private readonly zone: NgZone) {
@@ -36,7 +42,8 @@ export class PostMessageService {
             const message = event.data as PostMessage;
             this.messageSubject.next({
               message,
-              source: event.source
+              source: event.source,
+              origin: event.origin
             });
           } catch (error) {
             // Error processing postMessage: ${JSON.stringify(error)}
@@ -73,12 +80,13 @@ export class PostMessageService {
     return this.sendMessage(message, iframe.contentWindow, targetOrigin);
   }
 
-  getMessages<T extends PostMessage>(type: string): Observable<{ message: T, source: MessageEventSource | null }> {
+  getMessages<T extends PostMessage>(type: string): Observable<PostMessageEvent<T>> {
     return this.messages$.pipe(
       filter(event => event.message.type === type),
       map(event => ({
         message: event.message as T,
-        source: event.source
+        source: event.source,
+        origin: event.origin
       }))
     );
   }

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -1115,6 +1115,47 @@ describe('ReplayComponent', () => {
     expect(codingJobBackendServiceMock.resumeCodingJob).not.toHaveBeenCalled();
   });
 
+  it('should load coding-decision mode as editable without coding job access side effects', async () => {
+    const appService = TestBed.inject(AppService) as unknown as AppServiceMock;
+    routeParams = {
+      page: '0',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-123',
+      anchor: 'VAR1'
+    };
+    routeQueryParams = {
+      auth: 'valid-token',
+      mode: 'coding-decision',
+      originResponseId: '77',
+      workspaceId: '47'
+    };
+    appService.needsReAuthentication = true;
+    codingJobBackendServiceMock.getCodingJobUnits.mockClear();
+    codingJobBackendServiceMock.updateCodingJob.mockClear();
+    codingJobBackendServiceMock.resumeCodingJob.mockClear();
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(ReplayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(component.isCodingMode).toBe(true);
+    expect(component.isCodingDecisionMode).toBe(true);
+    expect(component.isReviewMode).toBe(false);
+    expect(component.isCodingIssueReviewMode).toBe(false);
+    expect(component.originResponseId).toBe(77);
+    expect(component.isCodingReadOnly()).toBe(false);
+    expect(component.isCodingInteractionBlockedByReAuthentication()).toBe(false);
+    expect(component.canSwitchAssignedCodingJobs()).toBe(false);
+    expect(codingJobBackendServiceMock.getCodingJobUnits).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.updateCodingJob).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.resumeCodingJob).not.toHaveBeenCalled();
+  });
+
   it('should reuse coding job units loaded from query params during replay navigation', async () => {
     routeParams = {
       page: '0',

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -102,6 +102,7 @@ interface ReplayCodingJobSwitchSnapshot {
   authToken: string;
   workspaceId: number;
   isCodingMode: boolean;
+  isCodingDecisionMode: boolean;
   isBookletReplayMode: boolean;
   isReviewMode: boolean;
   isCodingIssueReviewMode: boolean;
@@ -170,6 +171,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   testPerson: string = '';
   unitId: string = '';
   isCodingMode: boolean = false;
+  isCodingDecisionMode: boolean = false;
   isBookletReplayMode: boolean = false; // for replays without coding features
   isReviewMode: boolean = false;
   isCodingIssueReviewMode: boolean = false;
@@ -432,9 +434,13 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         const workspace = this.workspaceId ? String(this.workspaceId) : undefined;
         this.isReviewMode = queryParams.mode === 'coding-review';
         this.isCodingIssueReviewMode = queryParams.mode === 'coding-issue-review';
+        this.isCodingDecisionMode = queryParams.mode === 'coding-decision';
         this.codingService.isReviewMode = this.isReviewMode;
         this.codingService.isCodingIssueReviewMode = this.isCodingIssueReviewMode;
-        this.isCodingMode = queryParams.mode === 'coding' || this.isReviewMode || this.isCodingIssueReviewMode;
+        this.isCodingMode = queryParams.mode === 'coding' ||
+          this.isReviewMode ||
+          this.isCodingIssueReviewMode ||
+          this.isCodingDecisionMode;
         this.isBookletReplayMode = queryParams.mode === 'booklet-view' || queryParams.mode === 'booklet';
         this.originResponseId = queryParams.originResponseId ? Number(queryParams.originResponseId) : null;
         const suppressGeneralInstructions = this.getBooleanQueryParam(queryParams.suppressGeneralInstructions);
@@ -1162,14 +1168,17 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
   isCodingReadOnly(): boolean {
     return this.isSwitchingCodingJob ||
-      this.appService.needsReAuthentication ||
+      (!this.isCodingDecisionMode && this.appService.needsReAuthentication) ||
       this.isReviewMode ||
       (this.codingService.isCompletedJobReview && !this.isCodingIssueReviewMode) ||
       this.codingService.isCodingJobFinalized;
   }
 
   isCodingInteractionBlockedByReAuthentication(): boolean {
-    return this.isCodingMode && !this.isReviewMode && this.appService.needsReAuthentication;
+    return this.isCodingMode &&
+      !this.isReviewMode &&
+      !this.isCodingDecisionMode &&
+      this.appService.needsReAuthentication;
   }
 
   isSubmitCodingJobDisabled(): boolean {
@@ -1199,7 +1208,10 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   canSwitchAssignedCodingJobs(): boolean {
-    return this.isCodingMode && !this.isReviewMode && !this.isCodingIssueReviewMode;
+    return this.isCodingMode &&
+      !this.isReviewMode &&
+      !this.isCodingIssueReviewMode &&
+      !this.isCodingDecisionMode;
   }
 
   isCodingJobSwitchDisabled(): boolean {
@@ -1764,6 +1776,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       authToken: this.authToken,
       workspaceId: this.workspaceId,
       isCodingMode: this.isCodingMode,
+      isCodingDecisionMode: this.isCodingDecisionMode,
       isBookletReplayMode: this.isBookletReplayMode,
       isReviewMode: this.isReviewMode,
       isCodingIssueReviewMode: this.isCodingIssueReviewMode,
@@ -1817,6 +1830,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     this.authToken = snapshot.authToken;
     this.workspaceId = snapshot.workspaceId;
     this.isCodingMode = snapshot.isCodingMode;
+    this.isCodingDecisionMode = snapshot.isCodingDecisionMode;
     this.isBookletReplayMode = snapshot.isBookletReplayMode;
     this.isReviewMode = snapshot.isReviewMode;
     this.isCodingIssueReviewMode = snapshot.isCodingIssueReviewMode;
@@ -1908,6 +1922,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     this.codingService.setAuthToken(authToken);
     this.workspaceId = job.workspace_id;
     this.isCodingMode = true;
+    this.isCodingDecisionMode = false;
     this.isBookletReplayMode = false;
     this.isReviewMode = false;
     this.codingService.isReviewMode = false;

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2489,6 +2489,7 @@
       "status-mixed-conflict": "Mehrere Abweichungen",
       "status-match": "Übereinstimmung",
       "status-incomplete": "Unvollständig",
+      "replay-source": "Replay-Entscheidung",
       "tooltip-inter-coder-conflict": "Unterschiedliche Kodierer haben abweichende Ergebnisse",
       "tooltip-same-coder-conflict": "Derselbe Kodierer hat mehrere abweichende Ergebnisse",
       "tooltip-mixed-conflict": "Es gibt Abweichungen innerhalb eines Kodierers und zwischen Kodierern"
@@ -2559,10 +2560,12 @@
       "failed-to-apply": "Fehler beim Anwenden der Auflösungen",
       "no-decisions": "Keine Entscheidungen zum Anwenden ausgewählt",
       "no-decision-for-item": "Keine Entscheidung für diese Variable ausgewählt",
-      "replay-failed": "Replay konnte für diese Antwort nicht geöffnet werden"
+      "replay-failed": "Replay konnte für diese Antwort nicht geöffnet werden",
+      "replay-code-not-in-decisions": "Der im Replay gewählte Code kommt in den verfügbaren Kodierergebnissen nicht vor."
     },
     "success": {
-      "resolutions-applied": "{{count}} Auflösung(en) erfolgreich angewendet"
+      "resolutions-applied": "{{count}} Auflösung(en) erfolgreich angewendet",
+      "replay-code-selected": "Replay-Code als Entscheidung ausgewählt"
     }
   },
   "applied-results-overview": {

--- a/cypress/component/coding-job-result-dialog.component.cy.ts
+++ b/cypress/component/coding-job-result-dialog.component.cy.ts
@@ -9,18 +9,16 @@ import { of } from 'rxjs';
 import { CodingJobResultDialogComponent } from '../../apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component';
 import { CodingJobBackendService } from '../../apps/frontend/src/app/coding/services/coding-job-backend.service';
 import { CodingJob } from '../../apps/frontend/src/app/coding/models/coding-job.model';
-import { AppService } from '../../apps/frontend/src/app/core/services/app.service';
 import { SERVER_URL } from '../../apps/frontend/src/app/injection-tokens';
 import { FileService } from '../../apps/frontend/src/app/shared/services/file/file.service';
 import { base64ToUtf8 } from '../../apps/frontend/src/app/shared/utils/common-utils';
 
 describe('CodingJobResultDialogComponent review flow', () => {
-  it('opens the review replay on the variable page returned for the coding job unit', () => {
+  it('opens the coding issue review replay on the variable page returned for the coding job unit', () => {
     cy.viewport(1400, 900);
 
     const createUrlTree = cy.stub().returns({});
     const serializeUrl = cy.stub().returns('/replay/generated');
-    const createOwnToken = cy.stub().returns(of('review-token'));
 
     const codingJob: CodingJob = {
       id: 1,
@@ -83,12 +81,6 @@ describe('CodingJobResultDialogComponent review flow', () => {
           }
         },
         {
-          provide: AppService,
-          useValue: {
-            createOwnToken
-          }
-        },
-        {
           provide: FileService,
           useValue: {}
         },
@@ -127,17 +119,21 @@ describe('CodingJobResultDialogComponent review flow', () => {
       expect(openStub.firstCall.args[1]).to.equal('_blank');
     });
     cy.then(() => {
-      expect(createOwnToken).to.have.been.calledWith(5, 1);
       expect(createUrlTree).to.have.been.calledWith(
         ['replay/login@code@group@BOOKLET_A/UNIT_1/0/VAR_ON_ONLY_PAGE'],
         Cypress.sinon.match.object
       );
 
       const queryParams = createUrlTree.firstCall.args[1].queryParams;
-      expect(queryParams.auth).to.equal('review-token');
-      expect(queryParams.mode).to.equal('coding');
+      expect(queryParams).not.to.have.property('auth');
+      expect(queryParams.mode).to.equal('coding-issue-review');
+      expect(queryParams.workspaceId).to.equal(5);
 
       const unitsData = JSON.parse(base64ToUtf8(queryParams.unitsData));
+      expect(unitsData).to.include({
+        id: 1,
+        currentUnitIndex: 0
+      });
       expect(unitsData.units[0]).to.include({
         name: 'UNIT_1',
         testPerson: 'login@code@group@BOOKLET_A',

--- a/cypress/component/double-coded-review-replay-access.cy.ts
+++ b/cypress/component/double-coded-review-replay-access.cy.ts
@@ -1,0 +1,164 @@
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { DoubleCodedReviewComponent } from '../../apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component';
+import { CodingStatisticsService } from '../../apps/frontend/src/app/coding/services/coding-statistics.service';
+import { TestPersonCodingService } from '../../apps/frontend/src/app/coding/services/test-person-coding.service';
+import { AppService } from '../../apps/frontend/src/app/core/services/app.service';
+import { CodingFacadeService } from '../../apps/frontend/src/app/services/facades/coding-facade.service';
+import { WorkspaceBackendService } from '../../apps/frontend/src/app/workspace/services/workspace-backend.service';
+
+describe('DoubleCodedReviewComponent replay access', () => {
+  it('opens editable replay decisions for a study manager without coding permission', () => {
+    cy.viewport(1400, 900);
+
+    const getReplayUrl = cy.stub().returns(of({
+      replayUrl: 'http://localhost:3333/#/replay/person-1@P001@Booklet%201/Unit%20A/0/VAR_1?workspaceId=1'
+    }));
+
+    cy.window().then(win => {
+      cy.stub(win, 'open').as('windowOpen');
+    });
+
+    cy.mount(DoubleCodedReviewComponent, {
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: AppService,
+          useValue: {
+            selectedWorkspaceId: 1,
+            authData: {
+              userName: 'Study Manager',
+              workspaces: [{ id: 1, accessLevel: 2, canCode: false }]
+            },
+            loggedUser: undefined
+          }
+        },
+        {
+          provide: MatDialogRef,
+          useValue: { close: () => {} }
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {}
+        },
+        {
+          provide: WorkspaceBackendService,
+          useValue: {
+            getWorkspaceCoders: () => of({
+              data: [
+                { userId: 10, username: 'Coder A' },
+                { userId: 20, username: 'Coder B' }
+              ]
+            })
+          }
+        },
+        {
+          provide: CodingFacadeService,
+          useValue: {
+            getJobDefinitions: () => of([
+              { id: 99, status: 'approved', createdJobsCount: 2 }
+            ]),
+            getCoderTrainings: () => of([])
+          }
+        },
+        {
+          provide: TestPersonCodingService,
+          useValue: {
+            getDoubleCodedVariablesForReview: () => of({
+              data: [{
+                responseId: 501,
+                unitName: 'Unit A',
+                variableId: 'VAR_1',
+                personLogin: 'person-1',
+                personCode: 'P001',
+                bookletName: 'Booklet 1',
+                givenAnswer: 'answer',
+                isResolved: false,
+                appliedCode: null,
+                appliedScore: null,
+                appliedComment: null,
+                coderResults: [
+                  {
+                    coderId: 10,
+                    coderName: 'Coder A',
+                    jobId: 1001,
+                    jobName: 'Definition 99 / A',
+                    code: 1,
+                    score: 0,
+                    notes: null,
+                    supervisorComment: null,
+                    codedAt: '2026-05-20T09:00:00.000Z'
+                  },
+                  {
+                    coderId: 20,
+                    coderName: 'Coder B',
+                    jobId: 1002,
+                    jobName: 'Definition 99 / B',
+                    code: 2,
+                    score: 1,
+                    notes: null,
+                    supervisorComment: null,
+                    codedAt: '2026-05-20T09:10:00.000Z'
+                  }
+                ]
+              }],
+              total: 1,
+              page: 1,
+              limit: 50
+            }),
+            applyDoubleCodedResolutions: () => of({
+              success: true,
+              appliedCount: 1,
+              failedCount: 0,
+              skippedCount: 0,
+              message: 'ok'
+            })
+          }
+        },
+        {
+          provide: CodingStatisticsService,
+          useValue: { getReplayUrl }
+        },
+        {
+          provide: MatSnackBar,
+          useValue: {
+            open: () => ({ dismiss: () => {} })
+          }
+        },
+        {
+          provide: MatDialog,
+          useValue: {
+            open: () => ({ afterClosed: () => of(null) })
+          }
+        }
+      ]
+    });
+
+    cy.contains('Unit A').should('be.visible');
+    cy.contains('tr', 'Unit A')
+      .find('mat-icon')
+      .contains('play_circle')
+      .parents('button')
+      .click({ force: true });
+
+    cy.then(() => {
+      expect(getReplayUrl).to.have.been.calledWith(1, 501);
+    });
+    cy.get('@windowOpen').then(windowOpen => {
+      const openStub = windowOpen as unknown as {
+        firstCall: { args: [string, string] };
+      };
+      const openedUrl = openStub.firstCall.args[0];
+      expect(openedUrl).to.contain('/#/replay/person-1@P001@Booklet%201/Unit%20A/0/VAR_1');
+      expect(openedUrl).to.contain('workspaceId=1');
+      expect(openedUrl).to.contain('mode=coding-decision');
+      expect(openedUrl).to.contain('originResponseId=501');
+      expect(openStub.firstCall.args[1]).to.equal('_blank');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refs #705

This PR adds a dedicated replay decision flow so review and training discussion contexts can open editable replays without requiring normal coding-job access.

## Changes

- Adds `mode=coding-decision` for replay windows opened from double-coded review and training comparison flows.
- Tracks replay message `source` and `origin` in the double-coded review flow before accepting a selected code.
- Allows explicit replay decisions when the selected replay code does not match an existing coder result.
- Extends the double-coded resolution API contract for replay-provided decisions.
- Validates explicit replay codes server-side and derives regular-code scores from the coding scheme instead of trusting the client payload.

## Validation

- `npx nx test frontend`
- `npx nx lint frontend`
- `npx nx test backend`
- `npx nx lint backend`
- `npx nx test backend --runTestsByPath=apps/backend/src/app/database/services/coding/coding-review.service.spec.ts`
- `git diff --check develop..HEAD`

Note: the backend test run completed successfully; Jest printed the existing worker teardown warning after completion.
