### PR TITLE
Fix job definition availability updates

### DIFF
--- a/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.ts
@@ -103,13 +103,14 @@ export class CreateJobDefinitionDto {
   @ApiProperty({
     description: 'Maximum number of coding cases',
     example: 100,
-    required: false
+    required: false,
+    nullable: true
   })
   @IsNumber()
   @Min(1)
   @Type(() => Number)
   @IsOptional()
-    maxCodingCases?: number;
+    maxCodingCases?: number | null;
 
   @ApiProperty({
     description: 'Absolute number of cases per variable that should be double coded',

--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
@@ -94,7 +94,7 @@ const DISTRIBUTION_SNAPSHOT_SCHEMA = {
       settings: {
         type: 'object',
         properties: {
-          maxCodingCases: { type: 'number' },
+          maxCodingCases: { type: 'number', nullable: true },
           doubleCodingAbsolute: { type: 'number' },
           doubleCodingPercentage: { type: 'number' },
           caseOrderingMode: { type: 'string', enum: ['continuous', 'alternating'] }
@@ -215,7 +215,7 @@ export class WorkspaceCodingJobDefinitionController {
           missings_profile_id: { type: 'number', nullable: true },
           distribution_seed: { type: 'string' },
           duration_seconds: { type: 'number' },
-          max_coding_cases: { type: 'number' },
+          max_coding_cases: { type: 'number', nullable: true },
           double_coding_absolute: { type: 'number' },
           double_coding_percentage: { type: 'number' },
           show_score: { type: 'boolean' },
@@ -267,7 +267,7 @@ export class WorkspaceCodingJobDefinitionController {
           missings_profile_id: { type: 'number', nullable: true },
           distribution_seed: { type: 'string' },
           duration_seconds: { type: 'number' },
-          max_coding_cases: { type: 'number' },
+          max_coding_cases: { type: 'number', nullable: true },
           double_coding_absolute: { type: 'number' },
           double_coding_percentage: { type: 'number' },
           show_score: { type: 'boolean' },

--- a/apps/backend/src/app/database/entities/job-definition.entity.ts
+++ b/apps/backend/src/app/database/entities/job-definition.entity.ts
@@ -74,7 +74,7 @@ export interface JobDefinitionDistributionSnapshot {
   selectedVariableBundles: JobDefinitionVariableBundle[];
   selectedCoders: JobDefinitionDistributionSnapshotCoder[];
   settings: {
-    maxCodingCases?: number;
+    maxCodingCases?: number | null;
     doubleCodingAbsolute?: number;
     doubleCodingPercentage?: number;
     caseOrderingMode?: CaseOrderingMode;
@@ -146,7 +146,7 @@ export class JobDefinition {
     duration_seconds?: number;
 
   @Column({ type: 'int', nullable: true })
-    max_coding_cases?: number;
+    max_coding_cases?: number | null;
 
   @Column({ type: 'int', nullable: true })
     double_coding_absolute?: number;

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -129,7 +129,7 @@ describe('JobDefinitionService', () => {
         variables?: { unitName: string; variableId: string; includeDeriveError?: boolean }[];
       }[];
       selectedVariables?: { unitName: string; variableId: string; includeDeriveError?: boolean }[];
-      maxCodingCases?: number;
+      maxCodingCases?: number | null;
     }) => {
       const incompleteVariables = await codingValidationService.getCodingIncompleteVariables() as Array<{
         unitName: string;
@@ -1277,6 +1277,38 @@ describe('JobDefinitionService', () => {
     })).resolves.toMatchObject({ id: 2, max_coding_cases: 5 });
   });
 
+  it('checks availability as unlimited when an existing case limit is cleared', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'draft',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous'
+    };
+    const competingDefinition = {
+      id: 8,
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      max_coding_cases: 3
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition, competingDefinition]);
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValue([
+      { unitName: 'Unit 1', variableId: 'Var 1', availableCases: 8 }
+    ]);
+
+    await expect(service.updateJobDefinition(2, 7, {
+      maxCodingCases: null
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(jobDefinitionRepository.save).not.toHaveBeenCalled();
+  });
+
   it('validates availability when an update approves a definition', async () => {
     const editedDefinition = {
       id: 2,
@@ -1843,7 +1875,7 @@ describe('JobDefinitionService', () => {
     }));
   });
 
-  it('allows saving an existing definition with created jobs when its own cases cover the request', async () => {
+  it('allows saving an unchanged existing definition with created jobs without rechecking availability', async () => {
     const existingDefinition = {
       id: 2,
       workspace_id: 7,
@@ -1859,12 +1891,6 @@ describe('JobDefinitionService', () => {
     jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
     jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
     codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
-    codingValidationService.getCodingIncompleteVariables.mockResolvedValueOnce([
-      { unitName: 'Unit 1', variableId: 'Var 1', availableCases: 5 }
-    ]);
-    codingJobService.calculateDistributionVariableUsageByStatusBatch.mockResolvedValueOnce(new Map([
-      ['requested', new Map([['Unit 1::Var 1', { regular: 5, deriveError: 0, total: 5 }]])]
-    ]));
 
     await expect(service.updateJobDefinition(2, 7, {
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
@@ -1879,13 +1905,46 @@ describe('JobDefinitionService', () => {
       case_ordering_mode: 'continuous'
     });
 
-    expect(codingValidationService.getCodingIncompleteVariables).toHaveBeenCalledWith(
-      7,
-      undefined,
-      undefined,
-      false,
-      2
-    );
+    expect(codingValidationService.getCodingIncompleteVariables).not.toHaveBeenCalled();
+    expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).not.toHaveBeenCalled();
+    expect(jobDefinitionRepository.save).toHaveBeenCalled();
+  });
+
+  it('skips variable conflict checks when an unchanged draft definition is saved with a null case limit', async () => {
+    const assignedVariables = [
+      { unitName: 'MV14828', variableId: '01' },
+      { unitName: 'MV14855', variableId: '01' },
+      { unitName: 'MV14868', variableId: '01' }
+    ];
+    const existingDefinition = {
+      id: 70,
+      workspace_id: 12,
+      status: 'draft',
+      assigned_variables: assignedVariables,
+      assigned_variable_bundles: [],
+      assigned_coders: [7, 8],
+      duration_seconds: 1,
+      max_coding_cases: null,
+      case_ordering_mode: 'continuous'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+
+    await expect(service.updateJobDefinition(70, 12, {
+      assignedVariables,
+      assignedVariableBundles: [],
+      maxCodingCases: null,
+      caseOrderingMode: 'continuous'
+    })).resolves.toMatchObject({
+      id: 70,
+      assigned_variables: assignedVariables,
+      assigned_variable_bundles: [],
+      max_coding_cases: null,
+      case_ordering_mode: 'continuous'
+    });
+
+    expect(codingValidationService.getCodingIncompleteVariables).not.toHaveBeenCalled();
+    expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).not.toHaveBeenCalled();
     expect(jobDefinitionRepository.save).toHaveBeenCalled();
   });
 

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -57,7 +57,7 @@ interface JobDefinitionForUsage {
   id?: number;
   assigned_variables?: JobDefinitionVariable[];
   assigned_variable_bundles?: JobDefinitionBundleForUsage[];
-  max_coding_cases?: number;
+  max_coding_cases?: number | null;
   case_ordering_mode?: CaseOrderingMode;
   distribution_seed?: string;
 }
@@ -81,7 +81,7 @@ interface JobDefinitionValidationState {
   assignedVariableBundles?: JobDefinitionVariableBundle[];
   assignedCoders?: number[];
   durationSeconds?: number;
-  maxCodingCases?: number;
+  maxCodingCases?: number | null;
   doubleCodingAbsolute?: number;
   doubleCodingPercentage?: number;
   caseOrderingMode?: CaseOrderingMode;
@@ -99,6 +99,13 @@ type ExistingJobBoundUpdateField =
   | 'doubleCodingPercentage'
   | 'caseOrderingMode';
 
+const DISTRIBUTION_RELEVANT_UPDATE_FIELDS = new Set<ExistingJobBoundUpdateField>([
+  'assignedVariables',
+  'assignedVariableBundles',
+  'maxCodingCases',
+  'caseOrderingMode'
+]);
+
 interface PreparedJobDefinitionUpdate {
   existingDefinition: JobDefinition;
   updatedDefinition: JobDefinition;
@@ -114,7 +121,7 @@ interface VariableConflictCheckRequest {
   jobDefinitionId?: number;
   assignedVariables: JobDefinitionVariable[];
   assignedVariableBundles: JobDefinitionVariableBundle[];
-  maxCodingCases?: number;
+  maxCodingCases?: number | null;
   caseOrderingMode?: CaseOrderingMode;
   distributionSeed?: string;
   excludeJobDefinitionId?: number;
@@ -125,7 +132,7 @@ type PlannedVariableUsageBatchRequest = {
   key: string | number;
   selectedVariables: JobDefinitionVariable[];
   selectedVariableBundles: JobDefinitionDistributionVariableBundle[];
-  maxCodingCases?: number;
+  maxCodingCases?: number | null;
   caseOrderingMode?: CaseOrderingMode;
   jobDefinitionId?: number;
   excludeJobDefinitionId?: number;
@@ -151,7 +158,7 @@ type DefinitionDistributionRequest = {
   doubleCodingAbsolute?: number;
   doubleCodingPercentage?: number;
   caseOrderingMode?: CaseOrderingMode;
-  maxCodingCases?: number;
+  maxCodingCases?: number | null;
   jobDefinitionId: number;
   distributionSeed: string;
   showScore: boolean;
@@ -1477,6 +1484,10 @@ export class JobDefinitionService {
     return countsByDefinitionId.get(jobDefinition.id) || 0;
   }
 
+  private hasDistributionRelevantChanges(fields: ExistingJobBoundUpdateField[]): boolean {
+    return fields.some(field => DISTRIBUTION_RELEVANT_UPDATE_FIELDS.has(field));
+  }
+
   private collectExistingJobBoundChanges(
     jobDefinition: JobDefinition,
     updateDto: UpdateJobDefinitionDto,
@@ -1543,7 +1554,8 @@ export class JobDefinitionService {
 
     if (
       updateDto.maxCodingCases !== undefined &&
-      updateDto.maxCodingCases !== jobDefinition.max_coding_cases
+      this.toOptionalNumber(updateDto.maxCodingCases) !==
+        this.toOptionalNumber(jobDefinition.max_coding_cases)
     ) {
       changedFields.push('maxCodingCases');
     }
@@ -1675,7 +1687,9 @@ export class JobDefinitionService {
       assignedVariableBundles: nextAssignedVariableBundles,
       assignedCoders: nextCoderAssignments.assignedCoders,
       durationSeconds: updateDto.durationSeconds ?? jobDefinition.duration_seconds,
-      maxCodingCases: updateDto.maxCodingCases ?? jobDefinition.max_coding_cases,
+      maxCodingCases: updateDto.maxCodingCases !== undefined ?
+        updateDto.maxCodingCases :
+        jobDefinition.max_coding_cases,
       doubleCodingAbsolute: updateDto.doubleCodingAbsolute ?? jobDefinition.double_coding_absolute,
       doubleCodingPercentage: updateDto.doubleCodingPercentage ??
         this.toOptionalNumber(jobDefinition.double_coding_percentage),
@@ -1709,12 +1723,15 @@ export class JobDefinitionService {
       );
     }
 
-    if (
-      updateDto.assignedVariables !== undefined ||
-      updateDto.assignedVariableBundles !== undefined ||
-      updateDto.maxCodingCases !== undefined ||
-      updateDto.caseOrderingMode !== undefined
-    ) {
+    const changedExistingJobBoundFields = this.collectExistingJobBoundChanges(
+      jobDefinition,
+      updateDto,
+      nextCoderAssignments,
+      currentMissingsProfileId,
+      nextMissingsProfileId
+    );
+
+    if (this.hasDistributionRelevantChanges(changedExistingJobBoundFields)) {
       const conflicts = await this.checkVariableConflicts(
         jobDefinition.workspace_id,
         {
@@ -1746,14 +1763,6 @@ export class JobDefinitionService {
         distribution_seed: distributionSeed
       } as JobDefinition);
     }
-
-    const changedExistingJobBoundFields = this.collectExistingJobBoundChanges(
-      jobDefinition,
-      updateDto,
-      nextCoderAssignments,
-      currentMissingsProfileId,
-      nextMissingsProfileId
-    );
 
     return {
       existingDefinition: jobDefinition,

--- a/apps/frontend/src/app/coding/components/coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component.ts
@@ -36,7 +36,7 @@ export interface BulkCreationData {
   doubleCodingAbsolute?: number;
   doubleCodingPercentage?: number;
   caseOrderingMode?: 'continuous' | 'alternating';
-  maxCodingCases?: number;
+  maxCodingCases?: number | null;
   distributionSeed?: string;
   creationResults?: {
     doubleCodingInfo: Record<string, {
@@ -188,7 +188,7 @@ export class CodingJobBulkCreationDialogComponent {
         this.data.doubleCodingPercentage,
         this.data.selectedVariableBundles,
         this.data.caseOrderingMode,
-        this.data.maxCodingCases,
+        this.data.maxCodingCases ?? undefined,
         this.data.distributionSeed
       ));
 

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
@@ -78,7 +78,7 @@ export interface JobDefinition {
   plannedVariableUsage?: Record<string, number>;
   plannedVariableUsageByStatus?: Record<string, DistributionVariableUsageByStatus>;
   durationSeconds?: number;
-  maxCodingCases?: number;
+  maxCodingCases?: number | null;
   doubleCodingAbsolute?: number;
   doubleCodingPercentage?: number;
   caseOrderingMode?: 'continuous' | 'alternating';

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
@@ -59,7 +59,7 @@ interface JobDefinition {
   distributionSeed?: string;
   plannedVariableUsage?: Record<string, number>;
   durationSeconds?: number;
-  maxCodingCases?: number;
+  maxCodingCases?: number | null;
   doubleCodingAbsolute?: number;
   doubleCodingPercentage?: number;
   caseOrderingMode?: 'continuous' | 'alternating';

--- a/apps/frontend/src/app/coding/models/coding-job.model.ts
+++ b/apps/frontend/src/app/coding/models/coding-job.model.ts
@@ -31,7 +31,7 @@ export interface CodingJob {
   training_id?: number;
   training?: CoderTraining;
   durationSeconds?: number;
-  maxCodingCases?: number;
+  maxCodingCases?: number | null;
   doubleCodingAbsolute?: number;
   doubleCodingPercentage?: number;
   caseOrderingMode?: 'continuous' | 'alternating';

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -85,7 +85,7 @@ interface JobDefinitionApiResponse {
   planned_variable_usage_by_status?: Record<string, DistributionVariableUsageByStatus>;
   plannedVariableUsageByStatus?: Record<string, DistributionVariableUsageByStatus>;
   duration_seconds?: number;
-  max_coding_cases?: number;
+  max_coding_cases?: number | null;
   double_coding_absolute?: number;
   double_coding_percentage?: number;
   case_ordering_mode?: 'continuous' | 'alternating';
@@ -120,7 +120,7 @@ export interface JobDefinitionDistributionSnapshot {
   }>;
   selectedCoders: { coderId: number; capacityPercent: number }[];
   settings: {
-    maxCodingCases?: number;
+    maxCodingCases?: number | null;
     doubleCodingAbsolute?: number;
     doubleCodingPercentage?: number;
     caseOrderingMode?: 'continuous' | 'alternating';
@@ -168,7 +168,7 @@ export interface JobDefinition {
   plannedVariableUsage?: Record<string, number>;
   plannedVariableUsageByStatus?: Record<string, DistributionVariableUsageByStatus>;
   durationSeconds?: number;
-  maxCodingCases?: number;
+  maxCodingCases?: number | null;
   doubleCodingAbsolute?: number;
   doubleCodingPercentage?: number;
   caseOrderingMode?: 'continuous' | 'alternating';


### PR DESCRIPTION
## Summary

This fixes editing existing coding job definitions when the frontend sends unchanged distribution fields back to the backend.

## Root Cause

The update path re-ran variable conflict checks whenever distribution-related fields were present in the update DTO, even if their values were unchanged. For an existing definition, that could make the definition compete with already assigned or materialized availability and reject a no-op save.

## Changes

- Only run variable conflict checks when distribution-relevant fields actually changed.
- Treat `maxCodingCases: null` as an explicit nullable value instead of falling back to the previous value.
- Model nullable job-definition case limits consistently across backend DTO/entity/service types and frontend job-definition models.
- Add regression coverage for unchanged saves and for clearing an existing case limit.

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts --runInBand` passed, 63 tests.
- `npx nx build backend` passed.
- `npx nx build frontend` passed. Existing warnings remain for `test-results.component.html` optional chaining and the `coding-management-manual.component.scss` budget.

Related to #681. This PR intentionally does not close the issue.