### PR TITLE
Improve freshness auto-coding dialog tracking

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -21,6 +21,7 @@ import { TestPersonCodingService } from '../../services/test-person-coding.servi
 import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
 import { Success } from '../../models/success.model';
+import { TestPersonCodingDialogComponent } from '../test-person-coding-dialog/test-person-coding-dialog.component';
 
 describe('CodingManagementComponent', () => {
   let component: CodingManagementComponent;
@@ -33,6 +34,7 @@ describe('CodingManagementComponent', () => {
   let mockTestPersonCodingService: jest.Mocked<Partial<TestPersonCodingService>>;
   let mockRouter: jest.Mocked<Partial<Router>>;
   let mockSnackBar: jest.Mocked<Partial<MatSnackBar>>;
+  let autoCodingCompletedSubject: Subject<{ jobId?: string }>;
 
   const fakeActivatedRoute = {
     snapshot: { data: {} }
@@ -89,9 +91,10 @@ describe('CodingManagementComponent', () => {
       getAutoFetchCodingStatistics: jest.fn().mockReturnValue(of(false)),
       getEnableRegexSearch: jest.fn().mockReturnValue(of(false))
     };
+    autoCodingCompletedSubject = new Subject<{ jobId?: string }>();
 
     mockTestPersonCodingService = {
-      autoCodingCompleted$: of(),
+      autoCodingCompleted$: autoCodingCompletedSubject.asObservable(),
       testResultsChanged$: of(),
       getCodingFreshness: jest.fn().mockReturnValue(of({
         workspaceId: 1,
@@ -520,6 +523,159 @@ describe('CodingManagementComponent', () => {
         'Schließen',
         { duration: 6000 }
       );
+    });
+
+    it('should open the test person coding dialog with the started freshness job', () => {
+      jest.useFakeTimers();
+      try {
+        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
+          totalResponses: 42,
+          statusCounts: {},
+          jobId: 'freshness-job-1',
+          message: 'Processing in background',
+          unitCount: 7,
+          personCount: 3,
+          groupNames: ['TG1']
+        }));
+
+        component.startFreshnessCoding('v1');
+
+        expect(mockDialog.open).toHaveBeenCalledWith(
+          TestPersonCodingDialogComponent,
+          expect.objectContaining({
+            height: '90vh',
+            maxWidth: '100vw',
+            maxHeight: '100vh',
+            data: {
+              initialJobId: 'freshness-job-1',
+              initialAutoCoderRun: 1
+            }
+          })
+        );
+      } finally {
+        component.ngOnDestroy();
+        jest.useRealTimers();
+      }
+    });
+
+    it('should resume parent freshness polling only after the job dialog closes', () => {
+      jest.useFakeTimers();
+      const afterClosed$ = new Subject<void>();
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(afterClosed$),
+        close: jest.fn()
+      };
+
+      try {
+        (mockDialog.open as jest.Mock).mockReturnValueOnce(dialogRef);
+        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
+          totalResponses: 42,
+          statusCounts: {},
+          jobId: 'freshness-job-1',
+          message: 'Processing in background',
+          unitCount: 7,
+          personCount: 3,
+          groupNames: ['TG1']
+        }));
+
+        component.startFreshnessCoding('v1');
+
+        expect(jest.getTimerCount()).toBe(0);
+
+        afterClosed$.next();
+        afterClosed$.complete();
+
+        expect(jest.getTimerCount()).toBe(1);
+      } finally {
+        component.ngOnDestroy();
+        jest.useRealTimers();
+      }
+    });
+
+    it('should not resume parent freshness polling when the dialog reports a terminal status for the started job', () => {
+      jest.useFakeTimers();
+      const afterClosed$ = new Subject<{ initialJobId: string; jobId: string; jobStatus: 'failed' }>();
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(afterClosed$),
+        close: jest.fn()
+      };
+
+      try {
+        (mockDialog.open as jest.Mock).mockReturnValueOnce(dialogRef);
+        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
+          totalResponses: 42,
+          statusCounts: {},
+          jobId: 'freshness-job-1',
+          message: 'Processing in background',
+          unitCount: 7,
+          personCount: 3,
+          groupNames: ['TG1']
+        }));
+
+        component.startFreshnessCoding('v1');
+        afterClosed$.next({
+          initialJobId: 'freshness-job-1',
+          jobId: 'freshness-job-1',
+          jobStatus: 'failed'
+        });
+        afterClosed$.complete();
+
+        expect(jest.getTimerCount()).toBe(0);
+        expect(component.activeFreshnessJobId).toBeNull();
+      } finally {
+        component.ngOnDestroy();
+        jest.useRealTimers();
+      }
+    });
+
+    it('should resume parent freshness polling when the dialog reports a status for another job', () => {
+      jest.useFakeTimers();
+      const afterClosed$ = new Subject<{ initialJobId: string; jobId: string; jobStatus: 'failed' }>();
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(afterClosed$),
+        close: jest.fn()
+      };
+
+      try {
+        (mockDialog.open as jest.Mock).mockReturnValueOnce(dialogRef);
+        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
+          totalResponses: 42,
+          statusCounts: {},
+          jobId: 'freshness-job-1',
+          message: 'Processing in background',
+          unitCount: 7,
+          personCount: 3,
+          groupNames: ['TG1']
+        }));
+
+        component.startFreshnessCoding('v1');
+        afterClosed$.next({
+          initialJobId: 'freshness-job-1',
+          jobId: 'other-job',
+          jobStatus: 'failed'
+        });
+        afterClosed$.complete();
+
+        expect(jest.getTimerCount()).toBe(1);
+      } finally {
+        component.ngOnDestroy();
+        jest.useRealTimers();
+      }
+    });
+
+    it('should keep active freshness tracking when a different auto-coding job completes', () => {
+      component.activeFreshnessJobId = 'freshness-job-1';
+      component.activeFreshnessJobProgress = 42;
+
+      autoCodingCompletedSubject.next({ jobId: 'other-job' });
+
+      expect(component.activeFreshnessJobId).toBe('freshness-job-1');
+      expect(component.activeFreshnessJobProgress).toBe(42);
+
+      autoCodingCompletedSubject.next({ jobId: 'freshness-job-1' });
+
+      expect(component.activeFreshnessJobId).toBeNull();
+      expect(component.activeFreshnessJobProgress).toBeNull();
     });
   });
 

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -19,7 +19,7 @@ import {
   MatAnchor,
   MatButton
 } from '@angular/material/button';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { PageEvent } from '@angular/material/paginator';
 import { Sort } from '@angular/material/sort';
 import { Router } from '@angular/router';
