### PR TITLE
Normalize replay math text array values

### DIFF
--- a/apps/frontend/src/app/replay/components/unit-player/unit-player.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/unit-player/unit-player.component.spec.ts
@@ -82,6 +82,39 @@ describe('UnitPlayerComponent', () => {
     expect(emitSpy).toHaveBeenCalledTimes(2);
   });
 
+  it('should normalize math text array values in replay data parts', () => {
+    component.ngOnChanges({
+      unitDef: new SimpleChange(undefined, JSON.stringify({
+        BaseVariables: {
+          Variable: [
+            {
+              id: '02b',
+              type: 'json',
+              format: 'math-text-mix'
+            },
+            {
+              id: 'other',
+              type: 'json'
+            }
+          ]
+        }
+      }), true),
+      unitResponses: new SimpleChange(undefined, {
+        responses: [{
+          id: 'chunk1',
+          content: JSON.stringify([
+            { id: '02b', value: [], status: 2 },
+            { id: 'other', value: ['kept'], status: 2 }
+          ])
+        }]
+      }, true)
+    });
+
+    const [mathTextResponse, otherResponse] = JSON.parse(component.dataParts.chunk1);
+    expect(mathTextResponse.value).toBe('[]');
+    expect(otherResponse.value).toEqual(['kept']);
+  });
+
   it('should not emit a page error when requested page 0 is valid and current', () => {
     const emitSpy = jest.spyOn(component.invalidPage, 'emit');
 

--- a/apps/frontend/src/app/replay/components/unit-player/unit-player.component.ts
+++ b/apps/frontend/src/app/replay/components/unit-player/unit-player.component.ts
@@ -17,6 +17,7 @@ import { FileService } from '../../../shared/services/file/file.service';
 import { ResponseDto } from '../../../../../../../api-dto/responses/response-dto';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { PageData } from '../../models/page-data.model';
+import { normalizeMathTextReplayDataParts } from '../../utils/replay-data-parts-normalization';
 
 export type Progress = 'none' | 'some' | 'complete';
 
@@ -133,7 +134,7 @@ export class UnitPlayerComponent implements AfterViewInit, OnChanges, OnDestroy 
 
   private handleResponsesChange(unitResponses: ResponseDto): void {
     if (unitResponses?.responses) {
-      this.dataParts = unitResponses.responses.reduce(
+      const dataParts = unitResponses.responses.reduce(
         (acc: { [key: string]: string }, response: { id: string; content: string }) => {
           if (typeof response.content === 'object' && response.content !== null) {
             acc[response.id] = JSON.stringify(response.content);
@@ -148,6 +149,7 @@ export class UnitPlayerComponent implements AfterViewInit, OnChanges, OnDestroy 
           return acc;
         }, {}
       );
+      this.dataParts = normalizeMathTextReplayDataParts(dataParts, this.unitDef);
     }
   }
 
@@ -396,11 +398,14 @@ export class UnitPlayerComponent implements AfterViewInit, OnChanges, OnDestroy 
     if (this.playerApiVersion === 1) {
       postMessageData.type = 'vo.ToPlayer.DataTransfer';
     } else {
+      const dataParts = this.dataParts ?
+        normalizeMathTextReplayDataParts(this.dataParts, this.unitDef) :
+        this.dataParts;
       this.isLoaded.next(true);
       Object.assign(postMessageData, {
         type: 'vopStartCommand',
         unitState: {
-          dataParts: this.dataParts,
+          dataParts,
           presentationProgress: 'none',
           responseProgress: 'none'
         },

--- a/apps/frontend/src/app/replay/utils/replay-data-parts-normalization.spec.ts
+++ b/apps/frontend/src/app/replay/utils/replay-data-parts-normalization.spec.ts
@@ -1,0 +1,133 @@
+import {
+  getMathTextResponseIds,
+  normalizeMathTextReplayDataParts
+} from './replay-data-parts-normalization';
+
+describe('replay data parts normalization', () => {
+  it('normalizes empty array values for math-text-mix variables', () => {
+    const dataParts = {
+      chunk1: JSON.stringify([
+        { id: '02b', value: [], status: 2 },
+        { id: 'other', value: ['kept'], status: 2 }
+      ])
+    };
+
+    const normalized = normalizeMathTextReplayDataParts(dataParts, {
+      BaseVariables: {
+        Variable: [
+          {
+            id: '02b',
+            alias: '02b_alias',
+            type: 'json',
+            format: 'math-text-mix'
+          },
+          { id: 'other', type: 'json' }
+        ]
+      }
+    });
+
+    const responses = JSON.parse(normalized.chunk1);
+    expect(responses[0].value).toBe('[]');
+    expect(responses[1].value).toEqual(['kept']);
+  });
+
+  it('normalizes token array values for text-area-math elements', () => {
+    const value = [
+      { type: 'text', value: '' },
+      { type: 'formula', value: 'x^2' }
+    ];
+    const dataParts = {
+      chunk1: JSON.stringify([{ id: 'formula_1', value, status: 3 }])
+    };
+
+    const normalized = normalizeMathTextReplayDataParts(dataParts, {
+      pages: [{
+        sections: [{
+          elements: [{ id: 'formula_1', type: 'text-area-math' }]
+        }]
+      }]
+    });
+
+    const [response] = JSON.parse(normalized.chunk1);
+    expect(response.value).toBe(JSON.stringify(value));
+  });
+
+  it('keeps already stringified math text values unchanged', () => {
+    const dataParts = {
+      chunk1: JSON.stringify([{ id: '02b', value: '[]', status: 2 }])
+    };
+
+    const normalized = normalizeMathTextReplayDataParts(dataParts, {
+      BaseVariables: {
+        Variable: [{ id: '02b', type: 'json', format: 'math-text-mix' }]
+      }
+    });
+
+    const [response] = JSON.parse(normalized.chunk1);
+    expect(response.value).toBe('[]');
+  });
+
+  it('keeps array values for other variables unchanged', () => {
+    const dataParts = {
+      chunk1: JSON.stringify([{ id: 'choice_1', value: [true, false], status: 3 }])
+    };
+
+    const normalized = normalizeMathTextReplayDataParts(dataParts, {
+      pages: [{
+        sections: [{
+          elements: [{ id: 'formula_1', type: 'text-area-math' }]
+        }]
+      }]
+    });
+
+    const [response] = JSON.parse(normalized.chunk1);
+    expect(response.value).toEqual([true, false]);
+  });
+
+  it('uses aliases from math-text-mix variable definitions', () => {
+    const dataParts = {
+      chunk1: JSON.stringify([{ id: '02b_alias', value: [], status: 2 }])
+    };
+
+    const normalized = normalizeMathTextReplayDataParts(dataParts, {
+      Unit: {
+        BaseVariables: [{
+          Variable: [{
+            $: {
+              id: '02b',
+              alias: '02b_alias',
+              type: 'json',
+              format: 'math-text-mix'
+            }
+          }]
+        }]
+      }
+    });
+
+    const [response] = JSON.parse(normalized.chunk1);
+    expect(response.value).toBe('[]');
+  });
+
+  it('extracts ids from both modern json and xml2js style definitions', () => {
+    const responseIds = getMathTextResponseIds({
+      pages: [{
+        sections: [{
+          elements: [{ id: 'formula_1', type: 'text-area-math' }]
+        }]
+      }],
+      Unit: {
+        BaseVariables: [{
+          Variable: [{
+            $: {
+              id: '02b',
+              alias: '02b_alias',
+              format: 'math-text-mix'
+            }
+          }]
+        }]
+      }
+    });
+
+    expect(responseIds).toEqual(new Set(['formula_1', '02b', '02b_alias']));
+  });
+});

--- a/apps/frontend/src/app/replay/utils/replay-data-parts-normalization.ts
+++ b/apps/frontend/src/app/replay/utils/replay-data-parts-normalization.ts
@@ -1,0 +1,163 @@
+type ReplayDataParts = Record<string, string>;
+type UnknownRecord = Record<string, unknown>;
+
+const TEXT_AREA_MATH_TYPE = 'text-area-math';
+const MATH_TEXT_MIX_FORMAT = 'math-text-mix';
+const ID_KEYS = [
+  'id',
+  'alias',
+  'variableId',
+  'variable',
+  'responseId',
+  'responseIdentifier',
+  'elementAlias',
+  'dataElementAlias',
+  'data-element-alias'
+];
+const ATTRIBUTE_KEYS = ['$', 'attributes', '_attributes'];
+const TYPE_KEYS = ['type', 'elementType', 'dataElementType', 'data-element-type', 'aspectType', 'data-aspect-type'];
+
+export function normalizeMathTextReplayDataParts(
+  dataParts: ReplayDataParts,
+  unitDefinition: unknown
+): ReplayDataParts {
+  const mathTextResponseIds = getMathTextResponseIds(unitDefinition);
+  if (mathTextResponseIds.size === 0) {
+    return dataParts;
+  }
+
+  let hasChanges = false;
+  const normalizedDataParts = Object.entries(dataParts).reduce<ReplayDataParts>((acc, [chunkId, content]) => {
+    const normalizedContent = normalizeReplayChunkContent(content, mathTextResponseIds);
+    if (normalizedContent !== content) {
+      hasChanges = true;
+    }
+    acc[chunkId] = normalizedContent;
+    return acc;
+  }, {});
+
+  return hasChanges ? normalizedDataParts : dataParts;
+}
+
+export function getMathTextResponseIds(unitDefinition: unknown): Set<string> {
+  const responseIds = new Set<string>();
+  collectMathTextResponseIds(unitDefinition, responseIds, new Set<unknown>());
+  return responseIds;
+}
+
+function collectMathTextResponseIds(
+  value: unknown,
+  responseIds: Set<string>,
+  visited: Set<unknown>
+): void {
+  if (!value || typeof value !== 'object' || visited.has(value)) {
+    return;
+  }
+  visited.add(value);
+
+  if (Array.isArray(value)) {
+    value.forEach(item => collectMathTextResponseIds(item, responseIds, visited));
+    return;
+  }
+
+  const record = value as UnknownRecord;
+  if (isMathTextDefinition(record)) {
+    getCandidateResponseIds(record).forEach(id => responseIds.add(id));
+  }
+
+  Object.values(record).forEach(child => collectMathTextResponseIds(child, responseIds, visited));
+}
+
+function isMathTextDefinition(record: UnknownRecord): boolean {
+  return getAttributeRecords(record).some(attributeRecord => {
+    const format = getStringValue(attributeRecord, 'format');
+    if (format?.trim().toLowerCase() === MATH_TEXT_MIX_FORMAT) {
+      return true;
+    }
+
+    return TYPE_KEYS.some(key => getStringValue(attributeRecord, key)?.trim().toLowerCase() === TEXT_AREA_MATH_TYPE);
+  });
+}
+
+function getCandidateResponseIds(record: UnknownRecord): string[] {
+  const ids: string[] = [];
+  getAttributeRecords(record).forEach(attributeRecord => {
+    ID_KEYS.forEach(key => {
+      const id = getStringValue(attributeRecord, key)?.trim();
+      if (id) {
+        ids.push(id);
+      }
+    });
+  });
+  return ids;
+}
+
+function getAttributeRecords(record: UnknownRecord): UnknownRecord[] {
+  const records = [record];
+  ATTRIBUTE_KEYS.forEach(key => {
+    const value = record[key];
+    if (isRecord(value)) {
+      records.push(value);
+    }
+  });
+  return records;
+}
+
+function normalizeReplayChunkContent(content: string, mathTextResponseIds: Set<string>): string {
+  try {
+    const parsedContent = JSON.parse(content);
+    const normalized = normalizeChunkResponses(parsedContent, mathTextResponseIds);
+    return normalized.hasChanges ? JSON.stringify(normalized.value) : content;
+  } catch {
+    return content;
+  }
+}
+
+function normalizeChunkResponses(
+  content: unknown,
+  mathTextResponseIds: Set<string>
+): { value: unknown; hasChanges: boolean } {
+  if (Array.isArray(content)) {
+    let hasChanges = false;
+    const value = content.map(response => {
+      const normalized = normalizeResponseValue(response, mathTextResponseIds);
+      hasChanges = hasChanges || normalized.hasChanges;
+      return normalized.value;
+    });
+    return { value, hasChanges };
+  }
+
+  const normalized = normalizeResponseValue(content, mathTextResponseIds);
+  return normalized.hasChanges ? normalized : { value: content, hasChanges: false };
+}
+
+function normalizeResponseValue(
+  response: unknown,
+  mathTextResponseIds: Set<string>
+): { value: unknown; hasChanges: boolean } {
+  if (!isRecord(response)) {
+    return { value: response, hasChanges: false };
+  }
+
+  const responseId = getStringValue(response, 'id');
+  if (!responseId || !mathTextResponseIds.has(responseId) || !Array.isArray(response.value)) {
+    return { value: response, hasChanges: false };
+  }
+
+  return {
+    value: {
+      ...response,
+      value: JSON.stringify(response.value)
+    },
+    hasChanges: true
+  };
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getStringValue(record: UnknownRecord, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}


### PR DESCRIPTION
## Summary

Related to #717.

Replay data parts now normalize array response values for `math-text-mix` and `text-area-math` definitions into JSON strings before they reach the Aspect Player. Already stringified values and unrelated response arrays stay unchanged.

## Details

- adds a replay normalization utility that derives affected response IDs from the unit definition
- applies the normalization when replay responses are loaded and again before posting the unit state to the player
- adds focused Jest coverage for math text arrays, aliases, already-stringified values, and unrelated arrays

## Validation

- `npx nx lint frontend`
- `npx nx test frontend`