### PR TITLE
Improve manual coding panel

### DIFF
--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -411,7 +411,8 @@ describe('CoderTrainingService', () => {
         {
           caseSelectionMode: 'oldest_first',
           referenceTrainingIds: undefined,
-          referenceMode: undefined
+          referenceMode: undefined,
+          assignedVariableBundles
         }
       );
 
@@ -1596,6 +1597,78 @@ describe('CoderTrainingService', () => {
       );
 
       expect(result[0].responses).toEqual([]);
+    });
+
+    it('samples bundle variables by shared case for training packages', async () => {
+      const responsesByVariable = new Map<string, Array<ReturnType<typeof makeResponseEntity>>>([
+        ['var1', [
+          {
+            ...makeResponseEntity(1, { personLogin: 'person-a', personCode: 'A' }),
+            unitid: undefined as never
+          },
+          {
+            ...makeResponseEntity(3, { personLogin: 'person-b', personCode: 'B' }),
+            unitid: undefined as never
+          }
+        ]],
+        ['var2', [
+          {
+            ...makeResponseEntity(2, { personLogin: 'person-a', personCode: 'A' }),
+            variableid: 'var2',
+            unitid: undefined as never
+          },
+          {
+            ...makeResponseEntity(4, { personLogin: 'person-b', personCode: 'B' }),
+            variableid: 'var2',
+            unitid: undefined as never
+          }
+        ]]
+      ]);
+      let currentVariableId = '';
+      const responseQb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn((condition: unknown, parameters?: { variableId?: string }) => {
+          if (condition === 'response.variableid = :variableId' && parameters?.variableId) {
+            currentVariableId = parameters.variableId;
+          }
+          return responseQb;
+        }),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn(async () => responsesByVariable.get(currentVariableId) || [])
+      };
+      const responseRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(responseQb)
+      };
+      (service as unknown as { responseRepository: typeof responseRepository }).responseRepository = responseRepository;
+      mockRepository.find.mockResolvedValueOnce([{
+        id: 9,
+        workspace_id: 1,
+        variables: [
+          { unitName: 'Real Unit', variableId: 'var1' },
+          { unitName: 'Real Unit', variableId: 'var2' }
+        ]
+      }]);
+
+      const result = await service.generateCoderTrainingPackages(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [
+          { unitId: 'Real Unit', variableId: 'var1', sampleCount: 2 },
+          { unitId: 'Real Unit', variableId: 'var2', sampleCount: 2 }
+        ],
+        {
+          caseSelectionMode: 'oldest_first',
+          assignedVariableBundles: [{
+            id: 9,
+            name: 'Bundle',
+            sampleCount: 1
+          }]
+        }
+      );
+
+      expect(result[0].responses.map(response => response.responseId).sort()).toEqual([1, 2]);
+      expect(new Set(result[0].responses.map(response => response.personLogin))).toEqual(new Set(['person-a']));
     });
   });
 

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -1176,6 +1176,92 @@ export class CoderTrainingService {
     });
   }
 
