### PR TITLE
Fix variable analysis replay samples by code

### DIFF
--- a/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.spec.ts
@@ -10,7 +10,7 @@ const VARIABLE_PAIR_SEPARATOR = '\u001F';
 interface ResponseFixtureRow {
   unitId: string;
   variableId: string;
-  code_v1: string;
+  code_v1: string | null;
   score_v1: number;
   loginName?: string;
   loginCode?: string;
@@ -45,7 +45,7 @@ const toVariablePairKey = (unitId: string, variableId: string): string => (
 );
 
 const toAggregationKey = (row: ResponseFixtureRow): string => (
-  `${row.unitId}${VARIABLE_PAIR_SEPARATOR}${row.variableId}${VARIABLE_PAIR_SEPARATOR}${row.code_v1}`
+  `${row.unitId}${VARIABLE_PAIR_SEPARATOR}${row.variableId}${VARIABLE_PAIR_SEPARATOR}${row.code_v1 ?? ''}`
 );
 
 const createQueryBuilder = (
@@ -155,7 +155,7 @@ const getAggregatedRows = (rows: ResponseFixtureRow[]) => {
   const groupedRows = new Map<string, {
     unitId: string;
     variableId: string;
-    code_v1: string;
+    code_v1: string | null;
     occurrenceCount: number;
     score_V1: number;
   }>();
@@ -183,7 +183,7 @@ const getAggregatedRows = (rows: ResponseFixtureRow[]) => {
     .sort((a, b) => (
       a.unitId.localeCompare(b.unitId) ||
       a.variableId.localeCompare(b.variableId) ||
-      a.code_v1.localeCompare(b.code_v1)
+      (a.code_v1 ?? '').localeCompare(b.code_v1 ?? '')
     ))
     .map(row => ({
       ...row,
@@ -221,6 +221,7 @@ const getSampleInfoRows = (rows: ResponseFixtureRow[]) => {
   const groupedRows = new Map<string, {
     unitId: string;
     variableId: string;
+    code_v1: string | null;
     loginName: string;
     loginCode: string;
     loginGroup: string;
@@ -228,7 +229,7 @@ const getSampleInfoRows = (rows: ResponseFixtureRow[]) => {
   }>();
 
   rows.forEach(row => {
-    const key = toVariablePairKey(row.unitId, row.variableId);
+    const key = toAggregationKey(row);
     if (groupedRows.has(key)) {
       return;
     }
@@ -236,6 +237,7 @@ const getSampleInfoRows = (rows: ResponseFixtureRow[]) => {
     groupedRows.set(key, {
       unitId: row.unitId,
       variableId: row.variableId,
+      code_v1: row.code_v1,
       loginName: row.loginName || 'login',
       loginCode: row.loginCode || 'code',
       loginGroup: row.loginGroup || 'group',
@@ -265,13 +267,21 @@ describe('VariableAnalysisReplayService', () => {
       unitId: 'MDB002',
       variableId: '01',
       code_v1: '0',
-      score_v1: 0
+      score_v1: 0,
+      loginName: 'login-code-0',
+      loginCode: 'person-0',
+      loginGroup: 'group-0',
+      bookletId: 'booklet-0'
     },
     {
       unitId: 'MDB002',
       variableId: '01',
       code_v1: '1',
-      score_v1: 1
+      score_v1: 1,
+      loginName: 'login-code-1',
+      loginCode: 'person-1',
+      loginGroup: 'group-1',
+      bookletId: 'booklet-1'
     },
     {
       unitId: 'MDB002',
@@ -347,6 +357,20 @@ describe('VariableAnalysisReplayService', () => {
       relativeOccurrence: 0.5
     });
     expect(result.data[0].replayUrl).toContain('/MDB002/1/01?auth=token');
+    expect(result.data[0].replayUrl).toContain('login-code-0@person-0@group-0@booklet-0');
+  });
+
+  it('uses a replay sample from the matching code group for each distribution row', async () => {
+    const result = await service.getVariableAnalysis(7, 'token', 'http://server', 1, 10);
+    const rowByAggregationKey = new Map(result.data.map(row => [
+      `${row.unitId}${VARIABLE_PAIR_SEPARATOR}${row.variableId}${VARIABLE_PAIR_SEPARATOR}${row.code}`,
+      row
+    ]));
+
+    expect(rowByAggregationKey.get(`MDB002${VARIABLE_PAIR_SEPARATOR}01${VARIABLE_PAIR_SEPARATOR}0`)?.replayUrl)
+      .toContain('login-code-0@person-0@group-0@booklet-0');
+    expect(rowByAggregationKey.get(`MDB002${VARIABLE_PAIR_SEPARATOR}01${VARIABLE_PAIR_SEPARATOR}1`)?.replayUrl)
+      .toContain('login-code-1@person-1@group-1@booklet-1');
   });
 
   it('applies the derivation filter before counting and paginating', async () => {

--- a/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.ts
@@ -28,9 +28,19 @@ interface UnitVariablePair {
 interface VariableAnalysisAggregationRow {
   unitId: string;
   variableId: string;
-  code_v1: string;
+  code_v1: string | null;
   occurrenceCount: string;
   score_V1: string;
+}
+
+interface VariableAnalysisSampleInfoRow {
+  unitId: string;
+  variableId: string;
+  code_v1: string | null;
+  loginName: string;
+  loginCode: string;
+  loginGroup: string;
+  bookletId: string;
 }
 
 @Injectable()
@@ -212,6 +222,7 @@ export class VariableAnalysisReplayService {
       const sampleInfoQuery = this.responseRepository.createQueryBuilder('response')
         .select('unit.name', 'unitId')
         .addSelect('response.variableid', 'variableId')
+        .addSelect('response.code_v1', 'code_v1')
         .addSelect('person.login', 'loginName')
         .addSelect('person.code', 'loginCode')
         .addSelect('person.group', 'loginGroup')
@@ -226,16 +237,21 @@ export class VariableAnalysisReplayService {
 
       sampleInfoQuery.groupBy('unit.name')
         .addGroupBy('response.variableid')
+        .addGroupBy('response.code_v1')
         .addGroupBy('person.login')
         .addGroupBy('person.code')
         .addGroupBy('person.group')
         .addGroupBy('bookletinfo.name');
 
-      const sampleInfoResults = await sampleInfoQuery.getRawMany();
+      const sampleInfoResults = await sampleInfoQuery.getRawMany<VariableAnalysisSampleInfoRow>();
 
       const sampleInfoMap = new Map<string, { loginName: string; loginCode: string; loginGroup: string; bookletId: string }>();
       for (const result of sampleInfoResults) {
-        const key = this.toVariablePairKey(result.unitId, result.variableId);
+        const key = this.toAggregationKey(result.unitId, result.variableId, result.code_v1);
+        if (sampleInfoMap.has(key)) {
+          continue;
+        }
+
         sampleInfoMap.set(key, {
           loginName: result.loginName || '',
           loginCode: result.loginCode || '',
@@ -257,7 +273,7 @@ export class VariableAnalysisReplayService {
       for (const item of aggregatedResults) {
         const unitId = item.unitId;
         const variableId = item.variableId;
-        const code = item.code_v1;
+        const code = item.code_v1?.toString() ?? '';
         const occurrenceCount = parseInt(item.occurrenceCount, 10);
         const score = parseFloat(item.score_V1) || 0;
 
@@ -269,7 +285,7 @@ export class VariableAnalysisReplayService {
         const derivation = variableCoding?.sourceType || '';
         const description = variableCoding?.label || '';
 
-        const sampleInfo = sampleInfoMap.get(this.toVariablePairKey(unitId, variableId));
+        const sampleInfo = sampleInfoMap.get(this.toAggregationKey(unitId, variableId, code));
         const loginName = sampleInfo?.loginName || '';
         const loginCode = sampleInfo?.loginCode || '';
         const loginGroup = sampleInfo?.loginGroup || '';
@@ -380,5 +396,9 @@ export class VariableAnalysisReplayService {
 
   private toVariablePairKey(unitId: string, variableId: string): string {
     return `${unitId}\u001F${variableId}`;
+  }
+
+  private toAggregationKey(unitId: string, variableId: string, code: string | number | null | undefined): string {
+    return `${this.toVariablePairKey(unitId, variableId)}\u001F${code ?? ''}`;
   }
 }


### PR DESCRIPTION
## Summary
- Select replay sample rows for variable analysis by unit, variable, and code.
- Keep distribution counts and total counts unchanged.
- Add regression coverage for different codes within the same variable.

## Root cause
Replay sample lookup was keyed only by unit and variable, so all code rows of the same variable could reuse the same response.

## Validation
- npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.spec.ts --runInBand
- npx nx lint backend
- npx nx test backend --runInBand

Related issue: #710