### PR TITLE
Handle VOCS freshness after coding scheme changes

### DIFF
--- a/api-dto/coding/coding-freshness.dto.ts
+++ b/api-dto/coding/coding-freshness.dto.ts
@@ -12,7 +12,8 @@ export type CodingFreshnessReason =
   | 'RESULT_DELETED'
   | 'AUTOCODE_RUN'
   | 'MANUAL_CODING_APPLIED'
-  | 'RESET';
+  | 'RESET'
+  | 'CODING_SCHEME_CHANGED';
 
 export interface CodingFreshnessSummaryItemDto {
   version: CodingFreshnessVersion;

--- a/apps/backend/src/app/coding/coding.module.ts
+++ b/apps/backend/src/app/coding/coding.module.ts
@@ -45,6 +45,7 @@ import {
   CodingReadinessService,
   CodingItemMatrixExportService
 } from '../database/services/coding';
+import { CODING_PROCESS_CACHE_INVALIDATOR } from '../database/services/coding/coding-process-cache-invalidator.token';
 import { JobDefinitionService } from '../database/services/jobs';
 // eslint-disable-next-line import/no-cycle
 import { JobQueueModule } from '../job-queue/job-queue.module';
@@ -106,7 +107,11 @@ import { UserModule } from '../user/user.module';
     CodingAnalysisService,
     CodingFreshnessService,
     CodingReadinessService,
-    CodingItemMatrixExportService
+    CodingItemMatrixExportService,
+    {
+      provide: CODING_PROCESS_CACHE_INVALIDATOR,
+      useExisting: CodingProcessService
+    }
   ],
   exports: [
     CodingJobService,
@@ -129,7 +134,8 @@ import { UserModule } from '../user/user.module';
     CodingAnalysisService,
     CodingFreshnessService,
     CodingReadinessService,
-    CodingItemMatrixExportService
+    CodingItemMatrixExportService,
+    CODING_PROCESS_CACHE_INVALIDATOR
   ]
 })
 export class CodingModule { }

--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.spec.ts
@@ -50,6 +50,21 @@ describe('CodingFreshnessService', () => {
     );
   });
 
+  const mockCodingSchemeChangeQueries = (
+    unitIds: number[],
+    revision: number
+  ): void => {
+    (connection.query as jest.Mock).mockImplementation((sql: string) => {
+      if (sql.includes('WITH unit_candidates')) {
+        return Promise.resolve(unitIds.map(id => ({ id })));
+      }
+      if (sql.includes('workspace_test_results_revision')) {
+        return Promise.resolve([{ revision }]);
+      }
+      return Promise.resolve([]);
+    });
+  };
+
   it('summarizes freshness rows by version and state', async () => {
     (connection.query as jest.Mock).mockResolvedValue([{ revision: 7 }]);
     (freshnessRepository.createQueryBuilder as jest.Mock).mockReturnValue(
@@ -259,6 +274,118 @@ describe('CodingFreshnessService', () => {
         })
       ]),
       ['workspace_id', 'unit_id', 'version']
+    );
+  });
+
+  it('marks coding scheme rule changes stale for auto-coding and manual review', async () => {
+    mockCodingSchemeChangeQueries([10], 11);
+    const responseCountsQb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([{ unitId: 10, count: '3' }])
+    });
+    const workspacePresenceQb = queryBuilder({
+      getRawOne: jest.fn().mockResolvedValue({ v1: true, v2: true, v3: true })
+    });
+    const unitPresenceQb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([
+        {
+          unitId: 10,
+          v1: true,
+          v2: false,
+          v3: false
+        }
+      ])
+    });
+
+    (responseRepository.createQueryBuilder as jest.Mock)
+      .mockReturnValueOnce(responseCountsQb)
+      .mockReturnValueOnce(workspacePresenceQb)
+      .mockReturnValueOnce(unitPresenceQb);
+
+    await service.markUnitsStaleAfterCodingSchemeChange(1, {
+      autoCodingSchemeRefs: ['SEPARATE_SCHEME']
+    });
+
+    expect(connection.query).toHaveBeenCalledWith(
+      expect.stringContaining('codingschemeref'),
+      [1, ['SEPARATE_SCHEME']]
+    );
+    expect(freshnessRepository.upsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          unit_id: 10,
+          version: 'v1',
+          state: 'STALE',
+          reason: 'CODING_SCHEME_CHANGED',
+          affected_response_count: 3,
+          source_revision: 11
+        }),
+        expect.objectContaining({
+          unit_id: 10,
+          version: 'v3',
+          state: 'PENDING',
+          reason: 'CODING_SCHEME_CHANGED'
+        }),
+        expect.objectContaining({
+          unit_id: 10,
+          version: 'v2',
+          state: 'MANUAL_REVIEW_REQUIRED',
+          reason: 'CODING_SCHEME_CHANGED'
+        })
+      ]),
+      ['workspace_id', 'unit_id', 'version']
+    );
+    expect((freshnessRepository.upsert as jest.Mock).mock.calls[0][0])
+      .toHaveLength(3);
+    expect(connection.query).toHaveBeenLastCalledWith(
+      expect.stringContaining('UPDATE coding_job cj'),
+      [1, [10], 'stale_source', 'CODING_SCHEME_CHANGED']
+    );
+  });
+
+  it('marks coding scheme instruction-only changes for manual review only', async () => {
+    mockCodingSchemeChangeQueries([10], 12);
+    const responseCountsQb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([{ unitId: 10, count: '3' }])
+    });
+    const workspacePresenceQb = queryBuilder({
+      getRawOne: jest.fn().mockResolvedValue({ v1: true, v2: false, v3: false })
+    });
+    const unitPresenceQb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([
+        {
+          unitId: 10,
+          v1: true,
+          v2: false,
+          v3: false
+        }
+      ])
+    });
+
+    (responseRepository.createQueryBuilder as jest.Mock)
+      .mockReturnValueOnce(responseCountsQb)
+      .mockReturnValueOnce(workspacePresenceQb)
+      .mockReturnValueOnce(unitPresenceQb);
+
+    await service.markUnitsStaleAfterCodingSchemeChange(1, {
+      manualCodingSchemeRefs: ['UNIT_A']
+    });
+
+    expect(freshnessRepository.upsert).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          unit_id: 10,
+          version: 'v2',
+          state: 'MANUAL_REVIEW_REQUIRED',
+          reason: 'CODING_SCHEME_CHANGED',
+          affected_response_count: 3,
+          source_revision: 12
+        })
+      ],
+      ['workspace_id', 'unit_id', 'version']
+    );
+    expect(connection.query).toHaveBeenLastCalledWith(
+      expect.stringContaining('UPDATE coding_job cj'),
+      [1, [10], 'review_required', 'CODING_SCHEME_CHANGED']
     );
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
@@ -464,6 +464,110 @@ export class CodingFreshnessService {
     );
   }
 