@@ -34,7 +34,11 @@ import {
 } from '../export-dialog/export-dialog.component';
 import { Success } from '../../models/success.model';
 import { ResponseEntity } from '../../../shared/models/response-entity.model';
-import { TestPersonCodingDialogComponent } from '../test-person-coding-dialog/test-person-coding-dialog.component';
+import {
+  TestPersonCodingDialogComponent,
+  TestPersonCodingDialogData,
+  TestPersonCodingDialogResult
+} from '../test-person-coding-dialog/test-person-coding-dialog.component';
 import {
   AppliedResultsOverview,
   TestPersonCodingService
@@ -280,7 +284,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
     this.testPersonCodingService.autoCodingCompleted$
       .pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
+      .subscribe(event => {
+        if (event?.jobId && event.jobId === this.activeFreshnessJobId) {
+          this.stopFreshnessJobPolling();
+        }
         this.fetchCodingStatistics();
         this.loadCodingFreshness();
         this.loadManualAppliedResultsOverview();
@@ -462,7 +469,30 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
         this.activeFreshnessJobId = result.jobId;
         this.activeFreshnessJobProgress = 0;
-        this.startFreshnessJobPolling(result.jobId);
+        const dialogRef = this.openTestPersonCodingDialog({
+          initialJobId: result.jobId,
+          initialAutoCoderRun: version === 'v3' ? 2 : 1
+        });
+        dialogRef.afterClosed()
+          .pipe(takeUntil(this.destroy$))
+          .subscribe(dialogResult => {
+            if (this.activeFreshnessJobId !== result.jobId) {
+              return;
+            }
+
+            const dialogStatus = dialogResult?.jobId === result.jobId ?
+              dialogResult.jobStatus :
+              null;
+            if (this.isTerminalJobStatus(dialogStatus)) {
+              this.stopFreshnessJobPolling();
+              this.loadCodingFreshness();
+              this.loadManualAppliedResultsOverview();
+              this.loadAutocodingReadiness(true);
+              return;
+            }
+
+            this.startFreshnessJobPolling(result.jobId);
+          });
         this.snackBar.open(
           `Auto-Coding für ${result.unitCount} betroffene Einträge gestartet.`,
           'Schließen',
@@ -953,7 +983,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
           if (['completed', 'failed', 'cancelled', 'paused'].includes(status.status)) {
             this.stopFreshnessJobPolling();
             if (status.status === 'completed') {
-              this.testPersonCodingService.notifyAutoCodingCompleted();
+              this.testPersonCodingService.notifyAutoCodingCompleted(jobId);
               this.snackBar.open(
                 'Betroffene Ergebnisse wurden kodiert.',
                 'Schließen',
@@ -1156,15 +1186,31 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   // Dialog Methods
   onAutoCode(): void {
+    this.openTestPersonCodingDialog();
+  }
+
+  private openTestPersonCodingDialog(
+    data?: TestPersonCodingDialogData
+  ): MatDialogRef<TestPersonCodingDialogComponent, TestPersonCodingDialogResult | undefined> {
     const dialogRef = this.dialog.open(TestPersonCodingDialogComponent, {
       height: '90vh',
       maxWidth: '100vw',
-      maxHeight: '100vh'
+      maxHeight: '100vh',
+      disableClose: true,
+      data
     });
 
-    dialogRef.afterClosed().subscribe(() => {
-      this.fetchCodingStatistics();
-    });
+    dialogRef.afterClosed()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.fetchCodingStatistics();
+      });
+
+    return dialogRef;
+  }
+
+  private isTerminalJobStatus(status?: string | null): boolean {
+    return ['completed', 'failed', 'cancelled', 'paused'].includes(status || '');
   }
 
   fetchCodingList(): void {

--- a/apps/frontend/src/app/coding/components/test-person-coding-dialog/test-person-coding-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/test-person-coding-dialog/test-person-coding-dialog.component.html
@@ -4,7 +4,10 @@
   </div>
 
   <div class="dialog-content">
-    <coding-box-test-person-coding></coding-box-test-person-coding>
+    <coding-box-test-person-coding
+      [initialJobId]="data?.initialJobId || null"
+      [initialAutoCoderRun]="data?.initialAutoCoderRun || null">
+    </coding-box-test-person-coding>
   </div>
 
   <div class="dialog-footer">

--- a/apps/frontend/src/app/coding/components/test-person-coding-dialog/test-person-coding-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/test-person-coding-dialog/test-person-coding-dialog.component.ts
@@ -1,9 +1,27 @@
-import { Component } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import {
+  Component,
+  OnDestroy,
+  ViewChild,
+  inject
+} from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
+import { Subject, takeUntil } from 'rxjs';
 import { TestPersonCodingComponent } from '../test-person-coding/test-person-coding.component';
+import { JobStatus } from '../../services/test-person-coding.service';
+
+export interface TestPersonCodingDialogData {
+  initialJobId?: string;
+  initialAutoCoderRun?: 1 | 2;
+}
+
+export interface TestPersonCodingDialogResult {
+  initialJobId?: string;
+  jobId?: string | null;
+  jobStatus?: JobStatus['status'] | null;
+}
 
 @Component({
   selector: 'coding-box-test-person-coding-dialog',
@@ -12,12 +30,45 @@ import { TestPersonCodingComponent } from '../test-person-coding/test-person-cod
   standalone: true,
   imports: [TestPersonCodingComponent, MatIconModule, MatButtonModule, TranslateModule]
 })
-export class TestPersonCodingDialogComponent {
+export class TestPersonCodingDialogComponent implements OnDestroy {
+  data = inject<TestPersonCodingDialogData | null>(MAT_DIALOG_DATA, { optional: true });
+  @ViewChild(TestPersonCodingComponent) testPersonCodingComponent?: TestPersonCodingComponent;
+
+  private destroy$ = new Subject<void>();
+
   constructor(
     public dialogRef: MatDialogRef<TestPersonCodingDialogComponent>
-  ) {}
+  ) {
+    this.dialogRef.backdropClick()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.closeDialog());
+
+    this.dialogRef.keydownEvents()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          this.closeDialog();
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 
   closeDialog(): void {
-    this.dialogRef.close();
+    this.dialogRef.close(this.getDialogResult());
+  }
+
+  private getDialogResult(): TestPersonCodingDialogResult {
+    const initialJobId = this.data?.initialJobId ?? null;
+
+    return {
+      initialJobId: initialJobId ?? undefined,
+      jobId: initialJobId ?? this.testPersonCodingComponent?.lastObservedJobId ?? null,
+      jobStatus: this.testPersonCodingComponent?.getLastObservedJobStatus(initialJobId) ?? null
+    };
   }
 }

--- a/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { AppService } from '../../../core/services/app.service';
+import { TestResultService } from '../../../shared/services/test-result/test-result.service';
+import { BackendMessageTranslatorService } from '../../services/backend-message-translator.service';
+import {
+  JobStatus,
+  TestPersonCodingService
+} from '../../services/test-person-coding.service';
+import { TestPersonCodingComponent } from './test-person-coding.component';
+
+describe('TestPersonCodingComponent', () => {
+  let fixture: ComponentFixture<TestPersonCodingComponent>;
+  let component: TestPersonCodingComponent;
+  let mockTestPersonCodingService: jest.Mocked<Partial<TestPersonCodingService>>;
+
+  beforeEach(async () => {
+    mockTestPersonCodingService = {
+      getAllJobs: jest.fn().mockReturnValue(of([])),
+      getWorkspaceGroups: jest.fn().mockReturnValue(of([])),
+      getJobStatus: jest.fn(),
+      notifyAutoCodingCompleted: jest.fn()
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        TestPersonCodingComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: TestPersonCodingService,
+          useValue: mockTestPersonCodingService
+        },
+        {
+          provide: AppService,
+          useValue: { selectedWorkspaceId: 1 }
+        },
+        {
+          provide: TestResultService,
+          useValue: {}
+        },
+        {
+          provide: BackendMessageTranslatorService,
+          useValue: { translateMessage: jest.fn(message => message) }
+        },
+        {
+          provide: MatSnackBar,
+          useValue: { open: jest.fn() }
+        },
+        {
+          provide: MatDialog,
+          useValue: { open: jest.fn() }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestPersonCodingComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    component.ngOnDestroy();
+  });
+
+  it('should remember a terminal job status after polling state is cleared', () => {
+    jest.useFakeTimers();
+    try {
+      const failedStatus: JobStatus = {
+        status: 'failed',
+        progress: 100,
+        error: 'boom'
+      };
+      (mockTestPersonCodingService.getJobStatus as jest.Mock).mockReturnValueOnce(of(failedStatus));
+
+      component.startJobStatusPolling('freshness-job-1');
+
+      expect(component.jobStatus).toBeNull();
+      expect(component.activeJobId).toBeNull();
+      expect(component.lastObservedJobId).toBe('freshness-job-1');
+      expect(component.getLastObservedJobStatus('freshness-job-1')).toBe('failed');
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.ts
+++ b/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.ts
@@ -1,4 +1,9 @@
-import { Component, OnInit, inject } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnInit,
+  inject
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -76,6 +81,9 @@ export class TestPersonCodingComponent implements OnInit {
   private translateService = inject(TranslateService);
   private backendMessageTranslator = inject(BackendMessageTranslatorService);
   private dialog = inject(MatDialog);
+  @Input() initialJobId: string | null = null;
+  @Input() initialAutoCoderRun: 1 | 2 | null = null;
+
   Math = Math;
   get workspaceId(): number {
     return this.appService.selectedWorkspaceId;
@@ -107,6 +115,8 @@ export class TestPersonCodingComponent implements OnInit {
   activeJobId: string | null = null;
   jobStatus: JobStatus | null = null;
   jobStatusInterval: number | null = null;
+  lastObservedJobId: string | null = null;
+  private observedJobStatuses = new Map<string, JobStatus['status']>();
 
   allJobs: JobInfo[] = [];
   jobsLoading = false;
@@ -120,6 +130,15 @@ export class TestPersonCodingComponent implements OnInit {
   private lastNotifiedCompletedJobId: string | null = null;
 
   ngOnInit(): void {
+    if (this.initialAutoCoderRun) {
+      this.autoCoderRun = this.initialAutoCoderRun;
+    }
+
+    if (this.initialJobId) {
+      this.activeJobId = this.initialJobId;
+      this.startJobStatusPolling(this.initialJobId);
+    }
+
     this.loadAllJobs();
     this.startJobsRefreshInterval();
     this.loadWorkspaceGroups();
@@ -157,6 +176,7 @@ export class TestPersonCodingComponent implements OnInit {
               job => job.jobId === this.activeJobId
             );
             if (activeJob) {
+              this.rememberJobStatus(activeJob.jobId, activeJob);
               this.jobStatus = activeJob;
               if (
                 ['completed', 'failed', 'cancelled', 'paused'].includes(
@@ -295,71 +315,89 @@ export class TestPersonCodingComponent implements OnInit {
       clearInterval(this.jobStatusInterval);
     }
 
+    this.activeJobId = jobId;
+    this.jobStatus = null;
     this.jobStatusInterval = window.setInterval(() => {
-      this.testPersonCodingService
-        .getJobStatus(this.workspaceId, jobId)
-        .subscribe(status => {
-          if ('error' in status) {
+      this.loadJobStatus(jobId);
+    }, 2000);
+    this.loadJobStatus(jobId);
+  }
+
+  private loadJobStatus(jobId: string): void {
+    this.testPersonCodingService
+      .getJobStatus(this.workspaceId, jobId)
+      .subscribe(status => {
+        if (!('status' in status)) {
+          this.snackBar.open(
+            this.translateService.instant('test-person-coding.job-error', {
+              error: status.error
+            }),
+            this.translateService.instant('close'),
+            { duration: 5000 }
+          );
+          this.stopJobStatusPolling();
+          return;
+        }
+
+        this.jobStatus = status;
+        this.rememberJobStatus(jobId, status);
+
+        if (
+          ['completed', 'failed', 'cancelled', 'paused'].includes(
+            status.status
+          )
+        ) {
+          this.stopJobStatusPolling();
+
+          if (status.status === 'completed') {
             this.snackBar.open(
-              this.translateService.instant('test-person-coding.job-error', {
-                error: status.error
-              }),
+              this.translateService.instant(
+                'test-person-coding.job-completed'
+              ),
+              this.translateService.instant('close'),
+              { duration: 3000 }
+            );
+            this.handleAutoCodingCompleted(jobId);
+          } else if (status.status === 'failed') {
+            this.snackBar.open(
+              this.translateService.instant(
+                'test-person-coding.job-completed-with-error',
+                {
+                  error:
+                    status.error ||
+                    this.translateService.instant('error.unknown')
+                }
+              ),
               this.translateService.instant('close'),
               { duration: 5000 }
             );
-            this.stopJobStatusPolling();
-            return;
+          } else if (status.status === 'cancelled') {
+            this.snackBar.open(
+              this.translateService.instant(
+                'test-person-coding.job-cancelled'
+              ),
+              this.translateService.instant('close'),
+              { duration: 3000 }
+            );
+          } else if (status.status === 'paused') {
+            this.snackBar.open(
+              this.translateService.instant('test-person-coding.job-paused'),
+              this.translateService.instant('close'),
+              { duration: 3000 }
+            );
           }
+        }
+      });
+  }
 
-          this.jobStatus = status;
+  getLastObservedJobStatus(jobId?: string | null): JobStatus['status'] | null {
+    if (jobId) {
+      return this.observedJobStatuses.get(jobId) ?? null;
+    }
 
-          if (
-            ['completed', 'failed', 'cancelled', 'paused'].includes(
-              status.status
-            )
-          ) {
-            this.stopJobStatusPolling();
-
-            if (status.status === 'completed') {
-              this.snackBar.open(
-                this.translateService.instant(
-                  'test-person-coding.job-completed'
-                ),
-                this.translateService.instant('close'),
-                { duration: 3000 }
-              );
-              this.handleAutoCodingCompleted(jobId);
-            } else if (status.status === 'failed') {
-              this.snackBar.open(
-                this.translateService.instant(
-                  'test-person-coding.job-completed-with-error',
-                  {
-                    error:
-                      status.error ||
-                      this.translateService.instant('error.unknown')
-                  }
-                ),
-                this.translateService.instant('close'),
-                { duration: 5000 }
-              );
-            } else if (status.status === 'cancelled') {
-              this.snackBar.open(
-                this.translateService.instant(
-                  'test-person-coding.job-cancelled'
-                ),
-                this.translateService.instant('close'),
-                { duration: 3000 }
-              );
-            } else if (status.status === 'paused') {
-              this.snackBar.open(
-                this.translateService.instant('test-person-coding.job-paused'),
-                this.translateService.instant('close'),
-                { duration: 3000 }
-              );
-            }
-          }
-        });
-    }, 2000);
+    return this.lastObservedJobId ?
+      this.observedJobStatuses.get(this.lastObservedJobId) ?? null :
+      null;
   }
 
   stopJobStatusPolling(): void {
@@ -369,6 +407,11 @@ export class TestPersonCodingComponent implements OnInit {
     }
     this.activeJobId = null;
     this.jobStatus = null;
+  }
+
+  private rememberJobStatus(jobId: string, status: JobStatus): void {
+    this.lastObservedJobId = jobId;
+    this.observedJobStatuses.set(jobId, status.status);
   }
 
   private handleAutoCodingCompleted(jobId?: string): void {
@@ -381,7 +424,7 @@ export class TestPersonCodingComponent implements OnInit {
 
     this.loadStatistics();
     this.loadWorkspaceGroups();
-    this.testPersonCodingService.notifyAutoCodingCompleted();
+    this.testPersonCodingService.notifyAutoCodingCompleted(jobId);
   }
 
   cancelJob(jobId?: string): void {

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -154,6 +154,10 @@ export interface JobInfo extends JobStatus {
   jobId: string;
 }
 
+export interface AutoCodingCompletedEvent {
+  jobId?: string;
+}
+
 export interface WorkspaceGroupCodingStats {
   groupName: string;
   testPersonCount: number;
@@ -221,7 +225,7 @@ export interface AppliedResultsOverview {
 export class TestPersonCodingService {
   readonly serverUrl = inject(SERVER_URL);
   private http = inject(HttpClient);
-  private autoCodingCompletedSubject = new Subject<void>();
+  private autoCodingCompletedSubject = new Subject<AutoCodingCompletedEvent>();
   private testResultsChangedSubject = new Subject<void>();
   autoCodingCompleted$ = this.autoCodingCompletedSubject.asObservable();
   testResultsChanged$ = this.testResultsChangedSubject.asObservable();
@@ -234,8 +238,8 @@ export class TestPersonCodingService {
     return typeof jobId === 'string' && jobId.trim().length > 0;
   }
 
-  notifyAutoCodingCompleted(): void {
-    this.autoCodingCompletedSubject.next();
+  notifyAutoCodingCompleted(jobId?: string): void {
+    this.autoCodingCompletedSubject.next({ jobId });
   }
 
   notifyTestResultsChanged(): void {


### PR DESCRIPTION
## Summary
- starts the Testgruppen Kodieren dialog after launching a freshness auto-coding job
- passes the started job into the dialog and keeps terminal job status available for the parent
- scopes auto-coding completion events by job ID so unrelated jobs do not clear freshness tracking
- adds regression coverage for dialog close and completion-event edge cases

## Validation
- npx nx test frontend --runInBand --testFile=apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
- npx nx test frontend --runInBand --testFile=apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.spec.ts
- npx nx lint frontend
- npx nx test frontend --runInBand

Related to #754.
