### PR TITLE
Fix replay token export links

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -11,7 +11,10 @@ import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
 import { ResponseMatchingFlag } from '../../../ws-admin/services/workspace-settings.service';
 import { CoderService } from '../../services/coder.service';
-import { ExportJobService } from '../../../shared/services/file/export-job.service';
+import {
+  createReplayAuthTokenError,
+  ExportJobService
+} from '../../../shared/services/file/export-job.service';
 import { CohensKappaStatisticsComponent } from '../cohens-kappa-statistics/cohens-kappa-statistics.component';
 import { ManualCodingExportDialogComponent } from '../manual-coding-export-dialog/manual-coding-export-dialog.component';
 import type {
@@ -125,6 +128,10 @@ describe('CodingManagementManualComponent', () => {
         },
         'completed-jobs': {
           'readonly-note': 'Nur lesbar'
+        },
+        errors: {
+          'replay-auth-token-failed':
+            'Replay-Links konnten nicht vorbereitet werden, weil kein Auth-Token erstellt werden konnte. Exportjob wurde nicht gestartet.'
         },
         buttons: {
           'show-more-manual-code-warnings': '+{{count}} weitere anzeigen',
@@ -1475,6 +1482,49 @@ describe('CodingManagementManualComponent', () => {
         excludeAutoCoded: true,
         jobDefinitionIds: [11]
       })
+    );
+  });
+
+  it('should show a specific error when replay export auth token creation fails', () => {
+    const exportJobService = TestBed.inject(ExportJobService) as unknown as {
+      startJob: jest.Mock;
+    };
+    const snackBar = TestBed.inject(MatSnackBar) as unknown as {
+      open: jest.Mock;
+    };
+    const componentInternals = component as unknown as {
+      startManualCodingExport: (
+        context: 'training' | 'execution',
+        result: {
+          exportType: 'detailed';
+          includeReplayUrl: true;
+          jobDefinitionIds: number[];
+        }
+      ) => void;
+      appService: {
+        selectedWorkspaceId: number;
+        updateAuthData(authData: unknown): void;
+      };
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.appService.updateAuthData({ userId: 9 });
+    exportJobService.startJob.mockReturnValue(
+      throwError(() => createReplayAuthTokenError())
+    );
+
+    componentInternals.startManualCodingExport('execution', {
+      exportType: 'detailed',
+      includeReplayUrl: true,
+      jobDefinitionIds: [11]
+    });
+
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Replay-Links konnten nicht vorbereitet werden, weil kein Auth-Token erstellt werden konnte. Exportjob wurde nicht gestartet.',
+      'Schließen',
+      {
+        duration: 5000,
+        panelClass: ['error-snackbar']
+      }
     );
   });
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -108,7 +108,11 @@ import {
   isCodingFreshnessOpenWarning
 } from '../../../shared/utils/coding-freshness-text.util';
 import { UserBackendService } from '../../../shared/services/user/user-backend.service';
-import { ExportJobConfig, ExportJobService } from '../../../shared/services/file/export-job.service';
+import {
+  ExportJobConfig,
+  ExportJobService,
+  isReplayAuthTokenError
+} from '../../../shared/services/file/export-job.service';
 import { CoderService } from '../../services/coder.service';
 import {
   ManualCodingExportDialogComponent,
@@ -1205,7 +1209,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         next: () => {
           this.showSuccess('Exportjob wurde gestartet.');
         },
-        error: () => {
+        error: error => {
+          if (isReplayAuthTokenError(error)) {
+            this.showError(
+              this.translateService.instant('coding-management-manual.errors.replay-auth-token-failed')
+            );
+            return;
+          }
           this.showError('Exportjob konnte nicht gestartet werden.');
         }
       });

--- a/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
@@ -1,11 +1,17 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
-import { ExportJobService } from './export-job.service';
+import {
+  ExportJobService,
+  REPLAY_AUTH_TOKEN_ERROR_CODE,
+  isReplayAuthTokenError
+} from './export-job.service';
 import { CodingJobBackendService } from '../../../coding/services/coding-job-backend.service';
