### PR TITLE
Fix large autocoding freshness scopes

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
@@ -42,7 +42,8 @@ describe('CodingProcessService', () => {
   let mockResponses: ResponseEntity[];
 
   const mockJobQueueService = {
-    getTestPersonCodingJob: jest.fn()
+    getTestPersonCodingJob: jest.fn(),
+    addTestPersonCodingJob: jest.fn().mockResolvedValue({ id: 'job-123' })
   };
 
   const mockResponseManagementService = {
@@ -85,7 +86,7 @@ describe('CodingProcessService', () => {
 
   // Helper functions
   const createMockPerson = (id: number, workspaceId: number = 1) => ({
-    id: id.toString(),
+    id,
     workspace_id: workspaceId,
     group: 'test_group',
     login: `test_person_${id}`,
@@ -94,7 +95,7 @@ describe('CodingProcessService', () => {
     uploaded_at: new Date()
   });
 
-  const createMockBooklet = (id: number, personId: string) => ({
+  const createMockBooklet = (id: number, personId: number) => ({
     id,
     personid: personId
   });
@@ -250,6 +251,43 @@ describe('CodingProcessService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('codeUnitIds', () => {
+    it('uses array parameters for large unit-scoped autocoding jobs', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { unitId: '1', personId: '1', groupName: 'Group A' },
+        { unitId: '2', personId: '2', groupName: 'Group B' }
+      ]);
+
+      await service.codeUnitIds(1, [1, 2], 1, {
+        source: 'coding-freshness',
+        freshnessVersion: 'v1',
+        freshnessStates: ['PENDING', 'STALE'],
+        freshnessSourceRevision: 42
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'unit.id = ANY(:unitIds)',
+        { unitIds: [1, 2] }
+      );
+      expect(mockCodingReadinessService.assertAutoCodingCanProcess)
+        .toHaveBeenCalledWith(1, {
+          unitIds: [1, 2],
+          autoCoderRun: 1
+        });
+      expect(mockJobQueueService.addTestPersonCodingJob).toHaveBeenCalledWith({
+        workspaceId: 1,
+        personIds: ['1', '2'],
+        unitIds: [1, 2],
+        groupNames: 'Group A,Group B',
+        autoCoderRun: 1,
+        source: 'coding-freshness',
+        freshnessVersion: 'v1',
+        freshnessStates: ['PENDING', 'STALE'],
+        freshnessSourceRevision: 42
+      });
+    });
+  });
+
   describe('processTestPersonsBatch', () => {
     const workspaceId = 1;
     const personIds = ['1', '2'];
@@ -266,8 +304,8 @@ describe('CodingProcessService', () => {
         where: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([
-          createMockBooklet(1, '1'),
-          createMockBooklet(2, '2')
+          createMockBooklet(1, 1),
+          createMockBooklet(2, 2)
         ])
       };
       bookletRepository.createQueryBuilder = jest.fn().mockReturnValue(mockBookletQueryBuilder);
@@ -356,6 +394,36 @@ describe('CodingProcessService', () => {
 
       expect(result.totalResponses).toBe(0);
       expect(result.statusCounts).toEqual({});
+    });
+
+    it('uses array parameters for batch booklets and scoped units', async () => {
+      mockQueryBuilder.getMany
+        .mockResolvedValueOnce(mockUnits)
+        .mockResolvedValueOnce(mockResponses);
+
+      await service.processTestPersonsBatch(
+        workspaceId,
+        personIds,
+        autoCoderRun,
+        undefined,
+        jobId,
+        [1, 2]
+      );
+
+      const bookletQueryBuilder =
+        (bookletRepository.createQueryBuilder as jest.Mock).mock.results[0].value;
+      expect(bookletQueryBuilder.where).toHaveBeenCalledWith(
+        'booklet.personid = ANY(:personIds)',
+        { personIds: [1, 2] }
+      );
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        'unit.bookletid = ANY(:bookletIds)',
+        { bookletIds: [1, 2] }
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'unit.id = ANY(:unitIds)',
+        { unitIds: [1, 2] }
+      );
     });
 
     it('should handle no units found', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-process.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.ts
@@ -204,7 +204,7 @@ export class CodingProcessService {
       .addSelect('person.group', 'groupName')
       .where('person.workspace_id = :workspaceId', { workspaceId: workspace_id })
       .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('unit.id IN (:...unitIds)', { unitIds: ids })
+      .andWhere('unit.id = ANY(:unitIds)', { unitIds: ids })
       .getRawMany<{ unitId: number | string; personId: number | string; groupName: string | null }>();
 
     const includedUnitIds = this.uniquePositiveIds(rows.map(row => Number(row.unitId)));
@@ -664,7 +664,7 @@ export class CodingProcessService {
 
   private async fetchBooklets(personIds: number[]): Promise<Booklet[]> {
     return this.bookletRepository.createQueryBuilder('booklet')
-      .where('booklet.personid IN (:...personIds)', { personIds })
+      .where('booklet.personid = ANY(:personIds)', { personIds })
       .select(['booklet.id', 'booklet.personid'])
       .getMany();
   }
@@ -678,12 +678,12 @@ export class CodingProcessService {
     const query = this.unitRepository.createQueryBuilder('unit')
       .leftJoin('unit.booklet', 'booklet')
       .leftJoin('booklet.bookletinfo', 'bookletinfo')
-      .where('unit.bookletid IN (:...bookletIds)', { bookletIds })
+      .where('unit.bookletid = ANY(:bookletIds)', { bookletIds })
       .select(['unit.id', 'unit.bookletid', 'unit.name', 'unit.alias']);
 
     const ids = this.uniquePositiveIds(unitIds || []);
     if (ids.length > 0) {
-      query.andWhere('unit.id IN (:...unitIds)', { unitIds: ids });
+      query.andWhere('unit.id = ANY(:unitIds)', { unitIds: ids });
     }
 
     applyResolvedExclusionsToQuery(query, { globalIgnoredUnits, ignoredBooklets, testletIgnoredUnits });

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
@@ -31,6 +31,12 @@ type ReadinessFixture = {
   unitVariableMap: Map<string, Set<string>>;
 };
 
+type ReadinessQueryMocks = {
+  unitQuery: QueryBuilderMock;
+  countQuery: QueryBuilderMock;
+  candidateQuery: QueryBuilderMock;
+};
+
 const createQueryBuilderMock = (): QueryBuilderMock => {
   const queryBuilder = {
     leftJoin: jest.fn(),
@@ -94,7 +100,10 @@ const createResponse = (
   value
 } as ResponseEntity);
 
-const createService = (fixture: ReadinessFixture): CodingReadinessService => {
+const createService = (
+  fixture: ReadinessFixture,
+  queryMocks?: Partial<ReadinessQueryMocks>
+): CodingReadinessService => {
   const unitQuery = createQueryBuilderMock();
   unitQuery.getMany.mockResolvedValue(fixture.units);
 
@@ -108,6 +117,12 @@ const createService = (fixture: ReadinessFixture): CodingReadinessService => {
   fileRevisionQuery.getRawOne.mockResolvedValue({
     file_count: fixture.unitFiles.length + (fixture.codingSchemeFiles || []).length,
     max_created_at: '2026-05-20T08:00:00.000Z'
+  });
+
+  Object.assign(queryMocks || {}, {
+    unitQuery,
+    countQuery,
+    candidateQuery
   });
 
   const responseRepository = {
@@ -146,6 +161,56 @@ const createService = (fixture: ReadinessFixture): CodingReadinessService => {
 };
 
 describe('CodingReadinessService', () => {
+  it('uses array parameters for large scoped unit filters', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK'),
+        createUnit(2, 'UNIT_OTHER')
+      ],
+      rawResponsesTotal: 2,
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 1 },
+        { unitid: 2, variableid: 'var2', response_count: 1 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>'),
+        createFile('UNIT_OTHER', '<Unit><codingSchemeRef>SCHEME_OTHER</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1')),
+        createFile('SCHEME_OTHER', createCodingScheme('var2'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])],
+        ['UNIT_OTHER', new Set(['var2'])]
+      ])
+    }, queryMocks);
+
+    await service.getReadiness(1, {
+      forceRefresh: true,
+      unitIds: [1, 2],
+      personIds: ['11', '12']
+    });
+
+    expect(queryMocks.unitQuery?.andWhere).toHaveBeenCalledWith(
+      'person.id = ANY(:personIds)',
+      { personIds: [11, 12] }
+    );
+    expect(queryMocks.unitQuery?.andWhere).toHaveBeenCalledWith(
+      'unit.id = ANY(:unitIds)',
+      { unitIds: [1, 2] }
+    );
+    expect(queryMocks.countQuery?.andWhere).toHaveBeenCalledWith(
+      'unit.id = ANY(:unitIds)',
+      { unitIds: [1, 2] }
+    );
+    expect(queryMocks.candidateQuery?.andWhere).toHaveBeenCalledWith(
+      'unit.id = ANY(:unitIds)',
+      { unitIds: [1, 2] }
+    );
+  });
+
   it('keeps missing files as diagnostics without blocking partially codeable data', async () => {
     const service = createService({
       units: [

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
@@ -298,12 +298,12 @@ export class CodingReadinessService {
 
     const personIds = this.uniquePositiveIds((options.personIds || []).map(id => Number(id)));
     if (personIds.length > 0) {
-      query.andWhere('person.id IN (:...personIds)', { personIds });
+      query.andWhere('person.id = ANY(:personIds)', { personIds });
     }
 
     const unitIds = this.uniquePositiveIds(options.unitIds || []);
     if (unitIds.length > 0) {
-      query.andWhere('unit.id IN (:...unitIds)', { unitIds });
+      query.andWhere('unit.id = ANY(:unitIds)', { unitIds });
     }
 
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
@@ -379,12 +379,12 @@ export class CodingReadinessService {
 
     const personIds = this.uniquePositiveIds((options.personIds || []).map(id => Number(id)));
     if (personIds.length > 0) {
-      query.andWhere('person.id IN (:...personIds)', { personIds });
+      query.andWhere('person.id = ANY(:personIds)', { personIds });
     }
 
     const unitIds = this.uniquePositiveIds(options.unitIds || []);
     if (unitIds.length > 0) {
-      query.andWhere('unit.id IN (:...unitIds)', { unitIds });
+      query.andWhere('unit.id = ANY(:unitIds)', { unitIds });
     }
 
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);


### PR DESCRIPTION
## Summary

This fixes the large Freshness auto-coding start path for issue #754 without closing the issue yet.

The Freshness flow can pass very large unit scopes into TypeORM queries before adding the background job. Those queries used expanded `IN (:...ids)` parameters, which can become too large for Postgres/TypeORM when many coding units are affected.

## Changes

- Use array-bound `= ANY(:ids)` filters for large unit, person, and booklet scopes in the auto-coding process path.
- Use array-bound `= ANY(:ids)` filters for scoped auto-coding readiness checks.
- Add focused unit coverage to keep the large-scope query shape from regressing.
- Keep the issue open for server verification with VERA_3_TEST.

## Validation

- `npx nx test backend --runInBand --testFile=apps/backend/src/app/database/services/coding/coding-process.service.spec.ts`
- `npx nx test backend --runInBand --testFile=apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts`
- `npx nx lint backend`
- `npx nx test backend --runInBand`