### PR TITLE
Replay coder markers for double-coded review

### DIFF
--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
@@ -20,6 +20,10 @@
   font-weight: 500;
 }
 
+.code-row.has-review-code-selection {
+  border-color: rgba(25, 118, 210, 0.32);
+}
+
 .code-row.read-only {
   opacity: 0.56;
 }
@@ -27,6 +31,15 @@
 .code-row.read-only:hover {
   background-color: transparent;
   border-color: transparent;
+}
+
+.code-row.read-only.has-review-code-selection:hover {
+  border-color: rgba(25, 118, 210, 0.32);
+}
+
+.code-row.selected.has-review-code-selection,
+.code-row.selected.read-only.has-review-code-selection:hover {
+  border-color: #2196f3;
 }
 
 .general-instruction-row {
@@ -105,6 +118,27 @@
 .code-score {
   color: rgba(0, 0, 0, 0.6);
   font-style: italic;
+}
+
+.review-code-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  min-width: 26px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 4px;
+  background-color: #e8f0fe;
+  color: #174ea6;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 20px;
+}
+
+.review-code-badge mat-icon {
+  width: 14px;
+  height: 14px;
+  font-size: 14px;
 }
 
 .code-instruction {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
@@ -105,8 +105,11 @@
         <div class="legacy-code-note">{{ legacyCodeNoteTranslationKey | translate }}</div>
       </div>
       <div class="code-row" [class.selected]="item.id === selectedCode"
+        [class.has-review-code-selection]="hasReviewCodeSelection(item.id)"
         [class.read-only]="isReadOnly || isRegularSelectionDisabled" *ngFor="let item of regularCodes;"
         [style.cursor]="(isReadOnly || isRegularSelectionDisabled) ? 'not-allowed' : 'pointer'"
+        [matTooltip]="getReviewCodeSelectionTooltip(item.id)"
+        [matTooltipDisabled]="!hasReviewCodeSelection(item.id)"
         (click)="(isReadOnly || isRegularSelectionDisabled) ? null : onSelect(item.id)">
 
         <div class="code-content">
@@ -114,6 +117,10 @@
             <span class="code-id">{{ item.id }}</span>
             <span class="code-score" *ngIf="showScore && item.score !== undefined">{{ 'code-selector.score-label' |
               translate }} {{ item.score }}</span>
+            <span class="review-code-badge" *ngIf="getReviewCodeSelectionCount(item.id) as reviewCoderCount">
+              <mat-icon>group</mat-icon>
+              <span>{{ reviewCoderCount }}</span>
+            </span>
           </span>
         </div>
         <div class="code-instruction" *ngIf="item.manualInstruction"
@@ -128,15 +135,20 @@
 
   <div class="uncertain-codes-section fixed-section">
     <div class="code-row" [class.selected]="item.id === selectedCodingIssueOption"
+      [class.has-review-code-selection]="hasReviewCodeSelection(item.id)"
       [class.read-only]="isCodingIssueOptionDisabled(item)" *ngFor="let item of codingIssueOptionCodes;"
       [style.cursor]="isCodingIssueOptionDisabled(item) ? 'not-allowed' : 'pointer'"
       [attr.aria-disabled]="isCodingIssueOptionDisabled(item)"
-      [matTooltip]="getCodingIssueOptionTooltip(item)"
-      [matTooltipDisabled]="!getCodingIssueOptionTooltip(item)"
+      [matTooltip]="getCodingIssueOptionRowTooltip(item)"
+      [matTooltipDisabled]="!getCodingIssueOptionRowTooltip(item)"
       (click)="isCodingIssueOptionDisabled(item) ? null : onSelect(item.id)">
       <div class="code-content">
         <span class="shortcut-icon" *ngIf="getShortcutLabel(item.id)">{{ getShortcutLabel(item.id) }}</span>
         <span class="uncertain-text">{{ item.label }}</span>
+        <span class="review-code-badge" *ngIf="getReviewCodeSelectionCount(item.id) as reviewCoderCount">
+          <mat-icon>group</mat-icon>
+          <span>{{ reviewCoderCount }}</span>
+        </span>
       </div>
     </div>
   </div>

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -1,7 +1,7 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { CodingScheme } from '../../../models/coding-interfaces';
 import { CodeSelectorComponent } from './code-selector.component';
 
@@ -297,6 +297,56 @@ describe('CodeSelectorComponent', () => {
       code: mixedCodingScheme.variableCodings[0].codes[0],
       codingIssueOption: null
     });
+  });
+
+  it('shows review coder badges for codes selected by previous coders', () => {
+    const translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('de', {
+      'code-selector': {
+        'review-coders-tooltip': 'Von folgenden Kodierern vergeben: {{coders}}'
+      }
+    });
+    translateService.setDefaultLang('de');
+    translateService.use('de');
+
+    component.codingScheme = mixedCodingScheme;
+    component.variableId = 'VAR1';
+    component.reviewCodeSelections = [
+      { code: 1, coderNames: ['Coder A', 'Coder B'] },
+      { code: 2, coderNames: ['Coder C'] },
+      { code: -2, coderNames: ['Coder D', 'Coder E'] }
+    ];
+
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, mixedCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR1', false)
+    });
+    fixture.detectChanges();
+
+    const badge = fixture.nativeElement.querySelector('.review-code-badge') as HTMLElement;
+    const codeRow = fixture.nativeElement.querySelector('.code-row.has-review-code-selection') as HTMLElement;
+    const issueBadge = fixture.nativeElement
+      .querySelector('.uncertain-codes-section .review-code-badge') as HTMLElement;
+    const issueRows = fixture.nativeElement
+      .querySelectorAll('.uncertain-codes-section .code-row.has-review-code-selection') as NodeListOf<HTMLElement>;
+
+    expect(component.hasReviewCodeSelection(1)).toBe(true);
+    expect(component.getReviewCodeSelectionCount(1)).toBe(2);
+    expect(component.hasReviewCodeSelection(2)).toBe(true);
+    expect(component.getReviewCodeSelectionCount(-2)).toBe(2);
+    expect(component.getReviewCodeSelectionCount(99)).toBe(0);
+    expect(badge.textContent).toContain('2');
+    expect(codeRow).toBeTruthy();
+    expect(issueBadge.textContent).toContain('2');
+    expect(issueRows).toHaveLength(1);
+    expect(component.getCodingIssueOptionRowTooltip(
+      component.codingIssueOptionCodes.find(item => item.id === -2)!
+    )).toContain('Coder D, Coder E');
+
+    component.onSelect(1);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.code-row.selected.has-review-code-selection')).toBeTruthy();
   });
 
   it('shows a stored legacy code without making it regularly selectable', () => {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -14,7 +14,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { DomSanitizer } from '@angular/platform-browser';
-import { UnitsReplay, UnitsReplayUnit } from '../../../replay/services/units-replay.service';
+import { ReviewCodeSelection, UnitsReplay, UnitsReplayUnit } from '../../../replay/services/units-replay.service';
 import { ReplayCodingService } from '../../../replay/services/replay-coding.service';
 import {
   Code,
@@ -58,6 +58,7 @@ export class CodeSelectorComponent implements OnChanges {
   @Input() isNavigationDisabled: boolean = false;
   @Input() hasSaveError: boolean = false;
   @Input() clearCodingIssueOnRegularSelection: boolean = false;
+  @Input() reviewCodeSelections: ReviewCodeSelection[] = [];
 
   @Output() codeSelected = new EventEmitter<CodeSelectedEvent>();
   @Output() notesChanged = new EventEmitter<string>();
@@ -297,6 +298,32 @@ export class CodeSelectorComponent implements OnChanges {
     return this.selectableItems.filter(item => item.type !== 'codingIssueOption');
   }
 
+  hasReviewCodeSelection(codeId: number): boolean {
+    return this.getReviewCodeSelectionCount(codeId) > 0;
+  }
+
+  getReviewCodeSelectionCount(codeId: number): number {
+    return this.getReviewCodeSelection(codeId)?.coderNames.length || 0;
+  }
+
+  getReviewCodeSelectionTooltip(codeId: number): string {
+    const selection = this.getReviewCodeSelection(codeId);
+    if (!selection) {
+      return '';
+    }
+
+    return this.translateService.instant('code-selector.review-coders-tooltip', {
+      coders: selection.coderNames.join(', ')
+    });
+  }
+
+  private getReviewCodeSelection(codeId: number): ReviewCodeSelection | undefined {
+    return this.reviewCodeSelections.find(selection => (
+      selection.code === codeId &&
+      selection.coderNames.length > 0
+    ));
+  }
+
   get codingIssueOptionCodes(): SelectableItem[] {
     return this.selectableItems.filter(
       item => item.type === 'codingIssueOption' && this.isCodingIssueOptionAvailable(item)
@@ -322,6 +349,13 @@ export class CodeSelectorComponent implements OnChanges {
     }
 
     return '';
+  }
+
+  getCodingIssueOptionRowTooltip(item: SelectableItem): string {
+    return [
+      this.getCodingIssueOptionTooltip(item),
+      this.getReviewCodeSelectionTooltip(item.id)
+    ].filter(Boolean).join(' - ');
   }
 
   private isCodingIssueOptionAvailable(item: SelectableItem): boolean {

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
@@ -337,10 +337,16 @@ describe('DoubleCodedReviewComponent', () => {
     component.openReplay(501);
 
     expect(codingStatisticsService.getReplayUrl).toHaveBeenCalledWith(1, 501);
-    expect(openSpy).toHaveBeenCalledWith(
-      `${window.location.origin}/#/replay/person/unit/0/VAR_1?workspaceId=1&mode=coding-decision&originResponseId=501`,
-      '_blank'
+    const openedUrl = openSpy.mock.calls[0][0] as string;
+    expect(openedUrl).toContain(
+      `${window.location.origin}/#/replay/person/unit/0/VAR_1?workspaceId=1&mode=coding-decision&originResponseId=501`
     );
+    const reviewCodeSelections = new URLSearchParams(openedUrl.split('?')[1]).get('reviewCodeSelections');
+    expect(JSON.parse(reviewCodeSelections || '[]')).toEqual([
+      { code: 1, coderNames: ['Coder A'] },
+      { code: 2, coderNames: ['Coder B'] }
+    ]);
+    expect(openSpy).toHaveBeenCalledWith(openedUrl, '_blank');
   });
 
   it('selects an available coder result from a replay code selection', async () => {

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -37,6 +37,7 @@ import {
   appendReplayUrlParams,
   normalizeReplayUrlToCurrentOrigin
 } from '../../utils/replay-url.util';
+import { ReviewCodeSelection } from '../../../replay/services/units-replay.service';
 
 interface CoderResult {
   coderId: number;
@@ -729,8 +730,14 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     return value;
   }
 
-  openReplay(responseId: number): void {
+  openReplay(itemOrResponseId: DoubleCodedItem | number): void {
     const workspaceId = this.appService.selectedWorkspaceId;
+    const responseId = typeof itemOrResponseId === 'number' ?
+      itemOrResponseId :
+      itemOrResponseId.responseId;
+    const item = typeof itemOrResponseId === 'number' ?
+      this.allData.find(reviewItem => reviewItem.responseId === responseId) :
+      itemOrResponseId;
 
     if (!workspaceId || !responseId) {
       this.showError(this.translateService.instant('coding-management.descriptions.missing-replay-info'));
@@ -750,7 +757,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
           return;
         }
 
-        const replayWindow = window.open(this.buildReplayDecisionUrl(result.replayUrl, responseId), '_blank');
+        const replayWindow = window.open(this.buildReplayDecisionUrl(result.replayUrl, responseId, item), '_blank');
         if (replayWindow) {
           this.replayWindowByResponseId.set(responseId, replayWindow);
         }
@@ -761,15 +768,46 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     });
   }
 
-  private buildReplayDecisionUrl(replayUrl: string, responseId: number): string {
+  private buildReplayDecisionUrl(
+    replayUrl: string,
+    responseId: number,
+    item?: DoubleCodedItem
+  ): string {
     return appendReplayUrlParams(
       normalizeReplayUrlToCurrentOrigin(replayUrl),
       {
         mode: 'coding-decision',
         originResponseId: responseId,
-        workspaceId: this.appService.selectedWorkspaceId
+        workspaceId: this.appService.selectedWorkspaceId,
+        reviewCodeSelections: item ? this.serializeReviewCodeSelections(item) : undefined
       }
     );
+  }
+
+  private serializeReviewCodeSelections(item: DoubleCodedItem): string | undefined {
+    const selections = this.getReviewCodeSelections(item);
+    return selections.length > 0 ? JSON.stringify(selections) : undefined;
+  }
+
+  private getReviewCodeSelections(item: DoubleCodedItem): ReviewCodeSelection[] {
+    const coderNamesByCode = new Map<number, string[]>();
+
+    item.coderResults.forEach(result => {
+      if (result.code === null || result.code === undefined) {
+        return;
+      }
+
+      const coderNames = coderNamesByCode.get(result.code) || [];
+      const coderName = this.getCoderDisplayName(result);
+      if (!coderNames.includes(coderName)) {
+        coderNames.push(coderName);
+      }
+      coderNamesByCode.set(result.code, coderNames);
+    });
+
+    return Array.from(coderNamesByCode.entries())
+      .sort(([codeA], [codeB]) => codeA - codeB)
+      .map(([code, coderNames]) => ({ code, coderNames }));
   }
 
   private handleReplayCodeSelected(

--- a/apps/frontend/src/app/replay/components/replay/replay.component.html
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.html
@@ -94,6 +94,7 @@
         [isReadOnly]="isCodingReadOnly()" [isNavigationDisabled]="isCodingInteractionBlockedByReAuthentication()"
         [hasSaveError]="codingService.hasSaveError"
         [clearCodingIssueOnRegularSelection]="isCodingIssueReviewMode"
+        [reviewCodeSelections]="reviewCodeSelections"
         (codeSelected)="onCodeSelected($event)"
         (notesChanged)="onNotesChanged($event)" (openNavigateDialog)="openNavigateDialog()"
         (openCommentDialog)="openCommentDialog()" (pauseCodingJob)="pauseCodingJob()"

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -352,7 +352,7 @@ describe('ReplayComponent', () => {
     window.history.pushState(
       {},
       '',
-      `/#/replay/login@@group@BOOKLET_A/UNIT_1/0/0?auth=secret&mode=booklet-view&unitsData=${unitsData}`
+      `/#/replay/login@@group@BOOKLET_A/UNIT_1/0/0?auth=secret&mode=booklet-view&unitsData=${unitsData}&reviewCodeSelections=${encodeURIComponent('[{"code":1,"coderNames":["Coder A"]}]')}`
     );
 
     replayBackendService.storeReplayStatistics.mockClear();
@@ -370,6 +370,7 @@ describe('ReplayComponent', () => {
     const replayUrl = replayBackendService.storeReplayStatistics.mock.calls[0][1].replayUrl as string;
     expect(replayUrl).not.toContain('auth=');
     expect(replayUrl).not.toContain('unitsData=');
+    expect(replayUrl).not.toContain('reviewCodeSelections=');
     expect(replayUrl.length).toBeLessThan(2000);
   });
 
@@ -1156,7 +1157,12 @@ describe('ReplayComponent', () => {
       auth: 'valid-token',
       mode: 'coding-decision',
       originResponseId: '77',
-      workspaceId: '47'
+      workspaceId: '47',
+      reviewCodeSelections: JSON.stringify([
+        { code: 1, coderNames: ['Coder A', 'Coder B', 'Coder A'] },
+        { code: '2', coderNames: ['Coder C'] },
+        { code: 'invalid', coderNames: ['Coder D'] }
+      ])
     };
     appService.needsReAuthentication = true;
     codingJobBackendServiceMock.getCodingJobUnits.mockClear();
@@ -1177,6 +1183,10 @@ describe('ReplayComponent', () => {
     expect(component.isReviewMode).toBe(false);
     expect(component.isCodingIssueReviewMode).toBe(false);
     expect(component.originResponseId).toBe(77);
+    expect((component as unknown as { reviewCodeSelections: unknown }).reviewCodeSelections).toEqual([
+      { code: 1, coderNames: ['Coder A', 'Coder B'] },
+      { code: 2, coderNames: ['Coder C'] }
+    ]);
     expect(component.isCodingReadOnly()).toBe(false);
     expect(component.isCodingInteractionBlockedByReAuthentication()).toBe(false);
     expect(component.canSwitchAssignedCodingJobs()).toBe(false);

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -31,7 +31,7 @@ import { FilesDto } from '../../../../../../../api-dto/files/files.dto';
 import { ErrorMessages } from '../../models/error-messages.model';
 import { validateToken, isTestperson } from '../../utils/token-utils';
 import { scrollToElementByAlias, highlightAspectSectionWithAnchor } from '../../utils/dom-utils';
-import { UnitsReplay, UnitsReplayUnit } from '../../services/units-replay.service';
+import { ReviewCodeSelection, UnitsReplay, UnitsReplayUnit } from '../../services/units-replay.service';
 import { UnitsReplayComponent } from '../units-replay/units-replay.component';
 import { CodeSelectorComponent } from '../../../coding/components/code-selector/code-selector.component';
 import { CodingJobCommentDialogComponent } from '../../../coding/components/coding-job-comment-dialog/coding-job-comment-dialog.component';
@@ -219,6 +219,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   protected reloadKey: number = 0;
   workspaceId: number = 0;
   originResponseId: number | null = null;
+  protected reviewCodeSelections: ReviewCodeSelection[] = [];
   private watermarkElement: ElementRef<HTMLElement> | null = null;
   private watermarkObserver: ResizeObserver | null = null;
   private watermarkCheckPending: boolean = false;
@@ -408,6 +409,48 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
+  private deserializeReviewCodeSelections(value: unknown): ReviewCodeSelection[] {
+    if (typeof value !== 'string' || value.trim() === '') {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed
+        .map(item => this.normalizeReviewCodeSelection(item))
+        .filter((item): item is ReviewCodeSelection => item !== null);
+    } catch {
+      return [];
+    }
+  }
+
+  private normalizeReviewCodeSelection(value: unknown): ReviewCodeSelection | null {
+    if (!value || typeof value !== 'object') {
+      return null;
+    }
+
+    const candidate = value as { code?: unknown; coderNames?: unknown };
+    const code = typeof candidate.code === 'number' ? candidate.code : Number(candidate.code);
+    const coderNames = Array.isArray(candidate.coderNames) ?
+      candidate.coderNames
+        .filter((coderName): coderName is string => typeof coderName === 'string' && coderName.trim().length > 0)
+        .map(coderName => coderName.trim()) :
+      [];
+
+    if (!Number.isFinite(code) || coderNames.length === 0) {
+      return null;
+    }
+
+    return {
+      code,
+      coderNames: [...new Set(coderNames)]
+    };
+  }
+
   private getBooleanQueryParam(value: unknown): boolean | null {
     if (value === true || value === 'true') {
       return true;
@@ -444,6 +487,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
           this.isCodingDecisionMode;
         this.isBookletReplayMode = queryParams.mode === 'booklet-view' || queryParams.mode === 'booklet';
         this.originResponseId = queryParams.originResponseId ? Number(queryParams.originResponseId) : null;
+        this.reviewCodeSelections = this.deserializeReviewCodeSelections(queryParams.reviewCodeSelections);
         const suppressGeneralInstructions = this.getBooleanQueryParam(queryParams.suppressGeneralInstructions);
         if (this.isCodingMode || this.isBookletReplayMode) {
           let deserializedUnits = null as UnitsReplay | null;
@@ -913,6 +957,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         const hashParams = new URLSearchParams(url.hash.slice(hashQueryStart + 1));
         hashParams.delete('auth');
         hashParams.delete('unitsData');
+        hashParams.delete('reviewCodeSelections');
 
         const query = hashParams.toString();
         url.hash = query ? `${hashPath}?${query}` : hashPath;
@@ -920,6 +965,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
       url.searchParams.delete('auth');
       url.searchParams.delete('unitsData');
+      url.searchParams.delete('reviewCodeSelections');
 
       return url.toString();
     } catch (error) {
@@ -1055,6 +1101,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     this.page = undefined;
     this.responses = undefined;
     this.serverTimings = null;
+    this.reviewCodeSelections = [];
     this.codingService.resetCodingData();
   }
 

--- a/apps/frontend/src/app/replay/services/units-replay.service.ts
+++ b/apps/frontend/src/app/replay/services/units-replay.service.ts
@@ -8,6 +8,11 @@ import {
 } from 'rxjs';
 import { FileService } from '../../shared/services/file/file.service';
 
+export interface ReviewCodeSelection {
+  code: number;
+  coderNames: string[];
+}
+
 export interface UnitsReplayUnit {
   id: number;
   name: string;
@@ -19,6 +24,7 @@ export interface UnitsReplayUnit {
   variableId?: string;
   variableAnchor?: string;
   variablePage?: string;
+  reviewCodeSelections?: ReviewCodeSelection[];
 }
 
 export interface UnitsReplay {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1053,6 +1053,7 @@
     "legacy-code-label": "Bisher gespeicherter Code:",
     "legacy-code-note": "Dieser Code ist nicht mehr manuell auswählbar.",
     "legacy-code-missing-note": "Dieser Code ist im aktuellen Kodierschema nicht mehr vorhanden.",
+    "review-coders-tooltip": "Von folgenden Kodierern vergeben: {{coders}}",
     "coder-notes": "Notiz zu diesem Kodierfall",
     "coder-notes-placeholder": "Notiz zu diesem Kodierfall",
     "code-assignment-uncertain-requires-code": "Code-Vergabe unsicher kann erst nach einem regulären Code ausgewählt werden.",


### PR DESCRIPTION
## Summary

- add coder-code markers to the double-coded review replay flow
- pass prior coder selections into replay decision mode and show badges/tooltips in the code selector
- include regular codes and coding issue options, while keeping replay statistics URLs free of the marker payload

Refs #701

## Validation

- `npx nx lint frontend`
- `npx nx test frontend --runInBand=true`