+  async markUnitsStaleAfterCodingSchemeChange(
+    workspaceId: number,
+    scope: {
+      autoCodingSchemeRefs?: string[];
+      manualCodingSchemeRefs?: string[];
+    }
+  ): Promise<void> {
+    const autoCodingUnitIds = await this.getUnitIdsByCodingSchemeRefs(
+      workspaceId,
+      scope.autoCodingSchemeRefs || []
+    );
+    const manualCodingUnitIds = await this.getUnitIdsByCodingSchemeRefs(
+      workspaceId,
+      [
+        ...(scope.manualCodingSchemeRefs || []),
+        ...(scope.autoCodingSchemeRefs || [])
+      ]
+    );
+    const allUnitIds = await this.filterIncludedUnitIds(
+      workspaceId,
+      this.uniquePositiveIds([
+        ...autoCodingUnitIds,
+        ...manualCodingUnitIds
+      ])
+    );
+    if (allUnitIds.length === 0) {
+      return;
+    }
+
+    const includedUnitIdSet = new Set(allUnitIds);
+    const includedAutoCodingUnitIds = autoCodingUnitIds
+      .filter(unitId => includedUnitIdSet.has(unitId));
+    const includedManualCodingUnitIds = manualCodingUnitIds
+      .filter(unitId => includedUnitIdSet.has(unitId));
+
+    const revision = await this.incrementRevision(workspaceId);
+    const responseCounts = await this.getResponseCountsByUnit(
+      workspaceId,
+      allUnitIds
+    );
+    const workspacePresence = await this.getWorkspaceCodingPresence(workspaceId);
+    const unitPresence = await this.getUnitCodingPresence(workspaceId, allUnitIds);
+    const rows: FreshnessUpsert[] = [];
+
+    if (includedAutoCodingUnitIds.length > 0) {
+      this.getAutoCodingVersionsToRefresh(workspacePresence).forEach(version => {
+        includedAutoCodingUnitIds.forEach(unitId => {
+          const state: CodingFreshnessState =
+            unitPresence.get(unitId)?.[version] ? 'STALE' : 'PENDING';
+          rows.push(this.buildRow(
+            workspaceId,
+            unitId,
+            version,
+            state,
+            'CODING_SCHEME_CHANGED',
+            responseCounts.get(unitId) || 0,
+            revision,
+            null
+          ));
+        });
+      });
+    }
+
+    includedManualCodingUnitIds.forEach(unitId => {
+      const presence = unitPresence.get(unitId);
+      if (!presence?.v1 && !presence?.v2 && !presence?.v3) {
+        return;
+      }
+      rows.push(this.buildRow(
+        workspaceId,
+        unitId,
+        'v2',
+        'MANUAL_REVIEW_REQUIRED',
+        'CODING_SCHEME_CHANGED',
+        responseCounts.get(unitId) || 0,
+        revision,
+        null
+      ));
+    });
+
+    await this.upsertRows(rows);
+
+    if (includedAutoCodingUnitIds.length > 0) {
+      await this.markCodingJobsStaleForUnitIds(
+        workspaceId,
+        includedAutoCodingUnitIds,
+        'CODING_SCHEME_CHANGED',
+        'stale_source'
+      );
+    }
+
+    const includedAutoCodingUnitIdSet = new Set(includedAutoCodingUnitIds);
+    const includedManualOnlyUnitIds = includedManualCodingUnitIds
+      .filter(unitId => !includedAutoCodingUnitIdSet.has(unitId));
+    if (includedManualOnlyUnitIds.length > 0) {
+      await this.markCodingJobsStaleForUnitIds(
+        workspaceId,
+        includedManualOnlyUnitIds,
+        'CODING_SCHEME_CHANGED',
+        'review_required'
+      );
+    }
+  }
+
   async markVersionCurrent(
     workspaceId: number,
     unitIds: number[],
@@ -1096,6 +1200,82 @@ export class CodingFreshnessService {
     return Array.from(new Set(values
       .map(value => value?.trim())
       .filter((value): value is string => Boolean(value))));
+  }
+
+  private normalizeCodingSchemeRef(value: string): string {
+    return value
+      .trim()
+      .toUpperCase()
+      .replace(/\.VOCS$/i, '')
+      .replace(/\.XML$/i, '');
+  }
+
+  private getCodingSchemeRefCandidates(values: string[]): string[] {
+    const candidates = new Set<string>();
+    this.uniqueStrings(values).forEach(value => {
+      const normalized = this.normalizeCodingSchemeRef(value);
+      if (!normalized) {
+        return;
+      }
+
+      candidates.add(normalized);
+      const basename = normalized.split('/').pop();
+      if (basename) {
+        candidates.add(basename);
+      }
+    });
+    return Array.from(candidates);
+  }
+
+  private async getUnitIdsByCodingSchemeRefs(
+    workspaceId: number,
+    codingSchemeRefs: string[]
+  ): Promise<number[]> {
+    const schemeRefCandidates =
+      this.getCodingSchemeRefCandidates(codingSchemeRefs);
+    if (schemeRefCandidates.length === 0) {
+      return [];
+    }
+
+    const rows = await this.connection.query(
+      `
+        WITH unit_candidates AS (
+          SELECT
+            unit.id AS id,
+            REGEXP_REPLACE(UPPER(unit.name), '\\.XML$', '', 'i') AS unit_name,
+            REGEXP_REPLACE(UPPER(COALESCE(unit.alias, '')), '\\.XML$', '', 'i') AS unit_alias,
+            REGEXP_REPLACE(
+              UPPER(COALESCE(
+                (REGEXP_MATCH(unit_file.data, '<\\s*codingschemeref[^>]*>\\s*([^<]+)', 'i'))[1],
+                ''
+              )),
+              '\\.VOCS$',
+              '',
+              'i'
+            ) AS scheme_ref
+          FROM "unit" unit
+          INNER JOIN booklet booklet ON booklet.id = unit.bookletid
+          INNER JOIN persons person ON person.id = booklet.personid
+          LEFT JOIN file_upload unit_file
+            ON unit_file.workspace_id = person.workspace_id
+            AND unit_file.file_type = 'Unit'
+            AND REGEXP_REPLACE(UPPER(unit_file.file_id), '\\.XML$', '', 'i') IN (
+              REGEXP_REPLACE(UPPER(unit.name), '\\.XML$', '', 'i'),
+              REGEXP_REPLACE(UPPER(COALESCE(unit.alias, '')), '\\.XML$', '', 'i')
+            )
+          WHERE person.workspace_id = $1
+        )
+        SELECT DISTINCT id
+        FROM unit_candidates
+        WHERE unit_name = ANY($2::text[])
+          OR unit_alias = ANY($2::text[])
+          OR scheme_ref = ANY($2::text[])
+          OR REGEXP_REPLACE(scheme_ref, '^.*/', '') = ANY($2::text[])
+      `,
+      [workspaceId, schemeRefCandidates]
+    ) as Array<{ id: number | string }>;
+
+    return this.uniquePositiveIds(rows.map(row => Number(row.id)));
   }
 
   private async markCodingJobsStaleForAddedUnitIds(

--- a/apps/backend/src/app/database/services/coding/coding-process-cache-invalidator.token.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process-cache-invalidator.token.ts
@@ -1,0 +1,6 @@
+export const CODING_PROCESS_CACHE_INVALIDATOR =
+  'CODING_PROCESS_CACHE_INVALIDATOR';
+
+export interface CodingProcessCacheInvalidator {
+  invalidateWorkspaceCaches(workspaceId: number): void;
+}

--- a/apps/backend/src/app/database/services/coding/coding-process.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.ts
@@ -874,6 +874,17 @@ export class CodingProcessService {
     return `${workspaceId}:${fileId}`;
   }
 
+  invalidateWorkspaceCaches(workspaceId: number): void {
+    this.testFileCache.delete(workspaceId);
+
+    const schemeCachePrefix = `${workspaceId}:`;
+    for (const key of Array.from(this.codingSchemeCache.keys())) {
+      if (key.startsWith(schemeCachePrefix)) {
+        this.codingSchemeCache.delete(key);
+      }
+    }
+  }
+
   private cleanupCaches(): void {
     const now = Date.now();
     for (const [key, entry] of this.codingSchemeCache.entries()) {

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
@@ -129,6 +129,243 @@ describe('WorkspaceFilesService.handleFile', () => {
   });
 });
 
+describe('WorkspaceFilesService coding scheme freshness', () => {
+  type CtorParams = ConstructorParameters<typeof WorkspaceFilesService>;
+
+  const createCodingScheme = (
+    options: {
+      processing?: string[];
+      codeModel?: string;
+      manualInstruction?: string;
+    } = {}
+  ): string => JSON.stringify({
+    version: '3.4',
+    variableCodings: [
+      {
+        id: 'VAR_A',
+        alias: 'var_a',
+        sourceType: 'BASE',
+        processing: options.processing || [],
+        codeModel: options.codeModel || 'MANUAL_AND_RULES',
+        codes: [
+          {
+            id: 1,
+            score: 1,
+            manualInstruction: options.manualInstruction || '<p>old</p>',
+            ruleSets: [
+              {
+                rules: [
+                  {
+                    method: 'MATCH',
+                    parameters: ['A']
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  });
+
+  const createVocsFile = (data: string): FileIo => ({
+    fieldname: 'files',
+    originalname: 'UNIT_A.vocs',
+    encoding: '7bit',
+    mimetype: 'application/octet-stream',
+    buffer: Buffer.from(data),
+    size: Buffer.byteLength(data)
+  });
+
+  const mockFileUploadRepository = {
+    create: jest.fn((value: unknown) => value),
+    createQueryBuilder: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    upsert: jest.fn().mockResolvedValue(undefined)
+  };
+  const mockCodingFreshnessService = {
+    markUnitsStaleAfterCodingSchemeChange: jest.fn().mockResolvedValue(undefined)
+  };
+
+  function makeService(): WorkspaceFilesService {
+    return new WorkspaceFilesService(
+      mockFileUploadRepository as unknown as CtorParams[0],
+      {} as unknown as CtorParams[1],
+      {} as unknown as CtorParams[2],
+      {} as unknown as CtorParams[3],
+      {} as unknown as CtorParams[4],
+      {} as unknown as CtorParams[5],
+      {} as unknown as CtorParams[6],
+      {} as unknown as CtorParams[7],
+      {} as unknown as CtorParams[8],
+      {} as unknown as CtorParams[9],
+      { delete: jest.fn() } as unknown as CtorParams[10],
+      { invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined) } as unknown as CtorParams[11],
+      undefined,
+      mockCodingFreshnessService as unknown as CtorParams[13]
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('marks auto-coding and manual coding stale after coding scheme rule changes', async () => {
+    const service = makeService();
+    const oldData = createCodingScheme({ processing: [] });
+    const newData = createCodingScheme({ processing: ['IGNORE_CASE'] });
+    mockFileUploadRepository.findOne.mockResolvedValue({
+      file_id: 'UNIT_A.VOCS',
+      data: oldData
+    });
+
+    await (
+      service as unknown as {
+        handleOctetStreamFile: (...args: unknown[]) => Promise<unknown>;
+      }
+    ).handleOctetStreamFile(1, createVocsFile(newData), true);
+
+    expect(mockCodingFreshnessService.markUnitsStaleAfterCodingSchemeChange)
+      .toHaveBeenCalledWith(1, {
+        autoCodingSchemeRefs: ['UNIT_A'],
+        manualCodingSchemeRefs: ['UNIT_A']
+      });
+  });
+
+  it('marks auto-coding and manual coding stale after coding scheme code model changes', async () => {
+    const service = makeService();
+    const oldData = createCodingScheme({ codeModel: 'MANUAL_ONLY' });
+    const newData = createCodingScheme({ codeModel: 'MANUAL_AND_RULES' });
+    mockFileUploadRepository.findOne.mockResolvedValue({
+      file_id: 'UNIT_A.VOCS',
+      data: oldData
+    });
+
+    await (
+      service as unknown as {
+        handleOctetStreamFile: (...args: unknown[]) => Promise<unknown>;
+      }
+    ).handleOctetStreamFile(1, createVocsFile(newData), true);
+
+    expect(mockCodingFreshnessService.markUnitsStaleAfterCodingSchemeChange)
+      .toHaveBeenCalledWith(1, {
+        autoCodingSchemeRefs: ['UNIT_A'],
+        manualCodingSchemeRefs: ['UNIT_A']
+      });
+  });
+
+  it('marks only manual coding stale after instruction-only coding scheme changes', async () => {
+    const service = makeService();
+    const oldData = createCodingScheme({ manualInstruction: '<p>old</p>' });
+    const newData = createCodingScheme({ manualInstruction: '<p>new</p>' });
+    mockFileUploadRepository.findOne.mockResolvedValue({
+      file_id: 'UNIT_A.VOCS',
+      data: oldData
+    });
+
+    await (
+      service as unknown as {
+        handleOctetStreamFile: (...args: unknown[]) => Promise<unknown>;
+      }
+    ).handleOctetStreamFile(1, createVocsFile(newData), true);
+
+    expect(mockCodingFreshnessService.markUnitsStaleAfterCodingSchemeChange)
+      .toHaveBeenCalledWith(1, {
+        autoCodingSchemeRefs: [],
+        manualCodingSchemeRefs: ['UNIT_A']
+      });
+  });
+
+  it('does not mark coding freshness when coding scheme JSON is semantically unchanged', async () => {
+    const service = makeService();
+    const oldData = JSON.stringify({
+      version: '3.4',
+      variableCodings: [
+        {
+          id: 'VAR_A',
+          alias: 'var_a',
+          sourceType: 'BASE',
+          codes: [{ id: 1, manualInstruction: '<p>old</p>' }]
+        }
+      ]
+    });
+    const newData = JSON.stringify({
+      variableCodings: [
+        {
+          sourceType: 'BASE',
+          alias: 'var_a',
+          codes: [{ manualInstruction: '<p>old</p>', id: 1 }],
+          id: 'VAR_A'
+        }
+      ],
+      version: '3.4'
+    });
+    mockFileUploadRepository.findOne.mockResolvedValue({
+      file_id: 'UNIT_A.VOCS',
+      data: oldData
+    });
+
+    await (
+      service as unknown as {
+        handleOctetStreamFile: (...args: unknown[]) => Promise<unknown>;
+      }
+    ).handleOctetStreamFile(1, createVocsFile(newData), true);
+
+    expect(mockCodingFreshnessService.markUnitsStaleAfterCodingSchemeChange)
+      .not.toHaveBeenCalled();
+  });
+
+  it('invalidates workspace file caches after Testcenter import writes files', async () => {
+    const service = makeService();
+    const conflictQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([])
+    };
+    const insertQueryBuilder = {
+      insert: jest.fn().mockReturnThis(),
+      into: jest.fn().mockReturnThis(),
+      values: jest.fn().mockReturnThis(),
+      orIgnore: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue(undefined)
+    };
+    mockFileUploadRepository.createQueryBuilder
+      .mockReturnValueOnce(conflictQueryBuilder)
+      .mockReturnValueOnce(insertQueryBuilder);
+    mockFileUploadRepository.find.mockResolvedValue([]);
+    const invalidateSpy = jest
+      .spyOn(
+        service as unknown as {
+          invalidateWorkspaceFileCaches: (workspaceId: number) => Promise<void>;
+        },
+        'invalidateWorkspaceFileCaches'
+      )
+      .mockResolvedValue(undefined);
+
+    await service.testCenterImport([
+      {
+        workspace_id: 1,
+        file_id: 'UNIT_A.VOCS',
+        filename: 'UNIT_A.VOCS',
+        file_type: 'Resource',
+        file_size: 12,
+        data: createCodingScheme()
+      }
+    ]);
+
+    expect(invalidateSpy).toHaveBeenCalledWith(1);
+  });
+});
+
 describe('WorkspaceFilesService.onModuleInit', () => {
   type CtorParams = ConstructorParameters<typeof WorkspaceFilesService>;
 

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -3,7 +3,8 @@ import {
   Inject,
   Injectable,
   Logger,
-  OnModuleInit
+  OnModuleInit,
+  Optional
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -48,6 +49,13 @@ import {
 import Persons from '../../entities/persons.entity';
 // eslint-disable-next-line import/no-cycle
 import { CodingStatisticsService } from '../coding/coding-statistics.service';
+import { CodingFileCacheService } from '../coding/coding-file-cache.service';
+// eslint-disable-next-line import/no-cycle
+import { CodingFreshnessService } from '../coding/coding-freshness.service';
+import {
+  CODING_PROCESS_CACHE_INVALIDATOR,
+  CodingProcessCacheInvalidator
+} from '../coding/coding-process-cache-invalidator.token';
 import { WorkspaceXmlSchemaValidationService } from './workspace-xml-schema-validation.service';
 import { WorkspaceFileStorageService } from './workspace-file-storage.service';
 import { WorkspaceFileParsingService } from './workspace-file-parsing.service';
@@ -89,6 +97,33 @@ interface ParsedVariableElement {
   };
   Values?: unknown;
   ValuePositionLabels?: unknown;
+}
+
+interface VocsCode {
+  id?: unknown;
+  label?: unknown;
+  manualInstruction?: unknown;
+  [key: string]: unknown;
+}
+
+interface VocsVariableCoding {
+  id?: unknown;
+  alias?: unknown;
+  label?: unknown;
+  page?: unknown;
+  codeModel?: unknown;
+  manualInstruction?: unknown;
+  codes?: VocsCode[];
+  [key: string]: unknown;
+}
+
+interface ParsedCodingScheme {
+  variableCodings?: VocsVariableCoding[];
+}
+
+interface CodingSchemeFreshnessImpact {
+  autoCodingChanged: boolean;
+  manualCodingChanged: boolean;
 }
 
 @Injectable()
@@ -147,7 +182,14 @@ export class WorkspaceFilesService implements OnModuleInit {
     private cacheService: CacheService,
     @Inject(forwardRef(() => WorkspaceTestResultsService))
     private readonly workspaceTestResultsService: WorkspaceTestResultsService,
-    private readonly workspaceExclusionService?: WorkspaceExclusionService
+    private readonly workspaceExclusionService?: WorkspaceExclusionService,
+    @Optional()
+    private readonly codingFreshnessService?: CodingFreshnessService,
+    @Optional()
+    private readonly codingFileCacheService?: CodingFileCacheService,
+    @Optional()
+    @Inject(CODING_PROCESS_CACHE_INVALIDATOR)
+    private readonly codingProcessCacheInvalidator?: CodingProcessCacheInvalidator
   ) {}
 
   private normalizeFileUnitId(value: string | null | undefined): string {
@@ -226,6 +268,238 @@ export class WorkspaceFilesService implements OnModuleInit {
   private getResourceSubtypeExtension(fileType: string): string | null {
     const match = fileType.match(/^Resource\s*\((\.[^)]+)\)$/i);
     return match ? match[1].toLowerCase() : null;
+  }
+
+  private isCodingSchemeFileId(fileId: unknown): boolean {
+    return String(fileId || '').trim().toUpperCase().endsWith('.VOCS');
+  }
+
+  private normalizeCodingSchemeUnitName(fileId: unknown): string {
+    return String(fileId || '')
+      .trim()
+      .toUpperCase()
+      .replace(/\.VOCS$/i, '');
+  }
+
+  private parseCodingSchemeData(data: unknown): ParsedCodingScheme | null {
+    if (data === null || data === undefined) {
+      return null;
+    }
+
+    try {
+      const parsed =
+        typeof data === 'string' || Buffer.isBuffer(data) ?
+          JSON.parse(Buffer.isBuffer(data) ? data.toString('utf8') : data) :
+          data;
+
+      if (!parsed || typeof parsed !== 'object') {
+        return null;
+      }
+
+      return parsed as ParsedCodingScheme;
+    } catch {
+      return null;
+    }
+  }
+
+  private getCodingSchemeVariableMap(
+    data: unknown
+  ): Map<string, VocsVariableCoding> | null {
+    const parsed = this.parseCodingSchemeData(data);
+    if (!parsed || !Array.isArray(parsed.variableCodings)) {
+      return null;
+    }
+
+    const variables = new Map<string, VocsVariableCoding>();
+    parsed.variableCodings.forEach(variableCoding => {
+      const key = this.getCodingSchemeVariableKey(variableCoding);
+      if (key) {
+        variables.set(key, variableCoding);
+      }
+    });
+    return variables;
+  }
+
+  private getCodingSchemeVariableKey(variableCoding: VocsVariableCoding): string {
+    return String(variableCoding.id || variableCoding.alias || '').trim();
+  }
+
+  private getCodingSchemeRuleSignature(variableCoding: VocsVariableCoding): string {
+    return this.stableStringify(
+      this.omitKeysDeep(
+        variableCoding,
+        new Set(['manualInstruction', 'label', 'page'])
+      )
+    );
+  }
+
+  private getCodingSchemeManualSignature(variableCoding: VocsVariableCoding): string {
+    const codes = Array.isArray(variableCoding.codes) ?
+      variableCoding.codes.map(code => ({
+        id: code.id ?? null,
+        label: code.label ?? null,
+        manualInstruction: code.manualInstruction ?? null
+      })) :
+      [];
+
+    return this.stableStringify({
+      codeModel: variableCoding.codeModel ?? null,
+      label: variableCoding.label ?? null,
+      manualInstruction: variableCoding.manualInstruction ?? null,
+      page: variableCoding.page ?? null,
+      codes
+    });
+  }
+
+  private omitKeysDeep(value: unknown, omittedKeys: Set<string>): unknown {
+    if (Array.isArray(value)) {
+      return value.map(item => this.omitKeysDeep(item, omittedKeys));
+    }
+
+    if (!value || typeof value !== 'object') {
+      return value ?? null;
+    }
+
+    const result: Record<string, unknown> = {};
+    Object.keys(value as Record<string, unknown>)
+      .sort()
+      .forEach(key => {
+        if (!omittedKeys.has(key)) {
+          result[key] = this.omitKeysDeep(
+            (value as Record<string, unknown>)[key],
+            omittedKeys
+          );
+        }
+      });
+    return result;
+  }
+
+  private stableStringify(value: unknown): string {
+    return JSON.stringify(this.sortObjectKeysDeep(value));
+  }
+
+  private sortObjectKeysDeep(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map(item => this.sortObjectKeysDeep(item));
+    }
+
+    if (!value || typeof value !== 'object') {
+      return value ?? null;
+    }
+
+    const result: Record<string, unknown> = {};
+    Object.keys(value as Record<string, unknown>)
+      .sort()
+      .forEach(key => {
+        result[key] = this.sortObjectKeysDeep(
+          (value as Record<string, unknown>)[key]
+        );
+      });
+    return result;
+  }
+
+  private codingSchemeDataToText(data: unknown): string {
+    if (data === null || data === undefined) {
+      return '';
+    }
+    if (Buffer.isBuffer(data)) {
+      return data.toString('utf8');
+    }
+    if (typeof data === 'string') {
+      return data;
+    }
+    return this.stableStringify(data);
+  }
+
+  private getCodingSchemeFreshnessImpact(
+    previousData: unknown,
+    nextData: unknown
+  ): CodingSchemeFreshnessImpact {
+    const previousVariables = previousData === null || previousData === undefined ?
+      new Map<string, VocsVariableCoding>() :
+      this.getCodingSchemeVariableMap(previousData);
+    const nextVariables = this.getCodingSchemeVariableMap(nextData);
+
+    if (!previousVariables || !nextVariables) {
+      const changed =
+        this.codingSchemeDataToText(previousData) !== this.codingSchemeDataToText(nextData);
+      return {
+        autoCodingChanged: changed,
+        manualCodingChanged: changed
+      };
+    }
+
+    const allVariableKeys = new Set([
+      ...previousVariables.keys(),
+      ...nextVariables.keys()
+    ]);
+    let autoCodingChanged = false;
+    let manualCodingChanged = false;
+
+    allVariableKeys.forEach(variableKey => {
+      const previousVariable = previousVariables.get(variableKey);
+      const nextVariable = nextVariables.get(variableKey);
+
+      if (!previousVariable || !nextVariable) {
+        autoCodingChanged = true;
+        manualCodingChanged = true;
+        return;
+      }
+
+      if (
+        this.getCodingSchemeRuleSignature(previousVariable) !==
+        this.getCodingSchemeRuleSignature(nextVariable)
+      ) {
+        autoCodingChanged = true;
+        manualCodingChanged = true;
+        return;
+      }
+
+      if (
+        this.getCodingSchemeManualSignature(previousVariable) !==
+        this.getCodingSchemeManualSignature(nextVariable)
+      ) {
+        manualCodingChanged = true;
+      }
+    });
+
+    return { autoCodingChanged, manualCodingChanged };
+  }
+
+  private async markCodingSchemeFreshnessAfterFileChange(
+    workspaceId: number,
+    fileId: unknown,
+    previousData: unknown,
+    nextData: unknown
+  ): Promise<void> {
+    if (!this.codingFreshnessService || !this.isCodingSchemeFileId(fileId)) {
+      return;
+    }
+
+    const unitName = this.normalizeCodingSchemeUnitName(fileId);
+    if (!unitName) {
+      return;
+    }
+
+    const impact = this.getCodingSchemeFreshnessImpact(previousData, nextData);
+    if (!impact.autoCodingChanged && !impact.manualCodingChanged) {
+      return;
+    }
+
+    try {
+      await this.codingFreshnessService.markUnitsStaleAfterCodingSchemeChange(
+        workspaceId,
+        {
+          autoCodingSchemeRefs: impact.autoCodingChanged ? [unitName] : [],
+          manualCodingSchemeRefs: impact.manualCodingChanged ? [unitName] : []
+        }
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not update coding freshness after coding scheme change ${unitName}: ${detail}`
+      );
+    }
   }
 
   async findAllFileTypes(workspaceId: number): Promise<string[]> {
@@ -1409,6 +1683,12 @@ ${bookletRefs}
         'file_id',
         'workspace_id'
       ]);
+      await this.markCodingSchemeFreshnessAfterFileChange(
+        workspaceId,
+        fileUpload.file_id,
+        existing?.data,
+        fileContent
+      );
       this.logger.log(
         `Successfully processed octet-stream file: ${file.originalname} as ${fileType}`
       );
@@ -1520,6 +1800,44 @@ ${bookletRefs}
     );
   }
 
+  private async collectCodingSchemeChangesForFreshness(
+    workspaceId: number,
+    entries: Record<string, unknown>[]
+  ): Promise<Array<{ fileId: string; previousData: unknown; nextData: unknown }>> {
+    if (!workspaceId || entries.length === 0) {
+      return [];
+    }
+
+    const codingSchemeEntries = entries
+      .map(entry => ({
+        fileId: String(entry.file_id || '').trim(),
+        data: entry.data
+      }))
+      .filter(entry => this.isCodingSchemeFileId(entry.fileId));
+    if (codingSchemeEntries.length === 0) {
+      return [];
+    }
+
+    const fileIds = Array.from(new Set(
+      codingSchemeEntries.map(entry => entry.fileId)
+    ));
+    const existingFiles = await this.fileUploadRepository.find({
+      where: {
+        workspace_id: workspaceId,
+        file_id: In(fileIds)
+      }
+    });
+    const existingDataByFileId = new Map(
+      existingFiles.map(file => [String(file.file_id || ''), file.data])
+    );
+
+    return codingSchemeEntries.map(entry => ({
+      fileId: entry.fileId,
+      previousData: existingDataByFileId.get(entry.fileId),
+      nextData: entry.data
+    }));
+  }
+
   async testCenterImport(
     entries: Record<string, unknown>[]
   ): Promise<TestFilesUploadResultDto>;
@@ -1586,6 +1904,11 @@ ${bookletRefs}
         const id = String((e as { file_id?: unknown }).file_id ?? '');
         return !!id && conflictIds.has(id) && shouldOverwrite(id);
       });
+      const changedCodingSchemes =
+        await this.collectCodingSchemeChangesForFreshness(
+          workspaceId,
+          [...insertableEntries, ...overwriteEntries]
+        );
 
       const registry = this.fileUploadRepository.create(insertableEntries);
       if (registry.length > 0) {
@@ -1609,6 +1932,17 @@ ${bookletRefs}
           'file_id',
           'workspace_id'
         ]);
+      }
+      await Promise.all(changedCodingSchemes.map(change => (
+        this.markCodingSchemeFreshnessAfterFileChange(
+          workspaceId,
+          change.fileId,
+          change.previousData,
+          change.nextData
+        )
+      )));
+      if (registry.length > 0 || overwriteRegistry.length > 0) {
+        await this.invalidateWorkspaceFileCaches(workspaceId);
       }
       return {
         total: attemptedFiles.length,
@@ -3577,6 +3911,8 @@ ${bookletRefs}
     await this.workspaceTestResultsService.invalidateWorkspaceStatsCache(
       workspaceId
     );
+    this.codingFileCacheService?.clearCaches();
+    this.codingProcessCacheInvalidator?.invalidateWorkspaceCaches(workspaceId);
     this.logger.log(
       `Invalidated workspace files caches for workspace ${workspaceId} in Redis`
     );

--- a/apps/frontend/src/app/coding/components/scheme-editor-dialog/scheme-editor-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/scheme-editor-dialog/scheme-editor-dialog.component.spec.ts
@@ -149,8 +149,13 @@ describe('SchemeEditorDialogComponent', () => {
     component.save();
     tick();
 
-    expect(mockFileService.deleteFiles).toHaveBeenCalledWith(1, ['r1']);
-    expect(mockFileService.uploadTestFiles).toHaveBeenCalled();
+    expect(mockFileService.deleteFiles).not.toHaveBeenCalled();
+    expect(mockFileService.uploadTestFiles).toHaveBeenCalledWith(
+      1,
+      expect.any(FormData),
+      true,
+      ['test-scheme.json']
+    );
     expect(mockSnackBar.open).toHaveBeenCalledWith('coding.schemer.save-success', 'Success', expect.any(Object));
     expect(mockDialogRef.close).toHaveBeenCalledWith(true);
   }));

--- a/apps/frontend/src/app/coding/components/scheme-editor-dialog/scheme-editor-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/scheme-editor-dialog/scheme-editor-dialog.component.ts
@@ -251,18 +251,11 @@ export class SchemeEditorDialogComponent implements OnInit {
       .subscribe({
         next: response => {
           const existingFile = response.data?.find(file => file.filename === schemeFilename && file.file_type === 'Resource');
-          if (existingFile) {
-            this.fileService.deleteFiles(this.data.workspaceId, [existingFile.id])
-              .subscribe(deleteSuccess => {
-                if (deleteSuccess) {
-                  this.uploadSchemeFile(schemeFilename);
-                } else {
-                  this.snackBar.open('Failed to update scheme', 'Error', { duration: 3000 });
-                }
-              });
-          } else {
-            this.uploadSchemeFile(schemeFilename);
-          }
+          this.uploadSchemeFile(
+            schemeFilename,
+            !!existingFile,
+            existingFile ? [schemeFilename] : undefined
+          );
         },
         error: () => {
           this.snackBar.open('Failed to fetch files list', 'Error', { duration: 3000 });
@@ -270,14 +263,23 @@ export class SchemeEditorDialogComponent implements OnInit {
       });
   }
 
-  private uploadSchemeFile(filename: string): void {
+  private uploadSchemeFile(
+    filename: string,
+    overwriteExisting: boolean = false,
+    overwriteFileIds?: string[]
+  ): void {
     const blob = new Blob([this.unitScheme.scheme], { type: 'application/octet-stream' });
     const file = new File([blob], filename, { type: 'application/octet-stream' });
 
     const formData = new FormData();
     formData.append('files', file);
 
-    this.fileService.uploadTestFiles(this.data.workspaceId, formData)
+    this.fileService.uploadTestFiles(
+      this.data.workspaceId,
+      formData,
+      overwriteExisting,
+      overwriteFileIds
+    )
       .subscribe(result => {
         const conflicts = result.conflicts || [];
         const ok = result.failed === 0 && conflicts.length === 0;


### PR DESCRIPTION
## Summary

- detect VOCS coding scheme changes and mark affected coding freshness states
- distinguish auto-coding-relevant changes from instruction-only changes
- preserve previous VOCS data during scheme editor saves by using overwrite upload
- invalidate workspace and coding caches after changed test files are written

## Validation

- `npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/components/scheme-editor-dialog/scheme-editor-dialog.component.spec.ts --runInBand`
- `npx nx test backend --runTestsByPath apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts --runInBand`
- `npx nx lint frontend`
- `npx nx lint backend`
- `git diff --check`

Related issue: #688. The issue should remain open after this PR.