### PR TITLE
Fix coder training selection cards

### DIFF
--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.html
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.html
@@ -137,13 +137,20 @@
 
       <div class="coder-grid">
         <div *ngFor="let coder of coders; trackBy: trackByCoderId" class="coder-item"
-          [class.selected]="isCoderSelected(coder)" (click)="toggleCoderSelection(coder)">
-          <mat-checkbox [checked]="isCoderSelected(coder)" (click)="$event.preventDefault()" color="primary">
-          </mat-checkbox>
-          <div class="coder-info">
-            <span class="coder-name">{{coder.name}}</span>
-            <span class="coder-login">{{coder.email}}</span>
+          [class.selected]="isCoderSelected(coder)" role="button" tabindex="0"
+          [attr.aria-pressed]="isCoderSelected(coder)"
+          (click)="toggleCoderSelection(coder)"
+          (keydown.enter)="toggleCoderSelection(coder)"
+          (keydown.space)="toggleCoderSelection(coder); $event.preventDefault()">
+          <div class="coder-avatar">
+            <mat-icon class="avatar-icon">person</mat-icon>
           </div>
+          <div class="coder-info">
+            <span class="coder-name">{{coder.displayName || coder.name}}</span>
+            <span *ngIf="coder.displayName && coder.displayName !== coder.name" class="coder-login">{{coder.name}}</span>
+            <span *ngIf="coder.email" class="coder-login">{{coder.email}}</span>
+          </div>
+          <mat-icon *ngIf="isCoderSelected(coder)" class="selected-icon">check_circle</mat-icon>
         </div>
       </div>
 

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.scss
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.scss
@@ -108,29 +108,58 @@
   width: 100%;
 
   .coder-item {
+    position: relative;
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 10px 16px;
+    gap: 14px;
+    min-height: 78px;
+    padding: 14px 16px;
     background: #ffffff;
-    border: 1px solid #e2e8f0;
+    border: 2px solid #e2e8f0;
     border-radius: 8px;
     cursor: pointer;
-    transition: all 0.1s ease;
+    transition: border-color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
 
     &:hover {
-      border-color: #cbd5e0;
+      border-color: #3182ce;
       background: #f7fafc;
+      box-shadow: 0 4px 8px rgba(49, 130, 206, 0.12);
+    }
+
+    &:focus-visible {
+      outline: 3px solid rgba(49, 130, 206, 0.35);
+      outline-offset: 2px;
     }
 
     &.selected {
-      border-color: #3182ce;
-      background: #ebf8ff;
+      border-color: #4caf50;
+      background: #f1f8e9;
+      box-shadow: 0 4px 8px rgba(76, 175, 80, 0.18);
+    }
+
+    .coder-avatar {
+      display: flex;
+      flex: 0 0 auto;
+      align-items: center;
+      justify-content: center;
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      background-color: #bbdefb;
+
+      .avatar-icon {
+        width: 26px;
+        height: 26px;
+        color: #1976d2;
+        font-size: 26px;
+      }
     }
 
     .coder-info {
       display: flex;
+      flex: 1;
       flex-direction: column;
+      min-width: 0;
       overflow: hidden;
 
       .coder-name {
@@ -146,6 +175,14 @@
         text-overflow: ellipsis;
         overflow: hidden;
       }
+    }
+
+    .selected-icon {
+      flex: 0 0 auto;
+      width: 24px;
+      height: 24px;
+      color: #2e7d32;
+      font-size: 24px;
     }
   }
 }

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
@@ -186,6 +186,25 @@ describe('CoderTrainingComponent', () => {
     expect(codingTrainingBackendService.createCoderTrainingJobs).toHaveBeenCalled();
   });
 
+  it('renders coder selection as toggle cards without checkboxes', () => {
+    fixture.detectChanges();
+
+    const firstCoderCard = fixture.nativeElement.querySelector('.coder-grid .coder-item') as HTMLElement;
+
+    expect(fixture.nativeElement.querySelector('.coder-grid mat-checkbox')).toBeNull();
+    expect(firstCoderCard.classList.contains('selected')).toBe(false);
+    expect(firstCoderCard.querySelector('.coder-login')).toBeNull();
+
+    firstCoderCard.click();
+    fixture.detectChanges();
+
+    const selectedCoderCard = fixture.nativeElement.querySelector('.coder-grid .coder-item') as HTMLElement;
+
+    expect(component.isCoderSelected(component.coders[0])).toBe(true);
+    expect(selectedCoderCard.classList.contains('selected')).toBe(true);
+    expect(selectedCoderCard.querySelector('.selected-icon')).not.toBeNull();
+  });
+
   it('covers removal, validation and error paths', () => {
     coderService.getCoders.mockReturnValueOnce(throwError(() => new Error('load failed')));
     component.loadCoders();


### PR DESCRIPTION
## Summary
- replace the coder training checkbox list with clickable selection cards
- show selected state through card styling, a check icon, and `aria-pressed`
- add regression coverage for the card-based selection UI

## Why
The checkbox in the coder training creation dialog could toggle the underlying selection without keeping the visible checkmark in sync. The training dialog now follows the card-based selection pattern used by coding job definitions.

Related to #719.

## Validation
- Checked in local Docker UI at `http://localhost:4200/#/workspace-admin/1/coding/manual`
- Verified card click and keyboard selection update the counter, selected styles, check icon, and `aria-pressed`
- `npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts --runInBand`
- `npx nx lint frontend`
