### PR TITLE
Preserve all training display options in discussion replay

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -284,6 +284,8 @@ describe('CodingResultsComparisonComponent', () => {
       created_at: new Date('2026-06-11T12:00:00Z'),
       updated_at: new Date('2026-06-11T12:00:00Z'),
       jobsCount: 2,
+      show_score: true,
+      allow_comments: false,
       suppress_general_instructions: true
     }];
 
@@ -296,7 +298,7 @@ describe('CodingResultsComparisonComponent', () => {
     } as never);
 
     expect(openSpy).toHaveBeenCalledWith(
-      'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1&mode=coding-decision&originResponseId=77&suppressGeneralInstructions=true',
+      'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1&mode=coding-decision&originResponseId=77&showScore=true&allowComments=false&suppressGeneralInstructions=true',
       '_blank'
     );
   });

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -117,6 +117,12 @@ type NotesFilterMode = 'all' | 'none' | 'with-notes';
 type ComparisonStatus = 'match' | 'differ' | 'incomplete' | 'not_comparable';
 type ComparisonCoderResult = TrainingComparison['coders'][number] | WithinTrainingComparison['coders'][number];
 
+interface ReplayDisplayOptions {
+  showScore?: boolean;
+  allowComments?: boolean;
+  suppressGeneralInstructions?: boolean;
+}
+
 interface ComparisonFilters {
   unitName: string;
   variableId: string;
@@ -1226,7 +1232,7 @@ export class CodingResultsComparisonComponent implements OnInit {
     });
   }
 
-  private getReplayDisplayOptions(): { suppressGeneralInstructions?: boolean } {
+  private getReplayDisplayOptions(): ReplayDisplayOptions {
     if (this.comparisonMode !== 'within-training') {
       return {};
     }
@@ -1237,6 +1243,8 @@ export class CodingResultsComparisonComponent implements OnInit {
     }
 
     return {
+      showScore: selectedTraining.show_score ?? false,
+      allowComments: selectedTraining.allow_comments ?? true,
       suppressGeneralInstructions: selectedTraining.suppress_general_instructions ?? false
     };
   }
@@ -1244,7 +1252,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   private buildReplayUrl(
     replayUrl: string,
     responseId: number,
-    displayOptions: { suppressGeneralInstructions?: boolean } = {}
+    displayOptions: ReplayDisplayOptions = {}
   ): string {
     const [baseUrl, fragment = ''] = replayUrl.split('#', 2);
     const appendParams = (value: string): string => {
@@ -1252,6 +1260,12 @@ export class CodingResultsComparisonComponent implements OnInit {
       const params = new URLSearchParams(query);
       params.set('mode', 'coding-decision');
       params.set('originResponseId', responseId.toString());
+      if (displayOptions.showScore !== undefined) {
+        params.set('showScore', String(displayOptions.showScore));
+      }
+      if (displayOptions.allowComments !== undefined) {
+        params.set('allowComments', String(displayOptions.allowComments));
+      }
       if (displayOptions.suppressGeneralInstructions !== undefined) {
         params.set('suppressGeneralInstructions', String(displayOptions.suppressGeneralInstructions));
       }

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -227,7 +227,7 @@ describe('ReplayComponent', () => {
     expect(component.responses).toBeDefined();
   });
 
-  it('should apply suppress general instructions from query params', async () => {
+  it('should apply display options from query params', async () => {
     routeParams = {
       page: '0',
       testPerson: 'valid@test@person',
@@ -238,6 +238,8 @@ describe('ReplayComponent', () => {
       auth: 'valid-token',
       mode: 'coding',
       workspaceId: '47',
+      showScore: 'true',
+      allowComments: 'false',
       suppressGeneralInstructions: 'true'
     };
 
@@ -250,6 +252,8 @@ describe('ReplayComponent', () => {
       setTimeout(resolve, 0);
     });
 
+    expect(component.codingService.showScore).toBe(true);
+    expect(component.codingService.allowComments).toBe(false);
     expect(component.codingService.suppressGeneralInstructions).toBe(true);
   });
 

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -488,6 +488,8 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         this.isBookletReplayMode = queryParams.mode === 'booklet-view' || queryParams.mode === 'booklet';
         this.originResponseId = queryParams.originResponseId ? Number(queryParams.originResponseId) : null;
         this.reviewCodeSelections = this.deserializeReviewCodeSelections(queryParams.reviewCodeSelections);
+        const showScore = this.getBooleanQueryParam(queryParams.showScore);
+        const allowComments = this.getBooleanQueryParam(queryParams.allowComments);
         const suppressGeneralInstructions = this.getBooleanQueryParam(queryParams.suppressGeneralInstructions);
         if (this.isCodingMode || this.isBookletReplayMode) {
           let deserializedUnits = null as UnitsReplay | null;
@@ -598,6 +600,12 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
         if (suppressGeneralInstructions !== null) {
           this.codingService.suppressGeneralInstructions = suppressGeneralInstructions;
+        }
+        if (showScore !== null) {
+          this.codingService.showScore = showScore;
+        }
+        if (allowComments !== null) {
+          this.codingService.allowComments = allowComments;
         }
 
         if (this.authToken) {


### PR DESCRIPTION
## Summary
- pass all selected coder training display options into discussion replay URLs
- let the replay view read `showScore`, `allowComments`, and `suppressGeneralInstructions` from query parameters
- extend focused frontend tests for the discussion replay URL and replay initialization

## Root cause
The previous follow-up for #697 only forwarded `suppressGeneralInstructions`. After #713, coder trainings can also configure `showScore` and `allowComments`, so the discussion replay needs to carry those options as well.

## Validation
- `npx nx test frontend --runInBand --testPathPatterns='coding-results-comparison.component.spec.ts|replay.component.spec.ts'` (ran all frontend tests: 178 suites, 1477 tests)
- `npx nx lint frontend`
- `git diff --check`

Related to #697. Does not close the issue.