### PR TITLE
Apply profile missing codes in result application

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
@@ -31,7 +31,10 @@ describe('CodingResultsService', () => {
   let codingStatisticsService: jest.Mocked<CodingStatisticsService>;
   let codingValidationService: jest.Mocked<Pick<CodingValidationService, 'invalidateIncompleteVariablesCache'>>;
   let codingAnalysisService: jest.Mocked<Pick<CodingAnalysisService, 'invalidateCache'>>;
-  let missingsProfilesService: jest.Mocked<Pick<MissingsProfilesService, 'getMissingByIdForProfileOrDefault'>>;
+  let missingsProfilesService: jest.Mocked<Pick<
+  MissingsProfilesService,
+  'getMissingByIdForProfileOrDefault' | 'getMissingByCodeForProfileOrDefault'
+  >>;
   let codingFreshnessService: jest.Mocked<Pick<CodingFreshnessService, 'markManualCodingCurrent'>>;
 
   const createQueryBuilderMock = (rows: unknown[]) => ({
@@ -120,6 +123,14 @@ describe('CodingResultsService', () => {
         return {
           id: 'mir', label: 'missing invalid response', code: -98, score: 0
         };
+      }),
+      getMissingByCodeForProfileOrDefault: jest.fn(async (_workspaceId, _profileId, code) => {
+        if (code === -99) {
+          return {
+            id: 'mbi_mbo', label: 'mbi / mbo', code: -99, score: 4
+          };
+        }
+        throw new Error(`Missing code ${code} not found`);
       })
     };
 
@@ -263,6 +274,57 @@ describe('CodingResultsService', () => {
         status_v2: 5
       }
     );
+  });
+
+  it('resolves an already stored profile missing code from the coding job profile', async () => {
+    codingJobService.getCodingJobById.mockResolvedValueOnce({
+      id: 10,
+      status: 'completed',
+      missings_profile_id: 77
+    } as never);
+    codingJobService.getCodingProgress.mockResolvedValueOnce({
+      'person@code@booklet::booklet::UNIT::VAR': {
+        id: -99
+      }
+    });
+
+    const result = await service.applyCodingResults(17, 10);
+
+    expect(result.success).toBe(true);
+    expect(missingsProfilesService.getMissingByCodeForProfileOrDefault).toHaveBeenCalledWith(
+      17,
+      77,
+      -99
+    );
+    expect(queryRunner.manager.update).toHaveBeenCalledWith(
+      ResponseEntity,
+      99,
+      {
+        code_v2: -99,
+        score_v2: 4,
+        status_v2: 5
+      }
+    );
+  });
+
+  it('does not silently apply an already stored missing code when its profile score is absent', async () => {
+    codingJobService.getCodingJobById.mockResolvedValueOnce({
+      id: 10,
+      status: 'completed',
+      missings_profile_id: 77
+    } as never);
+    codingJobService.getCodingProgress.mockResolvedValueOnce({
+      'person@code@booklet::booklet::UNIT::VAR': {
+        id: -99
+      }
+    });
+    missingsProfilesService.getMissingByCodeForProfileOrDefault.mockRejectedValueOnce(
+      new Error("Missing 'mbi_mbo' must define a score")
+    );
+
+    await expect(service.applyCodingResults(17, 10)).rejects.toThrow('score');
+    expect(queryRunner.manager.update).not.toHaveBeenCalled();
+    expect(codingJobService.markCodingJobResultsApplied).not.toHaveBeenCalled();
   });
 
   it('does not silently apply a manual missing when its profile score is absent', async () => {
@@ -569,7 +631,12 @@ describe('CodingResultsService', () => {
 
   it('marks resolved double-coding results as applied when no response updates are needed', async () => {
     (responseRepository.manager.query as jest.Mock)
-      .mockResolvedValueOnce([{ id: 99, statusV2: 5 }])
+      .mockResolvedValueOnce([{
+        id: 99,
+        statusV2: 5,
+        codeV2: 0,
+        scoreV2: 0
+      }])
       .mockResolvedValueOnce([{ responseId: 99, statusV2: 5 }]);
 
     const result = await service.applyCodingResults(17, 10);
@@ -585,6 +652,53 @@ describe('CodingResultsService', () => {
     );
     expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(17);
     expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(17);
+  });
+
+  it('keeps existing v2 values by default even when status is not complete', async () => {
+    (responseRepository.manager.query as jest.Mock)
+      .mockResolvedValueOnce([{
+        id: 99,
+        statusV2: statusStringToNumber('CODING_INCOMPLETE'),
+        codeV2: null,
+        scoreV2: null
+      }]);
+
+    const result = await service.applyCodingResults(17, 10);
+
+    expect(result.success).toBe(true);
+    expect(result.updatedResponsesCount).toBe(0);
+    expect(result.skippedAlreadyCodedCount).toBe(1);
+    expect(queryRunner.manager.update).not.toHaveBeenCalled();
+    expect(codingJobService.markCodingJobResultsApplied).toHaveBeenCalledWith(
+      10,
+      17,
+      queryRunner.manager
+    );
+  });
+
+  it('overwrites existing direct v2 values only when explicitly requested', async () => {
+    (responseRepository.manager.query as jest.Mock)
+      .mockResolvedValueOnce([{
+        id: 99,
+        statusV2: statusStringToNumber('CODING_INCOMPLETE'),
+        codeV2: null,
+        scoreV2: null
+      }]);
+
+    const result = await service.applyCodingResults(17, 10, { overwriteExisting: true });
+
+    expect(result.success).toBe(true);
+    expect(result.updatedResponsesCount).toBe(1);
+    expect(result.overwrittenExistingCount).toBe(1);
+    expect(queryRunner.manager.update).toHaveBeenCalledWith(
+      ResponseEntity,
+      99,
+      {
+        code_v2: 0,
+        score_v2: 0,
+        status_v2: 5
+      }
+    );
   });
 
   it('does not propagate matching sibling responses when aggregation is disabled', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-results.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.ts
@@ -31,6 +31,12 @@ export interface ApplyCodingResultsResult {
   messageParams?: Record<string, unknown>;
 }
 
+interface ExistingV2State {
+  status: number | null;
+  code: number | null;
+  score: number | null;
+}
+
 @Injectable()
 export class CodingResultsService {
   private readonly logger = new Logger(CodingResultsService.name);
@@ -102,7 +108,7 @@ export class CodingResultsService {
       const codingJobUnits = await this.codingJobService.getCodingJobUnits(codingJobId);
       const codingProgress = await this.codingJobService.getCodingProgress(codingJobId);
       const directResponseIds = Array.from(new Set(codingJobUnits.map(unit => unit.responseId)));
-      const existingV2StatusByResponseId = await this.getExistingV2StatusByResponseId(directResponseIds);
+      const existingV2StateByResponseId = await this.getExistingV2StateByResponseId(directResponseIds);
       const resolvedIssueReviewResponseIds = new Set(
         await this.codingJobService.getResolvedCodingIssueReviewResponseIds(codingJobId)
       );
@@ -165,8 +171,8 @@ export class CodingResultsService {
           continue;
         }
 
-        const existingStatusV2 = existingV2StatusByResponseId.get(unit.responseId);
-        if (existingStatusV2 === completedStatus) {
+        const existingV2State = existingV2StateByResponseId.get(unit.responseId);
+        if (this.hasExistingV2Value(existingV2State)) {
           if (!overwriteExisting) {
             skippedAlreadyCodedCount += 1;
             continue;
@@ -192,6 +198,14 @@ export class CodingResultsService {
               workspaceId,
               codingJob.missings_profile_id,
               missingId
+            );
+            code = missing.code;
+            score = missing.score;
+          } else if (progress.id < 0) {
+            const missing = await this.missingsProfilesService.getMissingByCodeForProfileOrDefault(
+              workspaceId,
+              codingJob.missings_profile_id,
+              progress.id
             );
             code = missing.code;
             score = missing.score;
@@ -554,14 +568,27 @@ export class CodingResultsService {
     this.logger.log(`Invalidated manual coding variables cache for workspace ${workspaceId}`);
   }
 
-  private async getExistingV2StatusByResponseId(responseIds: number[]): Promise<Map<number, number | null>> {
+  private hasExistingV2Value(state: ExistingV2State | undefined): boolean {
+    return state !== undefined &&
+      (
+        state.status !== null ||
+        state.code !== null ||
+        state.score !== null
+      );
+  }
+
+  private async getExistingV2StateByResponseId(responseIds: number[]): Promise<Map<number, ExistingV2State>> {
     if (responseIds.length === 0) {
       return new Map();
     }
 
     const rows = await this.responseRepository.manager.query(
       `
-        SELECT id, status_v2 as "statusV2"
+        SELECT
+          id,
+          status_v2 as "statusV2",
+          code_v2 as "codeV2",
+          score_v2 as "scoreV2"
         FROM response
         WHERE id = ANY($1::int[])
       `,
@@ -570,7 +597,11 @@ export class CodingResultsService {
 
     return new Map(rows.map(row => [
       Number(row.id),
-      row.statusV2 === null || row.statusV2 === undefined ? null : Number(row.statusV2)
+      {
+        status: row.statusV2 === null || row.statusV2 === undefined ? null : Number(row.statusV2),
+        code: row.codeV2 === null || row.codeV2 === undefined ? null : Number(row.codeV2),
+        score: row.scoreV2 === null || row.scoreV2 === undefined ? null : Number(row.scoreV2)
+      }
     ]));
   }
 

--- a/apps/frontend/src/app/coding/components/coding-jobs/apply-coding-results-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/apply-coding-results-dialog.component.ts
@@ -71,13 +71,13 @@ export interface ApplyCodingResultsDialogResult {
       </div>
 
       <mat-checkbox [(ngModel)]="overwriteExisting" color="warn">
-        Bestehende Kodierungen für passende aggregierte Antworten überschreiben
+        Bestehende v2-Kodierungen überschreiben
       </mat-checkbox>
 
       <div class="warning-box" *ngIf="overwriteExisting">
         <mat-icon>warning</mat-icon>
         <span>
-          Vorhandene v2-Kodierungen in passenden Aggregationsgruppen werden ersetzt.
+          Vorhandene v2-Kodierungen für direkte Ergebnisse und passende Aggregationsgruppen werden ersetzt.
           Diese Option sollte nur für bewusst neu zu berechnende Ergebnisse genutzt werden.
         </span>
       </div>

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
@@ -285,6 +285,69 @@ describe('CodingJobResultDialogComponent', () => {
     expect(component.getCodedResultCount()).toBe(1);
   });
 
+  it('should resolve already stored profile missing codes from the coding job missing profile', () => {
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      status: 'completed',
+      missings_profile_id: 77
+    };
+    mockMissingsProfileService.getMissingsProfileDetails.mockReturnValue(of({
+      id: 77,
+      label: 'Custom',
+      missings: JSON.stringify([
+        {
+          id: 'mir',
+          label: 'Custom MIR',
+          description: '',
+          code: -123,
+          score: 7
+        },
+        {
+          id: 'mci',
+          label: 'Custom MCI',
+          description: '',
+          code: -124,
+          score: 8
+        },
+        {
+          id: 'mbi_mbo',
+          label: 'Custom omission',
+          description: '',
+          code: -99,
+          score: 4
+        }
+      ])
+    }));
+    mockCodingJobBackendService.getCodingJobUnits.mockReturnValue(of([{
+      responseId: 1,
+      unitName: 'UNIT_1',
+      unitAlias: 'UNIT_1',
+      variableId: 'VAR_1',
+      variableAnchor: 'VAR_1',
+      bookletName: 'BOOKLET_A',
+      personLogin: 'login',
+      personCode: 'code',
+      personGroup: 'group',
+      isDoubleCoded: false,
+      otherCoders: []
+    }]));
+    mockCodingJobBackendService.getCodingProgress.mockReturnValue(of({
+      'login@code@group@BOOKLET_A::BOOKLET_A::UNIT_1::VAR_1': {
+        id: -99
+      }
+    }));
+
+    component.loadCodingResults();
+
+    expect(component.dataSource.data[0]).toMatchObject({
+      code: -99,
+      score: 4,
+      codeLabel: 'Custom omission',
+      unresolvedMissing: false
+    });
+    expect(component.canApplyCodingResults()).toBe(true);
+  });
+
   it('should block applying results when a manual missing cannot be resolved from the profile', () => {
     component.data.codingJob = {
       ...component.data.codingJob,
@@ -331,6 +394,59 @@ describe('CodingJobResultDialogComponent', () => {
     expect(component.getCodeDisplay(result)).toBe('Missing nicht auflösbar');
     expect(component.canApplyCodingResults()).toBe(false);
     expect(component.getApplyButtonTooltip()).toContain('Missing-Kodierung');
+  });
+
+  it('should block applying results when an already stored profile missing code cannot be resolved', () => {
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      status: 'completed',
+      missings_profile_id: 77
+    };
+    mockMissingsProfileService.getMissingsProfileDetails.mockReturnValue(of({
+      id: 77,
+      label: 'Incomplete',
+      missings: JSON.stringify([
+        {
+          id: 'mir',
+          label: 'Custom MIR',
+          description: '',
+          code: -123,
+          score: 7
+        },
+        {
+          id: 'mci',
+          label: 'Custom MCI',
+          description: '',
+          code: -124,
+          score: 8
+        }
+      ])
+    }));
+    mockCodingJobBackendService.getCodingJobUnits.mockReturnValue(of([{
+      responseId: 1,
+      unitName: 'UNIT_1',
+      unitAlias: 'UNIT_1',
+      variableId: 'VAR_1',
+      variableAnchor: 'VAR_1',
+      bookletName: 'BOOKLET_A',
+      personLogin: 'login',
+      personCode: 'code',
+      personGroup: 'group',
+      isDoubleCoded: false,
+      otherCoders: []
+    }]));
+    mockCodingJobBackendService.getCodingProgress.mockReturnValue(of({
+      'login@code@group@BOOKLET_A::BOOKLET_A::UNIT_1::VAR_1': {
+        id: -99
+      }
+    }));
+
+    component.loadCodingResults();
+
+    const result = component.dataSource.data[0];
+    expect(result.unresolvedMissing).toBe(true);
+    expect(component.getCodeDisplay(result)).toBe('Missing nicht auflösbar');
+    expect(component.canApplyCodingResults()).toBe(false);
   });
 
   it.each([

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
@@ -93,6 +93,11 @@ interface ResolvedMissingPreview {
   label?: string;
 }
 
+interface MissingPreviewLookup {
+  byIssueOption: Map<number, ResolvedMissingPreview>;
+  byCode: Map<number, ResolvedMissingPreview>;
+}
+
 @Component({
   selector: 'coding-box-coding-job-result-dialog',
   templateUrl: './coding-job-result-dialog.component.html',
@@ -227,12 +232,12 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
       next: ({
         units, progress, notes, missingProfile
       }) => {
-        const manualMissingLookup = this.getManualMissingLookup(missingProfile);
+        const missingPreviewLookup = this.getMissingPreviewLookup(missingProfile);
         this.dataSource.data = (units || []).map(unit => this.mapCodingResult(
           unit as CodingJobUnitResult,
           progress as Record<string, CodingProgressEntry>,
           notes as Record<string, string>,
-          manualMissingLookup
+          missingPreviewLookup
         ));
         this.isMissingProfileUnavailable = this.getUnresolvedMissingCount() > 0;
         this.applyFilters();
@@ -249,19 +254,19 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
     unit: CodingJobUnitResult,
     progressResult: Record<string, CodingProgressEntry>,
     notesResult: Record<string, string>,
-    manualMissingLookup: Map<number, ResolvedMissingPreview>
+    missingPreviewLookup: MissingPreviewLookup
   ): CodingResult {
     const progressKey = this.getCodingProgressKey(unit);
     const progress = progressResult[progressKey];
     const notes = notesResult ? notesResult[progressKey] : undefined;
-    const mappedCode = this.getMappedResultCode(progress, manualMissingLookup);
-    const mappedScore = this.getMappedResultScore(progress, manualMissingLookup);
+    const mappedCode = this.getMappedResultCode(progress, missingPreviewLookup);
+    const mappedScore = this.getMappedResultScore(progress, missingPreviewLookup);
     const reviewIssueOption = this.getReviewIssueOption(progress);
     const testPerson = this.getTestPersonLabel(unit);
     const otherCoders = (unit.otherCoders || []).filter(Boolean);
     const progressCode = this.toNumericCode(progress?.id);
-    const missingPreview = progressCode === null ? undefined : manualMissingLookup.get(progressCode);
-    const unresolvedMissing = this.isManualMissingIssueOption(progressCode) && !missingPreview;
+    const missingPreview = this.getMissingPreviewForProgressCode(progressCode, missingPreviewLookup);
+    const unresolvedMissing = this.isMissingProgressCode(progressCode) && !missingPreview;
 
     return {
       unitName: unit.unitName,
@@ -318,18 +323,28 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
     return Object.assign(new MissingsProfilesDto(), profile);
   }
 
-  private getManualMissingLookup(profile: MissingsProfilesDto | null): Map<number, ResolvedMissingPreview> {
-    const lookup = new Map<number, ResolvedMissingPreview>();
+  private getMissingPreviewLookup(profile: MissingsProfilesDto | null): MissingPreviewLookup {
+    const lookup: MissingPreviewLookup = {
+      byIssueOption: new Map<number, ResolvedMissingPreview>(),
+      byCode: new Map<number, ResolvedMissingPreview>()
+    };
     if (!profile) {
       return lookup;
     }
 
     const missings = this.toMissingProfileDto(profile).parseMissings();
+    missings.forEach(missing => {
+      const resolved = this.toResolvedMissingPreview(missing);
+      if (resolved) {
+        lookup.byCode.set(resolved.code, resolved);
+      }
+    });
+
     this.manualMissingIdsByIssueOptionId.forEach((missingId, issueOptionId) => {
       const missing = missings.find(entry => entry.id === missingId);
       const resolved = this.toResolvedMissingPreview(missing);
       if (resolved) {
-        lookup.set(issueOptionId, resolved);
+        lookup.byIssueOption.set(issueOptionId, resolved);
       }
     });
 
@@ -740,13 +755,14 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
 
   private getMappedResultCode(
     progress: CodingProgressEntry | undefined,
-    manualMissingLookup: Map<number, ResolvedMissingPreview>
+    missingPreviewLookup: MissingPreviewLookup
   ): number | null {
     const code = this.toNumericCode(progress?.id);
-    if (code !== null && manualMissingLookup.has(code)) {
-      return manualMissingLookup.get(code)?.code ?? null;
+    const missingPreview = this.getMissingPreviewForProgressCode(code, missingPreviewLookup);
+    if (missingPreview) {
+      return missingPreview.code;
     }
-    if (this.isManualMissingIssueOption(code)) {
+    if (this.isMissingProgressCode(code)) {
       return null;
     }
     return code;
@@ -754,16 +770,44 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
 
   private getMappedResultScore(
     progress: CodingProgressEntry | undefined,
-    manualMissingLookup: Map<number, ResolvedMissingPreview>
+    missingPreviewLookup: MissingPreviewLookup
   ): number | undefined {
     const code = this.toNumericCode(progress?.id);
-    if (code !== null && manualMissingLookup.has(code)) {
-      return manualMissingLookup.get(code)?.score;
+    const missingPreview = this.getMissingPreviewForProgressCode(code, missingPreviewLookup);
+    if (missingPreview) {
+      return missingPreview.score;
     }
-    if (this.isManualMissingIssueOption(code)) {
+    if (this.isMissingProgressCode(code)) {
       return undefined;
     }
     return progress?.score;
+  }
+
+  private getMissingPreviewForProgressCode(
+    code: number | null,
+    missingPreviewLookup: MissingPreviewLookup
+  ): ResolvedMissingPreview | undefined {
+    if (code === null) {
+      return undefined;
+    }
+
+    if (this.isManualMissingIssueOption(code)) {
+      return missingPreviewLookup.byIssueOption.get(code);
+    }
+
+    if (this.isProfileMissingCode(code)) {
+      return missingPreviewLookup.byCode.get(code);
+    }
+
+    return undefined;
+  }
+
+  private isMissingProgressCode(code: number | null): boolean {
+    return this.isManualMissingIssueOption(code) || this.isProfileMissingCode(code);
+  }
+
+  private isProfileMissingCode(code: number | null): boolean {
+    return code !== null && code < 0 && code !== -1 && code !== -2;
   }
 
   private isManualMissingIssueOption(code: number | null): boolean {


### PR DESCRIPTION
## Summary

This PR narrows the remaining #615 implementation path to already-set missing codings during result application.

Changes:
- Resolve already stored profile missing codes, such as negative missing codes from an upstream process, through the coding job missing profile before writing `v2`.
- Keep `code_v2` and `score_v2` profile-derived, with missing or invalid scores still blocking application instead of falling back silently.
- Preserve any existing `v2` value by default, not only completed `v2` results; explicit overwrite is required to replace it.
- Show already stored profile missing codes in the result dialog using the resolved profile code/score, and block applying when they cannot be resolved.
- Update the apply dialog text so the overwrite option matches the backend behavior.

## Validation

- `npx nx test backend --runInBand --testFile=apps/backend/src/app/database/services/coding/coding-results.service.spec.ts`
- `npx nx test frontend --runInBand --testFile=apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts`
- `npx nx lint backend`
- `npx nx lint frontend`
- `git diff --check`

Refs #615.