+  private getTrainingBundleCaseKey(response: CoderTrainingResponse): string {
+    return [
+      response.personLogin,
+      response.personCode,
+      response.personGroup,
+      response.bookletName,
+      response.unitName
+    ].join('\u001F');
+  }
+
+  private sampleBundleResponseGroups(
+    groupsByCaseKey: Map<string, CoderTrainingResponse[]>,
+    sampleCount: number,
+    caseSelectionMode: CaseSelectionMode
+  ): CoderTrainingResponse[][] {
+    const representativeByCaseKey = new Map<string, CoderTrainingResponse>();
+    groupsByCaseKey.forEach((responses, caseKey) => {
+      const representative = [...responses].sort((a, b) => {
+        const tsA = a.chunkTs ?? a.responseId;
+        const tsB = b.chunkTs ?? b.responseId;
+        return tsA - tsB || a.responseId - b.responseId;
+      })[0];
+      representativeByCaseKey.set(caseKey, representative);
+    });
+
+    const representatives = Array.from(representativeByCaseKey.values());
+    const selectedRepresentatives = this.sampleResponses(
+      representatives,
+      sampleCount,
+      caseSelectionMode
+    );
+
+    return selectedRepresentatives
+      .map(representative => groupsByCaseKey.get(this.getTrainingBundleCaseKey(representative)) || [])
+      .filter(responses => responses.length > 0);
+  }
+
+  private async applyBundleCaseSampling(
+    workspaceId: number,
+    sampledResponsesByConfig: Map<string, CoderTrainingResponse[]>,
+    candidateResponsesByConfig: Map<string, CoderTrainingResponse[]>,
+    assignedVariableBundles: JobDefinitionVariableBundle[],
+    caseSelectionMode: CaseSelectionMode
+  ): Promise<void> {
+    const bundleIds = this.getValidatedBundleIds(assignedVariableBundles);
+    if (bundleIds.length === 0) {
+      return;
+    }
+
+    const fetchedBundlesById = await this.getWorkspaceVariableBundlesById(
+      workspaceId,
+      bundleIds
+    );
+
+    for (const assignedBundle of assignedVariableBundles) {
+      const bundleVariables = fetchedBundlesById.get(assignedBundle.id)?.variables || [];
+      const groupsByCaseKey = new Map<string, CoderTrainingResponse[]>();
+
+      bundleVariables.forEach(variable => {
+        const configKey = `${variable.unitName}:${variable.variableId}`;
+        const candidates = candidateResponsesByConfig.get(configKey) || [];
+        candidates.forEach(response => {
+          const caseKey = this.getTrainingBundleCaseKey(response);
+          const responses = groupsByCaseKey.get(caseKey) || [];
+          responses.push(response);
+          groupsByCaseKey.set(caseKey, responses);
+        });
+      });
+
+      const selectedGroups = this.sampleBundleResponseGroups(
+        groupsByCaseKey,
+        assignedBundle.sampleCount || 10,
+        caseSelectionMode
+      );
+
+      bundleVariables.forEach(variable => {
+        const configKey = `${variable.unitName}:${variable.variableId}`;
+        const selectedResponses = selectedGroups.flatMap(group => group.filter(response => (
+          response.unitName === variable.unitName &&
+          response.variableId === variable.variableId
+        )));
+        sampledResponsesByConfig.set(configKey, selectedResponses);
+      });
+    }
+  }
+
   async generateCoderTrainingPackages(
     workspaceId: number,
     selectedCoders: { id: number; name: string }[],
@@ -1184,6 +1270,7 @@ export class CoderTrainingService {
       caseSelectionMode?: CaseSelectionMode;
       referenceTrainingIds?: number[];
       referenceMode?: ReferenceMode;
+      assignedVariableBundles?: JobDefinitionVariableBundle[];
     }
   ): Promise<TrainingPackage[]> {
     const caseSelectionMode = options?.caseSelectionMode ?? 'oldest_first';
@@ -1212,6 +1299,7 @@ export class CoderTrainingService {
 
     // Pre-sample responses for each variable configuration to ensure consistency across all coders
     const sampledResponsesByConfig: Map<string, CoderTrainingResponse[]> = new Map();
+    const candidateResponsesByConfig: Map<string, CoderTrainingResponse[]> = new Map();
 
     for (const config of variableConfigs) {
       const variableId = config.variableId;
@@ -1358,12 +1446,21 @@ export class CoderTrainingService {
         referenceResponseIdsByConfig,
         configKey
       );
+      candidateResponsesByConfig.set(configKey, responsesForSampling);
 
       const sampledResponses = this.sampleResponses(responsesForSampling, sampleCount, caseSelectionMode);
       sampledResponsesByConfig.set(configKey, sampledResponses);
 
       this.logger.log(`Sampled ${sampledResponses.length} consistent responses for unit ${unitId}, variable ${variableId}`);
     }
+
+    await this.applyBundleCaseSampling(
+      workspaceId,
+      sampledResponsesByConfig,
+      candidateResponsesByConfig,
+      options?.assignedVariableBundles || [],
+      caseSelectionMode
+    );
 
     // Create training packages for each coder using the pre-sampled responses
     const result: TrainingPackage[] = [];
@@ -1480,7 +1577,8 @@ export class CoderTrainingService {
       const trainingPackages = await this.generateCoderTrainingPackages(workspaceId, selectedCoders, trainingVariableConfigs, {
         caseSelectionMode: caseSelectionMode ?? 'oldest_first',
         referenceTrainingIds,
-        referenceMode
+        referenceMode,
+        ...((assignedVariableBundles?.length || 0) > 0 ? { assignedVariableBundles } : {})
       });
 
       // Build mapping from variable to bundle id and bundle sorting mode
@@ -2325,7 +2423,10 @@ export class CoderTrainingService {
         const trainingPackages = await this.generateCoderTrainingPackages(workspaceId, selectedCoders, effectiveTrainingVariableConfigs, {
           caseSelectionMode: newCaseSelectionMode,
           referenceTrainingIds: effectiveReferenceTrainingIds,
-          referenceMode: newReferenceMode ?? undefined
+          referenceMode: newReferenceMode ?? undefined,
+          ...(effectiveAssignedVariableBundles.length > 0 ?
+            { assignedVariableBundles: effectiveAssignedVariableBundles } :
+            {})
         });
 
         // Build mapping from variable to bundle id and bundle sorting mode

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -237,9 +237,9 @@ describe('CodingJobService distribution from job definitions', () => {
 
     const doubleCodingSummary = Object.values(result.doubleCodingInfo);
     expect(doubleCodingSummary.reduce((sum, item) => sum + item.distinctCases, 0)).toBe(7);
-    expect(doubleCodingSummary.reduce((sum, item) => sum + item.codingTasksTotal, 0)).toBe(10);
-    expect(doubleCodingSummary.reduce((sum, item) => sum + item.doubleCodedCases, 0)).toBe(3);
-    expect(doubleCodingSummary.reduce((sum, item) => sum + item.singleCodedCasesAssigned, 0)).toBe(4);
+    expect(doubleCodingSummary.reduce((sum, item) => sum + item.codingTasksTotal, 0)).toBe(9);
+    expect(doubleCodingSummary.reduce((sum, item) => sum + item.doubleCodedCases, 0)).toBe(2);
+    expect(doubleCodingSummary.reduce((sum, item) => sum + item.singleCodedCasesAssigned, 0)).toBe(5);
 
     expect(createdJobCalls.every(call => call.dto.jobDefinitionId === 77)).toBe(true);
     expect(createdJobCalls.every(call => call.subset.length > 0)).toBe(true);
@@ -259,7 +259,7 @@ describe('CodingJobService distribution from job definitions', () => {
     createdJobCalls.flatMap(call => call.subset).forEach(response => {
       assignedResponseCounts.set(response.id, (assignedResponseCounts.get(response.id) || 0) + 1);
     });
-    expect([...assignedResponseCounts.values()].filter(count => count === 2)).toHaveLength(3);
+    expect([...assignedResponseCounts.values()].filter(count => count === 2)).toHaveLength(2);
     expect(Math.max(...assignedResponseCounts.values())).toBe(2);
   });
 
@@ -782,6 +782,99 @@ describe('CodingJobService distribution from job definitions', () => {
     expect(result.aggregationInfo).toEqual(preview.aggregationInfo);
     expect(createdJobCalls).toHaveLength(1);
     expect(createdJobCalls[0].subset.map(response => response.id).sort((a, b) => a - b)).toEqual([1, 3]);
+  });
+
+  it('assigns all variables of the same bundle case to the same coder', async () => {
+    const responses = [
+      {
+        ...makeResponse(1, 'Unit 1', 'Var 1'),
+        personLogin: 'Person A',
+        personCode: 'A',
+        personGroup: 'G1'
+      },
+      {
+        ...makeResponse(2, 'Unit 1', 'Var 2'),
+        personLogin: 'Person A',
+        personCode: 'A',
+        personGroup: 'G1'
+      },
+      {
+        ...makeResponse(3, 'Unit 1', 'Var 1'),
+        personLogin: 'Person B',
+        personCode: 'B',
+        personGroup: 'G1'
+      },
+      {
+        ...makeResponse(4, 'Unit 1', 'Var 2'),
+        personLogin: 'Person B',
+        personCode: 'B',
+        personGroup: 'G1'
+      }
+    ];
+    const createdJobCalls: Array<{
+      dto: { assignedCoders?: number[] };
+      subset: SlimResponseForTest[];
+    }> = [];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+    jest.spyOn(
+      service as unknown as {
+        createCodingJobWithUnitSubsetInManager: (
+          workspaceId: number,
+          dto: { assignedCoders?: number[] },
+          subset: SlimResponseForTest[]
+        ) => Promise<CodingJob>
+      },
+      'createCodingJobWithUnitSubsetInManager'
+    ).mockImplementation(async (_workspaceId, dto, subset) => {
+      createdJobCalls.push({ dto, subset: subset as SlimResponseForTest[] });
+      return { id: 450 + createdJobCalls.length } as CodingJob;
+    });
+
+    const result = await service.createDistributedCodingJobs(5, {
+      selectedVariables: [],
+      selectedVariableBundles: [{
+        id: 9,
+        name: 'Bundle A',
+        caseOrderingMode: 'alternating',
+        variables: [
+          { unitName: 'Unit 1', variableId: 'Var 1' },
+          { unitName: 'Unit 1', variableId: 'Var 2' }
+        ]
+      }],
+      selectedCoders: [
+        { id: 1, name: 'Ada', username: 'ada' },
+        { id: 2, name: 'Bea', username: 'bea' }
+      ],
+      caseOrderingMode: 'continuous',
+      jobDefinitionId: 86,
+      distributionSeed: 'bundle-case-grouping'
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.distribution['bundle:9']).toEqual({ Ada: 1, Bea: 1 });
+    expect(result.doubleCodingInfo['bundle:9']).toMatchObject({
+      distinctCases: 2,
+      codingTasksTotal: 4,
+      doubleCodedCases: 0,
+      singleCodedCasesAssigned: 2
+    });
+    expect(createdJobCalls).toHaveLength(2);
+
+    const coderByResponseId = new Map<number, number>();
+    createdJobCalls.forEach(call => {
+      call.subset.forEach(response => {
+        coderByResponseId.set(response.id, call.dto.assignedCoders![0]);
+      });
+    });
+
+    expect(coderByResponseId.get(1)).toBe(coderByResponseId.get(2));
+    expect(coderByResponseId.get(3)).toBe(coderByResponseId.get(4));
+    expect([...coderByResponseId.keys()].sort((a, b) => a - b)).toEqual([
+      1, 2, 3, 4
+    ]);
   });
 
   it('keeps bundles with duplicate names separate by bundle id', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -42,6 +42,7 @@ const createQueryBuilder = (result: unknown = []) => {
     'innerJoinAndSelect',
     'where',
     'andWhere',
+    'orWhere',
     'groupBy',
     'addGroupBy',
     'orderBy',
@@ -4483,5 +4484,97 @@ describe('CodingJobService', () => {
       variableId: 'VAR_WITH_OVERRIDE',
       variablePage: '1'
     });
+  });
+
+  it('returns auto-coded bundle siblings for coding job units', async () => {
+    codingJobRepository.findOne.mockResolvedValue({
+      id: 10,
+      workspace_id: 3,
+      job_definition_id: 5,
+      training_id: null,
+      case_ordering_mode: 'continuous',
+      codingJobCoders: []
+    });
+    codingJobVariableBundleRepository.find.mockResolvedValue([
+      {
+        variable_bundle_id: 9,
+        case_ordering_mode: 'alternating'
+      }
+    ]);
+    variableBundleRepository.find.mockResolvedValue([
+      {
+        id: 9,
+        workspace_id: 3,
+        variables: [
+          { unitName: 'UNIT', variableId: 'MANUAL' },
+          { unitName: 'UNIT', variableId: 'AUTO' }
+        ]
+      }
+    ]);
+    codingJobUnitRepository.find
+      .mockResolvedValueOnce([
+        {
+          response_id: 99,
+          unit_name: 'UNIT',
+          unit_alias: 'UNIT',
+          variable_id: 'MANUAL',
+          variable_anchor: 'MANUAL',
+          booklet_name: 'BOOKLET',
+          person_login: 'login',
+          person_code: 'code',
+          person_group: 'group',
+          notes: null,
+          variable_bundle_id: 9
+        }
+      ])
+      .mockResolvedValueOnce([]);
+    responseRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([
+      {
+        responseId: 99,
+        variableId: 'MANUAL',
+        statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+        isAutocoderGenerated: false,
+        unitName: 'UNIT',
+        bookletName: 'BOOKLET',
+        personLogin: 'login',
+        personCode: 'code',
+        personGroup: 'group'
+      },
+      {
+        responseId: 100,
+        variableId: 'AUTO',
+        statusV1: statusStringToNumber('CODING_COMPLETE'),
+        isAutocoderGenerated: true,
+        unitName: 'UNIT',
+        bookletName: 'BOOKLET',
+        personLogin: 'login',
+        personCode: 'code',
+        personGroup: 'group'
+      }
+    ]));
+    codingFileCacheService.getVariablePageMap.mockResolvedValue(
+      new Map([['MANUAL', '0']])
+    );
+
+    const result = await service.getCodingJobUnits(10);
+
+    expect(result[0].variableBundleCaseVariables).toEqual([
+      {
+        unitName: 'UNIT',
+        variableId: 'AUTO',
+        responseId: 100,
+        statusV1: statusStringToNumber('CODING_COMPLETE'),
+        isManualCodingUnit: false,
+        isAutoCoded: true
+      },
+      {
+        unitName: 'UNIT',
+        variableId: 'MANUAL',
+        responseId: 99,
+        statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+        isManualCodingUnit: true,
+        isAutoCoded: false
+      }
+    ]);
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -230,13 +230,22 @@ type DistributionPlanItem = {
   uniqueCases: number;
   totalResponses: number;
   availableResponses: SlimResponse[];
+  availableCases: DistributionSelectableCase[];
   caseStatusesByResponseId: Map<number, DistributionVariableUsageCaseStatus>;
   selectedResponses: SlimResponse[];
+};
+
+type DistributionSelectableCase = {
+  item: DistributionPlanItem;
+  response: SlimResponse;
+  responses: SlimResponse[];
+  caseKey: string;
 };
 
 type DistributionPlanCase = {
   item: DistributionPlanItem;
   response: SlimResponse;
+  responses: SlimResponse[];
   isDoubleCoded: boolean;
   assignedCoderIds: number[];
 };
@@ -245,6 +254,27 @@ type DistributionPlanJob = {
   coder: NormalizedDistributionCoder;
   item: DistributionPlanItem;
   unitSubset: SlimResponse[];
+};
+
+type BundleCaseVariable = {
+  unitName: string;
+  variableId: string;
+  responseId: number | null;
+  statusV1: number | null;
+  isManualCodingUnit: boolean;
+  isAutoCoded: boolean;
+};
+
+type BundleCaseVariableResponseRow = {
+  responseId: number | string;
+  variableId: string;
+  statusV1: number | string | null;
+  isAutocoderGenerated: boolean | string | null;
+  unitName: string;
+  bookletName: string;
+  personLogin: string;
+  personCode: string;
+  personGroup: string;
 };
 
 type DistributionPlan = {
@@ -1645,7 +1675,11 @@ export class CodingJobService {
       existingRows.map(row => row.responseId)
     );
     const plannedResponseIds = new Set(
-      plan.plannedCases.map(plannedCase => plannedCase.response.id)
+      plan.plannedCases.flatMap(
+        plannedCase => this.getDistributionPlanCaseResponses(plannedCase).map(
+          response => response.id
+        )
+      )
     );
     const retainedCases = [...plannedResponseIds].filter(responseId => existingResponseIds.has(responseId)
     ).length;
@@ -1749,18 +1783,31 @@ export class CodingJobService {
     return existing;
   }
 
+  private getDistributionPlanCaseResponses(
+    plannedCase: DistributionPlanCase
+  ): SlimResponse[] {
+    if (plannedCase.responses?.length) {
+      return plannedCase.responses;
+    }
+
+    const legacyResponse = (plannedCase as { response?: SlimResponse }).response;
+    return legacyResponse ? [legacyResponse] : [];
+  }
+
   private buildPlannedTaskCountByItemCoderAndResponse(
     plannedCases: DistributionPlanCase[]
   ): Map<string, number> {
     const planned = new Map<string, number>();
     plannedCases.forEach(plannedCase => {
       plannedCase.assignedCoderIds.forEach(coderId => {
-        const key = this.getRefreshTaskKey(
-          plannedCase.item.itemKey,
-          coderId,
-          plannedCase.response.id
-        );
-        planned.set(key, (planned.get(key) || 0) + 1);
+        this.getDistributionPlanCaseResponses(plannedCase).forEach(response => {
+          const key = this.getRefreshTaskKey(
+            plannedCase.item.itemKey,
+            coderId,
+            response.id
+          );
+          planned.set(key, (planned.get(key) || 0) + 1);
+        });
       });
     });
     return planned;
@@ -1869,7 +1916,11 @@ export class CodingJobService {
         const plannedResponseIds = new Set(
           plan.plannedCases
             .filter(plannedCase => plannedCase.item.itemKey === itemKey)
-            .map(plannedCase => plannedCase.response.id)
+            .flatMap(
+              plannedCase => this.getDistributionPlanCaseResponses(plannedCase).map(
+                response => response.id
+              )
+            )
         );
         const codingTasksByCoderId = this.buildJobDefinitionRefreshCoderDeltas(
           plan,
@@ -4251,6 +4302,8 @@ export class CodingJobService {
       personGroup: string;
       notes: string | null;
       variableBundleId: number | null;
+      variableBundleCaseOrderingMode: 'continuous' | 'alternating' | null;
+      variableBundleCaseVariables: BundleCaseVariable[];
       isDoubleCoded: boolean;
       otherCoders: string[];
     }[]
@@ -4278,9 +4331,12 @@ export class CodingJobService {
       order: { id: 'ASC' }
     });
 
-    const bundleModes = new Map<number, string>();
+    const bundleModes = new Map<number, 'continuous' | 'alternating'>();
     for (const b of bundles) {
-      bundleModes.set(b.variable_bundle_id, b.case_ordering_mode || globalMode);
+      bundleModes.set(
+        b.variable_bundle_id,
+        (b.case_ordering_mode || globalMode) as 'continuous' | 'alternating'
+      );
     }
 
     const codingJobUnits = await this.codingJobUnitRepository.find({
@@ -4390,6 +4446,11 @@ export class CodingJobService {
       visibleCodingJobUnits,
       codingJob.workspace_id
     );
+    const bundleCaseVariablesByKey = await this.getBundleCaseVariablesByKey(
+      codingJob.workspace_id,
+      visibleCodingJobUnits,
+      bundles
+    );
 
     return sortedUnits.map(unit => {
       const otherCoders = Array.from(
@@ -4413,10 +4474,183 @@ export class CodingJobService {
         personGroup: unit.person_group,
         notes: unit.notes,
         variableBundleId: unit.variable_bundle_id,
+        variableBundleCaseOrderingMode: unit.variable_bundle_id ?
+          bundleModes.get(unit.variable_bundle_id) || null :
+          null,
+        variableBundleCaseVariables: unit.variable_bundle_id ?
+          bundleCaseVariablesByKey.get(this.getCodingJobUnitBundleCaseKey(unit)) || [] :
+          [],
         isDoubleCoded: otherCoders.length > 0,
         otherCoders: otherCoders
       };
     });
+  }
+
+  private getCodingJobUnitBundleCaseKey(unit: CodingJobUnit): string {
+    return [
+      unit.variable_bundle_id || '',
+      unit.person_login || '',
+      unit.person_code || '',
+      unit.person_group || '',
+      unit.booklet_name || '',
+      unit.unit_name || ''
+    ].join('\u001F');
+  }
+
+  private getBundleCaseVariableKey(
+    bundleId: number,
+    unitName: string,
+    variableId: string
+  ): string {
+    return [bundleId, unitName, variableId].join('\u001F');
+  }
+
+  private async getBundleCaseVariablesByKey(
+    workspaceId: number,
+    visibleCodingJobUnits: CodingJobUnit[],
+    codingJobBundles: CodingJobVariableBundle[]
+  ): Promise<Map<string, BundleCaseVariable[]>> {
+    const bundledUnits = visibleCodingJobUnits.filter(
+      unit => !!unit.variable_bundle_id
+    );
+    if (bundledUnits.length === 0 || codingJobBundles.length === 0) {
+      return new Map();
+    }
+
+    const bundleIds = Array.from(
+      new Set(
+        codingJobBundles
+          .map(bundle => bundle.variable_bundle_id)
+          .filter(id => Number.isInteger(id))
+      )
+    );
+    if (bundleIds.length === 0) {
+      return new Map();
+    }
+
+    const variableBundles = await this.variableBundleRepository.find({
+      where: { id: In(bundleIds), workspace_id: workspaceId }
+    });
+    const variablesByBundleId = new Map(
+      variableBundles.map(bundle => [bundle.id, bundle.variables || []])
+    );
+    const bundleCaseKeys = new Set(
+      bundledUnits.map(unit => this.getCodingJobUnitBundleCaseKey(unit))
+    );
+    const manualVariableKeys = new Set(
+      bundledUnits.map(unit => this.getBundleCaseVariableKey(
+        unit.variable_bundle_id!,
+        unit.unit_name,
+        unit.variable_id
+      ))
+    );
+
+    const bundleVariables = Array.from(variablesByBundleId.entries())
+      .flatMap(([bundleId, variables]) => variables.map(variable => ({
+        bundleId,
+        unitName: variable.unitName,
+        variableId: variable.variableId
+      })));
+    if (bundleVariables.length === 0) {
+      return new Map();
+    }
+
+    const responseQuery = this.responseRepository
+      .createQueryBuilder('response')
+      .select('response.id', 'responseId')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('response.status_v1', 'statusV1')
+      .addSelect('response.is_autocoder_generated', 'isAutocoderGenerated')
+      .addSelect('unit.name', 'unitName')
+      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
+      .addSelect("COALESCE(person.login, '')", 'personLogin')
+      .addSelect("COALESCE(person.code, '')", 'personCode')
+      .addSelect("COALESCE(person.group, '')", 'personGroup')
+      .innerJoin('response.unit', 'unit')
+      .innerJoin('unit.booklet', 'booklet')
+      .leftJoin('booklet.bookletinfo', 'bookletinfo')
+      .innerJoin('booklet.person', 'person')
+      .where('person.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('person.consider = :consider', { consider: true });
+    responseQuery.andWhere(new Brackets(qb => {
+      bundleVariables.forEach((variable, index) => {
+        const condition =
+          `(unit.name = :bundleUnitName${index} AND response.variableid = :bundleVariableId${index})`;
+        const parameters = {
+          [`bundleUnitName${index}`]: variable.unitName,
+          [`bundleVariableId${index}`]: variable.variableId
+        };
+        if (index === 0) {
+          qb.where(condition, parameters);
+        } else {
+          qb.orWhere(condition, parameters);
+        }
+      });
+    }));
+
+    const rawResponses = await responseQuery
+      .orderBy('response.id', 'ASC')
+      .getRawMany<BundleCaseVariableResponseRow>();
+    const responsesByCaseAndVariable = new Map<string, BundleCaseVariableResponseRow>();
+
+    rawResponses.forEach(response => {
+      bundleIds.forEach(bundleId => {
+        const caseKey = [
+          bundleId,
+          response.personLogin || '',
+          response.personCode || '',
+          response.personGroup || '',
+          response.bookletName || '',
+          response.unitName || ''
+        ].join('\u001F');
+        if (!bundleCaseKeys.has(caseKey)) {
+          return;
+        }
+        responsesByCaseAndVariable.set(
+          `${caseKey}\u001F${response.variableId}`,
+          response
+        );
+      });
+    });
+
+    const result = new Map<string, BundleCaseVariable[]>();
+    bundleCaseKeys.forEach(caseKey => {
+      const [bundleIdPart,,,,, unitName] = caseKey.split('\u001F');
+      const bundleId = Number(bundleIdPart);
+      const variables = (variablesByBundleId.get(bundleId) || [])
+        .filter(variable => variable.unitName === unitName)
+        .sort((a, b) => a.variableId.localeCompare(b.variableId));
+      const caseVariables = variables.map(variable => {
+        const response = responsesByCaseAndVariable.get(
+          `${caseKey}\u001F${variable.variableId}`
+        );
+        const statusV1 =
+          response?.statusV1 !== undefined && response?.statusV1 !== null ?
+            Number(response.statusV1) :
+            null;
+        const isAutocoderGenerated =
+          response?.isAutocoderGenerated === true ||
+          response?.isAutocoderGenerated === 'true';
+        const isManualCodingUnit = manualVariableKeys.has(
+          this.getBundleCaseVariableKey(bundleId, variable.unitName, variable.variableId)
+        );
+
+        return {
+          unitName: variable.unitName,
+          variableId: variable.variableId,
+          responseId: response ? Number(response.responseId) : null,
+          statusV1,
+          isManualCodingUnit,
+          isAutoCoded: !isManualCodingUnit && (
+            isAutocoderGenerated ||
+            statusV1 === statusStringToNumber('CODING_COMPLETE')
+          )
+        };
+      });
+      result.set(caseKey, caseVariables);
+    });
+
+    return result;
   }
 
   private async getVariablePageMapsForUnits(
@@ -5628,6 +5862,43 @@ export class CodingJobService {
     };
   }
 
+  private addBundleAvailabilityWarnings(
+    warnings: JobCreationWarning[],
+    warnedVariables: Set<string>,
+    planItem: DistributionPlanItem,
+    totalCases: DistributionSelectableCase[]
+  ): void {
+    planItem.itemVariables.forEach(variable => {
+      const variableKey = `${variable.unitName}::${variable.variableId}`;
+      if (warnedVariables.has(variableKey)) {
+        return;
+      }
+
+      const totalVariableCases = totalCases.filter(selectableCase => selectableCase.responses.some(response => this.responseMatchesVariableReference(response, variable))
+      ).length;
+      const availableVariableCases = planItem.availableCases.filter(selectableCase => selectableCase.responses.some(response => this.responseMatchesVariableReference(response, variable))
+      ).length;
+      const casesInJobs = Math.max(0, totalVariableCases - availableVariableCases);
+
+      warnedVariables.add(variableKey);
+      if (
+        totalVariableCases === 0 ||
+        casesInJobs === 0 ||
+        availableVariableCases >= totalVariableCases
+      ) {
+        return;
+      }
+
+      warnings.push({
+        unitName: variable.unitName,
+        variableId: variable.variableId,
+        message: `Variable: nur noch ${availableVariableCases} von ${totalVariableCases} Fällen verfügbar`,
+        casesInJobs,
+        availableCases: availableVariableCases
+      });
+    });
+  }
+
   private getDistributionSeed(
     workspaceId: number,
     request: Pick<
@@ -5749,6 +6020,66 @@ export class CodingJobService {
     }
 
     return result;
+  }
+
+  private getBundleCaseKey(response: SlimResponse): string {
+    return [
+      response.personLogin,
+      response.personCode,
+      response.personGroup,
+      response.bookletName,
+      response.unitName
+    ].join('\u001F');
+  }
+
+  private getSelectableCaseKey(
+    item: DistributionPlanItem,
+    response: SlimResponse
+  ): string {
+    return item.type === 'bundle' ?
+      this.getBundleCaseKey(response) :
+      String(response.id);
+  }
+
+  private buildSelectableCasesForItem(
+    item: DistributionPlanItem,
+    allItemResponses: SlimResponse[],
+    sortedResponses: SlimResponse[],
+    assignedResponseIds: Set<number>
+  ): DistributionSelectableCase[] {
+    if (item.type !== 'bundle') {
+      return sortedResponses.map(response => ({
+        item,
+        response,
+        responses: [response],
+        caseKey: this.getSelectableCaseKey(item, response)
+      }));
+    }
+
+    const assignedBundleCaseKeys = new Set(
+      allItemResponses
+        .filter(response => assignedResponseIds.has(response.id))
+        .map(response => this.getBundleCaseKey(response))
+    );
+    const casesByKey = new Map<string, SlimResponse[]>();
+
+    sortedResponses.forEach(response => {
+      const caseKey = this.getBundleCaseKey(response);
+      if (assignedBundleCaseKeys.has(caseKey)) {
+        return;
+      }
+
+      const responses = casesByKey.get(caseKey) || [];
+      responses.push(response);
+      casesByKey.set(caseKey, responses);
+    });
+
+    return Array.from(casesByKey.entries()).map(([caseKey, responses]) => ({
+      item,
+      response: responses[0],
+      responses,
+      caseKey
+    }));
   }
 
   private normalizeDistributionCoders(
@@ -5951,9 +6282,9 @@ export class CodingJobService {
   private selectCasesWithGlobalCap(
     planItems: DistributionPlanItem[],
     maxCodingCases?: number
-  ): { item: DistributionPlanItem; response: SlimResponse }[] {
+  ): DistributionSelectableCase[] {
     const totalAvailable = planItems.reduce(
-      (sum, item) => sum + item.availableResponses.length,
+      (sum, item) => sum + item.availableCases.length,
       0
     );
     const targetCases =
@@ -5962,10 +6293,9 @@ export class CodingJobService {
         totalAvailable;
     const queues = planItems.map(item => ({
       item,
-      responses: [...item.availableResponses]
+      cases: [...item.availableCases]
     }));
-    const selected: { item: DistributionPlanItem; response: SlimResponse }[] =
-      [];
+    const selected: DistributionSelectableCase[] = [];
     const selectedResponseIds = new Set<number>();
 
     while (selected.length < targetCases) {
@@ -5976,15 +6306,20 @@ export class CodingJobService {
           break;
         }
 
-        while (queue.responses.length > 0) {
-          const response = queue.responses.shift();
-          if (!response || selectedResponseIds.has(response.id)) {
+        while (queue.cases.length > 0) {
+          const selectableCase = queue.cases.shift();
+          if (
+            !selectableCase ||
+            selectableCase.responses.some(response => selectedResponseIds.has(response.id))
+          ) {
             continue;
           }
 
-          selected.push({ item: queue.item, response });
-          queue.item.selectedResponses.push(response);
-          selectedResponseIds.add(response.id);
+          selected.push(selectableCase);
+          queue.item.selectedResponses.push(...selectableCase.responses);
+          selectableCase.responses.forEach(response => {
+            selectedResponseIds.add(response.id);
+          });
           progressed = true;
           break;
         }
@@ -5996,6 +6331,14 @@ export class CodingJobService {
     }
 
     return selected;
+  }
+
+  private getDoubleCodingDistributionKey(
+    selectedCase: DistributionSelectableCase
+  ): string {
+    return selectedCase.item.type === 'bundle' ?
+      selectedCase.item.itemKey :
+      this.getResponseVariableKey(selectedCase.response);
   }
 
   private getDoubleCodingCount(
@@ -6100,17 +6443,18 @@ export class CodingJobService {
     coderLoads: Map<number, { tasks: number; doubleTasks: number }>,
     pairCounts: Map<string, number>,
     seed: string,
-    response: SlimResponse
+    response: SlimResponse,
+    taskCount: number
   ): NormalizedDistributionCoder[] {
     return [...coderCombinations].sort((a, b) => {
       const score = (combination: NormalizedDistributionCoder[]) => {
         const projectedRatios = combination.map(coder => {
           const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-          return (load.tasks + 1) / coder.weight;
+          return (load.tasks + taskCount) / coder.weight;
         });
         const projectedDoubleRatios = combination.map(coder => {
           const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-          return (load.doubleTasks + 1) / coder.weight;
+          return (load.doubleTasks + taskCount) / coder.weight;
         });
         const pairKey = combination
           .map(coder => coder.id)
@@ -6218,6 +6562,13 @@ export class CodingJobService {
           .itemVariables
       )
     );
+    const bundleVariableKeys = new Set(
+      items
+        .filter(itemObj => itemObj.type === 'bundle')
+        .flatMap(itemObj => this.getItemDetails(itemObj, caseOrderingMode, bundleNameCounts)
+          .itemVariables)
+        .map(variable => `${variable.unitName}::${variable.variableId}`)
+    );
     const allResponses = await this.getSlimResponsesForVariables(
       workspaceId,
       allVariables,
@@ -6234,7 +6585,7 @@ export class CodingJobService {
 
     for (const variable of allVariables) {
       const variableKey = `${variable.unitName}::${variable.variableId}`;
-      if (warnedVariables.has(variableKey)) {
+      if (warnedVariables.has(variableKey) || bundleVariableKeys.has(variableKey)) {
         continue;
       }
 
@@ -6295,6 +6646,21 @@ export class CodingJobService {
         distributionSeed,
         itemKey
       );
+      const totalResponsesForBundleCases =
+        itemObj.type === 'bundle' ?
+          this.sortResponsesForDistribution(
+            this.getDistributableResponses(
+              allItemResponses,
+              new Set(),
+              matchingFlags,
+              aggregationThreshold,
+              response => isDerivedVariable(response.unitName, response.variableid)
+            ).filteredResponses,
+            itemCaseOrderingMode,
+            distributionSeed,
+            itemKey
+          ) :
+          [];
       const planItem: DistributionPlanItem = {
         type: itemObj.type,
         item: itemObj.item,
@@ -6305,9 +6671,29 @@ export class CodingJobService {
         uniqueCases,
         totalResponses,
         availableResponses,
+        availableCases: [],
         caseStatusesByResponseId,
         selectedResponses: []
       };
+      planItem.availableCases = this.buildSelectableCasesForItem(
+        planItem,
+        allItemResponses,
+        availableResponses,
+        assignedResponseIds
+      );
+      if (itemObj.type === 'bundle') {
+        this.addBundleAvailabilityWarnings(
+          warnings,
+          warnedVariables,
+          planItem,
+          this.buildSelectableCasesForItem(
+            planItem,
+            allItemResponses,
+            totalResponsesForBundleCases,
+            new Set()
+          )
+        );
+      }
 
       planItems.push(planItem);
       aggregationInfo[itemKey] = {
@@ -6331,23 +6717,23 @@ export class CodingJobService {
       request.maxCodingCases
     );
     this.getDoubleCodingSettings(request);
-    const selectedCaseCountsByVariableKey = new Map<string, number>();
+    const selectedCaseCountsByDistributionKey = new Map<string, number>();
     selectedCases.forEach(selectedCase => {
-      const variableKey = this.getResponseVariableKey(selectedCase.response);
-      selectedCaseCountsByVariableKey.set(
-        variableKey,
-        (selectedCaseCountsByVariableKey.get(variableKey) || 0) + 1
+      const distributionKey = this.getDoubleCodingDistributionKey(selectedCase);
+      selectedCaseCountsByDistributionKey.set(
+        distributionKey,
+        (selectedCaseCountsByDistributionKey.get(distributionKey) || 0) + 1
       );
     });
-    const doubleCodingCountsByVariableKey = new Map<string, number>();
-    selectedCaseCountsByVariableKey.forEach((caseCount, variableKey) => {
-      doubleCodingCountsByVariableKey.set(
-        variableKey,
+    const doubleCodingCountsByDistributionKey = new Map<string, number>();
+    selectedCaseCountsByDistributionKey.forEach((caseCount, distributionKey) => {
+      doubleCodingCountsByDistributionKey.set(
+        distributionKey,
         this.getDoubleCodingCount(request, caseCount)
       );
     });
     const totalDoubleCodingCount = Array.from(
-      doubleCodingCountsByVariableKey.values()
+      doubleCodingCountsByDistributionKey.values()
     ).reduce((sum, count) => sum + count, 0);
 
     if (
@@ -6370,22 +6756,23 @@ export class CodingJobService {
       totalDoubleCodingCount > 0 ?
         this.getCoderCombinations(coders, codersPerDoubleCodedCase) :
         [];
-    const assignedDoubleCodingCountsByVariableKey = new Map<string, number>();
+    const assignedDoubleCodingCountsByDistributionKey = new Map<string, number>();
 
     selectedCases.forEach(selectedCase => {
-      const variableKey = this.getResponseVariableKey(selectedCase.response);
+      const distributionKey = this.getDoubleCodingDistributionKey(selectedCase);
       const assignedDoubleCodingCount =
-        assignedDoubleCodingCountsByVariableKey.get(variableKey) || 0;
+        assignedDoubleCodingCountsByDistributionKey.get(distributionKey) || 0;
       const isDoubleCoded =
         assignedDoubleCodingCount <
-        (doubleCodingCountsByVariableKey.get(variableKey) || 0);
+        (doubleCodingCountsByDistributionKey.get(distributionKey) || 0);
       const assignedCoders = isDoubleCoded ?
         this.chooseDoubleCodingCoders(
           doubleCodingCoderCombinations,
           coderLoads,
           pairCounts,
           distributionSeed,
-          selectedCase.response
+          selectedCase.response,
+          selectedCase.responses.length
         ) :
         [
           this.chooseSingleCoder(
@@ -6398,8 +6785,8 @@ export class CodingJobService {
       const assignedCoderIds = assignedCoders.map(coder => coder.id);
 
       if (isDoubleCoded) {
-        assignedDoubleCodingCountsByVariableKey.set(
-          variableKey,
+        assignedDoubleCodingCountsByDistributionKey.set(
+          distributionKey,
           assignedDoubleCodingCount + 1
         );
         const pairKey = [...assignedCoderIds].sort((a, b) => a - b).join('-');
@@ -6408,9 +6795,9 @@ export class CodingJobService {
 
       assignedCoders.forEach(coder => {
         const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-        load.tasks += 1;
+        load.tasks += selectedCase.responses.length;
         if (isDoubleCoded) {
-          load.doubleTasks += 1;
+          load.doubleTasks += selectedCase.responses.length;
         }
         coderLoads.set(coder.id, load);
 
@@ -6433,7 +6820,7 @@ export class CodingJobService {
           jobsByItemAndCoder.get(selectedCase.item.itemKey) ||
           new Map<number, SlimResponse[]>();
         const coderResponses = itemJobs.get(coder.id) || [];
-        coderResponses.push(selectedCase.response);
+        coderResponses.push(...selectedCase.responses);
         itemJobs.set(coder.id, coderResponses);
         jobsByItemAndCoder.set(selectedCase.item.itemKey, itemJobs);
       });
@@ -6441,6 +6828,7 @@ export class CodingJobService {
       plannedCases.push({
         item: selectedCase.item,
         response: selectedCase.response,
+        responses: selectedCase.responses,
         isDoubleCoded,
         assignedCoderIds
       });
@@ -6454,9 +6842,12 @@ export class CodingJobService {
         plannedCase => plannedCase.isDoubleCoded
       ).length;
       const singleCases = itemCases.length - doubleCases;
-      const codingTasksTotal = Object.values(
-        distributionByCoderId[planItem.itemKey]
-      ).reduce((sum, value) => sum + value, 0);
+      const codingTasksTotal = itemCases.reduce(
+        (sum, itemCase) => (
+          sum + itemCase.responses.length * itemCase.assignedCoderIds.length
+        ),
+        0
+      );
 
       doubleCodingInfo[planItem.itemKey].distinctCases = itemCases.length;
       doubleCodingInfo[planItem.itemKey].codingTasksTotal = codingTasksTotal;
@@ -6706,8 +7097,7 @@ export class CodingJobService {
         distributionSeed,
         itemKey
       );
-
-      planItems.push({
+      const planItem: DistributionPlanItem = {
         type: itemObj.type,
         item: itemObj.item,
         itemKey,
@@ -6717,9 +7107,18 @@ export class CodingJobService {
         uniqueCases,
         totalResponses,
         availableResponses,
+        availableCases: [],
         caseStatusesByResponseId,
         selectedResponses: []
-      });
+      };
+      planItem.availableCases = this.buildSelectableCasesForItem(
+        planItem,
+        allItemResponses,
+        availableResponses,
+        assignedResponseIds
+      );
+
+      planItems.push(planItem);
     }
 
     const selectedCases = this.selectCasesWithGlobalCap(
@@ -6728,13 +7127,15 @@ export class CodingJobService {
     );
     const usageByVariable = new Map<string, DistributionVariableUsageByStatus>();
 
-    selectedCases.forEach(({ item, response }) => {
-      this.addResponseToVariableUsageByStatus(
-        usageByVariable,
-        response,
-        item.caseStatusesByResponseId.get(response.id) ||
-          this.getResponseUsageStatus(response)
-      );
+    selectedCases.forEach(({ item, responses }) => {
+      responses.forEach(response => {
+        this.addResponseToVariableUsageByStatus(
+          usageByVariable,
+          response,
+          item.caseStatusesByResponseId.get(response.id) ||
+            this.getResponseUsageStatus(response)
+        );
+      });
     });
 
     return usageByVariable;

--- a/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
+++ b/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
@@ -1156,7 +1156,27 @@ export class WsgCodingJobController {
           variablePage: { type: 'string' },
           bookletName: { type: 'string' },
           personLogin: { type: 'string' },
-          personCode: { type: 'string' }
+          personCode: { type: 'string' },
+          variableBundleId: { type: 'number', nullable: true },
+          variableBundleCaseOrderingMode: {
+            type: 'string',
+            enum: ['continuous', 'alternating'],
+            nullable: true
+          },
+          variableBundleCaseVariables: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                unitName: { type: 'string' },
+                variableId: { type: 'string' },
+                responseId: { type: 'number', nullable: true },
+                statusV1: { type: 'number', nullable: true },
+                isManualCodingUnit: { type: 'boolean' },
+                isAutoCoded: { type: 'boolean' }
+              }
+            }
+          }
         }
       }
     }
@@ -1187,6 +1207,16 @@ export class WsgCodingJobController {
         personLogin: string;
         personCode: string;
         personGroup: string;
+        variableBundleId: number | null;
+        variableBundleCaseOrderingMode: 'continuous' | 'alternating' | null;
+        variableBundleCaseVariables: {
+          unitName: string;
+          variableId: string;
+          responseId: number | null;
+          statusV1: number | null;
+          isManualCodingUnit: boolean;
+          isAutoCoded: boolean;
+        }[];
         isDoubleCoded: boolean;
         otherCoders: string[];
       }>

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
@@ -1,12 +1,20 @@
 .code-row {
   display: flex;
-  flex-direction: column;
-  padding: 8px 12px;
-  margin-bottom: 4px;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 5px 8px;
+  margin-bottom: 2px;
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.2s ease, border-color 0.2s ease;
   border: 2px solid transparent;
+}
+
+.code-row.general-instruction-row,
+.code-row.legacy-code-row {
+  flex-direction: column;
+  gap: 0;
 }
 
 .code-row:hover {
@@ -105,6 +113,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .code-id {
@@ -142,9 +151,10 @@
 }
 
 .code-instruction {
-  margin-left: 24px;
-  margin-top: 4px;
+  margin-left: 0;
+  margin-top: 0;
   color: rgba(0, 0, 0, 0.78);
+  min-width: 0;
 }
 
 .code-row:not(.general-instruction-row) .code-instruction {
@@ -153,6 +163,15 @@
 
 .code-instruction img {
   max-width: none;
+}
+
+::ng-deep .code-row:not(.general-instruction-row) .code-instruction p:first-child {
+  display: inline;
+  margin-top: 0;
+}
+
+::ng-deep .code-row:not(.general-instruction-row) .code-instruction p:last-child {
+  margin-bottom: 0;
 }
 
 .hint {
@@ -217,13 +236,15 @@
 
 /* Enhanced Progress Section */
 .progress-info {
-  text-align: center;
-  padding: 12px 8px;
-  margin-bottom: 12px;
-  background: rgba(0, 0, 0, 0.04);
-  border-radius: 8px;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 6px;
+  padding: 2px 4px;
+  margin-bottom: 4px;
   font-size: 14px;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+  line-height: 1.25;
+  flex-wrap: wrap;
 }
 
 .progress-text {
@@ -234,7 +255,6 @@
 .progress-numbers {
   font-weight: 600;
   color: #1976d2;
-  margin: 0 8px;
 }
 
 .progress-percentage {
@@ -242,21 +262,21 @@
 }
 
 .progress-open {
-  display: block;
-  margin-top: 4px;
+  display: inline;
+  margin-left: 2px;
   color: #f57c00;
-  font-size: 13px;
+  font-size: 12px;
 }
 
 .custom-progress-bar {
-  margin-bottom: 16px;
-  height: 10px;
-  border-radius: 5px;
+  margin-bottom: 8px;
+  height: 6px;
+  border-radius: 3px;
   background: rgba(0, 0, 0, 0.1);
 }
 
 .custom-progress-bar ::ng-deep .mat-mdc-progress-bar-primary-bar {
-  border-radius: 5px;
+  border-radius: 3px;
 }
 
 /* Progress colors are dynamically set via Material theme colors */
@@ -265,9 +285,9 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 12px;
-  margin-bottom: 8px;
-  padding: 4px 0;
+  gap: 8px;
+  margin-bottom: 6px;
+  padding: 2px 0;
 }
 
 .nav-controls {
@@ -324,10 +344,53 @@
 }
 
 .uncertain-codes-section {
-  margin-top: 16px;
-  padding-top: 8px;
+  margin-top: 0;
+  padding-top: 6px;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   flex-shrink: 0;
+}
+
+.auxiliary-section {
+  margin-top: 6px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.auxiliary-section.collapsed {
+  margin-top: 4px;
+}
+
+.auxiliary-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 32px;
+  padding: 3px 2px 3px 8px;
+  border: 0;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.72);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.auxiliary-toggle:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.auxiliary-toggle mat-icon {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  font-size: 20px;
+}
+
+.auxiliary-content {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .nav-button {
@@ -364,6 +427,86 @@
 
 .variable-dropdown-wrapper {
   position: relative;
+}
+
+.variable-chip-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(76px, 1fr));
+  gap: 6px;
+}
+
+.variable-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  min-width: 0;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid rgba(0, 0, 0, 0.23);
+  border-radius: 4px;
+  background: #fff;
+  color: rgba(0, 0, 0, 0.78);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.variable-chip:hover:not(:disabled) {
+  border-color: #1976d2;
+  background: #f5f9ff;
+}
+
+.variable-chip.active {
+  border-color: #1976d2;
+  background: #e3f2fd;
+  color: #0d47a1;
+  font-weight: 600;
+}
+
+.variable-chip.complete:not(.active) {
+  border-color: rgba(46, 125, 50, 0.45);
+  background: #f1f8e9;
+}
+
+.variable-chip.auto-coded {
+  border-style: dashed;
+  border-color: rgba(97, 97, 97, 0.7);
+  background:
+    repeating-linear-gradient(
+      135deg,
+      rgba(117, 117, 117, 0.08) 0,
+      rgba(117, 117, 117, 0.08) 4px,
+      transparent 4px,
+      transparent 8px
+    ),
+    #fafafa;
+  color: rgba(0, 0, 0, 0.66);
+}
+
+.variable-chip:disabled {
+  opacity: 0.72;
+  cursor: not-allowed;
+}
+
+.variable-chip-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.variable-chip-count {
+  flex: 0 0 auto;
+  color: rgba(0, 0, 0, 0.62);
+  font-size: 11px;
+}
+
+.variable-chip-auto {
+  flex: 0 0 auto;
+  color: rgba(0, 0, 0, 0.62);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
 }
 
 .variable-trigger-btn {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
@@ -2,15 +2,34 @@
   @if (showProgress) {
   <div class="progress-info">
     <span class="progress-text">{{ 'replay.coding-progress' | translate }}</span>
-    <span class="progress-numbers">{{ completedCount }}/{{ totalUnits }}</span>
-    <span class="progress-percentage">({{ progressPercentage }}%)</span>
+    <span class="progress-numbers">{{ progressSummary }}</span>
     @if (openCount > 0) {
-    <span class="progress-open">{{ 'replay.open-count' | translate }}: {{ openCount }}</span>
+    <span class="progress-open">{{ 'replay.open-count' | translate }} {{ openCount }}</span>
     }
   </div>
-  <mat-progress-bar mode="determinate" [value]="progressPercentage" class="custom-progress-bar"></mat-progress-bar>
-  @if (availableVariables.length > 1) {
+  <mat-progress-bar mode="determinate" [value]="progressPercentage" class="custom-progress-bar"
+    [matTooltip]="progressTooltip"></mat-progress-bar>
+  @if (shouldShowBundleVariableChips || (!usesCompactBundleVariableMode && availableVariables.length > 1)) {
   <div class="variable-selector-section">
+    @if (shouldShowBundleVariableChips) {
+    <div class="variable-chip-row">
+      @for (v of activeBundleVariables; track v.key) {
+      @let prog = getProgressForKey(v.key);
+      <button type="button" class="variable-chip"
+        [class.complete]="!v.isAutoCoded && prog.percentage === 100" [class.auto-coded]="v.isAutoCoded"
+        [class.active]="v.navigationKey === activeBundleVariableKey"
+        [disabled]="isNavigationDisabled || !v.isNavigable" (click)="selectVariable(v.navigationKey)"
+        [matTooltip]="v.isAutoCoded ? ('coding.auto-coded-bundle-variable-tooltip' | translate: { variableId: v.variableId }) : (v.unitName + ' / ' + v.variableId)">
+        <span class="variable-chip-name">{{ v.variableId }}</span>
+        @if (v.isAutoCoded) {
+        <span class="variable-chip-auto">{{ 'coding.auto-coded-short' | translate }}</span>
+        } @else {
+        <span class="variable-chip-count">{{ prog.coded }}/{{ prog.total }}</span>
+        }
+      </button>
+      }
+    </div>
+    } @else {
     <div class="variable-dropdown-wrapper">
       <button class="variable-trigger-btn" (click)="toggleVariablePanel()" [disabled]="isNavigationDisabled" type="button">
         <span class="variable-trigger-label">
@@ -45,6 +64,7 @@
       </div>
       }
     </div>
+    }
   </div>
   }
 
@@ -84,6 +104,12 @@
         <mat-icon>pause</mat-icon>
       </button>
       }
+      @if (hasCodingJob && !isCompletedJobReview) {
+      <button mat-icon-button (click)="onNavigateToJobListClick()" class="job-list-button"
+        matTooltip="{{ 'coding.my-coding-jobs.title' | translate }}">
+        <mat-icon>home</mat-icon>
+      </button>
+      }
     </div>
   </div>
   }
@@ -107,6 +133,7 @@
       <div class="code-row" [class.selected]="item.id === selectedCode"
         [class.has-review-code-selection]="hasReviewCodeSelection(item.id)"
         [class.read-only]="isReadOnly || isRegularSelectionDisabled" *ngFor="let item of regularCodes;"
+        [attr.data-code-selector-code-id]="item.id"
         [style.cursor]="(isReadOnly || isRegularSelectionDisabled) ? 'not-allowed' : 'pointer'"
         [matTooltip]="getReviewCodeSelectionTooltip(item.id)"
         [matTooltipDisabled]="!hasReviewCodeSelection(item.id)"
@@ -133,38 +160,51 @@
     </div>
   </div>
 
-  <div class="uncertain-codes-section fixed-section">
-    <div class="code-row" [class.selected]="item.id === selectedCodingIssueOption"
-      [class.has-review-code-selection]="hasReviewCodeSelection(item.id)"
-      [class.read-only]="isCodingIssueOptionDisabled(item)" *ngFor="let item of codingIssueOptionCodes;"
-      [style.cursor]="isCodingIssueOptionDisabled(item) ? 'not-allowed' : 'pointer'"
-      [attr.aria-disabled]="isCodingIssueOptionDisabled(item)"
-      [matTooltip]="getCodingIssueOptionRowTooltip(item)"
-      [matTooltipDisabled]="!getCodingIssueOptionRowTooltip(item)"
-      (click)="isCodingIssueOptionDisabled(item) ? null : onSelect(item.id)">
-      <div class="code-content">
-        <span class="shortcut-icon" *ngIf="getShortcutLabel(item.id)">{{ getShortcutLabel(item.id) }}</span>
-        <span class="uncertain-text">{{ item.label }}</span>
-        <span class="review-code-badge" *ngIf="getReviewCodeSelectionCount(item.id) as reviewCoderCount">
-          <mat-icon>group</mat-icon>
-          <span>{{ reviewCoderCount }}</span>
-        </span>
+  <div class="auxiliary-section fixed-section" [class.collapsed]="!isAuxiliarySectionExpanded">
+    <button type="button" class="auxiliary-toggle" (click)="toggleAuxiliarySection()"
+      [attr.aria-expanded]="isAuxiliarySectionExpanded">
+      <span>{{ 'code-selector.general-codes-and-notes' | translate }}</span>
+      <mat-icon>{{ isAuxiliarySectionExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+    </button>
+
+    @if (isAuxiliarySectionExpanded) {
+    <div class="auxiliary-content">
+      <div class="uncertain-codes-section">
+        <div class="code-row" [class.selected]="item.id === selectedCodingIssueOption"
+          [class.has-review-code-selection]="hasReviewCodeSelection(item.id)"
+          [class.read-only]="isCodingIssueOptionDisabled(item)" *ngFor="let item of codingIssueOptionCodes;"
+          [attr.data-code-selector-code-id]="item.id"
+          [style.cursor]="isCodingIssueOptionDisabled(item) ? 'not-allowed' : 'pointer'"
+          [attr.aria-disabled]="isCodingIssueOptionDisabled(item)"
+          [matTooltip]="getCodingIssueOptionRowTooltip(item)"
+          [matTooltipDisabled]="!getCodingIssueOptionRowTooltip(item)"
+          (click)="isCodingIssueOptionDisabled(item) ? null : onSelect(item.id)">
+          <div class="code-content">
+            <span class="shortcut-icon" *ngIf="getShortcutLabel(item.id)">{{ getShortcutLabel(item.id) }}</span>
+            <span class="uncertain-text">{{ item.label }}</span>
+            <span class="review-code-badge" *ngIf="getReviewCodeSelectionCount(item.id) as reviewCoderCount">
+              <mat-icon>group</mat-icon>
+              <span>{{ reviewCoderCount }}</span>
+            </span>
+          </div>
+        </div>
       </div>
+
+      <div class="deselect-container">
+        <button mat-button class="deselect-button" [disabled]="isReadOnly" (click)="deselectAll()">Auswahl entfernen</button>
+      </div>
+
+      @if (allowComments) {
+      <mat-form-field appearance="outline" class="notes-field">
+        <textarea #notesTextarea matInput [(ngModel)]="coderNotes" (input)="onNotesChanged()"
+          [disabled]="isReadOnly" [attr.aria-invalid]="newCodeCommentValidationError ? 'true' : null"
+          placeholder="{{ 'code-selector.coder-notes-placeholder' | translate }}" rows="3"></textarea>
+      </mat-form-field>
+      <div *ngIf="newCodeCommentValidationError" class="notes-validation-error" role="alert">
+        {{ 'code-selector.new-code-comment-required' | translate }}
+      </div>
+      }
     </div>
+    }
   </div>
-
-  <div class="deselect-container fixed-section">
-    <button mat-button class="deselect-button" [disabled]="isReadOnly" (click)="deselectAll()">Auswahl entfernen</button>
-  </div>
-
-  @if (allowComments) {
-  <mat-form-field appearance="outline" class="notes-field fixed-section">
-    <textarea #notesTextarea matInput [(ngModel)]="coderNotes" (input)="onNotesChanged()"
-      [disabled]="isReadOnly" [attr.aria-invalid]="newCodeCommentValidationError ? 'true' : null"
-      placeholder="{{ 'code-selector.coder-notes-placeholder' | translate }}" rows="3"></textarea>
-  </mat-form-field>
-  <div *ngIf="newCodeCommentValidationError" class="notes-validation-error fixed-section" role="alert">
-    {{ 'code-selector.new-code-comment-required' | translate }}
-  </div>
-  }
 </div>

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -280,6 +280,84 @@ describe('CodeSelectorComponent', () => {
     });
   });
 
+  it('shows progress in a compact summary with open count in the tooltip', () => {
+    const translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('de', {
+      replay: {
+        'coding-progress': 'Kodierfortschritt:',
+        'open-count': 'Offen:'
+      }
+    });
+    translateService.setDefaultLang('de');
+    translateService.use('de');
+
+    component.showProgress = true;
+    component.completedCount = 6;
+    component.totalUnits = 80;
+    component.progressPercentage = 8;
+    component.openCount = 74;
+
+    fixture.detectChanges();
+
+    expect(component.progressSummary).toBe('6/80 (8%)');
+    expect(component.progressTooltip).toBe('Kodierfortschritt: 6/80 (8%) · Offen: 74');
+    expect(fixture.nativeElement.querySelector('.progress-info').textContent).toContain('6/80 (8%)');
+  });
+
+  it('keeps general coding issue options and notes expanded by default and allows collapsing them', () => {
+    component.codingScheme = mixedCodingScheme;
+    component.variableId = 'VAR1';
+
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, mixedCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR1', false)
+    });
+    fixture.detectChanges();
+
+    expect(component.isAuxiliarySectionExpanded).toBe(true);
+    expect(fixture.nativeElement.querySelectorAll('.uncertain-codes-section .code-row')).toHaveLength(4);
+    expect(fixture.nativeElement.querySelector('textarea')).toBeTruthy();
+
+    component.toggleAuxiliarySection();
+    fixture.detectChanges();
+
+    expect(component.isAuxiliarySectionExpanded).toBe(false);
+    expect(fixture.nativeElement.querySelector('.uncertain-codes-section')).toBeNull();
+    expect(fixture.nativeElement.querySelector('textarea')).toBeNull();
+  });
+
+  it('expands and scrolls to a general code selected by numpad shortcut', () => {
+    jest.useFakeTimers();
+    const scrollSpy = jest.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollSpy;
+    component.codingScheme = mixedCodingScheme;
+    component.variableId = 'VAR1';
+    component.isAuxiliarySectionExpanded = false;
+
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, mixedCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR1', false)
+    });
+    jest.runOnlyPendingTimers();
+    fixture.detectChanges();
+
+    const event = new KeyboardEvent('keydown', { code: 'NumpadAdd' });
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+    component.handleKeyboardEvent(event);
+    fixture.detectChanges();
+    jest.runOnlyPendingTimers();
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(component.isAuxiliarySectionExpanded).toBe(true);
+    expect(component.selectedCodingIssueOption).toBe(-2);
+    expect(fixture.nativeElement.querySelector('[data-code-selector-code-id="-2"].selected')).toBeTruthy();
+    expect(scrollSpy).toHaveBeenCalled();
+
+    HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    jest.useRealTimers();
+  });
+
   it('keeps manual codes selectable when mixed with empty manual instructions', () => {
     component.codingScheme = mixedCodingScheme;
     component.variableId = 'VAR1';
@@ -589,6 +667,300 @@ describe('CodeSelectorComponent', () => {
     expect(scrollSpy).toHaveBeenCalled();
     expect(focusSpy).toHaveBeenCalled();
     jest.useRealTimers();
+  });
+
+  it('shows compact variable chips for small alternating bundles', () => {
+    component.showProgress = true;
+    component.unitsData = {
+      id: 1,
+      name: 'job',
+      currentUnitIndex: 0,
+      units: [
+        {
+          id: 1,
+          name: 'UNIT1',
+          alias: 'UNIT1',
+          bookletId: 0,
+          variableId: 'V1',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating'
+        },
+        {
+          id: 2,
+          name: 'UNIT1',
+          alias: 'UNIT1',
+          bookletId: 0,
+          variableId: 'V2',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating'
+        }
+      ]
+    };
+
+    fixture.detectChanges();
+
+    expect(component.shouldShowBundleVariableChips).toBe(true);
+    expect(fixture.nativeElement.querySelectorAll('.variable-chip')).toHaveLength(2);
+    expect(fixture.nativeElement.querySelector('.variable-trigger-btn')).toBeNull();
+  });
+
+  it('marks auto-coded bundle variables as disabled chips', () => {
+    const translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('de', {
+      coding: {
+        'auto-coded-short': 'Auto',
+        'auto-coded-bundle-variable-tooltip': 'Variable {{variableId}} ist in diesem Bundel automatisch kodiert.'
+      }
+    });
+    translateService.setDefaultLang('de');
+    translateService.use('de');
+
+    component.showProgress = true;
+    component.unitsData = {
+      id: 1,
+      name: 'job',
+      currentUnitIndex: 0,
+      units: [
+        {
+          id: 1,
+          name: 'UNIT1',
+          alias: 'UNIT1',
+          bookletId: 0,
+          variableId: 'V1',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating',
+          variableBundleCaseVariables: [
+            {
+              unitName: 'UNIT1',
+              variableId: 'V1',
+              responseId: 1,
+              statusV1: 8,
+              isManualCodingUnit: true,
+              isAutoCoded: false
+            },
+            {
+              unitName: 'UNIT1',
+              variableId: 'V2',
+              responseId: 2,
+              statusV1: 5,
+              isManualCodingUnit: false,
+              isAutoCoded: true
+            }
+          ]
+        }
+      ]
+    };
+
+    fixture.detectChanges();
+
+    const chips = fixture.nativeElement.querySelectorAll('.variable-chip');
+    expect(chips).toHaveLength(2);
+    expect(chips[1].classList.contains('auto-coded')).toBe(true);
+    expect(chips[1].disabled).toBe(true);
+    expect(chips[1].textContent).toContain('Auto');
+  });
+
+  it('uses unit aliases for bundle chip navigation when bundle variables use unit names', () => {
+    component.showProgress = true;
+    component.unitsData = {
+      id: 1,
+      name: 'job',
+      currentUnitIndex: 0,
+      units: [
+        {
+          id: 1,
+          name: 'UNIT_KEY',
+          alias: 'UNIT_ALIAS',
+          bookletId: 0,
+          variableId: 'V1',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating',
+          variableBundleCaseVariables: [
+            {
+              unitName: 'UNIT_KEY',
+              variableId: 'V1',
+              responseId: 1,
+              statusV1: 8,
+              isManualCodingUnit: true,
+              isAutoCoded: false
+            },
+            {
+              unitName: 'UNIT_KEY',
+              variableId: 'V2',
+              responseId: 2,
+              statusV1: 8,
+              isManualCodingUnit: true,
+              isAutoCoded: false
+            }
+          ]
+        },
+        {
+          id: 2,
+          name: 'UNIT_KEY',
+          alias: 'UNIT_ALIAS',
+          bookletId: 0,
+          variableId: 'V2',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating'
+        }
+      ]
+    };
+    component.codingService = {
+      isUnitCoded: jest.fn().mockReturnValue(false)
+    } as never;
+    const emitSpy = jest.spyOn(component.unitChanged, 'emit');
+
+    fixture.detectChanges();
+
+    const chips = fixture.nativeElement.querySelectorAll('.variable-chip');
+    expect(chips).toHaveLength(2);
+    expect(chips[0].classList.contains('active')).toBe(true);
+    expect(component.activeBundleVariables.map(variable => variable.key)).toEqual([
+      'UNIT_ALIAS::V1',
+      'UNIT_ALIAS::V2'
+    ]);
+
+    chips[1].click();
+
+    expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[1]);
+  });
+
+  it('navigates bundle chips within the current bundle case only', () => {
+    component.showProgress = true;
+    component.unitsData = {
+      id: 1,
+      name: 'job',
+      currentUnitIndex: 2,
+      units: [
+        {
+          id: 1,
+          name: 'UNIT_KEY',
+          alias: 'UNIT_ALIAS',
+          bookletId: 0,
+          testPerson: 'person-a@code-a@group@booklet',
+          variableId: 'V1',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating'
+        },
+        {
+          id: 2,
+          name: 'UNIT_KEY',
+          alias: 'UNIT_ALIAS',
+          bookletId: 0,
+          testPerson: 'person-a@code-a@group@booklet',
+          variableId: 'V2',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating'
+        },
+        {
+          id: 3,
+          name: 'UNIT_KEY',
+          alias: 'UNIT_ALIAS',
+          bookletId: 0,
+          testPerson: 'person-b@code-b@group@booklet',
+          variableId: 'V1',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating',
+          variableBundleCaseVariables: [
+            {
+              unitName: 'UNIT_KEY',
+              variableId: 'V1',
+              responseId: 3,
+              statusV1: 8,
+              isManualCodingUnit: true,
+              isAutoCoded: false
+            },
+            {
+              unitName: 'UNIT_KEY',
+              variableId: 'V2',
+              responseId: 4,
+              statusV1: 8,
+              isManualCodingUnit: true,
+              isAutoCoded: false
+            }
+          ]
+        },
+        {
+          id: 4,
+          name: 'UNIT_KEY',
+          alias: 'UNIT_ALIAS',
+          bookletId: 0,
+          testPerson: 'person-b@code-b@group@booklet',
+          variableId: 'V2',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating'
+        }
+      ]
+    };
+    component.codingService = {
+      isUnitCoded: jest.fn().mockReturnValue(false)
+    } as never;
+    const emitSpy = jest.spyOn(component.unitChanged, 'emit');
+
+    fixture.detectChanges();
+
+    const chips = fixture.nativeElement.querySelectorAll('.variable-chip');
+    expect(chips).toHaveLength(2);
+
+    chips[1].click();
+
+    expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[3]);
+  });
+
+  it('does not create navigable bundle chips for missing manual units from the current case', () => {
+    component.showProgress = true;
+    component.unitsData = {
+      id: 1,
+      name: 'job',
+      currentUnitIndex: 1,
+      units: [
+        {
+          id: 1,
+          name: 'UNIT_KEY',
+          alias: 'UNIT_ALIAS',
+          bookletId: 0,
+          testPerson: 'person-a@code-a@group@booklet',
+          variableId: 'V2',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating'
+        },
+        {
+          id: 2,
+          name: 'UNIT_KEY',
+          alias: 'UNIT_ALIAS',
+          bookletId: 0,
+          testPerson: 'person-b@code-b@group@booklet',
+          variableId: 'V1',
+          variableBundleId: 9,
+          variableBundleCaseOrderingMode: 'alternating',
+          variableBundleCaseVariables: [
+            {
+              unitName: 'UNIT_KEY',
+              variableId: 'V1',
+              responseId: 2,
+              statusV1: 8,
+              isManualCodingUnit: true,
+              isAutoCoded: false
+            },
+            {
+              unitName: 'UNIT_KEY',
+              variableId: 'V2',
+              responseId: 3,
+              statusV1: 8,
+              isManualCodingUnit: true,
+              isAutoCoded: false
+            }
+          ]
+        }
+      ]
+    };
+
+    fixture.detectChanges();
+
+    expect(component.activeBundleVariables.map(variable => variable.variableId)).toEqual(['V1']);
+    expect(component.shouldShowBundleVariableChips).toBe(false);
+    expect(fixture.nativeElement.querySelectorAll('.variable-chip')).toHaveLength(0);
+    expect(fixture.nativeElement.querySelector('.variable-trigger-btn')).toBeNull();
   });
 
   it('hides the pause button for completed job reviews', () => {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -26,6 +26,16 @@ import {
 } from '../../../models/coding-interfaces';
 import { hasManualInstruction } from '../../utils/manual-coding.util';
 
+type BundleVariableChip = {
+  key: string;
+  navigationKey: string;
+  variableId: string;
+  unitName: string;
+  isAutoCoded: boolean;
+  isManualCodingUnit: boolean;
+  isNavigable: boolean;
+};
+
 @Component({
   selector: 'app-code-selector',
   standalone: true,
@@ -65,6 +75,7 @@ export class CodeSelectorComponent implements OnChanges {
   @Output() openNavigateDialog = new EventEmitter<void>();
   @Output() openCommentDialog = new EventEmitter<void>();
   @Output() pauseCodingJob = new EventEmitter<void>();
+  @Output() navigateToJobList = new EventEmitter<void>();
   @Output() unitChanged = new EventEmitter<UnitsReplayUnit>();
   @ViewChild('variablePanel') variablePanel?: ElementRef<HTMLElement>;
   @ViewChild('notesTextarea') notesTextarea?: ElementRef<HTMLTextAreaElement>;
@@ -72,6 +83,7 @@ export class CodeSelectorComponent implements OnChanges {
   selectableItems: SelectableItem[] = [];
   selectedCode: number | null = null;
   selectedCodingIssueOption: number | null = null;
+  isAuxiliarySectionExpanded = true;
   newCodeCommentValidationError = false;
   variableManualInstruction: string | null = null;
   legacySelectedCode: SelectableItem | null = null;
@@ -257,7 +269,7 @@ export class CodeSelectorComponent implements OnChanges {
     throw new Error(`Invalid item type for conversion: ${item.type}`);
   }
 
-  onSelect(codeId: number): void {
+  onSelect(codeId: number, scrollIntoView = false): void {
     if (this.isReadOnly) return;
     const selectedItem = this.selectableItems.find(item => item.id === codeId);
     if (!selectedItem) return;
@@ -272,6 +284,9 @@ export class CodeSelectorComponent implements OnChanges {
       // Clear regular code selection when selecting -3 or -4
       if (codeId === -3 || codeId === -4) {
         this.selectedCode = null;
+      }
+      if (scrollIntoView) {
+        this.isAuxiliarySectionExpanded = true;
       }
     } else {
       this.selectedCode = codeId;
@@ -292,6 +307,10 @@ export class CodeSelectorComponent implements OnChanges {
       code: codeDto,
       codingIssueOption: codingIssueOption
     });
+
+    if (scrollIntoView) {
+      this.scrollCodeIntoView(codeId);
+    }
   }
 
   get regularCodes(): SelectableItem[] {
@@ -396,6 +415,14 @@ export class CodeSelectorComponent implements OnChanges {
     this.pauseCodingJob.emit();
   }
 
+  onNavigateToJobListClick(): void {
+    this.navigateToJobList.emit();
+  }
+
+  toggleAuxiliarySection(): void {
+    this.isAuxiliarySectionExpanded = !this.isAuxiliarySectionExpanded;
+  }
+
   onNotesChanged(): void {
     if (this.isReadOnly) return;
     this.updateNewCodeCommentValidationState();
@@ -409,6 +436,7 @@ export class CodeSelectorComponent implements OnChanges {
     }
 
     if (showValidationMessage) {
+      this.isAuxiliarySectionExpanded = true;
       this.newCodeCommentValidationError = true;
       setTimeout(() => this.notesTextarea?.nativeElement.focus(), 0);
     }
@@ -515,7 +543,7 @@ export class CodeSelectorComponent implements OnChanges {
       const option = this.selectableItems.find(item => item.id === targetId);
       if (option && this.isCodingIssueOptionAvailable(option) && !this.isCodingIssueOptionDisabled(option)) {
         event.preventDefault(); // Prevent default browser action (e.g. quick find with '/')
-        this.onSelect(targetId);
+        this.onSelect(targetId, true);
       }
     }
   }
@@ -536,6 +564,19 @@ export class CodeSelectorComponent implements OnChanges {
 
   get currentNavigationIndex(): number {
     return (this.unitsData?.currentUnitIndex || 0) + 1;
+  }
+
+  get progressSummary(): string {
+    return `${this.completedCount}/${this.totalUnits} (${this.progressPercentage}%)`;
+  }
+
+  get progressTooltip(): string {
+    const progressText = `${this.translateService.instant('replay.coding-progress')} ${this.progressSummary}`;
+    if (this.openCount <= 0) {
+      return progressText;
+    }
+
+    return `${progressText} · ${this.translateService.instant('replay.open-count')} ${this.openCount}`;
   }
 
   isVariablePanelOpen = false;
@@ -590,14 +631,99 @@ export class CodeSelectorComponent implements OnChanges {
     const result: { key: string; variableId: string; unitName: string }[] = [];
     for (const unit of this.unitsData.units) {
       if (unit.variableId) {
-        const key = `${unit.alias || unit.name}::${unit.variableId}`;
+        const key = this.getUnitVariableKey(unit);
         if (!seen.has(key)) {
           seen.add(key);
-          result.push({ key, variableId: unit.variableId, unitName: unit.alias || unit.name });
+          result.push({
+            key,
+            variableId: unit.variableId,
+            unitName: this.getUnitDisplayName(unit)
+          });
         }
       }
     }
     return result;
+  }
+
+  get activeBundleVariables(): BundleVariableChip[] {
+    if (!this.unitsData?.units) return [];
+    const currentUnit = this.unitsData.units[this.unitsData.currentUnitIndex];
+    const bundleId = currentUnit?.variableBundleId;
+    if (!bundleId) return [];
+
+    const seen = new Set<string>();
+    const result: BundleVariableChip[] = [];
+    const bundleCaseVariables = currentUnit.variableBundleCaseVariables || [];
+    if (bundleCaseVariables.length > 0) {
+      for (const variable of bundleCaseVariables) {
+        const matchingUnit = this.findUnitForBundleVariable(currentUnit, variable.unitName, variable.variableId);
+        if (!matchingUnit && !variable.isAutoCoded) {
+          continue;
+        }
+        const unitName = matchingUnit ? this.getUnitDisplayName(matchingUnit) : variable.unitName;
+        const key = matchingUnit ?
+          this.getUnitVariableKey(matchingUnit) :
+          this.getVariableKey(unitName, variable.variableId);
+        if (!seen.has(key)) {
+          seen.add(key);
+          result.push({
+            key,
+            navigationKey: matchingUnit ? this.getUnitCaseVariableKey(matchingUnit) : '',
+            variableId: variable.variableId,
+            unitName,
+            isAutoCoded: variable.isAutoCoded,
+            isManualCodingUnit: variable.isManualCodingUnit,
+            isNavigable: !!matchingUnit && !variable.isAutoCoded
+          });
+        }
+      }
+      return result;
+    }
+
+    for (const unit of this.unitsData.units) {
+      if (
+        !unit.variableId ||
+        unit.variableBundleId !== bundleId ||
+        !this.isSameBundleCase(currentUnit, unit)
+      ) {
+        continue;
+      }
+
+      const unitName = this.getUnitDisplayName(unit);
+      const key = this.getUnitVariableKey(unit);
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push({
+          key,
+          navigationKey: this.getUnitCaseVariableKey(unit),
+          variableId: unit.variableId,
+          unitName,
+          isAutoCoded: false,
+          isManualCodingUnit: true,
+          isNavigable: true
+        });
+      }
+    }
+    return result;
+  }
+
+  get shouldShowBundleVariableChips(): boolean {
+    return this.usesCompactBundleVariableMode &&
+      this.activeBundleVariables.length > 1;
+  }
+
+  get usesCompactBundleVariableMode(): boolean {
+    if (!this.unitsData?.units) return false;
+    const currentUnit = this.unitsData.units[this.unitsData.currentUnitIndex];
+    return currentUnit?.variableBundleCaseOrderingMode === 'alternating' &&
+      this.activeBundleVariables.length < 5;
+  }
+
+  get activeBundleVariableKey(): string {
+    if (!this.unitsData?.units) return '';
+    const unit = this.unitsData.units[this.unitsData.currentUnitIndex];
+    if (!unit?.variableId) return '';
+    return this.getUnitCaseVariableKey(unit);
   }
 
   /** Composite key (unitName::variableId) for the unit currently being displayed. */
@@ -605,7 +731,7 @@ export class CodeSelectorComponent implements OnChanges {
     if (!this.unitsData?.units) return '';
     const unit = this.unitsData.units[this.unitsData.currentUnitIndex];
     if (!unit?.variableId) return '';
-    return `${unit.alias || unit.name}::${unit.variableId}`;
+    return this.getUnitVariableKey(unit);
   }
 
   /** Progress (coded / total) for the unit+variable of the current unit. */
@@ -613,7 +739,7 @@ export class CodeSelectorComponent implements OnChanges {
     if (!this.unitsData?.units || !this.codingService) return null;
     const currentUnit = this.unitsData.units[this.unitsData.currentUnitIndex];
     if (!currentUnit?.variableId) return null;
-    const unitName = currentUnit.alias || currentUnit.name;
+    const unitName = this.getUnitDisplayName(currentUnit);
     const varId = currentUnit.variableId;
     // Count all units with the same unitName+variableId combo
     const variableUnits = this.unitsData.units.filter(
@@ -632,10 +758,7 @@ export class CodeSelectorComponent implements OnChanges {
   jumpToVariable(key: string): void {
     if (this.isNavigationDisabled) return;
     if (!this.unitsData?.units) return;
-    const [unitName, variableId] = key.split('::');
-    const variableUnits = this.unitsData.units
-      .map((unit, index) => ({ unit, index }))
-      .filter(({ unit }) => (unit.alias || unit.name) === unitName && unit.variableId === variableId);
+    const variableUnits = this.getUnitsForVariableKey(key);
     if (variableUnits.length === 0) return;
 
     // Prefer first uncoded unit
@@ -644,5 +767,78 @@ export class CodeSelectorComponent implements OnChanges {
     );
     const target = firstUncoded ?? variableUnits[0];
     this.unitChanged.emit(target.unit);
+  }
+
+  private getUnitsForVariableKey(
+    key: string
+  ): { unit: UnitsReplayUnit; index: number }[] {
+    if (!this.unitsData?.units) return [];
+    if (key.includes('\u001F')) {
+      const [testPerson, unitName, variableId] = key.split('\u001F');
+      return this.unitsData.units
+        .map((unit, index) => ({ unit, index }))
+        .filter(({ unit }) => (
+          (unit.testPerson || '') === testPerson &&
+          this.getUnitDisplayName(unit) === unitName &&
+          unit.variableId === variableId
+        ));
+    }
+
+    const [unitName, variableId] = key.split('::');
+    const variableUnits = this.unitsData.units
+      .map((unit, index) => ({ unit, index }))
+      .filter(({ unit }) => (unit.alias || unit.name) === unitName && unit.variableId === variableId);
+    return variableUnits;
+  }
+
+  private scrollCodeIntoView(codeId: number): void {
+    setTimeout(() => {
+      const row = (this.elementRef.nativeElement as HTMLElement)
+        .querySelector<HTMLElement>(`[data-code-selector-code-id="${codeId}"]`);
+      row?.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+    }, 0);
+  }
+
+  private getUnitDisplayName(unit: Pick<UnitsReplayUnit, 'alias' | 'name'>): string {
+    return unit.alias || unit.name;
+  }
+
+  private getVariableKey(unitName: string, variableId: string): string {
+    return `${unitName}::${variableId}`;
+  }
+
+  private getUnitVariableKey(unit: UnitsReplayUnit): string {
+    return this.getVariableKey(this.getUnitDisplayName(unit), unit.variableId || '');
+  }
+
+  private getUnitCaseVariableKey(unit: UnitsReplayUnit): string {
+    return [
+      unit.testPerson || '',
+      this.getUnitDisplayName(unit),
+      unit.variableId || ''
+    ].join('\u001F');
+  }
+
+  private findUnitForBundleVariable(
+    currentUnit: UnitsReplayUnit,
+    unitName: string,
+    variableId: string
+  ): UnitsReplayUnit | undefined {
+    return this.unitsData?.units.find(unit => (
+      this.isSameBundleCase(currentUnit, unit) &&
+      (unit.name === unitName || unit.alias === unitName) &&
+      unit.variableId === variableId
+    ));
+  }
+
+  private isSameBundleCase(
+    currentUnit: UnitsReplayUnit,
+    candidate: UnitsReplayUnit
+  ): boolean {
+    return (
+      currentUnit.variableBundleId === candidate.variableBundleId &&
+      currentUnit.name === candidate.name &&
+      (currentUnit.testPerson || '') === (candidate.testPerson || '')
+    );
   }
 }

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -818,6 +818,16 @@ export class CodingJobBackendService {
       personLogin: string;
       personCode: string;
       personGroup: string;
+      variableBundleId?: number | null;
+      variableBundleCaseOrderingMode?: 'continuous' | 'alternating' | null;
+      variableBundleCaseVariables?: {
+        unitName: string;
+        variableId: string;
+        responseId: number | null;
+        statusV1: number | null;
+        isManualCodingUnit: boolean;
+        isAutoCoded: boolean;
+      }[];
       isDoubleCoded: boolean;
       otherCoders: string[];
     }>
@@ -839,6 +849,16 @@ export class CodingJobBackendService {
       personLogin: string;
       personCode: string;
       personGroup: string;
+      variableBundleId?: number | null;
+      variableBundleCaseOrderingMode?: 'continuous' | 'alternating' | null;
+      variableBundleCaseVariables?: {
+        unitName: string;
+        variableId: string;
+        responseId: number | null;
+        statusV1: number | null;
+        isManualCodingUnit: boolean;
+        isAutoCoded: boolean;
+      }[];
       isDoubleCoded: boolean;
       otherCoders: string[];
     }>

--- a/apps/frontend/src/app/replay/components/replay/replay.component.html
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.html
@@ -35,50 +35,6 @@
     @if (isCodingMode && hasCodingJobPanelContent()) {
     <div class="resize-handle" (mousedown)="onResizeStart($event)"></div>
     <div class="code-selector-container" [style.width.px]="codePanelWidth" [style.min-width.px]="codePanelWidth">
-      @if (canSwitchAssignedCodingJobs() && assignedCodingJobs.length > 1) {
-      <div class="coding-job-switcher">
-        <mat-form-field appearance="outline" class="coding-job-select">
-          <mat-label>{{ 'replay.job-switcher.label' | translate }}</mat-label>
-          <mat-select
-            [value]="selectedCodingJobKey"
-            [disabled]="isCodingJobSwitchDisabled()"
-            [matTooltip]="getCodingJobSwitchDisabledTooltip()"
-            (selectionChange)="onCodingJobSelectionChange($event.value)">
-            @for (job of assignedCodingJobs; track getCodingJobOptionKey(job)) {
-            <mat-option [value]="getCodingJobOptionKey(job)">
-              <span class="coding-job-option">
-                <span class="coding-job-option-name">{{ job.name }}</span>
-                <span class="coding-job-option-meta">{{ getCodingJobOptionMeta(job) }}</span>
-              </span>
-            </mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
-        @if (isLoadingAssignedCodingJobs || isSwitchingCodingJob) {
-        <mat-icon class="coding-job-switcher-icon">sync</mat-icon>
-        }
-      </div>
-      }
-      @if (canSwitchAssignedCodingJobs() && isLoadingAssignedCodingJobs && assignedCodingJobs.length <= 1) {
-      <div class="coding-job-switcher-message">
-        <mat-icon class="coding-job-switcher-icon">sync</mat-icon>
-        <span>{{ 'replay.job-switcher.loading' | translate }}</span>
-      </div>
-      }
-      @if (canSwitchAssignedCodingJobs() && hasAssignedCodingJobsLoadError) {
-      <div class="coding-job-switcher-message coding-job-switcher-error">
-        <mat-icon>warning</mat-icon>
-        <span>{{ 'replay.job-switcher.load-error' | translate }}</span>
-        <button
-          mat-icon-button
-          type="button"
-          [disabled]="isLoadingAssignedCodingJobs"
-          [matTooltip]="'replay.job-switcher.retry' | translate"
-          (click)="retryLoadAssignedCodingJobs()">
-          <mat-icon>refresh</mat-icon>
-        </button>
-      </div>
-      }
       @if (codingService.codingScheme && codingService.currentVariableId) {
       <app-code-selector [codingScheme]="codingService.codingScheme" [variableId]="codingService.currentVariableId"
         [preSelectedCodeId]="getPreSelectedCodeId(codingService.currentVariableId)"
@@ -98,6 +54,7 @@
         (codeSelected)="onCodeSelected($event)"
         (notesChanged)="onNotesChanged($event)" (openNavigateDialog)="openNavigateDialog()"
         (openCommentDialog)="openCommentDialog()" (pauseCodingJob)="pauseCodingJob()"
+        (navigateToJobList)="navigateToJobList()"
         (unitChanged)="handleUnitChanged($event)">
       </app-code-selector>
       }

--- a/apps/frontend/src/app/replay/components/replay/replay.component.scss
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.scss
@@ -38,70 +38,6 @@
     flex-direction: column;
   }
 
-  .coding-job-switcher {
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    margin-bottom: 12px;
-    flex-shrink: 0;
-  }
-
-  .coding-job-select {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .coding-job-option {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    line-height: 1.25;
-  }
-
-  .coding-job-option-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .coding-job-option-meta {
-    color: #666;
-    font-size: 12px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .coding-job-switcher-icon {
-    color: #1976d2;
-    margin-top: 14px;
-    animation: job-switcher-spin 1s linear infinite;
-  }
-
-  .coding-job-switcher-message {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 12px;
-    color: #555;
-    font-size: 13px;
-    line-height: 1.35;
-
-    .coding-job-switcher-icon {
-      margin-top: 0;
-      flex-shrink: 0;
-    }
-  }
-
-  .coding-job-switcher-error {
-    color: #b00020;
-
-    button {
-      margin-left: auto;
-      flex-shrink: 0;
-    }
-  }
-
   .resize-handle {
     width: 5px;
     cursor: col-resize;
@@ -135,16 +71,6 @@
     position: sticky;
     top: 0;
     z-index: 10;
-  }
-}
-
-@keyframes job-switcher-spin {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(360deg);
   }
 }
 

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line max-classes-per-file
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   BehaviorSubject, of, Subject, throwError
@@ -22,6 +22,7 @@ import { CodingJob } from '../../../coding/models/coding-job.model';
 import { CodingJobBackendService } from '../../../coding/services/coding-job-backend.service';
 import { utf8ToBase64 } from '../../../shared/utils/common-utils';
 import { CodingScheme } from '../../../models/coding-interfaces';
+import { UserService } from '../../../shared/services/user/user.service';
 
 function createUnsignedJwt(payload: Record<string, unknown>): string {
   const encode = (value: Record<string, unknown>) => btoa(JSON.stringify(value))
@@ -29,6 +30,12 @@ function createUnsignedJwt(payload: Record<string, unknown>): string {
     .replace(/\//g, '_')
     .replace(/=+$/u, '');
   return `${encode({ alg: 'none', typ: 'JWT' })}.${encode(payload)}.`;
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 // Beispielhafte Mocks für Services, die im Component per inject() genutzt werden
@@ -64,6 +71,7 @@ class ReplayBackendServiceMock {
 
 interface AppServiceAuthDataMock {
   userId: number;
+  isAdmin?: boolean;
   workspaces: { id: number; name: string }[];
 }
 
@@ -71,6 +79,7 @@ class AppServiceMock {
   selectedWorkspaceId = 42;
   authData: AppServiceAuthDataMock = {
     userId: 1,
+    isAdmin: false,
     workspaces: [
       { id: 47, name: 'Workspace 47' },
       { id: 48, name: 'Workspace 48' }
@@ -104,6 +113,21 @@ class MatSnackBarMock {
   });
 
   dismiss = jest.fn();
+}
+
+class RouterMock {
+  navigate = jest.fn().mockResolvedValue(true);
+}
+
+class UserServiceMock {
+  getUsers = jest.fn().mockImplementation((workspaceId: number) => of([
+    {
+      id: 1,
+      accessLevel: 1,
+      canCode: true,
+      workspaceId
+    }
+  ]));
 }
 
 let routeParams: {
@@ -196,6 +220,8 @@ describe('ReplayComponent', () => {
         { provide: ReplayBackendService, useClass: ReplayBackendServiceMock },
         { provide: CodingJobBackendService, useValue: codingJobBackendServiceMock },
         { provide: AppService, useClass: AppServiceMock },
+        { provide: Router, useClass: RouterMock },
+        { provide: UserService, useClass: UserServiceMock },
         { provide: MatSnackBar, useClass: MatSnackBarMock }
       ],
       imports: [ReplayComponent, TranslateModule.forRoot()]
@@ -1542,6 +1568,42 @@ describe('ReplayComponent', () => {
       });
     });
 
+    it('should scroll to regular codes selected by digit shortcuts when the code selector is available', () => {
+      component.isCodingMode = true;
+      const unitsData = {
+        id: 123,
+        name: 'job',
+        currentUnitIndex: 0,
+        units: [
+          {
+            id: 1,
+            name: 'UNIT1',
+            alias: 'UNIT1',
+            bookletId: 0,
+            testPerson: 'tp1@code1@grp@booklet',
+            variableId: 'V1',
+            variableAnchor: 'V1'
+          }
+        ]
+      };
+      const replayComponent = component as ReplayComponent & { unitsData: typeof unitsData };
+      const privateComponent = component as unknown as {
+        codeSelectorComponent: { onSelect: jest.Mock };
+      };
+      const onSelect = jest.fn();
+      replayComponent.unitsData = unitsData;
+      component.codingService.currentVariableId = 'V1';
+      component.codingService.codingScheme = digitShortcutCodingScheme;
+      privateComponent.codeSelectorComponent = { onSelect };
+      const onCodeSelectedSpy = jest.spyOn(component, 'onCodeSelected').mockResolvedValue();
+      const event = new KeyboardEvent('keydown', { key: '2', code: 'Numpad2' });
+
+      component.onKeyDown(event);
+
+      expect(onSelect).toHaveBeenCalledWith(2, true);
+      expect(onCodeSelectedSpy).not.toHaveBeenCalled();
+    });
+
     it('should ignore digit shortcuts in coding review mode', () => {
       component.isCodingMode = true;
       component.isReviewMode = true;
@@ -2181,7 +2243,7 @@ describe('ReplayComponent', () => {
       expect(component.codingService.codingScheme).toEqual(targetScheme);
     });
 
-    it('renders the coding job switcher even when no coding scheme is available', () => {
+    it('does not render the coding panel for assigned jobs alone when no coding scheme is available', () => {
       const currentJob = createJob(77, 47, 'Current Job', 'active');
       const targetJob = createJob(88, 47, 'Target Job', 'open');
       const privateComponent = component as unknown as {
@@ -2197,8 +2259,38 @@ describe('ReplayComponent', () => {
 
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.querySelector('.coding-job-switcher')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('.coding-job-switcher')).toBeNull();
+      expect(fixture.nativeElement.querySelector('.code-selector-container')).toBeNull();
       expect(fixture.nativeElement.querySelector('app-code-selector')).toBeNull();
+    });
+
+    it('navigates back to the personal coding jobs view from the coding panel', async () => {
+      const router = TestBed.inject(Router) as unknown as RouterMock;
+      component.workspaceId = 47;
+
+      component.navigateToJobList();
+      await flushPromises();
+
+      expect(router.navigate).toHaveBeenCalledWith(['/coding']);
+    });
+
+    it('navigates back to the workspace coding jobs view when personal coding jobs are guarded away', async () => {
+      const router = TestBed.inject(Router) as unknown as RouterMock;
+      const userService = TestBed.inject(UserService) as unknown as UserServiceMock;
+      userService.getUsers.mockImplementation((workspaceId: number) => of([
+        {
+          id: 1,
+          accessLevel: workspaceId === 48 ? 2 : 1,
+          canCode: true,
+          workspaceId
+        }
+      ]));
+      component.workspaceId = 47;
+
+      component.navigateToJobList();
+      await flushPromises();
+
+      expect(router.navigate).toHaveBeenCalledWith(['/workspace-admin', 47, 'coding', 'my-jobs']);
     });
 
     it('does not render or use the coding job switcher in review mode', async () => {
@@ -2265,7 +2357,8 @@ describe('ReplayComponent', () => {
 
       expect(privateComponent.hasAssignedCodingJobsLoadError).toBe(true);
       expect(privateComponent.assignedCodingJobsLoaded).toBe(false);
-      expect(fixture.nativeElement.querySelector('.coding-job-switcher-error')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('.coding-job-switcher-error')).toBeNull();
+      expect(fixture.nativeElement.querySelector('.code-selector-container')).toBeNull();
 
       await privateComponent.retryLoadAssignedCodingJobs();
 

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -2,18 +2,15 @@ import {
   Component, ElementRef, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild, HostListener, inject,
   input
 } from '@angular/core';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { ActivatedRoute, Params } from '@angular/router';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import {
-  firstValueFrom, of, Subject, Subscription, catchError
+  firstValueFrom, forkJoin, of, Subject, Subscription, catchError
 } from 'rxjs';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
 import { MatSnackBar, MatSnackBarRef, TextOnlySnackBar } from '@angular/material/snack-bar';
@@ -40,12 +37,12 @@ import { ReplayCodingService } from '../../services/replay-coding.service';
 import { base64ToUtf8 } from '../../../shared/utils/common-utils';
 import { CodingJobBackendService } from '../../../coding/services/coding-job-backend.service';
 import { hasManualInstruction } from '../../../coding/utils/manual-coding.util';
-import { CodingJob } from '../../../coding/models/coding-job.model';
-
-interface AssignedCodingJobWorkspace {
-  id: number;
-  name: string;
-}
+import { UserService } from '../../../shared/services/user/user.service';
+import { hasAdminBypass } from '../../../core/guards/admin-access';
+import {
+  getCurrentUserWorkspaceAccesses,
+  hasManagementWorkspaceAccess
+} from '../../../shared/utils/workspace-access';
 
 interface CodingJobUnitApi {
   responseId: number;
@@ -58,6 +55,16 @@ interface CodingJobUnitApi {
   personLogin: string;
   personCode: string;
   personGroup: string;
+  variableBundleId?: number | null;
+  variableBundleCaseOrderingMode?: 'continuous' | 'alternating' | null;
+  variableBundleCaseVariables?: {
+    unitName: string;
+    variableId: string;
+    responseId: number | null;
+    statusV1: number | null;
+    isManualCodingUnit: boolean;
+    isAutoCoded: boolean;
+  }[];
 }
 
 interface ReplayUnitPayload {
@@ -73,69 +80,13 @@ interface ReplayUnitPayload {
   serverTimings?: ReplayServerTimings;
 }
 
-interface ReplayCodingServiceSnapshot {
-  codingScheme: ReplayCodingService['codingScheme'];
-  currentVariableId: string;
-  codingJobId: number | null;
-  selectedCodes: ReplayCodingService['selectedCodes'];
-  openUnitKeys: ReplayCodingService['openUnitKeys'];
-  notes: ReplayCodingService['notes'];
-  codingJobComment: string;
-  isPausingJob: boolean;
-  isCodingJobCompleted: boolean;
-  isCodingJobPaused: boolean;
-  isSubmittingJob: boolean;
-  isResumingJob: boolean;
-  isCodingJobFinalized: boolean;
-  isCompletedJobReview: boolean;
-  isReviewMode: boolean;
-  isCodingIssueReviewMode: boolean;
-  hasSaveError: boolean;
-  lastSaveError: string | null;
-  currentCodingJobStatus: string | null;
-  showScore: boolean;
-  allowComments: boolean;
-  suppressGeneralInstructions: boolean;
-}
-
-interface ReplayCodingJobSwitchSnapshot {
-  authToken: string;
-  workspaceId: number;
-  isCodingMode: boolean;
-  isCodingDecisionMode: boolean;
-  isBookletReplayMode: boolean;
-  isReviewMode: boolean;
-  isCodingIssueReviewMode: boolean;
-  unitsData: UnitsReplay | null;
-  loadedCodingJobUnitsKey: string | null;
-  codingProgressLoadedForJobKey: string | null;
-  activeStatusUpdatedForJobKey: string | null;
-  selectedCodingJobKey: string;
-  totalUnits: number;
-  currentUnitIndex: number;
-  testPerson: string;
-  unitId: string;
-  player: string;
-  unitDef: string;
-  page: string | undefined;
-  anchor: string | undefined;
-  responses: unknown | undefined;
-  serverTimings: ReplayServerTimings | null;
-  successStoredForCurrentReplay: boolean;
-  reloadKey: number;
-  codingService: ReplayCodingServiceSnapshot;
-}
-
 @Component({
   providers: [ReplayCodingService],
   selector: 'coding-box-replay',
   imports: [
-    MatFormFieldModule,
-    MatInputModule,
     MatButtonModule,
     MatDialogModule,
     MatIconModule,
-    MatSelectModule,
     MatTooltipModule,
     ReactiveFormsModule,
     TranslateModule,
@@ -153,12 +104,14 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private replayBackendService = inject(ReplayBackendService);
   private appService = inject(AppService);
   private route = inject(ActivatedRoute);
+  private router = inject(Router);
   private errorSnackBar = inject(MatSnackBar);
   private pageErrorSnackBar = inject(MatSnackBar);
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
   codingService = inject(ReplayCodingService);
   private codingJobBackendService = inject(CodingJobBackendService);
+  private userService = inject(UserService);
 
   player: string = '';
   unitDef: string = '';
@@ -188,18 +141,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private loadedCodingJobUnitsKey: string | null = null;
   private codingProgressLoadedForJobKey: string | null = null;
   private activeStatusUpdatedForJobKey: string | null = null;
-  protected assignedCodingJobs: CodingJob[] = [];
-  protected selectedCodingJobKey: string = '';
-  protected isLoadingAssignedCodingJobs = false;
-  protected isSwitchingCodingJob = false;
-  protected hasAssignedCodingJobsLoadError = false;
-  private assignedCodingJobsLoaded = false;
-  private assignedCodingJobsReloadRequested = false;
-  private authDataSubscription: Subscription | null = null;
   private authBootstrapSubscription: Subscription | null = null;
   private replayReAuthenticationPending = false;
   private replayTokenRefreshRunning = false;
-  private codingJobWorkspaceNames = new Map<number, string>();
   @ViewChild(UnitPlayerComponent) unitPlayerComponent: UnitPlayerComponent | undefined;
   @ViewChild(CodeSelectorComponent) codeSelectorComponent: CodeSelectorComponent | undefined;
   @ViewChild('watermark')
@@ -239,11 +183,6 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnInit(): void {
     this.replayStartTime = performance.now();
-    this.authDataSubscription = this.appService.authData$.subscribe(() => {
-      if (this.canSwitchAssignedCodingJobs()) {
-        this.requestAssignedCodingJobsReload().catch(() => undefined);
-      }
-    });
     this.authBootstrapSubscription = this.appService.authBootstrapStatus$.subscribe(status => {
       if (status === 'session-expired') {
         this.replayReAuthenticationPending = true;
@@ -574,7 +513,6 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
               if (this.codingService.codingJobId && this.workspaceId) {
                 const jobId = this.codingService.codingJobId;
                 const jobKey = this.getCodingJobKeyFromIds(this.workspaceId, jobId);
-                this.selectedCodingJobKey = jobKey;
                 if (this.codingProgressLoadedForJobKey !== jobKey) {
                   await this.codingService.loadSavedCodingProgress(this.workspaceId, jobId);
                   this.codingProgressLoadedForJobKey = jobKey;
@@ -589,9 +527,6 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
                 }
                 if (!this.codingService.isCompletedJobReview) {
                   this.codingService.checkCodingJobCompletion(this.unitsData);
-                }
-                if (this.canSwitchAssignedCodingJobs()) {
-                  this.requestAssignedCodingJobsReload().catch(() => undefined);
                 }
               }
             }
@@ -1019,7 +954,6 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
   async handleUnitChanged(unit: UnitsReplayUnit): Promise<void> {
     if (this.isCodingInteractionBlockedByReAuthentication()) return;
-    if (this.isSwitchingCodingJob) return;
     if (!this.canLeaveCurrentCodingCase()) return;
     await this.applyUnitChanged(unit);
   }
@@ -1115,10 +1049,8 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnDestroy(): void {
     this.routerSubscription?.unsubscribe();
-    this.authDataSubscription?.unsubscribe();
     this.authBootstrapSubscription?.unsubscribe();
     this.routerSubscription = null;
-    this.authDataSubscription = null;
     this.authBootstrapSubscription = null;
     this.cancelPendingAnchorHighlight();
     this.resetSnackBars();
@@ -1231,8 +1163,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   isCodingReadOnly(): boolean {
-    return this.isSwitchingCodingJob ||
-      (!this.isCodingDecisionMode && this.appService.needsReAuthentication) ||
+    return (!this.isCodingDecisionMode && this.appService.needsReAuthentication) ||
       this.isReviewMode ||
       (this.codingService.isCompletedJobReview && !this.isCodingIssueReviewMode) ||
       this.codingService.isCodingJobFinalized;
@@ -1249,68 +1180,12 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     return this.codingService.isSubmittingJob || this.isCodingInteractionBlockedByReAuthentication();
   }
 
-  getCodingJobSwitchDisabledTooltip(): string {
-    if (this.isCodingInteractionBlockedByReAuthentication()) {
-      return this.translateService.instant('replay.reauthentication-required');
-    }
-
-    return this.codingService.hasSaveError ? this.translateService.instant('replay.job-switcher.save-error') : '';
-  }
-
   hasCodingJobPanelContent(): boolean {
-    return this.hasCodingJobSwitchStatus() || this.hasCodingSchemeForCurrentVariable();
-  }
-
-  hasCodingJobSwitchStatus(): boolean {
-    return this.canSwitchAssignedCodingJobs() && (this.assignedCodingJobs.length > 1 ||
-      this.isLoadingAssignedCodingJobs ||
-      this.hasAssignedCodingJobsLoadError);
+    return this.hasCodingSchemeForCurrentVariable();
   }
 
   hasCodingSchemeForCurrentVariable(): boolean {
     return !!this.codingService.codingScheme && !!this.codingService.currentVariableId;
-  }
-
-  canSwitchAssignedCodingJobs(): boolean {
-    return this.isCodingMode &&
-      !this.isReviewMode &&
-      !this.isCodingIssueReviewMode &&
-      !this.isCodingDecisionMode;
-  }
-
-  isCodingJobSwitchDisabled(): boolean {
-    return !this.canSwitchAssignedCodingJobs() ||
-      this.isLoadingAssignedCodingJobs ||
-      this.isSwitchingCodingJob ||
-      this.isCodingInteractionBlockedByReAuthentication() ||
-      this.codingService.hasSaveError;
-  }
-
-  getCodingJobOptionKey(job: CodingJob): string {
-    return this.getCodingJobKeyFromIds(job.workspace_id, job.id);
-  }
-
-  getCodingJobOptionMeta(job: CodingJob): string {
-    const workspaceName = this.codingJobWorkspaceNames.get(job.workspace_id) || `Arbeitsbereich ${job.workspace_id}`;
-    return `${workspaceName} · ${this.getCodingJobStatusText(job.status)} · ${this.getCodingJobProgressText(job)}`;
-  }
-
-  async onCodingJobSelectionChange(jobKey: string): Promise<void> {
-    await this.switchToAssignedCodingJob(jobKey);
-  }
-
-  async retryLoadAssignedCodingJobs(): Promise<void> {
-    await this.requestAssignedCodingJobsReload();
-  }
-
-  private async requestAssignedCodingJobsReload(): Promise<void> {
-    this.assignedCodingJobsLoaded = false;
-    if (this.isLoadingAssignedCodingJobs) {
-      this.assignedCodingJobsReloadRequested = true;
-      return;
-    }
-
-    await this.loadAssignedCodingJobs();
   }
 
   getPreSelectedCodeId(variableId: string): number | null {
@@ -1324,7 +1199,6 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   pauseCodingJob(): void {
     if (
       this.codingService.codingJobId &&
-      !this.isSwitchingCodingJob &&
       !this.isCodingInteractionBlockedByReAuthentication() &&
       !this.isReviewMode &&
       !this.codingService.isCompletedJobReview &&
@@ -1332,6 +1206,53 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     ) {
       this.codingService.pauseCodingJob(this.workspaceId, this.codingService.codingJobId);
     }
+  }
+
+  navigateToJobList(): void {
+    this.getCodingJobListRoute()
+      .then(route => this.router.navigate(route).catch(() => undefined))
+      .catch(() => this.router.navigate(['/coding']).catch(() => undefined));
+  }
+
+  private async getCodingJobListRoute(): Promise<(string | number)[]> {
+    if (this.workspaceId > 0 && await this.shouldUseWorkspaceCodingJobsRoute()) {
+      return ['/workspace-admin', this.workspaceId, 'coding', 'my-jobs'];
+    }
+
+    return ['/coding'];
+  }
+
+  private async shouldUseWorkspaceCodingJobsRoute(): Promise<boolean> {
+    const authData = this.appService.authData;
+    if (hasAdminBypass(this.getLoggedUserRoles(), authData?.isAdmin)) {
+      return true;
+    }
+
+    const userId = authData?.userId ?? 0;
+    const workspaceIds = [...new Set(
+      (authData?.workspaces || [])
+        .map(workspace => workspace.id)
+        .filter((workspaceId): workspaceId is number => Number.isInteger(workspaceId) && workspaceId > 0)
+    )];
+
+    if (userId <= 0 || workspaceIds.length === 0) {
+      return false;
+    }
+
+    const workspaceUsers = await firstValueFrom(forkJoin(
+      workspaceIds.map(workspaceId => this.userService.getUsers(workspaceId))
+    ));
+    const currentUserAccess = getCurrentUserWorkspaceAccesses(workspaceUsers, userId);
+
+    return currentUserAccess.some(hasManagementWorkspaceAccess);
+  }
+
+  private getLoggedUserRoles(): string[] {
+    const loggedUser = this.appService.loggedUser as {
+      realm_access?: { roles?: string[] };
+      realmAccess?: { roles?: string[] };
+    } | undefined;
+    return loggedUser?.realm_access?.roles || loggedUser?.realmAccess?.roles || [];
   }
 
   resumeCodingJob(): void {
@@ -1382,7 +1303,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   openNavigateDialog(): void {
-    if (!this.unitsData || this.isSwitchingCodingJob || this.isCodingInteractionBlockedByReAuthentication()) return;
+    if (!this.unitsData || this.isCodingInteractionBlockedByReAuthentication()) return;
 
     const dialogData: NavigateCodingCasesDialogData = {
       unitsData: this.unitsData,
@@ -1416,7 +1337,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       return;
     }
 
-    if ((this.isSwitchingCodingJob || this.isCodingInteractionBlockedByReAuthentication()) &&
+    if (this.isCodingInteractionBlockedByReAuthentication() &&
       ['Enter', 'ArrowRight', 'ArrowLeft'].includes(keyboardEvent.key)) {
       keyboardEvent.preventDefault();
       return;
@@ -1478,10 +1399,14 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
           if (variableCoding) {
             const code = variableCoding.codes.find((c: any) => c.id === codeId && hasManualInstruction(c));
             if (code) {
-              this.onCodeSelected({
-                variableId: this.codingService.currentVariableId,
-                code: code
-              });
+              if (this.codeSelectorComponent) {
+                this.codeSelectorComponent.onSelect(codeId, true);
+              } else {
+                this.onCodeSelected({
+                  variableId: this.codingService.currentVariableId,
+                  code: code
+                });
+              }
             }
           }
         }
@@ -2055,7 +1980,10 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
           `${item.personLogin}@${item.personCode}@${item.bookletName}`,
         variableId: item.variableId,
         variableAnchor: item.variableAnchor,
-        variablePage: item.variablePage
+        variablePage: item.variablePage,
+        variableBundleId: item.variableBundleId ?? null,
+        variableBundleCaseOrderingMode: item.variableBundleCaseOrderingMode ?? null,
+        variableBundleCaseVariables: item.variableBundleCaseVariables || []
       })),
       currentUnitIndex: 0
     };

--- a/apps/frontend/src/app/replay/services/units-replay.service.ts
+++ b/apps/frontend/src/app/replay/services/units-replay.service.ts
@@ -24,6 +24,16 @@ export interface UnitsReplayUnit {
   variableId?: string;
   variableAnchor?: string;
   variablePage?: string;
+  variableBundleId?: number | null;
+  variableBundleCaseOrderingMode?: 'continuous' | 'alternating' | null;
+  variableBundleCaseVariables?: {
+    unitName: string;
+    variableId: string;
+    responseId: number | null;
+    statusV1: number | null;
+    isManualCodingUnit: boolean;
+    isAutoCoded: boolean;
+  }[];
   reviewCodeSelections?: ReviewCodeSelection[];
 }
 

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -661,6 +661,8 @@
     "details_request": "Anfrage:"
   },
   "coding": {
+    "auto-coded-short": "Auto",
+    "auto-coded-bundle-variable-tooltip": "Variable {{variableId}} ist in diesem Bündel automatisch kodiert.",
     "schemer": {
       "save-success": "Antwortschema erfolgreich gespeichert",
       "save-error": "Fehler beim Speichern des Antwortschemas",
@@ -1057,6 +1059,7 @@
     "review-coders-tooltip": "Von folgenden Kodierern vergeben: {{coders}}",
     "coder-notes": "Notiz zu diesem Kodierfall",
     "coder-notes-placeholder": "Notiz zu diesem Kodierfall",
+    "general-codes-and-notes": "Allgemeine Codes / Notiz",
     "code-assignment-uncertain-requires-code": "Code-Vergabe unsicher kann erst nach einem regulären Code ausgewählt werden.",
     "new-code-comment-required": "Bitte begründen Sie „Neuer Code nötig“ im Kommentar zu diesem Kodierfall.",
     "coding-issue-options": {


### PR DESCRIPTION
## Zusammenfassung

- überarbeitet das manuelle Kodierpanel mit kompakterem Fortschritt, aktualisierten Zeilen und einklappbaren Hilfsbereichen
- entfernt den Kodierjob-Wechsler aus der Replay-Ansicht
- ergänzt Backend-/Frontend-Unterstützung für Variablen-Bundles bei Kodierjob-Verteilung, Training und Replay

Bezieht sich auf #683, schließt das Issue aber bewusst noch nicht.

## Tests

- `git diff --check`
- `npx nx lint backend`
- `npx nx test backend` (ein voller Lauf hatte einmal einen Timeout in einer unveränderten Export-Spec)
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx test frontend --testFile=apps/frontend/src/app/replay/components/replay/replay.component.spec.ts --runInBand --skip-nx-cache`