+import { AppService } from '../../../core/services/app.service';
 
 describe('ExportJobService', () => {
   let service: ExportJobService;
   let codingJobBackendServiceMock: jest.Mocked<CodingJobBackendService>;
+  let appServiceMock: jest.Mocked<AppService>;
 
   beforeEach(() => {
     codingJobBackendServiceMock = {
@@ -14,11 +20,15 @@ describe('ExportJobService', () => {
       cancelExportJob: jest.fn(),
       downloadExportFile: jest.fn()
     } as unknown as jest.Mocked<CodingJobBackendService>;
+    appServiceMock = {
+      createOwnToken: jest.fn().mockReturnValue(of('auth-token'))
+    } as unknown as jest.Mocked<AppService>;
 
     TestBed.configureTestingModule({
       providers: [
         ExportJobService,
-        { provide: CodingJobBackendService, useValue: codingJobBackendServiceMock }
+        { provide: CodingJobBackendService, useValue: codingJobBackendServiceMock },
+        { provide: AppService, useValue: appServiceMock }
       ]
     });
 
@@ -61,6 +71,81 @@ describe('ExportJobService', () => {
         }
       });
 
+      expect(service.activeJobs.length).toBe(0);
+    });
+
+    it('should add auth token and server url when replay urls are requested', () => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(of({ jobId: 'j1', message: 'Job started' }));
+
+      service.startJob(1, {
+        exportType: 'detailed',
+        includeReplayUrl: true
+      }).subscribe();
+
+      expect(appServiceMock.createOwnToken).toHaveBeenCalledWith(1, 60);
+      expect(codingJobBackendServiceMock.startExportJob).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          exportType: 'detailed',
+          includeReplayUrl: true,
+          authToken: 'auth-token',
+          serverUrl: window.location.origin
+        })
+      );
+    });
+
+    it('should not create auth token when replay urls are disabled', () => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(of({ jobId: 'j1', message: 'Job started' }));
+
+      service.startJob(1, {
+        exportType: 'detailed',
+        includeReplayUrl: false
+      }).subscribe();
+
+      expect(appServiceMock.createOwnToken).not.toHaveBeenCalled();
+      expect(codingJobBackendServiceMock.startExportJob).toHaveBeenCalledWith(
+        1,
+        expect.not.objectContaining({
+          authToken: expect.any(String)
+        })
+      );
+    });
+
+    it('should keep existing auth token when replay urls are requested', () => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(of({ jobId: 'j1', message: 'Job started' }));
+
+      service.startJob(1, {
+        exportType: 'detailed',
+        includeReplayUrl: true,
+        authToken: 'existing-token'
+      }).subscribe();
+
+      expect(appServiceMock.createOwnToken).not.toHaveBeenCalled();
+      expect(codingJobBackendServiceMock.startExportJob).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          includeReplayUrl: true,
+          authToken: 'existing-token'
+        })
+      );
+    });
+
+    it('should surface replay auth token errors without starting an export job', () => {
+      appServiceMock.createOwnToken.mockReturnValue(
+        throwError(() => new Error('token failed'))
+      );
+
+      service.startJob(1, {
+        exportType: 'detailed',
+        includeReplayUrl: true
+      }).subscribe({
+        error: error => {
+          expect(isReplayAuthTokenError(error)).toBe(true);
+          expect(error.code).toBe(REPLAY_AUTH_TOKEN_ERROR_CODE);
+        }
+      });
+
+      expect(codingJobBackendServiceMock.startExportJob).not.toHaveBeenCalled();
       expect(service.activeJobs.length).toBe(0);
     });
   });

