### PR TITLE
Expand manual code warning list

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -84,24 +84,34 @@
             class="manual-code-availability-list"
           >
             <span
-              *ngFor="let warning of getManualCodeAvailabilityPreview()"
+              *ngFor="let warning of getVisibleManualCodeAvailabilityWarnings()"
               class="manual-code-availability-chip"
             >
               {{ warning.unitName }} / {{ warning.variableId }}
             </span>
-            <span
-              *ngIf="
-                manualCodeAvailabilityWarningCount >
-                getManualCodeAvailabilityPreview().length
-              "
-              class="manual-code-availability-chip"
+            <button
+              *ngIf="hasHiddenManualCodeAvailabilityWarnings"
+              mat-button
+              type="button"
+              class="manual-code-availability-toggle"
+              [attr.aria-expanded]="showAllManualCodeAvailabilityWarnings"
+              (click)="toggleManualCodeAvailabilityWarnings()"
             >
-              +{{
-                manualCodeAvailabilityWarningCount -
-                  getManualCodeAvailabilityPreview().length
+              <mat-icon>{{
+                showAllManualCodeAvailabilityWarnings
+                  ? 'expand_less'
+                  : 'expand_more'
+              }}</mat-icon>
+              {{
+                showAllManualCodeAvailabilityWarnings
+                  ? ('coding-management-manual.buttons.show-fewer-manual-code-warnings'
+                    | translate)
+                  : ('coding-management-manual.buttons.show-more-manual-code-warnings'
+                    | translate: {
+                      count: hiddenManualCodeAvailabilityWarningCount
+                    })
               }}
-              weitere
-            </span>
+            </button>
           </div>
         </div>
       </div>

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
@@ -641,6 +641,25 @@
       padding: 5px 8px;
     }
 
+    .manual-code-availability-toggle {
+      min-height: 28px;
+      height: auto;
+      border-radius: 999px;
+      padding: 2px 8px;
+      color: #5f4217;
+      font-size: 12px;
+      font-weight: 650;
+      line-height: 1.2;
+
+      mat-icon {
+        color: currentColor;
+        margin-right: 2px;
+        font-size: 18px;
+        height: 18px;
+        width: 18px;
+      }
+    }
+
     &.status-attention {
       background-color: #fff8e1;
       border-color: rgba(255, 193, 7, 0.35);

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -14,6 +14,9 @@ import { CoderService } from '../../services/coder.service';
 import { ExportJobService } from '../../../shared/services/file/export-job.service';
 import { CohensKappaStatisticsComponent } from '../cohens-kappa-statistics/cohens-kappa-statistics.component';
 import { ManualCodingExportDialogComponent } from '../manual-coding-export-dialog/manual-coding-export-dialog.component';
+import type {
+  ManualCodeAvailabilityWarningDto
+} from '../../../../../../../api-dto/coding/manual-code-availability.dto';
 
 type VariableCoverageOverview = NonNullable<
 CodingManagementManualComponent['variableCoverageOverview']
@@ -27,6 +30,22 @@ CodingManagementManualComponent['codingProgressOverview']
 type ManualAppliedResultsOverview = NonNullable<
 CodingManagementManualComponent['appliedResultsOverview']
 >;
+
+const createManualCodeAvailabilityWarning = (
+  unitName: string,
+  variableId: string
+): ManualCodeAvailabilityWarningDto => ({
+  unitName,
+  variableId,
+  responseCount: 5,
+  casesInJobs: 0,
+  availableCases: 5,
+  uniqueCasesAfterAggregation: 5,
+  regularCodeCount: 2,
+  selectableRegularCodeCount: 0,
+  onlySpecialOptionsAvailable: true,
+  message: 'Variable hat keine regulären Codes mit manueller Instruktion.'
+});
 
 describe('CodingManagementManualComponent', () => {
   let component: CodingManagementManualComponent;
@@ -106,6 +125,10 @@ describe('CodingManagementManualComponent', () => {
         },
         'completed-jobs': {
           'readonly-note': 'Nur lesbar'
+        },
+        buttons: {
+          'show-more-manual-code-warnings': '+{{count}} weitere anzeigen',
+          'show-fewer-manual-code-warnings': 'Weniger anzeigen'
         }
       }
     });
@@ -911,18 +934,7 @@ describe('CodingManagementManualComponent', () => {
     setCodingProgress(10, 4);
     setAppliedResults(10, 0, 10);
     component.manualCodeAvailabilityWarnings = [
-      {
-        unitName: 'UNIT1',
-        variableId: 'VAR1',
-        responseCount: 5,
-        casesInJobs: 0,
-        availableCases: 5,
-        uniqueCasesAfterAggregation: 5,
-        regularCodeCount: 2,
-        selectableRegularCodeCount: 0,
-        onlySpecialOptionsAvailable: true,
-        message: 'Variable hat keine regulären Codes mit manueller Instruktion.'
-      }
+      createManualCodeAvailabilityWarning('UNIT1', 'VAR1')
     ];
 
     expect(component.hasManualCodeAvailabilityWarnings).toBe(true);
@@ -955,22 +967,47 @@ describe('CodingManagementManualComponent', () => {
     );
   });
 
+  it('should expand all manual code availability warnings from the status banner', () => {
+    setCompletePlanningState();
+    component.manualCodeAvailabilityWarnings = [
+      createManualCodeAvailabilityWarning('UNIT1', 'VAR1'),
+      createManualCodeAvailabilityWarning('UNIT2', 'VAR2'),
+      createManualCodeAvailabilityWarning('UNIT3', 'VAR3'),
+      createManualCodeAvailabilityWarning('UNIT4', 'VAR4'),
+      createManualCodeAvailabilityWarning('UNIT5', 'VAR5'),
+      createManualCodeAvailabilityWarning('UNIT6', 'VAR6'),
+      createManualCodeAvailabilityWarning('UNIT7', 'VAR7')
+    ];
+
+    fixture.detectChanges();
+
+    const statusBanner = fixture.nativeElement.querySelector(
+      '.planning-status-banner'
+    ) as HTMLElement;
+    const toggleButton = statusBanner.querySelector(
+      '.manual-code-availability-toggle'
+    ) as HTMLButtonElement;
+
+    expect(statusBanner.textContent).toContain('UNIT1 / VAR1');
+    expect(statusBanner.textContent).toContain('UNIT5 / VAR5');
+    expect(statusBanner.textContent).not.toContain('UNIT6 / VAR6');
+    expect(toggleButton.textContent).toContain('+2 weitere anzeigen');
+    expect(toggleButton.getAttribute('aria-expanded')).toBe('false');
+
+    toggleButton.click();
+    fixture.detectChanges();
+
+    expect(statusBanner.textContent).toContain('UNIT6 / VAR6');
+    expect(statusBanner.textContent).toContain('UNIT7 / VAR7');
+    expect(toggleButton.textContent).toContain('Weniger anzeigen');
+    expect(toggleButton.getAttribute('aria-expanded')).toBe('true');
+  });
+
   it('should keep the affected variables scroll target while coverage is loading', () => {
     component.selectedManualTabIndex = component.manualCodingTabs.indexOf('planning');
     component.variableCoverageOverview = null;
     component.manualCodeAvailabilityWarnings = [
-      {
-        unitName: 'UNIT1',
-        variableId: 'VAR1',
-        responseCount: 5,
-        casesInJobs: 0,
-        availableCases: 5,
-        uniqueCasesAfterAggregation: 5,
-        regularCodeCount: 2,
-        selectableRegularCodeCount: 0,
-        onlySpecialOptionsAvailable: true,
-        message: 'Variable hat keine regulären Codes mit manueller Instruktion.'
-      }
+      createManualCodeAvailabilityWarning('UNIT1', 'VAR1')
     ];
 
     fixture.detectChanges();
@@ -1024,18 +1061,7 @@ describe('CodingManagementManualComponent', () => {
       }
     };
     component.manualCodeAvailabilityWarnings = [
-      {
-        unitName: 'UNIT1',
-        variableId: 'VAR1',
-        responseCount: 5,
-        casesInJobs: 0,
-        availableCases: 5,
-        uniqueCasesAfterAggregation: 5,
-        regularCodeCount: 2,
-        selectableRegularCodeCount: 0,
-        onlySpecialOptionsAvailable: true,
-        message: 'Variable hat keine regulären Codes mit manueller Instruktion.'
-      }
+      createManualCodeAvailabilityWarning('UNIT1', 'VAR1')
     ];
 
     expect(component.getPlanningStatusClass()).toBe('status-warning');

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -346,6 +346,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   manualCodingScopeSummary: ManualCodingScopeSummary | null = null;
   manualCodeAvailabilityWarnings: ManualCodeAvailabilityWarningDto[] = [];
+  showAllManualCodeAvailabilityWarnings = false;
+  readonly manualCodeAvailabilityPreviewLimit = 5;
 
   statusDistribution: { [status: string]: number } = {};
   statusDistributionV2: { [status: string]: number } = {};
@@ -2106,8 +2108,41 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return this.manualCodeAvailabilityWarningCount > 0;
   }
 
+  get hiddenManualCodeAvailabilityWarningCount(): number {
+    return Math.max(
+      0,
+      this.manualCodeAvailabilityWarningCount -
+        this.manualCodeAvailabilityPreviewLimit
+    );
+  }
+
+  get hasHiddenManualCodeAvailabilityWarnings(): boolean {
+    return this.hiddenManualCodeAvailabilityWarningCount > 0;
+  }
+
   getManualCodeAvailabilityPreview(): ManualCodeAvailabilityWarningDto[] {
-    return this.manualCodeAvailabilityWarnings.slice(0, 5);
+    return this.manualCodeAvailabilityWarnings.slice(
+      0,
+      this.manualCodeAvailabilityPreviewLimit
+    );
+  }
+
+  getVisibleManualCodeAvailabilityWarnings(): ManualCodeAvailabilityWarningDto[] {
+    return this.showAllManualCodeAvailabilityWarnings ?
+      this.manualCodeAvailabilityWarnings :
+      this.getManualCodeAvailabilityPreview();
+  }
+
+  toggleManualCodeAvailabilityWarnings(): void {
+    this.showAllManualCodeAvailabilityWarnings =
+      !this.showAllManualCodeAvailabilityWarnings;
+  }
+
+  private setManualCodeAvailabilityWarnings(
+    warnings: ManualCodeAvailabilityWarningDto[]
+  ): void {
+    this.manualCodeAvailabilityWarnings = warnings;
+    this.showAllManualCodeAvailabilityWarnings = false;
   }
 
   get autoCodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
@@ -2683,7 +2718,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     if (!workspaceId) {
       this.codingIncompleteVariables = [];
       this.manualCodingScopeSummary = null;
-      this.manualCodeAvailabilityWarnings = [];
+      this.setManualCodeAvailabilityWarnings([]);
       this.isLoadingManualCodeAvailability = false;
       return;
     }
@@ -2733,10 +2768,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       )
       .subscribe({
         next: result => {
-          this.manualCodeAvailabilityWarnings = result.warnings || [];
+          this.setManualCodeAvailabilityWarnings(result.warnings || []);
         },
         error: () => {
-          this.manualCodeAvailabilityWarnings = [];
+          this.setManualCodeAvailabilityWarnings([]);
         }
       });
   }

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1819,7 +1819,9 @@
     "buttons": {
       "try-again": "Erneut versuchen",
       "close": "Schließen",
-      "download-excel": "Als Excel herunterladen"
+      "download-excel": "Als Excel herunterladen",
+      "show-more-manual-code-warnings": "+{{count}} weitere anzeigen",
+      "show-fewer-manual-code-warnings": "Weniger anzeigen"
     },
     "table": {
       "headers": {


### PR DESCRIPTION
## Summary

Refs #584.

This PR makes the manual-code availability warning list expandable in the manual coding planning banner. The banner still starts with a compact preview, but the `+N weitere anzeigen` action now reveals all affected variables and can be collapsed again.

## Details

- Shows a five-item preview for affected variables in the planning status banner.
- Replaces the static `+N weitere` chip with an accessible toggle button using `aria-expanded`.
- Resets the expanded state whenever the warning list is reloaded.
- Adds German translation keys for the toggle labels.
- Adds component test coverage for preview, expand, and collapse state.

## Validation

- `npx nx lint frontend`
- `npx nx test frontend`