### PR TITLE
Exact variable ID filter for coding overview

### DIFF
--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -800,6 +800,44 @@ describe('WorkspaceTestResultsService', () => {
       );
     });
 
+    it('should filter variable IDs by contains search by default', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(0);
+
+      await service.searchResponses(
+        1,
+        { variableId: '01' },
+        { page: 1, limit: 100 }
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'response.variableid ILIKE :variableId',
+        { variableId: '%01%' }
+      );
+    });
+
+    it('should filter variable IDs exactly when wrapped in double quotes', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(0);
+
+      await service.searchResponses(
+        1,
+        { variableId: ' "01_unique" ' },
+        { page: 1, limit: 100 }
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'LOWER(response.variableid) = LOWER(:variableId)',
+        { variableId: '01_unique' }
+      );
+      expect(qb.andWhere).not.toHaveBeenCalledWith(
+        'response.variableid ILIKE :variableId',
+        expect.objectContaining({ variableId: expect.stringContaining('%') })
+      );
+    });
+
     it('should filter GeoGebra searches by raw and data-uri ggb response values', async () => {
       const qb = mockQueryBuilder();
       (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -188,6 +188,11 @@ interface LogAnomalySqlFragment {
   params: Record<string, string | string[]>;
 }
 
+interface TextSearchFilter {
+  value: string;
+  exact: boolean;
+}
+
 interface LogAnomalyDashboardSummary {
   totalBooklets: number;
   affectedBooklets: number;
@@ -302,6 +307,21 @@ export class WorkspaceTestResultsService {
 
   private static createGeoGebraUnitExistsCondition(unitAlias: string): string {
     return `EXISTS (SELECT 1 FROM response r2 WHERE r2.unitid = ${unitAlias}.id AND ${WorkspaceTestResultsService.createGeoGebraValueCondition('r2')})`;
+  }
+
+  private static parseQuotedExactSearchFilter(filter: string): TextSearchFilter {
+    const trimmed = filter.trim();
+    if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+      return {
+        value: trimmed.slice(1, -1),
+        exact: true
+      };
+    }
+
+    return {
+      value: filter,
+      exact: false
+    };
   }
 
   private static parseStoredResponseValue(value: string | null, variableId?: string): unknown {
@@ -6547,9 +6567,16 @@ export class WorkspaceTestResultsService {
       }
 
       if (searchParams.variableId) {
-        query.andWhere('response.variableid ILIKE :variableId', {
-          variableId: `%${searchParams.variableId}%`
-        });
+        const variableIdFilter = WorkspaceTestResultsService.parseQuotedExactSearchFilter(searchParams.variableId);
+        if (variableIdFilter.exact) {
+          query.andWhere('LOWER(response.variableid) = LOWER(:variableId)', {
+            variableId: variableIdFilter.value
+          });
+        } else {
+          query.andWhere('response.variableid ILIKE :variableId', {
+            variableId: `%${variableIdFilter.value}%`
+          });
+        }
       }
 
       if (searchParams.unitName) {


### PR DESCRIPTION
## Summary

Adds exact matching for the variable ID filter in the coding overview when the input is wrapped in double quotes, for example `"01"`.

The existing contains-search behavior remains unchanged for unquoted input such as `01`.

Refs #687

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts --runInBand`
- `npx nx lint backend`
- Previously also ran `npx nx test backend --runInBand` before branching this patch from `develop`.
