### PR TITLE
Schulungsauswertung: Filter näher an Tabelle

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
@@ -196,96 +196,6 @@
             withinTrainingData.length > 0))
       "
     >
-      <div class="table-filters">
-        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('unitName')">
-          <mat-label>Aufgabe</mat-label>
-          <input
-            matInput
-            [(ngModel)]="tableFilters.unitName"
-            (ngModelChange)="applyTableFilters()"
-          />
-          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('unitName')">
-            {{ 'search-filter.invalid-regex' | translate }}
-          </mat-hint>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('variableId')">
-          <mat-label>Variable</mat-label>
-          <input
-            matInput
-            [(ngModel)]="tableFilters.variableId"
-            (ngModelChange)="applyTableFilters()"
-          />
-          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('variableId')">
-            {{ 'search-filter.invalid-regex' | translate }}
-          </mat-hint>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('personLogin')">
-          <mat-label>Person Login</mat-label>
-          <input
-            matInput
-            [(ngModel)]="tableFilters.personLogin"
-            (ngModelChange)="applyTableFilters()"
-          />
-          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('personLogin')">
-            {{ 'search-filter.invalid-regex' | translate }}
-          </mat-hint>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('personGroup')">
-          <mat-label>Person Gruppe</mat-label>
-          <input
-            matInput
-            [(ngModel)]="tableFilters.personGroup"
-            (ngModelChange)="applyTableFilters()"
-          />
-          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('personGroup')">
-            {{ 'search-filter.invalid-regex' | translate }}
-          </mat-hint>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('bookletName')">
-          <mat-label>Testheft-Name</mat-label>
-          <input
-            matInput
-            [(ngModel)]="tableFilters.bookletName"
-            (ngModelChange)="applyTableFilters()"
-          />
-          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('bookletName')">
-            {{ 'search-filter.invalid-regex' | translate }}
-          </mat-hint>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline">
-          <mat-label>Übereinstimmung</mat-label>
-          <mat-select
-            [(ngModel)]="tableFilters.match"
-            (selectionChange)="applyTableFilters()"
-          >
-            <mat-option value="all">Alle</mat-option>
-            <mat-option value="match">Nur Übereinstimmung</mat-option>
-            <mat-option value="differ">Nur Abweichung</mat-option>
-          </mat-select>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline">
-          <mat-label>Notizen</mat-label>
-          <mat-select
-            [(ngModel)]="tableFilters.notesMode"
-            (selectionChange)="applyTableFilters()"
-          >
-            <mat-option value="all">Alle</mat-option>
-            <mat-option value="none">Keine</mat-option>
-            <mat-option value="with-notes">Mit Notiz</mat-option>
-          </mat-select>
-        </mat-form-field>
-
-        <button mat-stroked-button type="button" (click)="resetTableFilters()">
-          Filter zurücksetzen
-        </button>
-      </div>
-
       <div class="comparison-warning-list" *ngIf="getComparisonWarnings().length > 0">
         <div
           class="comparison-warning"
@@ -664,6 +574,96 @@
             </div>
           </div>
         </div>
+      </div>
+
+      <div class="table-filters">
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('unitName')">
+          <mat-label>Aufgabe</mat-label>
+          <input
+            matInput
+            [(ngModel)]="tableFilters.unitName"
+            (ngModelChange)="applyTableFilters()"
+          />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('unitName')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('variableId')">
+          <mat-label>Variable</mat-label>
+          <input
+            matInput
+            [(ngModel)]="tableFilters.variableId"
+            (ngModelChange)="applyTableFilters()"
+          />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('variableId')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('personLogin')">
+          <mat-label>Person Login</mat-label>
+          <input
+            matInput
+            [(ngModel)]="tableFilters.personLogin"
+            (ngModelChange)="applyTableFilters()"
+          />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('personLogin')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('personGroup')">
+          <mat-label>Person Gruppe</mat-label>
+          <input
+            matInput
+            [(ngModel)]="tableFilters.personGroup"
+            (ngModelChange)="applyTableFilters()"
+          />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('personGroup')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" [class.regex-filter-invalid]="isTableRegexFilterInvalid('bookletName')">
+          <mat-label>Testheft-Name</mat-label>
+          <input
+            matInput
+            [(ngModel)]="tableFilters.bookletName"
+            (ngModelChange)="applyTableFilters()"
+          />
+          <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('bookletName')">
+            {{ 'search-filter.invalid-regex' | translate }}
+          </mat-hint>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Übereinstimmung</mat-label>
+          <mat-select
+            [(ngModel)]="tableFilters.match"
+            (selectionChange)="applyTableFilters()"
+          >
+            <mat-option value="all">Alle</mat-option>
+            <mat-option value="match">Nur Übereinstimmung</mat-option>
+            <mat-option value="differ">Nur Abweichung</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Notizen</mat-label>
+          <mat-select
+            [(ngModel)]="tableFilters.notesMode"
+            (selectionChange)="applyTableFilters()"
+          >
+            <mat-option value="all">Alle</mat-option>
+            <mat-option value="none">Keine</mat-option>
+            <mat-option value="with-notes">Mit Notiz</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <button mat-stroked-button type="button" (click)="resetTableFilters()">
+          Filter zurücksetzen
+        </button>
       </div>
 
       <div class="comparison-empty-state" *ngIf="hasNoSelectedCodersState()">

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -396,6 +396,51 @@ describe('CodingResultsComparisonComponent', () => {
     expect(discussionHeader?.textContent).toContain('Manager: reichlej@gmx.de');
   });
 
+  it('should place table filters directly before the comparison table', () => {
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 1;
+    component.availableCoders = [
+      { jobId: 1, coderName: 'Coder1' },
+      { jobId: 2, coderName: 'Coder2' }
+    ];
+    component.codersFormControl.setValue([1, 2]);
+    component.withinTrainingData = [
+      {
+        responseId: 1,
+        unitName: 'Unit1',
+        variableId: 'Var1',
+        testperson: 'Test1',
+        coders: [
+          {
+            jobId: 1,
+            coderName: 'Coder1',
+            code: '1',
+            score: 1
+          },
+          {
+            jobId: 2,
+            coderName: 'Coder2',
+            code: '2',
+            score: 0
+          }
+        ]
+      }
+    ];
+    component.dataSource.data = component.withinTrainingData;
+    component.calculateStatistics();
+
+    fixture.detectChanges();
+
+    const comparisonTable: HTMLElement = fixture.nativeElement.querySelector('.comparison-table');
+    const childClasses = Array.from(comparisonTable.children)
+      .map(child => (child as HTMLElement).className);
+
+    expect(childClasses.findIndex(className => className.includes('kappa-section')))
+      .toBeLessThan(childClasses.findIndex(className => className.includes('table-filters')));
+    expect(childClasses.findIndex(className => className.includes('table-filters')))
+      .toBeLessThan(childClasses.findIndex(className => className.includes('table-container')));
+  });
+
   it('should apply combined table filters for task, variable, person, agreement and notes', () => {
     component.comparisonMode = 'between-trainings';
     component.codersFromTrainingsFormControl.setValue(['1_101', '2_201']);


### PR DESCRIPTION
## Zusammenfassung
- verschiebt die Tabellenfilter in der Schulungsauswertung direkt vor die Ergebnistabelle
- ergänzt eine Regression-Spec für die DOM-Reihenfolge

## Issue
#758 bleibt bis zur Abnahme offen.

## Validierung
- npx nx lint frontend
- npx nx test frontend