### PR TITLE
Überarbeite Sondercodes in manueller Kodierung

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -2815,6 +2815,203 @@ describe('CodingJobService', () => {
     );
   });
 
+  it.each([
+    { id: -2, codingIssueOption: -2 },
+    { id: 7, codingIssueOption: -1 }
+  ])(
+    'rejects comment-bound coding issue options when comments are disabled',
+    async selectedCode => {
+      const job = { id: 1, workspace_id: 3, allowComments: false };
+      const unit = {
+        coding_job_id: 1,
+        unit_name: 'UNIT',
+        variable_id: 'VAR',
+        person_login: 'login',
+        person_code: 'code',
+        booklet_name: 'booklet',
+        is_open: false,
+        code: null,
+        score: null,
+        coding_issue_option: null,
+        notes: null
+      };
+      codingJobRepository.findOne.mockResolvedValue(job);
+      codingJobUnitRepository.findOne.mockResolvedValue(unit);
+
+      await expect(
+        service.saveCodingProgress(1, {
+          testPerson: 'login@code@booklet',
+          unitId: 'UNIT',
+          variableId: 'VAR',
+          selectedCode
+        } as never)
+      ).rejects.toThrow(
+        'Coding issue options requiring comments are disabled for this coding job'
+      );
+
+      expect(codingJobUnitRepository.save).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects code-assignment-uncertain without a regular code', async () => {
+    const job = { id: 1, workspace_id: 3, allowComments: true };
+    const unit = {
+      coding_job_id: 1,
+      unit_name: 'UNIT',
+      variable_id: 'VAR',
+      person_login: 'login',
+      person_code: 'code',
+      booklet_name: 'booklet',
+      is_open: false,
+      code: null,
+      score: null,
+      coding_issue_option: null,
+      notes: null
+    };
+    codingJobRepository.findOne.mockResolvedValue(job);
+    codingJobUnitRepository.findOne.mockResolvedValue(unit);
+
+    await expect(
+      service.saveCodingProgress(1, {
+        testPerson: 'login@code@booklet',
+        unitId: 'UNIT',
+        variableId: 'VAR',
+        selectedCode: { id: -1, codingIssueOption: -1 }
+      } as never)
+    ).rejects.toThrow('Code assignment uncertain requires a regular code');
+
+    expect(codingJobUnitRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects code-assignment-uncertain attached to a non-regular code', async () => {
+    const job = { id: 1, workspace_id: 3, allowComments: true };
+    const unit = {
+      coding_job_id: 1,
+      unit_name: 'UNIT',
+      variable_id: 'VAR',
+      person_login: 'login',
+      person_code: 'code',
+      booklet_name: 'booklet',
+      is_open: false,
+      code: null,
+      score: null,
+      coding_issue_option: null,
+      notes: 'needs a new code'
+    };
+    codingJobRepository.findOne.mockResolvedValue(job);
+    codingJobUnitRepository.findOne.mockResolvedValue(unit);
+
+    await expect(
+      service.saveCodingProgress(1, {
+        testPerson: 'login@code@booklet',
+        unitId: 'UNIT',
+        variableId: 'VAR',
+        selectedCode: { id: -2, codingIssueOption: -1 }
+      } as never)
+    ).rejects.toThrow('Code assignment uncertain requires a regular code');
+
+    expect(codingJobUnitRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects new-code-needed without coder notes', async () => {
+    const job = { id: 1, workspace_id: 3, allowComments: true };
+    const unit = {
+      coding_job_id: 1,
+      unit_name: 'UNIT',
+      variable_id: 'VAR',
+      person_login: 'login',
+      person_code: 'code',
+      booklet_name: 'booklet',
+      is_open: false,
+      code: null,
+      score: null,
+      coding_issue_option: null,
+      notes: null
+    };
+    codingJobRepository.findOne.mockResolvedValue(job);
+    codingJobUnitRepository.findOne.mockResolvedValue(unit);
+
+    await expect(
+      service.saveCodingProgress(1, {
+        testPerson: 'login@code@booklet',
+        unitId: 'UNIT',
+        variableId: 'VAR',
+        selectedCode: { id: -2, codingIssueOption: -2 }
+      } as never)
+    ).rejects.toThrow('New code needed requires coder notes');
+
+    expect(codingJobUnitRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('accepts new-code-needed when coder notes already exist', async () => {
+    const job = { id: 1, workspace_id: 3, allowComments: true };
+    const unit = {
+      coding_job_id: 1,
+      unit_name: 'UNIT',
+      variable_id: 'VAR',
+      person_login: 'login',
+      person_code: 'code',
+      booklet_name: 'booklet',
+      is_open: false,
+      code: null,
+      score: null,
+      coding_issue_option: null,
+      notes: 'needs a new code'
+    };
+    codingJobRepository.findOne.mockResolvedValue(job);
+    codingJobUnitRepository.findOne.mockResolvedValue(unit);
+    (
+      service as unknown as { checkAndUpdateCodingJobCompletion: jest.Mock }
+    ).checkAndUpdateCodingJobCompletion = jest.fn();
+
+    await service.saveCodingProgress(1, {
+      testPerson: 'login@code@booklet',
+      unitId: 'UNIT',
+      variableId: 'VAR',
+      selectedCode: { id: -2, codingIssueOption: -2 }
+    } as never);
+
+    expect(codingJobUnitRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: -2,
+        score: null,
+        coding_issue_option: -2,
+        notes: 'needs a new code'
+      })
+    );
+  });
+
+  it('rejects new-code-needed when progress explicitly clears existing coder notes', async () => {
+    const job = { id: 1, workspace_id: 3, allowComments: true };
+    const unit = {
+      coding_job_id: 1,
+      unit_name: 'UNIT',
+      variable_id: 'VAR',
+      person_login: 'login',
+      person_code: 'code',
+      booklet_name: 'booklet',
+      is_open: false,
+      code: null,
+      score: null,
+      coding_issue_option: null,
+      notes: 'old note'
+    };
+    codingJobRepository.findOne.mockResolvedValue(job);
+    codingJobUnitRepository.findOne.mockResolvedValue(unit);
+
+    await expect(
+      service.saveCodingProgress(1, {
+        testPerson: 'login@code@booklet',
+        unitId: 'UNIT',
+        variableId: 'VAR',
+        selectedCode: { id: -2, codingIssueOption: -2 },
+        notes: null
+      } as never)
+    ).rejects.toThrow('New code needed requires coder notes');
+
+    expect(codingJobUnitRepository.save).not.toHaveBeenCalled();
+  });
+
   it('rejects unsupported negative coding issue codes', async () => {
     const job = { id: 1, workspace_id: 3 };
     const unit = {
@@ -3081,6 +3278,82 @@ describe('CodingJobService', () => {
         code: null,
         score: null,
         coding_issue_option: null
+      })
+    );
+    expect(codingJobRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('clears new-code-needed progress and reopens a completed job when required notes are deleted', async () => {
+    const job = { id: 1, workspace_id: 3, status: 'completed' };
+    const unit = {
+      coding_job_id: 1,
+      unit_name: 'UNIT',
+      variable_id: 'VAR',
+      person_login: 'login',
+      person_code: 'code',
+      person_group: 'group',
+      booklet_name: 'booklet',
+      is_open: false,
+      code: -2,
+      score: null,
+      coding_issue_option: -2,
+      notes: 'needs a new code'
+    };
+    codingJobRepository.findOne.mockResolvedValue(job);
+    codingJobUnitRepository.findOne.mockResolvedValue(unit);
+
+    await service.saveCodingNotes(1, {
+      testPerson: 'login@code@group@booklet',
+      unitId: 'UNIT',
+      variableId: 'VAR',
+      notes: '   '
+    });
+
+    expect(codingJobUnitRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notes: null,
+        code: null,
+        score: null,
+        coding_issue_option: null,
+        is_open: false
+      })
+    );
+    expect(codingJobRepository.update).toHaveBeenCalledWith(1, { status: 'active' });
+  });
+
+  it('keeps regular progress and clears only new-code-needed marker when required notes are deleted', async () => {
+    const job = { id: 1, workspace_id: 3, status: 'completed' };
+    const unit = {
+      coding_job_id: 1,
+      unit_name: 'UNIT',
+      variable_id: 'VAR',
+      person_login: 'login',
+      person_code: 'code',
+      person_group: 'group',
+      booklet_name: 'booklet',
+      is_open: false,
+      code: 7,
+      score: 1,
+      coding_issue_option: -2,
+      notes: 'needs a new code'
+    };
+    codingJobRepository.findOne.mockResolvedValue(job);
+    codingJobUnitRepository.findOne.mockResolvedValue(unit);
+
+    await service.saveCodingNotes(1, {
+      testPerson: 'login@code@group@booklet',
+      unitId: 'UNIT',
+      variableId: 'VAR',
+      notes: '   '
+    });
+
+    expect(codingJobUnitRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notes: null,
+        code: 7,
+        score: 1,
+        coding_issue_option: null,
+        is_open: false
       })
     );
     expect(codingJobRepository.update).not.toHaveBeenCalled();

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -3302,7 +3302,8 @@ export class CodingJobService {
     const selectedCode = await this.validateProgressSelectedCode(
       progress,
       codingJobUnit,
-      codingJob.workspace_id
+      codingJob.workspace_id,
+      codingJob.allowComments !== false
     );
 
     this.applyProgressToCodingJobUnit(
@@ -3349,6 +3350,36 @@ export class CodingJobService {
     if (progress.notes !== undefined) {
       codingJobUnit.notes = progress.notes || null;
     }
+  }
+
+  private clearNewCodeNeededProgressWithoutNotes(
+    codingJobUnit: CodingJobUnit
+  ): boolean {
+    if (codingJobUnit.notes) return false;
+    if (
+      codingJobUnit.coding_issue_option === -2 &&
+      codingJobUnit.code !== null &&
+      codingJobUnit.code >= 0
+    ) {
+      codingJobUnit.coding_issue_option = null;
+      return false;
+    }
+    if (codingJobUnit.code !== -2 && codingJobUnit.coding_issue_option !== -2) {
+      return false;
+    }
+
+    codingJobUnit.code = null;
+    codingJobUnit.score = null;
+    codingJobUnit.coding_issue_option = null;
+    codingJobUnit.is_open = false;
+    return true;
+  }
+
+  private async reopenCodingJobAfterProgressCleared(
+    codingJob: CodingJob
+  ): Promise<void> {
+    if (!['completed', 'open'].includes(codingJob.status)) return;
+    await this.codingJobRepository.update(codingJob.id, { status: 'active' });
   }
 
   private getCodingJobUnitWhereForEntry(
@@ -3586,7 +3617,8 @@ export class CodingJobService {
     const selectedCode = await this.validateProgressSelectedCode(
       progress,
       sourceUnit,
-      sourceCodingJob.workspace_id
+      sourceCodingJob.workspace_id,
+      sourceCodingJob.allowComments !== false
     );
 
     if (progress.isOpen !== true && selectedCode === null) {
@@ -3628,7 +3660,8 @@ export class CodingJobService {
   private async validateProgressSelectedCode(
     progress: SaveCodingProgressDto,
     codingJobUnit: CodingJobUnit,
-    workspaceId: number
+    workspaceId: number,
+    allowComments: boolean
   ): Promise<NonNullable<SaveCodingProgressDto['selectedCode']> | null> {
     if (progress.isOpen === true) {
       return null;
@@ -3663,6 +3696,41 @@ export class CodingJobService {
     ) {
       throw new BadRequestException(
         `Unsupported coding issue option: ${selectedCode.codingIssueOption}`
+      );
+    }
+
+    const commentBoundIssueCodes = new Set([-1, -2]);
+    const codingIssueOption = selectedCode.codingIssueOption ?? null;
+    if (
+      !allowComments &&
+      (commentBoundIssueCodes.has(selectedCode.id) ||
+        (codingIssueOption !== null && commentBoundIssueCodes.has(codingIssueOption)))
+    ) {
+      throw new BadRequestException(
+        'Coding issue options requiring comments are disabled for this coding job'
+      );
+    }
+
+    if (
+      selectedCode.id === -1 ||
+      (selectedCode.codingIssueOption === -1 && selectedCode.id < 0)
+    ) {
+      throw new BadRequestException(
+        'Code assignment uncertain requires a regular code'
+      );
+    }
+
+    const newCodeNeededCode = -2;
+    const nextNotes = Object.prototype.hasOwnProperty.call(progress, 'notes') ?
+      progress.notes :
+      codingJobUnit.notes;
+    if (
+      (selectedCode.id === newCodeNeededCode ||
+        selectedCode.codingIssueOption === newCodeNeededCode) &&
+      !(nextNotes ?? '').trim()
+    ) {
+      throw new BadRequestException(
+        'New code needed requires coder notes'
       );
     }
 
@@ -3983,7 +4051,11 @@ export class CodingJobService {
     }
 
     codingJobUnit.notes = notesDto.notes?.trim() || null;
+    const clearedProgress = this.clearNewCodeNeededProgressWithoutNotes(codingJobUnit);
     await this.codingJobUnitRepository.save(codingJobUnit);
+    if (clearedProgress) {
+      await this.reopenCodingJobAfterProgressCleared(codingJob);
+    }
 
     return codingJob;
   }
@@ -4044,12 +4116,14 @@ export class CodingJobService {
       createdReviewUnit.is_open = false;
       createdReviewUnit.coding_issue_option = null;
       createdReviewUnit.notes = notesDto.notes?.trim() || null;
+      this.clearNewCodeNeededProgressWithoutNotes(createdReviewUnit);
       await this.codingJobUnitRepository.save(createdReviewUnit);
 
       return sourceCodingJob;
     }
 
     reviewUnit.notes = notesDto.notes?.trim() || null;
+    this.clearNewCodeNeededProgressWithoutNotes(reviewUnit);
     await this.codingJobUnitRepository.save(reviewUnit);
 
     return sourceCodingJob;

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
@@ -20,6 +20,15 @@
   font-weight: 500;
 }
 
+.code-row.read-only {
+  opacity: 0.56;
+}
+
+.code-row.read-only:hover {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .general-instruction-row {
   cursor: default;
 }
@@ -147,6 +156,13 @@
 
 .notes-field {
   width: 100%;
+}
+
+.notes-validation-error {
+  margin: -8px 0 8px;
+  color: #ba1a1a;
+  font-size: 0.75rem;
+  line-height: 1.25;
 }
 
 ::ng-deep .notes-field .mat-mdc-form-field .mat-mdc-text-field-wrapper {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
@@ -127,9 +127,13 @@
   </div>
 
   <div class="uncertain-codes-section fixed-section">
-    <div class="code-row" [class.selected]="item.id === selectedCodingIssueOption" [class.read-only]="isReadOnly"
-      *ngFor="let item of codingIssueOptionCodes;" [style.cursor]="isReadOnly ? 'not-allowed' : 'pointer'"
-      (click)="isReadOnly ? null : onSelect(item.id)">
+    <div class="code-row" [class.selected]="item.id === selectedCodingIssueOption"
+      [class.read-only]="isCodingIssueOptionDisabled(item)" *ngFor="let item of codingIssueOptionCodes;"
+      [style.cursor]="isCodingIssueOptionDisabled(item) ? 'not-allowed' : 'pointer'"
+      [attr.aria-disabled]="isCodingIssueOptionDisabled(item)"
+      [matTooltip]="getCodingIssueOptionTooltip(item)"
+      [matTooltipDisabled]="!getCodingIssueOptionTooltip(item)"
+      (click)="isCodingIssueOptionDisabled(item) ? null : onSelect(item.id)">
       <div class="code-content">
         <span class="shortcut-icon" *ngIf="getShortcutLabel(item.id)">{{ getShortcutLabel(item.id) }}</span>
         <span class="uncertain-text">{{ item.label }}</span>
@@ -143,8 +147,12 @@
 
   @if (allowComments) {
   <mat-form-field appearance="outline" class="notes-field fixed-section">
-    <textarea matInput [(ngModel)]="coderNotes" (input)="onNotesChanged()"
-      [disabled]="isReadOnly" placeholder="{{ 'code-selector.coder-notes-placeholder' | translate }}" rows="3"></textarea>
+    <textarea #notesTextarea matInput [(ngModel)]="coderNotes" (input)="onNotesChanged()"
+      [disabled]="isReadOnly" [attr.aria-invalid]="newCodeCommentValidationError ? 'true' : null"
+      placeholder="{{ 'code-selector.coder-notes-placeholder' | translate }}" rows="3"></textarea>
   </mat-form-field>
+  <div *ngIf="newCodeCommentValidationError" class="notes-validation-error fixed-section" role="alert">
+    {{ 'code-selector.new-code-comment-required' | translate }}
+  </div>
   }
 </div>

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -151,7 +151,7 @@ describe('CodeSelectorComponent', () => {
     expect(component.codingIssueOptionCodes).toHaveLength(4);
   });
 
-  it('keeps coding issue options and general instructions visible without regular manual codes', () => {
+  it('keeps available coding issue options and general instructions visible without regular manual codes', () => {
     component.codingScheme = issueOnlyCodingScheme;
     component.variableId = 'VAR2';
     const emitSpy = jest.spyOn(component.codeSelected, 'emit');
@@ -170,17 +170,113 @@ describe('CodeSelectorComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('.uncertain-codes-section .code-row')).toHaveLength(4);
 
     component.onSelect(-1);
-    expect(emitSpy).toHaveBeenLastCalledWith({
-      variableId: 'VAR2',
-      code: null,
-      codingIssueOption: expect.objectContaining({ code: -1 })
-    });
+    expect(emitSpy).not.toHaveBeenCalled();
 
     component.onSelect(-2);
     expect(emitSpy).toHaveBeenLastCalledWith({
       variableId: 'VAR2',
       code: null,
       codingIssueOption: expect.objectContaining({ code: -2 })
+    });
+  });
+
+  it('hides comment-bound coding issue options when comments are disabled', () => {
+    component.codingScheme = mixedCodingScheme;
+    component.variableId = 'VAR1';
+    component.allowComments = false;
+    const emitSpy = jest.spyOn(component.codeSelected, 'emit');
+
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, mixedCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR1', false)
+    });
+    fixture.detectChanges();
+
+    expect(component.codingIssueOptionCodes.map(code => code.id)).toEqual([-3, -4]);
+    expect(fixture.nativeElement.querySelectorAll('.uncertain-codes-section .code-row')).toHaveLength(2);
+
+    component.onSelect(-1);
+    component.onSelect(-2);
+
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not preselect hidden comment-bound coding issue options when comments are disabled', () => {
+    jest.useFakeTimers();
+    component.codingScheme = mixedCodingScheme;
+    component.variableId = 'VAR1';
+    component.allowComments = false;
+    component.preSelectedCodeId = -2;
+    component.preSelectedCodingIssueOptionId = -2;
+
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, mixedCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR1', false),
+      preSelectedCodeId: new SimpleChange(null, -2, false),
+      preSelectedCodingIssueOptionId: new SimpleChange(null, -2, false)
+    });
+    jest.runOnlyPendingTimers();
+    fixture.detectChanges();
+
+    expect(component.codingIssueOptionCodes.map(code => code.id)).toEqual([-3, -4]);
+    expect(component.selectedCode).toBeNull();
+    expect(component.selectedCodingIssueOption).toBeNull();
+    expect(component.legacySelectedCode).toBeNull();
+    jest.useRealTimers();
+  });
+
+  it('clears selected comment-bound coding issue options when comments are disabled later', () => {
+    jest.useFakeTimers();
+    component.codingScheme = mixedCodingScheme;
+    component.variableId = 'VAR1';
+    component.preSelectedCodeId = -2;
+    component.preSelectedCodingIssueOptionId = -2;
+
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, mixedCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR1', false),
+      preSelectedCodeId: new SimpleChange(null, -2, false),
+      preSelectedCodingIssueOptionId: new SimpleChange(null, -2, false)
+    });
+    jest.runOnlyPendingTimers();
+
+    expect(component.selectedCodingIssueOption).toBe(-2);
+
+    component.allowComments = false;
+    component.ngOnChanges({
+      allowComments: new SimpleChange(true, false, false)
+    });
+
+    expect(component.selectedCode).toBeNull();
+    expect(component.selectedCodingIssueOption).toBeNull();
+    expect(component.legacySelectedCode).toBeNull();
+    jest.useRealTimers();
+  });
+
+  it('requires a regular code before selecting code-assignment-uncertain', () => {
+    component.codingScheme = mixedCodingScheme;
+    component.variableId = 'VAR1';
+    const emitSpy = jest.spyOn(component.codeSelected, 'emit');
+
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, mixedCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR1', false)
+    });
+
+    component.onSelect(-1);
+
+    expect(component.selectedCodingIssueOption).toBeNull();
+    expect(emitSpy).not.toHaveBeenCalled();
+
+    component.onSelect(1);
+    component.onSelect(-1);
+
+    expect(component.selectedCode).toBe(1);
+    expect(component.selectedCodingIssueOption).toBe(-1);
+    expect(emitSpy).toHaveBeenLastCalledWith({
+      variableId: 'VAR1',
+      code: mixedCodingScheme.variableCodings[0].codes[0],
+      codingIssueOption: expect.objectContaining({ code: -1 })
     });
   });
 
@@ -291,7 +387,7 @@ describe('CodeSelectorComponent', () => {
     expect(component.selectedCode).toBe(1);
   });
 
-  it('clears stored legacy code when selecting a coding issue option', () => {
+  it('clears stored legacy code when selecting a standalone coding issue option', () => {
     component.codingScheme = mixedCodingScheme;
     component.variableId = 'VAR1';
     component.preSelectedCodeId = 2;
@@ -302,14 +398,14 @@ describe('CodeSelectorComponent', () => {
       variableId: new SimpleChange(null, 'VAR1', false),
       preSelectedCodeId: new SimpleChange(null, 2, false)
     });
-    component.onSelect(-1);
+    component.onSelect(-2);
 
     expect(component.legacySelectedCode).toBeNull();
-    expect(component.selectedCodingIssueOption).toBe(-1);
+    expect(component.selectedCodingIssueOption).toBe(-2);
     expect(emitSpy).toHaveBeenCalledWith({
       variableId: 'VAR1',
       code: null,
-      codingIssueOption: expect.objectContaining({ code: -1 })
+      codingIssueOption: expect.objectContaining({ code: -2 })
     });
   });
 
@@ -367,6 +463,46 @@ describe('CodeSelectorComponent', () => {
     component.nextUnit();
 
     expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[1]);
+  });
+
+  it('blocks nextUnit and focuses notes when new-code-needed has no comment', () => {
+    jest.useFakeTimers();
+    component.codingScheme = mixedCodingScheme;
+    component.variableId = 'VAR1';
+    component.unitsData = {
+      ...interleavedUnitsData,
+      currentUnitIndex: 0
+    };
+    const emitSpy = jest.spyOn(component.unitChanged, 'emit');
+
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, mixedCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR1', false)
+    });
+    jest.runOnlyPendingTimers();
+    component.onSelect(-2);
+    fixture.detectChanges();
+
+    const notesTextarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+    const focusSpy = jest.spyOn(notesTextarea, 'focus').mockImplementation(() => { });
+    component.nextUnit();
+    jest.runAllTimers();
+    fixture.detectChanges();
+
+    expect(emitSpy).not.toHaveBeenCalled();
+    expect(component.newCodeCommentValidationError).toBe(true);
+    expect(fixture.nativeElement.querySelector('.notes-validation-error').textContent).toContain(
+      'code-selector.new-code-comment-required'
+    );
+    expect(focusSpy).toHaveBeenCalled();
+
+    component.coderNotes = 'needs a new code';
+    component.onNotesChanged();
+    component.nextUnit();
+
+    expect(component.newCodeCommentValidationError).toBe(false);
+    expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[1]);
+    jest.useRealTimers();
   });
 
   it('previousUnit should navigate to immediate previous case for interleaved variables', () => {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -66,14 +66,23 @@ export class CodeSelectorComponent implements OnChanges {
   @Output() pauseCodingJob = new EventEmitter<void>();
   @Output() unitChanged = new EventEmitter<UnitsReplayUnit>();
   @ViewChild('variablePanel') variablePanel?: ElementRef<HTMLElement>;
+  @ViewChild('notesTextarea') notesTextarea?: ElementRef<HTMLTextAreaElement>;
 
   selectableItems: SelectableItem[] = [];
   selectedCode: number | null = null;
   selectedCodingIssueOption: number | null = null;
+  newCodeCommentValidationError = false;
   variableManualInstruction: string | null = null;
   legacySelectedCode: SelectableItem | null = null;
   private allRegularCodeItems: SelectableItem[] = [];
   private hasResolvedCodingScheme = false;
+  private readonly codeAssignmentUncertainOptionId = -1;
+  private readonly newCodeNeededOptionId = -2;
+  private readonly commentBoundCodingIssueOptionIds = new Set<number>([
+    this.codeAssignmentUncertainOptionId,
+    this.newCodeNeededOptionId
+  ]);
+
   constructor(private sanitizer: DomSanitizer, private translateService: TranslateService, private elementRef: ElementRef) { }
 
   @HostListener('document:click', ['$event'])
@@ -87,7 +96,7 @@ export class CodeSelectorComponent implements OnChanges {
     if (changes.codingScheme || changes.variableId || changes.missings) {
       this.loadCodes();
     }
-    if (changes.preSelectedCodeId || changes.preSelectedCodingIssueOptionId) {
+    if (changes.preSelectedCodeId || changes.preSelectedCodingIssueOptionId || changes.allowComments) {
       this.selectPreSelectedCode();
     }
   }
@@ -138,7 +147,7 @@ export class CodeSelectorComponent implements OnChanges {
 
       const codingIssueOptions: SelectableItem[] = [
         {
-          id: -1,
+          id: this.codeAssignmentUncertainOptionId,
           label: this.translateService.instant('code-selector.coding-issue-options.code-assignment-uncertain'),
           type: 'codingIssueOption'
         },
@@ -153,7 +162,7 @@ export class CodeSelectorComponent implements OnChanges {
           type: 'codingIssueOption'
         },
         {
-          id: -2,
+          id: this.newCodeNeededOptionId,
           label: this.translateService.instant('code-selector.coding-issue-options.new-code-needed'),
           type: 'codingIssueOption'
         }
@@ -183,7 +192,9 @@ export class CodeSelectorComponent implements OnChanges {
       const preSelectedItem = this.selectableItems.find(item => item.id === this.preSelectedCodeId);
       if (preSelectedItem) {
         if (preSelectedItem.type === 'codingIssueOption') {
-          this.selectedCodingIssueOption = this.preSelectedCodeId;
+          if (this.isCodingIssueOptionAvailable(preSelectedItem)) {
+            this.selectedCodingIssueOption = this.preSelectedCodeId;
+          }
         } else {
           this.selectedCode = this.preSelectedCodeId;
         }
@@ -197,7 +208,11 @@ export class CodeSelectorComponent implements OnChanges {
 
     if (this.preSelectedCodingIssueOptionId !== null) {
       const codingIssueItem = this.selectableItems.find(item => item.id === this.preSelectedCodingIssueOptionId);
-      if (codingIssueItem && codingIssueItem.type === 'codingIssueOption') {
+      if (
+        codingIssueItem &&
+        codingIssueItem.type === 'codingIssueOption' &&
+        this.isCodingIssueOptionAvailable(codingIssueItem)
+      ) {
         this.selectedCodingIssueOption = this.preSelectedCodingIssueOptionId;
         // Clear regular code selection when pre-selecting -3 or -4
         if (this.preSelectedCodingIssueOptionId === -3 || this.preSelectedCodingIssueOptionId === -4) {
@@ -250,6 +265,7 @@ export class CodeSelectorComponent implements OnChanges {
     if (selectedItem.type !== 'codingIssueOption' && this.isRegularSelectionDisabled) return;
 
     if (selectedItem.type === 'codingIssueOption') {
+      if (!this.isCodingIssueOptionAvailable(selectedItem) || this.isCodingIssueOptionDisabled(selectedItem)) return;
       this.selectedCodingIssueOption = codeId;
       this.legacySelectedCode = null;
       // Clear regular code selection when selecting -3 or -4
@@ -263,6 +279,7 @@ export class CodeSelectorComponent implements OnChanges {
         this.selectedCodingIssueOption = null;
       }
     }
+    this.updateNewCodeCommentValidationState();
     const codeDto = this.selectedCode !== null ? this.createCodeOrCodingIssueOption(
       this.selectableItems.find(item => item.id === this.selectedCode)!
     ) : null;
@@ -281,7 +298,9 @@ export class CodeSelectorComponent implements OnChanges {
   }
 
   get codingIssueOptionCodes(): SelectableItem[] {
-    return this.selectableItems.filter(item => item.type === 'codingIssueOption');
+    return this.selectableItems.filter(
+      item => item.type === 'codingIssueOption' && this.isCodingIssueOptionAvailable(item)
+    );
   }
 
   get hasVariableManualInstruction(): boolean {
@@ -290,6 +309,23 @@ export class CodeSelectorComponent implements OnChanges {
 
   get isRegularSelectionDisabled(): boolean {
     return this.selectedCodingIssueOption === -3 || this.selectedCodingIssueOption === -4;
+  }
+
+  isCodingIssueOptionDisabled(item: SelectableItem): boolean {
+    if (this.isReadOnly) return true;
+    return item.id === this.codeAssignmentUncertainOptionId && this.selectedCode === null;
+  }
+
+  getCodingIssueOptionTooltip(item: SelectableItem): string {
+    if (!this.isReadOnly && item.id === this.codeAssignmentUncertainOptionId && this.selectedCode === null) {
+      return this.translateService.instant('code-selector.code-assignment-uncertain-requires-code');
+    }
+
+    return '';
+  }
+
+  private isCodingIssueOptionAvailable(item: SelectableItem): boolean {
+    return this.allowComments || !this.commentBoundCodingIssueOptionIds.has(item.id);
   }
 
   private hasCurrentSelection(): boolean {
@@ -303,6 +339,7 @@ export class CodeSelectorComponent implements OnChanges {
     this.selectedCode = null;
     this.selectedCodingIssueOption = null;
     this.legacySelectedCode = null;
+    this.newCodeCommentValidationError = false;
     this.codeSelected.emit({
       variableId: this.variableId,
       code: null,
@@ -327,7 +364,35 @@ export class CodeSelectorComponent implements OnChanges {
 
   onNotesChanged(): void {
     if (this.isReadOnly) return;
+    this.updateNewCodeCommentValidationState();
     this.notesChanged.emit(this.coderNotes);
+  }
+
+  canLeaveCurrentUnit(showValidationMessage = true): boolean {
+    if (!this.requiresNewCodeComment() || this.hasNewCodeComment()) {
+      this.newCodeCommentValidationError = false;
+      return true;
+    }
+
+    if (showValidationMessage) {
+      this.newCodeCommentValidationError = true;
+      setTimeout(() => this.notesTextarea?.nativeElement.focus(), 0);
+    }
+    return false;
+  }
+
+  private requiresNewCodeComment(): boolean {
+    return this.allowComments && this.selectedCodingIssueOption === this.newCodeNeededOptionId;
+  }
+
+  private hasNewCodeComment(): boolean {
+    return this.coderNotes.trim().length > 0;
+  }
+
+  private updateNewCodeCommentValidationState(): void {
+    if (!this.requiresNewCodeComment() || this.hasNewCodeComment()) {
+      this.newCodeCommentValidationError = false;
+    }
   }
 
   nextUnit(): void {
@@ -337,6 +402,7 @@ export class CodeSelectorComponent implements OnChanges {
     if (this.isNavigationDisabled) return;
     if (this.hasSaveError) return;
     if (!this.isReadOnly && !this.hasCurrentSelection()) return;
+    if (!this.isReadOnly && !this.canLeaveCurrentUnit()) return;
 
     const currentIndex = data.currentUnitIndex;
     const nextIndex = currentIndex + 1;
@@ -412,8 +478,8 @@ export class CodeSelectorComponent implements OnChanges {
     }
 
     if (targetId !== null) {
-      const optionExists = this.selectableItems.some(item => item.id === targetId);
-      if (optionExists) {
+      const option = this.selectableItems.find(item => item.id === targetId);
+      if (option && this.isCodingIssueOptionAvailable(option) && !this.isCodingIssueOptionDisabled(option)) {
         event.preventDefault(); // Prevent default browser action (e.g. quick find with '/')
         this.onSelect(targetId);
       }

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -447,7 +447,8 @@ describe('ReplayComponent', () => {
       'valid@test@person',
       'unit-123',
       'VAR1',
-      'note'
+      'note',
+      null
     );
   });
 
@@ -572,6 +573,34 @@ describe('ReplayComponent', () => {
     expect(component.page).toBe('1');
     expect(component.anchor).toBe('ANCHOR_2');
     expect(component.codingService.currentVariableId).toBe('VAR_2');
+  });
+
+  it('should not change coding units when the code selector blocks leaving the current case', async () => {
+    const canLeaveCurrentUnit = jest.fn().mockReturnValue(false);
+    const privateComponent = component as unknown as {
+      codeSelectorComponent: { canLeaveCurrentUnit: jest.Mock };
+    };
+
+    component.isCodingMode = true;
+    component.unitId = 'UNIT_1';
+    component.page = '0';
+    component.codingService.currentVariableId = 'VAR_1';
+    privateComponent.codeSelectorComponent = { canLeaveCurrentUnit };
+
+    await component.handleUnitChanged({
+      id: 2,
+      name: 'UNIT_2',
+      alias: null,
+      bookletId: 0,
+      variableId: 'VAR_2',
+      variableAnchor: 'VAR_2',
+      variablePage: '1'
+    });
+
+    expect(canLeaveCurrentUnit).toHaveBeenCalled();
+    expect(component.unitId).toBe('UNIT_1');
+    expect(component.page).toBe('0');
+    expect(component.codingService.currentVariableId).toBe('VAR_1');
   });
 
   it('should ignore external unit changes while a coding job switch is running', async () => {

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -201,6 +201,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private replayTokenRefreshRunning = false;
   private codingJobWorkspaceNames = new Map<number, string>();
   @ViewChild(UnitPlayerComponent) unitPlayerComponent: UnitPlayerComponent | undefined;
+  @ViewChild(CodeSelectorComponent) codeSelectorComponent: CodeSelectorComponent | undefined;
   @ViewChild('watermark')
   set watermarkRef(ref: ElementRef<HTMLElement> | undefined) {
     this.watermarkElement = ref ?? null;
@@ -965,7 +966,13 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   async handleUnitChanged(unit: UnitsReplayUnit): Promise<void> {
     if (this.isCodingInteractionBlockedByReAuthentication()) return;
     if (this.isSwitchingCodingJob) return;
+    if (!this.canLeaveCurrentCodingCase()) return;
     await this.applyUnitChanged(unit);
+  }
+
+  private canLeaveCurrentCodingCase(): boolean {
+    if (this.isCodingReadOnly()) return true;
+    return this.codeSelectorComponent?.canLeaveCurrentUnit() ?? true;
   }
 
   private async applyUnitChanged(unit: UnitsReplayUnit): Promise<void> {
@@ -1150,7 +1157,8 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       this.testPerson,
       this.unitId,
       this.codingService.currentVariableId,
-      notes
+      notes,
+      this.unitsData
     ).catch(() => undefined);
   }
 

--- a/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
@@ -101,6 +101,53 @@ describe('ReplayCodingService', () => {
       expect(service.showScore).toBe(true);
     });
 
+    it('preserves coding issue options on regular codes loaded from saved progress', async () => {
+      service.currentVariableId = 'VAR1';
+      service.codingScheme = {
+        id: 'scheme-1',
+        label: 'Scheme',
+        variableCodings: [
+          {
+            id: 'VAR1',
+            alias: 'VAR1',
+            sourceType: 'manual',
+            codes: [
+              {
+                id: 7,
+                code: '7',
+                label: 'Regular',
+                score: 1,
+                type: 'manual'
+              }
+            ]
+          }
+        ]
+      } as never;
+      const key = service.generateCompositeKey('p1', 'u1', 'VAR1');
+
+      codingJobBackendServiceMock.getCodingProgress.mockReturnValue(of({
+        [key]: {
+          id: 7,
+          code: '7',
+          label: 'Regular',
+          score: 1,
+          codingIssueOption: -1
+        }
+      }));
+      codingJobBackendServiceMock.getCodingNotes.mockReturnValue(of({}));
+      codingJobBackendServiceMock.getCodingJob.mockReturnValue(of({} as CodingJob));
+
+      await service.loadSavedCodingProgress(1, 100);
+
+      expect(service.selectedCodes.get(key)).toEqual({
+        id: 7,
+        code: '7',
+        label: 'Regular',
+        score: 1,
+        codingIssueOption: -1
+      });
+    });
+
     it('should pass the replay auth token while loading progress, notes, and job details', async () => {
       codingJobBackendServiceMock.getCodingProgress.mockReturnValue(of({}));
       codingJobBackendServiceMock.getCodingNotes.mockReturnValue(of({}));
@@ -468,6 +515,89 @@ describe('ReplayCodingService', () => {
       await expect(second).resolves.toBeNull();
       expect(service.selectedCodes.get(key)?.id).toBe(9);
     });
+
+    it('keeps new-code-needed without notes local and incomplete without persisting it', async () => {
+      codingJobBackendServiceMock.saveCodingProgress.mockReturnValue(of({} as CodingJob));
+      service.codingJobId = 100;
+      const unitsData = {
+        id: 1,
+        name: 'job',
+        currentUnitIndex: 0,
+        units: [
+          {
+            id: 1,
+            name: 'u1',
+            alias: 'u1',
+            bookletId: 0,
+            testPerson: 'p1',
+            variableId: 'v1'
+          }
+        ]
+      };
+      const key = service.generateCompositeKey('p1', 'u1', 'v1');
+      service.openUnitKeys.add(key);
+
+      await service.handleCodeSelected(
+        {
+          variableId: 'v1',
+          code: null,
+          codingIssueOption: {
+            id: 'uncertain--2',
+            label: 'New code needed',
+            description: '',
+            code: -2
+          }
+        },
+        'p1',
+        'u1',
+        1,
+        unitsData
+      );
+
+      expect(codingJobBackendServiceMock.saveCodingProgress).not.toHaveBeenCalled();
+      expect(service.selectedCodes.get(key)?.id).toBe(-2);
+      expect(service.openUnitKeys.has(key)).toBe(false);
+      expect(service.getCompletedCount(unitsData)).toBe(0);
+      expect(service.isCodingJobCompleted).toBe(false);
+    });
+
+    it('does not clear persisted regular progress when new-code-needed is selected without notes', async () => {
+      codingJobBackendServiceMock.saveCodingProgress.mockReturnValue(of({} as CodingJob));
+      service.codingJobId = 100;
+      const key = service.generateCompositeKey('p1', 'u1', 'v1');
+      service.selectedCodes.set(key, {
+        id: 7,
+        code: '7',
+        label: 'Regular',
+        score: 1
+      });
+
+      await service.handleCodeSelected(
+        {
+          variableId: 'v1',
+          code: { id: 7, label: 'Regular', score: 1 } as never,
+          codingIssueOption: {
+            id: 'uncertain--2',
+            label: 'New code needed',
+            description: '',
+            code: -2
+          }
+        },
+        'p1',
+        'u1',
+        1,
+        null
+      );
+
+      expect(codingJobBackendServiceMock.saveCodingProgress).not.toHaveBeenCalled();
+      expect(service.selectedCodes.get(key)).toMatchObject({
+        id: 7,
+        code: '7',
+        label: 'Regular',
+        score: 1,
+        codingIssueOption: -2
+      });
+    });
   });
 
   describe('resetCodingData', () => {
@@ -658,6 +788,287 @@ describe('ReplayCodingService', () => {
 
       expect(service.hasSaveError).toBe(false);
       expect(service.lastSaveError).toBeNull();
+    });
+
+    it('persists deferred new-code-needed progress after notes are added', async () => {
+      codingJobBackendServiceMock.saveCodingNotes.mockReturnValue(of({} as CodingJob));
+      codingJobBackendServiceMock.saveCodingProgress.mockReturnValue(of({} as CodingJob));
+      service.codingJobId = 100;
+      const key = service.generateCompositeKey('p1', 'u1', 'v1');
+      service.selectedCodes.set(key, {
+        id: -2,
+        code: '-2',
+        label: 'New code needed',
+        codingIssueOption: -2
+      });
+      service.openUnitKeys.add(key);
+      const unitsData = {
+        id: 1,
+        name: 'job',
+        currentUnitIndex: 0,
+        units: [
+          {
+            id: 1,
+            name: 'u1',
+            alias: 'u1',
+            bookletId: 0,
+            testPerson: 'p1',
+            variableId: 'v1'
+          }
+        ]
+      };
+
+      await service.saveNotes(1, 'p1', 'u1', 'v1', 'needs a new code', unitsData);
+
+      expect(codingJobBackendServiceMock.saveCodingProgress).toHaveBeenCalledWith(
+        1,
+        100,
+        {
+          testPerson: 'p1',
+          unitId: 'u1',
+          variableId: 'v1',
+          selectedCode: {
+            id: -2,
+            code: '-2',
+            label: 'New code needed',
+            score: null,
+            codingIssueOption: -2
+          }
+        }
+      );
+      expect(service.openUnitKeys.has(key)).toBe(false);
+      expect(service.isCodingJobCompleted).toBe(true);
+    });
+
+    it('does not let deferred new-code-needed note sync overwrite newer selections', async () => {
+      const noteSubject = new Subject<CodingJob>();
+      const progressSubjects: Subject<CodingJob>[] = [];
+      codingJobBackendServiceMock.saveCodingNotes.mockReturnValue(noteSubject.asObservable());
+      codingJobBackendServiceMock.saveCodingProgress.mockImplementation(() => {
+        const subject = new Subject<CodingJob>();
+        progressSubjects.push(subject);
+        return subject.asObservable();
+      });
+      service.codingJobId = 100;
+      const key = service.generateCompositeKey('p1', 'u1', 'v1');
+      service.selectedCodes.set(key, {
+        id: -2,
+        code: '-2',
+        label: 'New code needed',
+        codingIssueOption: -2
+      });
+
+      const noteSave = service.saveNotes(1, 'p1', 'u1', 'v1', 'needs a new code');
+      await Promise.resolve();
+      expect(codingJobBackendServiceMock.saveCodingNotes).toHaveBeenCalledTimes(1);
+
+      const regularSave = service.handleCodeSelected(
+        {
+          variableId: 'v1',
+          code: { id: 7, label: 'Regular', score: 1 } as never,
+          codingIssueOption: null
+        },
+        'p1',
+        'u1',
+        1,
+        null
+      );
+      await Promise.resolve();
+      expect(codingJobBackendServiceMock.saveCodingProgress).not.toHaveBeenCalled();
+
+      noteSubject.next({} as CodingJob);
+      noteSubject.complete();
+      await noteSave;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(codingJobBackendServiceMock.saveCodingProgress).toHaveBeenCalledTimes(1);
+      expect(codingJobBackendServiceMock.saveCodingProgress).toHaveBeenCalledWith(
+        1,
+        100,
+        {
+          testPerson: 'p1',
+          unitId: 'u1',
+          variableId: 'v1',
+          selectedCode: {
+            id: 7,
+            code: '7',
+            label: 'Regular',
+            score: 1,
+            codingIssueOption: null
+          }
+        }
+      );
+
+      progressSubjects[0].next({} as CodingJob);
+      progressSubjects[0].complete();
+      await regularSave;
+      expect(service.selectedCodes.get(key)?.id).toBe(7);
+    });
+
+    it('persists latest new-code-needed selection when it is chosen during a note save', async () => {
+      const noteSubject = new Subject<CodingJob>();
+      const progressSubjects: Subject<CodingJob>[] = [];
+      codingJobBackendServiceMock.saveCodingNotes.mockReturnValue(noteSubject.asObservable());
+      codingJobBackendServiceMock.saveCodingProgress.mockImplementation(() => {
+        const subject = new Subject<CodingJob>();
+        progressSubjects.push(subject);
+        return subject.asObservable();
+      });
+      service.codingJobId = 100;
+      const key = service.generateCompositeKey('p1', 'u1', 'v1');
+
+      const noteSave = service.saveNotes(1, 'p1', 'u1', 'v1', 'needs a new code');
+      const newCodeNeededSelection = service.handleCodeSelected(
+        {
+          variableId: 'v1',
+          code: null,
+          codingIssueOption: {
+            id: 'uncertain--2',
+            label: 'New code needed',
+            description: '',
+            code: -2
+          }
+        },
+        'p1',
+        'u1',
+        1,
+        null
+      );
+      await newCodeNeededSelection;
+      await Promise.resolve();
+      expect(codingJobBackendServiceMock.saveCodingNotes).toHaveBeenCalledTimes(1);
+      expect(codingJobBackendServiceMock.saveCodingProgress).not.toHaveBeenCalled();
+
+      noteSubject.next({} as CodingJob);
+      noteSubject.complete();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(codingJobBackendServiceMock.saveCodingProgress).toHaveBeenCalledWith(
+        1,
+        100,
+        {
+          testPerson: 'p1',
+          unitId: 'u1',
+          variableId: 'v1',
+          selectedCode: {
+            id: -2,
+            code: '-2',
+            label: 'New code needed',
+            score: null,
+            description: '',
+            codingIssueOption: -2
+          }
+        }
+      );
+      progressSubjects[0].next({} as CodingJob);
+      progressSubjects[0].complete();
+      await noteSave;
+      expect(service.selectedCodes.get(key)?.id).toBe(-2);
+    });
+
+    it('clears persisted new-code-needed progress when required notes are deleted', async () => {
+      codingJobBackendServiceMock.saveCodingNotes.mockReturnValue(of({} as CodingJob));
+      codingJobBackendServiceMock.saveCodingProgress.mockReturnValue(of({} as CodingJob));
+      service.codingJobId = 100;
+      const key = service.generateCompositeKey('p1', 'u1', 'v1');
+      service.notes.set(key, 'old note');
+      service.selectedCodes.set(key, {
+        id: -2,
+        code: '-2',
+        label: 'New code needed',
+        codingIssueOption: -2
+      });
+      service.isCodingJobCompleted = true;
+      const unitsData = {
+        id: 1,
+        name: 'job',
+        currentUnitIndex: 0,
+        units: [
+          {
+            id: 1,
+            name: 'u1',
+            alias: 'u1',
+            bookletId: 0,
+            testPerson: 'p1',
+            variableId: 'v1'
+          }
+        ]
+      };
+
+      await service.saveNotes(1, 'p1', 'u1', 'v1', '   ', unitsData);
+
+      expect(codingJobBackendServiceMock.saveCodingProgress).toHaveBeenCalledWith(
+        1,
+        100,
+        {
+          testPerson: 'p1',
+          unitId: 'u1',
+          variableId: 'v1',
+          selectedCode: null
+        }
+      );
+      expect(service.selectedCodes.get(key)?.id).toBe(-2);
+      expect(service.notes.has(key)).toBe(false);
+      expect(service.isCodingJobCompleted).toBe(false);
+    });
+
+    it('keeps regular progress when notes for attached new-code-needed are deleted', async () => {
+      codingJobBackendServiceMock.saveCodingNotes.mockReturnValue(of({} as CodingJob));
+      codingJobBackendServiceMock.saveCodingProgress.mockReturnValue(of({} as CodingJob));
+      service.codingJobId = 100;
+      const key = service.generateCompositeKey('p1', 'u1', 'v1');
+      service.notes.set(key, 'old note');
+      service.selectedCodes.set(key, {
+        id: 7,
+        code: '7',
+        label: 'Regular',
+        score: 1,
+        codingIssueOption: -2
+      });
+      const unitsData = {
+        id: 1,
+        name: 'job',
+        currentUnitIndex: 0,
+        units: [
+          {
+            id: 1,
+            name: 'u1',
+            alias: 'u1',
+            bookletId: 0,
+            testPerson: 'p1',
+            variableId: 'v1'
+          }
+        ]
+      };
+
+      await service.saveNotes(1, 'p1', 'u1', 'v1', '   ', unitsData);
+
+      expect(codingJobBackendServiceMock.saveCodingProgress).toHaveBeenCalledWith(
+        1,
+        100,
+        {
+          testPerson: 'p1',
+          unitId: 'u1',
+          variableId: 'v1',
+          selectedCode: {
+            id: 7,
+            code: '7',
+            label: 'Regular',
+            score: 1,
+            codingIssueOption: null
+          }
+        }
+      );
+      expect(service.selectedCodes.get(key)).toEqual({
+        id: 7,
+        code: '7',
+        label: 'Regular',
+        score: 1
+      });
+      expect(service.notes.has(key)).toBe(false);
+      expect(service.isCodingJobCompleted).toBe(true);
     });
   });
 

--- a/apps/frontend/src/app/replay/services/replay-coding.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.ts
@@ -32,6 +32,7 @@ export class ReplayCodingService {
   private translate = inject(TranslateService);
   private snackBar = inject(MatSnackBar);
   private authToken?: string;
+  private readonly newCodeNeededOptionId = -2;
 
   codingScheme: CodingScheme | null = null;
   currentVariableId: string = '';
@@ -55,6 +56,7 @@ export class ReplayCodingService {
   private rowMutationChains = new Map<string, Promise<void>>();
   private pendingRowMutations = new Set<Promise<void>>();
   private latestSelectionRevisionByKey = new Map<string, number>();
+  private latestRequestedSelectionByKey = new Map<string, SavedCode | null>();
   private selectionRevision = 0;
   private codingDataRunId = 0;
   currentCodingJobStatus: string | null = null;
@@ -87,6 +89,7 @@ export class ReplayCodingService {
     this.rowMutationChains.clear();
     this.pendingRowMutations.clear();
     this.latestSelectionRevisionByKey.clear();
+    this.latestRequestedSelectionByKey.clear();
     this.selectionRevision = 0;
     this.currentCodingJobStatus = null;
     this.showScore = false;
@@ -155,6 +158,7 @@ export class ReplayCodingService {
     this.selectedCodes.clear();
     this.openUnitKeys.clear();
     this.notes.clear();
+    this.latestRequestedSelectionByKey.clear();
 
     try {
       const savedProgress = await firstValueFrom(
@@ -170,6 +174,9 @@ export class ReplayCodingService {
         if (partialCode?.id !== null && partialCode?.id !== undefined) {
           const fullCode = this.findCodeById(partialCode.id);
           const toStore: SavedCode = fullCode ? this.convertCodeToSavedCode(fullCode) : partialCode;
+          if (partialCode.codingIssueOption !== undefined && partialCode.codingIssueOption !== null) {
+            toStore.codingIssueOption = partialCode.codingIssueOption;
+          }
           this.selectedCodes.set(compositeKey, toStore);
           this.openUnitKeys.delete(compositeKey);
         }
@@ -302,7 +309,18 @@ export class ReplayCodingService {
         const unitId = parts[2];
         const variableId = parts[3];
 
-        savePromises.push(this.saveCodingProgress(workspaceId, jobId, testPerson, unitId, variableId, selectedCode));
+        if (this.isSelectedCodePersistable(compositeKey, selectedCode)) {
+          savePromises.push(
+            this.saveCodingProgress(
+              workspaceId,
+              jobId,
+              testPerson,
+              unitId,
+              variableId,
+              selectedCode
+            )
+          );
+        }
       }
     }
 
@@ -338,6 +356,7 @@ export class ReplayCodingService {
     const revision = this.nextSelectionRevision(compositeKey);
 
     if (event.code === null && event.codingIssueOption === null) {
+      this.latestRequestedSelectionByKey.set(compositeKey, null);
       if (this.codingJobId) {
         await this.saveCodingProgress(workspaceId, this.codingJobId, testPerson, unitId, event.variableId, null);
       }
@@ -364,9 +383,18 @@ export class ReplayCodingService {
       if (event.codingIssueOption) {
         normalizedCode.codingIssueOption = event.codingIssueOption.code;
       }
+      this.latestRequestedSelectionByKey.set(compositeKey, normalizedCode);
 
       if (this.codingJobId) {
-        await this.saveCodingProgress(workspaceId, this.codingJobId, testPerson, unitId, event.variableId, normalizedCode);
+        await this.saveCodingProgressIfSelectedCodePersistable(
+          compositeKey,
+          workspaceId,
+          this.codingJobId,
+          testPerson,
+          unitId,
+          event.variableId,
+          normalizedCode
+        );
       }
       if (!this.shouldApplySelectionMutation(compositeKey, revision, contextSnapshot)) {
         return null;
@@ -384,8 +412,17 @@ export class ReplayCodingService {
         description: codingIssueOption.description,
         codingIssueOption: codingIssueOption.code
       };
+      this.latestRequestedSelectionByKey.set(compositeKey, normalizedCode);
       if (this.codingJobId) {
-        await this.saveCodingProgress(workspaceId, this.codingJobId, testPerson, unitId, event.variableId, normalizedCode);
+        await this.saveCodingProgressIfSelectedCodePersistable(
+          compositeKey,
+          workspaceId,
+          this.codingJobId,
+          testPerson,
+          unitId,
+          event.variableId,
+          normalizedCode
+        );
       }
       if (!this.shouldApplySelectionMutation(compositeKey, revision, contextSnapshot)) {
         return null;
@@ -426,9 +463,7 @@ export class ReplayCodingService {
     if (!unitsData || !unitsData.units || unitsData.units.length === 0) return;
     const totalReplays = unitsData.units.length;
     const completedReplays = this.getCompletedCount(unitsData);
-    if (completedReplays === totalReplays) {
-      this.isCodingJobCompleted = true;
-    }
+    this.isCodingJobCompleted = completedReplays === totalReplays;
   }
 
   getCompletedCount(unitsData: UnitsReplay | null): number {
@@ -440,7 +475,7 @@ export class ReplayCodingService {
           unit.name || '',
           unit.variableId
         );
-        return this.selectedCodes.has(compositeKey);
+        return this.isUnitCodedByCompositeKey(compositeKey);
       }
       return false;
     }).length;
@@ -487,7 +522,8 @@ export class ReplayCodingService {
     testPerson: string,
     unitId: string,
     variableId: string,
-    notes: string
+    notes: string,
+    unitsData: UnitsReplay | null = null
   ): Promise<void> {
     const jobId = this.codingJobId;
     const authToken = this.authToken;
@@ -497,6 +533,7 @@ export class ReplayCodingService {
     if (this.isReviewMode) return;
 
     const compositeKey = this.generateCompositeKey(testPerson, unitId, variableId);
+    const selectionRevisionAtStart = this.latestSelectionRevisionByKey.get(compositeKey) ?? 0;
     const saveFailureKey = this.getSaveFailureKey('notes', compositeKey);
     const trimmedNotes = notes.trim();
     await this.enqueueRowMutation(compositeKey, async () => {
@@ -537,6 +574,21 @@ export class ReplayCodingService {
         throw error;
       }
     });
+
+    if (this.isCurrentCodingContext(contextSnapshot)) {
+      await this.syncNewCodeNeededProgressAfterNotes(
+        workspaceId,
+        jobId,
+        testPerson,
+        unitId,
+        variableId,
+        compositeKey,
+        selectionRevisionAtStart
+      );
+      if (unitsData) {
+        this.checkCodingJobCompletion(unitsData);
+      }
+    }
   }
 
   async saveCodingJobComment(workspaceId: number, comment: string): Promise<void> {
@@ -650,7 +702,7 @@ export class ReplayCodingService {
           unit.variableId
         );
 
-        if (!this.selectedCodes.has(compositeKey)) {
+        if (!this.isUnitCodedByCompositeKey(compositeKey)) {
           return i;
         }
       }
@@ -669,7 +721,100 @@ export class ReplayCodingService {
       unit.variableId
     );
 
-    return this.selectedCodes.has(compositeKey);
+    return this.isUnitCodedByCompositeKey(compositeKey);
+  }
+
+  private isUnitCodedByCompositeKey(compositeKey: string): boolean {
+    return this.isCompletedSelection(compositeKey, this.selectedCodes.get(compositeKey));
+  }
+
+  private isCompletedSelection(compositeKey: string, selectedCode: SavedCode | undefined): boolean {
+    if (!selectedCode) return false;
+    return !this.isNewCodeNeededSelection(selectedCode) || this.hasNewCodeNeededNote(compositeKey);
+  }
+
+  private isSelectedCodePersistable(compositeKey: string, selectedCode: SavedCode): boolean {
+    return this.isCompletedSelection(compositeKey, selectedCode);
+  }
+
+  private async saveCodingProgressIfSelectedCodePersistable(
+    compositeKey: string,
+    workspaceId: number,
+    jobId: number,
+    testPerson: string,
+    unitId: string,
+    variableId: string,
+    selectedCode: SavedCode
+  ): Promise<void> {
+    if (!this.isSelectedCodePersistable(compositeKey, selectedCode)) return;
+
+    await this.saveCodingProgress(
+      workspaceId,
+      jobId,
+      testPerson,
+      unitId,
+      variableId,
+      selectedCode
+    );
+  }
+
+  private isNewCodeNeededSelection(selectedCode: SavedCode): boolean {
+    return selectedCode.id === this.newCodeNeededOptionId ||
+      selectedCode.codingIssueOption === this.newCodeNeededOptionId;
+  }
+
+  private hasNewCodeNeededNote(compositeKey: string): boolean {
+    return !!this.notes.get(compositeKey)?.trim();
+  }
+
+  private async syncNewCodeNeededProgressAfterNotes(
+    workspaceId: number,
+    jobId: number,
+    testPerson: string,
+    unitId: string,
+    variableId: string,
+    compositeKey: string,
+    selectionRevisionAtStart: number
+  ): Promise<void> {
+    const latestSelectionRevision = this.latestSelectionRevisionByKey.get(compositeKey) ?? 0;
+    const didSelectionChange = latestSelectionRevision !== selectionRevisionAtStart;
+    const selectedCode = didSelectionChange ?
+      this.latestRequestedSelectionByKey.get(compositeKey) :
+      this.selectedCodes.get(compositeKey);
+    if (!selectedCode || !this.isNewCodeNeededSelection(selectedCode)) return;
+
+    const isPersistable = this.isSelectedCodePersistable(compositeKey, selectedCode);
+    const selectedCodeToSave = isPersistable ?
+      selectedCode :
+      this.getSelectionAfterNewCodeNeededNoteRemoval(selectedCode);
+    if (didSelectionChange && selectedCodeToSave === null) return;
+    if (selectedCodeToSave === undefined) return;
+
+    this.openUnitKeys.delete(compositeKey);
+    if (selectedCodeToSave !== null) {
+      this.selectedCodes.set(compositeKey, selectedCodeToSave);
+      this.latestRequestedSelectionByKey.set(compositeKey, selectedCodeToSave);
+    }
+    await this.saveCodingProgress(
+      workspaceId,
+      jobId,
+      testPerson,
+      unitId,
+      variableId,
+      selectedCodeToSave
+    );
+  }
+
+  private getSelectionAfterNewCodeNeededNoteRemoval(selectedCode: SavedCode): SavedCode | null | undefined {
+    if (selectedCode.codingIssueOption === this.newCodeNeededOptionId && selectedCode.id !== this.newCodeNeededOptionId) {
+      const selectionWithoutNewCodeNeeded = { ...selectedCode };
+      delete selectionWithoutNewCodeNeeded.codingIssueOption;
+      return {
+        ...selectionWithoutNewCodeNeeded
+      };
+    }
+
+    return selectedCode.id === this.newCodeNeededOptionId ? null : undefined;
   }
 
   getNextJumpableUnitIndex(unitsData: UnitsReplay | null, fromIndex: number): number {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1055,6 +1055,8 @@
     "legacy-code-missing-note": "Dieser Code ist im aktuellen Kodierschema nicht mehr vorhanden.",
     "coder-notes": "Notiz zu diesem Kodierfall",
     "coder-notes-placeholder": "Notiz zu diesem Kodierfall",
+    "code-assignment-uncertain-requires-code": "Code-Vergabe unsicher kann erst nach einem regulären Code ausgewählt werden.",
+    "new-code-comment-required": "Bitte begründen Sie „Neuer Code nötig“ im Kommentar zu diesem Kodierfall.",
     "coding-issue-options": {
       "code-assignment-uncertain": "Code-Vergabe unsicher",
       "new-code-needed": "Neuer Code nötig",


### PR DESCRIPTION
## Änderungen

- blendet kommentargebundene Sondercodes aus, wenn Kommentare deaktiviert sind
- erlaubt „Code-Vergabe unsicher“ nur zusammen mit einem regulären Code
- verlangt für „Neuer Code nötig“ eine Notiz und fokussiert das Notizfeld bei fehlender Begründung
- synchronisiert die Persistenz, wenn Notizen nachträglich ergänzt oder gelöscht werden
- ergänzt Backend-Validierung für dieselben Regeln und sichert Reload-/Löschfälle ab

## Bezug

Issue: #682 bleibt offen.

## Validierung

- `npx nx test frontend --testFile=apps/frontend/src/app/replay/services/replay-coding.service.spec.ts --runInBand`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job.service.spec.ts --runInBand`
- `npx nx lint frontend`
- `npx nx lint backend`
- `git diff --check`

Zusätzlich vorher ausgeführt:

- `npx nx test frontend --runInBand`
- `npx nx test backend --runInBand`