### PR TITLE
Add optional regex search filters

### DIFF
--- a/apps/backend/src/app/admin/workspace-coding/workspace-coding-admin.module.ts
+++ b/apps/backend/src/app/admin/workspace-coding/workspace-coding-admin.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '../../database/database.module';
 import { CodingModule } from '../../coding/coding.module';
 import { WorkspaceModule } from '../../workspace/workspace.module';
@@ -21,6 +22,7 @@ import { WorkspaceCodingJobDefinitionController } from '../workspace/workspace-c
 import { WorkspaceCodingResultsController } from '../workspace/workspace-coding-results.controller';
 import { WorkspaceTestCenterController } from '../workspace/workspace-test-center.controller';
 import { WorkspacePlayerController } from '../workspace/workspace-player.controller';
+import { Setting } from '../../database/entities/setting.entity';
 
 @Module({
   imports: [
@@ -30,7 +32,8 @@ import { WorkspacePlayerController } from '../workspace/workspace-player.control
     AuthModule,
     JobQueueModule,
     HttpModule,
-    CacheModule
+    CacheModule,
+    TypeOrmModule.forFeature([Setting])
   ],
   controllers: [
     WorkspaceCodingController,

--- a/apps/backend/src/app/admin/workspace-test-results/workspace-test-results-admin.module.ts
+++ b/apps/backend/src/app/admin/workspace-test-results/workspace-test-results-admin.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '../../database/database.module';
 import { WorkspaceModule } from '../../workspace/workspace.module';
 import { AuthModule } from '../../auth/auth.module';
@@ -13,6 +14,7 @@ import { WorkspaceTestResultsResponseController } from '../workspace/workspace-t
 import { WorkspaceTestResultsAnalysisController } from '../workspace/workspace-test-results-analysis.controller';
 import { WorkspaceTestResultsImportController } from '../workspace/workspace-test-results-import.controller';
 import { WorkspaceTestResultsExportController } from '../workspace/workspace-test-results-export.controller';
+import { Setting } from '../../database/entities/setting.entity';
 
 @Module({
   imports: [
@@ -23,7 +25,8 @@ import { WorkspaceTestResultsExportController } from '../workspace/workspace-tes
       name: 'database-export'
     }),
     JobQueueModule,
-    CacheModule
+    CacheModule,
+    TypeOrmModule.forFeature([Setting])
   ],
   controllers: [
     WorkspaceTestResultsController,

--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
@@ -460,6 +460,7 @@ export class WorkspaceCoderTrainingController {
           personCode: { type: 'string', description: 'Person Code' },
           personLogin: { type: 'string', description: 'Person Login' },
           personGroup: { type: 'string', description: 'Person Group' },
+          bookletName: { type: 'string', description: 'Test booklet name' },
           testPerson: { type: 'string', description: 'Test Person' },
           coders: {
             type: 'array',
@@ -499,6 +500,7 @@ export class WorkspaceCoderTrainingController {
         personCode: string;
         personLogin: string;
         personGroup: string;
+        bookletName: string;
         testPerson: string;
         coders: Array<{
           trainingId: number;
@@ -548,6 +550,9 @@ export class WorkspaceCoderTrainingController {
           unitName: { type: 'string', description: 'Name of the unit' },
           variableId: { type: 'string', description: 'Variable ID' },
           personCode: { type: 'string', description: 'Person code' },
+          personLogin: { type: 'string', description: 'Person login' },
+          personGroup: { type: 'string', description: 'Person group' },
+          bookletName: { type: 'string', description: 'Test booklet name' },
           testPerson: { type: 'string', description: 'Test person details' },
           givenAnswer: { type: 'string', description: 'Given answer' },
           discussionCode: { type: 'number', nullable: true },
@@ -589,6 +594,7 @@ export class WorkspaceCoderTrainingController {
         personCode: string;
         personLogin: string;
         personGroup: string;
+        bookletName: string;
         testPerson: string;
         givenAnswer: string;
         replayCode: number | null;

--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.spec.ts
@@ -15,6 +15,7 @@ describe('WorkspaceCodingAnalysisController', () => {
       {} as never,
       codingValidationService as never,
       {} as never,
+      {} as never,
       {} as never
     );
 

--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
@@ -7,6 +7,7 @@ import {
   Res,
   UseGuards
 } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import {
   ApiOkResponse,
   ApiParam,
@@ -14,6 +15,7 @@ import {
   ApiBody,
   ApiTags
 } from '@nestjs/swagger';
+import { Repository } from 'typeorm';
 import { Response } from 'express';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
@@ -28,6 +30,8 @@ import { ValidateCodingCompletenessResponseDto } from '../../../../../../api-dto
 import { ExportValidationResultsRequestDto } from '../../../../../../api-dto/coding/export-validation-results-request.dto';
 import { ManualCodeAvailabilityValidationDto } from '../../../../../../api-dto/coding/manual-code-availability.dto';
 import { ResponseMatchingFlag } from '../../database/services/coding/coding-job.service';
+import { Setting } from '../../database/entities/setting.entity';
+import { getWorkspaceRegexSearchEnabled } from '../../utils/regex-search.util';
 
 @ApiTags('Admin Workspace Coding')
 @Controller('admin/workspace')
@@ -37,7 +41,9 @@ export class WorkspaceCodingAnalysisController {
     private exportValidationResultsService: ExportValidationResultsService,
     private codingValidationService: CodingValidationService,
     private codingAnalysisService: CodingAnalysisService,
-    private missingsProfilesService: MissingsProfilesService
+    private missingsProfilesService: MissingsProfilesService,
+    @InjectRepository(Setting)
+    private readonly settingRepository: Repository<Setting>
   ) { }
 
   @Get(':workspace_id/coding/variable-analysis')
@@ -87,6 +93,12 @@ export class WorkspaceCodingAnalysisController {
     description: 'Filter by derivation type',
     type: String
   })
+  @ApiQuery({
+    name: 'regexSearch',
+    required: false,
+    description: 'Interpret variable ID filter as a case-sensitive regular expression',
+    type: Boolean
+  })
   async getVariableAnalysis(
     @WorkspaceId() workspace_id: number,
       @Query('authToken') authToken: string,
@@ -95,7 +107,8 @@ export class WorkspaceCodingAnalysisController {
                    @Query('limit') limit: number = 100,
                    @Query('unitId') unitId?: string,
                    @Query('variableId') variableId?: string,
-                   @Query('derivation') derivation?: string
+                   @Query('derivation') derivation?: string,
+                   @Query('regexSearch') regexSearch?: string
   ): Promise<{
         data: VariableAnalysisItemDto[];
         total: number;
@@ -104,6 +117,8 @@ export class WorkspaceCodingAnalysisController {
       }> {
     const validPage = Math.max(1, page);
     const validLimit = Math.min(Math.max(1, limit), 500); // Set maximum limit to 500
+    const effectiveRegexSearch = regexSearch === 'true' &&
+      await getWorkspaceRegexSearchEnabled(this.settingRepository, workspace_id);
 
     return this.variableAnalysisReplayService.getVariableAnalysis(
       workspace_id,
@@ -113,7 +128,8 @@ export class WorkspaceCodingAnalysisController {
       validLimit,
       unitId,
       variableId,
-      derivation
+      derivation,
+      effectiveRegexSearch
     );
   }
 

--- a/apps/backend/src/app/admin/workspace/workspace-files.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-files.controller.ts
@@ -16,6 +16,7 @@ import {
   UploadedFiles,
   Put
 } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import {
   ApiBearerAuth,
   ApiConsumes,
@@ -26,6 +27,7 @@ import {
   ApiTags,
   ApiBadRequestResponse
 } from '@nestjs/swagger';
+import { Repository } from 'typeorm';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { FilesDto } from '../../../../../../api-dto/files/files.dto';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
@@ -37,6 +39,11 @@ import { TestFilesUploadResultDto } from '../../../../../../api-dto/files/test-f
 import { WorkspaceSettingsDto } from '../../../../../../api-dto/workspaces/workspace-settings-dto';
 import { PersonService } from '../../database/services/test-results';
 import { CodingStatisticsService, CodingValidationService } from '../../database/services/coding';
+import { Setting } from '../../database/entities/setting.entity';
+import {
+  getWorkspaceRegexSearchEnabled,
+  toRegexSearchException
+} from '../../utils/regex-search.util';
 
 @ApiTags('Admin Workspace Files')
 @Controller('admin/workspace')
@@ -48,7 +55,9 @@ export class WorkspaceFilesController {
     private readonly workspaceCoreService: WorkspaceCoreService,
     private readonly personService: PersonService,
     private readonly codingStatisticsService: CodingStatisticsService,
-    private readonly codingValidationService: CodingValidationService
+    private readonly codingValidationService: CodingValidationService,
+    @InjectRepository(Setting)
+    private readonly settingRepository: Repository<Setting>
   ) { }
 
   @Get(':workspace_id/files')
@@ -95,7 +104,8 @@ export class WorkspaceFilesController {
                            @Query('limit') limit: number = 20,
                            @Query('fileType') fileType?: string,
                            @Query('fileSize') fileSize?: string,
-                           @Query('searchText') searchText?: string
+                           @Query('searchText') searchText?: string,
+                           @Query('regexSearch') regexSearch?: string
   ): Promise<{
         data: FilesDto[];
         total: number;
@@ -109,13 +119,16 @@ export class WorkspaceFilesController {
       );
     }
     try {
+      const effectiveRegexSearch = regexSearch === 'true' &&
+        await getWorkspaceRegexSearchEnabled(this.settingRepository, workspace_id);
       const [files, total, fileTypes] =
         await this.workspaceFilesService.findFiles(workspace_id, {
           page,
           limit,
           fileType,
           fileSize,
-          searchText
+          searchText,
+          regexSearch: effectiveRegexSearch
         });
       return {
         data: files,
@@ -125,6 +138,11 @@ export class WorkspaceFilesController {
         fileTypes
       };
     } catch (error) {
+      const regexError = toRegexSearchException(error, 'searchText');
+      if (regexError) {
+        throw regexError;
+      }
+
       throw new BadRequestException(
         `An error occurred while fetching files for workspace ${workspace_id}: ${error.message} `
       );

--- a/apps/backend/src/app/admin/workspace/workspace-test-results-response.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-test-results-response.controller.ts
@@ -13,6 +13,7 @@ import {
   DefaultValuePipe,
   Logger
 } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import {
   ApiOkResponse,
   ApiOperation,
@@ -21,6 +22,7 @@ import {
   ApiTags,
   ApiBadRequestResponse
 } from '@nestjs/swagger';
+import { Repository } from 'typeorm';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { AccessLevelGuard, RequireAccessLevel } from './access-level.guard';
 import { WorkspaceGuard } from './workspace.guard';
@@ -34,6 +36,11 @@ import { ResponseEntity } from '../../database/entities/response.entity';
 import { RequestWithUser, ResolveDuplicateResponsesRequest, ResponseSearchResult } from './dto/workspace-test-results.interfaces';
 import { CacheService } from '../../cache/cache.service';
 import { JobQueueService } from '../../job-queue/job-queue.service';
+import { Setting } from '../../database/entities/setting.entity';
+import {
+  getWorkspaceRegexSearchEnabled,
+  toRegexSearchException
+} from '../../utils/regex-search.util';
 
 @ApiTags('Admin Workspace Test Results')
 @Controller('admin/workspace')
@@ -44,7 +51,9 @@ export class WorkspaceTestResultsResponseController {
     private workspaceTestResultsService: WorkspaceTestResultsService,
     private responseManagementService: ResponseManagementService,
     private cacheService: CacheService,
-    private jobQueueService: JobQueueService
+    private jobQueueService: JobQueueService,
+    @InjectRepository(Setting)
+    private readonly settingRepository: Repository<Setting>
   ) { }
 
   private async invalidateFlatResponseFilterOptionsCache(
@@ -245,6 +254,12 @@ export class WorkspaceTestResultsResponseController {
     description: 'Sort direction',
     enum: ['asc', 'desc']
   })
+  @ApiQuery({
+    name: 'regexSearch',
+    required: false,
+    description: 'Interpret selected text filters as case-sensitive regular expressions',
+    type: Boolean
+  })
   @ApiBadRequestResponse({ description: 'Failed to search for responses' })
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   async searchResponses(
@@ -266,6 +281,7 @@ export class WorkspaceTestResultsResponseController {
       @Query('personLogin') personLogin?: string,
       @Query('sortBy') sortBy?: ResponseSearchSortBy,
       @Query('sortDirection') sortDirection?: ResponseSearchSortDirection,
+      @Query('regexSearch') regexSearch?: string,
                                          @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number = 1,
                                          @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number = 20
   ): Promise<ResponseSearchResult> {
@@ -274,6 +290,8 @@ export class WorkspaceTestResultsResponseController {
     }
 
     try {
+      const effectiveRegexSearch = regexSearch === 'true' &&
+        await getWorkspaceRegexSearchEnabled(this.settingRepository, workspace_id);
       return await this.workspaceTestResultsService.searchResponses(
         workspace_id,
         {
@@ -291,7 +309,8 @@ export class WorkspaceTestResultsResponseController {
           geogebra: geogebra === 'true',
           derivedOnly: derivedOnly === 'true',
           responseSource,
-          personLogin
+          personLogin,
+          regexSearch: effectiveRegexSearch
         },
         {
           page,
@@ -301,6 +320,11 @@ export class WorkspaceTestResultsResponseController {
         }
       );
     } catch (error) {
+      const regexError = toRegexSearchException(error);
+      if (regexError) {
+        throw regexError;
+      }
+
       this.logger.error(`Error searching for responses: ${error}`);
       throw new BadRequestException(
         `Failed to search for responses. ${error.message}`

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -1716,6 +1716,7 @@ export class CoderTrainingService {
       personCode: string;
       personLogin: string;
       personGroup: string;
+      bookletName: string;
       testPerson: string;
       coders: Array<{
         trainingId: number;
@@ -1759,6 +1760,7 @@ export class CoderTrainingService {
       personCode: string;
       personLogin: string;
       personGroup: string;
+      bookletName: string;
       testPerson: string;
     }>();
 
@@ -1779,6 +1781,7 @@ export class CoderTrainingService {
               personCode: unit.person_code,
               personLogin: unit.person_login,
               personGroup: personGroup,
+              bookletName: unit.booklet_name,
               testPerson
             });
           }
@@ -1793,6 +1796,7 @@ export class CoderTrainingService {
       personCode: string;
       personLogin: string;
       personGroup: string;
+      bookletName: string;
       testPerson: string;
       coders: Array<{
         trainingId: number;
@@ -1867,6 +1871,7 @@ export class CoderTrainingService {
         personCode: info.personCode,
         personLogin: info.personLogin,
         personGroup: info.personGroup,
+        bookletName: info.bookletName,
         testPerson: info.testPerson,
         coders: codersData
       });
@@ -1896,6 +1901,7 @@ export class CoderTrainingService {
       personCode: string;
       personLogin: string;
       personGroup: string;
+      bookletName: string;
       testPerson: string;
       givenAnswer: string;
       replayCode: number | null;
@@ -1933,6 +1939,7 @@ export class CoderTrainingService {
       personCode: string;
       personLogin: string;
       personGroup: string;
+      bookletName: string;
       testPerson: string;
       givenAnswer: string;
       replayCode: number | null;
@@ -1957,6 +1964,7 @@ export class CoderTrainingService {
             personCode: unit.person_code,
             personLogin: unit.person_login,
             personGroup: personGroup,
+            bookletName: unit.booklet_name,
             testPerson,
             givenAnswer,
             replayCode: unit.response?.code_v3 ?? unit.response?.code_v2 ?? unit.response?.code_v1 ?? null,
@@ -2075,6 +2083,7 @@ export class CoderTrainingService {
         personCode: unitVar.personCode,
         personLogin: unitVar.personLogin,
         personGroup: unitVar.personGroup,
+        bookletName: unitVar.bookletName,
         testPerson: unitVar.testPerson,
         givenAnswer: unitVar.givenAnswer,
         replayCode: unitVar.replayCode,

--- a/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.spec.ts
@@ -126,6 +126,11 @@ const filterRows = (
   let filteredRows = [...responseRows];
   const unitIdFilter = getLikeFilter(qb.params.unitId);
   const variableIdFilter = getLikeFilter(qb.params.variableId);
+  const variableIdRegexFilter = [
+    qb.params.variableIdRegex,
+    qb.params.aggregationVariableIdRegex,
+    qb.params.totalCountVariableIdRegex
+  ].find((value): value is string => typeof value === 'string');
   const pairKeyFilters = Object.values(qb.params)
     .filter((value): value is string[] => (
       Array.isArray(value) &&
@@ -138,6 +143,11 @@ const filterRows = (
 
   if (variableIdFilter) {
     filteredRows = filteredRows.filter(row => row.variableId.includes(variableIdFilter));
+  }
+
+  if (variableIdRegexFilter) {
+    const variableIdRegex = new RegExp(variableIdRegexFilter);
+    filteredRows = filteredRows.filter(row => variableIdRegex.test(row.variableId));
   }
 
   pairKeyFilters.forEach(pairKeys => {
@@ -251,7 +261,7 @@ const getSampleInfoRows = (rows: ResponseFixtureRow[]) => {
 describe('VariableAnalysisReplayService', () => {
   let service: VariableAnalysisReplayService;
   let fileUploadRepository: { find: jest.Mock };
-  let responseRepository: { createQueryBuilder: jest.Mock };
+  let responseRepository: { createQueryBuilder: jest.Mock; manager: { connection: { createQueryRunner: jest.Mock } } };
   let workspaceFilesService: { getUnitVariableMap: jest.Mock };
   let codingListService: { getVariablePageMap: jest.Mock };
   let workspaceExclusionService: { resolveExclusionsForQueries: jest.Mock };
@@ -313,7 +323,19 @@ describe('VariableAnalysisReplayService', () => {
           queryKinds[responseRepository.createQueryBuilder.mock.calls.length - 1],
           responseRows
         )
-      ))
+      )),
+      manager: {
+        connection: {
+          createQueryRunner: jest.fn().mockReturnValue({
+            connect: jest.fn().mockResolvedValue(undefined),
+            startTransaction: jest.fn().mockResolvedValue(undefined),
+            query: jest.fn().mockResolvedValue(undefined),
+            commitTransaction: jest.fn().mockResolvedValue(undefined),
+            rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+            release: jest.fn().mockResolvedValue(undefined)
+          })
+        }
+      }
     };
     workspaceFilesService = {
       getUnitVariableMap: jest.fn().mockResolvedValue(new Map([
@@ -394,5 +416,36 @@ describe('VariableAnalysisReplayService', () => {
       totalCount: 1
     });
     expect(result.data[0].replayUrl).toContain('/MDB002/2/02?auth=token');
+  });
+
+  it('uses a regex variable filter when requested', async () => {
+    const result = await service.getVariableAnalysis(
+      7,
+      'token',
+      'http://server',
+      1,
+      10,
+      undefined,
+      '^0[12]$',
+      undefined,
+      true
+    );
+
+    expect(result.total).toBe(3);
+    expect(result.data.map(row => row.variableId)).toEqual(['01', '01', '02']);
+  });
+
+  it('rejects an invalid regex variable filter', async () => {
+    await expect(service.getVariableAnalysis(
+      7,
+      'token',
+      'http://server',
+      1,
+      10,
+      undefined,
+      '[',
+      undefined,
+      true
+    )).rejects.toThrow('Invalid regular expression');
   });
 });

--- a/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.spec.ts
@@ -434,18 +434,4 @@ describe('VariableAnalysisReplayService', () => {
     expect(result.total).toBe(3);
     expect(result.data.map(row => row.variableId)).toEqual(['01', '01', '02']);
   });
-
-  it('rejects an invalid regex variable filter', async () => {
-    await expect(service.getVariableAnalysis(
-      7,
-      'token',
-      'http://server',
-      1,
-      10,
-      undefined,
-      '[',
-      undefined,
-      true
-    )).rejects.toThrow('Invalid regular expression');
-  });
 });

--- a/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Like, Repository } from 'typeorm';
+import { Like, QueryRunner, Repository } from 'typeorm';
 import FileUpload from '../../entities/file_upload.entity';
 import { ResponseEntity } from '../../entities/response.entity';
 import { VariableAnalysisItemDto } from '../../../../../../../api-dto/coding/variable-analysis-item.dto';
@@ -10,6 +10,11 @@ import {
   applyResolvedExclusionsToQuery,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
+import {
+  assertValidRegexSearchPattern,
+  toRegexSearchException,
+  withRegexSearchStatementTimeout
+} from '../../../utils/regex-search.util';
 
 interface CodingScheme {
   variableCodings?: {
@@ -65,7 +70,8 @@ export class VariableAnalysisReplayService {
     limit: number = 100,
     unitIdFilter?: string,
     variableIdFilter?: string,
-    derivationFilter?: string
+    derivationFilter?: string,
+    regexSearch?: boolean
   ): Promise<{
       data: VariableAnalysisItemDto[];
       total: number;
@@ -73,252 +79,296 @@ export class VariableAnalysisReplayService {
       limit: number;
     }> {
     try {
-      this.logger.log(`Getting variable analysis for workspace ${workspace_id} (page ${page}, limit ${limit})`);
-      const startTime = Date.now();
-      const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspace_id);
+      const runAnalysis = async (
+        queryRunner?: QueryRunner
+      ): Promise<{
+        data: VariableAnalysisItemDto[];
+        total: number;
+        page: number;
+        limit: number;
+      }> => {
+        this.logger.log(`Getting variable analysis for workspace ${workspace_id} (page ${page}, limit ${limit})`);
+        const startTime = Date.now();
+        const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspace_id);
 
-      this.logger.log('Getting unit variables mapping...');
-      const unitVariablesMap = await this.workspaceFilesService.getUnitVariableMap(workspace_id);
-      this.logger.log(`Retrieved unit variables map with ${unitVariablesMap.size} units`);
+        this.logger.log('Getting unit variables mapping...');
+        const unitVariablesMap = await this.workspaceFilesService.getUnitVariableMap(workspace_id);
+        this.logger.log(`Retrieved unit variables map with ${unitVariablesMap.size} units`);
 
-      // Step 2: Pre-fetch all coding schemes for the workspace to get derivations and descriptions for the response
-      this.logger.log('Pre-fetching coding schemes for derivation info...');
-      const codingSchemes = await this.fileUploadRepository.find({
-        where: {
-          workspace_id,
-          file_type: 'Resource',
-          file_id: Like('%.VOCS')
+        // Step 2: Pre-fetch all coding schemes for the workspace to get derivations and descriptions for the response
+        this.logger.log('Pre-fetching coding schemes for derivation info...');
+        const codingSchemes = await this.fileUploadRepository.find({
+          where: {
+            workspace_id,
+            file_type: 'Resource',
+            file_id: Like('%.VOCS')
+          }
+        });
+
+        const codingSchemeMap = new Map<string, CodingScheme>();
+        for (const scheme of codingSchemes) {
+          try {
+            const unitId = scheme.file_id.replace('.VOCS', '');
+            const parsedScheme = JSON.parse(scheme.data) as CodingScheme;
+            codingSchemeMap.set(unitId, parsedScheme);
+          } catch (error) {
+            this.logger.error(`Error parsing coding scheme ${scheme.file_id}: ${error.message}`, error.stack);
+          }
         }
-      });
+        this.logger.log(`Pre-fetched ${codingSchemeMap.size} coding schemes in ${Date.now() - startTime}ms`);
 
-      const codingSchemeMap = new Map<string, CodingScheme>();
-      for (const scheme of codingSchemes) {
-        try {
-          const unitId = scheme.file_id.replace('.VOCS', '');
-          const parsedScheme = JSON.parse(scheme.data) as CodingScheme;
-          codingSchemeMap.set(unitId, parsedScheme);
-        } catch (error) {
-          this.logger.error(`Error parsing coding scheme ${scheme.file_id}: ${error.message}`, error.stack);
+        const validVariablePairKeys = this.getValidVariablePairKeys(
+          unitVariablesMap,
+          codingSchemeMap,
+          derivationFilter
+        );
+
+        if (validVariablePairKeys.length === 0) {
+          return {
+            data: [],
+            total: 0,
+            page,
+            limit
+          };
         }
-      }
-      this.logger.log(`Pre-fetched ${codingSchemeMap.size} coding schemes in ${Date.now() - startTime}ms`);
 
-      const validVariablePairKeys = this.getValidVariablePairKeys(
-        unitVariablesMap,
-        codingSchemeMap,
-        derivationFilter
-      );
+        const countQuery = this.responseRepository.createQueryBuilder('response', queryRunner)
+          .select('COUNT(DISTINCT CONCAT(unit.name, CHR(31), response.variableid, CHR(31), response.code_v1))', 'count')
+          .leftJoin('response.unit', 'unit')
+          .leftJoin('unit.booklet', 'booklet')
+          .leftJoin('booklet.bookletinfo', 'bookletinfo')
+          .leftJoin('booklet.person', 'person')
+          .where('person.workspace_id = :workspace_id', { workspace_id });
+        applyResolvedExclusionsToQuery(countQuery, exclusions);
+        this.applyVariablePairFilter(countQuery, validVariablePairKeys, 'validVariablePairKeys');
 
-      if (validVariablePairKeys.length === 0) {
+        if (unitIdFilter) {
+          countQuery.andWhere('unit.name LIKE :unitId', { unitId: `%${unitIdFilter}%` });
+        }
+
+        if (variableIdFilter) {
+          if (regexSearch) {
+            const variableIdRegex = assertValidRegexSearchPattern(variableIdFilter, 'variableId');
+            if (variableIdRegex) {
+              countQuery.andWhere('response.variableid ~ :variableIdRegex', { variableIdRegex });
+            }
+          } else {
+            countQuery.andWhere('response.variableid LIKE :variableId', { variableId: `%${variableIdFilter}%` });
+          }
+        }
+
+        const totalCountResult = await countQuery.getRawOne();
+        const totalCount = parseInt(totalCountResult?.count || '0', 10);
+        this.logger.log(`Total unique combinations: ${totalCount}`);
+
+        const aggregationQuery = this.responseRepository.createQueryBuilder('response', queryRunner)
+          .select('unit.name', 'unitId')
+          .addSelect('response.variableid', 'variableId')
+          .addSelect('response.code_v1', 'code_v1')
+          .addSelect('COUNT(response.id)', 'occurrenceCount')
+          .addSelect('MAX(response.score_v1)', 'score_V1') // Use MAX as a sample score
+          .leftJoin('response.unit', 'unit')
+          .leftJoin('unit.booklet', 'booklet')
+          .leftJoin('booklet.person', 'person')
+          .leftJoin('booklet.bookletinfo', 'bookletinfo')
+          .where('person.workspace_id = :workspace_id', { workspace_id });
+        applyResolvedExclusionsToQuery(aggregationQuery, exclusions);
+        this.applyVariablePairFilter(aggregationQuery, validVariablePairKeys, 'aggregationVariablePairKeys');
+
+        if (unitIdFilter) {
+          aggregationQuery.andWhere('unit.name LIKE :unitId', { unitId: `%${unitIdFilter}%` });
+        }
+
+        if (variableIdFilter) {
+          if (regexSearch) {
+            const aggregationVariableIdRegex = assertValidRegexSearchPattern(variableIdFilter, 'variableId');
+            if (aggregationVariableIdRegex) {
+              aggregationQuery.andWhere('response.variableid ~ :aggregationVariableIdRegex', { aggregationVariableIdRegex });
+            }
+          } else {
+            aggregationQuery.andWhere('response.variableid LIKE :variableId', { variableId: `%${variableIdFilter}%` });
+          }
+        }
+
+        aggregationQuery
+          .groupBy('unit.name')
+          .addGroupBy('response.variableid')
+          .addGroupBy('response.code_v1')
+          .orderBy('unit.name', 'ASC')
+          .addOrderBy('response.variableid', 'ASC')
+          .addOrderBy('response.code_v1', 'ASC')
+          .offset((page - 1) * limit)
+          .limit(limit);
+
+        const aggregatedResults = await aggregationQuery.getRawMany<VariableAnalysisAggregationRow>();
+        this.logger.log(`Retrieved ${aggregatedResults.length} aggregated combinations for page ${page}`);
+
+        if (aggregatedResults.length === 0) {
+          return {
+            data: [],
+            total: totalCount,
+            page,
+            limit
+          };
+        }
+        const unitVariableCounts = new Map<string, Map<string, number>>();
+        const unitVariableCombinations = this.getUniqueUnitVariablePairs(aggregatedResults);
+        const pageVariablePairKeys = unitVariableCombinations.map(combo => this.toVariablePairKey(combo.unitId, combo.variableId));
+
+        const totalCountsQuery = this.responseRepository.createQueryBuilder('response', queryRunner)
+          .select('unit.name', 'unitId')
+          .addSelect('response.variableid', 'variableId')
+          .addSelect('COUNT(response.id)', 'totalCount')
+          .leftJoin('response.unit', 'unit')
+          .leftJoin('unit.booklet', 'booklet')
+          .leftJoin('booklet.bookletinfo', 'bookletinfo')
+          .leftJoin('booklet.person', 'person')
+          .where('person.workspace_id = :workspace_id', { workspace_id });
+        applyResolvedExclusionsToQuery(totalCountsQuery, exclusions, { parameterPrefix: 'variableAnalysisTotals' });
+        this.applyVariablePairFilter(totalCountsQuery, pageVariablePairKeys, 'totalCountVariablePairKeys');
+
+        if (unitIdFilter) {
+          totalCountsQuery.andWhere('unit.name LIKE :unitId', { unitId: `%${unitIdFilter}%` });
+        }
+
+        if (variableIdFilter) {
+          if (regexSearch) {
+            const totalCountVariableIdRegex = assertValidRegexSearchPattern(variableIdFilter, 'variableId');
+            if (totalCountVariableIdRegex) {
+              totalCountsQuery.andWhere('response.variableid ~ :totalCountVariableIdRegex', { totalCountVariableIdRegex });
+            }
+          } else {
+            totalCountsQuery.andWhere('response.variableid LIKE :variableId', { variableId: `%${variableIdFilter}%` });
+          }
+        }
+
+        totalCountsQuery.groupBy('unit.name')
+          .addGroupBy('response.variableid');
+
+        const totalCountsResults = await totalCountsQuery.getRawMany();
+
+        for (const result of totalCountsResults) {
+          if (!unitVariableCounts.has(result.unitId)) {
+            unitVariableCounts.set(result.unitId, new Map<string, number>());
+          }
+          unitVariableCounts.get(result.unitId)?.set(result.variableId, parseInt(result.totalCount, 10));
+        }
+
+        const sampleInfoQuery = this.responseRepository.createQueryBuilder('response', queryRunner)
+          .select('unit.name', 'unitId')
+          .addSelect('response.variableid', 'variableId')
+          .addSelect('response.code_v1', 'code_v1')
+          .addSelect('person.login', 'loginName')
+          .addSelect('person.code', 'loginCode')
+          .addSelect('person.group', 'loginGroup')
+          .addSelect('bookletinfo.name', 'bookletId')
+          .leftJoin('response.unit', 'unit')
+          .leftJoin('unit.booklet', 'booklet')
+          .leftJoin('booklet.person', 'person')
+          .leftJoin('booklet.bookletinfo', 'bookletinfo')
+          .where('person.workspace_id = :workspace_id', { workspace_id });
+        applyResolvedExclusionsToQuery(sampleInfoQuery, exclusions, { parameterPrefix: 'variableAnalysisSample' });
+        this.applyVariablePairFilter(sampleInfoQuery, pageVariablePairKeys, 'sampleVariablePairKeys');
+
+        sampleInfoQuery.groupBy('unit.name')
+          .addGroupBy('response.variableid')
+          .addGroupBy('response.code_v1')
+          .addGroupBy('person.login')
+          .addGroupBy('person.code')
+          .addGroupBy('person.group')
+          .addGroupBy('bookletinfo.name');
+
+        const sampleInfoResults = await sampleInfoQuery.getRawMany<VariableAnalysisSampleInfoRow>();
+
+        const sampleInfoMap = new Map<string, { loginName: string; loginCode: string; loginGroup: string; bookletId: string }>();
+        for (const result of sampleInfoResults) {
+          const key = this.toAggregationKey(result.unitId, result.variableId, result.code_v1);
+          if (sampleInfoMap.has(key)) {
+            continue;
+          }
+
+          sampleInfoMap.set(key, {
+            loginName: result.loginName || '',
+            loginCode: result.loginCode || '',
+            loginGroup: result.loginGroup || '',
+            bookletId: result.bookletId || ''
+          });
+        }
+
+        const result: VariableAnalysisItemDto[] = [];
+
+        // Pre-load variable page maps for all unique units
+        const uniqueUnitIds = new Set(unitVariableCombinations.map(item => item.unitId));
+        const variablePageMaps = new Map<string, Map<string, string>>();
+        for (const unitId of uniqueUnitIds) {
+          const pageMap = await this.codingListService.getVariablePageMap(unitId, workspace_id);
+          variablePageMaps.set(unitId, pageMap);
+        }
+
+        for (const item of aggregatedResults) {
+          const unitId = item.unitId;
+          const variableId = item.variableId;
+          const code = item.code_v1?.toString() ?? '';
+          const occurrenceCount = parseInt(item.occurrenceCount, 10);
+          const score = parseFloat(item.score_V1) || 0;
+
+          const variableTotalCount = unitVariableCounts.get(unitId)?.get(variableId) || 0;
+
+          const relativeOccurrence = variableTotalCount > 0 ? occurrenceCount / variableTotalCount : 0;
+
+          const variableCoding = this.getVariableCoding(codingSchemeMap, unitId, variableId);
+          const derivation = variableCoding?.sourceType || '';
+          const description = variableCoding?.label || '';
+
+          const sampleInfo = sampleInfoMap.get(this.toAggregationKey(unitId, variableId, code));
+          const loginName = sampleInfo?.loginName || '';
+          const loginCode = sampleInfo?.loginCode || '';
+          const loginGroup = sampleInfo?.loginGroup || '';
+          const bookletId = sampleInfo?.bookletId || '';
+
+          // Get variable page from VOUD data
+          const variablePage = variablePageMaps.get(unitId)?.get(variableId) || '0';
+          const replayUrl = `${serverUrl}/#/replay/${loginName}@${loginCode}@${loginGroup}@${bookletId}/${unitId}/${variablePage}/${variableId}?auth=${authToken}`;
+
+          result.push({
+            replayUrl,
+            unitId,
+            variableId,
+            derivation,
+            code,
+            description,
+            score,
+            occurrenceCount,
+            totalCount: variableTotalCount,
+            relativeOccurrence
+          });
+        }
+
+        const endTime = Date.now();
+        this.logger.log(`Variable analysis completed in ${endTime - startTime}ms`);
+
         return {
-          data: [],
-          total: 0,
-          page,
-          limit
-        };
-      }
-
-      const countQuery = this.responseRepository.createQueryBuilder('response')
-        .select('COUNT(DISTINCT CONCAT(unit.name, CHR(31), response.variableid, CHR(31), response.code_v1))', 'count')
-        .leftJoin('response.unit', 'unit')
-        .leftJoin('unit.booklet', 'booklet')
-        .leftJoin('booklet.bookletinfo', 'bookletinfo')
-        .leftJoin('booklet.person', 'person')
-        .where('person.workspace_id = :workspace_id', { workspace_id });
-      applyResolvedExclusionsToQuery(countQuery, exclusions);
-      this.applyVariablePairFilter(countQuery, validVariablePairKeys, 'validVariablePairKeys');
-
-      if (unitIdFilter) {
-        countQuery.andWhere('unit.name LIKE :unitId', { unitId: `%${unitIdFilter}%` });
-      }
-
-      if (variableIdFilter) {
-        countQuery.andWhere('response.variableid LIKE :variableId', { variableId: `%${variableIdFilter}%` });
-      }
-
-      const totalCountResult = await countQuery.getRawOne();
-      const totalCount = parseInt(totalCountResult?.count || '0', 10);
-      this.logger.log(`Total unique combinations: ${totalCount}`);
-
-      const aggregationQuery = this.responseRepository.createQueryBuilder('response')
-        .select('unit.name', 'unitId')
-        .addSelect('response.variableid', 'variableId')
-        .addSelect('response.code_v1', 'code_v1')
-        .addSelect('COUNT(response.id)', 'occurrenceCount')
-        .addSelect('MAX(response.score_v1)', 'score_V1') // Use MAX as a sample score
-        .leftJoin('response.unit', 'unit')
-        .leftJoin('unit.booklet', 'booklet')
-        .leftJoin('booklet.person', 'person')
-        .leftJoin('booklet.bookletinfo', 'bookletinfo')
-        .where('person.workspace_id = :workspace_id', { workspace_id });
-      applyResolvedExclusionsToQuery(aggregationQuery, exclusions);
-      this.applyVariablePairFilter(aggregationQuery, validVariablePairKeys, 'aggregationVariablePairKeys');
-
-      if (unitIdFilter) {
-        aggregationQuery.andWhere('unit.name LIKE :unitId', { unitId: `%${unitIdFilter}%` });
-      }
-
-      if (variableIdFilter) {
-        aggregationQuery.andWhere('response.variableid LIKE :variableId', { variableId: `%${variableIdFilter}%` });
-      }
-
-      aggregationQuery
-        .groupBy('unit.name')
-        .addGroupBy('response.variableid')
-        .addGroupBy('response.code_v1')
-        .orderBy('unit.name', 'ASC')
-        .addOrderBy('response.variableid', 'ASC')
-        .addOrderBy('response.code_v1', 'ASC')
-        .offset((page - 1) * limit)
-        .limit(limit);
-
-      const aggregatedResults = await aggregationQuery.getRawMany<VariableAnalysisAggregationRow>();
-      this.logger.log(`Retrieved ${aggregatedResults.length} aggregated combinations for page ${page}`);
-
-      if (aggregatedResults.length === 0) {
-        return {
-          data: [],
+          data: result,
           total: totalCount,
           page,
           limit
         };
-      }
-      const unitVariableCounts = new Map<string, Map<string, number>>();
-      const unitVariableCombinations = this.getUniqueUnitVariablePairs(aggregatedResults);
-      const pageVariablePairKeys = unitVariableCombinations.map(combo => this.toVariablePairKey(combo.unitId, combo.variableId));
-
-      const totalCountsQuery = this.responseRepository.createQueryBuilder('response')
-        .select('unit.name', 'unitId')
-        .addSelect('response.variableid', 'variableId')
-        .addSelect('COUNT(response.id)', 'totalCount')
-        .leftJoin('response.unit', 'unit')
-        .leftJoin('unit.booklet', 'booklet')
-        .leftJoin('booklet.bookletinfo', 'bookletinfo')
-        .leftJoin('booklet.person', 'person')
-        .where('person.workspace_id = :workspace_id', { workspace_id });
-      applyResolvedExclusionsToQuery(totalCountsQuery, exclusions, { parameterPrefix: 'variableAnalysisTotals' });
-      this.applyVariablePairFilter(totalCountsQuery, pageVariablePairKeys, 'totalCountVariablePairKeys');
-
-      if (unitIdFilter) {
-        totalCountsQuery.andWhere('unit.name LIKE :unitId', { unitId: `%${unitIdFilter}%` });
-      }
-
-      if (variableIdFilter) {
-        totalCountsQuery.andWhere('response.variableid LIKE :variableId', { variableId: `%${variableIdFilter}%` });
-      }
-
-      totalCountsQuery.groupBy('unit.name')
-        .addGroupBy('response.variableid');
-
-      const totalCountsResults = await totalCountsQuery.getRawMany();
-
-      for (const result of totalCountsResults) {
-        if (!unitVariableCounts.has(result.unitId)) {
-          unitVariableCounts.set(result.unitId, new Map<string, number>());
-        }
-        unitVariableCounts.get(result.unitId)?.set(result.variableId, parseInt(result.totalCount, 10));
-      }
-
-      const sampleInfoQuery = this.responseRepository.createQueryBuilder('response')
-        .select('unit.name', 'unitId')
-        .addSelect('response.variableid', 'variableId')
-        .addSelect('response.code_v1', 'code_v1')
-        .addSelect('person.login', 'loginName')
-        .addSelect('person.code', 'loginCode')
-        .addSelect('person.group', 'loginGroup')
-        .addSelect('bookletinfo.name', 'bookletId')
-        .leftJoin('response.unit', 'unit')
-        .leftJoin('unit.booklet', 'booklet')
-        .leftJoin('booklet.person', 'person')
-        .leftJoin('booklet.bookletinfo', 'bookletinfo')
-        .where('person.workspace_id = :workspace_id', { workspace_id });
-      applyResolvedExclusionsToQuery(sampleInfoQuery, exclusions, { parameterPrefix: 'variableAnalysisSample' });
-      this.applyVariablePairFilter(sampleInfoQuery, pageVariablePairKeys, 'sampleVariablePairKeys');
-
-      sampleInfoQuery.groupBy('unit.name')
-        .addGroupBy('response.variableid')
-        .addGroupBy('response.code_v1')
-        .addGroupBy('person.login')
-        .addGroupBy('person.code')
-        .addGroupBy('person.group')
-        .addGroupBy('bookletinfo.name');
-
-      const sampleInfoResults = await sampleInfoQuery.getRawMany<VariableAnalysisSampleInfoRow>();
-
-      const sampleInfoMap = new Map<string, { loginName: string; loginCode: string; loginGroup: string; bookletId: string }>();
-      for (const result of sampleInfoResults) {
-        const key = this.toAggregationKey(result.unitId, result.variableId, result.code_v1);
-        if (sampleInfoMap.has(key)) {
-          continue;
-        }
-
-        sampleInfoMap.set(key, {
-          loginName: result.loginName || '',
-          loginCode: result.loginCode || '',
-          loginGroup: result.loginGroup || '',
-          bookletId: result.bookletId || ''
-        });
-      }
-
-      const result: VariableAnalysisItemDto[] = [];
-
-      // Pre-load variable page maps for all unique units
-      const uniqueUnitIds = new Set(unitVariableCombinations.map(item => item.unitId));
-      const variablePageMaps = new Map<string, Map<string, string>>();
-      for (const unitId of uniqueUnitIds) {
-        const pageMap = await this.codingListService.getVariablePageMap(unitId, workspace_id);
-        variablePageMaps.set(unitId, pageMap);
-      }
-
-      for (const item of aggregatedResults) {
-        const unitId = item.unitId;
-        const variableId = item.variableId;
-        const code = item.code_v1?.toString() ?? '';
-        const occurrenceCount = parseInt(item.occurrenceCount, 10);
-        const score = parseFloat(item.score_V1) || 0;
-
-        const variableTotalCount = unitVariableCounts.get(unitId)?.get(variableId) || 0;
-
-        const relativeOccurrence = variableTotalCount > 0 ? occurrenceCount / variableTotalCount : 0;
-
-        const variableCoding = this.getVariableCoding(codingSchemeMap, unitId, variableId);
-        const derivation = variableCoding?.sourceType || '';
-        const description = variableCoding?.label || '';
-
-        const sampleInfo = sampleInfoMap.get(this.toAggregationKey(unitId, variableId, code));
-        const loginName = sampleInfo?.loginName || '';
-        const loginCode = sampleInfo?.loginCode || '';
-        const loginGroup = sampleInfo?.loginGroup || '';
-        const bookletId = sampleInfo?.bookletId || '';
-
-        // Get variable page from VOUD data
-        const variablePage = variablePageMaps.get(unitId)?.get(variableId) || '0';
-        const replayUrl = `${serverUrl}/#/replay/${loginName}@${loginCode}@${loginGroup}@${bookletId}/${unitId}/${variablePage}/${variableId}?auth=${authToken}`;
-
-        result.push({
-          replayUrl,
-          unitId,
-          variableId,
-          derivation,
-          code,
-          description,
-          score,
-          occurrenceCount,
-          totalCount: variableTotalCount,
-          relativeOccurrence
-        });
-      }
-
-      const endTime = Date.now();
-      this.logger.log(`Variable analysis completed in ${endTime - startTime}ms`);
-
-      return {
-        data: result,
-        total: totalCount,
-        page,
-        limit
       };
+
+      if (regexSearch) {
+        return await withRegexSearchStatementTimeout(
+          this.responseRepository.manager.connection,
+          runAnalysis
+        );
+      }
+
+      return await runAnalysis();
     } catch (error) {
+      const regexError = toRegexSearchException(error);
+      if (regexError) {
+        throw regexError;
+      }
+
       this.logger.error(`Error getting variable analysis: ${error.message}`, error.stack);
       throw new Error('Could not retrieve variable analysis data. Please check the database connection or query.');
     }

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -865,9 +865,13 @@ describe('WorkspaceTestResultsService', () => {
       );
     });
 
-    it('should reject invalid regex filters', async () => {
+    it('should convert PostgreSQL invalid regex errors into bad request errors', async () => {
       const qb = mockQueryBuilder();
       (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockRejectedValue({
+        code: '2201B',
+        message: 'invalid regular expression: brackets [] not balanced'
+      });
 
       await expect(service.searchResponses(
         1,

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -193,7 +193,10 @@ describe('WorkspaceTestResultsService', () => {
     dataSource = {
       createQueryRunner: jest.fn().mockReturnValue({
         connect: jest.fn().mockResolvedValue(undefined),
+        startTransaction: jest.fn().mockResolvedValue(undefined),
         query: jest.fn().mockResolvedValue([]),
+        commitTransaction: jest.fn().mockResolvedValue(undefined),
+        rollbackTransaction: jest.fn().mockResolvedValue(undefined),
         release: jest.fn().mockResolvedValue(undefined)
       }),
       createQueryBuilder: jest.fn(() => mockQueryBuilder()),
@@ -815,6 +818,62 @@ describe('WorkspaceTestResultsService', () => {
         'response.variableid ILIKE :variableId',
         { variableId: '%01%' }
       );
+    });
+
+    it('should filter selected response fields with regex when requested', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(0);
+
+      await service.searchResponses(
+        1,
+        {
+          variableId: '^VAR_\\d+$',
+          unitName: '^Unit',
+          bookletName: 'Booklet-[AB]',
+          group: '^G[12]$',
+          code: '^P-',
+          personLogin: 'user-[0-9]+',
+          regexSearch: true
+        },
+        { page: 1, limit: 100 }
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'response.variableid ~ :variableIdRegex',
+        { variableIdRegex: '^VAR_\\d+$' }
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'unit.name ~ :unitNameRegex',
+        { unitNameRegex: '^Unit' }
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'bookletinfo.name ~ :bookletNameRegex',
+        { bookletNameRegex: 'Booklet-[AB]' }
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'person.group ~ :groupRegex',
+        { groupRegex: '^G[12]$' }
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'person.code ~ :codeRegex',
+        { codeRegex: '^P-' }
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'person.login ~ :personLoginRegex',
+        { personLoginRegex: 'user-[0-9]+' }
+      );
+    });
+
+    it('should reject invalid regex filters', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+
+      await expect(service.searchResponses(
+        1,
+        { variableId: '[', regexSearch: true },
+        { page: 1, limit: 100 }
+      )).rejects.toThrow('Invalid regular expression');
     });
 
     it('should filter variable IDs exactly when wrapped in double quotes', async () => {

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -7,6 +7,7 @@ import {
   EntityManager,
   EntityTarget,
   ObjectLiteral,
+  QueryRunner,
   Repository,
   SelectQueryBuilder
 } from 'typeorm';
@@ -74,6 +75,11 @@ import {
   TestResultsResponseCleanupSampleDto,
   TestResultsTimestampSource
 } from '../../../../../../../api-dto/test-results/test-results-deletion.dto';
+import {
+  assertValidRegexSearchPattern,
+  toRegexSearchException,
+  withRegexSearchStatementTimeout
+} from '../../../utils/regex-search.util';
 
 interface PersonWhere {
   code: string;
@@ -6503,6 +6509,7 @@ export class WorkspaceTestResultsService {
       derivedOnly?: boolean;
       responseSource?: 'base' | 'derived' | 'all';
       personLogin?: string;
+      regexSearch?: boolean;
     },
     options: {
       page?: number;
@@ -6550,212 +6557,286 @@ export class WorkspaceTestResultsService {
         )} (page: ${page}, limit: ${limit})`
       );
 
-      const query = this.responseRepository
-        .createQueryBuilder('response')
-        .innerJoinAndSelect('response.unit', 'unit')
-        .innerJoinAndSelect('unit.booklet', 'booklet')
-        .innerJoinAndSelect('booklet.person', 'person')
-        .innerJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
-        .where('person.workspace_id = :workspaceId', { workspaceId })
-        .andWhere('person.consider = :consider', { consider: true });
+      const runSearch = async (
+        queryRunner?: QueryRunner
+      ): Promise<{
+        data: {
+          responseId: number;
+          variableId: string;
+          value: string;
+          status: string;
+          code?: number;
+          score?: number;
+          codedStatus?: string;
+          unitId: number;
+          unitName: string;
+          unitAlias: string | null;
+          bookletId: number;
+          bookletName: string;
+          personId: number;
+          personLogin: string;
+          personCode: string;
+          personGroup: string;
+          variablePage?: string;
+        }[];
+        total: number;
+      }> => {
+        const query = this.responseRepository
+          .createQueryBuilder('response', queryRunner)
+          .innerJoinAndSelect('response.unit', 'unit')
+          .innerJoinAndSelect('unit.booklet', 'booklet')
+          .innerJoinAndSelect('booklet.person', 'person')
+          .innerJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
+          .where('person.workspace_id = :workspaceId', { workspaceId })
+          .andWhere('person.consider = :consider', { consider: true });
 
-      const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-      this.applyExclusionsToQuery(query, exclusions);
+        const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+        this.applyExclusionsToQuery(query, exclusions);
 
-      if (searchParams.value) {
-        query.andWhere('response.value ILIKE :value', {
-          value: `%${searchParams.value}%`
-        });
-      }
-
-      if (searchParams.variableId) {
-        const variableIdFilter = WorkspaceTestResultsService.parseQuotedExactSearchFilter(searchParams.variableId);
-        if (variableIdFilter.exact) {
-          query.andWhere('LOWER(response.variableid) = LOWER(:variableId)', {
-            variableId: variableIdFilter.value
-          });
-        } else {
-          query.andWhere('response.variableid ILIKE :variableId', {
-            variableId: `%${variableIdFilter.value}%`
+        if (searchParams.value) {
+          query.andWhere('response.value ILIKE :value', {
+            value: `%${searchParams.value}%`
           });
         }
-      }
 
-      if (searchParams.unitName) {
-        query.andWhere('unit.name ILIKE :unitName', {
-          unitName: `%${searchParams.unitName}%`
-        });
-      }
+        if (searchParams.variableId) {
+          const variableIdFilter = WorkspaceTestResultsService.parseQuotedExactSearchFilter(searchParams.variableId);
+          if (searchParams.regexSearch) {
+            const variableIdRegex = assertValidRegexSearchPattern(searchParams.variableId, 'variableId');
+            if (variableIdRegex) {
+              query.andWhere('response.variableid ~ :variableIdRegex', { variableIdRegex });
+            }
+          } else if (variableIdFilter.exact) {
+            query.andWhere('LOWER(response.variableid) = LOWER(:variableId)', {
+              variableId: variableIdFilter.value
+            });
+          } else {
+            query.andWhere('response.variableid ILIKE :variableId', {
+              variableId: `%${variableIdFilter.value}%`
+            });
+          }
+        }
 
-      if (searchParams.bookletName) {
-        query.andWhere('bookletinfo.name ILIKE :bookletName', {
-          bookletName: `%${searchParams.bookletName}%`
-        });
-      }
+        if (searchParams.unitName) {
+          if (searchParams.regexSearch) {
+            const unitNameRegex = assertValidRegexSearchPattern(searchParams.unitName, 'unitName');
+            if (unitNameRegex) {
+              query.andWhere('unit.name ~ :unitNameRegex', { unitNameRegex });
+            }
+          } else {
+            query.andWhere('unit.name ILIKE :unitName', {
+              unitName: `%${searchParams.unitName}%`
+            });
+          }
+        }
 
-      if (searchParams.status) {
-        query.andWhere('response.status = :status', {
-          status: searchParams.status
-        });
-      }
+        if (searchParams.bookletName) {
+          if (searchParams.regexSearch) {
+            const bookletNameRegex = assertValidRegexSearchPattern(searchParams.bookletName, 'bookletName');
+            if (bookletNameRegex) {
+              query.andWhere('bookletinfo.name ~ :bookletNameRegex', { bookletNameRegex });
+            }
+          } else {
+            query.andWhere('bookletinfo.name ILIKE :bookletName', {
+              bookletName: `%${searchParams.bookletName}%`
+            });
+          }
+        }
 
-      if (searchParams.codedStatus) {
-        const codedStatusNumber = statusStringToNumber(searchParams.codedStatus);
-        if (codedStatusNumber === null) {
-          query.andWhere('1=0');
-        } else {
+        if (searchParams.status) {
+          query.andWhere('response.status = :status', {
+            status: searchParams.status
+          });
+        }
+
+        if (searchParams.codedStatus) {
+          const codedStatusNumber = statusStringToNumber(searchParams.codedStatus);
+          if (codedStatusNumber === null) {
+            query.andWhere('1=0');
+          } else {
+            const effectiveStatusExpression = getEffectiveCodingStatusExpression(version);
+            query.andWhere(`${effectiveStatusExpression} = :codedStatus`, {
+              codedStatus: codedStatusNumber
+            });
+          }
+        }
+
+        if (searchParams.group) {
+          if (searchParams.regexSearch) {
+            const groupRegex = assertValidRegexSearchPattern(searchParams.group, 'group');
+            if (groupRegex) {
+              query.andWhere('person.group ~ :groupRegex', { groupRegex });
+            }
+          } else {
+            query.andWhere('person.group = :group', { group: searchParams.group });
+          }
+        }
+
+        if (searchParams.code) {
+          if (searchParams.regexSearch) {
+            const codeRegex = assertValidRegexSearchPattern(searchParams.code, 'code');
+            if (codeRegex) {
+              query.andWhere('person.code ~ :codeRegex', { codeRegex });
+            }
+          } else {
+            query.andWhere('person.code = :code', { code: searchParams.code });
+          }
+        }
+
+        if (searchParams.codingCode) {
+          const codingCodeFilter = searchParams.codingCode.trim();
+          const codingCode = Number(codingCodeFilter);
+          if (codingCodeFilter !== '' && Number.isInteger(codingCode)) {
+            query.andWhere(`response.code_${version} = :codingCode`, { codingCode });
+          } else {
+            query.andWhere('1=0');
+          }
+        }
+
+        if (searchParams.score) {
+          const scoreFilter = searchParams.score.trim();
+          const score = Number(scoreFilter);
+          if (scoreFilter !== '' && Number.isInteger(score)) {
+            query.andWhere(`response.score_${version} = :score`, { score });
+          } else {
+            query.andWhere('1=0');
+          }
+        }
+
+        if (searchParams.personLogin) {
+          if (searchParams.regexSearch) {
+            const personLoginRegex = assertValidRegexSearchPattern(searchParams.personLogin, 'personLogin');
+            if (personLoginRegex) {
+              query.andWhere('person.login ~ :personLoginRegex', { personLoginRegex });
+            }
+          } else {
+            query.andWhere('person.login ILIKE :personLogin', {
+              personLogin: `%${searchParams.personLogin}%`
+            });
+          }
+        }
+
+        if (searchParams.geogebra) {
+          query.andWhere(
+            WorkspaceTestResultsService.createGeoGebraValueCondition('response'),
+            WorkspaceTestResultsService.geoGebraValueParams
+          );
+        }
+
+        const requestedResponseSource = searchParams.derivedOnly ? 'derived' : searchParams.responseSource || 'base';
+        const responseSource = searchParams.geogebra && requestedResponseSource === 'all' ?
+          'base' :
+          requestedResponseSource;
+
+        if (responseSource === 'derived') {
           const effectiveStatusExpression = getEffectiveCodingStatusExpression(version);
-          query.andWhere(`${effectiveStatusExpression} = :codedStatus`, {
-            codedStatus: codedStatusNumber
+          query.andWhere('response.is_autocoder_generated = :derivedOnly', {
+            derivedOnly: true
           });
-        }
-      }
-
-      if (searchParams.group) {
-        query.andWhere('person.group = :group', { group: searchParams.group });
-      }
-
-      if (searchParams.code) {
-        query.andWhere('person.code = :code', { code: searchParams.code });
-      }
-
-      if (searchParams.codingCode) {
-        const codingCodeFilter = searchParams.codingCode.trim();
-        const codingCode = Number(codingCodeFilter);
-        if (codingCodeFilter !== '' && Number.isInteger(codingCode)) {
-          query.andWhere(`response.code_${version} = :codingCode`, { codingCode });
+          query.andWhere(`${effectiveStatusExpression} IS NOT NULL`);
+          query.andWhere(`${effectiveStatusExpression} NOT IN (:...ignoredDerivedCodingStatuses)`, {
+            ignoredDerivedCodingStatuses: WorkspaceTestResultsService.ignoredDerivedCodingStatuses
+          });
+          await this.applyValidCodingVariableFilter(query, workspaceId);
+        } else if (responseSource === 'all') {
+          const effectiveStatusExpression = getEffectiveCodingStatusExpression(version);
+          query.andWhere(`${effectiveStatusExpression} IS NOT NULL`);
+          query.andWhere(`${effectiveStatusExpression} NOT IN (:...ignoredDerivedCodingStatuses)`, {
+            ignoredDerivedCodingStatuses: WorkspaceTestResultsService.ignoredDerivedCodingStatuses
+          });
+          await this.applyValidCodingVariableFilter(query, workspaceId);
         } else {
-          query.andWhere('1=0');
+          this.excludeAutocoderGeneratedResponses(query);
         }
-      }
 
-      if (searchParams.score) {
-        const scoreFilter = searchParams.score.trim();
-        const score = Number(scoreFilter);
-        if (scoreFilter !== '' && Number.isInteger(score)) {
-          query.andWhere(`response.score_${version} = :score`, { score });
-        } else {
-          query.andWhere('1=0');
-        }
-      }
-
-      if (searchParams.personLogin) {
-        query.andWhere('person.login ILIKE :personLogin', {
-          personLogin: `%${searchParams.personLogin}%`
-        });
-      }
-
-      if (searchParams.geogebra) {
-        query.andWhere(
-          WorkspaceTestResultsService.createGeoGebraValueCondition('response'),
-          WorkspaceTestResultsService.geoGebraValueParams
+        const total = await query.getCount();
+        this.applyResponseSearchSorting(
+          query,
+          version,
+          searchParams.geogebra === true,
+          options.sortBy,
+          options.sortDirection
         );
-      }
 
-      const requestedResponseSource = searchParams.derivedOnly ? 'derived' : searchParams.responseSource || 'base';
-      const responseSource = searchParams.geogebra && requestedResponseSource === 'all' ?
-        'base' :
-        requestedResponseSource;
+        if (total === 0) {
+          this.logger.log(
+            `No responses found matching the criteria in workspace: ${workspaceId}`
+          );
+          return { data: [], total: 0 };
+        }
 
-      if (responseSource === 'derived') {
-        const effectiveStatusExpression = getEffectiveCodingStatusExpression(version);
-        query.andWhere('response.is_autocoder_generated = :derivedOnly', {
-          derivedOnly: true
-        });
-        query.andWhere(`${effectiveStatusExpression} IS NOT NULL`);
-        query.andWhere(`${effectiveStatusExpression} NOT IN (:...ignoredDerivedCodingStatuses)`, {
-          ignoredDerivedCodingStatuses: WorkspaceTestResultsService.ignoredDerivedCodingStatuses
-        });
-        await this.applyValidCodingVariableFilter(query, workspaceId);
-      } else if (responseSource === 'all') {
-        const effectiveStatusExpression = getEffectiveCodingStatusExpression(version);
-        query.andWhere(`${effectiveStatusExpression} IS NOT NULL`);
-        query.andWhere(`${effectiveStatusExpression} NOT IN (:...ignoredDerivedCodingStatuses)`, {
-          ignoredDerivedCodingStatuses: WorkspaceTestResultsService.ignoredDerivedCodingStatuses
-        });
-        await this.applyValidCodingVariableFilter(query, workspaceId);
-      } else {
-        this.excludeAutocoderGeneratedResponses(query);
-      }
+        query.skip(skip).take(limit);
 
-      const total = await query.getCount();
-      this.applyResponseSearchSorting(
-        query,
-        version,
-        searchParams.geogebra === true,
-        options.sortBy,
-        options.sortDirection
-      );
+        const responses = await query.getMany();
 
-      if (total === 0) {
         this.logger.log(
-          `No responses found matching the criteria in workspace: ${workspaceId}`
+          `Found ${total} responses matching the criteria in workspace: ${workspaceId}, returning ${responses.length} for page ${page}`
         );
-        return { data: [], total: 0 };
-      }
 
-      query.skip(skip).take(limit);
+        // Pre-load variable page maps for all unique units
+        const uniqueUnitNames = [...new Set(responses.map(r => r.unit.name))];
+        const variablePageMaps = new Map<string, Map<string, string>>();
+        for (const unitName of uniqueUnitNames) {
+          const pageMap = await this.codingListService.getVariablePageMap(
+            unitName,
+            workspaceId
+          );
+          variablePageMaps.set(unitName, pageMap);
+        }
 
-      const responses = await query.getMany();
-
-      this.logger.log(
-        `Found ${total} responses matching the criteria in workspace: ${workspaceId}, returning ${responses.length} for page ${page}`
-      );
-
-      // Pre-load variable page maps for all unique units
-      const uniqueUnitNames = [...new Set(responses.map(r => r.unit.name))];
-      const variablePageMaps = new Map<string, Map<string, string>>();
-      for (const unitName of uniqueUnitNames) {
-        const pageMap = await this.codingListService.getVariablePageMap(
-          unitName,
-          workspaceId
-        );
-        variablePageMaps.set(unitName, pageMap);
-      }
-
-      const data = responses.map(response => {
-        const code = response[
-          `code_${version}` as keyof ResponseEntity
-        ] as number;
-        const score = response[
-          `score_${version}` as keyof ResponseEntity
-        ] as number;
-        const codedStatus = response[
-          `status_${version}` as keyof ResponseEntity
-        ] as number;
-        const variablePage =
+        const data = responses.map(response => {
+          const code = response[
+            `code_${version}` as keyof ResponseEntity
+          ] as number;
+          const score = response[
+            `score_${version}` as keyof ResponseEntity
+          ] as number;
+          const codedStatus = response[
+            `status_${version}` as keyof ResponseEntity
+          ] as number;
+          const variablePage =
           variablePageMaps.get(response.unit.name)?.get(response.variableid) ||
           '0';
 
-        return {
-          responseId: response.id,
-          variableId: response.variableid,
-          value: response.value || '',
-          status: statusNumberToString(response.status) || 'UNSET',
-          code,
-          score,
-          codedStatus: statusNumberToString(codedStatus) || 'UNSET',
-          code_v1: response.code_v1,
-          code_v2: response.code_v2,
-          code_v3: response.code_v3,
-          status_v1: statusNumberToString(response.status_v1) || 'UNSET',
-          status_v2: statusNumberToString(response.status_v2) || 'UNSET',
-          status_v3: statusNumberToString(response.status_v3) || 'UNSET',
-          unitId: response.unit.id,
-          unitName: response.unit.name,
-          unitAlias: response.unit.alias,
-          bookletId: response.unit.booklet.id,
-          bookletName: response.unit.booklet.bookletinfo.name,
-          personId: response.unit.booklet.person.id,
-          personLogin: response.unit.booklet.person.login,
-          personCode: response.unit.booklet.person.code,
-          personGroup: response.unit.booklet.person.group,
-          variablePage
-        };
-      });
+          return {
+            responseId: response.id,
+            variableId: response.variableid,
+            value: response.value || '',
+            status: statusNumberToString(response.status) || 'UNSET',
+            code,
+            score,
+            codedStatus: statusNumberToString(codedStatus) || 'UNSET',
+            code_v1: response.code_v1,
+            code_v2: response.code_v2,
+            code_v3: response.code_v3,
+            status_v1: statusNumberToString(response.status_v1) || 'UNSET',
+            status_v2: statusNumberToString(response.status_v2) || 'UNSET',
+            status_v3: statusNumberToString(response.status_v3) || 'UNSET',
+            unitId: response.unit.id,
+            unitName: response.unit.name,
+            unitAlias: response.unit.alias,
+            bookletId: response.unit.booklet.id,
+            bookletName: response.unit.booklet.bookletinfo.name,
+            personId: response.unit.booklet.person.id,
+            personLogin: response.unit.booklet.person.login,
+            personCode: response.unit.booklet.person.code,
+            personGroup: response.unit.booklet.person.group,
+            variablePage
+          };
+        });
 
-      return { data, total };
+        return { data, total };
+      };
+
+      return searchParams.regexSearch ?
+        await withRegexSearchStatementTimeout(this.connection, runSearch) :
+        await runSearch();
     } catch (error) {
+      const regexError = toRegexSearchException(error);
+      if (regexError) {
+        throw regexError;
+      }
+
       this.logger.error(
         `Failed to search for responses in workspace: ${workspaceId}`,
         error.stack

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
@@ -659,7 +659,19 @@ describe('WorkspaceFilesService.findAllFileTypes', () => {
   };
 
   const mockFileUploadRepository = {
-    createQueryBuilder: jest.fn()
+    createQueryBuilder: jest.fn(),
+    manager: {
+      connection: {
+        createQueryRunner: jest.fn().mockReturnValue({
+          connect: jest.fn().mockResolvedValue(undefined),
+          startTransaction: jest.fn().mockResolvedValue(undefined),
+          query: jest.fn().mockResolvedValue(undefined),
+          commitTransaction: jest.fn().mockResolvedValue(undefined),
+          rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+          release: jest.fn().mockResolvedValue(undefined)
+        })
+      }
+    }
   };
 
   function makeService(): WorkspaceFilesService {
@@ -734,7 +746,19 @@ describe('WorkspaceFilesService.findFiles', () => {
   };
 
   const mockFileUploadRepository = {
-    createQueryBuilder: jest.fn()
+    createQueryBuilder: jest.fn(),
+    manager: {
+      connection: {
+        createQueryRunner: jest.fn().mockReturnValue({
+          connect: jest.fn().mockResolvedValue(undefined),
+          startTransaction: jest.fn().mockResolvedValue(undefined),
+          query: jest.fn().mockResolvedValue(undefined),
+          commitTransaction: jest.fn().mockResolvedValue(undefined),
+          rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+          release: jest.fn().mockResolvedValue(undefined)
+        })
+      }
+    }
   };
 
   const mockService = () => new WorkspaceFilesService(
@@ -770,6 +794,21 @@ describe('WorkspaceFilesService.findFiles', () => {
     expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
       'LOWER(file.filename) LIKE :extension',
       { extension: '%.vocs' }
+    );
+  });
+
+  it('should use a case-sensitive regex search when enabled', async () => {
+    const service = mockService();
+    await service.findFiles(1, {
+      page: 1,
+      limit: 20,
+      searchText: '^Unit_\\d+\\.xml$',
+      regexSearch: true
+    });
+
+    expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+      "(file.filename ~ :searchRegex OR file.file_type ~ :searchRegex OR TO_CHAR(file.created_at, 'DD.MM.YYYY HH24:MI') ~ :searchRegex)",
+      { searchRegex: '^Unit_\\d+\\.xml$' }
     );
   });
 });

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
-  FindOperator, In, Like, Repository
+  FindOperator, In, Like, QueryRunner, Repository
 } from 'typeorm';
 import * as cheerio from 'cheerio';
 import AdmZip = require('adm-zip');
@@ -72,6 +72,10 @@ import {
   WorkspaceExclusionService
 } from './workspace-exclusion.service';
 import { getManualCodingScopeKey } from '../../utils/manual-coding-scope.util';
+import {
+  assertValidRegexSearchPattern,
+  withRegexSearchStatementTimeout
+} from '../../../utils/regex-search.util';
 
 type WorkspaceUnitVisibility = {
   globalIgnoredUnits: Set<string>;
@@ -554,6 +558,7 @@ export class WorkspaceFilesService implements OnModuleInit {
       fileType?: string;
       fileSize?: string;
       searchText?: string;
+      regexSearch?: boolean;
     }
   ): Promise<[FilesDto[], number, string[]]> {
     this.logger.log(`Fetching test files for workspace: ${workspaceId}`);
@@ -562,92 +567,116 @@ export class WorkspaceFilesService implements OnModuleInit {
       limit = 20,
       fileType,
       fileSize,
-      searchText
+      searchText,
+      regexSearch
     } = options || {};
     const MAX_LIMIT = 10000;
     const validPage = Math.max(1, page);
     const validLimit = Math.min(Math.max(1, limit), MAX_LIMIT);
 
-    let qb = this.fileUploadRepository
-      .createQueryBuilder('file')
-      .where('file.workspace_id = :workspaceId', { workspaceId });
+    const runFindFiles = async (
+      queryRunner?: QueryRunner
+    ): Promise<[FilesDto[], number, string[]]> => {
+      let qb = this.fileUploadRepository
+        .createQueryBuilder('file', queryRunner)
+        .where('file.workspace_id = :workspaceId', { workspaceId });
 
-    if (fileType) {
-      const resourceExtension = this.getResourceSubtypeExtension(fileType);
-      if (resourceExtension) {
-        qb = qb
-          .andWhere('file.file_type = :fileType', {
-            fileType: this.resourceTypeLabel
-          })
-          .andWhere('LOWER(file.filename) LIKE :extension', {
-            extension: `%${resourceExtension}`
-          });
-      } else {
-        qb = qb.andWhere('file.file_type = :fileType', { fileType });
+      if (fileType) {
+        const resourceExtension = this.getResourceSubtypeExtension(fileType);
+        if (resourceExtension) {
+          qb = qb
+            .andWhere('file.file_type = :fileType', {
+              fileType: this.resourceTypeLabel
+            })
+            .andWhere('LOWER(file.filename) LIKE :extension', {
+              extension: `%${resourceExtension}`
+            });
+        } else {
+          qb = qb.andWhere('file.file_type = :fileType', { fileType });
+        }
       }
-    }
 
-    if (fileSize) {
-      const KB = 1024;
-      const MB = 1024 * KB;
-      // eslint-disable-next-line default-case
-      switch (fileSize) {
-        case '0-10KB':
-          qb = qb.andWhere('file.file_size < :max', { max: 10 * KB });
-          break;
-        case '10KB-100KB':
-          qb = qb.andWhere('file.file_size >= :min AND file.file_size < :max', {
-            min: 10 * KB,
-            max: 100 * KB
-          });
-          break;
-        case '100KB-1MB':
-          qb = qb.andWhere('file.file_size >= :min AND file.file_size < :max', {
-            min: 100 * KB,
-            max: MB
-          });
-          break;
-        case '1MB-10MB':
-          qb = qb.andWhere('file.file_size >= :min AND file.file_size < :max', {
-            min: MB,
-            max: 10 * MB
-          });
-          break;
-        case '10MB+':
-          qb = qb.andWhere('file.file_size >= :min', { min: 10 * MB });
-          break;
+      if (fileSize) {
+        const KB = 1024;
+        const MB = 1024 * KB;
+        // eslint-disable-next-line default-case
+        switch (fileSize) {
+          case '0-10KB':
+            qb = qb.andWhere('file.file_size < :max', { max: 10 * KB });
+            break;
+          case '10KB-100KB':
+            qb = qb.andWhere('file.file_size >= :min AND file.file_size < :max', {
+              min: 10 * KB,
+              max: 100 * KB
+            });
+            break;
+          case '100KB-1MB':
+            qb = qb.andWhere('file.file_size >= :min AND file.file_size < :max', {
+              min: 100 * KB,
+              max: MB
+            });
+            break;
+          case '1MB-10MB':
+            qb = qb.andWhere('file.file_size >= :min AND file.file_size < :max', {
+              min: MB,
+              max: 10 * MB
+            });
+            break;
+          case '10MB+':
+            qb = qb.andWhere('file.file_size >= :min', { min: 10 * MB });
+            break;
+        }
       }
-    }
 
-    if (searchText) {
-      const search = `%${searchText.toLowerCase()}%`;
-      qb = qb.andWhere(
-        "(LOWER(file.filename) LIKE :search OR LOWER(file.file_type) LIKE :search OR TO_CHAR(file.created_at, 'DD.MM.YYYY HH24:MI') ILIKE :search)",
-        { search }
+      if (searchText) {
+        if (regexSearch) {
+          const searchRegex = assertValidRegexSearchPattern(searchText, 'searchText');
+          if (searchRegex) {
+            qb = qb.andWhere(
+              "(file.filename ~ :searchRegex OR file.file_type ~ :searchRegex OR TO_CHAR(file.created_at, 'DD.MM.YYYY HH24:MI') ~ :searchRegex)",
+              { searchRegex }
+            );
+          }
+        } else {
+          const search = `%${searchText.toLowerCase()}%`;
+          qb = qb.andWhere(
+            "(LOWER(file.filename) LIKE :search OR LOWER(file.file_type) LIKE :search OR TO_CHAR(file.created_at, 'DD.MM.YYYY HH24:MI') ILIKE :search)",
+            { search }
+          );
+        }
+      }
+
+      qb = qb
+        .select([
+          'file.id',
+          'file.filename',
+          'file.file_id',
+          'file.file_size',
+          'file.file_type',
+          'file.created_at'
+        ])
+        .orderBy('file.created_at', 'DESC')
+        .skip((validPage - 1) * validLimit)
+        .take(validLimit);
+
+      const [files, total] = await qb.getManyAndCount();
+      this.logger.log(
+        `Found ${files.length} files (page ${validPage}, limit ${validLimit}, total ${total}).`
+      );
+
+      const fileTypes = await this.findAllFileTypes(workspaceId);
+
+      return [files, total, fileTypes];
+    };
+
+    if (regexSearch) {
+      return withRegexSearchStatementTimeout(
+        this.fileUploadRepository.manager.connection,
+        runFindFiles
       );
     }
 
-    qb = qb
-      .select([
-        'file.id',
-        'file.filename',
-        'file.file_id',
-        'file.file_size',
-        'file.file_type',
-        'file.created_at'
-      ])
-      .orderBy('file.created_at', 'DESC')
-      .skip((validPage - 1) * validLimit)
-      .take(validLimit);
-
-    const [files, total] = await qb.getManyAndCount();
-    this.logger.log(
-      `Found ${files.length} files (page ${validPage}, limit ${validLimit}, total ${total}).`
-    );
-
-    const fileTypes = await this.findAllFileTypes(workspaceId);
-
-    return [files, total, fileTypes];
+    return runFindFiles();
   }
 
   async deleteTestFiles(

--- a/apps/backend/src/app/utils/regex-search.util.spec.ts
+++ b/apps/backend/src/app/utils/regex-search.util.spec.ts
@@ -8,13 +8,12 @@ import {
 } from './regex-search.util';
 
 describe('regex-search.util', () => {
-  it('keeps JavaScript-valid patterns for query usage', () => {
+  it('keeps normalized patterns for PostgreSQL query usage', () => {
     expect(assertValidRegexSearchPattern('(?=A)A', 'variableId')).toBe('(?=A)A');
   });
 
-  it('returns a bad request exception for JavaScript-invalid patterns', () => {
-    expect(() => assertValidRegexSearchPattern('[', 'variableId'))
-      .toThrow(InvalidRegexSearchPatternException);
+  it('does not use JavaScript regex parsing for PostgreSQL patterns', () => {
+    expect(assertValidRegexSearchPattern('[', 'variableId')).toBe('[');
   });
 
   it('rejects patterns that exceed the configured length limit', () => {

--- a/apps/backend/src/app/utils/regex-search.util.spec.ts
+++ b/apps/backend/src/app/utils/regex-search.util.spec.ts
@@ -1,0 +1,76 @@
+import {
+  assertValidRegexSearchPattern,
+  InvalidRegexSearchPatternException,
+  REGEX_SEARCH_PATTERN_MAX_LENGTH,
+  toInvalidRegexSearchPatternException,
+  toRegexSearchException,
+  withRegexSearchStatementTimeout
+} from './regex-search.util';
+
+describe('regex-search.util', () => {
+  it('keeps JavaScript-valid patterns for query usage', () => {
+    expect(assertValidRegexSearchPattern('(?=A)A', 'variableId')).toBe('(?=A)A');
+  });
+
+  it('returns a bad request exception for JavaScript-invalid patterns', () => {
+    expect(() => assertValidRegexSearchPattern('[', 'variableId'))
+      .toThrow(InvalidRegexSearchPatternException);
+  });
+
+  it('rejects patterns that exceed the configured length limit', () => {
+    const oversizedPattern = 'a'.repeat(REGEX_SEARCH_PATTERN_MAX_LENGTH + 1);
+
+    expect(() => assertValidRegexSearchPattern(oversizedPattern, 'variableId'))
+      .toThrow(`pattern must not exceed ${REGEX_SEARCH_PATTERN_MAX_LENGTH} characters`);
+  });
+
+  it('converts PostgreSQL invalid regex errors into bad request exceptions', () => {
+    const error = toInvalidRegexSearchPatternException(
+      {
+        code: '2201B',
+        message: 'invalid regular expression: quantifier operand invalid'
+      },
+      'variableId'
+    );
+
+    expect(error).toBeInstanceOf(InvalidRegexSearchPatternException);
+    expect(error?.getStatus()).toBe(400);
+    expect(error?.message).toContain('variableId');
+  });
+
+  it('converts PostgreSQL statement timeouts into bad request exceptions', () => {
+    const error = toRegexSearchException({
+      code: '57014',
+      message: 'canceling statement due to statement timeout'
+    });
+
+    expect(error?.getStatus()).toBe(400);
+    expect(error?.message).toContain('timed out');
+  });
+
+  it('runs work inside a transaction with a local statement timeout', async () => {
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined)
+    };
+    const dataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(queryRunner)
+    };
+    const work = jest.fn().mockResolvedValue('done');
+
+    await expect(
+      withRegexSearchStatementTimeout(dataSource, work, 1234)
+    ).resolves.toBe('done');
+
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      "SET LOCAL statement_timeout = '1234ms'"
+    );
+    expect(work).toHaveBeenCalledWith(queryRunner);
+    expect(queryRunner.commitTransaction).toHaveBeenCalled();
+    expect(queryRunner.release).toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/app/utils/regex-search.util.ts
+++ b/apps/backend/src/app/utils/regex-search.util.ts
@@ -1,0 +1,186 @@
+import { BadRequestException } from '@nestjs/common';
+import { DataSource, QueryRunner, Repository } from 'typeorm';
+import { Setting } from '../database/entities/setting.entity';
+
+export const REGEX_SEARCH_PATTERN_MAX_LENGTH = 256;
+export const REGEX_SEARCH_STATEMENT_TIMEOUT_MS = 3000;
+
+export class InvalidRegexSearchPatternException extends BadRequestException {
+  constructor(fieldName?: string, details?: string) {
+    const target = fieldName ? ` for ${fieldName}` : '';
+    const detailText = details ? `: ${details}` : '';
+    super(`Invalid regular expression${target}${detailText}`);
+  }
+}
+
+export async function getWorkspaceRegexSearchEnabled(
+  settingRepository: Pick<Repository<Setting>, 'findOne'>,
+  workspaceId: number
+): Promise<boolean> {
+  const setting = await settingRepository.findOne({
+    where: { key: `workspace-${workspaceId}-enable-regex-search` }
+  });
+
+  if (!setting) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(setting.content);
+    return parsed.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+export function assertValidRegexSearchPattern(
+  pattern: string | undefined,
+  fieldName: string
+): string | null {
+  const normalizedPattern = (pattern || '').trim();
+  if (!normalizedPattern) {
+    return null;
+  }
+
+  if (normalizedPattern.length > REGEX_SEARCH_PATTERN_MAX_LENGTH) {
+    throw new InvalidRegexSearchPatternException(
+      fieldName,
+      `pattern must not exceed ${REGEX_SEARCH_PATTERN_MAX_LENGTH} characters`
+    );
+  }
+
+  try {
+    RegExp(normalizedPattern);
+    return normalizedPattern;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new InvalidRegexSearchPatternException(fieldName, message);
+  }
+}
+
+export function toInvalidRegexSearchPatternException(
+  error: unknown,
+  fieldName?: string
+): InvalidRegexSearchPatternException | null {
+  if (error instanceof InvalidRegexSearchPatternException) {
+    return error;
+  }
+
+  const postgresError = findPostgresRegexError(error);
+  if (!postgresError) {
+    return null;
+  }
+
+  return new InvalidRegexSearchPatternException(
+    fieldName,
+    getErrorMessage(postgresError)
+  );
+}
+
+export async function withRegexSearchStatementTimeout<T>(
+  dataSource: Pick<DataSource, 'createQueryRunner'>,
+  work: (queryRunner: QueryRunner) => Promise<T>,
+  timeoutMs = REGEX_SEARCH_STATEMENT_TIMEOUT_MS
+): Promise<T> {
+  const queryRunner = dataSource.createQueryRunner();
+
+  await queryRunner.connect();
+  await queryRunner.startTransaction();
+
+  try {
+    await queryRunner.query(`SET LOCAL statement_timeout = '${timeoutMs}ms'`);
+    const result = await work(queryRunner);
+    await queryRunner.commitTransaction();
+    return result;
+  } catch (error) {
+    try {
+      await queryRunner.rollbackTransaction();
+    } catch {
+      // Preserve the original query error for consistent HTTP mapping.
+    }
+    throw error;
+  } finally {
+    await queryRunner.release();
+  }
+}
+
+export function toRegexSearchException(
+  error: unknown,
+  fieldName?: string
+): BadRequestException | null {
+  const invalidRegexError = toInvalidRegexSearchPatternException(error, fieldName);
+  if (invalidRegexError) {
+    return invalidRegexError;
+  }
+
+  if (findPostgresStatementTimeoutError(error)) {
+    return createRegexSearchTimeoutException();
+  }
+
+  return null;
+}
+
+export function createRegexSearchTimeoutException(
+  timeoutMs = REGEX_SEARCH_STATEMENT_TIMEOUT_MS
+): BadRequestException {
+  return new BadRequestException(
+    `Regular expression search timed out after ${timeoutMs} ms. ` +
+    'Please use a more specific pattern.'
+  );
+}
+
+function findPostgresRegexError(error: unknown): unknown | null {
+  if (!error || typeof error !== 'object') {
+    return null;
+  }
+
+  const candidate = error as {
+    code?: unknown;
+    message?: unknown;
+    driverError?: unknown;
+    cause?: unknown;
+  };
+
+  if (candidate.code === '2201B') {
+    return error;
+  }
+
+  if (typeof candidate.message === 'string' &&
+    candidate.message.toLowerCase().includes('invalid regular expression')) {
+    return error;
+  }
+
+  return findPostgresRegexError(candidate.driverError) ||
+    findPostgresRegexError(candidate.cause);
+}
+
+function findPostgresStatementTimeoutError(error: unknown): unknown | null {
+  if (!error || typeof error !== 'object') {
+    return null;
+  }
+
+  const candidate = error as {
+    code?: unknown;
+    message?: unknown;
+    driverError?: unknown;
+    cause?: unknown;
+  };
+
+  if (candidate.code === '57014' &&
+    typeof candidate.message === 'string' &&
+    candidate.message.toLowerCase().includes('statement timeout')) {
+    return error;
+  }
+
+  return findPostgresStatementTimeoutError(candidate.driverError) ||
+    findPostgresStatementTimeoutError(candidate.cause);
+}
+
+function getErrorMessage(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return String(error);
+  }
+
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' ? message : String(error);
+}

--- a/apps/backend/src/app/utils/regex-search.util.ts
+++ b/apps/backend/src/app/utils/regex-search.util.ts
@@ -49,13 +49,7 @@ export function assertValidRegexSearchPattern(
     );
   }
 
-  try {
-    RegExp(normalizedPattern);
-    return normalizedPattern;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new InvalidRegexSearchPatternException(fieldName, message);
-  }
+  return normalizedPattern;
 }
 
 export function toInvalidRegexSearchPatternException(

--- a/apps/backend/src/app/workspace/workspace-settings.controller.spec.ts
+++ b/apps/backend/src/app/workspace/workspace-settings.controller.spec.ts
@@ -42,4 +42,18 @@ describe('WorkspaceSettingsController', () => {
         'Controls whether DERIVE_ERROR responses can be included in manual coding jobs'
     });
   });
+
+  it('returns regex search disabled by default when it is missing', async () => {
+    settingRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      controller.getWorkspaceSetting(5, 'enable-regex-search')
+    ).resolves.toEqual({
+      id: 0,
+      key: 'workspace-5-enable-regex-search',
+      value: JSON.stringify({ enabled: false }),
+      description:
+        'Controls whether selected workspace search fields interpret input as regular expressions'
+    });
+  });
 });

--- a/apps/backend/src/app/workspace/workspace-settings.controller.ts
+++ b/apps/backend/src/app/workspace/workspace-settings.controller.ts
@@ -66,6 +66,15 @@ export class WorkspaceSettingsController {
             'Controls whether DERIVE_ERROR responses can be included in manual coding jobs'
         };
       }
+      if (key === 'enable-regex-search') {
+        return {
+          id: 0,
+          key: settingKey,
+          value: JSON.stringify({ enabled: false }),
+          description:
+            'Controls whether selected workspace search fields interpret input as regular expressions'
+        };
+      }
       if (key === 'response-matching-mode') {
         return {
           id: 0,

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
@@ -181,7 +181,8 @@
       <!-- Filter Section -->
       <div class="filters-section">
         <app-response-filters [filterParams]="filterParams" [availableStatuses]="getAvailableStatuses()"
-          [isLoading]="isLoading" [isGeogebraAvailable]="isGeogebraAvailable" (filterChange)="onFilterChange($event)"
+          [isLoading]="isLoading" [isGeogebraAvailable]="isGeogebraAvailable"
+          [enableRegexSearch]="enableRegexSearch" (filterChange)="onFilterChange($event)"
           (clearFilters)="onClearFilters()">
         </app-response-filters>
       </div>

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -86,7 +86,8 @@ describe('CodingManagementComponent', () => {
     };
 
     mockWorkspaceSettingsService = {
-      getAutoFetchCodingStatistics: jest.fn().mockReturnValue(of(false))
+      getAutoFetchCodingStatistics: jest.fn().mockReturnValue(of(false)),
+      getEnableRegexSearch: jest.fn().mockReturnValue(of(false))
     };
 
     mockTestPersonCodingService = {
@@ -268,6 +269,10 @@ describe('CodingManagementComponent', () => {
 
     it('should check auto-fetch setting on init', () => {
       expect(mockWorkspaceSettingsService.getAutoFetchCodingStatistics).toHaveBeenCalledWith(1);
+    });
+
+    it('should check regex search setting on init', () => {
+      expect(mockWorkspaceSettingsService.getEnableRegexSearch).toHaveBeenCalledWith(1);
     });
 
     it('should load autocoding readiness for the first autocoder run', () => {
@@ -548,7 +553,7 @@ describe('CodingManagementComponent', () => {
         version: 'v1'
       }));
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        component.filterParams,
+        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
         1,
         100,
         undefined,
@@ -595,7 +600,7 @@ describe('CodingManagementComponent', () => {
 
       expect(component.filterParams.version).toBe('v2');
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        component.filterParams,
+        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
         1,
         100,
         undefined,
@@ -619,7 +624,7 @@ describe('CodingManagementComponent', () => {
 
       expect(component.filterParams.responseSource).toBe('base');
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        component.filterParams,
+        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
         1,
         100,
         undefined,
@@ -675,7 +680,7 @@ describe('CodingManagementComponent', () => {
       expect(component.currentStatusFilter).toBeNull();
       expect(component.pageIndex).toBe(0);
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        component.filterParams,
+        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
         1,
         100,
         undefined,
@@ -734,7 +739,7 @@ describe('CodingManagementComponent', () => {
       expect(component.sortDirection).toBe('desc');
       expect(component.pageIndex).toBe(0);
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        component.filterParams,
+        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
         1,
         100,
         'score',
@@ -809,7 +814,7 @@ describe('CodingManagementComponent', () => {
       component.onReviewClick();
 
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        component.filterParams,
+        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
         1,
         2,
         undefined,

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -171,6 +171,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   manualAppliedResultsOverview: AppliedResultsOverview | null = null;
   isLoadingManualAppliedResultsOverview = false;
   manualAppliedResultsOverviewLoadFailed = false;
+  enableRegexSearch = false;
   isStartingFreshnessCoding = false;
   activeFreshnessJobId: string | null = null;
   activeFreshnessJobProgress: number | null = null;
@@ -204,6 +205,12 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
           if (autoFetch) {
             this.fetchCodingStatistics();
           }
+        });
+      this.workspaceSettingsService
+        .getEnableRegexSearch(workspaceId)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(enabled => {
+          this.enableRegexSearch = enabled;
         });
 
       this.codingManagementService.hasGeogebraResponses()
@@ -618,7 +625,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     }
 
     this.isLoadingReview = true;
-    const reviewFilterParams = { ...this.filterParams };
+    const reviewFilterParams = {
+      ...this.filterParams,
+      regexSearch: this.enableRegexSearch
+    };
     const reviewBatchSize = Math.min(this.reviewBatchSize, totalReviewRecords);
     const reviewPageCount = Math.ceil(totalReviewRecords / reviewBatchSize);
 
@@ -1065,7 +1075,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     }
 
     this.codingManagementService.searchResponses(
-      this.filterParams,
+      {
+        ...this.filterParams,
+        regexSearch: this.enableRegexSearch
+      },
       this.pageIndex + 1,
       this.pageSize,
       this.sortBy || undefined,
@@ -1363,6 +1376,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     return Object.entries(filterParams).some(
       ([key, value]) => {
         if (key === 'version') return false;
+        if (key === 'regexSearch') return false;
         if (key === 'responseSource') return value !== 'all';
         return typeof value === 'string' ? value.trim() !== '' : value === true;
       }

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.html
@@ -26,10 +26,13 @@
         </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="filter-field">
+    <mat-form-field appearance="outline" class="filter-field" [class.regex-filter-invalid]="isRegexFilterInvalid('unitName')">
         <mat-label>{{ 'coding-management.filters.unit-name' | translate }}</mat-label>
         <input matInput [(ngModel)]="filterParams.unitName" (input)="onTextFilterChange()"
             placeholder="{{ 'coding-management.filters.unit-name-placeholder' | translate }}">
+        @if (isRegexFilterInvalid('unitName')) {
+        <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+        }
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="filter-field">
@@ -50,34 +53,49 @@
             placeholder="{{ 'coding-management.filters.score-placeholder' | translate }}">
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="filter-field">
+    <mat-form-field appearance="outline" class="filter-field" [class.regex-filter-invalid]="isRegexFilterInvalid('code')">
         <mat-label>{{ 'coding-management.filters.person-code' | translate }}</mat-label>
         <input matInput [(ngModel)]="filterParams.code" (input)="onTextFilterChange()"
             placeholder="{{ 'coding-management.filters.person-code-placeholder' | translate }}">
+        @if (isRegexFilterInvalid('code')) {
+        <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+        }
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="filter-field">
+    <mat-form-field appearance="outline" class="filter-field" [class.regex-filter-invalid]="isRegexFilterInvalid('personLogin')">
         <mat-label>{{ 'coding-management.filters.person-login' | translate }}</mat-label>
         <input matInput [(ngModel)]="filterParams.personLogin" (input)="onTextFilterChange()"
             placeholder="{{ 'coding-management.filters.person-login-placeholder' | translate }}">
+        @if (isRegexFilterInvalid('personLogin')) {
+        <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+        }
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="filter-field">
+    <mat-form-field appearance="outline" class="filter-field" [class.regex-filter-invalid]="isRegexFilterInvalid('group')">
         <mat-label>{{ 'coding-management.filters.person-group' | translate }}</mat-label>
         <input matInput [(ngModel)]="filterParams.group" (input)="onTextFilterChange()"
             placeholder="{{ 'coding-management.filters.person-group-placeholder' | translate }}">
+        @if (isRegexFilterInvalid('group')) {
+        <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+        }
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="filter-field">
+    <mat-form-field appearance="outline" class="filter-field" [class.regex-filter-invalid]="isRegexFilterInvalid('bookletName')">
         <mat-label>{{ 'coding-management.filters.booklet-name' | translate }}</mat-label>
         <input matInput [(ngModel)]="filterParams.bookletName" (input)="onTextFilterChange()"
             placeholder="{{ 'coding-management.filters.booklet-name-placeholder' | translate }}">
+        @if (isRegexFilterInvalid('bookletName')) {
+        <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+        }
     </mat-form-field>
 
-    <mat-form-field appearance="outline" class="filter-field">
+    <mat-form-field appearance="outline" class="filter-field" [class.regex-filter-invalid]="isRegexFilterInvalid('variableId')">
         <mat-label>{{ 'coding-management.filters.variable-id' | translate }}</mat-label>
         <input matInput [(ngModel)]="filterParams.variableId" (input)="onTextFilterChange()"
             placeholder="{{ 'coding-management.filters.variable-id-placeholder' | translate }}">
+        @if (isRegexFilterInvalid('variableId')) {
+        <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+        }
     </mat-form-field>
 
     @if (isGeogebraAvailable) {

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.scss
@@ -18,6 +18,23 @@
     ::ng-deep .mat-mdc-form-field-subscript-wrapper {
         display: none;
     }
+
+    &.regex-filter-invalid {
+        ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+            display: block;
+        }
+
+        ::ng-deep .mdc-notched-outline__leading,
+        ::ng-deep .mdc-notched-outline__notch,
+        ::ng-deep .mdc-notched-outline__trailing {
+            border-color: #d32f2f !important;
+            border-width: 2px;
+        }
+    }
+}
+
+.regex-filter-error {
+    color: #d32f2f;
 }
 
 .filter-checkbox {

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.spec.ts
@@ -69,6 +69,33 @@ describe('ResponseFiltersComponent', () => {
     expect(component.filterChange.emit).toHaveBeenCalledWith(component.filterParams);
   });
 
+  it('should emit a copy of local filter params', () => {
+    jest.spyOn(component.filterChange, 'emit');
+
+    component.filterParams.unitName = 'Unit';
+    component.onInstantFilterChange();
+
+    const emittedFilterParams = (component.filterChange.emit as jest.Mock).mock.calls[0][0];
+    expect(emittedFilterParams).toEqual(component.filterParams);
+    expect(emittedFilterParams).not.toBe(component.filterParams);
+  });
+
+  it('should not mutate input filter params when a regex filter becomes invalid', () => {
+    jest.spyOn(component.filterChange, 'emit');
+    const parentFilterParams = {
+      ...component.filterParams,
+      variableId: 'VAR_01'
+    };
+    component.filterParams = parentFilterParams;
+    component.enableRegexSearch = true;
+
+    component.filterParams.variableId = '[';
+    component.onTextFilterChange();
+
+    expect(parentFilterParams.variableId).toBe('VAR_01');
+    expect(component.filterChange.emit).not.toHaveBeenCalled();
+  });
+
   it('should keep DERIVE_ERROR as the visible status label', () => {
     expect(component.mapStatusToString('4')).toBe('DERIVE_ERROR');
     expect(component.mapStatusToString('DERIVE_ERROR')).toBe('DERIVE_ERROR');

--- a/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/components/response-filters/response-filters.component.ts
@@ -17,6 +17,27 @@ import { MatIcon } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 import { FilterParams } from '../../../../services/coding-management.service';
 import { getResponseStatusLabel } from '../../../../../shared/utils/response-status-metadata.util';
+import { hasInvalidRegexFilter } from '../../../../../shared/utils/regex-filter.util';
+
+type RegexFilterField = 'unitName' | 'code' | 'personLogin' | 'group' | 'bookletName' | 'variableId';
+
+function createDefaultFilterParams(): FilterParams {
+  return {
+    value: '',
+    unitName: '',
+    codedStatus: '',
+    version: 'v1',
+    code: '',
+    codingCode: '',
+    score: '',
+    group: '',
+    bookletName: '',
+    variableId: '',
+    geogebra: false,
+    responseSource: 'all',
+    personLogin: ''
+  };
+}
 
 @Component({
   selector: 'app-response-filters',
@@ -37,25 +58,24 @@ import { getResponseStatusLabel } from '../../../../../shared/utils/response-sta
   ]
 })
 export class ResponseFiltersComponent implements OnDestroy {
-  @Input() filterParams: FilterParams = {
-    value: '',
-    unitName: '',
-    codedStatus: '',
-    version: 'v1',
-    code: '',
-    codingCode: '',
-    score: '',
-    group: '',
-    bookletName: '',
-    variableId: '',
-    geogebra: false,
-    responseSource: 'all',
-    personLogin: ''
-  };
+  private localFilterParams: FilterParams = createDefaultFilterParams();
+
+  @Input()
+  set filterParams(value: FilterParams) {
+    this.localFilterParams = {
+      ...createDefaultFilterParams(),
+      ...value
+    };
+  }
+
+  get filterParams(): FilterParams {
+    return this.localFilterParams;
+  }
 
   @Input() availableStatuses: string[] = [];
   @Input() isLoading = false;
   @Input() isGeogebraAvailable = false;
+  @Input() enableRegexSearch = false;
 
   @Output() filterChange = new EventEmitter<FilterParams>();
   @Output() clearFilters = new EventEmitter<void>();
@@ -75,14 +95,21 @@ export class ResponseFiltersComponent implements OnDestroy {
   onTextFilterChange(): void {
     this.clearFilterTimer();
 
+    if (this.hasInvalidRegexFilters()) {
+      return;
+    }
+
     this.filterTimer = setTimeout(() => {
-      this.filterChange.emit(this.filterParams);
+      this.emitFilterChange();
     }, 500);
   }
 
   onInstantFilterChange(): void {
     this.clearFilterTimer();
-    this.filterChange.emit(this.filterParams);
+    if (this.hasInvalidRegexFilters()) {
+      return;
+    }
+    this.emitFilterChange();
   }
 
   onGeoGebraFilterChange(): void {
@@ -103,7 +130,28 @@ export class ResponseFiltersComponent implements OnDestroy {
     }
   }
 
+  private emitFilterChange(): void {
+    this.filterChange.emit({ ...this.filterParams });
+  }
+
   mapStatusToString(status: string): string {
     return getResponseStatusLabel(status) || status;
+  }
+
+  isRegexFilterInvalid(field: RegexFilterField): boolean {
+    return hasInvalidRegexFilter(this.filterParams[field], this.enableRegexSearch);
+  }
+
+  private hasInvalidRegexFilters(): boolean {
+    const fields: RegexFilterField[] = [
+      'unitName',
+      'code',
+      'personLogin',
+      'group',
+      'bookletName',
+      'variableId'
+    ];
+
+    return fields.some(field => this.isRegexFilterInvalid(field));
   }
 }

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
@@ -197,40 +197,64 @@
       "
     >
       <div class="table-filters">
-        <mat-form-field appearance="outline">
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('unitName')">
           <mat-label>Aufgabe</mat-label>
           <input
             matInput
             [(ngModel)]="tableFilters.unitName"
             (ngModelChange)="applyTableFilters()"
           />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('unitName')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
         </mat-form-field>
 
-        <mat-form-field appearance="outline">
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('variableId')">
           <mat-label>Variable</mat-label>
           <input
             matInput
             [(ngModel)]="tableFilters.variableId"
             (ngModelChange)="applyTableFilters()"
           />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('variableId')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
         </mat-form-field>
 
-        <mat-form-field appearance="outline">
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('personLogin')">
           <mat-label>Person Login</mat-label>
           <input
             matInput
             [(ngModel)]="tableFilters.personLogin"
             (ngModelChange)="applyTableFilters()"
           />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('personLogin')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
         </mat-form-field>
 
-        <mat-form-field appearance="outline">
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('personGroup')">
           <mat-label>Person Gruppe</mat-label>
           <input
             matInput
             [(ngModel)]="tableFilters.personGroup"
             (ngModelChange)="applyTableFilters()"
           />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('personGroup')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('bookletName')">
+          <mat-label>Testheft-Name</mat-label>
+          <input
+            matInput
+            [(ngModel)]="tableFilters.bookletName"
+            (ngModelChange)="applyTableFilters()"
+          />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('bookletName')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
         </mat-form-field>
 
         <mat-form-field appearance="outline">
@@ -708,6 +732,7 @@
                 <div class="person-login">{{ comparison.personLogin || '-' }}</div>
                 <div class="person-code">{{ comparison.personCode || '-' }}</div>
                 <div class="person-group">{{ comparison.personGroup || '-' }}</div>
+                <div class="booklet-name">{{ comparison.bookletName || '-' }}</div>
               </div>
             </td>
           </ng-container>

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
@@ -198,6 +198,18 @@
         height: 40px;
         margin-top: 4px;
       }
+
+      mat-form-field.regex-filter-invalid {
+        ::ng-deep .mdc-notched-outline__leading,
+        ::ng-deep .mdc-notched-outline__notch,
+        ::ng-deep .mdc-notched-outline__trailing {
+          border-color: #f44336 !important;
+        }
+      }
+
+      .regex-filter-error {
+        color: #f44336;
+      }
     }
 
     .comparison-warning-list {
@@ -729,7 +741,8 @@
             }
 
             .person-code,
-            .person-group {
+            .person-group,
+            .booklet-name {
               font-size: 12px;
               color: #616161;
             }

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -16,6 +16,7 @@ import { SERVER_URL } from '../../../injection-tokens';
 import { CodingStatisticsService } from '../../services/coding-statistics.service';
 import { AppService } from '../../../core/services/app.service';
 import { CoderTraining } from '../../models/coder-training.model';
+import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
 
 describe('CodingResultsComparisonComponent', () => {
   let component: CodingResultsComparisonComponent;
@@ -42,6 +43,9 @@ describe('CodingResultsComparisonComponent', () => {
   };
   let snackBar: {
     open: jest.Mock;
+  };
+  let workspaceSettingsService: {
+    getEnableRegexSearch: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -75,6 +79,9 @@ describe('CodingResultsComparisonComponent', () => {
     };
     snackBar = {
       open: jest.fn()
+    };
+    workspaceSettingsService = {
+      getEnableRegexSearch: jest.fn().mockReturnValue(of(false))
     };
 
     await TestBed.configureTestingModule({
@@ -116,6 +123,10 @@ describe('CodingResultsComparisonComponent', () => {
         {
           provide: AppService,
           useValue: appService
+        },
+        {
+          provide: WorkspaceSettingsService,
+          useValue: workspaceSettingsService
         }
       ]
     }).compileComponents();
@@ -485,6 +496,7 @@ describe('CodingResultsComparisonComponent', () => {
       variableId: 'var_2',
       personLogin: 'LOGIN-2',
       personGroup: 'group a',
+      bookletName: '',
       match: 'differ',
       notesMode: 'with-notes'
     };
@@ -494,6 +506,82 @@ describe('CodingResultsComparisonComponent', () => {
     expect(component.dataSource.filteredData.map(row => row.responseId)).toEqual([2]);
     expect(component.totalComparisons).toBe(1);
     expect(component.matchingComparisons).toBe(0);
+  });
+
+  it('should apply regex filters when workspace regex search is enabled', () => {
+    component.enableRegexSearch = true;
+    component.comparisonMode = 'between-trainings';
+    component.codersFromTrainingsFormControl.setValue(['1_101', '2_201']);
+    component.selectedCodersFromTrainings = new Set(['1_101', '2_201']);
+    component.comparisonData = [
+      {
+        responseId: 1,
+        unitName: 'Unit A',
+        variableId: 'VAR_100',
+        testPerson: 'Test1',
+        personLogin: 'alpha',
+        personCode: 'Code1',
+        personGroup: 'Group A',
+        bookletName: 'Booklet-01',
+        coders: [
+          {
+            trainingId: 1,
+            trainingLabel: 'Training 1',
+            coderId: 101,
+            coderName: 'Coder 101',
+            code: '1',
+            score: 1,
+            notes: null
+          },
+          {
+            trainingId: 2,
+            trainingLabel: 'Training 2',
+            coderId: 201,
+            coderName: 'Coder 201',
+            code: '1',
+            score: 1,
+            notes: null
+          }
+        ]
+      },
+      {
+        responseId: 2,
+        unitName: 'Unit B',
+        variableId: 'VAR_200',
+        testPerson: 'Test2',
+        personLogin: 'beta',
+        personCode: 'Code2',
+        personGroup: 'Group B',
+        bookletName: 'Practice-01',
+        coders: [
+          {
+            trainingId: 1,
+            trainingLabel: 'Training 1',
+            coderId: 101,
+            coderName: 'Coder 101',
+            code: '1',
+            score: 1,
+            notes: null
+          },
+          {
+            trainingId: 2,
+            trainingLabel: 'Training 2',
+            coderId: 201,
+            coderName: 'Coder 201',
+            code: '1',
+            score: 1,
+            notes: null
+          }
+        ]
+      }
+    ];
+    component.dataSource.data = component.comparisonData;
+    component.tableFilters.variableId = '^VAR_1';
+    component.tableFilters.bookletName = 'Booklet-\\d+$';
+
+    component.applyTableFilters();
+
+    expect(component.dataSource.filteredData.map(row => row.responseId)).toEqual([1]);
   });
 
   it('should distinguish rows without visible coder notes from rows with visible coder notes', () => {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -35,6 +35,11 @@ import { CodingTrainingBackendService } from '../../services/coding-training-bac
 import { CoderTraining } from '../../models/coder-training.model';
 import { CodingStatisticsService } from '../../services/coding-statistics.service';
 import { AppService } from '../../../core/services/app.service';
+import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
+import {
+  hasInvalidRegexFilter,
+  matchesTextFilter
+} from '../../../shared/utils/regex-filter.util';
 import {
   getTrainingOptionMeta,
   getTrainingOptionTitle
@@ -71,6 +76,7 @@ interface TrainingComparison {
   personCode: string;
   personLogin: string;
   personGroup: string;
+  bookletName?: string;
   testPerson: string;
   givenAnswer?: string;
   coders: Array<{
@@ -93,6 +99,7 @@ interface WithinTrainingComparison {
   personLogin?: string;
   personCode?: string;
   personGroup?: string;
+  bookletName?: string;
   givenAnswer?: string;
   replayCode?: number | null;
   replayScore?: number | null;
@@ -128,9 +135,12 @@ interface ComparisonFilters {
   variableId: string;
   personLogin: string;
   personGroup: string;
+  bookletName: string;
   match: 'all' | 'match' | 'differ';
   notesMode: NotesFilterMode;
 }
+
+type RegexComparisonFilterField = 'unitName' | 'variableId' | 'personLogin' | 'personGroup' | 'bookletName';
 
 interface KappaCoderPair {
   coder1Id: number;
@@ -243,6 +253,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   private snackBar = inject(MatSnackBar);
   private codingStatisticsService = inject(CodingStatisticsService);
   private appService = inject(AppService);
+  private workspaceSettingsService = inject(WorkspaceSettingsService);
   private postMessageService = inject(PostMessageService);
   private dialog = inject(MatDialog);
   private ngUnsubscribe = new Subject<void>();
@@ -305,9 +316,12 @@ export class CodingResultsComparisonComponent implements OnInit {
     variableId: '',
     personLogin: '',
     personGroup: '',
+    bookletName: '',
     match: 'all',
     notesMode: 'all'
   };
+
+  enableRegexSearch = false;
 
   discussionManagerLabel = '';
   discussionCodeByResponseId: Record<number, string> = {};
@@ -347,6 +361,13 @@ export class CodingResultsComparisonComponent implements OnInit {
     this.discussionManagerLabel = this.appService.authData.userName || this.appService.loggedUser?.preferred_username || 'Diskussion';
     this.comparisonMode = this.data.initialMode || 'between-trainings';
 
+    this.workspaceSettingsService.getEnableRegexSearch(this.data.workspaceId)
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe(enabled => {
+        this.enableRegexSearch = enabled;
+        this.applyTableFilters();
+      });
+
     this.loadCoderTrainings().then(() => {
       if (this.data.selectedTraining) {
         this.comparisonMode = 'within-training';
@@ -371,10 +392,6 @@ export class CodingResultsComparisonComponent implements OnInit {
     this.dataSource.sort = this.sort;
   }
 
-  private getFilterValue(value: string | undefined): string {
-    return (value || '').trim().toLowerCase();
-  }
-
   private getSelectedCoderResults(comparison: TrainingComparison | WithinTrainingComparison): ComparisonCoderResult[] {
     if (this.comparisonMode === 'between-trainings') {
       const selectedKeys = this.codersFromTrainingsFormControl.value || [];
@@ -396,22 +413,22 @@ export class CodingResultsComparisonComponent implements OnInit {
 
   private setupFilterPredicate(): void {
     this.dataSource.filterPredicate = (row: TrainingComparison | WithinTrainingComparison, filterJson: string): boolean => {
-      const filters = JSON.parse(filterJson) as ComparisonFilters;
-      const unitName = this.getFilterValue((row as TrainingComparison).unitName);
-      const variableId = this.getFilterValue((row as TrainingComparison).variableId);
-      const personLogin = this.getFilterValue((row as TrainingComparison).personLogin);
-      const personGroup = this.getFilterValue((row as TrainingComparison).personGroup);
+      const filters = JSON.parse(filterJson) as ComparisonFilters & { regexSearch?: boolean };
+      const regexSearch = filters.regexSearch === true;
 
-      if (filters.unitName && !unitName.includes(this.getFilterValue(filters.unitName))) {
+      if (!matchesTextFilter((row as TrainingComparison).unitName, filters.unitName, regexSearch)) {
         return false;
       }
-      if (filters.variableId && !variableId.includes(this.getFilterValue(filters.variableId))) {
+      if (!matchesTextFilter((row as TrainingComparison).variableId, filters.variableId, regexSearch)) {
         return false;
       }
-      if (filters.personLogin && !personLogin.includes(this.getFilterValue(filters.personLogin))) {
+      if (!matchesTextFilter((row as TrainingComparison).personLogin, filters.personLogin, regexSearch)) {
         return false;
       }
-      if (filters.personGroup && !personGroup.includes(this.getFilterValue(filters.personGroup))) {
+      if (!matchesTextFilter((row as TrainingComparison).personGroup, filters.personGroup, regexSearch)) {
+        return false;
+      }
+      if (!matchesTextFilter((row as TrainingComparison).bookletName, filters.bookletName, regexSearch)) {
         return false;
       }
 
@@ -432,7 +449,14 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   applyTableFilters(): void {
-    this.dataSource.filter = JSON.stringify(this.tableFilters);
+    if (this.hasInvalidTableRegexFilters()) {
+      return;
+    }
+
+    this.dataSource.filter = JSON.stringify({
+      ...this.tableFilters,
+      regexSearch: this.enableRegexSearch
+    });
     this.dataSource.paginator?.firstPage();
     this.calculateStatistics();
   }
@@ -443,6 +467,7 @@ export class CodingResultsComparisonComponent implements OnInit {
       variableId: '',
       personLogin: '',
       personGroup: '',
+      bookletName: '',
       match: 'all',
       notesMode: 'all'
     };
@@ -463,9 +488,24 @@ export class CodingResultsComparisonComponent implements OnInit {
       this.tableFilters.variableId.trim() ||
       this.tableFilters.personLogin.trim() ||
       this.tableFilters.personGroup.trim() ||
+      this.tableFilters.bookletName.trim() ||
       this.tableFilters.match !== 'all' ||
       this.tableFilters.notesMode !== 'all'
     );
+  }
+
+  isTableRegexFilterInvalid(field: RegexComparisonFilterField): boolean {
+    return hasInvalidRegexFilter(this.tableFilters[field], this.enableRegexSearch);
+  }
+
+  private hasInvalidTableRegexFilters(): boolean {
+    return ([
+      'unitName',
+      'variableId',
+      'personLogin',
+      'personGroup',
+      'bookletName'
+    ] as RegexComparisonFilterField[]).some(field => this.isTableRegexFilterInvalid(field));
   }
 
   hasNoSelectedCodersState(): boolean {
@@ -1552,6 +1592,7 @@ export class CodingResultsComparisonComponent implements OnInit {
             personLogin: item.personLogin,
             personCode: item.personCode,
             personGroup: item.personGroup,
+            bookletName: item.bookletName,
             givenAnswer: item.givenAnswer,
             replayCode: item.replayCode,
             replayScore: item.replayScore,

--- a/apps/frontend/src/app/coding/components/variable-analysis-dialog/variable-analysis-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/variable-analysis-dialog/variable-analysis-dialog.component.html
@@ -14,12 +14,15 @@
           </button>
         </mat-form-field>
 
-        <mat-form-field class="filter-field">
+        <mat-form-field class="filter-field" [class.regex-filter-invalid]="isVariableIdRegexInvalid()">
           <mat-label>Variablen-ID Filter</mat-label>
           <input matInput [(ngModel)]="variableIdFilter" placeholder="Filter nach Variablen-ID" (input)="onVariableAnalysisFilterChange()">
           <button *ngIf="variableIdFilter" matSuffix mat-icon-button aria-label="Clear" (click)="variableIdFilter=''; onVariableAnalysisFilterChange()">
             <mat-icon>close</mat-icon>
           </button>
+          @if (isVariableIdRegexInvalid()) {
+            <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+          }
         </mat-form-field>
 
 

--- a/apps/frontend/src/app/coding/components/variable-analysis-dialog/variable-analysis-dialog.component.scss
+++ b/apps/frontend/src/app/coding/components/variable-analysis-dialog/variable-analysis-dialog.component.scss
@@ -60,6 +60,18 @@
     input {
       font-size: 15px;
     }
+
+    &.regex-filter-invalid {
+      ::ng-deep .mdc-notched-outline__leading,
+      ::ng-deep .mdc-notched-outline__notch,
+      ::ng-deep .mdc-notched-outline__trailing {
+        border-color: #f44336 !important;
+      }
+    }
+  }
+
+  .regex-filter-error {
+    color: #f44336;
   }
 }
 

--- a/apps/frontend/src/app/coding/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
@@ -21,11 +21,14 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateModule } from '@ngx-translate/core';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { CodingStatisticsService } from '../../services/coding-statistics.service';
 import { AppService } from '../../../core/services/app.service';
 import { VariableAnalysisItemDto } from '../../../../../../../api-dto/coding/variable-analysis-item.dto';
+import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
+import { hasInvalidRegexFilter } from '../../../shared/utils/regex-filter.util';
 
 export interface VariableAnalysisDialogData {
   workspaceId: number;
@@ -82,7 +85,8 @@ function createVariableAnalysisPaginatorIntl(): MatPaginatorIntl {
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
-    MatTooltipModule
+    MatTooltipModule,
+    TranslateModule
   ]
 })
 export class VariableAnalysisDialogComponent implements OnInit {
@@ -112,6 +116,7 @@ export class VariableAnalysisDialogComponent implements OnInit {
   variableAnalysisPageSizeOptions = [100, 200, 500];
   unitIdFilter = '';
   variableIdFilter = '';
+  enableRegexSearch = false;
   isLoadingVariableAnalysis = false;
   variableAnalysisFilterChanged = new Subject<void>();
 
@@ -124,10 +129,15 @@ export class VariableAnalysisDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: VariableAnalysisDialogData,
     private statisticsService: CodingStatisticsService,
     private appService: AppService,
+    private workspaceSettingsService: WorkspaceSettingsService,
     private snackBar: MatSnackBar
   ) { }
 
   ngOnInit(): void {
+    this.workspaceSettingsService.getEnableRegexSearch(this.data.workspaceId).subscribe(enabled => {
+      this.enableRegexSearch = enabled;
+    });
+
     this.variableAnalysisFilterChanged.pipe(
       debounceTime(500),
       distinctUntilChanged()
@@ -147,6 +157,10 @@ export class VariableAnalysisDialogComponent implements OnInit {
   }
 
   fetchVariableAnalysis(page: number = 1, limit: number = 100): void {
+    if (this.isVariableIdRegexInvalid()) {
+      return;
+    }
+
     const workspaceId = this.data.workspaceId;
     this.isLoadingVariableAnalysis = true;
 
@@ -158,7 +172,9 @@ export class VariableAnalysisDialogComponent implements OnInit {
       page,
       limit,
       unitId,
-      variableId
+      variableId,
+      undefined,
+      this.enableRegexSearch
     )
       .subscribe({
         next: response => {
@@ -199,7 +215,15 @@ export class VariableAnalysisDialogComponent implements OnInit {
   }
 
   onVariableAnalysisFilterChange(): void {
+    if (this.isVariableIdRegexInvalid()) {
+      return;
+    }
+
     this.variableAnalysisFilterChanged.next();
+  }
+
+  isVariableIdRegexInvalid(): boolean {
+    return hasInvalidRegexFilter(this.variableIdFilter, this.enableRegexSearch);
   }
 
   close(): void {

--- a/apps/frontend/src/app/coding/services/coding-management.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-management.service.ts
@@ -42,6 +42,7 @@ export interface FilterParams {
   geogebra: boolean;
   responseSource: ResponseSource;
   personLogin: string;
+  regexSearch?: boolean;
 }
 
 @Injectable({
@@ -257,6 +258,7 @@ export class CodingManagementService {
       geogebra: filterParams.geogebra,
       responseSource: filterParams.responseSource,
       personLogin: filterParams.personLogin,
+      regexSearch: filterParams.regexSearch,
       sortBy,
       sortDirection
     };

--- a/apps/frontend/src/app/coding/services/coding-statistics.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-statistics.service.spec.ts
@@ -122,12 +122,14 @@ describe('CodingStatisticsService', () => {
     const mockRes = {
       data: [], total: 0, page: 1, limit: 10
     };
-    service.getVariableAnalysis(1, 1, 10, 'unit1').subscribe(res => {
+    service.getVariableAnalysis(1, 1, 10, 'unit1', 'VAR_.*', undefined, true).subscribe(res => {
       expect(res.total).toBe(0);
     });
 
     const req = httpMock.expectOne(request => request.url === `${mockServerUrl}admin/workspace/1/coding/variable-analysis` &&
-            request.params.get('unitId') === 'unit1'
+            request.params.get('unitId') === 'unit1' &&
+            request.params.get('variableId') === 'VAR_.*' &&
+            request.params.get('regexSearch') === 'true'
     );
     expect(req.request.method).toBe('GET');
     req.flush(mockRes);

--- a/apps/frontend/src/app/coding/services/coding-statistics.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-statistics.service.ts
@@ -115,7 +115,8 @@ export class CodingStatisticsService {
     limit: number = 100,
     unitId?: string,
     variableId?: string,
-    derivation?: string
+    derivation?: string,
+    regexSearch?: boolean
   ): Observable<PaginatedResponse<VariableAnalysisItemDto>> {
     return this.appService.createOwnToken(workspace_id, 60).pipe(
       catchError(() => of('')),
@@ -136,6 +137,10 @@ export class CodingStatisticsService {
 
         if (derivation) {
           params = params.set('derivation', derivation);
+        }
+
+        if (regexSearch) {
+          params = params.set('regexSearch', 'true');
         }
 
         return this.http

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -32,6 +32,7 @@ export interface TrainingCodingResult {
   personCode: string;
   personLogin: string;
   personGroup: string;
+  bookletName: string;
   testPerson: string;
   coders: Array<{
     trainingId: number;
@@ -52,6 +53,7 @@ export interface WithinTrainingCodingResult {
   personCode: string;
   personLogin: string;
   personGroup: string;
+  bookletName: string;
   testPerson: string;
   givenAnswer: string;
   replayCode: number | null;

--- a/apps/frontend/src/app/models/coding-interfaces.ts
+++ b/apps/frontend/src/app/models/coding-interfaces.ts
@@ -125,6 +125,7 @@ export interface SearchResponsesParams {
   derivedOnly?: boolean;
   responseSource?: 'base' | 'derived' | 'all';
   personLogin?: string;
+  regexSearch?: boolean;
   sortBy?: CodingResponseSortBy;
   sortDirection?: CodingResponseSortDirection;
 }

--- a/apps/frontend/src/app/services/facades/coding-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/coding-facade.service.ts
@@ -422,8 +422,8 @@ export class CodingFacadeService {
     return this.replayBackendService.getFailureDistributionByHour(workspaceId, options);
   }
 
-  getVariableAnalysis(workspaceId: number, page: number = 1, limit: number = 100, unitId?: string, variableId?: string, derivation?: string): Observable<PaginatedResponse<VariableAnalysisItemDto>> {
-    return this.codingStatisticsService.getVariableAnalysis(workspaceId, page, limit, unitId, variableId, derivation);
+  getVariableAnalysis(workspaceId: number, page: number = 1, limit: number = 100, unitId?: string, variableId?: string, derivation?: string, regexSearch?: boolean): Observable<PaginatedResponse<VariableAnalysisItemDto>> {
+    return this.codingStatisticsService.getVariableAnalysis(workspaceId, page, limit, unitId, variableId, derivation, regexSearch);
   }
 
   createDistributedCodingJobs(workspaceId: number, selectedVariables: { unitName: string; variableId: string }[], selectedCoders: DistributedCodingCoderSelection[], doubleCodingAbsolute?: number, doubleCodingPercentage?: number, selectedVariableBundles?: { id: number; name: string; variables: { unitName: string; variableId: string }[] }[], caseOrderingMode?: 'continuous' | 'alternating', maxCodingCases?: number, displayOptions?: DistributedCodingDisplayOptions, distributionSeed?: string): Observable<DistributedCodingJobsResponse> {

--- a/apps/frontend/src/app/services/facades/workspace-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/workspace-facade.service.ts
@@ -165,8 +165,8 @@ export class WorkspaceFacadeService {
     return this.fileService.uploadTestResults(workspaceId, files, resultType, overwriteExisting, overwriteMode, scope, filters);
   }
 
-  getFilesList(workspaceId: number, page: number = 1, limit: number = 10000, fileType?: string, fileSize?: string, searchText?: string): Observable<PaginatedResponse<FilesInListDto> & { fileTypes: string[] }> {
-    return this.fileService.getFilesList(workspaceId, page, limit, fileType, fileSize, searchText);
+  getFilesList(workspaceId: number, page: number = 1, limit: number = 10000, fileType?: string, fileSize?: string, searchText?: string, regexSearch?: boolean): Observable<PaginatedResponse<FilesInListDto> & { fileTypes: string[] }> {
+    return this.fileService.getFilesList(workspaceId, page, limit, fileType, fileSize, searchText, regexSearch);
   }
 
   getUnitDef(workspaceId: number, unit: string, authToken?: string): Observable<FilesDto[]> {

--- a/apps/frontend/src/app/shared/search-filter/search-filter.component.html
+++ b/apps/frontend/src/app/shared/search-filter/search-filter.component.html
@@ -1,5 +1,5 @@
 <div class="search-field-container">
-  <mat-form-field class="search-field">
+  <mat-form-field class="search-field" [class.regex-filter-invalid]="invalid()">
     <mat-label>{{ title() }}</mat-label>
     <input #filterInput
            matInput
@@ -13,6 +13,8 @@
             (click)="clearFilter()">
       <coding-box-wrapped-icon icon="close"></coding-box-wrapped-icon>
     </button>
+    @if (invalid()) {
+      <mat-hint class="regex-filter-error">{{ errorText() | translate }}</mat-hint>
+    }
   </mat-form-field>
 </div>
-

--- a/apps/frontend/src/app/shared/search-filter/search-filter.component.scss
+++ b/apps/frontend/src/app/shared/search-filter/search-filter.component.scss
@@ -15,3 +15,14 @@
 :host ::ng-deep .mat-mdc-form-field-infix{
   overflow:hidden
 }
+
+:host ::ng-deep .regex-filter-invalid .mdc-notched-outline__leading,
+:host ::ng-deep .regex-filter-invalid .mdc-notched-outline__notch,
+:host ::ng-deep .regex-filter-invalid .mdc-notched-outline__trailing {
+  border-color: #d32f2f !important;
+  border-width: 2px;
+}
+
+.regex-filter-error {
+  color: #d32f2f;
+}

--- a/apps/frontend/src/app/shared/search-filter/search-filter.component.ts
+++ b/apps/frontend/src/app/shared/search-filter/search-filter.component.ts
@@ -11,7 +11,12 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatIconButton } from '@angular/material/button';
 import { MatInput } from '@angular/material/input';
-import { MatFormField, MatLabel, MatSuffix } from '@angular/material/form-field';
+import {
+  MatFormField,
+  MatHint,
+  MatLabel,
+  MatSuffix
+} from '@angular/material/form-field';
 import {
   Subject,
   fromEvent,
@@ -28,6 +33,7 @@ import { WrappedIconComponent } from '../wrapped-icon/wrapped-icon.component';
   imports: [
     MatFormField,
     MatLabel,
+    MatHint,
     MatInput,
     MatIconButton,
     MatSuffix,
@@ -42,6 +48,8 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
   value: string = '';
   readonly title = input.required<string>();
   readonly initialValue = input<string>('');
+  readonly invalid = input<boolean>(false);
+  readonly errorText = input<string>('search-filter.invalid-regex');
   readonly valueChange = output<string>();
 
   // Debounce time in milliseconds

--- a/apps/frontend/src/app/shared/services/file/file.service.ts
+++ b/apps/frontend/src/app/shared/services/file/file.service.ts
@@ -84,7 +84,8 @@ export class FileService {
     limit: number = 10000,
     fileType?: string,
     fileSize?: string,
-    searchText?: string
+    searchText?: string,
+    regexSearch?: boolean
   ): Observable<PaginatedResponse<FilesInListDto> & { fileTypes: string[] }> {
     let params = new HttpParams()
       .set('page', page.toString())
@@ -92,6 +93,7 @@ export class FileService {
     if (fileType) params = params.set('fileType', fileType);
     if (fileSize) params = params.set('fileSize', fileSize);
     if (searchText) params = params.set('searchText', searchText);
+    if (regexSearch) params = params.set('regexSearch', 'true');
 
     return this.http.get<
     PaginatedResponse<FilesInListDto> & { fileTypes: string[] }

--- a/apps/frontend/src/app/shared/services/response/response.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/response/response.service.spec.ts
@@ -83,7 +83,8 @@ describe('ResponseService', () => {
         value: 'test',
         codingCode: '12',
         score: '1',
-        responseSource: 'all' as const
+        responseSource: 'all' as const,
+        regexSearch: true
       };
       const mockResponse = { data: [], total: 0 };
 
@@ -96,7 +97,8 @@ describe('ResponseService', () => {
         request.params.get('value') === 'test' &&
         request.params.get('codingCode') === '12' &&
         request.params.get('score') === '1' &&
-        request.params.get('responseSource') === 'all'
+        request.params.get('responseSource') === 'all' &&
+        request.params.get('regexSearch') === 'true'
       );
       req.flush(mockResponse);
     });

--- a/apps/frontend/src/app/shared/services/response/response.service.ts
+++ b/apps/frontend/src/app/shared/services/response/response.service.ts
@@ -155,7 +155,7 @@ export class ResponseService {
 
   searchResponses(
     workspaceId: number,
-    searchParams: { value?: string; variableId?: string; unitName?: string; bookletName?: string; status?: string; codedStatus?: string; group?: string; code?: string; codingCode?: string; score?: string; version?: 'v1' | 'v2' | 'v3'; geogebra?: boolean; derivedOnly?: boolean; responseSource?: 'base' | 'derived' | 'all'; personLogin?: string; sortBy?: CodingResponseSortBy; sortDirection?: CodingResponseSortDirection },
+    searchParams: { value?: string; variableId?: string; unitName?: string; bookletName?: string; status?: string; codedStatus?: string; group?: string; code?: string; codingCode?: string; score?: string; version?: 'v1' | 'v2' | 'v3'; geogebra?: boolean; derivedOnly?: boolean; responseSource?: 'base' | 'derived' | 'all'; personLogin?: string; regexSearch?: boolean; sortBy?: CodingResponseSortBy; sortDirection?: CodingResponseSortDirection },
     page?: number,
     limit?: number
   ): Observable<{
@@ -240,6 +240,10 @@ export class ResponseService {
 
     if (searchParams.personLogin) {
       params = params.set('personLogin', searchParams.personLogin);
+    }
+
+    if (searchParams.regexSearch) {
+      params = params.set('regexSearch', 'true');
     }
 
     if (searchParams.sortBy) {

--- a/apps/frontend/src/app/shared/utils/regex-filter.util.spec.ts
+++ b/apps/frontend/src/app/shared/utils/regex-filter.util.spec.ts
@@ -1,0 +1,25 @@
+import {
+  isRegexPatternValid,
+  matchesTextFilter,
+  REGEX_FILTER_PATTERN_MAX_LENGTH
+} from './regex-filter.util';
+
+describe('regex-filter.util', () => {
+  it('accepts regex patterns up to the backend length limit', () => {
+    const pattern = 'a'.repeat(REGEX_FILTER_PATTERN_MAX_LENGTH);
+
+    expect(isRegexPatternValid(pattern)).toBe(true);
+  });
+
+  it('rejects regex patterns beyond the backend length limit', () => {
+    const pattern = 'a'.repeat(REGEX_FILTER_PATTERN_MAX_LENGTH + 1);
+
+    expect(isRegexPatternValid(pattern)).toBe(false);
+  });
+
+  it('does not match oversized regex filters', () => {
+    const pattern = 'a'.repeat(REGEX_FILTER_PATTERN_MAX_LENGTH + 1);
+
+    expect(matchesTextFilter(pattern, pattern, true)).toBe(false);
+  });
+});

--- a/apps/frontend/src/app/shared/utils/regex-filter.util.ts
+++ b/apps/frontend/src/app/shared/utils/regex-filter.util.ts
@@ -1,0 +1,52 @@
+export const REGEX_FILTER_PATTERN_MAX_LENGTH = 256;
+
+export function isRegexPatternValid(pattern: string): boolean {
+  const normalizedPattern = pattern.trim();
+  if (!normalizedPattern) {
+    return true;
+  }
+
+  if (normalizedPattern.length > REGEX_FILTER_PATTERN_MAX_LENGTH) {
+    return false;
+  }
+
+  try {
+    RegExp(normalizedPattern);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function hasInvalidRegexFilter(
+  pattern: string | null | undefined,
+  regexSearch: boolean
+): boolean {
+  return regexSearch && !isRegexPatternValid(pattern || '');
+}
+
+export function matchesTextFilter(
+  value: string | number | null | undefined,
+  filter: string | null | undefined,
+  regexSearch: boolean
+): boolean {
+  const normalizedFilter = (filter || '').trim();
+  if (!normalizedFilter) {
+    return true;
+  }
+
+  const text = String(value ?? '');
+  if (regexSearch) {
+    if (!isRegexPatternValid(normalizedFilter)) {
+      return false;
+    }
+
+    try {
+      return new RegExp(normalizedFilter).test(text);
+    } catch {
+      return false;
+    }
+  }
+
+  return text.toLowerCase().includes(normalizedFilter.toLowerCase());
+}

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.html
@@ -100,6 +100,7 @@
     <div class="search-section">
       <div class="filter-container">
         <coding-box-search-filter [title]="'search-filter.filter-test-files' | translate"
+          [invalid]="isTextFilterRegexInvalid()"
           (valueChange)="onTextFilterChange($event)">
         </coding-box-search-filter>
 

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.spec.ts
@@ -18,6 +18,7 @@ import { TestFilesUploadConflictsDialogComponent } from './test-files-upload-con
 import { ContentPoolIntegrationService } from '../../services/content-pool-integration.service';
 import { ContentDialogComponent } from '../../../shared/dialogs/content-dialog/content-dialog.component';
 import { utf8ToBase64 } from '../../../shared/utils/common-utils';
+import { WorkspaceSettingsService } from '../../services/workspace-settings.service';
 
 describe('TestFilesComponent', () => {
   let component: TestFilesComponent;
@@ -85,6 +86,10 @@ describe('TestFilesComponent', () => {
         {
           provide: ContentPoolIntegrationService,
           useValue: contentPoolIntegrationServiceMock
+        },
+        {
+          provide: WorkspaceSettingsService,
+          useValue: { getEnableRegexSearch: jest.fn().mockReturnValue(of(false)) }
         }
       ]
     }).compileComponents();
@@ -108,7 +113,7 @@ describe('TestFilesComponent', () => {
 
   describe('ngOnInit', () => {
     it('should load test files on init', () => {
-      expect(fileService.getFilesList).toHaveBeenCalledWith(1, 1, 100, '', '', '');
+      expect(fileService.getFilesList).toHaveBeenCalledWith(1, 1, 100, '', '', '', false);
     });
   });
 

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.ts
@@ -93,6 +93,8 @@ import { ContentPoolIntegrationService } from '../../services/content-pool-integ
 import { ContentPoolSettings } from '../../models/content-pool.model';
 import { ValidationService } from '../../../shared/services/validation/validation.service';
 import { ValidationTaskDto } from '../../../models/validation-task.dto';
+import { WorkspaceSettingsService } from '../../services/workspace-settings.service';
+import { hasInvalidRegexFilter } from '../../../shared/utils/regex-filter.util';
 import {
   ContentPoolImportDialogComponent,
   ContentPoolImportDialogResult
@@ -157,6 +159,7 @@ export class TestFilesComponent implements OnInit, OnDestroy {
   private translate = inject(TranslateService);
   private contentPoolIntegrationService = inject(ContentPoolIntegrationService);
   private validationService = inject(ValidationService);
+  private workspaceSettingsService = inject(WorkspaceSettingsService);
 
   displayedColumns: string[] = [
     'selectCheckbox',
@@ -202,6 +205,7 @@ export class TestFilesComponent implements OnInit, OnDestroy {
 
   selectedFileType: string = '';
   selectedFileSize: string = '';
+  enableRegexSearch = false;
   fileTypes: string[] = [];
   fileSizeRanges: { value: string; display: string }[] = [
     { value: '', display: 'Alle Größen' },
@@ -232,6 +236,11 @@ export class TestFilesComponent implements OnInit, OnDestroy {
   total: number = 0;
 
   ngOnInit(): void {
+    this.workspaceSettingsService
+      .getEnableRegexSearch(this.appService.selectedWorkspaceId)
+      .subscribe(enabled => {
+        this.enableRegexSearch = enabled;
+      });
     this.loadTestFiles();
     this.loadContentPoolSettings();
     this.textFilterSubscription = this.textFilterChanged
@@ -313,6 +322,10 @@ export class TestFilesComponent implements OnInit, OnDestroy {
   }
 
   loadTestFiles(): void {
+    if (this.isTextFilterRegexInvalid()) {
+      return;
+    }
+
     this.isLoading = true;
     this.isValidating = false;
     this.fileService
@@ -322,7 +335,8 @@ export class TestFilesComponent implements OnInit, OnDestroy {
         this.limit,
         this.selectedFileType,
         this.selectedFileSize,
-        this.textFilterValue
+        this.textFilterValue,
+        this.enableRegexSearch
       )
       .pipe(
         finalize(() => {
@@ -355,6 +369,10 @@ export class TestFilesComponent implements OnInit, OnDestroy {
   }
 
   applyFilters(): void {
+    if (this.isTextFilterRegexInvalid()) {
+      return;
+    }
+
     this.page = 1;
     this.tableCheckboxSelection.clear();
     this.loadTestFiles();
@@ -362,6 +380,9 @@ export class TestFilesComponent implements OnInit, OnDestroy {
 
   onTextFilterChange(value: string): void {
     this.textFilterValue = value.trim();
+    if (this.isTextFilterRegexInvalid()) {
+      return;
+    }
     this.textFilterChanged.next(this.textFilterValue);
   }
 
@@ -370,6 +391,10 @@ export class TestFilesComponent implements OnInit, OnDestroy {
     this.selectedFileType = '';
     this.selectedFileSize = '';
     this.applyFilters();
+  }
+
+  isTextFilterRegexInvalid(): boolean {
+    return hasInvalidRegexFilter(this.textFilterValue, this.enableRegexSearch);
   }
 
   private loadContentPoolSettings(): void {

--- a/apps/frontend/src/app/ws-admin/components/ws-settings/ws-settings.component.html
+++ b/apps/frontend/src/app/ws-admin/components/ws-settings/ws-settings.component.html
@@ -139,6 +139,19 @@
             </mat-slide-toggle>
           </div>
         </div>
+        <div class="setting-item">
+          <div class="setting-info">
+            <h4>{{ 'ws-settings.enable-regex-search' | translate }}</h4>
+            <p>{{ 'ws-settings.enable-regex-search-description' | translate }}</p>
+          </div>
+          <div class="setting-control">
+            <mat-slide-toggle
+              [checked]="enableRegexSearch"
+              (change)="toggleEnableRegexSearch($event)">
+              {{enableRegexSearch ? ('ws-settings.enabled' | translate) : ('ws-settings.disabled' | translate)}}
+            </mat-slide-toggle>
+          </div>
+        </div>
       </div>
     </mat-card-content>
   </mat-card>

--- a/apps/frontend/src/app/ws-admin/components/ws-settings/ws-settings.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/ws-settings/ws-settings.component.spec.ts
@@ -60,7 +60,9 @@ describe('WsSettingsComponent', () => {
       getIncludeDeriveErrorInManualCoding: jest.fn().mockReturnValue(of(false)),
       setIncludeDeriveErrorInManualCoding: jest.fn().mockReturnValue(of({})),
       getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false)),
-      setShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of({}))
+      setShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of({})),
+      getEnableRegexSearch: jest.fn().mockReturnValue(of(false)),
+      setEnableRegexSearch: jest.fn().mockReturnValue(of({}))
     } as unknown as jest.Mocked<WorkspaceSettingsService>;
 
     mockClipboard = {
@@ -126,6 +128,8 @@ describe('WsSettingsComponent', () => {
       expect(component.includeDeriveErrorInManualCoding).toBe(false);
       expect(mockWorkspaceSettingsService.getShowTestResultsLogAnomalies).toHaveBeenCalledWith(1);
       expect(component.showTestResultsLogAnomalies).toBe(false);
+      expect(mockWorkspaceSettingsService.getEnableRegexSearch).toHaveBeenCalledWith(1);
+      expect(component.enableRegexSearch).toBe(false);
     });
   });
 
@@ -270,6 +274,22 @@ describe('WsSettingsComponent', () => {
       component.showTestResultsLogAnomalies = true;
       component.toggleShowTestResultsLogAnomalies({ checked: false });
       expect(component.showTestResultsLogAnomalies).toBe(true);
+      expect(mockSnackBar.open).toHaveBeenCalled();
+    });
+  });
+
+  describe('toggleEnableRegexSearch', () => {
+    it('should call service with true', () => {
+      component.toggleEnableRegexSearch({ checked: true });
+      expect(component.enableRegexSearch).toBe(true);
+      expect(mockWorkspaceSettingsService.setEnableRegexSearch).toHaveBeenCalledWith(1, true);
+    });
+
+    it('should revert state on error', () => {
+      mockWorkspaceSettingsService.setEnableRegexSearch.mockReturnValue(throwError(() => new Error('error')));
+      component.enableRegexSearch = true;
+      component.toggleEnableRegexSearch({ checked: false });
+      expect(component.enableRegexSearch).toBe(true);
       expect(mockSnackBar.open).toHaveBeenCalled();
     });
   });

--- a/apps/frontend/src/app/ws-admin/components/ws-settings/ws-settings.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/ws-settings/ws-settings.component.ts
@@ -90,6 +90,7 @@ export class WsSettingsComponent implements OnInit, OnDestroy {
   autoFetchCodingStatistics = true;
   autoRefreshManualCodingJobs = true;
   includeDeriveErrorInManualCoding = false;
+  enableRegexSearch = false;
   showTestResultsLogAnomalies = false;
   isExporting = false;
   databaseExportProgress = 0;
@@ -113,6 +114,11 @@ export class WsSettingsComponent implements OnInit, OnDestroy {
         .getIncludeDeriveErrorInManualCoding(workspaceId)
         .subscribe(enabled => {
           this.includeDeriveErrorInManualCoding = enabled;
+        });
+      this.workspaceSettingsService
+        .getEnableRegexSearch(workspaceId)
+        .subscribe(enabled => {
+          this.enableRegexSearch = enabled;
         });
       this.workspaceSettingsService
         .getShowTestResultsLogAnomalies(workspaceId)
@@ -335,6 +341,42 @@ export class WsSettingsComponent implements OnInit, OnDestroy {
             );
             this.includeDeriveErrorInManualCoding =
               !this.includeDeriveErrorInManualCoding;
+          }
+        });
+    }
+  }
+
+  toggleEnableRegexSearch(toggleEvent: { checked: boolean }): void {
+    this.enableRegexSearch = toggleEvent.checked;
+    const workspaceId = this.appService.selectedWorkspaceId;
+
+    if (workspaceId) {
+      this.workspaceSettingsService
+        .setEnableRegexSearch(workspaceId, this.enableRegexSearch)
+        .subscribe({
+          next: () => {
+            this.snackBar.open(
+              this.enableRegexSearch ?
+                this.translateService.instant(
+                  'ws-settings.enable-regex-search-enabled'
+                ) :
+                this.translateService.instant(
+                  'ws-settings.enable-regex-search-disabled'
+                ),
+              this.translateService.instant('close'),
+              { duration: 3000 }
+            );
+          },
+          error: () => {
+            this.snackBar.open(
+              this.translateService.instant('ws-settings.error-saving-setting'),
+              this.translateService.instant('close'),
+              {
+                duration: 3000,
+                panelClass: ['error-snackbar']
+              }
+            );
+            this.enableRegexSearch = !this.enableRegexSearch;
           }
         });
     }

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
@@ -176,6 +176,39 @@ describe('WorkspaceSettingsService', () => {
     });
   });
 
+  describe('getEnableRegexSearch', () => {
+    it('should return parsed boolean', () => {
+      service.getEnableRegexSearch(1).subscribe(val => {
+        expect(val).toBe(true);
+      });
+      const req = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/enable-regex-search`);
+      req.flush({ value: '{"enabled":true}' });
+    });
+
+    it('should return false on error', () => {
+      service.getEnableRegexSearch(1).subscribe(val => {
+        expect(val).toBe(false);
+      });
+      const req = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/enable-regex-search`);
+      req.flush({}, { status: 404, statusText: 'Not Found' });
+    });
+  });
+
+  describe('setEnableRegexSearch', () => {
+    it('should persist the setting', () => {
+      service.setEnableRegexSearch(1, true).subscribe();
+
+      const req = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        key: 'enable-regex-search',
+        value: '{"enabled":true}',
+        description: 'Controls whether selected workspace search fields interpret input as regular expressions'
+      });
+      req.flush({});
+    });
+  });
+
   describe('getAggregationThreshold', () => {
     it('should return a persisted threshold', () => {
       service.getAggregationThreshold(1).subscribe(val => {

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
@@ -178,6 +178,37 @@ export class WorkspaceSettingsService {
     );
   }
 
+  getEnableRegexSearch(workspaceId: number): Observable<boolean> {
+    return new Observable(observer => {
+      this.getWorkspaceSetting(workspaceId, 'enable-regex-search', true)
+        .subscribe({
+          next: setting => {
+            try {
+              const parsed = JSON.parse(setting.value);
+              observer.next(parsed.enabled ?? false);
+            } catch {
+              observer.next(false);
+            }
+            observer.complete();
+          },
+          error: () => {
+            observer.next(false);
+            observer.complete();
+          }
+        });
+    });
+  }
+
+  setEnableRegexSearch(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+    const value = JSON.stringify({ enabled });
+    return this.setWorkspaceSetting(
+      workspaceId,
+      'enable-regex-search',
+      value,
+      'Controls whether selected workspace search fields interpret input as regular expressions'
+    );
+  }
+
   getResponseMatchingMode(workspaceId: number): Observable<ResponseMatchingFlag[]> {
     return new Observable(observer => {
       this.getWorkspaceSetting(workspaceId, 'response-matching-mode')

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -540,7 +540,8 @@
     "enter-filter": "Suchbegriff",
     "filter-test-persons": "Suche nach Testpersonen",
     "filter-test-groups": "Suche nach Testgruppen",
-    "filter-test-files": "Suche nach Testdateien"
+    "filter-test-files": "Suche nach Testdateien",
+    "invalid-regex": "Ungültiger regulärer Ausdruck"
   },
   "access-rights": {
     "hint": "Zugriffsrechte: Bitte links Nutzer:in wählen",
@@ -1090,6 +1091,10 @@
     "include-derive-error-in-manual-coding-description": "Wenn aktiviert, können DERIVE_ERROR-Fälle bei Kodierjobdefinitionen gezielt in die manuelle Kodierung aufgenommen werden. Standardmäßig ist diese Funktion deaktiviert.",
     "include-derive-error-in-manual-coding-enabled": "DERIVE_ERROR-Fälle können in die manuelle Kodierung aufgenommen werden",
     "include-derive-error-in-manual-coding-disabled": "DERIVE_ERROR-Fälle werden nicht in die manuelle Kodierung aufgenommen",
+    "enable-regex-search": "Reguläre Ausdrücke in Suchfeldern",
+    "enable-regex-search-description": "Wenn aktiviert, werden ausgewählte Suchfelder in diesem Arbeitsbereich als reguläre Ausdrücke ausgewertet. Die Suche ist dann groß-/kleinschreibungssensitiv und findet Teiltreffer, sofern keine Anker wie ^ und $ verwendet werden.",
+    "enable-regex-search-enabled": "Reguläre Ausdrücke in Suchfeldern aktiviert",
+    "enable-regex-search-disabled": "Reguläre Ausdrücke in Suchfeldern deaktiviert",
     "test-results": "Testergebnisse",
     "show-test-results-log-anomalies": "Log-Auffälligkeiten in Testergebnissen anzeigen",
     "show-test-results-log-anomalies-description": "Wenn aktiviert, werden die Log-Qualität und die Logstatus-Spalte in der Ergebnistabelle angezeigt. Wenn deaktiviert, werden diese Anzeigen ausgeblendet; die Logfilter bleiben verfügbar.",


### PR DESCRIPTION
## Summary

Adds an opt-in workspace setting for regular-expression search in selected filter fields.

- adds backend regex validation, PostgreSQL regex query paths, and a local statement timeout for regex searches
- wires frontend workspace settings, API query params, and invalid-regex UI feedback
- extends training comparison filters with booklet metadata and regex-aware local filtering

Refs #689

## Validation

- `npx nx test frontend --runInBand --runTestsByPath apps/frontend/src/app/shared/utils/regex-filter.util.spec.ts`
- `npx nx test backend --runInBand --runTestsByPath apps/backend/src/app/utils/regex-search.util.spec.ts`
- `npx nx lint frontend`
- `npx nx lint backend`
- `git diff --check origin/develop..HEAD`

Note: The Nx test commands ran the broader frontend/backend suites in this workspace.
