### PR TITLE
Guard manual code progress selection

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -124,7 +124,8 @@ describe('CodingJobService', () => {
     variableId = 'VAR',
     variableAlias,
     codeId = 7,
-    score = 2
+    score = 2,
+    manualInstruction = '<p>Manual instruction</p>'
   }: {
     unitFileId?: string;
     schemeRef?: string;
@@ -133,6 +134,7 @@ describe('CodingJobService', () => {
     variableAlias?: string;
     codeId?: number;
     score?: number | null;
+    manualInstruction?: string | null;
   } = {}) => {
     fileUploadRepository.find
       .mockResolvedValueOnce([
@@ -156,7 +158,8 @@ describe('CodingJobService', () => {
                     id: codeId,
                     code: String(codeId),
                     label: `Code ${codeId}`,
-                    score
+                    score,
+                    manualInstruction
                   }
                 ]
               }
@@ -3127,6 +3130,45 @@ describe('CodingJobService', () => {
 
     expect(codingJobUnitRepository.save).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { manualInstruction: '', label: 'empty' },
+    { manualInstruction: '   ', label: 'whitespace-only' },
+    { manualInstruction: null, label: 'missing' }
+  ])(
+    'rejects positive selected codes with $label manual instructions',
+    async ({ manualInstruction }) => {
+      const job = { id: 1, workspace_id: 3 };
+      const unit = {
+        coding_job_id: 1,
+        unit_name: 'UNIT',
+        unit_alias: 'ALIAS',
+        variable_id: 'VAR',
+        person_login: 'login',
+        person_code: 'code',
+        booklet_name: 'booklet',
+        is_open: false,
+        code: null,
+        score: null,
+        coding_issue_option: null,
+        notes: null
+      };
+      codingJobRepository.findOne.mockResolvedValue(job);
+      codingJobUnitRepository.findOne.mockResolvedValue(unit);
+      mockCodingScheme({ codeId: 7, score: 2, manualInstruction });
+
+      await expect(
+        service.saveCodingProgress(1, {
+          testPerson: 'login@code@booklet',
+          unitId: 'UNIT',
+          variableId: 'VAR',
+          selectedCode: { id: 7 }
+        } as never)
+      ).rejects.toThrow('Code is not available for manual coding: 7');
+
+      expect(codingJobUnitRepository.save).not.toHaveBeenCalled();
+    }
+  );
 
   it('uses the coding scheme score instead of a client-provided score', async () => {
     const job = { id: 1, workspace_id: 3 };

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -97,6 +97,7 @@ interface CodingSchemeCode {
   code?: string;
   label?: string;
   score?: number;
+  manualInstruction?: string | null;
 }
 
 interface CodingSchemeVariableCoding {
@@ -3742,6 +3743,11 @@ export class CodingJobService {
       workspaceId,
       selectedCode.id
     );
+    if (!this.hasManualInstruction(schemeCode)) {
+      throw new BadRequestException(
+        `Code is not available for manual coding: ${selectedCode.id}`
+      );
+    }
     selectedCode.score = schemeCode.score ?? null;
 
     if (
@@ -3755,6 +3761,10 @@ export class CodingJobService {
     }
 
     return selectedCode;
+  }
+
+  private hasManualInstruction(code: { manualInstruction?: string | null }): boolean {
+    return !!code.manualInstruction?.trim();
   }
 
   async getCodingSchemeScoreForUnitCode(


### PR DESCRIPTION
## Summary
- reject saving positive progress codes when the current coding scheme code has no non-empty manual instruction
- keep score lookup behavior unchanged
- cover empty, whitespace-only, and missing instruction cases

## Validation
- npx nx run backend:test --testFile=apps/backend/src/app/database/services/coding/coding-job.service.spec.ts --skip-nx-cache
- npx nx lint backend --skip-nx-cache
- npx nx test backend --skip-nx-cache (one suite timed out once in prototype-methods.spec.ts)
- npx nx run backend:test --testFile=apps/backend/src/app/prototype-methods.spec.ts --skip-nx-cache
- git diff --check

Related: #553
