### PR TITLE
Highlight replay table cells with overlay

### DIFF
--- a/apps/frontend/src/app/replay/utils/dom-utils.spec.ts
+++ b/apps/frontend/src/app/replay/utils/dom-utils.spec.ts
@@ -1,6 +1,8 @@
 import { highlightAspectSectionWithAnchor, scrollToElementByAlias } from './dom-utils';
 
 describe('replay dom-utils', () => {
+  const highlightOverlaySelector = '[data-coding-box-anchor-highlight-overlay="true"]';
+
   function createIframe(html: string): HTMLIFrameElement {
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
@@ -124,9 +126,8 @@ describe('replay dom-utils', () => {
 
     expect(highlighted).toEqual([section]);
     expect(sectionFrame.style.border).toBe('');
-    expect(cellA.style.outline).toBe('');
-    expect(cellB.style.outline).toBe('3px solid #4285f4');
-    expect(cellB.style.outlineOffset).toBe('-3px');
+    expect(cellA.querySelector(highlightOverlaySelector)).toBeNull();
+    expect(cellB.querySelector(highlightOverlaySelector)).not.toBeNull();
     expect(fieldB.style.border).toBe('');
   });
 
@@ -150,9 +151,8 @@ describe('replay dom-utils', () => {
 
     expect(highlighted).toEqual([section]);
     expect(sectionFrame.style.border).toBe('');
-    expect(fieldA.style.outline).toBe('3px solid #4285f4');
-    expect(fieldA.style.outlineOffset).toBe('-3px');
-    expect(fieldB.style.outline).toBe('');
+    expect(fieldA.querySelector(highlightOverlaySelector)).not.toBeNull();
+    expect(fieldB.querySelector(highlightOverlaySelector)).toBeNull();
   });
 
   it('highlights the real player table cell container for table text fields', () => {
@@ -194,9 +194,59 @@ describe('replay dom-utils', () => {
 
     expect(highlighted).toEqual([section]);
     expect(sectionFrame.style.border).toBe('');
-    expect(cellA.style.outline).toBe('');
-    expect(cellB.style.outline).toBe('3px solid #4285f4');
-    expect(fieldB.style.outline).toBe('');
+    expect(cellA.querySelector(highlightOverlaySelector)).toBeNull();
+    expect(cellB.querySelector(highlightOverlaySelector)).not.toBeNull();
+    expect(fieldB.querySelector(highlightOverlaySelector)).toBeNull();
+  });
+
+  it('clears a table cell overlay before highlighting another anchor', () => {
+    const iframe = createIframe(`
+      <aspect-section id="section">
+        <div id="section-frame">
+          <aspect-table id="table" role="grid">
+            <div id="cell-a" role="gridcell">
+              <span id="field-a" data-element-alias="01a"></span>
+            </div>
+            <div id="cell-b" role="gridcell" style="position: absolute;">
+              <span id="field-b" data-element-alias="01b"></span>
+            </div>
+          </aspect-table>
+        </div>
+      </aspect-section>
+    `);
+
+    const cellA = iframe.contentDocument?.querySelector('#cell-a') as HTMLElement;
+    const cellB = iframe.contentDocument?.querySelector('#cell-b') as HTMLElement;
+
+    highlightAspectSectionWithAnchor(iframe, '01a');
+    expect(cellA.style.position).toBe('relative');
+    expect(cellA.querySelector(highlightOverlaySelector)).not.toBeNull();
+
+    highlightAspectSectionWithAnchor(iframe, '01b');
+    expect(cellA.style.position).toBe('');
+    expect(cellA.querySelector(highlightOverlaySelector)).toBeNull();
+    expect(cellB.style.position).toBe('absolute');
+    expect(cellB.querySelector(highlightOverlaySelector)).not.toBeNull();
+  });
+
+  it('falls back to inset field highlighting when a table target cannot host an overlay', () => {
+    const iframe = createIframe(`
+      <aspect-section id="section">
+        <div id="section-frame">
+          <aspect-table id="table" role="grid">
+            <input id="field-a" data-element-alias="01a" style="grid-row: 2; grid-column: 2">
+          </aspect-table>
+        </div>
+      </aspect-section>
+    `);
+
+    const highlighted = highlightAspectSectionWithAnchor(iframe, '01a');
+    const section = iframe.contentDocument?.querySelector('#section') as HTMLElement;
+    const fieldA = iframe.contentDocument?.querySelector('#field-a') as HTMLElement;
+
+    expect(highlighted).toEqual([section]);
+    expect(fieldA.querySelector(highlightOverlaySelector)).toBeNull();
+    expect(fieldA.style.boxShadow).toBe('inset 0 0 0 2px #4285f4');
   });
 
   it('highlights a standalone text field instead of the whole section grid', () => {

--- a/apps/frontend/src/app/replay/utils/dom-utils.ts
+++ b/apps/frontend/src/app/replay/utils/dom-utils.ts
@@ -5,6 +5,8 @@
 const HIGHLIGHT_BORDER = '3px solid #4285f4';
 const HIGHLIGHT_FIELD_SHADOW = 'inset 0 0 0 2px #4285f4';
 const HIGHLIGHT_ATTR = 'data-coding-box-anchor-highlight';
+const HIGHLIGHT_OVERLAY_ATTR = 'data-coding-box-anchor-highlight-overlay';
+const HIGHLIGHT_PREVIOUS_POSITION_ATTR = 'data-coding-box-anchor-highlight-previous-position';
 const NATIVE_FIELD_SELECTOR = [
   'input:not([type="hidden"])',
   'textarea',
@@ -12,6 +14,18 @@ const NATIVE_FIELD_SELECTOR = [
   '[role="textbox"]',
   '[role="spinbutton"]',
   '[contenteditable="true"]'
+].join(',');
+const OVERLAY_HOST_UNSUPPORTED_SELECTOR = [
+  'input',
+  'textarea',
+  'select',
+  'img',
+  'iframe',
+  'embed',
+  'object',
+  'video',
+  'audio',
+  'canvas'
 ].join(',');
 const FIELD_HOST_SELECTOR = [
   'aspect-text-field',
@@ -25,10 +39,25 @@ const FIELD_CONTROL_SELECTOR = [
 const FIELD_OUTLINE_SELECTOR = '.mdc-notched-outline';
 
 function clearHighlight(element: HTMLElement): void {
+  if (element.getAttribute(HIGHLIGHT_OVERLAY_ATTR) === 'true') {
+    element.remove();
+    return;
+  }
+
+  element.querySelectorAll(`[${HIGHLIGHT_OVERLAY_ATTR}="true"]`).forEach(el => {
+    el.remove();
+  });
+
   element.style.border = '';
   element.style.outline = '';
   element.style.outlineOffset = '';
   element.style.boxShadow = '';
+
+  if (element.hasAttribute(HIGHLIGHT_PREVIOUS_POSITION_ATTR)) {
+    element.style.position = element.getAttribute(HIGHLIGHT_PREVIOUS_POSITION_ATTR) || '';
+    element.removeAttribute(HIGHLIGHT_PREVIOUS_POSITION_ATTR);
+  }
+
   element.removeAttribute(HIGHLIGHT_ATTR);
 }
 
@@ -37,10 +66,31 @@ function highlightWithBorder(element: HTMLElement): void {
   element.setAttribute(HIGHLIGHT_ATTR, 'true');
 }
 
-function highlightWithOutline(element: HTMLElement, outlineOffset = '-3px'): void {
-  element.style.outline = HIGHLIGHT_BORDER;
-  element.style.outlineOffset = outlineOffset;
+function highlightWithOverlay(element: HTMLElement): void {
+  const view = element.ownerDocument.defaultView;
+  const computedPosition = view?.getComputedStyle(element).position;
+
+  if (!computedPosition || computedPosition === 'static') {
+    element.setAttribute(HIGHLIGHT_PREVIOUS_POSITION_ATTR, element.style.position);
+    element.style.position = 'relative';
+  }
+
+  const overlay = element.ownerDocument.createElement('div');
+  overlay.setAttribute(HIGHLIGHT_ATTR, 'true');
+  overlay.setAttribute(HIGHLIGHT_OVERLAY_ATTR, 'true');
+  overlay.style.position = 'absolute';
+  overlay.style.inset = '0';
+  overlay.style.boxSizing = 'border-box';
+  overlay.style.border = HIGHLIGHT_BORDER;
+  overlay.style.pointerEvents = 'none';
+  overlay.style.zIndex = '2147483647';
+
+  element.appendChild(overlay);
   element.setAttribute(HIGHLIGHT_ATTR, 'true');
+}
+
+function canHighlightWithOverlay(element: HTMLElement): boolean {
+  return !element.matches(OVERLAY_HOST_UNSUPPORTED_SELECTOR);
 }
 
 function highlightField(element: HTMLElement): void {
@@ -161,8 +211,8 @@ function getFieldHighlightTarget(anchorElement: HTMLElement): HTMLElement | null
 /**
  * Highlights the direct child div elements of aspect-section tags that contain an element with the specified anchor.
  * If an anchor is provided, finds aspect-section tags that contain the element with that data-element-alias
- * and highlights their direct child div elements with a blue border. Multi-field cloze and table elements
- * are highlighted directly instead, using a border or outline on the focused field or cell.
+ * and highlights their direct child div elements with a blue border. Multi-field cloze elements
+ * are highlighted directly, while table cells get a non-layout-shifting overlay.
  *
  * @param iframe The iframe element containing the player's HTML
  * @param anchor Optional data-element-alias to filter aspect-section tags
@@ -206,7 +256,11 @@ export function highlightAspectSectionWithAnchor(iframe: HTMLIFrameElement, anch
 
         const tableHighlightTarget = getTableHighlightTarget(anchorElement);
         if (tableHighlightTarget) {
-          highlightWithOutline(tableHighlightTarget);
+          if (canHighlightWithOverlay(tableHighlightTarget)) {
+            highlightWithOverlay(tableHighlightTarget);
+          } else {
+            highlightField(tableHighlightTarget);
+          }
           const parentSection = getParentSection(anchorElement);
           if (parentSection) {
             result.push(parentSection);


### PR DESCRIPTION
## Summary
- replace replay table-cell outline highlighting with an absolutely positioned overlay inside the cell host
- restore temporary host positioning when highlights are cleared
- cover table-cell overlay cleanup and native-input fallback in replay DOM utility tests

## Root Cause
The previous negative-offset outline could be clipped or hidden by table-cell borders and neighboring cells, leaving only some edges visible in ASPECT table replays.

## Validation
- npx nx test frontend -- --runTestsByPath apps/frontend/src/app/replay/utils/dom-utils.spec.ts --runInBand
  - ran the frontend suite: 179 passed, 1491 passed
- npx nx lint frontend
- npx nx build frontend --configuration=development
- git diff --check
- UI checked in local replay environment:
  - MGV098 01/02 in workspace 49
  - MMV068 01a/01b in workspace 49
  - MMV086 01a/01b in workspace 47

Related to #651.