### PR TITLE
Hide visually empty manual coding instructions

### DIFF
--- a/apps/backend/src/app/admin/code-book/codebook-generator.class.spec.ts
+++ b/apps/backend/src/app/admin/code-book/codebook-generator.class.spec.ts
@@ -124,7 +124,8 @@ describe('CodebookGenerator', () => {
       [
         manualCode,
         { ...manualCode, id: 2, manualInstruction: '' },
-        { ...manualCode, id: 3, manualInstruction: '   ' }
+        { ...manualCode, id: 3, manualInstruction: '   ' },
+        { ...manualCode, id: 4, manualInstruction: '<p style="margin-top: 0; min-height: 1em"></p>' }
       ],
       { ...contentSetting, hasOnlyManualCoding: true, hasClosedVars: false }
     ) as { id: string; description: string }[];
@@ -151,11 +152,11 @@ describe('CodebookGenerator', () => {
     expect(codeInfos.map(codeInfo => codeInfo.id)).toEqual(['1', '2', '3']);
   });
 
-  it('treats whitespace-only manual instructions as missing for variable filtering', () => {
+  it('treats visually empty HTML manual instructions as missing for variable filtering', () => {
     const generator = CodebookGenerator as unknown as Record<string, (...args: unknown[]) => unknown>;
     const whitespaceManualVariable = {
       ...variableCoding,
-      codes: [{ ...manualCode, manualInstruction: '   ' }]
+      codes: [{ ...manualCode, manualInstruction: '<p style="margin-top: 0; min-height: 1em"></p>' }]
     };
 
     expect(generator.isManual(whitespaceManualVariable)).toBe(false);

--- a/apps/backend/src/app/admin/code-book/codebook-generator.class.ts
+++ b/apps/backend/src/app/admin/code-book/codebook-generator.class.ts
@@ -12,6 +12,7 @@ import {
   UnitPropertiesForCodebook
 } from './codebook.interfaces';
 import { CodebookDocxGenerator } from './codebook-docx-generator.class';
+import { hasVisibleManualInstruction } from '../../utils/manual-instruction.util';
 
 /**
  * Class for generating codebooks
@@ -143,7 +144,7 @@ export class CodebookGenerator {
   }
 
   private static hasManualInstruction(codeData: CodeData): boolean {
-    return !!codeData.manualInstruction?.trim();
+    return hasVisibleManualInstruction(codeData);
   }
 
   private static shouldHideCodeInManualCodebook(

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -3134,6 +3134,10 @@ describe('CodingJobService', () => {
   it.each([
     { manualInstruction: '', label: 'empty' },
     { manualInstruction: '   ', label: 'whitespace-only' },
+    {
+      manualInstruction: '<p style="margin-top: 0; min-height: 1em"></p>',
+      label: 'visually empty HTML'
+    },
     { manualInstruction: null, label: 'missing' }
   ])(
     'rejects positive selected codes with $label manual instructions',

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -81,6 +81,7 @@ import {
   isCodingIssueReviewJobType
 } from './coding-job-type.util';
 import { statusStringToNumber } from '../../utils/response-status-converter';
+import { hasVisibleManualInstruction } from '../../../utils/manual-instruction.util';
 
 function isSafeKey(key: string): boolean {
   return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
@@ -3764,7 +3765,7 @@ export class CodingJobService {
   }
 
   private hasManualInstruction(code: { manualInstruction?: string | null }): boolean {
-    return !!code.manualInstruction?.trim();
+    return hasVisibleManualInstruction(code);
   }
 
   async getCodingSchemeScoreForUnitCode(

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -1241,6 +1241,11 @@ describe('CodingValidationService', () => {
                   id: 2,
                   label: 'Whitespace',
                   manualInstruction: '   '
+                },
+                {
+                  id: 3,
+                  label: 'Visually empty HTML',
+                  manualInstruction: '<p style="margin-top: 0; min-height: 1em"></p>'
                 }
               ]
             }
@@ -1261,7 +1266,7 @@ describe('CodingValidationService', () => {
             casesInJobs: 0,
             availableCases: 5,
             uniqueCasesAfterAggregation: 5,
-            regularCodeCount: 2,
+            regularCodeCount: 3,
             selectableRegularCodeCount: 0,
             onlySpecialOptionsAvailable: true
           })

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -42,6 +42,7 @@ import {
   createManualCodingVariableReferences,
   DERIVE_ERROR_STATUS
 } from '../../utils/manual-coding-candidate.util';
+import { hasVisibleManualInstruction } from '../../../utils/manual-instruction.util';
 import {
   applyNonCodingIssueReviewJobFilter,
   getNonCodingIssueReviewJobSqlCondition
@@ -924,7 +925,7 @@ export class CodingValidationService {
   private hasManualInstruction(
     code: { manualInstruction?: string | null }
   ): boolean {
-    return !!code.manualInstruction?.trim();
+    return hasVisibleManualInstruction(code);
   }
 
   private getManualCodeAvailabilityKey(

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -76,6 +76,7 @@ import {
   assertValidRegexSearchPattern,
   withRegexSearchStatementTimeout
 } from '../../../utils/regex-search.util';
+import { hasVisibleManualInstruction } from '../../../utils/manual-instruction.util';
 
 type WorkspaceUnitVisibility = {
   globalIgnoredUnits: Set<string>;
@@ -2891,7 +2892,7 @@ ${bookletRefs}
                   intendedIncompleteSchemeIds.add(vc.id);
                 }
                 const hasManualInstruction = vc.codes.some(
-                  code => !!code.manualInstruction?.trim()
+                  code => hasVisibleManualInstruction(code)
                 );
                 if (hasManualInstruction) {
                   manualInstructionSchemeIds.add(vc.id);
@@ -3505,8 +3506,7 @@ ${bookletRefs}
 
                 // Check if any code has manual instruction (similar to isManual() in codebook-generator)
                 const hasManualInstruction = vc.codes.some(
-                  code => code.manualInstruction &&
-                    code.manualInstruction.trim() !== ''
+                  code => hasVisibleManualInstruction(code)
                 );
                 if (hasManualInstruction) {
                   variableManualInstructions.set(vc.id, true);

--- a/apps/backend/src/app/utils/manual-instruction.util.spec.ts
+++ b/apps/backend/src/app/utils/manual-instruction.util.spec.ts
@@ -1,0 +1,23 @@
+import {
+  getVisibleManualInstructionText,
+  hasVisibleManualInstruction
+} from './manual-instruction.util';
+
+describe('manual-instruction.util', () => {
+  it('treats visually empty HTML instructions as missing', () => {
+    expect(hasVisibleManualInstruction({
+      manualInstruction: '<p style="margin-top: 0; min-height: 1em">&nbsp;</p>'
+    })).toBe(false);
+  });
+
+  it('treats zero-width characters as missing', () => {
+    expect(hasVisibleManualInstruction({
+      manualInstruction: '<p>&#8203;\u200d\ufeff</p>'
+    })).toBe(false);
+  });
+
+  it('does not throw for invalid numeric HTML entities', () => {
+    expect(getVisibleManualInstructionText('&#999999999999;')).toBe('&#999999999999;');
+    expect(getVisibleManualInstructionText('&#xFFFFFFFF;')).toBe('&#xFFFFFFFF;');
+  });
+});

--- a/apps/backend/src/app/utils/manual-instruction.util.ts
+++ b/apps/backend/src/app/utils/manual-instruction.util.ts
@@ -38,7 +38,9 @@ function decodeCodePoint(codePoint: number, fallback: string): string {
   return String.fromCodePoint(codePoint);
 }
 
-export function getVisibleManualInstructionText(manualInstruction?: string | null): string {
+export function getVisibleManualInstructionText(
+  manualInstruction?: string | null
+): string {
   if (!manualInstruction) return '';
 
   return decodeHtmlEntities(manualInstruction.replace(/<[^>]*>/g, ' '))
@@ -48,6 +50,8 @@ export function getVisibleManualInstructionText(manualInstruction?: string | nul
     .trim();
 }
 
-export function hasManualInstruction(code: { manualInstruction?: string | null }): boolean {
+export function hasVisibleManualInstruction(
+  code: { manualInstruction?: string | null }
+): boolean {
   return getVisibleManualInstructionText(code.manualInstruction).length > 0;
 }

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -82,6 +82,15 @@ describe('CodeSelectorComponent', () => {
             ruleSetOperatorAnd: false,
             ruleSets: [],
             manualInstruction: '   '
+          },
+          {
+            id: 4,
+            type: 'RESIDUAL',
+            label: 'Visually empty HTML code',
+            score: 0,
+            ruleSetOperatorAnd: false,
+            ruleSets: [],
+            manualInstruction: '<p style="margin-top: 0; min-height: 1em"></p>'
           }
         ]
       }

--- a/apps/frontend/src/app/coding/utils/manual-coding.util.spec.ts
+++ b/apps/frontend/src/app/coding/utils/manual-coding.util.spec.ts
@@ -1,0 +1,23 @@
+import {
+  getVisibleManualInstructionText,
+  hasManualInstruction
+} from './manual-coding.util';
+
+describe('manual-coding.util', () => {
+  it('treats visually empty HTML instructions as missing', () => {
+    expect(hasManualInstruction({
+      manualInstruction: '<p style="margin-top: 0; min-height: 1em">&nbsp;</p>'
+    })).toBe(false);
+  });
+
+  it('treats zero-width characters as missing', () => {
+    expect(hasManualInstruction({
+      manualInstruction: '<p>&#8203;\u200d\ufeff</p>'
+    })).toBe(false);
+  });
+
+  it('does not throw for invalid numeric HTML entities', () => {
+    expect(getVisibleManualInstructionText('&#999999999999;')).toBe('&#999999999999;');
+    expect(getVisibleManualInstructionText('&#xFFFFFFFF;')).toBe('&#xFFFFFFFF;');
+  });
+});

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -1350,6 +1350,15 @@ describe('ReplayComponent', () => {
               ruleSetOperatorAnd: false,
               ruleSets: [],
               manualInstruction: '<p>Manual instruction</p>'
+            },
+            {
+              id: 4,
+              type: 'RESIDUAL',
+              label: 'Visually empty HTML code',
+              score: 0,
+              ruleSetOperatorAnd: false,
+              ruleSets: [],
+              manualInstruction: '<p style="margin-top: 0; min-height: 1em"></p>'
             }
           ]
         }
@@ -1501,6 +1510,38 @@ describe('ReplayComponent', () => {
       component.codingService.codingScheme = digitShortcutCodingScheme;
       const onCodeSelectedSpy = jest.spyOn(component, 'onCodeSelected').mockResolvedValue();
       const event = new KeyboardEvent('keydown', { key: '1', code: 'Digit1' });
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+      component.onKeyDown(event);
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(onCodeSelectedSpy).not.toHaveBeenCalled();
+    });
+
+    it('should ignore digit shortcuts for regular codes with visually empty HTML manual instructions', () => {
+      component.isCodingMode = true;
+      const unitsData = {
+        id: 123,
+        name: 'job',
+        currentUnitIndex: 0,
+        units: [
+          {
+            id: 1,
+            name: 'UNIT1',
+            alias: 'UNIT1',
+            bookletId: 0,
+            testPerson: 'tp1@code1@grp@booklet',
+            variableId: 'V1',
+            variableAnchor: 'V1'
+          }
+        ]
+      };
+      const replayComponent = component as ReplayComponent & { unitsData: typeof unitsData };
+      replayComponent.unitsData = unitsData;
+      component.codingService.currentVariableId = 'V1';
+      component.codingService.codingScheme = digitShortcutCodingScheme;
+      const onCodeSelectedSpy = jest.spyOn(component, 'onCodeSelected').mockResolvedValue();
+      const event = new KeyboardEvent('keydown', { key: '4', code: 'Digit4' });
       const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
       component.onKeyDown(event);


### PR DESCRIPTION
## Summary

- Treat manual instructions as available only when they contain visible text after removing HTML tags, entities, whitespace, and zero-width characters.
- Apply the same check in the code selector, replay digit shortcuts, backend save validation, manual availability validation, workspace metadata, and codebook generation.
- Add frontend and backend tests for visually empty HTML, invalid numeric HTML entities, and replay shortcut behavior.

## Context

Relates to #485. The issue is intentionally not closed by this PR.

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/coding/utils/manual-coding.util.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/replay/components/replay/replay.component.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts --runInBand`
- `npx nx test backend --testFile=apps/backend/src/app/utils/manual-instruction.util.spec.ts --runInBand`
- `npx nx lint frontend`
- `npx nx lint backend`
