### PR TITLE
Fix manual coding tab bar position

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -1,4 +1,15 @@
 <div class="fx-column-start-stretch fx-gap-10 coding-container">
+  <mat-tab-group
+    class="manual-coding-tabs"
+    [selectedIndex]="selectedManualTabIndex"
+    (selectedIndexChange)="onManualTabChanged($event)"
+  >
+    <mat-tab
+      *ngFor="let tab of visibleManualCodingTabs"
+      [label]="getManualTabLabel(tab)"
+    ></mat-tab>
+  </mat-tab-group>
+
   <div
     *ngIf="
       validationProgress &&
@@ -134,17 +145,6 @@
           </div>
         </div>
       </div>
-
-      <mat-tab-group
-        class="manual-coding-tabs"
-        [selectedIndex]="selectedManualTabIndex"
-        (selectedIndexChange)="onManualTabChanged($event)"
-      >
-        <mat-tab
-          *ngFor="let tab of visibleManualCodingTabs"
-          [label]="getManualTabLabel(tab)"
-        ></mat-tab>
-      </mat-tab-group>
 
       <div
         *ngIf="isManualTab('planning')"

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
@@ -6,7 +6,7 @@
 }
 
 .coding-container {
-  padding: clamp(8px, 2vw, 24px);
+  padding: 0 clamp(8px, 2vw, 24px) clamp(8px, 2vw, 24px);
   width: 100%;
   max-width: 100%;
   height: auto;
@@ -14,7 +14,7 @@
   box-sizing: border-box;
   animation: fadeIn 0.3s ease-in-out;
   min-width: 0;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 .table-responsive {
@@ -27,7 +27,23 @@
 
 .manual-coding-tabs {
   display: block;
-  margin: 8px 0 24px;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  margin: 0 0 16px;
+  background-color: white;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+
+:host ::ng-deep .manual-coding-tabs {
+  .mat-mdc-tab-header {
+    background-color: white;
+  }
+
+  .mat-mdc-tab-body-wrapper {
+    display: none;
+  }
 }
 
 .manual-tab-actions {


### PR DESCRIPTION
## Summary
- Move the manual coding sub-tab bar above the manual coding content card.
- Keep the sub-tab bar sticky inside the workspace admin scroll panel.
- Preserve the tab content rendering outside the Material tab body so the existing manual-coding sections keep their current behavior.

## Validation
- `npx nx lint frontend`
- `npx nx test frontend`
- Browser check on `http://127.0.0.1:4200/#/workspace-admin/1/coding/manual`: after scrolling the workspace panel, the sub-tab bar remains fixed directly below the main tab navigation.

Related to #759.
