### PR TITLE
Handle job definition availability on updates

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.spec.ts
@@ -6,6 +6,32 @@ import { WorkspaceGuard } from './workspace.guard';
 import { WorkspaceCodingAnalysisController } from './workspace-coding-analysis.controller';
 
 describe('WorkspaceCodingAnalysisController', () => {
+  it('passes excludeJobDefinitionId to incomplete variable availability', async () => {
+    const codingValidationService = {
+      getCodingIncompleteVariables: jest.fn().mockResolvedValue([])
+    };
+    const controller = new WorkspaceCodingAnalysisController(
+      {} as never,
+      {} as never,
+      codingValidationService as never,
+      {} as never,
+      {} as never
+    );
+
+    await expect(
+      controller.getCodingIncompleteVariables(
+        7,
+        undefined,
+        'false',
+        'true',
+        '55'
+      )
+    ).resolves.toEqual([]);
+
+    expect(codingValidationService.getCodingIncompleteVariables)
+      .toHaveBeenCalledWith(7, undefined, false, true, 55);
+  });
+
   it('requires coding-manager access for getVariableAnalysis', () => {
     const handler = WorkspaceCodingAnalysisController.prototype.getVariableAnalysis;
 

--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
@@ -211,6 +211,12 @@ export class WorkspaceCodingAnalysisController {
     description: 'Also include variables that only have DERIVE_ERROR responses and expose DERIVE_ERROR-aware case counts',
     type: Boolean
   })
+  @ApiQuery({
+    name: 'excludeJobDefinitionId',
+    required: false,
+    description: 'Ignore coding jobs from this job definition when calculating remaining cases',
+    type: Number
+  })
   @ApiOkResponse({
     description: 'Manual coding variables retrieved successfully.',
     schema: {
@@ -261,7 +267,8 @@ export class WorkspaceCodingAnalysisController {
     @WorkspaceId() workspace_id: number,
       @Query('unitName') unitName?: string,
       @Query('trainingRequired') trainingRequired?: string,
-      @Query('includeDeriveErrorOnly') includeDeriveErrorOnly?: string
+      @Query('includeDeriveErrorOnly') includeDeriveErrorOnly?: string,
+      @Query('excludeJobDefinitionId') excludeJobDefinitionId?: string
   ): Promise<
       {
         unitName: string;
@@ -282,11 +289,18 @@ export class WorkspaceCodingAnalysisController {
     } else if (trainingRequired === 'false') {
       trainingRequiredParam = false;
     }
+    const parsedExcludeJobDefinitionId = Number(excludeJobDefinitionId);
+    const excludeJobDefinitionIdParam =
+      Number.isInteger(parsedExcludeJobDefinitionId) &&
+      parsedExcludeJobDefinitionId > 0 ?
+        parsedExcludeJobDefinitionId :
+        undefined;
     return this.codingValidationService.getCodingIncompleteVariables(
       workspace_id,
       unitName,
       trainingRequiredParam,
-      includeDeriveErrorOnly === 'true'
+      includeDeriveErrorOnly === 'true',
+      excludeJobDefinitionIdParam
     );
   }
 

--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
@@ -589,6 +589,31 @@ export class WorkspaceCodingJobDefinitionController {
     );
   }
 
+  @Post(':workspace_id/coding/job-definitions/:id/update-refresh-preview')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
+  @RequireAccessLevel(2)
+  @ApiTags('coding')
+  @ApiParam({ name: 'workspace_id', type: Number })
+  @ApiParam({ name: 'id', type: Number, description: 'Job definition ID' })
+  @ApiBody({
+    description: 'Preview a job definition update and the required job refresh',
+    type: UpdateJobDefinitionDto
+  })
+  @ApiOkResponse({
+    description: 'Preview how existing coding jobs would change after updating the job definition.'
+  })
+  async previewJobDefinitionUpdateRefresh(
+    @WorkspaceId() workspace_id: number,
+      @Param('id') id: number,
+      @Body(new ValidationPipe({ transform: true, whitelist: true })) updateDto: UpdateJobDefinitionDto
+  ): Promise<JobDefinitionRefreshPreviewDto> {
+    return this.jobDefinitionService.previewJobDefinitionUpdateRefresh(
+      id,
+      workspace_id,
+      updateDto
+    );
+  }
+
   @Post(':workspace_id/coding/job-definitions/:id/refresh-apply')
   @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @RequireAccessLevel(2)
@@ -605,6 +630,31 @@ export class WorkspaceCodingJobDefinitionController {
     return this.jobDefinitionService.refreshCodingJobFromDefinition(
       id,
       workspace_id
+    );
+  }
+
+  @Post(':workspace_id/coding/job-definitions/:id/update-refresh-apply')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
+  @RequireAccessLevel(2)
+  @ApiTags('coding')
+  @ApiParam({ name: 'workspace_id', type: Number })
+  @ApiParam({ name: 'id', type: Number, description: 'Job definition ID' })
+  @ApiBody({
+    description: 'Apply a job definition update and refresh its existing coding jobs',
+    type: UpdateJobDefinitionDto
+  })
+  @ApiOkResponse({
+    description: 'Updated job definition and regenerated coding jobs.'
+  })
+  async applyJobDefinitionUpdateRefresh(
+    @WorkspaceId() workspace_id: number,
+      @Param('id') id: number,
+      @Body(new ValidationPipe({ transform: true, whitelist: true })) updateDto: UpdateJobDefinitionDto
+  ): Promise<JobDefinitionRefreshApplyResultDto> {
+    return this.jobDefinitionService.refreshCodingJobFromUpdatedDefinition(
+      id,
+      workspace_id,
+      updateDto
     );
   }
 }

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -927,6 +927,92 @@ describe('CodingJobService distribution from job definitions', () => {
     ]);
   });
 
+  it('calculates usage for existing job definitions with their own assigned cases available', async () => {
+    const responses = [
+      ...Array.from(
+        { length: 3 },
+        (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1')
+      )
+    ];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode')
+      .mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+    const assignedResponseIdsSpy = (
+      service as unknown as { getAssignedResponseIdsForVariables: jest.Mock }
+    ).getAssignedResponseIdsForVariables;
+    assignedResponseIdsSpy.mockImplementation(
+      async (_workspaceId, _variables, excludeJobDefinitionId?: number) => (
+        excludeJobDefinitionId === 12 ?
+          new Set([2]) :
+          new Set([1, 2])
+      )
+    );
+
+    const usageByKey = await service.calculateDistributionVariableUsageBatch(5, [
+      {
+        key: 'edited-definition',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        maxCodingCases: 3,
+        caseOrderingMode: 'continuous',
+        distributionSeed: 'seed-1',
+        jobDefinitionId: 12,
+        excludeJobDefinitionId: 12
+      }
+    ]);
+
+    expect(
+      Object.fromEntries(usageByKey.get('edited-definition')?.entries() || [])
+    ).toEqual({ 'Unit 1::Var 1': 2 });
+    expect(assignedResponseIdsSpy).toHaveBeenCalledWith(
+      5,
+      [{ unitName: 'Unit 1', variableId: 'Var 1' }]
+    );
+    expect(assignedResponseIdsSpy).toHaveBeenCalledWith(
+      5,
+      [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      12
+    );
+  });
+
+  it('does not run exclusion queries for job definition ids without explicit exclusion', async () => {
+    const responses = [
+      ...Array.from(
+        { length: 3 },
+        (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1')
+      )
+    ];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode')
+      .mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+    const assignedResponseIdsSpy = (
+      service as unknown as { getAssignedResponseIdsForVariables: jest.Mock }
+    ).getAssignedResponseIdsForVariables;
+
+    const usageByKey = await service.calculateDistributionVariableUsageBatch(5, [
+      {
+        key: 'listed-definition',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        maxCodingCases: 3,
+        caseOrderingMode: 'continuous',
+        distributionSeed: 'seed-1',
+        jobDefinitionId: 12
+      }
+    ]);
+
+    expect(
+      Object.fromEntries(usageByKey.get('listed-definition')?.entries() || [])
+    ).toEqual({ 'Unit 1::Var 1': 3 });
+    expect(assignedResponseIdsSpy).toHaveBeenCalledTimes(1);
+    expect(assignedResponseIdsSpy).toHaveBeenCalledWith(
+      5,
+      [{ unitName: 'Unit 1', variableId: 'Var 1' }]
+    );
+  });
+
   it('does not aggregate derived variables even when their values are empty', async () => {
     const request = {
       selectedVariables: [{ unitName: 'Derived Unit', variableId: 'Derived Var' }],

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -2707,6 +2707,47 @@ export class CodingJobService {
     return savedCodingJob;
   }
 
+  async updateCodingJobDisplayOptionsByDefinitionId(
+    workspaceId: number,
+    jobDefinitionId: number,
+    options: {
+      showScore?: boolean;
+      allowComments?: boolean;
+      suppressGeneralInstructions?: boolean;
+    },
+    manager?: EntityManager
+  ): Promise<number> {
+    const updateValues: Partial<CodingJob> = {};
+
+    if (options.showScore !== undefined) {
+      updateValues.showScore = options.showScore;
+    }
+    if (options.allowComments !== undefined) {
+      updateValues.allowComments = options.allowComments;
+    }
+    if (options.suppressGeneralInstructions !== undefined) {
+      updateValues.suppressGeneralInstructions =
+        options.suppressGeneralInstructions;
+    }
+
+    if (Object.keys(updateValues).length === 0) {
+      return 0;
+    }
+
+    const repository = manager ?
+      manager.getRepository(CodingJob) :
+      this.codingJobRepository;
+    const result = await repository.update(
+      {
+        workspace_id: workspaceId,
+        job_definition_id: jobDefinitionId
+      },
+      updateValues
+    );
+
+    return result.affected || 0;
+  }
+
   async pauseCodingJob(id: number, workspaceId: number): Promise<CodingJob> {
     return this.setOwnCodingJobStatus(id, workspaceId, 'paused');
   }

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -184,6 +184,7 @@ type DistributionVariableUsageRequest = {
   caseOrderingMode?: 'continuous' | 'alternating';
   maxCodingCases?: number;
   jobDefinitionId?: number;
+  excludeJobDefinitionId?: number;
   distributionSeed?: string | number;
 };
 
@@ -205,6 +206,7 @@ type DistributionVariableUsageContext = {
   derivedVariableSets: Map<string, Set<string>>;
   allResponses: SlimResponse[];
   assignedResponseIds: Set<number>;
+  assignedResponseIdsByExcludedJobDefinitionId: Map<number, Set<number>>;
 };
 
 type DistributionPlanItem = {
@@ -6402,22 +6404,44 @@ export class CodingJobService {
         aggregationThreshold: null,
         derivedVariableSets: new Map(),
         allResponses: [],
-        assignedResponseIds: new Set()
+        assignedResponseIds: new Set(),
+        assignedResponseIdsByExcludedJobDefinitionId: new Map()
       };
     }
 
+    const excludedJobDefinitionIds = Array.from(
+      new Set(
+        requests
+          .map(request => Number(request.excludeJobDefinitionId))
+          .filter(jobDefinitionId => (
+            Number.isInteger(jobDefinitionId) &&
+            jobDefinitionId > 0
+          ))
+      )
+    );
     const [
       matchingFlags,
       aggregationThreshold,
       derivedVariableMap,
       allResponses,
-      assignedResponseIds
+      assignedResponseIds,
+      assignedResponseIdsByExcludedJobDefinitionIdEntries
     ] = await Promise.all([
       this.getResponseMatchingMode(workspaceId),
       this.getAggregationThreshold(workspaceId),
       this.workspaceFilesService.getDerivedVariableMap(workspaceId),
       this.getSlimResponsesForVariables(workspaceId, allVariables),
-      this.getAssignedResponseIdsForVariables(workspaceId, allVariables)
+      this.getAssignedResponseIdsForVariables(workspaceId, allVariables),
+      Promise.all(
+        excludedJobDefinitionIds.map(async jobDefinitionId => [
+          jobDefinitionId,
+          await this.getAssignedResponseIdsForVariables(
+            workspaceId,
+            allVariables,
+            jobDefinitionId
+          )
+        ] as const)
+      )
     ]);
 
     return {
@@ -6425,7 +6449,10 @@ export class CodingJobService {
       aggregationThreshold,
       derivedVariableSets: this.buildDerivedVariableSets(derivedVariableMap),
       allResponses,
-      assignedResponseIds
+      assignedResponseIds,
+      assignedResponseIdsByExcludedJobDefinitionId: new Map(
+        assignedResponseIdsByExcludedJobDefinitionIdEntries
+      )
     };
   }
 
@@ -6438,6 +6465,16 @@ export class CodingJobService {
     const distributionSeed = this.getDistributionSeed(workspaceId, request);
     const items = this.buildDistributionItems(request);
     const bundleNameCounts = this.getBundleNameCounts(items);
+    const normalizedExcludeJobDefinitionId = Number(request.excludeJobDefinitionId);
+    const assignedResponseIdsByExcludedJobDefinitionId =
+      context.assignedResponseIdsByExcludedJobDefinitionId ||
+      new Map<number, Set<number>>();
+    const assignedResponseIds =
+      Number.isInteger(normalizedExcludeJobDefinitionId) &&
+      normalizedExcludeJobDefinitionId > 0 ?
+        assignedResponseIdsByExcludedJobDefinitionId.get(normalizedExcludeJobDefinitionId) ||
+          context.assignedResponseIds :
+        context.assignedResponseIds;
 
     if (items.length === 0) {
       return new Map();
@@ -6462,7 +6499,7 @@ export class CodingJobService {
       const { filteredResponses, uniqueCases, totalResponses } =
         this.getDistributableResponses(
           allItemResponses,
-          context.assignedResponseIds,
+          assignedResponseIds,
           context.matchingFlags,
           context.aggregationThreshold,
           response => isDerivedVariable(response.unitName, response.variableid)

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -509,7 +509,8 @@ export class CodingValidationService {
     workspaceId: number,
     unitName?: string,
     trainingRequired?: boolean,
-    includeDeriveErrorOnly = false
+    includeDeriveErrorOnly = false,
+    excludeJobDefinitionId?: number
   ): Promise<
     {
       unitName: string;
@@ -526,9 +527,19 @@ export class CodingValidationService {
     }[]
     > {
     try {
-      if (unitName || trainingRequired !== undefined || includeDeriveErrorOnly) {
+      if (
+        unitName ||
+        trainingRequired !== undefined ||
+        includeDeriveErrorOnly ||
+        excludeJobDefinitionId !== undefined
+      ) {
+        const queryDetails = [
+          unitName ? ` and unit ${unitName}` : '',
+          trainingRequired !== undefined ? ` (trainingRequired: ${trainingRequired})` : '',
+          excludeJobDefinitionId !== undefined ? ` excluding job definition ${excludeJobDefinitionId}` : ''
+        ].join('');
         this.logger.log(
-          `Querying manual coding variables for workspace ${workspaceId}${unitName ? ` and unit ${unitName}` : ''}${trainingRequired !== undefined ? ` (trainingRequired: ${trainingRequired})` : ''} (not cached)`
+          `Querying manual coding variables for workspace ${workspaceId}${queryDetails} (not cached)`
         );
         const variables = await this.fetchCodingIncompleteVariablesFromDb(
           workspaceId,
@@ -539,7 +550,8 @@ export class CodingValidationService {
         return await this.enrichVariablesWithCaseInfo(
           workspaceId,
           variables,
-          includeDeriveErrorOnly
+          includeDeriveErrorOnly,
+          excludeJobDefinitionId
         );
       }
       const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
@@ -701,12 +713,14 @@ export class CodingValidationService {
   private async enrichVariablesWithCaseInfo(
     workspaceId: number,
     variables: ManualCodingVariableCaseCounts[],
-    includeDeriveErrorInCaseInfo = false
+    includeDeriveErrorInCaseInfo = false,
+    excludeJobDefinitionId?: number
   ): Promise<ManualCodingVariableWithCaseInfo[]> {
     const caseInfoMap = await this.computeVariableCaseInfo(
       workspaceId,
       variables,
-      includeDeriveErrorInCaseInfo
+      includeDeriveErrorInCaseInfo,
+      excludeJobDefinitionId
     );
 
     return variables.map(variable => {
@@ -732,7 +746,8 @@ export class CodingValidationService {
   private async computeVariableCaseInfo(
     workspaceId: number,
     variables: ManualCodingVariableCaseCounts[],
-    includeDeriveErrorInCaseInfo = false
+    includeDeriveErrorInCaseInfo = false,
+    excludeJobDefinitionId?: number
   ): Promise<Map<string, VariableCaseInfo>> {
     const result = new Map<string, VariableCaseInfo>();
 
@@ -753,7 +768,11 @@ export class CodingValidationService {
         workspaceId,
         variableReferences
       ) as Promise<SlimCodingResponse[]>,
-      this.getAssignedResponseIdsByVariable(workspaceId, variableReferences)
+      this.getAssignedResponseIdsByVariable(
+        workspaceId,
+        variableReferences,
+        excludeJobDefinitionId
+      )
     ]);
 
     const derivedVariableMap = new Map<string, Set<string>>();
@@ -917,7 +936,8 @@ export class CodingValidationService {
 
   private async getAssignedResponseIdsByVariable(
     workspaceId: number,
-    variables: { unitName: string; variableId: string }[]
+    variables: { unitName: string; variableId: string }[],
+    excludeJobDefinitionId?: number
   ): Promise<Map<string, Set<number>>> {
     const result = new Map<string, Set<number>>();
 
@@ -934,6 +954,16 @@ export class CodingValidationService {
       .leftJoin('cju.coding_job', 'coding_job')
       .where('coding_job.workspace_id = :workspaceId', { workspaceId })
       .andWhere('coding_job.training_id IS NULL');
+
+    if (
+      excludeJobDefinitionId !== undefined &&
+      excludeJobDefinitionId !== null
+    ) {
+      query.andWhere(
+        '(coding_job.job_definition_id IS NULL OR coding_job.job_definition_id != :excludeJobDefinitionId)',
+        { excludeJobDefinitionId }
+      );
+    }
 
     const conditions: string[] = [];
     const parameters: Record<string, string> = {};

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -1263,8 +1263,8 @@ describe('JobDefinitionService', () => {
     ]);
   });
 
-  it('rejects updates once coding jobs exist for a definition', async () => {
-    jobDefinitionRepository.findOne.mockResolvedValue({
+  it('allows display option updates once coding jobs exist for a definition', async () => {
+    const existingDefinition = {
       id: 2,
       workspace_id: 7,
       status: 'approved',
@@ -1272,9 +1272,100 @@ describe('JobDefinitionService', () => {
       assigned_variable_bundles: [],
       assigned_coders: [1],
       duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+    codingJobService.calculateDistributionVariableUsageBatch.mockClear();
+
+    await expect(service.updateJobDefinition(2, 7, {
+      showScore: true,
+      allowComments: false,
+      suppressGeneralInstructions: true
+    })).resolves.toMatchObject({
+      id: 2,
+      show_score: true,
+      allow_comments: false,
+      suppress_general_instructions: true
+    });
+
+    expect(codingJobService.calculateDistributionVariableUsageBatch).not.toHaveBeenCalled();
+    expect(jobDefinitionRepository.save).toHaveBeenCalled();
+  });
+
+  it('allows saving an existing definition with created jobs when its own cases cover the request', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValueOnce([
+      { unitName: 'Unit 1', variableId: 'Var 1', availableCases: 5 }
+    ]);
+    codingJobService.calculateDistributionVariableUsageBatch.mockResolvedValueOnce(new Map([
+      ['requested', new Map([['Unit 1::Var 1', 5]])]
+    ]));
+
+    await expect(service.updateJobDefinition(2, 7, {
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedVariableBundles: [],
+      maxCodingCases: 5,
+      caseOrderingMode: 'continuous'
+    })).resolves.toMatchObject({
+      id: 2,
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      max_coding_cases: 5,
       case_ordering_mode: 'continuous'
     });
+
+    expect(codingValidationService.getCodingIncompleteVariables).toHaveBeenCalledWith(
+      7,
+      undefined,
+      undefined,
+      false,
+      2
+    );
+    expect(jobDefinitionRepository.save).toHaveBeenCalled();
+  });
+
+  it('still rejects existing definition updates with created jobs when the adjusted pool is insufficient', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
     codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValueOnce([
+      { unitName: 'Unit 1', variableId: 'Var 1', availableCases: 5 }
+    ]);
+    codingJobService.calculateDistributionVariableUsageBatch.mockResolvedValueOnce(new Map([
+      ['requested', new Map([['Unit 2::Var 2', 1]])]
+    ]));
 
     await expect(service.updateJobDefinition(2, 7, {
       assignedVariables: [{ unitName: 'Unit 2', variableId: 'Var 2' }]

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -10,13 +10,24 @@ jest.mock('../coding/coding-validation.service', () => ({
   CodingValidationService: jest.fn()
 }));
 
-const createRepo = () => ({
-  find: jest.fn(),
-  findOne: jest.fn(),
-  create: jest.fn(value => value),
-  save: jest.fn(value => Promise.resolve(value)),
-  remove: jest.fn()
-});
+const createRepo = () => {
+  const repo = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(value => value),
+    save: jest.fn(value => Promise.resolve(value)),
+    remove: jest.fn(),
+    manager: {
+      transaction: jest.fn(async (callback: (manager: {
+        getRepository: jest.Mock;
+      }) => Promise<unknown>) => callback({
+        getRepository: jest.fn(() => repo)
+      }))
+    }
+  };
+
+  return repo;
+};
 
 describe('JobDefinitionService', () => {
   let jobDefinitionRepository: ReturnType<typeof createRepo>;
@@ -25,7 +36,9 @@ describe('JobDefinitionService', () => {
   let codingJobService: {
     createCodingJob: jest.Mock;
     createDistributedCodingJobs: jest.Mock;
+    previewJobDefinitionRefresh: jest.Mock;
     refreshDistributedCodingJobs: jest.Mock;
+    updateCodingJobDisplayOptionsByDefinitionId: jest.Mock;
     calculateDistribution: jest.Mock;
     calculateDistributionVariableUsage: jest.Mock;
     calculateDistributionVariableUsageBatch: jest.Mock;
@@ -45,6 +58,19 @@ describe('JobDefinitionService', () => {
     codingJobService = {
       createCodingJob: jest.fn(),
       createDistributedCodingJobs: jest.fn().mockResolvedValue({ success: true, jobsCreated: 0, jobs: [] }),
+      previewJobDefinitionRefresh: jest.fn().mockResolvedValue({
+        jobDefinitionId: 1,
+        existingJobsCount: 0,
+        staleJobsCount: 0,
+        existingCases: 0,
+        plannedCases: 0,
+        retainedCases: 0,
+        addedCases: 0,
+        removedCases: 0,
+        addedCodingTasks: 0,
+        removedCodingTasks: 0,
+        canApply: true
+      }),
       refreshDistributedCodingJobs: jest.fn().mockResolvedValue({
         success: true,
         jobsCreated: 0,
@@ -63,6 +89,7 @@ describe('JobDefinitionService', () => {
           canApply: true
         }
       }),
+      updateCodingJobDisplayOptionsByDefinitionId: jest.fn().mockResolvedValue(0),
       calculateDistribution: jest.fn().mockResolvedValue({
         distribution: {},
         distributionByCoderId: {},
@@ -1295,7 +1322,291 @@ describe('JobDefinitionService', () => {
     });
 
     expect(codingJobService.calculateDistributionVariableUsageBatch).not.toHaveBeenCalled();
+    expect(codingJobService.updateCodingJobDisplayOptionsByDefinitionId).toHaveBeenCalledWith(
+      7,
+      2,
+      {
+        showScore: true,
+        allowComments: false,
+        suppressGeneralInstructions: true
+      },
+      expect.objectContaining({
+        getRepository: expect.any(Function)
+      })
+    );
+    expect(jobDefinitionRepository.manager.transaction).toHaveBeenCalledTimes(1);
     expect(jobDefinitionRepository.save).toHaveBeenCalled();
+    expect(jobDefinitionRepository.save.mock.calls[0][0]).not.toHaveProperty(
+      'missings_profile_id'
+    );
+  });
+
+  it('keeps existing variable and bundle order when an update only reorders the same selections', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [
+        { unitName: 'Unit 1', variableId: 'Var 1' },
+        { unitName: 'Unit 2', variableId: 'Var 2' }
+      ],
+      assigned_variable_bundles: [
+        { id: 1, name: 'Bundle 1', caseOrderingMode: 'continuous' },
+        { id: 2, name: 'Bundle 2', caseOrderingMode: 'alternating' }
+      ],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous'
+    };
+    const bundles = [
+      {
+        id: 1,
+        name: 'Bundle 1',
+        variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }]
+      },
+      {
+        id: 2,
+        name: 'Bundle 2',
+        variables: [{ unitName: 'Unit 2', variableId: 'Var 2' }]
+      }
+    ];
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    variableBundleRepository.find.mockResolvedValue(bundles);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+
+    await expect(service.updateJobDefinition(2, 7, {
+      assignedVariables: [
+        { unitName: 'Unit 2', variableId: 'Var 2' },
+        { unitName: 'Unit 1', variableId: 'Var 1' }
+      ],
+      assignedVariableBundles: [
+        { id: 2, name: 'Bundle 2', caseOrderingMode: 'alternating' },
+        { id: 1, name: 'Bundle 1', caseOrderingMode: 'continuous' }
+      ]
+    })).resolves.toMatchObject({ id: 2 });
+
+    expect(jobDefinitionRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+      assigned_variables: [
+        { unitName: 'Unit 1', variableId: 'Var 1' },
+        { unitName: 'Unit 2', variableId: 'Var 2' }
+      ],
+      assigned_variable_bundles: [
+        { id: 1, name: 'Bundle 1', caseOrderingMode: 'continuous' },
+        { id: 2, name: 'Bundle 2', caseOrderingMode: 'alternating' }
+      ]
+    }));
+  });
+
+  it('rejects distribution-relevant direct updates once coding jobs exist for a definition', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+
+    await expect(service.updateJobDefinition(2, 7, {
+      maxCodingCases: 4
+    })).rejects.toThrow(/must be refreshed/);
+
+    expect(jobDefinitionRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('previews refresh for proposed distribution-relevant updates', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+
+    await expect(service.previewJobDefinitionUpdateRefresh(2, 7, {
+      maxCodingCases: 4
+    })).resolves.toMatchObject({
+      canApply: true
+    });
+
+    expect(codingJobService.previewJobDefinitionRefresh).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        jobDefinitionId: 2,
+        maxCodingCases: 4,
+        distributionSeed: 'seed-2',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }]
+      })
+    );
+  });
+
+  it('keeps bundle order while applying proposed bundle mode changes in update refresh previews', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [],
+      assigned_variable_bundles: [
+        { id: 1, name: 'Bundle 1', caseOrderingMode: 'continuous' },
+        { id: 2, name: 'Bundle 2', caseOrderingMode: 'continuous' }
+      ],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2'
+    };
+    const bundles = [
+      {
+        id: 2,
+        name: 'Bundle 2',
+        variables: [{ unitName: 'Unit 2', variableId: 'Var 2' }]
+      },
+      {
+        id: 1,
+        name: 'Bundle 1',
+        variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }]
+      }
+    ];
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    variableBundleRepository.find.mockResolvedValue(bundles);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+
+    await expect(service.previewJobDefinitionUpdateRefresh(2, 7, {
+      assignedVariableBundles: [
+        { id: 2, name: 'Bundle 2', caseOrderingMode: 'alternating' },
+        { id: 1, name: 'Bundle 1', caseOrderingMode: 'continuous' }
+      ]
+    })).resolves.toMatchObject({
+      canApply: true
+    });
+
+    expect(codingJobService.previewJobDefinitionRefresh).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        selectedVariableBundles: [
+          expect.objectContaining({ id: 1, caseOrderingMode: 'continuous' }),
+          expect.objectContaining({ id: 2, caseOrderingMode: 'alternating' })
+        ]
+      })
+    );
+  });
+
+  it('applies proposed definition updates inside the refresh transaction', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      assigned_coder_configs: [{ coderId: 1, capacityPercent: 100 }],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
+    };
+    const refreshResult = {
+      success: true,
+      jobsCreated: 1,
+      message: 'Updated',
+      distribution: { 'Unit 1::Var 1': { 'Coder 1': 1 } },
+      distributionByCoderId: { 'Unit 1::Var 1': { 1: 1 } },
+      doubleCodingInfo: {},
+      aggregationInfo: {},
+      matchingFlags: [],
+      pairDistribution: {},
+      tasksPerCoder: {},
+      coderWeights: {},
+      jobs: [],
+      preview: {
+        jobDefinitionId: 2,
+        existingJobsCount: 1,
+        staleJobsCount: 1,
+        existingCases: 5,
+        plannedCases: 4,
+        retainedCases: 4,
+        addedCases: 0,
+        removedCases: 1,
+        addedCodingTasks: 0,
+        removedCodingTasks: 1,
+        canApply: true
+      }
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+    codingJobService.refreshDistributedCodingJobs.mockImplementation(
+      async (_workspaceId, _request, afterRefreshInTransaction) => {
+        if (afterRefreshInTransaction) {
+          await afterRefreshInTransaction(
+            { getRepository: () => jobDefinitionRepository } as never,
+            refreshResult
+          );
+        }
+
+        return refreshResult;
+      }
+    );
+
+    await expect(service.refreshCodingJobFromUpdatedDefinition(2, 7, {
+      maxCodingCases: 4
+    })).resolves.toMatchObject({
+      success: true,
+      jobsCreated: 1
+    });
+
+    expect(codingJobService.refreshDistributedCodingJobs).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        jobDefinitionId: 2,
+        maxCodingCases: 4,
+        distributionSeed: 'seed-2'
+      }),
+      expect.any(Function)
+    );
+    expect(jobDefinitionRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+      id: 2,
+      max_coding_cases: 4
+    }));
+    expect(jobDefinitionRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+      distribution_snapshots: [
+        expect.objectContaining({
+          source: 'refresh',
+          settings: expect.objectContaining({
+            maxCodingCases: 4
+          }),
+          refreshPreview: expect.objectContaining({
+            removedCases: 1
+          })
+        })
+      ]
+    }));
   });
 
   it('allows saving an existing definition with created jobs when its own cases cover the request', async () => {

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -82,6 +82,29 @@ interface JobDefinitionValidationState {
   caseOrderingMode?: CaseOrderingMode;
 }
 
+type ExistingJobBoundUpdateField =
+  | 'status'
+  | 'assignedVariables'
+  | 'assignedVariableBundles'
+  | 'assignedCoders'
+  | 'assignedCoderConfigs'
+  | 'missingsProfileId'
+  | 'maxCodingCases'
+  | 'doubleCodingAbsolute'
+  | 'doubleCodingPercentage'
+  | 'caseOrderingMode';
+
+interface PreparedJobDefinitionUpdate {
+  existingDefinition: JobDefinition;
+  updatedDefinition: JobDefinition;
+  nextState: JobDefinitionValidationState;
+  nextCoderAssignments: ResolvedCoderAssignments;
+  nextMissingsProfileId: number | undefined;
+  distributionSeed: string;
+  createdJobsCount: number;
+  changedExistingJobBoundFields: ExistingJobBoundUpdateField[];
+}
+
 interface VariableConflictCheckRequest {
   jobDefinitionId?: number;
   assignedVariables: JobDefinitionVariable[];
@@ -1141,24 +1164,340 @@ export class JobDefinitionService {
     }
   }
 
-  async updateJobDefinition(id: number, workspaceId: number, updateDto: UpdateJobDefinitionDto): Promise<JobDefinition> {
+  private toStoredAssignedVariableBundles(
+    bundles?: JobDefinitionVariableBundle[]
+  ): JobDefinitionVariableBundle[] {
+    return (bundles || []).map(bundle => ({
+      id: bundle.id,
+      name: bundle.name,
+      caseOrderingMode: bundle.caseOrderingMode
+    }));
+  }
+
+  private normalizeVariablesForComparison(
+    variables?: JobDefinitionVariable[]
+  ): JobDefinitionVariable[] {
+    return (variables || []).map(variable => ({
+      unitName: variable.unitName,
+      variableId: variable.variableId,
+      ...(variable.includeDeriveError === true ?
+        { includeDeriveError: true } :
+        {})
+    })).sort((left, right) => `${left.unitName}::${left.variableId}`
+      .localeCompare(`${right.unitName}::${right.variableId}`));
+  }
+
+  private normalizeBundlesForComparison(
+    bundles?: JobDefinitionVariableBundle[]
+  ): { id: number; caseOrderingMode?: CaseOrderingMode }[] {
+    return (bundles || [])
+      .map(bundle => ({
+        id: Number(bundle.id),
+        caseOrderingMode: bundle.caseOrderingMode
+      }))
+      .sort((left, right) => left.id - right.id);
+  }
+
+  private getVariableSelectionKey(variable: JobDefinitionVariable): string {
+    return `${variable.unitName}::${variable.variableId}`;
+  }
+
+  private normalizeVariableForSave(
+    variable: JobDefinitionVariable
+  ): JobDefinitionVariable {
+    return {
+      unitName: variable.unitName,
+      variableId: variable.variableId,
+      ...(variable.includeDeriveError === true ?
+        { includeDeriveError: true } :
+        {})
+    };
+  }
+
+  private haveSameVariableSelection(
+    currentVariables?: JobDefinitionVariable[],
+    proposedVariables?: JobDefinitionVariable[]
+  ): boolean {
+    const currentKeys = (currentVariables || [])
+      .map(variable => this.getVariableSelectionKey(variable))
+      .sort((left, right) => left.localeCompare(right));
+    const proposedKeys = (proposedVariables || [])
+      .map(variable => this.getVariableSelectionKey(variable))
+      .sort((left, right) => left.localeCompare(right));
+
+    return this.valuesDiffer(currentKeys, proposedKeys) === false;
+  }
+
+  private getAssignedVariablesForSave(
+    currentVariables?: JobDefinitionVariable[],
+    proposedVariables?: JobDefinitionVariable[]
+  ): JobDefinitionVariable[] {
+    if (!this.haveSameVariableSelection(currentVariables, proposedVariables)) {
+      return (proposedVariables || []).map(variable => this.normalizeVariableForSave(variable));
+    }
+
+    const proposedByKey = new Map(
+      (proposedVariables || []).map(variable => [
+        this.getVariableSelectionKey(variable),
+        this.normalizeVariableForSave(variable)
+      ])
+    );
+
+    return (currentVariables || []).map(currentVariable => {
+      const key = this.getVariableSelectionKey(currentVariable);
+      return proposedByKey.get(key) ||
+        this.normalizeVariableForSave(currentVariable);
+    });
+  }
+
+  private haveSameBundleSelection(
+    currentBundles?: JobDefinitionVariableBundle[],
+    proposedBundles?: JobDefinitionVariableBundle[]
+  ): boolean {
+    const currentIds = (currentBundles || [])
+      .map(bundle => Number(bundle.id))
+      .sort((left, right) => left - right);
+    const proposedIds = (proposedBundles || [])
+      .map(bundle => Number(bundle.id))
+      .sort((left, right) => left - right);
+
+    return this.valuesDiffer(currentIds, proposedIds) === false;
+  }
+
+  private getAssignedVariableBundlesForSave(
+    currentBundles?: JobDefinitionVariableBundle[],
+    proposedBundles?: JobDefinitionVariableBundle[]
+  ): JobDefinitionVariableBundle[] {
+    if (!this.haveSameBundleSelection(currentBundles, proposedBundles)) {
+      return this.toStoredAssignedVariableBundles(proposedBundles);
+    }
+
+    const proposedById = new Map(
+      (proposedBundles || []).map(bundle => [Number(bundle.id), bundle])
+    );
+
+    return (currentBundles || []).map(currentBundle => {
+      const proposedBundle = proposedById.get(Number(currentBundle.id));
+      return {
+        id: currentBundle.id,
+        name: currentBundle.name,
+        caseOrderingMode: proposedBundle?.caseOrderingMode
+      };
+    });
+  }
+
+  private valuesDiffer(first: unknown, second: unknown): boolean {
+    return JSON.stringify(first) !== JSON.stringify(second);
+  }
+
+  private doubleCodingValue(value: unknown): number {
+    return Number(this.toOptionalNumber(value) || 0);
+  }
+
+  private async getCreatedJobsCount(jobDefinition: JobDefinition): Promise<number> {
+    const countsByDefinitionId = await this.codingJobService.getCodingJobCountsByDefinitionIds(
+      jobDefinition.workspace_id,
+      [jobDefinition.id]
+    );
+    return countsByDefinitionId.get(jobDefinition.id) || 0;
+  }
+
+  private collectExistingJobBoundChanges(
+    jobDefinition: JobDefinition,
+    updateDto: UpdateJobDefinitionDto,
+    nextCoderAssignments: ResolvedCoderAssignments,
+    currentMissingsProfileId: number | undefined,
+    nextMissingsProfileId: number | undefined
+  ): ExistingJobBoundUpdateField[] {
+    const changedFields: ExistingJobBoundUpdateField[] = [];
+
+    if (
+      updateDto.status !== undefined &&
+      updateDto.status !== jobDefinition.status
+    ) {
+      changedFields.push('status');
+    }
+
+    if (
+      updateDto.assignedVariables !== undefined &&
+      this.valuesDiffer(
+        this.normalizeVariablesForComparison(jobDefinition.assigned_variables),
+        this.normalizeVariablesForComparison(updateDto.assignedVariables)
+      )
+    ) {
+      changedFields.push('assignedVariables');
+    }
+
+    if (
+      updateDto.assignedVariableBundles !== undefined &&
+      this.valuesDiffer(
+        this.normalizeBundlesForComparison(jobDefinition.assigned_variable_bundles),
+        this.normalizeBundlesForComparison(updateDto.assignedVariableBundles)
+      )
+    ) {
+      changedFields.push('assignedVariableBundles');
+    }
+
+    if (
+      (updateDto.assignedCoders !== undefined ||
+        updateDto.assignedCoderConfigs !== undefined) &&
+      this.valuesDiffer(
+        this.getStoredCoderAssignments(jobDefinition).assignedCoders,
+        nextCoderAssignments.assignedCoders
+      )
+    ) {
+      changedFields.push('assignedCoders');
+    }
+
+    if (
+      updateDto.assignedCoderConfigs !== undefined &&
+      this.valuesDiffer(
+        this.getStoredCoderAssignments(jobDefinition).assignedCoderConfigs,
+        nextCoderAssignments.assignedCoderConfigs
+      )
+    ) {
+      changedFields.push('assignedCoderConfigs');
+    }
+
+    if (
+      updateDto.missingsProfileId !== undefined &&
+      currentMissingsProfileId !== nextMissingsProfileId
+    ) {
+      changedFields.push('missingsProfileId');
+    }
+
+    if (
+      updateDto.maxCodingCases !== undefined &&
+      updateDto.maxCodingCases !== jobDefinition.max_coding_cases
+    ) {
+      changedFields.push('maxCodingCases');
+    }
+
+    if (
+      updateDto.doubleCodingAbsolute !== undefined &&
+      this.doubleCodingValue(updateDto.doubleCodingAbsolute) !==
+        this.doubleCodingValue(jobDefinition.double_coding_absolute)
+    ) {
+      changedFields.push('doubleCodingAbsolute');
+    }
+
+    if (
+      updateDto.doubleCodingPercentage !== undefined &&
+      this.doubleCodingValue(updateDto.doubleCodingPercentage) !==
+        this.doubleCodingValue(jobDefinition.double_coding_percentage)
+    ) {
+      changedFields.push('doubleCodingPercentage');
+    }
+
+    if (
+      updateDto.caseOrderingMode !== undefined &&
+      updateDto.caseOrderingMode !== jobDefinition.case_ordering_mode
+    ) {
+      changedFields.push('caseOrderingMode');
+    }
+
+    return changedFields;
+  }
+
+  private buildUpdatedDefinitionForSave(
+    jobDefinition: JobDefinition,
+    updateDto: UpdateJobDefinitionDto,
+    nextState: JobDefinitionValidationState,
+    nextCoderAssignments: ResolvedCoderAssignments,
+    nextMissingsProfileId: number | undefined
+  ): JobDefinition {
+    const updatedDefinition = {
+      ...jobDefinition,
+      assigned_variable_bundles: this.toStoredAssignedVariableBundles(
+        nextState.assignedVariableBundles
+      )
+    } as JobDefinition;
+
+    if (updateDto.status !== undefined) {
+      updatedDefinition.status = updateDto.status;
+    }
+    if (updateDto.assignedVariables !== undefined) {
+      updatedDefinition.assigned_variables = nextState.assignedVariables;
+    }
+    if (updateDto.assignedVariableBundles !== undefined) {
+      updatedDefinition.assigned_variable_bundles =
+        this.toStoredAssignedVariableBundles(nextState.assignedVariableBundles);
+    }
+    if (
+      updateDto.assignedCoders !== undefined ||
+      updateDto.assignedCoderConfigs !== undefined
+    ) {
+      updatedDefinition.assigned_coders = nextCoderAssignments.assignedCoders;
+      updatedDefinition.assigned_coder_configs =
+        nextCoderAssignments.assignedCoderConfigs;
+    }
+    if (updateDto.durationSeconds !== undefined) {
+      updatedDefinition.duration_seconds = updateDto.durationSeconds;
+    }
+    if (updateDto.maxCodingCases !== undefined) {
+      updatedDefinition.max_coding_cases = updateDto.maxCodingCases;
+    }
+    if (updateDto.doubleCodingAbsolute !== undefined) {
+      updatedDefinition.double_coding_absolute = updateDto.doubleCodingAbsolute;
+    }
+    if (updateDto.doubleCodingPercentage !== undefined) {
+      updatedDefinition.double_coding_percentage = updateDto.doubleCodingPercentage;
+    }
+    if (updateDto.caseOrderingMode !== undefined) {
+      updatedDefinition.case_ordering_mode = updateDto.caseOrderingMode;
+    }
+    if (updateDto.missingsProfileId !== undefined) {
+      updatedDefinition.missings_profile_id = nextMissingsProfileId;
+    }
+    if (updateDto.showScore !== undefined) {
+      updatedDefinition.show_score = updateDto.showScore;
+    }
+    if (updateDto.allowComments !== undefined) {
+      updatedDefinition.allow_comments = updateDto.allowComments;
+    }
+    if (updateDto.suppressGeneralInstructions !== undefined) {
+      updatedDefinition.suppress_general_instructions =
+        updateDto.suppressGeneralInstructions;
+    }
+
+    return updatedDefinition;
+  }
+
+  private async prepareJobDefinitionUpdate(
+    id: number,
+    workspaceId: number,
+    updateDto: UpdateJobDefinitionDto
+  ): Promise<PreparedJobDefinitionUpdate> {
     const jobDefinition = await this.getJobDefinition(id, workspaceId);
     const existingCoderAssignments = this.getStoredCoderAssignments(jobDefinition);
     const nextCoderAssignments = this.resolveCoderAssignments(updateDto, existingCoderAssignments);
     const distributionSeed = this.getDefinitionDistributionSeed(jobDefinition);
+    const currentMissingsProfileId = await this.missingsProfilesService.resolveMissingsProfileId(
+      jobDefinition.workspace_id,
+      jobDefinition.missings_profile_id
+    );
     const nextMissingsProfileId = updateDto.missingsProfileId !== undefined ?
       await this.missingsProfilesService.resolveMissingsProfileId(
         jobDefinition.workspace_id,
         updateDto.missingsProfileId
       ) :
-      await this.missingsProfilesService.resolveMissingsProfileId(
-        jobDefinition.workspace_id,
-        jobDefinition.missings_profile_id
-      );
+      currentMissingsProfileId;
+    const nextAssignedVariables = updateDto.assignedVariables !== undefined ?
+      this.getAssignedVariablesForSave(
+        jobDefinition.assigned_variables,
+        updateDto.assignedVariables
+      ) :
+      jobDefinition.assigned_variables ?? [];
+    const nextAssignedVariableBundles = updateDto.assignedVariableBundles !== undefined ?
+      this.getAssignedVariableBundlesForSave(
+        jobDefinition.assigned_variable_bundles,
+        updateDto.assignedVariableBundles
+      ) :
+      this.toStoredAssignedVariableBundles(jobDefinition.assigned_variable_bundles);
     const nextState: JobDefinitionValidationState = {
       status: updateDto.status ?? jobDefinition.status,
-      assignedVariables: updateDto.assignedVariables ?? jobDefinition.assigned_variables ?? [],
-      assignedVariableBundles: updateDto.assignedVariableBundles ?? jobDefinition.assigned_variable_bundles ?? [],
+      assignedVariables: nextAssignedVariables,
+      assignedVariableBundles: nextAssignedVariableBundles,
       assignedCoders: nextCoderAssignments.assignedCoders,
       durationSeconds: updateDto.durationSeconds ?? jobDefinition.duration_seconds,
       maxCodingCases: updateDto.maxCodingCases ?? jobDefinition.max_coding_cases,
@@ -1233,55 +1572,101 @@ export class JobDefinitionService {
       } as JobDefinition);
     }
 
-    if (updateDto.status !== undefined) {
-      jobDefinition.status = updateDto.status;
-    }
-    if (updateDto.assignedVariables !== undefined) {
-      jobDefinition.assigned_variables = updateDto.assignedVariables;
-    }
-    if (updateDto.assignedVariableBundles !== undefined) {
-      jobDefinition.assigned_variable_bundles = updateDto.assignedVariableBundles?.map(bundle => ({
-        id: bundle.id,
-        name: bundle.name,
-        caseOrderingMode: bundle.caseOrderingMode as CaseOrderingMode
-      }));
-    }
-    if (updateDto.assignedCoders !== undefined) {
-      jobDefinition.assigned_coders = nextCoderAssignments.assignedCoders;
-      jobDefinition.assigned_coder_configs = nextCoderAssignments.assignedCoderConfigs;
-    }
-    if (updateDto.assignedCoderConfigs !== undefined) {
-      jobDefinition.assigned_coders = nextCoderAssignments.assignedCoders;
-      jobDefinition.assigned_coder_configs = nextCoderAssignments.assignedCoderConfigs;
-    }
-    jobDefinition.missings_profile_id = nextMissingsProfileId;
-    if (updateDto.durationSeconds !== undefined) {
-      jobDefinition.duration_seconds = updateDto.durationSeconds;
-    }
-    if (updateDto.maxCodingCases !== undefined) {
-      jobDefinition.max_coding_cases = updateDto.maxCodingCases;
-    }
-    if (updateDto.doubleCodingAbsolute !== undefined) {
-      jobDefinition.double_coding_absolute = updateDto.doubleCodingAbsolute;
-    }
-    if (updateDto.doubleCodingPercentage !== undefined) {
-      jobDefinition.double_coding_percentage = updateDto.doubleCodingPercentage;
-    }
-    if (updateDto.caseOrderingMode !== undefined) {
-      jobDefinition.case_ordering_mode = updateDto.caseOrderingMode;
-    }
-    if (updateDto.showScore !== undefined) {
-      jobDefinition.show_score = updateDto.showScore;
-    }
-    if (updateDto.allowComments !== undefined) {
-      jobDefinition.allow_comments = updateDto.allowComments;
-    }
-    if (updateDto.suppressGeneralInstructions !== undefined) {
-      jobDefinition.suppress_general_instructions = updateDto.suppressGeneralInstructions;
+    const changedExistingJobBoundFields = this.collectExistingJobBoundChanges(
+      jobDefinition,
+      updateDto,
+      nextCoderAssignments,
+      currentMissingsProfileId,
+      nextMissingsProfileId
+    );
+
+    return {
+      existingDefinition: jobDefinition,
+      updatedDefinition: this.buildUpdatedDefinitionForSave(
+        jobDefinition,
+        updateDto,
+        nextState,
+        nextCoderAssignments,
+        nextMissingsProfileId
+      ),
+      nextState,
+      nextCoderAssignments,
+      nextMissingsProfileId,
+      distributionSeed,
+      createdJobsCount: await this.getCreatedJobsCount(jobDefinition),
+      changedExistingJobBoundFields
+    };
+  }
+
+  private assertUpdateRefreshIsRequired(
+    jobDefinitionId: number,
+    preparedUpdate: PreparedJobDefinitionUpdate
+  ): void {
+    if (preparedUpdate.createdJobsCount === 0) {
+      throw new BadRequestException(
+        `Cannot refresh coding jobs for job definition ${jobDefinitionId} because no coding jobs exist.`
+      );
     }
 
-    const savedDefinition = await this.jobDefinitionRepository.save(jobDefinition);
-    return savedDefinition;
+    if (preparedUpdate.changedExistingJobBoundFields.length === 0) {
+      throw new BadRequestException(
+        'The proposed update does not require regenerating coding jobs.'
+      );
+    }
+
+    if (preparedUpdate.changedExistingJobBoundFields.includes('status')) {
+      throw new BadRequestException(
+        'Status changes for job definitions with existing coding jobs are not part of the refresh flow.'
+      );
+    }
+  }
+
+  async updateJobDefinition(id: number, workspaceId: number, updateDto: UpdateJobDefinitionDto): Promise<JobDefinition> {
+    const preparedUpdate = await this.prepareJobDefinitionUpdate(
+      id,
+      workspaceId,
+      updateDto
+    );
+    if (
+      preparedUpdate.createdJobsCount > 0 &&
+      preparedUpdate.changedExistingJobBoundFields.length > 0
+    ) {
+      throw new BadRequestException(
+        `Cannot update job definition ${id} because existing coding jobs must be refreshed for changes to: ${preparedUpdate.changedExistingJobBoundFields.join(', ')}`
+      );
+    }
+
+    const syncExistingJobDisplayOptions = preparedUpdate.createdJobsCount > 0 &&
+      (
+        updateDto.showScore !== undefined ||
+        updateDto.allowComments !== undefined ||
+        updateDto.suppressGeneralInstructions !== undefined
+      );
+
+    if (syncExistingJobDisplayOptions) {
+      return this.jobDefinitionRepository.manager.transaction(async manager => {
+        const savedDefinition = await manager
+          .getRepository(JobDefinition)
+          .save(preparedUpdate.updatedDefinition);
+
+        await this.codingJobService.updateCodingJobDisplayOptionsByDefinitionId(
+          workspaceId,
+          id,
+          {
+            showScore: updateDto.showScore,
+            allowComments: updateDto.allowComments,
+            suppressGeneralInstructions: updateDto.suppressGeneralInstructions
+          },
+          manager
+        );
+
+        return savedDefinition;
+      });
+    }
+
+    return this.jobDefinitionRepository.save(
+      preparedUpdate.updatedDefinition
+    );
   }
 
   async approveJobDefinition(id: number, workspaceId: number, approveDto: ApproveJobDefinitionDto): Promise<JobDefinition> {
@@ -1398,9 +1783,11 @@ export class JobDefinitionService {
 
   private async buildDistributionRequestFromDefinition(
     jobDefinitionId: number,
-    workspaceId: number
+    workspaceId: number,
+    providedJobDefinition?: JobDefinition
   ): Promise<DefinitionDistributionRequest> {
-    const jobDefinition = await this.getJobDefinition(jobDefinitionId, workspaceId);
+    const jobDefinition = providedJobDefinition ||
+      await this.getJobDefinition(jobDefinitionId, workspaceId);
 
     if (jobDefinition.status !== 'approved') {
       throw new BadRequestException('Only approved job definitions can be used to create coding jobs');
@@ -1412,17 +1799,28 @@ export class JobDefinitionService {
         where: { id: In(variableBundleIds) }
       }) :
       [];
+    const fullVariableBundlesById = new Map(
+      fullVariableBundles.map(bundle => [bundle.id, bundle])
+    );
 
     const savedBundleModes = new Map(
       (jobDefinition.assigned_variable_bundles || [])
         .map(bundle => [bundle.id, bundle.caseOrderingMode])
     );
-    const hydratedBundles = fullVariableBundles.map(bundle => ({
-      id: bundle.id,
-      name: bundle.name,
-      variables: bundle.variables || [],
-      caseOrderingMode: savedBundleModes.get(bundle.id)
-    }));
+    const hydratedBundles = (jobDefinition.assigned_variable_bundles || [])
+      .map((savedBundle): JobDefinitionDistributionVariableBundle | undefined => {
+        const fullBundle = fullVariableBundlesById.get(savedBundle.id);
+        if (!fullBundle) {
+          return undefined;
+        }
+        return {
+          id: fullBundle.id,
+          name: fullBundle.name,
+          variables: fullBundle.variables || [],
+          caseOrderingMode: savedBundleModes.get(fullBundle.id)
+        };
+      })
+      .filter((bundle): bundle is JobDefinitionDistributionVariableBundle => bundle !== undefined);
     const variableSelection = this.buildDistributionVariableSelection(
       jobDefinition.assigned_variables || [],
       hydratedBundles
@@ -1503,6 +1901,31 @@ export class JobDefinitionService {
     return this.codingJobService.previewJobDefinitionRefresh(workspaceId, request);
   }
 
+  async previewJobDefinitionUpdateRefresh(
+    jobDefinitionId: number,
+    workspaceId: number,
+    updateDto: UpdateJobDefinitionDto
+  ): Promise<JobDefinitionRefreshPreviewDto> {
+    const preparedUpdate = await this.prepareJobDefinitionUpdate(
+      jobDefinitionId,
+      workspaceId,
+      updateDto
+    );
+
+    this.assertUpdateRefreshIsRequired(jobDefinitionId, preparedUpdate);
+
+    const request = await this.buildDistributionRequestFromDefinition(
+      jobDefinitionId,
+      workspaceId,
+      preparedUpdate.updatedDefinition
+    );
+
+    return this.codingJobService.previewJobDefinitionRefresh(
+      workspaceId,
+      request
+    );
+  }
+
   async refreshCodingJobFromDefinition(
     jobDefinitionId: number,
     workspaceId: number
@@ -1521,6 +1944,53 @@ export class JobDefinitionService {
         );
       }
     );
+    if (!result.success) {
+      throw new BadRequestException(result.message);
+    }
+
+    return {
+      success: true,
+      message: `Updated job definition ${jobDefinitionId}: created ${result.jobsCreated} coding jobs.`,
+      preview: result.preview,
+      jobsCreated: result.jobsCreated
+    };
+  }
+
+  async refreshCodingJobFromUpdatedDefinition(
+    jobDefinitionId: number,
+    workspaceId: number,
+    updateDto: UpdateJobDefinitionDto
+  ): Promise<JobDefinitionRefreshApplyResultDto> {
+    const preparedUpdate = await this.prepareJobDefinitionUpdate(
+      jobDefinitionId,
+      workspaceId,
+      updateDto
+    );
+
+    this.assertUpdateRefreshIsRequired(jobDefinitionId, preparedUpdate);
+
+    const request = await this.buildDistributionRequestFromDefinition(
+      jobDefinitionId,
+      workspaceId,
+      preparedUpdate.updatedDefinition
+    );
+    const result = await this.codingJobService.refreshDistributedCodingJobs(
+      workspaceId,
+      request,
+      async (manager, transactionResult) => {
+        await manager.getRepository(JobDefinition).save(
+          preparedUpdate.updatedDefinition
+        );
+        await this.appendDistributionSnapshot(
+          jobDefinitionId,
+          'refresh',
+          request,
+          transactionResult,
+          manager
+        );
+      }
+    );
+
     if (!result.success) {
       throw new BadRequestException(result.message);
     }

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -100,6 +100,7 @@ type PlannedVariableUsageBatchRequest = {
   maxCodingCases?: number;
   caseOrderingMode?: CaseOrderingMode;
   jobDefinitionId?: number;
+  excludeJobDefinitionId?: number;
   distributionSeed?: string;
 };
 
@@ -206,7 +207,13 @@ export class JobDefinitionService {
       request.assignedVariableBundles,
       request.requireAssignedBundles
     );
-    const incompleteVariables = await this.codingValidationService.getCodingIncompleteVariables(workspaceId);
+    const incompleteVariables = await this.codingValidationService.getCodingIncompleteVariables(
+      workspaceId,
+      undefined,
+      undefined,
+      false,
+      request.excludeJobDefinitionId
+    );
     const availableCasesByVariable = new Map(
       incompleteVariables.map(variable => [
         this.makeVariableKey(variable.unitName, variable.variableId),
@@ -238,6 +245,9 @@ export class JobDefinitionService {
         distribution_seed: request.distributionSeed
       }
     );
+    if (request.excludeJobDefinitionId !== undefined) {
+      requestedUsageRequest.excludeJobDefinitionId = request.excludeJobDefinitionId;
+    }
     const existingUsageRequests = (await Promise.all(
       existingDefinitions.map(async definition => {
         if (definition.id === request.excludeJobDefinitionId) {
@@ -1117,20 +1127,6 @@ export class JobDefinitionService {
     return this.attachCreatedJobsCounts(definitions);
   }
 
-  private async assertJobDefinitionHasNoCreatedJobs(jobDefinition: JobDefinition): Promise<void> {
-    const countsByDefinitionId = await this.codingJobService.getCodingJobCountsByDefinitionIds(
-      jobDefinition.workspace_id,
-      [jobDefinition.id]
-    );
-    const createdJobsCount = countsByDefinitionId.get(jobDefinition.id) || 0;
-
-    if (createdJobsCount > 0) {
-      throw new BadRequestException(
-        `Cannot modify job definition ${jobDefinition.id} because ${createdJobsCount} coding jobs already exist`
-      );
-    }
-  }
-
   private async assertJobDefinitionHasNoBlockingCreatedJobs(jobDefinition: JobDefinition): Promise<void> {
     const countsByDefinitionId = await this.codingJobService.getBlockingCodingJobCountsByDefinitionIds(
       jobDefinition.workspace_id,
@@ -1147,7 +1143,6 @@ export class JobDefinitionService {
 
   async updateJobDefinition(id: number, workspaceId: number, updateDto: UpdateJobDefinitionDto): Promise<JobDefinition> {
     const jobDefinition = await this.getJobDefinition(id, workspaceId);
-    await this.assertJobDefinitionHasNoCreatedJobs(jobDefinition);
     const existingCoderAssignments = this.getStoredCoderAssignments(jobDefinition);
     const nextCoderAssignments = this.resolveCoderAssignments(updateDto, existingCoderAssignments);
     const distributionSeed = this.getDefinitionDistributionSeed(jobDefinition);

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.html
@@ -11,7 +11,14 @@
   </h2>
   <mat-divider></mat-divider>
 
-  @if (isReadOnly && data.mode === 'definition') {
+  @if (hasExistingDefinitionJobs) {
+  <div class="readonly-definition-note">
+    <mat-icon>info</mat-icon>
+    <span>{{ 'coding-job-definition-dialog.existing-jobs-definition-note' | translate }}</span>
+  </div>
+  }
+
+  @if (isReadOnly && data.mode === 'definition' && !hasExistingDefinitionJobs) {
   <div class="readonly-definition-note">
     <mat-icon>lock</mat-icon>
     <span>{{ 'coding-job-definition-dialog.readonly-definition-note' | translate }}</span>
@@ -129,7 +136,7 @@
 
         <mat-divider class="section-divider"></mat-divider>
 
-        @if (data.isEdit && data.mode === 'definition') {
+        @if (data.isEdit && data.mode === 'definition' && !hasExistingDefinitionJobs) {
         <mat-form-field appearance="fill" class="full-width">
           <mat-label>{{ 'coding-job-definition-dialog.form-fields.status-label' | translate }}</mat-label>
           <mat-select formControlName="status">

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
@@ -116,7 +116,9 @@ describe('CodingJobDefinitionDialogComponent', () => {
       updateCodingJob: jest.fn(),
       createJobDefinition: jest.fn(),
       createCodingJob: jest.fn(),
-      updateJobDefinition: jest.fn()
+      updateJobDefinition: jest.fn(),
+      previewJobDefinitionUpdateRefresh: jest.fn(),
+      applyJobDefinitionUpdateRefresh: jest.fn()
     } as unknown as Partial<CodingJobBackendService>;
 
     mockDistributedCodingService = {
@@ -225,6 +227,30 @@ describe('CodingJobDefinitionDialogComponent', () => {
     });
 
     expect(fixture.nativeElement.querySelector('.readonly-definition-note')).toBeTruthy();
+  });
+
+  it('shows a guided refresh note for editable definitions with existing jobs', () => {
+    createComponent({
+      isEdit: true,
+      mode: 'definition',
+      jobDefinitionId: 55,
+      createdJobsCount: 2,
+      codingJob: {
+        id: 55,
+        status: 'approved',
+        assignedCoders: [1],
+        assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        missingsProfileId: 7,
+        maxCodingCases: 5,
+        doubleCodingAbsolute: 0,
+        doubleCodingPercentage: 0,
+        caseOrderingMode: 'continuous'
+      } as CodingJob
+    });
+
+    expect(component.hasExistingDefinitionJobs).toBe(true);
+    expect(fixture.nativeElement.querySelector('.readonly-definition-note')).toBeTruthy();
+    expect(component.codingJobForm.get('status')?.disabled).toBe(true);
   });
 
   it('should initialize form with default values', () => {
@@ -510,6 +536,118 @@ describe('CodingJobDefinitionDialogComponent', () => {
       assignedCoders: [1],
       assignedCoderConfigs: [{ coderId: 1, capacityPercent: 50 }]
     }));
+  });
+
+  it('saves display-only definition updates directly when coding jobs exist', fakeAsync(() => {
+    createComponent({
+      isEdit: true,
+      mode: 'definition',
+      jobDefinitionId: 55,
+      createdJobsCount: 2,
+      codingJob: {
+        id: 55,
+        status: 'approved',
+        assignedCoders: [1],
+        assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        missingsProfileId: 7,
+        maxCodingCases: 5,
+        doubleCodingAbsolute: 0,
+        doubleCodingPercentage: 0,
+        caseOrderingMode: 'continuous',
+        showScore: false,
+        allowComments: true,
+        suppressGeneralInstructions: false
+      } as CodingJob
+    });
+    (mockCodingJobBackendService.updateJobDefinition as jest.Mock).mockReturnValue(of({ id: 55 }));
+
+    component.codingJobForm.patchValue({ showScore: true });
+    component.onSubmit();
+    tick();
+
+    expect(mockCodingJobBackendService.updateJobDefinition).toHaveBeenCalledWith(
+      1,
+      55,
+      expect.objectContaining({
+        showScore: true
+      })
+    );
+    expect(mockCodingJobBackendService.updateJobDefinition).toHaveBeenCalledWith(
+      1,
+      55,
+      expect.not.objectContaining({
+        maxCodingCases: expect.anything(),
+        assignedVariables: expect.anything()
+      })
+    );
+    expect(mockCodingJobBackendService.previewJobDefinitionUpdateRefresh).not.toHaveBeenCalled();
+  }));
+
+  it('previews and applies distribution-relevant definition updates when coding jobs exist', async () => {
+    const preview = {
+      jobDefinitionId: 55,
+      existingJobsCount: 2,
+      staleJobsCount: 1,
+      existingCases: 5,
+      plannedCases: 4,
+      retainedCases: 4,
+      addedCases: 0,
+      removedCases: 1,
+      addedCodingTasks: 0,
+      removedCodingTasks: 1,
+      canApply: true
+    };
+    createComponent({
+      isEdit: true,
+      mode: 'definition',
+      jobDefinitionId: 55,
+      createdJobsCount: 2,
+      codingJob: {
+        id: 55,
+        status: 'approved',
+        assignedCoders: [1],
+        assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        missingsProfileId: 7,
+        maxCodingCases: 5,
+        doubleCodingAbsolute: 0,
+        doubleCodingPercentage: 0,
+        caseOrderingMode: 'continuous',
+        showScore: false,
+        allowComments: true,
+        suppressGeneralInstructions: false
+      } as CodingJob
+    });
+    (mockCodingJobBackendService.previewJobDefinitionUpdateRefresh as jest.Mock)
+      .mockReturnValue(of(preview));
+    (mockCodingJobBackendService.applyJobDefinitionUpdateRefresh as jest.Mock)
+      .mockReturnValue(of({
+        success: true,
+        message: 'updated',
+        preview,
+        jobsCreated: 2
+      }));
+    (mockMatDialog.open as jest.Mock).mockReturnValue({
+      afterClosed: () => of(true)
+    });
+
+    component.codingJobForm.patchValue({ maxCodingCases: 4 });
+    await component.onSubmit();
+
+    expect(mockCodingJobBackendService.previewJobDefinitionUpdateRefresh).toHaveBeenCalledWith(
+      1,
+      55,
+      expect.objectContaining({
+        maxCodingCases: 4
+      })
+    );
+    expect(mockCodingJobBackendService.applyJobDefinitionUpdateRefresh).toHaveBeenCalledWith(
+      1,
+      55,
+      expect.objectContaining({
+        maxCodingCases: 4
+      })
+    );
+    expect(mockCodingJobBackendService.updateJobDefinition).not.toHaveBeenCalled();
   });
 
   it('should include DERIVE_ERROR opt-in only for selected definition variables', async () => {

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
@@ -278,10 +278,56 @@ describe('CodingJobDefinitionDialogComponent', () => {
 
   it('should load variables and coders on init', () => {
     createComponent();
-    expect(mockCodingJobBackendService.getCodingIncompleteVariables).toHaveBeenCalledWith(1, undefined, undefined, undefined);
+    expect(mockCodingJobBackendService.getCodingIncompleteVariables).toHaveBeenCalledWith(
+      1,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    );
     expect(mockCoderService.getCoders).toHaveBeenCalled();
     expect(component.variables.length).toBe(3);
     expect(component.availableCoders.length).toBe(2);
+  });
+
+  it('loads edit availability excluding the current definition and keeps its variables editable', () => {
+    (mockCodingJobBackendService.getCodingIncompleteVariables as jest.Mock)
+      .mockReturnValue(of([
+        {
+          unitName: 'Unit 1',
+          variableId: 'Var 1',
+          responseCount: 10,
+          availableCases: 0,
+          uniqueCasesAfterAggregation: 10
+        },
+        {
+          unitName: 'Unit 2',
+          variableId: 'Var 2',
+          responseCount: 5,
+          availableCases: 0,
+          uniqueCasesAfterAggregation: 5
+        }
+      ]));
+
+    createComponent({
+      isEdit: true,
+      mode: 'definition',
+      jobDefinitionId: 55,
+      codingJob: {
+        id: 55,
+        assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }]
+      } as CodingJob
+    });
+
+    expect(mockCodingJobBackendService.getCodingIncompleteVariables).toHaveBeenCalledWith(
+      1,
+      undefined,
+      undefined,
+      undefined,
+      55
+    );
+    expect(component.isVariableDisabled(component.variables[0])).toBe(false);
+    expect(component.isVariableDisabled(component.variables[1])).toBe(true);
   });
 
   it('should apply availability filters correctly', () => {

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
@@ -53,6 +53,7 @@ import { TestPersonCodingService } from '../../services/test-person-coding.servi
 import { MissingsProfileService } from '../../services/missings-profile.service';
 import { CodingJobBulkCreationDialogComponent, BulkCreationData, BulkCreationResult } from '../coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component';
 import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
+import { JobDefinitionRefreshDialogComponent } from '../coding-job-definitions/job-definition-refresh-dialog.component';
 
 export interface CodingJobDefinitionDialogData {
   codingJob?: CodingJob;
@@ -61,6 +62,7 @@ export interface CodingJobDefinitionDialogData {
   jobDefinitionId?: number;
   preloadedVariables?: Variable[];
   readOnly?: boolean;
+  createdJobsCount?: number;
 }
 
 export interface JobDefinition {
@@ -176,6 +178,12 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
 
   get isReadOnly(): boolean {
     return this.data.readOnly === true;
+  }
+
+  get hasExistingDefinitionJobs(): boolean {
+    return this.data.mode === 'definition' &&
+      this.data.isEdit &&
+      (this.data.createdJobsCount ?? 0) > 0;
   }
 
   // Double coding configuration
@@ -602,6 +610,10 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     }
 
     this.codingJobForm = this.fb.group(formFields);
+
+    if (this.hasExistingDefinitionJobs) {
+      this.codingJobForm.get('status')?.disable({ emitEvent: false });
+    }
 
     if (this.isReadOnly) {
       this.codingJobForm.disable({ emitEvent: false });
@@ -1528,7 +1540,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
       }
 
       if (this.data.isEdit && this.data.jobDefinitionId) {
-        this.submitDefinitionUpdate();
+        await this.submitDefinitionUpdate();
       } else {
         this.submitDefinitionCreate();
       }
@@ -1907,16 +1919,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     });
   }
 
-  private submitDefinitionUpdate(): void {
-    this.isSaving = true;
-
-    const workspaceId = this.appService.selectedWorkspaceId;
-    if (!workspaceId) {
-      this.snackBar.open(this.translateService.instant('coding-job-definition-dialog.snackbars.no-workspace-selected'), this.translateService.instant('common.close'), { duration: 3000 });
-      this.isSaving = false;
-      return;
-    }
-
+  private buildDefinitionUpdatePayload(): Partial<JobDefinition> {
     const selectedCoderIds = this.selectedCoders.selected.map(c => c.id);
     const selectedCoderConfigs = this.getSelectedCoderConfigs();
 
@@ -1936,11 +1939,230 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
       suppressGeneralInstructions: this.codingJobForm.value.suppressGeneralInstructions
     };
 
-    if (this.codingJobForm.get('status')) {
-      jobDefinition.status = this.codingJobForm.value.status;
+    const statusControl = this.codingJobForm.get('status');
+    if (statusControl?.enabled) {
+      jobDefinition.status = statusControl.value;
     }
 
-    this.codingJobBackendService.updateJobDefinition(workspaceId, this.data.jobDefinitionId!, jobDefinition).subscribe({
+    return jobDefinition;
+  }
+
+  private buildExistingJobsDirectUpdatePayload(
+    jobDefinition: Partial<JobDefinition>
+  ): Partial<JobDefinition> {
+    return {
+      durationSeconds: jobDefinition.durationSeconds,
+      showScore: jobDefinition.showScore,
+      allowComments: jobDefinition.allowComments,
+      suppressGeneralInstructions: jobDefinition.suppressGeneralInstructions
+    };
+  }
+
+  private normalizeVariablesForComparison(variables?: Variable[]): Array<{
+    unitName: string;
+    variableId: string;
+    includeDeriveError: boolean;
+  }> {
+    return (variables || [])
+      .map(variable => ({
+        unitName: variable.unitName || '',
+        variableId: variable.variableId || '',
+        includeDeriveError: variable.includeDeriveError === true
+      }))
+      .sort((left, right) => `${left.unitName}::${left.variableId}`
+        .localeCompare(`${right.unitName}::${right.variableId}`));
+  }
+
+  private normalizeBundlesForComparison(bundles?: VariableBundle[]): Array<{
+    id: number;
+    caseOrderingMode?: 'continuous' | 'alternating';
+  }> {
+    return (bundles || [])
+      .map(bundle => ({
+        id: Number(bundle.id),
+        caseOrderingMode: bundle.caseOrderingMode
+      }))
+      .sort((left, right) => left.id - right.id);
+  }
+
+  private normalizeCoderIdsForComparison(coderIds?: number[]): number[] {
+    return [...(coderIds || [])].sort((left, right) => left - right);
+  }
+
+  private normalizeCoderConfigsForComparison(
+    coderConfigs?: JobDefinitionCoderConfig[],
+    fallbackCoderIds?: number[]
+  ): JobDefinitionCoderConfig[] {
+    const configs = coderConfigs && coderConfigs.length > 0 ?
+      coderConfigs :
+      (fallbackCoderIds || []).map(coderId => ({
+        coderId,
+        capacityPercent: this.defaultCoderCapacityPercent
+      }));
+
+    return configs
+      .map(config => ({
+        coderId: Number(config.coderId),
+        capacityPercent: this.normalizeCoderCapacityPercent(config.capacityPercent)
+      }))
+      .sort((left, right) => left.coderId - right.coderId);
+  }
+
+  private valuesDiffer(left: unknown, right: unknown): boolean {
+    return JSON.stringify(left) !== JSON.stringify(right);
+  }
+
+  private normalizedOptionalNumber(value: unknown): number | undefined {
+    return this.sanitizeNumber(value);
+  }
+
+  private normalizedDoubleCodingNumber(value: unknown): number {
+    return this.sanitizeNumber(value) ?? 0;
+  }
+
+  private hasRefreshRelevantDefinitionChanges(
+    jobDefinition: Partial<JobDefinition>
+  ): boolean {
+    const existingDefinition = this.data.codingJob;
+    if (!existingDefinition) {
+      return false;
+    }
+
+    const existingVariables = existingDefinition.assignedVariables ??
+      existingDefinition.variables;
+    const existingBundles = existingDefinition.assignedVariableBundles ??
+      existingDefinition.variableBundles;
+    const existingMissingProfileId =
+      existingDefinition.missingsProfileId ??
+      existingDefinition.missings_profile_id;
+
+    return [
+      this.valuesDiffer(
+        this.normalizeVariablesForComparison(jobDefinition.assignedVariables),
+        this.normalizeVariablesForComparison(existingVariables)
+      ),
+      this.valuesDiffer(
+        this.normalizeBundlesForComparison(jobDefinition.assignedVariableBundles),
+        this.normalizeBundlesForComparison(existingBundles)
+      ),
+      this.valuesDiffer(
+        this.normalizeCoderIdsForComparison(jobDefinition.assignedCoders),
+        this.normalizeCoderIdsForComparison(existingDefinition.assignedCoders)
+      ),
+      this.valuesDiffer(
+        this.normalizeCoderConfigsForComparison(
+          jobDefinition.assignedCoderConfigs,
+          jobDefinition.assignedCoders
+        ),
+        this.normalizeCoderConfigsForComparison(
+          existingDefinition.assignedCoderConfigs,
+          existingDefinition.assignedCoders
+        )
+      ),
+      this.normalizedOptionalNumber(jobDefinition.missingsProfileId) !==
+        this.normalizedOptionalNumber(existingMissingProfileId),
+      this.normalizedOptionalNumber(jobDefinition.maxCodingCases) !==
+        this.normalizedOptionalNumber(existingDefinition.maxCodingCases),
+      this.normalizedDoubleCodingNumber(jobDefinition.doubleCodingAbsolute) !==
+        this.normalizedDoubleCodingNumber(existingDefinition.doubleCodingAbsolute),
+      this.normalizedDoubleCodingNumber(jobDefinition.doubleCodingPercentage) !==
+        this.normalizedDoubleCodingNumber(existingDefinition.doubleCodingPercentage),
+      (jobDefinition.caseOrderingMode || 'continuous') !==
+        (existingDefinition.caseOrderingMode || 'continuous')
+    ].some(Boolean);
+  }
+
+  private async previewAndApplyDefinitionUpdateRefresh(
+    workspaceId: number,
+    jobDefinitionId: number,
+    jobDefinition: Partial<JobDefinition>
+  ): Promise<void> {
+    try {
+      const preview = await firstValueFrom(
+        this.codingJobBackendService.previewJobDefinitionUpdateRefresh(
+          workspaceId,
+          jobDefinitionId,
+          jobDefinition
+        )
+      );
+      const dialogRef = this.matDialog.open(JobDefinitionRefreshDialogComponent, {
+        width: '640px',
+        maxWidth: '95vw',
+        data: {
+          definitionId: jobDefinitionId,
+          preview,
+          mode: 'update'
+        },
+        autoFocus: false
+      });
+      const confirmed = await firstValueFrom(dialogRef.afterClosed());
+
+      if (!confirmed) {
+        this.isSaving = false;
+        return;
+      }
+
+      const result = await firstValueFrom(
+        this.codingJobBackendService.applyJobDefinitionUpdateRefresh(
+          workspaceId,
+          jobDefinitionId,
+          jobDefinition
+        )
+      );
+
+      this.isSaving = false;
+      this.snackBar.open(
+        this.translateService.instant(
+          'coding-job-definition-dialog.snackbars.definition-update-refresh-applied',
+          { count: result.jobsCreated }
+        ),
+        this.translateService.instant('common.close'),
+        { duration: 4000 }
+      );
+      this.dialogRef.close(result);
+    } catch (error) {
+      this.isSaving = false;
+      const message = this.getErrorMessage(error);
+      this.snackBar.open(
+        this.translateService.instant(
+          'coding-job-definition-dialog.snackbars.update-refresh-failed',
+          { error: message }
+        ),
+        this.translateService.instant('common.close'),
+        { duration: 5000 }
+      );
+    }
+  }
+
+  private async submitDefinitionUpdate(): Promise<void> {
+    this.isSaving = true;
+
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      this.snackBar.open(this.translateService.instant('coding-job-definition-dialog.snackbars.no-workspace-selected'), this.translateService.instant('common.close'), { duration: 3000 });
+      this.isSaving = false;
+      return;
+    }
+
+    const jobDefinition = this.buildDefinitionUpdatePayload();
+
+    if (
+      this.hasExistingDefinitionJobs &&
+      this.hasRefreshRelevantDefinitionChanges(jobDefinition)
+    ) {
+      await this.previewAndApplyDefinitionUpdateRefresh(
+        workspaceId,
+        this.data.jobDefinitionId!,
+        jobDefinition
+      );
+      return;
+    }
+
+    const directUpdatePayload = this.hasExistingDefinitionJobs ?
+      this.buildExistingJobsDirectUpdatePayload(jobDefinition) :
+      jobDefinition;
+
+    this.codingJobBackendService.updateJobDefinition(workspaceId, this.data.jobDefinitionId!, directUpdatePayload).subscribe({
       next: updatedDefinition => {
         this.isSaving = false;
         this.snackBar.open(this.translateService.instant('coding-job-definition-dialog.snackbars.definition-updated-success'), this.translateService.instant('common.close'), { duration: 3000 });

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
@@ -681,11 +681,16 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     }
 
     this.loadManualCodingScopeSummary(unitNameFilter || undefined, trainingRequired);
+    const excludeJobDefinitionId = this.data.mode === 'definition' &&
+      this.data.isEdit ?
+      this.data.jobDefinitionId :
+      undefined;
     this.codingJobBackendService.getCodingIncompleteVariables(
       workspaceId,
       unitNameFilter || undefined,
       trainingRequired,
-      this.includeDeriveErrorInManualCoding ? true : undefined
+      this.includeDeriveErrorInManualCoding ? true : undefined,
+      excludeJobDefinitionId
     ).subscribe({
       next: variables => {
         this.variables = variables;
@@ -1034,13 +1039,13 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
       return false;
     }
 
-    if (variable.availableCases !== undefined && variable.availableCases === 0) {
-      return true;
-    }
-
     // Allow variables that were originally assigned to the current job definition being edited
     if (this.data.isEdit && this.isVariableOriginallyAssigned(variable)) {
       return false;
+    }
+
+    if (variable.availableCases !== undefined && variable.availableCases === 0) {
+      return true;
     }
 
     // Disable variables that are included in currently selected variable bundles

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
@@ -187,7 +187,7 @@ describe('CodingJobDefinitionsComponent', () => {
     expect(component.getDefinitionsReadyForJobsCount()).toBe(0);
   });
 
-  it('opens locked definitions read-only and blocks delete while jobs still block deletion', async () => {
+  it('opens definitions with known existing jobs editable and blocks delete while jobs still block deletion', async () => {
     component.isLoading = false;
     component.selectionMode = false;
     const definition = {
@@ -220,7 +220,7 @@ describe('CodingJobDefinitionsComponent', () => {
       deleteJobDefinition: jest.Mock;
     };
 
-    expect(component.canModifyDefinition(definition)).toBe(false);
+    expect(component.canModifyDefinition(definition)).toBe(true);
     expect(component.canDeleteDefinition(definition)).toBe(false);
     expect(menuButtons[0].disabled).toBe(false);
     expect(deleteButton.disabled).toBe(false);
@@ -230,7 +230,8 @@ describe('CodingJobDefinitionsComponent', () => {
 
     expect(dialogOpenSpy).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({
       data: expect.objectContaining({
-        readOnly: true
+        readOnly: false,
+        createdJobsCount: 2
       })
     }));
     expect(codingJobBackendService.deleteJobDefinition).not.toHaveBeenCalled();

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
@@ -407,7 +407,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
   }
 
   canModifyDefinition(definition: JobDefinition): boolean {
-    return this.getCreatedJobsCount(definition) === 0;
+    return this.getCreatedJobsCount(definition) !== undefined;
   }
 
   canDeleteDefinition(definition: JobDefinition): boolean {
@@ -559,6 +559,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       mode: 'definition',
       jobDefinitionId: definition.id,
       readOnly: !this.canModifyDefinition(definition),
+      createdJobsCount: this.getCreatedJobsCount(definition),
       codingJob: {
         id: definition.id!,
         workspace_id: workspaceId,

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.html
@@ -5,9 +5,7 @@
     </mat-icon>
     <div>
       <h2 mat-dialog-title>
-        {{ (preview.canApply
-          ? 'coding-job-definitions.refresh-dialog.title.apply'
-          : 'coding-job-definitions.refresh-dialog.title.blocked') | translate }}
+        {{ getApplyTitleKey() | translate }}
       </h2>
       <p class="definition-label">
         {{ 'coding-job-definitions.refresh-dialog.definition-label' | translate: { id: data.definitionId } }}
@@ -17,9 +15,7 @@
 
   <mat-dialog-content>
     <p class="intro">
-      {{ (preview.canApply
-        ? 'coding-job-definitions.refresh-dialog.intro.apply'
-        : 'coding-job-definitions.refresh-dialog.intro.blocked') | translate }}
+      {{ getIntroKey() | translate }}
     </p>
 
     @if (!preview.canApply) {
@@ -42,7 +38,7 @@
       </div>
       <div class="rule-item">
         <mat-icon>schema</mat-icon>
-        <span>{{ 'coding-job-definitions.refresh-dialog.rules.use-current-definition' | translate }}</span>
+        <span>{{ getDefinitionRuleKey() | translate }}</span>
       </div>
     </div>
 
@@ -103,7 +99,7 @@
     @if (preview.canApply) {
     <button mat-raised-button color="primary" type="button" (click)="confirm()">
       <mat-icon>sync</mat-icon>
-      {{ 'coding-job-definitions.refresh-dialog.confirm' | translate }}
+      {{ getConfirmKey() | translate }}
     </button>
     }
   </mat-dialog-actions>

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.ts
@@ -17,6 +17,7 @@ import {
 export interface JobDefinitionRefreshDialogData {
   definitionId: number;
   preview: JobDefinitionRefreshPreviewDto;
+  mode?: 'refresh' | 'update';
 }
 
 type RefreshStatTone = 'default' | 'positive' | 'negative' | 'warning';
@@ -50,6 +51,44 @@ export class JobDefinitionRefreshDialogComponent {
 
   get preview(): JobDefinitionRefreshPreviewDto {
     return this.data.preview;
+  }
+
+  get isDefinitionUpdate(): boolean {
+    return this.data.mode === 'update';
+  }
+
+  getApplyTitleKey(): string {
+    if (!this.preview.canApply) {
+      return 'coding-job-definitions.refresh-dialog.title.blocked';
+    }
+
+    return this.isDefinitionUpdate ?
+      'coding-job-definitions.refresh-dialog.title.update-apply' :
+      'coding-job-definitions.refresh-dialog.title.apply';
+  }
+
+  getIntroKey(): string {
+    if (!this.preview.canApply) {
+      return this.isDefinitionUpdate ?
+        'coding-job-definitions.refresh-dialog.intro.update-blocked' :
+        'coding-job-definitions.refresh-dialog.intro.blocked';
+    }
+
+    return this.isDefinitionUpdate ?
+      'coding-job-definitions.refresh-dialog.intro.update-apply' :
+      'coding-job-definitions.refresh-dialog.intro.apply';
+  }
+
+  getDefinitionRuleKey(): string {
+    return this.isDefinitionUpdate ?
+      'coding-job-definitions.refresh-dialog.rules.use-updated-definition' :
+      'coding-job-definitions.refresh-dialog.rules.use-current-definition';
+  }
+
+  getConfirmKey(): string {
+    return this.isDefinitionUpdate ?
+      'coding-job-definitions.refresh-dialog.confirm-update' :
+      'coding-job-definitions.refresh-dialog.confirm';
   }
 
   getBlockingReason(): string {

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -375,6 +375,70 @@ describe('CodingJobBackendService', () => {
         validationTaskStateServiceMock.invalidateWorkspace
       ).toHaveBeenCalledWith(1);
     });
+
+    it('should preview a job definition update refresh with the proposed definition', () => {
+      const update = { maxCodingCases: 4 };
+
+      service.previewJobDefinitionUpdateRefresh(1, 42, update).subscribe(response => {
+        expect(response.plannedCases).toBe(4);
+        expect(response.canApply).toBe(true);
+      });
+
+      const req = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/1/coding/job-definitions/42/update-refresh-preview`
+      );
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(update);
+      req.flush({
+        jobDefinitionId: 42,
+        existingJobsCount: 2,
+        staleJobsCount: 1,
+        existingCases: 5,
+        plannedCases: 4,
+        retainedCases: 4,
+        addedCases: 0,
+        removedCases: 1,
+        addedCodingTasks: 0,
+        removedCodingTasks: 1,
+        canApply: true
+      });
+    });
+
+    it('should apply a job definition update refresh and invalidate validation state', () => {
+      const update = { maxCodingCases: 4 };
+
+      service.applyJobDefinitionUpdateRefresh(1, 42, update).subscribe(response => {
+        expect(response.success).toBe(true);
+        expect(response.jobsCreated).toBe(2);
+      });
+
+      const req = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/1/coding/job-definitions/42/update-refresh-apply`
+      );
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(update);
+      req.flush({
+        success: true,
+        message: 'updated',
+        jobsCreated: 2,
+        preview: {
+          jobDefinitionId: 42,
+          existingJobsCount: 2,
+          staleJobsCount: 1,
+          existingCases: 5,
+          plannedCases: 4,
+          retainedCases: 4,
+          addedCases: 0,
+          removedCases: 1,
+          addedCodingTasks: 0,
+          removedCodingTasks: 1,
+          canApply: true
+        }
+      });
+      expect(
+        validationTaskStateServiceMock.invalidateWorkspace
+      ).toHaveBeenCalledWith(1);
+    });
   });
 
   describe('auth token override', () => {

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -441,6 +441,26 @@ describe('CodingJobBackendService', () => {
     });
   });
 
+  describe('getCodingIncompleteVariables', () => {
+    it('should pass the excluded job definition id when loading availability', () => {
+      service
+        .getCodingIncompleteVariables(1, 'Unit 1', false, true, 55)
+        .subscribe(response => {
+          expect(response).toEqual([]);
+        });
+
+      const req = httpMock.expectOne(request => request.url ===
+          `${mockServerUrl}admin/workspace/1/coding/incomplete-variables` &&
+        request.params.get('unitName') === 'Unit 1' &&
+        request.params.get('trainingRequired') === 'false' &&
+        request.params.get('includeDeriveErrorOnly') === 'true' &&
+        request.params.get('excludeJobDefinitionId') === '55' &&
+        request.params.has('_t'));
+      expect(req.request.method).toBe('GET');
+      req.flush([]);
+    });
+  });
+
   describe('auth token override', () => {
     it('should use the supplied auth token when loading coding job units', () => {
       service.getCodingJobUnits(47, 123, 'url-token').subscribe();

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -1031,6 +1031,38 @@ export class CodingJobBackendService {
       );
   }
 
+  previewJobDefinitionUpdateRefresh(
+    workspaceId: number,
+    jobDefinitionId: number,
+    jobDefinition: Partial<JobDefinition>
+  ): Observable<JobDefinitionRefreshPreviewDto> {
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/job-definitions/${jobDefinitionId}/update-refresh-preview`;
+    return this.http.post<JobDefinitionRefreshPreviewDto>(url, jobDefinition, {
+      headers: this.authHeader
+    });
+  }
+
+  applyJobDefinitionUpdateRefresh(
+    workspaceId: number,
+    jobDefinitionId: number,
+    jobDefinition: Partial<JobDefinition>
+  ): Observable<JobDefinitionRefreshApplyResultDto> {
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/job-definitions/${jobDefinitionId}/update-refresh-apply`;
+    return this.http
+      .post<JobDefinitionRefreshApplyResultDto>(
+      url,
+      jobDefinition,
+      { headers: this.authHeader }
+    )
+      .pipe(
+        tap(result => {
+          if (result.success) {
+            this.validationTaskStateService.invalidateWorkspace(workspaceId);
+          }
+        })
+      );
+  }
+
   startExportJob(
     workspaceId: number,
     exportConfig: CodingExportConfig

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -564,7 +564,8 @@ export class CodingJobBackendService {
     workspaceId: number,
     unitName?: string,
     trainingRequired?: boolean,
-    includeDeriveErrorOnly?: boolean
+    includeDeriveErrorOnly?: boolean,
+    excludeJobDefinitionId?: number
   ): Observable<
     {
       unitName: string;
@@ -592,6 +593,12 @@ export class CodingJobBackendService {
       params = params.set(
         'includeDeriveErrorOnly',
         includeDeriveErrorOnly.toString()
+      );
+    }
+    if (excludeJobDefinitionId !== undefined) {
+      params = params.set(
+        'excludeJobDefinitionId',
+        excludeJobDefinitionId.toString()
       );
     }
     params = params.set('_t', Date.now().toString());

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2004,7 +2004,8 @@
       "create-btn": "Definition erstellen",
       "submit-for-review": "Zur Prüfung einreichen"
     },
-    "readonly-definition-note": "Diese Definition ist schreibgeschützt, weil daraus bereits Kodierjobs erzeugt wurden. Verteilungsänderungen erfolgen über „Kodierjobs neu verteilen“, solange noch keine Kodierarbeit vorliegt.",
+    "readonly-definition-note": "Diese Definition ist schreibgeschützt, weil der Status erzeugter Kodierjobs nicht geladen werden konnte.",
+    "existing-jobs-definition-note": "Diese Definition hat bereits Kodierjobs. Änderungen an Variablen, Bündeln, Kodierern, Missing-Profil, Obergrenzen oder Doppelkodierung werden erst nach Vorschau und Bestätigung auf bestehende Kodierjobs angewendet.",
     "job": {
       "edit": "Kodierjob bearbeiten",
       "create": "Neuer Kodierjob erstellen",
@@ -2160,6 +2161,8 @@
       "definition-updated-success": "Jobdefinition erfolgreich aktualisiert",
       "error-update-definition": "Fehler beim Aktualisieren der Jobdefinition",
       "error-updating-definition": "Fehler beim Aktualisieren der Jobdefinition: {{error}}",
+      "definition-update-refresh-applied": "Jobdefinition gespeichert und Kodierjobs aktualisiert: {{count}} Kodierjobs erstellt.",
+      "update-refresh-failed": "Änderung konnte nicht auf bestehende Kodierjobs angewendet werden: {{error}}",
       "definition-submitted-review": "Jobdefinition zur Prüfung eingereicht",
       "error-submit-review": "Fehler beim Einreichen zur Prüfung",
       "error-submitting-review": "Fehler beim Einreichen zur Prüfung: {{error}}"
@@ -2234,19 +2237,23 @@
     "refresh-dialog": {
       "title": {
         "apply": "Kodierjobs neu verteilen",
+        "update-apply": "Änderung anwenden und Kodierjobs aktualisieren",
         "blocked": "Neu verteilen nicht möglich"
       },
       "definition-label": "Definition #{{id}}",
       "intro": {
         "apply": "Die bestehenden, noch unbearbeiteten Kodierjobs werden gelöscht und anhand der aktuellen Definition neu erzeugt.",
-        "blocked": "Die Definition kann aktuell nicht neu verteilt werden, weil vorhandene Kodierjobs nicht sicher ersetzt werden können."
+        "update-apply": "Die Jobdefinition wird gespeichert. Die bestehenden, noch unbearbeiteten Kodierjobs werden gelöscht und anhand der geänderten Definition neu erzeugt.",
+        "blocked": "Die Definition kann aktuell nicht neu verteilt werden, weil vorhandene Kodierjobs nicht sicher ersetzt werden können.",
+        "update-blocked": "Die Änderung kann aktuell nicht angewendet werden, weil vorhandene Kodierjobs nicht sicher ersetzt werden können."
       },
       "blocking-fallback": "In vorhandenen Kodierjobs wurde bereits gearbeitet. Deshalb ist die Neuverteilung gesperrt.",
       "rules-label": "Wirkung der Neuverteilung",
       "rules": {
         "replace-open": "Nur unberührte Kodierjobs aus dieser Definition werden ersetzt.",
         "keep-work": "Kodierungen, Notizen und bereits geöffnete Fälle werden nicht überschrieben.",
-        "use-current-definition": "Die neue Verteilung nutzt Variablen, Kodierer, Obergrenzen und Doppelkodierung aus der aktuellen Definition."
+        "use-current-definition": "Die neue Verteilung nutzt Variablen, Kodierer, Obergrenzen und Doppelkodierung aus der aktuellen Definition.",
+        "use-updated-definition": "Die neue Verteilung nutzt Variablen, Kodierer, Missing-Profil, Obergrenzen und Doppelkodierung aus der geänderten Definition."
       },
       "preview-title": "Jobstatus",
       "case-title": "Fälle",
@@ -2264,7 +2271,8 @@
         "added-tasks": "Aufgaben hinzugefügt",
         "removed-tasks": "Aufgaben entfernt"
       },
-      "confirm": "Jobs neu verteilen"
+      "confirm": "Jobs neu verteilen",
+      "confirm-update": "Änderung anwenden"
     },
     "distribution-summary": {
       "title": "Verteilungsübersicht",


### PR DESCRIPTION
## Summary
- Treat cases already assigned by the edited job definition as available during update validation.
- Keep availability checks active while avoiding extra exclusion queries for listed definitions.
- Add backend coverage for existing definitions with created jobs and explicit exclusion behavior.

## Validation
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
- npx nx test backend --testFile=apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
- npx nx lint backend
- npx nx test backend
- git diff --check

Refs #681