### PR TITLE
Persist training discussion replay notes

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.spec.ts
@@ -6,6 +6,7 @@ describe('WorkspaceCoderTrainingController', () => {
   let coderTrainingService: {
     getWithinTrainingCodingComparison: jest.Mock;
     transformToCoderPairs: jest.Mock;
+    saveDiscussionResult: jest.Mock;
   };
   let codingStatisticsService: {
     calculateCohensKappa: jest.Mock;
@@ -15,7 +16,8 @@ describe('WorkspaceCoderTrainingController', () => {
   beforeEach(() => {
     coderTrainingService = {
       getWithinTrainingCodingComparison: jest.fn(),
-      transformToCoderPairs: jest.fn()
+      transformToCoderPairs: jest.fn(),
+      saveDiscussionResult: jest.fn()
     };
     codingStatisticsService = {
       calculateCohensKappa: jest.fn(),
@@ -159,5 +161,37 @@ describe('WorkspaceCoderTrainingController', () => {
     expect(result.workspaceSummary.weightingMethod).toBe('unweighted');
     expect(result.workspaceSummary.calculationLevel).toBe('code');
     expect(result.workspaceSummary.totalDoubleCodedResponses).toBe(2);
+  });
+
+  it('forwards discussion result notes to the service', async () => {
+    coderTrainingService.saveDiscussionResult.mockResolvedValue({
+      success: true,
+      code: 7,
+      score: 2,
+      notes: 'Replay note',
+      source: 'manual',
+      managerUserId: 23,
+      managerName: 'manager'
+    });
+
+    const result = await controller.saveDiscussionResult(
+      12,
+      5,
+      {
+        responseId: 101, code: 7, score: 2, notes: 'Replay note'
+      },
+      { user: { id: 23, username: 'manager' } } as never
+    );
+
+    expect(coderTrainingService.saveDiscussionResult).toHaveBeenCalledWith(
+      12,
+      5,
+      101,
+      23,
+      'manager',
+      7,
+      'Replay note'
+    );
+    expect(result.notes).toBe('Replay note');
   });
 });

--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
@@ -540,6 +540,7 @@ export class WorkspaceCoderTrainingController {
           givenAnswer: { type: 'string', description: 'Given answer' },
           discussionCode: { type: 'number', nullable: true },
           discussionScore: { type: 'number', nullable: true },
+          discussionNotes: { type: 'string', nullable: true },
           discussionManagerUserId: { type: 'number', nullable: true },
           discussionManagerName: { type: 'string', nullable: true },
           discussionSource: { type: 'string', enum: ['manual', 'auto_agreement'], nullable: true },
@@ -582,6 +583,7 @@ export class WorkspaceCoderTrainingController {
         replayScore: number | null;
         discussionCode: number | null;
         discussionScore: number | null;
+        discussionNotes: string | null;
         discussionManagerUserId: number | null;
         discussionManagerName: string | null;
         discussionSource: 'manual' | 'auto_agreement' | null;
@@ -626,7 +628,8 @@ export class WorkspaceCoderTrainingController {
           type: 'number',
           nullable: true,
           description: 'Deprecated input; score is derived on the server from coding scheme, missings, or stored results.'
-        }
+        },
+        notes: { type: 'string', nullable: true }
       },
       required: ['responseId']
     }
@@ -634,12 +637,13 @@ export class WorkspaceCoderTrainingController {
   async saveDiscussionResult(
     @WorkspaceId() workspace_id: number,
       @Param('trainingId') trainingId: number,
-      @Body() body: { responseId: number; code: number | null; score: number | null },
+      @Body() body: { responseId: number; code: number | null; score: number | null; notes?: string | null },
       @Req() req: Request
   ): Promise<{
         success: boolean;
         code: number | null;
         score: number | null;
+        notes: string | null;
         source: 'manual' | 'auto_agreement' | null;
         managerUserId: number | null;
         managerName: string | null;
@@ -656,7 +660,8 @@ export class WorkspaceCoderTrainingController {
       Number(body.responseId),
       Number.isNaN(managerUserId) ? null : managerUserId,
       managerName,
-      body.code
+      body.code,
+      body.notes
     );
   }
 

--- a/apps/backend/src/app/database/entities/coder-training-discussion-result.entity.ts
+++ b/apps/backend/src/app/database/entities/coder-training-discussion-result.entity.ts
@@ -28,6 +28,9 @@ export class CoderTrainingDiscussionResult {
   @Column({ nullable: true })
     score: number | null;
 
+  @Column({ type: 'text', nullable: true })
+    notes: string | null;
+
   @Column({ nullable: true })
     manager_user_id: number | null;
 

--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -2031,7 +2031,7 @@ describe('CoderTrainingService', () => {
       mockCodingJobService.getCodingSchemeScoreForUnitCode.mockResolvedValueOnce(2);
       mockDiscussionSave();
 
-      const result = await service.saveDiscussionResult(1, 5, 101, 99, 'Manager', 7);
+      const result = await service.saveDiscussionResult(1, 5, 101, 99, 'Manager', 7, 'Replay note');
 
       expect(mockCodingJobService.getCodingSchemeScoreForUnitCode).toHaveBeenCalledWith(unit, 1, 7);
       expect(coderTrainingDiscussionResultRepository.save).toHaveBeenCalledWith(expect.objectContaining({
@@ -2040,10 +2040,12 @@ describe('CoderTrainingService', () => {
         response_id: 101,
         code: 7,
         score: 2,
+        notes: 'Replay note',
         manager_user_id: 99,
         manager_name: 'Manager'
       }));
       expect(result.score).toBe(2);
+      expect(result.notes).toBe('Replay note');
       expect(result.source).toBe('manual');
     });
 
@@ -2217,6 +2219,7 @@ describe('CoderTrainingService', () => {
         success: true,
         code: 7,
         score: 2,
+        notes: null,
         source: 'auto_agreement',
         managerUserId: null,
         managerName: null

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -103,6 +103,7 @@ type SaveDiscussionResultResponse = {
   success: boolean;
   code: number | null;
   score: number | null;
+  notes: string | null;
   source: DiscussionSource;
   managerUserId: number | null;
   managerName: string | null;
@@ -960,7 +961,8 @@ export class CoderTrainingService {
     responseId: number,
     managerUserId: number | null,
     managerName: string | null,
-    code: number | null | undefined
+    code: number | null | undefined,
+    notes?: string | null
   ): Promise<SaveDiscussionResultResponse> {
     const training = await this.coderTrainingRepository.findOne({
       where: {
@@ -1012,6 +1014,7 @@ export class CoderTrainingService {
         success: true,
         code: automaticDiscussionResult?.code ?? null,
         score: automaticDiscussionResult?.score ?? null,
+        notes: null,
         source: automaticDiscussionResult ? 'auto_agreement' : null,
         managerUserId: null,
         managerName: null
@@ -1039,6 +1042,7 @@ export class CoderTrainingService {
 
     discussionResult.code = code;
     discussionResult.score = derivedScore;
+    discussionResult.notes = notes?.trim() || null;
     discussionResult.manager_user_id = managerUserId;
     discussionResult.manager_name = managerName;
 
@@ -1047,6 +1051,7 @@ export class CoderTrainingService {
       success: true,
       code: saved.code,
       score: saved.score,
+      notes: saved.notes ?? null,
       source: 'manual',
       managerUserId: saved.manager_user_id,
       managerName: saved.manager_name
@@ -1897,6 +1902,7 @@ export class CoderTrainingService {
       replayScore: number | null;
       discussionCode: number | null;
       discussionScore: number | null;
+      discussionNotes: string | null;
       discussionManagerUserId: number | null;
       discussionManagerName: string | null;
       discussionSource: DiscussionSource;
@@ -2046,6 +2052,7 @@ export class CoderTrainingService {
         );
       let discussionCode = automaticDiscussionResult?.code ?? null;
       let discussionScore = automaticDiscussionResult?.score ?? null;
+      let discussionNotes: string | null = null;
       let discussionManagerUserId: number | null = null;
       let discussionManagerName: string | null = null;
       let discussionSource: DiscussionSource = automaticDiscussionResult ? 'auto_agreement' : null;
@@ -2053,6 +2060,7 @@ export class CoderTrainingService {
       if (hasManualDiscussionResult) {
         discussionCode = discussionResult!.code;
         discussionScore = discussionResult!.score;
+        discussionNotes = discussionResult!.notes ?? null;
         discussionManagerUserId = discussionResult!.manager_user_id ?? null;
         discussionManagerName = discussionResult!.manager_user_id ?
           (managerNameById.get(discussionResult!.manager_user_id) ?? discussionResult!.manager_name ?? null) :
@@ -2073,6 +2081,7 @@ export class CoderTrainingService {
         replayScore: unitVar.replayScore,
         discussionCode,
         discussionScore,
+        discussionNotes,
         discussionManagerUserId,
         discussionManagerName,
         discussionSource,

--- a/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
@@ -329,6 +329,8 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
         training_id: 5,
         response_id: 123,
         code: 4,
+        score: 2,
+        notes: 'Replay note',
         manager_user_id: 2,
         manager_name: 'stored-manager',
         updated_at: new Date('2026-04-14T11:00:00.000Z')
@@ -352,8 +354,19 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
     const csv = buffer.toString('utf-8');
 
     expect(csv).not.toContain('"coder1";"U1";"V1"');
-    expect(csv).toContain('"p-login";"p-code";"G1";"manager1";"U1";"V1";"";');
-    expect(csv).toContain(';"4";""');
+    const managerRow = csv.split('\n').find(row => row.includes('"manager1";"U1";"V1"'));
+    expect(managerRow?.split(';')).toEqual([
+      '"p-login"',
+      '"p-code"',
+      '"G1"',
+      '"manager1"',
+      '"U1"',
+      '"V1"',
+      '"Replay note"',
+      expect.any(String),
+      '"4"',
+      '""'
+    ]);
   });
 
   it('leaves training discussion results empty when no manager result was stored', async () => {
@@ -839,11 +852,123 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
     expect(worksheet.getRow(2).getCell(scoreColumn).value).toBe(0);
   });
 
+  it('does not fall back to response scores for discussion manager rows without stored score', async () => {
+    const createQueryBuilder = (rawRows: unknown[] = []) => ({
+      innerJoin: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue(rawRows)
+    });
+
+    const variableRecordsQuery = createQueryBuilder([{
+      unitName: 'UNIT',
+      variableId: 'VAR',
+      bookletName: 'BOOKLET-A'
+    }]);
+    const coderRecordsQuery = createQueryBuilder([{ userName: 'Coder A' }]);
+    const personResultsQuery = createQueryBuilder([{
+      id: '10',
+      login: 'login-a',
+      code: 'code-a',
+      group: 'group-a',
+      bookletName: 'BOOKLET-A'
+    }]);
+    const manualCodingQuery = createQueryBuilder([{
+      personId: '10',
+      unitName: 'UNIT',
+      variableId: 'VAR',
+      cju_code: '7',
+      cju_score: '1',
+      coding_issue_option: null,
+      code_v1: '3',
+      score_v1: '9',
+      code_v2: null,
+      score_v2: null,
+      code_v3: null,
+      score_v3: null,
+      notes: null,
+      username: 'Coder A',
+      jobId: '1',
+      trainingId: '5',
+      missingsProfileId: null,
+      responseId: '100'
+    }]);
+    const discussionResult = {
+      training_id: 5,
+      response_id: 100,
+      code: 4,
+      score: null,
+      notes: 'Stored note',
+      manager_user_id: 2,
+      manager_name: null,
+      updated_at: new Date('2026-04-14T11:00:00.000Z')
+    };
+
+    const service = new CodingExportService(
+      { createQueryBuilder: jest.fn().mockReturnValue(personResultsQuery) } as unknown as Repository<ResponseEntity>,
+      { createQueryBuilder: jest.fn().mockReturnValue(coderRecordsQuery) } as unknown as Repository<CodingJob>,
+      {} as Repository<CodingJobVariable>,
+      {
+        createQueryBuilder: jest.fn()
+          .mockReturnValueOnce(variableRecordsQuery)
+          .mockReturnValueOnce(manualCodingQuery)
+      } as unknown as Repository<CodingJobUnit>,
+      { find: jest.fn().mockResolvedValue([discussionResult]) } as unknown as Repository<CoderTrainingDiscussionResult>,
+      { findBy: jest.fn().mockResolvedValue([{ id: 2, username: 'manager1' }]) } as unknown as Repository<User>,
+      {} as CodingListService,
+      {} as WorkspaceCoreService,
+      {
+        resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+          globalIgnoredUnits: [],
+          ignoredBooklets: [],
+          testletIgnoredUnits: []
+        })
+      } as unknown as WorkspaceExclusionService
+    );
+
+    const buffer = await service.exportCodingResultsAggregated(
+      7,
+      false,
+      false,
+      false,
+      false,
+      'new-row-per-variable',
+      true,
+      false,
+      '',
+      undefined,
+      false,
+      undefined,
+      undefined,
+      [5]
+    );
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer);
+    const worksheet = workbook.getWorksheet('Coding Results')!;
+    const headerValues = worksheet.getRow(1).values as unknown[];
+    const managerCodeColumn = headerValues.findIndex(value => value === 'manager1 Code');
+    const managerScoreColumn = headerValues.findIndex(value => value === 'manager1 Score');
+    const managerNoteColumn = headerValues.findIndex(value => value === 'manager1 Note');
+
+    expect(worksheet.getRow(2).getCell(managerCodeColumn).value).toBe('4');
+    expect(worksheet.getRow(2).getCell(managerScoreColumn).value).toBeNull();
+    expect(worksheet.getRow(2).getCell(managerNoteColumn).value).toBe('Stored note');
+  });
+
   it('keeps stored discussion manager names when manager users cannot be resolved', async () => {
     const discussionResult = {
       training_id: 5,
       response_id: 100,
       code: 2,
+      score: 1,
+      notes: 'Stored note',
       manager_user_id: 12,
       manager_name: 'Stored Manager',
       updated_at: new Date('2026-04-14T11:00:00.000Z')
@@ -877,6 +1002,8 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
 
     expect(discussionResults.get('5|100')).toMatchObject({
       code: 2,
+      score: 1,
+      notes: 'Stored note',
       managerUsername: 'Stored Manager',
       updatedAt: discussionResult.updated_at
     });

--- a/apps/backend/src/app/database/services/coding/coding-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.ts
@@ -84,6 +84,14 @@ interface CompactByVariableCoding {
   updatedAt: Date | string | null;
 }
 
+interface TrainingDiscussionExportResult {
+  code: number | null;
+  score: number | null;
+  notes: string | null;
+  managerUsername: string | null;
+  updatedAt: Date | null;
+}
+
 interface AggregatedMostFrequentCoding {
   code: number;
   codingIssueOption: number | null;
@@ -1079,7 +1087,14 @@ export class CodingExportService {
             ...row,
             username: discussionResult.managerUsername,
             cju_code: discussionResult.code,
-            notes: null
+            cju_score: discussionResult.score,
+            code_v1: null,
+            code_v2: null,
+            code_v3: null,
+            score_v1: null,
+            score_v2: null,
+            score_v3: null,
+            notes: discussionResult.notes
           });
         }
 
@@ -1470,8 +1485,14 @@ export class CodingExportService {
             ...row,
             username: discussionResult.managerUsername,
             cju_code: discussionResult.code,
-            cju_score: null,
-            notes: null
+            cju_score: discussionResult.score,
+            code_v1: null,
+            code_v2: null,
+            code_v3: null,
+            score_v1: null,
+            score_v2: null,
+            score_v3: null,
+            notes: discussionResult.notes
           });
         }
 
@@ -1902,7 +1923,14 @@ export class CodingExportService {
             ...row,
             username: discussionResult.managerUsername,
             cju_code: discussionResult.code,
-            notes: null
+            cju_score: discussionResult.score,
+            code_v1: null,
+            code_v2: null,
+            code_v3: null,
+            score_v1: null,
+            score_v2: null,
+            score_v3: null,
+            notes: discussionResult.notes
           });
         }
 
@@ -2270,7 +2298,7 @@ export class CodingExportService {
               const pData = personDataMap.get(pid)!;
               const variableKey = JSON.stringify([managerCase.unitName, managerCase.variableId]);
               const mappedCode = mapCodeForExport(discussion.code);
-              pData[variableKey] = outputCommentsInsteadOfCodes ? '' : mappedCode ?? '';
+              pData[variableKey] = outputCommentsInsteadOfCodes ? discussion.notes || '' : mappedCode ?? '';
               pData[`_metadata_${variableKey}`] = {
                 unitName: managerCase.unitName,
                 variableId: managerCase.variableId,
@@ -2515,7 +2543,7 @@ export class CodingExportService {
         .getRawMany();
 
       const coderNames = coderQuery.map(c => c.username).sort();
-      let discussionResultMap = new Map<string, { code: number | null, managerUsername: string | null, updatedAt: Date | null }>();
+      let discussionResultMap = new Map<string, TrainingDiscussionExportResult>();
       if (normalizedCoderTrainingIds.length > 0) {
         const managerCasesQuery = this.responseRepository.createQueryBuilder('resp')
           .innerJoin('resp.unit', 'unit')
@@ -2668,7 +2696,7 @@ export class CodingExportService {
               if (discussion?.managerUsername && !p.codings[discussion.managerUsername]) {
                 p.codings[discussion.managerUsername] = {
                   code: mapCodeForExport(discussion.code),
-                  notes: null,
+                  notes: discussion.notes,
                   status: d.status_v1,
                   codingIssueOption: null
                 };
@@ -2962,7 +2990,7 @@ export class CodingExportService {
               .filter((responseId): responseId is number => responseId !== null)
           ))
         ) :
-        new Map<string, { code: number | null, managerUsername: string | null, updatedAt: Date | null }>();
+        new Map<string, TrainingDiscussionExportResult>();
 
       for (const row of rows) {
         if (
@@ -3159,7 +3187,7 @@ export class CodingExportService {
   private addCompactDiscussionToGroup(
     group: CompactByVariableGroup,
     row: CompactByVariableRawRow,
-    discussionResultMap: Map<string, { code: number | null, managerUsername: string | null, updatedAt: Date | null }>
+    discussionResultMap: Map<string, TrainingDiscussionExportResult>
   ): void {
     const trainingId = this.toIntegerOrNull(row.trainingId);
     const responseId = this.toIntegerOrNull(row.responseId);
@@ -3170,7 +3198,7 @@ export class CodingExportService {
 
     group.codings.set(discussion.managerUsername, {
       code: mapCodeForExport(discussion.code),
-      notes: null,
+      notes: discussion.notes,
       codingIssueOption: null,
       updatedAt: discussion.updatedAt
     });
@@ -3407,7 +3435,7 @@ export class CodingExportService {
         );
         const unitsBatch = await unitsBatchQuery.getMany();
 
-        let discussionResultMap = new Map<string, { code: number | null, managerUsername: string | null, updatedAt: Date | null }>();
+        let discussionResultMap = new Map<string, TrainingDiscussionExportResult>();
         if (includeDiscussionResult && unitsBatch.length > 0) {
           const trainingIdSet = new Set<number>();
           const responseIdSet = new Set<number>();
@@ -3467,6 +3495,7 @@ export class CodingExportService {
           const discussionTimestamp = discussion.updatedAt ? new Date(discussion.updatedAt).toLocaleString('de-DE').replace(',', '') : '';
           const mappedDiscussionCode = mapCodeForExport(discussion.code);
           const discussionCodeValue = mappedDiscussionCode === null ? '' : mappedDiscussionCode.toString();
+          const discussionNoteValue = discussion.notes || '';
 
           const discussionRowFields = [
             escapeCsvField(personLogin),
@@ -3475,7 +3504,7 @@ export class CodingExportService {
             escapeCsvField(managerDisplayName),
             escapeCsvField(unitName),
             escapeCsvField(currentCaseRepresentative.variable_id),
-            escapeCsvField(''),
+            escapeCsvField(discussionNoteValue),
             escapeCsvField(discussionTimestamp),
             escapeCsvField(discussionCodeValue),
             escapeCsvField('')
@@ -3876,7 +3905,7 @@ export class CodingExportService {
     workspaceId: number,
     trainingIds?: number[],
     responseIds?: number[]
-  ): Promise<Map<string, { code: number | null, managerUsername: string | null, updatedAt: Date | null }>> {
+  ): Promise<Map<string, TrainingDiscussionExportResult>> {
     if (!trainingIds?.length) {
       return new Map();
     }
@@ -3925,6 +3954,8 @@ export class CodingExportService {
 
         return [`${result.training_id}|${result.response_id}`, {
           code: result.code,
+          score: result.score ?? null,
+          notes: result.notes ?? null,
           managerUsername,
           updatedAt: result.updated_at
         }];

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
@@ -770,6 +770,22 @@
                     discussionScoreByResponseId[comparison.responseId] ?? '-'
                   }}</span
                 >
+                <mat-form-field appearance="outline" class="discussion-notes">
+                  <mat-label>{{ 'double-coded-review.comment-label' | translate }}</mat-label>
+                  <textarea
+                    matInput
+                    rows="2"
+                    [placeholder]="'double-coded-review.comment-placeholder' | translate"
+                    [value]="discussionNotesByResponseId[comparison.responseId] || ''"
+                    (input)="
+                      onDiscussionNotesInput(
+                        comparison,
+                        $any($event.target).value
+                      )
+                    "
+                    (blur)="onDiscussionNotesBlur(comparison)"
+                  ></textarea>
+                </mat-form-field>
                 <span
                   class="discussion-saving"
                   *ngIf="isSavingDiscussionByResponseId[comparison.responseId]"

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
@@ -850,6 +850,15 @@
               width: 100%;
             }
 
+            .discussion-notes {
+              width: 100%;
+
+              textarea {
+                resize: vertical;
+                min-height: 48px;
+              }
+            }
+
             .discussion-score {
               font-size: 12px;
               color: #455a64;
@@ -974,8 +983,8 @@
         }
 
         .mat-column-discussion {
-          width: 230px;
-          max-width: 230px;
+          width: 280px;
+          max-width: 280px;
         }
       }
 

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -47,6 +47,7 @@ describe('CodingResultsComparisonComponent', () => {
         success: true,
         code: 7,
         score: 2,
+        notes: 'Replay note',
         source: 'manual',
         managerUserId: 2,
         managerName: 'Test User'
@@ -785,6 +786,7 @@ describe('CodingResultsComparisonComponent', () => {
       testperson: 'login@code@booklet',
       discussionCode: null,
       discussionScore: null,
+      discussionNotes: null,
       discussionSource: 'auto_agreement' as 'manual' | 'auto_agreement' | null,
       coders: [
         {
@@ -807,6 +809,7 @@ describe('CodingResultsComparisonComponent', () => {
         variableId: string;
         code: string;
         score: number | null;
+        notes?: string | null;
         responseId: number;
       }) => void;
     }).handleReplayCodeSelected({
@@ -816,14 +819,17 @@ describe('CodingResultsComparisonComponent', () => {
       variableId: 'Var1',
       code: '7',
       score: 2,
+      notes: 'Replay note',
       responseId: 1
     });
 
-    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledWith(1, 5, 1, 7, 2);
+    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledWith(1, 5, 1, 7, 2, 'Replay note');
     expect(component.discussionCodeByResponseId[1]).toBe('7');
     expect(component.discussionScoreByResponseId[1]).toBe(2);
+    expect(component.discussionNotesByResponseId[1]).toBe('Replay note');
     expect(row.discussionCode).toBe(7);
     expect(row.discussionScore).toBe(2);
+    expect(row.discussionNotes).toBe('Replay note');
     expect(row.discussionSource).toBe('manual');
   });
 
@@ -1106,6 +1112,7 @@ describe('CodingResultsComparisonComponent', () => {
       success: true,
       code: 7,
       score: 2,
+      notes: null,
       source: 'auto_agreement',
       managerUserId: null,
       managerName: null
@@ -1139,7 +1146,7 @@ describe('CodingResultsComparisonComponent', () => {
 
     component.onDiscussionCodeBlur(row);
 
-    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledWith(1, 5, 1, null, null);
+    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledWith(1, 5, 1, null, null, null);
     expect(component.discussionCodeByResponseId[1]).toBe('7');
     expect(component.discussionScoreByResponseId[1]).toBe(2);
     expect(row.discussionCode).toBe(7);

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -41,6 +41,7 @@ interface ReplayCodeSelectedMessage extends PostMessage {
   variableId: string;
   code: string;
   score?: number | null;
+  notes?: string | null;
   responseId?: number;
 }
 
@@ -86,6 +87,7 @@ interface WithinTrainingComparison {
   replayScore?: number | null;
   discussionCode?: number | null;
   discussionScore?: number | null;
+  discussionNotes?: string | null;
   discussionManagerUserId?: number | null;
   discussionManagerName?: string | null;
   discussionSource?: 'manual' | 'auto_agreement' | null;
@@ -291,6 +293,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   discussionManagerLabel = '';
   discussionCodeByResponseId: Record<number, string> = {};
   discussionScoreByResponseId: Record<number, number | null> = {};
+  discussionNotesByResponseId: Record<number, string> = {};
   discussionErrorByResponseId: Record<number, string> = {};
   isSavingDiscussionByResponseId: Record<number, boolean> = {};
   readonly emptyModalValueDisplay: ModalValueDisplay = {
@@ -895,6 +898,7 @@ export class CodingResultsComparisonComponent implements OnInit {
     comparison: WithinTrainingComparison,
     parsedCode: number | null,
     score: number | null,
+    notes: string | null,
     scoreOverride?: number | null
   ): boolean {
     if (scoreOverride !== undefined) {
@@ -902,7 +906,21 @@ export class CodingResultsComparisonComponent implements OnInit {
     }
 
     return parsedCode === (comparison.discussionCode ?? null) &&
-      score === (comparison.discussionScore ?? null);
+      score === (comparison.discussionScore ?? null) &&
+      notes === ((comparison.discussionNotes || '').trim() || null);
+  }
+
+  onDiscussionNotesInput(comparison: TrainingComparison | WithinTrainingComparison, value: string): void {
+    if (this.comparisonMode !== 'within-training') {
+      return;
+    }
+    const responseId = (comparison as WithinTrainingComparison).responseId;
+    this.discussionNotesByResponseId[responseId] = value;
+    this.discussionErrorByResponseId[responseId] = '';
+  }
+
+  onDiscussionNotesBlur(comparison: TrainingComparison | WithinTrainingComparison): void {
+    this.onDiscussionCodeBlur(comparison);
   }
 
   onDiscussionCodeBlur(
@@ -924,6 +942,8 @@ export class CodingResultsComparisonComponent implements OnInit {
       return;
     }
 
+    const notes = (this.discussionNotesByResponseId[responseId] || '').trim() || null;
+
     let score: number | null = null;
     if (parsedCode !== null) {
       score = scoreOverride !== undefined ?
@@ -932,9 +952,10 @@ export class CodingResultsComparisonComponent implements OnInit {
     }
     this.discussionErrorByResponseId[responseId] = '';
 
-    if (this.isUnchangedDiscussionValue(withinComparison, parsedCode, score, scoreOverride)) {
+    if (this.isUnchangedDiscussionValue(withinComparison, parsedCode, score, notes, scoreOverride)) {
       this.discussionCodeByResponseId[responseId] = parsedCode !== null ? parsedCode.toString() : '';
       this.discussionScoreByResponseId[responseId] = withinComparison.discussionScore ?? null;
+      this.discussionNotesByResponseId[responseId] = withinComparison.discussionNotes || '';
       return;
     }
 
@@ -945,13 +966,16 @@ export class CodingResultsComparisonComponent implements OnInit {
       this.selectedTrainingForWithin,
       responseId,
       parsedCode,
-      score
+      score,
+      notes
     ).subscribe({
       next: result => {
         this.discussionCodeByResponseId[responseId] = result.code !== null ? result.code.toString() : '';
         this.discussionScoreByResponseId[responseId] = result.score;
+        this.discussionNotesByResponseId[responseId] = result.notes || '';
         withinComparison.discussionCode = result.code;
         withinComparison.discussionScore = result.score;
+        withinComparison.discussionNotes = result.notes;
         withinComparison.discussionManagerUserId = result.managerUserId;
         withinComparison.discussionManagerName = result.managerName;
         withinComparison.discussionSource = result.source;
@@ -1015,6 +1039,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   private initDiscussionValues(data: WithinTrainingComparison[]): void {
     this.discussionCodeByResponseId = {};
     this.discussionScoreByResponseId = {};
+    this.discussionNotesByResponseId = {};
     this.discussionErrorByResponseId = {};
     this.isSavingDiscussionByResponseId = {};
 
@@ -1027,9 +1052,11 @@ export class CodingResultsComparisonComponent implements OnInit {
       if (item.discussionCode !== null && item.discussionCode !== undefined) {
         this.discussionCodeByResponseId[item.responseId] = this.mapCodeForDisplay(item.discussionCode.toString());
         this.discussionScoreByResponseId[item.responseId] = item.discussionScore ?? this.getDiscussionScoreFromKnownCodes(item, item.discussionCode);
+        this.discussionNotesByResponseId[item.responseId] = item.discussionNotes || '';
       } else {
         this.discussionCodeByResponseId[item.responseId] = '';
         this.discussionScoreByResponseId[item.responseId] = null;
+        this.discussionNotesByResponseId[item.responseId] = '';
       }
     });
   }
@@ -1377,6 +1404,7 @@ export class CodingResultsComparisonComponent implements OnInit {
             replayScore: item.replayScore,
             discussionCode: item.discussionCode,
             discussionScore: item.discussionScore,
+            discussionNotes: item.discussionNotes,
             discussionManagerUserId: item.discussionManagerUserId,
             discussionManagerName: item.discussionManagerName,
             discussionSource: item.discussionSource,
@@ -1740,6 +1768,7 @@ export class CodingResultsComparisonComponent implements OnInit {
       this.discussionCodeByResponseId[row.responseId] = this.mapCodeForDisplay(data.code);
       this.discussionScoreByResponseId[row.responseId] =
         data.score !== undefined ? data.score : this.getDiscussionScoreFromKnownCodes(row, parseInt(data.code, 10));
+      this.discussionNotesByResponseId[row.responseId] = data.notes || '';
       this.onDiscussionCodeBlur(row, data.score);
 
       this.snackBar.open(

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
@@ -181,4 +181,20 @@ describe('CodingTrainingBackendService', () => {
       req.flush({});
     });
   });
+
+  describe('saveDiscussionResult', () => {
+    it('should include discussion notes', () => {
+      service.saveDiscussionResult(1, 5, 99, 7, 2, 'Replay note').subscribe();
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/discussion-result`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        responseId: 99,
+        code: 7,
+        score: 2,
+        notes: 'Replay note'
+      });
+      req.flush({});
+    });
+  });
 });

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -52,6 +52,7 @@ export interface WithinTrainingCodingResult {
   replayScore: number | null;
   discussionCode: number | null;
   discussionScore: number | null;
+  discussionNotes: string | null;
   discussionManagerUserId: number | null;
   discussionManagerName: string | null;
   discussionSource: 'manual' | 'auto_agreement' | null;
@@ -223,11 +224,13 @@ export class CodingTrainingBackendService {
     trainingId: number,
     responseId: number,
     code: number | null,
-    score: number | null
+    score: number | null,
+    notes?: string | null
   ): Observable<{
       success: boolean;
       code: number | null;
       score: number | null;
+      notes: string | null;
       source: 'manual' | 'auto_agreement' | null;
       managerUserId: number | null;
       managerName: string | null;
@@ -237,12 +240,15 @@ export class CodingTrainingBackendService {
       success: boolean;
       code: number | null;
       score: number | null;
+      notes: string | null;
       source: 'manual' | 'auto_agreement' | null;
       managerUserId: number | null;
       managerName: string | null;
     }>(
       url,
-      { responseId, code, score },
+      {
+        responseId, code, score, notes
+      },
       { headers: this.authHeader }
     );
   }

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -405,6 +405,7 @@ describe('ReplayComponent', () => {
     component.testPerson = 'valid@test@person';
     component.unitId = 'unit-123';
     component.workspaceId = 5;
+    jest.spyOn(component.codingService, 'getNotes').mockReturnValue('Replay note');
     jest.spyOn(component.codingService, 'handleCodeSelected').mockResolvedValue({
       id: 7,
       code: '7',
@@ -428,6 +429,7 @@ describe('ReplayComponent', () => {
       variableId: 'VAR1',
       code: '7',
       score: 2,
+      notes: 'Replay note',
       responseId: 99
     }, '*');
   });

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -1181,6 +1181,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         variableId: event.variableId,
         code: savedCode.code,
         score: savedCode.score ?? null,
+        notes: this.codingService.getNotes(this.testPerson, this.unitId, event.variableId),
         responseId: this.originResponseId
       }, '*');
 

--- a/database/changelog/coding-box.changelog-1.16.1.sql
+++ b/database/changelog/coding-box.changelog-1.16.1.sql
@@ -101,3 +101,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS "uq_coding_issue_review_source_reviewer"
 -- rollback ALTER TABLE "public"."coding_job" DROP COLUMN IF EXISTS "reviewer_user_id";
 -- rollback ALTER TABLE "public"."coding_job" DROP COLUMN IF EXISTS "source_coding_job_id";
 -- rollback ALTER TABLE "public"."coding_job" DROP COLUMN IF EXISTS "job_type";
+
+-- changeset jurei733:4
+-- comment: Persist optional notes for coder-training discussion results
+
+ALTER TABLE "public"."coder_training_discussion_result"
+  ADD COLUMN IF NOT EXISTS "notes" TEXT;
+
+-- rollback ALTER TABLE "public"."coder_training_discussion_result" DROP COLUMN IF EXISTS "notes";


### PR DESCRIPTION
## Summary
- persist optional notes for training discussion results
- carry replay notes into within-training discussion decisions
- include discussion score and notes in detailed, aggregated, and compact exports
- add the database changeset under 1.16.1

## Validation
- npx nx test backend --runTestsByPath apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
- npx nx lint backend
- npx nx lint frontend
- npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
- git diff --check

Related: #700