### PR TITLE
Hide manual completion tab for coding managers

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -130,11 +130,10 @@
         [selectedIndex]="selectedManualTabIndex"
         (selectedIndexChange)="onManualTabChanged($event)"
       >
-        <mat-tab label="Vorbereitung"></mat-tab>
-        <mat-tab label="Planung"></mat-tab>
-        <mat-tab label="Schulung"></mat-tab>
-        <mat-tab label="Durchführung"></mat-tab>
-        <mat-tab label="Abschluss"></mat-tab>
+        <mat-tab
+          *ngFor="let tab of visibleManualCodingTabs"
+          [label]="getManualTabLabel(tab)"
+        ></mat-tab>
       </mat-tab-group>
 
       <div

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -691,7 +691,8 @@ describe('CodingManagementManualComponent', () => {
     expect(component.canShowCompletedJobApplyActions()).toBe(true);
   });
 
-  it('should keep completed jobs visible as read-only without study-manager permission', () => {
+  it('should hide the completion tab without study-manager permission', () => {
+    component.canApplyManualCodingResults = false;
     component.selectedManualTabIndex = 4;
     setAppliedResults(5, 0, 5);
     component.completedJobsReadyForApply = [
@@ -711,23 +712,27 @@ describe('CodingManagementManualComponent', () => {
 
     fixture.detectChanges();
 
+    expect(component.visibleManualCodingTabs).not.toContain('completion');
+    expect(component.activeManualTab).toBe('preparation');
+
     const row = fixture.nativeElement.querySelector(
       '.completed-job-apply-row'
     ) as HTMLElement | null;
-    const applyButtons = Array.from(
-      fixture.nativeElement.querySelectorAll('.completed-job-apply-row button')
-    ) as HTMLButtonElement[];
-    const readonlyNote = fixture.nativeElement.querySelector(
-      '.completed-job-readonly-note'
-    ) as HTMLElement | null;
+    const pageText = fixture.nativeElement.textContent as string;
 
-    expect(row?.textContent).toContain('Job 1');
-    expect(row?.textContent).toContain('5/5 Ergebnisse kodiert');
-    expect(
-      applyButtons.some(button => button.textContent?.includes('Ergebnisse anwenden')
-      )
-    ).toBe(false);
-    expect(readonlyNote?.textContent).toContain('Nur lesbar');
+    expect(row).toBeNull();
+    expect(pageText).not.toContain('Abschluss');
+    expect(pageText).not.toContain('Job 1');
+  });
+
+  it('should keep the completion tab available with study-manager permission', () => {
+    component.canApplyManualCodingResults = true;
+
+    expect(component.visibleManualCodingTabs).toContain('completion');
+
+    component.goToManualTab('completion');
+
+    expect(component.activeManualTab).toBe('completion');
   });
 
   it('blocks transfer action without coding-manager permission', () => {
@@ -828,6 +833,7 @@ describe('CodingManagementManualComponent', () => {
   });
 
   it('should describe completed coding with pending applied results as ready for completion', () => {
+    component.canApplyManualCodingResults = true;
     setCompletePlanningState();
     setCodingProgress(582, 582);
     setAppliedResults(581, 0, 581);
@@ -837,6 +843,28 @@ describe('CodingManagementManualComponent', () => {
     expect(component.getPlanningStatusTitle()).toBe('Bereit für den Abschluss');
     expect(component.getPlanningStatusDescription()).toBe(
       'Alle Kodierfälle sind abgeschlossen. Übernehmen Sie nun die Kodierergebnisse in den Datenbestand.'
+    );
+    expect(component.getPlanningNextStepTitle()).toBe('Ergebnisse übernehmen');
+    expect(component.getPlanningNextStepDescription()).toBe(
+      'Alle Kodierfälle sind bearbeitet. Übernehmen Sie jetzt die abgeschlossenen Ergebnisse in den Datenbestand.'
+    );
+  });
+
+  it('should describe completed coding as read-only for coding managers', () => {
+    component.canApplyManualCodingResults = false;
+    setCompletePlanningState();
+    setCodingProgress(582, 582);
+    setAppliedResults(581, 0, 581);
+
+    expect(component.getPlanningStatusClass()).toBe('status-attention');
+    expect(component.getPlanningStatusIcon()).toBe('published_with_changes');
+    expect(component.getPlanningStatusTitle()).toBe('Kodierfälle abgeschlossen');
+    expect(component.getPlanningStatusDescription()).toBe(
+      'Alle Kodierfälle sind abgeschlossen. Die Übernahme der Ergebnisse in den Datenbestand bleibt Studienmanager:innen vorbehalten.'
+    );
+    expect(component.getPlanningNextStepTitle()).toBe('Kodierjobs prüfen');
+    expect(component.getPlanningNextStepDescription()).toBe(
+      'Alle Kodierfälle sind bearbeitet. Sie können die abgeschlossenen Kodierjobs in der Durchführung einsehen.'
     );
   });
 
@@ -1532,6 +1560,7 @@ describe('CodingManagementManualComponent', () => {
   it('should switch to the completion tab before scrolling to completion work', () => {
     jest.useFakeTimers();
     try {
+      component.canApplyManualCodingResults = true;
       setCompletePlanningState();
       setCodingProgress(582, 582);
       setAppliedResults(581, 0, 581);
@@ -1561,9 +1590,46 @@ describe('CodingManagementManualComponent', () => {
     }
   });
 
+  it('should keep coding managers away from the hidden completion tab', () => {
+    jest.useFakeTimers();
+    try {
+      component.canApplyManualCodingResults = false;
+      setCompletePlanningState();
+      setCodingProgress(582, 582);
+      setAppliedResults(581, 0, 581);
+      component.selectedManualTabIndex = 1;
+
+      const componentInternals = component as unknown as {
+        loadManualTabData(tab: 'execution'): void;
+      };
+      const loadManualTabDataSpy = jest
+        .spyOn(componentInternals, 'loadManualTabData')
+        .mockImplementation();
+      const scrollToSectionSpy = jest
+        .spyOn(component, 'scrollToSection')
+        .mockImplementation();
+
+      expect(component.visibleManualCodingTabs).not.toContain('completion');
+      expect(component.getPlanningNextStepTargetTab()).toBe('execution');
+      expect(component.getPlanningNextStepActionLabel()).toBe('Zu den Kodierjobs');
+
+      component.performPlanningNextStep();
+
+      expect(component.selectedManualTabIndex).toBe(3);
+      expect(loadManualTabDataSpy).toHaveBeenCalledWith('execution');
+
+      jest.runOnlyPendingTimers();
+
+      expect(scrollToSectionSpy).toHaveBeenCalledWith('manual-execution');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('should switch from completion to execution when navigating to coding jobs', () => {
     jest.useFakeTimers();
     try {
+      component.canApplyManualCodingResults = true;
       component.selectedManualTabIndex = 4;
 
       const componentInternals = component as unknown as {
@@ -1682,6 +1748,7 @@ describe('CodingManagementManualComponent', () => {
   });
 
   it('shows aggregation savings in the completion overview as a positive count', () => {
+    component.canApplyManualCodingResults = true;
     component.selectedManualTabIndex = 4;
     setCompletePlanningState();
     setAppliedResults(543, 415, 128);

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -203,6 +203,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     'completion'
   ];
 
+  private readonly manualCodingTabsWithoutCompletion: ManualCodingTab[] = [
+    'preparation',
+    'planning',
+    'training',
+    'execution'
+  ];
+
   // Granular loading states
   isLoadingVariableCoverage = false;
   isLoadingCaseCoverage = false;
@@ -496,7 +503,32 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   get activeManualTab(): ManualCodingTab {
-    return this.manualCodingTabs[this.selectedManualTabIndex] || 'preparation';
+    return this.visibleManualCodingTabs[this.selectedManualTabIndex] || 'preparation';
+  }
+
+  get visibleManualCodingTabs(): ManualCodingTab[] {
+    if (this.canShowManualCompletionTab()) {
+      return this.manualCodingTabs;
+    }
+
+    return this.manualCodingTabsWithoutCompletion;
+  }
+
+  getManualTabLabel(tab: ManualCodingTab): string {
+    switch (tab) {
+      case 'preparation':
+        return 'Vorbereitung';
+      case 'planning':
+        return 'Planung';
+      case 'training':
+        return 'Schulung';
+      case 'execution':
+        return 'Durchführung';
+      case 'completion':
+        return 'Abschluss';
+      default:
+        return '';
+    }
   }
 
   isManualTab(tab: ManualCodingTab): boolean {
@@ -513,7 +545,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   goToManualTab(tab: ManualCodingTab, sectionId?: string): void {
-    const tabIndex = this.manualCodingTabs.indexOf(tab);
+    const tabIndex = this.visibleManualCodingTabs.indexOf(tab);
     if (tabIndex < 0) {
       return;
     }
@@ -1844,7 +1876,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'execution-ready':
         return 'Bereit für die Durchführung';
       case 'completion-ready':
-        return 'Bereit für den Abschluss';
+        return this.canShowManualCompletionTab() ?
+          'Bereit für den Abschluss' :
+          'Kodierfälle abgeschlossen';
       case 'progress-unavailable':
         return 'Kodierfortschritt nicht verfügbar';
       case 'complete':
@@ -1896,7 +1930,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         !!this.appliedResultsOverview &&
         this.hasManualCodingProgressScope() &&
         !this.hasExecutionOpenWork()) {
-      return 'Alle Kodierfälle sind abgeschlossen. Übernehmen Sie nun die Kodierergebnisse in den Datenbestand.';
+      return this.canShowManualCompletionTab() ?
+        'Alle Kodierfälle sind abgeschlossen. Übernehmen Sie nun die Kodierergebnisse in den Datenbestand.' :
+        'Alle Kodierfälle sind abgeschlossen. Die Übernahme der Ergebnisse in den Datenbestand bleibt Studienmanager:innen vorbehalten.';
     }
 
     return 'Prüfen Sie die Antwortanalyse und erstellen Sie danach passende Kodierjob-Definitionen.';
@@ -1915,7 +1951,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'execution-ready':
         return 'Kodierjobs bearbeiten lassen';
       case 'completion-ready':
-        return 'Ergebnisse übernehmen';
+        return this.canShowManualCompletionTab() ?
+          'Ergebnisse übernehmen' :
+          'Kodierjobs prüfen';
       case 'complete':
         return 'Workflow abgeschlossen';
       case 'progress-unavailable':
@@ -1948,7 +1986,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'execution-ready':
         return 'Die Fälle sind verteilt. Kodierer können nun ihre zugewiesenen Kodierjobs bearbeiten.';
       case 'completion-ready':
-        return 'Alle Kodierfälle sind bearbeitet. Übernehmen Sie jetzt die abgeschlossenen Ergebnisse in den Datenbestand.';
+        return this.canShowManualCompletionTab() ?
+          'Alle Kodierfälle sind bearbeitet. Übernehmen Sie jetzt die abgeschlossenen Ergebnisse in den Datenbestand.' :
+          'Alle Kodierfälle sind bearbeitet. Sie können die abgeschlossenen Kodierjobs in der Durchführung einsehen.';
       case 'complete':
         return 'Alle manuellen Kodierungen wurden abgeschlossen und übernommen.';
       case 'progress-unavailable':
@@ -1967,9 +2007,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'execution-ready':
         return 'Zu den Kodierjobs';
       case 'completion-ready':
-        return 'Zum Abschluss';
+        return this.canShowManualCompletionTab() ? 'Zum Abschluss' : 'Zu den Kodierjobs';
       case 'complete':
-        return 'Abschluss ansehen';
+        return this.canShowManualCompletionTab() ? 'Abschluss ansehen' : 'Zu den Kodierjobs';
       case 'loading':
       case 'progress-unavailable':
         return 'Aktualisieren';
@@ -1988,7 +2028,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         return 'manual-execution';
       case 'completion-ready':
       case 'complete':
-        return 'manual-completion';
+        return this.canShowManualCompletionTab() ? 'manual-completion' : 'manual-execution';
       default:
         return 'manual-planning';
     }
@@ -2000,7 +2040,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         return 'execution';
       case 'completion-ready':
       case 'complete':
-        return 'completion';
+        return this.canShowManualCompletionTab() ? 'completion' : 'execution';
       default:
         return 'planning';
     }
@@ -2194,6 +2234,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     tab: ManualCodingTab,
     options: { reloadCodingJobs?: boolean } = {}
   ): void {
+    if (!this.isManualTabAvailable(tab)) {
+      return;
+    }
+
     const reloadCodingJobs = options.reloadCodingJobs ?? true;
     switch (tab) {
       case 'preparation':
@@ -2249,8 +2293,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const userId = this.appService.authData.userId;
 
     if (this.appService.authData.isAdmin || !workspaceId || userId <= 0) {
+      const activeTab = this.activeManualTab;
       this.canApplyManualCodingResults = this.appService.authData.isAdmin === true;
       this.canManageManualCodingJobs = this.appService.authData.isAdmin === true;
+      this.keepAvailableManualTabSelected(activeTab);
       return;
     }
 
@@ -2259,16 +2305,39 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: users => {
+          const activeTab = this.activeManualTab;
           const currentUser = users.find(user => user.id === userId);
           const accessLevel = currentUser?.accessLevel ?? 0;
           this.canManageManualCodingJobs = accessLevel >= 2;
           this.canApplyManualCodingResults = accessLevel >= 3;
+          this.keepAvailableManualTabSelected(activeTab);
         },
         error: () => {
+          const activeTab = this.activeManualTab;
           this.canManageManualCodingJobs = false;
           this.canApplyManualCodingResults = false;
+          this.keepAvailableManualTabSelected(activeTab);
         }
       });
+  }
+
+  private canShowManualCompletionTab(): boolean {
+    return this.canApplyManualCodingResults;
+  }
+
+  private isManualTabAvailable(tab: ManualCodingTab): boolean {
+    return this.visibleManualCodingTabs.includes(tab);
+  }
+
+  private keepAvailableManualTabSelected(previousActiveTab: ManualCodingTab): void {
+    if (this.isManualTabAvailable(previousActiveTab)) {
+      this.selectedManualTabIndex = this.visibleManualCodingTabs.indexOf(previousActiveTab);
+      return;
+    }
+
+    const executionTabIndex = this.visibleManualCodingTabs.indexOf('execution');
+    this.selectedManualTabIndex = executionTabIndex >= 0 ? executionTabIndex : 0;
+    this.loadManualTabData(this.activeManualTab);
   }
 
   private loadJobDefinitionsForExport(): void {


### PR DESCRIPTION
## Summary
- hides the manual coding `Abschluss` tab for users who cannot apply manual coding results
- keeps study managers on the existing completion workflow
- adjusts status and next-step guidance so coding managers are sent back to the coding jobs view instead of result application

## Related issue
- #397

## Validation
- `npx nx lint frontend`
- `npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts`

Note: The related issue should remain open until it is verified.