--- a/apps/frontend/src/app/shared/services/file/export-job.service.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.ts
@@ -4,7 +4,10 @@ import {
   Observable,
   Subject,
   Subscription,
-  interval
+  catchError,
+  interval,
+  of,
+  throwError
 } from 'rxjs';
 import {
   map,
@@ -13,6 +16,7 @@ import {
   tap
 } from 'rxjs/operators';
 import { CodingExportEstimate, CodingJobBackendService } from '../../../coding/services/coding-job-backend.service';
+import { AppService } from '../../../core/services/app.service';
 
 export interface ExportJob {
   jobId: string;
@@ -63,6 +67,27 @@ export interface ExportJobConfig {
   coderTrainingIds?: number[];
   coderIds?: number[];
   authToken?: string;
+  serverUrl?: string;
+}
+
+export const REPLAY_AUTH_TOKEN_ERROR_CODE = 'replay-auth-token-failed';
+
+export type ReplayAuthTokenError = Error & {
+  code: typeof REPLAY_AUTH_TOKEN_ERROR_CODE;
+  originalError?: unknown;
+};
+
+export function createReplayAuthTokenError(originalError?: unknown): ReplayAuthTokenError {
+  const error = new Error('Replay auth token could not be created.') as ReplayAuthTokenError;
+  error.name = 'ReplayAuthTokenError';
+  error.code = REPLAY_AUTH_TOKEN_ERROR_CODE;
+  error.originalError = originalError;
+  return error;
+}
+
+export function isReplayAuthTokenError(error: unknown): error is ReplayAuthTokenError {
+  return error instanceof Error &&
+    (error as Partial<ReplayAuthTokenError>).code === REPLAY_AUTH_TOKEN_ERROR_CODE;
 }
 
 @Injectable({
@@ -75,7 +100,10 @@ export class ExportJobService implements OnDestroy {
 
   readonly jobs$ = this.jobsSubject.asObservable();
 
-  constructor(private codingJobBackendService: CodingJobBackendService) { }
+  constructor(
+    private codingJobBackendService: CodingJobBackendService,
+    private appService: AppService
+  ) { }
 
   get activeJobs(): ExportJob[] {
     return this.jobsSubject.value.filter(
@@ -96,7 +124,8 @@ export class ExportJobService implements OnDestroy {
   }
 
   startJob(workspaceId: number, config: ExportJobConfig): Observable<ExportJob> {
-    return this.codingJobBackendService.startExportJob(workspaceId, config).pipe(
+    return this.withReplayAuthToken(workspaceId, config).pipe(
+      switchMap(preparedConfig => this.codingJobBackendService.startExportJob(workspaceId, preparedConfig)),
       map((response: { jobId: string }) => ({
         jobId: response.jobId,
         workspaceId,
@@ -114,6 +143,24 @@ export class ExportJobService implements OnDestroy {
 
   estimateJob(workspaceId: number, config: ExportJobConfig): Observable<CodingExportEstimate> {
     return this.codingJobBackendService.estimateExportJob(workspaceId, config);
+  }
+
+  private withReplayAuthToken(
+    workspaceId: number,
+    config: ExportJobConfig
+  ): Observable<ExportJobConfig> {
+    if (!config.includeReplayUrl || config.authToken) {
+      return of(config);
+    }
+
+    return this.appService.createOwnToken(workspaceId, 60).pipe(
+      map(authToken => ({
+        ...config,
+        authToken,
+        serverUrl: config.serverUrl || window.location.origin
+      })),
+      catchError(error => throwError(() => createReplayAuthTokenError(error)))
+    );
   }
 
   private addJob(job: ExportJob): void {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1776,7 +1776,8 @@
       "server-error": "Server-Fehler beim Generieren der Excel-Datei. Bitte versuchen Sie es später erneut.",
       "network-error": "Netzwerk-Fehler. Bitte überprüfen Sie Ihre Internetverbindung.",
       "no-comparison-data": "Keine Vergleichsdaten zum Herunterladen verfügbar.",
-      "excel-create-error": "Fehler beim Erstellen der Excel-Datei"
+      "excel-create-error": "Fehler beim Erstellen der Excel-Datei",
+      "replay-auth-token-failed": "Replay-Links konnten nicht vorbereitet werden, weil kein Auth-Token erstellt werden konnte. Exportjob wurde nicht gestartet."
     },
     "success": {
       "validation-completed": "Validierung abgeschlossen. {{missing}} von {{total}} Kombinationen fehlen.",


### PR DESCRIPTION
## Summary

- Add replay auth-token preparation for background export jobs when Replay URLs are requested.
- Preserve an existing export auth token when one is already provided.
- Show a specific translated error message when the Replay auth token cannot be created.

## Context

Refs #679. This intentionally does not close the issue.

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/shared/services/file/export-job.service.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts --runInBand`
- `npx nx lint frontend`
- `git diff --check`