### PR TITLE
Fix manual coding freshness navigation

### DIFF
--- a/apps/backend/src/app/coding/coding.module.ts
+++ b/apps/backend/src/app/coding/coding.module.ts
@@ -47,6 +47,7 @@ import {
   CodingItemMatrixExportService
 } from '../database/services/coding';
 import { CODING_PROCESS_CACHE_INVALIDATOR } from '../database/services/coding/coding-process-cache-invalidator.token';
+import { CODING_READINESS_CACHE_INVALIDATOR } from '../database/services/coding/coding-readiness-cache-invalidator.token';
 import { JobDefinitionService } from '../database/services/jobs';
 // eslint-disable-next-line import/no-cycle
 import { JobQueueModule } from '../job-queue/job-queue.module';
@@ -113,6 +114,10 @@ import { UserModule } from '../user/user.module';
     {
       provide: CODING_PROCESS_CACHE_INVALIDATOR,
       useExisting: CodingProcessService
+    },
+    {
+      provide: CODING_READINESS_CACHE_INVALIDATOR,
+      useExisting: CodingReadinessService
     }
   ],
   exports: [
@@ -138,7 +143,8 @@ import { UserModule } from '../user/user.module';
     CodingFreshnessService,
     CodingReadinessService,
     CodingItemMatrixExportService,
-    CODING_PROCESS_CACHE_INVALIDATOR
+    CODING_PROCESS_CACHE_INVALIDATOR,
+    CODING_READINESS_CACHE_INVALIDATOR
   ]
 })
 export class CodingModule { }

--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
@@ -811,7 +811,8 @@ export class CodingFreshnessService {
   async clearVersionsAfterReset(
     workspaceId: number,
     versions: CodingFreshnessVersion[],
-    unitNames?: string[]
+    unitNames?: string[],
+    variableIds?: string[]
   ): Promise<void> {
     if (versions.length === 0) {
       return;
@@ -824,16 +825,30 @@ export class CodingFreshnessService {
       .where('workspace_id = :workspaceId', { workspaceId })
       .andWhere('version IN (:...versions)', { versions });
 
-    if (unitNames && unitNames.length > 0) {
-      const unitIds = await this.connection
+    const scopedUnitNames = this.uniqueStrings(unitNames || []);
+    const scopedVariableIds = this.uniqueStrings(variableIds || []);
+    if (scopedUnitNames.length > 0 || scopedVariableIds.length > 0) {
+      const unitQuery = this.connection
         .createQueryBuilder()
-        .select('unit.id', 'id')
+        .select('DISTINCT unit.id', 'id')
         .from('unit', 'unit')
         .innerJoin('booklet', 'booklet', 'booklet.id = unit.bookletid')
         .innerJoin('persons', 'person', 'person.id = booklet.personid')
-        .where('person.workspace_id = :workspaceId', { workspaceId })
-        .andWhere('unit.name IN (:...unitNames)', { unitNames })
-        .getRawMany<{ id: number | string }>();
+        .where('person.workspace_id = :workspaceId', { workspaceId });
+
+      if (scopedUnitNames.length > 0) {
+        unitQuery.andWhere('unit.name IN (:...unitNames)', { unitNames: scopedUnitNames });
+      }
+
+      if (scopedVariableIds.length > 0) {
+        unitQuery
+          .innerJoin('response', 'response', 'response.unitid = unit.id')
+          .andWhere('response.variableid IN (:...variableIds)', {
+            variableIds: scopedVariableIds
+          });
+      }
+
+      const unitIds = await unitQuery.getRawMany<{ id: number | string }>();
       const ids = this.uniquePositiveIds(unitIds.map(row => Number(row.id)));
       if (ids.length === 0) {
         return;

--- a/apps/backend/src/app/database/services/coding/coding-readiness-cache-invalidator.token.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness-cache-invalidator.token.ts
@@ -1,0 +1,6 @@
+export const CODING_READINESS_CACHE_INVALIDATOR =
+  'CODING_READINESS_CACHE_INVALIDATOR';
+
+export interface CodingReadinessCacheInvalidator {
+  invalidateWorkspaceReadinessCache(workspaceId: number): void;
+}

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
@@ -211,6 +211,32 @@ describe('CodingReadinessService', () => {
     );
   });
 
+  it('invalidates cached and in-flight readiness entries for a workspace', () => {
+    const service = createService({
+      units: [],
+      rawResponsesTotal: 0,
+      candidateRows: [],
+      unitFiles: [],
+      unitVariableMap: new Map()
+    });
+    const internals = service as unknown as {
+      readinessCache: Map<string, unknown>;
+      readinessInFlight: Map<string, unknown>;
+      cacheRevisionByWorkspace: Map<number, number>;
+    };
+    internals.readinessCache.set('1|1|1|files|0|scope', {});
+    internals.readinessCache.set('2|1|1|files|0|scope', {});
+    internals.readinessInFlight.set('1|1|1|files|0|scope', Promise.resolve({}));
+    internals.cacheRevisionByWorkspace.set(1, 4);
+
+    service.invalidateWorkspaceReadinessCache(1);
+
+    expect(internals.readinessCache.has('1|1|1|files|0|scope')).toBe(false);
+    expect(internals.readinessCache.has('2|1|1|files|0|scope')).toBe(true);
+    expect(internals.readinessInFlight.has('1|1|1|files|0|scope')).toBe(false);
+    expect(internals.cacheRevisionByWorkspace.get(1)).toBe(5);
+  });
+
   it('keeps missing files as diagnostics without blocking partially codeable data', async () => {
     const service = createService({
       units: [

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
@@ -36,6 +36,7 @@ export type AutocodingReadinessOptions = {
 type ReadinessCacheSignature = {
   sourceRevision: number;
   fileRevision: string;
+  cacheRevision: number;
   scopedUnitHash: string;
 };
 
@@ -90,6 +91,7 @@ export class CodingReadinessService {
   private readonly cacheTtlMs = 60_000;
   private readonly readinessCache = new Map<string, ReadinessCacheEntry>();
   private readonly readinessInFlight = new Map<string, Promise<AutocodingReadinessDto>>();
+  private readonly cacheRevisionByWorkspace = new Map<number, number>();
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -116,7 +118,12 @@ export class CodingReadinessService {
         this.emptyReadiness(workspaceId, autoCoderRun, 'NO_RESULTS'),
         startedAt,
         false,
-        { sourceRevision: 0, fileRevision: '0:', scopedUnitHash: '' }
+        {
+          sourceRevision: 0,
+          fileRevision: '0:',
+          cacheRevision: this.getWorkspaceCacheRevision(workspaceId),
+          scopedUnitHash: ''
+        }
       );
     }
 
@@ -164,6 +171,24 @@ export class CodingReadinessService {
     }
 
     throw new BadRequestException(this.buildBlockedMessage(readiness));
+  }
+
+  invalidateWorkspaceReadinessCache(workspaceId: number): void {
+    const workspaceKeyPrefix = `${workspaceId}|`;
+    for (const key of Array.from(this.readinessCache.keys())) {
+      if (key.startsWith(workspaceKeyPrefix)) {
+        this.readinessCache.delete(key);
+      }
+    }
+    for (const key of Array.from(this.readinessInFlight.keys())) {
+      if (key.startsWith(workspaceKeyPrefix)) {
+        this.readinessInFlight.delete(key);
+      }
+    }
+    this.cacheRevisionByWorkspace.set(
+      workspaceId,
+      this.getWorkspaceCacheRevision(workspaceId) + 1
+    );
   }
 
   async filterResponsesValidVariables(
@@ -832,8 +857,13 @@ export class CodingReadinessService {
     return {
       sourceRevision,
       fileRevision,
+      cacheRevision: this.getWorkspaceCacheRevision(workspaceId),
       scopedUnitHash: this.hashScope(unitIds, options)
     };
+  }
+
+  private getWorkspaceCacheRevision(workspaceId: number): number {
+    return this.cacheRevisionByWorkspace.get(workspaceId) || 0;
   }
 
   private hashScope(
@@ -897,6 +927,7 @@ export class CodingReadinessService {
       autoCoderRun,
       signature.sourceRevision,
       signature.fileRevision,
+      signature.cacheRevision,
       signature.scopedUnitHash
     ].join('|');
   }

--- a/apps/backend/src/app/database/services/coding/coding-version.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-version.service.spec.ts
@@ -44,6 +44,7 @@ describe('CodingVersionService', () => {
   const mockCodingFreshnessService = {
     markVersionsPendingAfterReset: jest.fn().mockResolvedValue(undefined),
     markExistingAutoCodingVersionsPendingAfterResetScope: jest.fn().mockResolvedValue(undefined),
+    clearVersionsAfterReset: jest.fn().mockResolvedValue(undefined),
     markAppliedCodingJobsResultsClearedForUnitIds: jest.fn().mockResolvedValue(undefined),
     markAppliedCodingJobsResultsClearedForResponseIds: jest.fn().mockResolvedValue(undefined),
     reconcileAppliedManualCodingJobs: jest.fn().mockResolvedValue(0)
@@ -102,6 +103,7 @@ describe('CodingVersionService', () => {
     mockCodingValidationService.invalidateIncompleteVariablesCache.mockClear();
     mockCodingFreshnessService.markVersionsPendingAfterReset.mockClear();
     mockCodingFreshnessService.markExistingAutoCodingVersionsPendingAfterResetScope.mockClear();
+    mockCodingFreshnessService.clearVersionsAfterReset.mockClear();
     mockCodingFreshnessService.markAppliedCodingJobsResultsClearedForUnitIds.mockClear();
     mockCodingFreshnessService.markAppliedCodingJobsResultsClearedForResponseIds.mockClear();
     mockCodingFreshnessService.reconcileAppliedManualCodingJobs.mockClear();
@@ -340,6 +342,12 @@ describe('CodingVersionService', () => {
 
       expect(mockCodingFreshnessService.markAppliedCodingJobsResultsClearedForResponseIds)
         .toHaveBeenCalledWith(1, [1], 'RESET', 'stale_source');
+      expect(mockCodingFreshnessService.clearVersionsAfterReset)
+        .toHaveBeenCalledWith(1, ['v2'], undefined, undefined);
+      expect(mockCodingFreshnessService.markVersionsPendingAfterReset)
+        .toHaveBeenCalledWith(1, {
+          v1: [10]
+        });
       expect(mockCodingFreshnessService.reconcileAppliedManualCodingJobs)
         .toHaveBeenCalledWith(1, 'RESET', 'stale_source', {
           unitNames: undefined,
@@ -523,6 +531,8 @@ describe('CodingVersionService', () => {
       expect(mockCodingStatisticsService.invalidateCache).toHaveBeenCalledWith(1, 'v2');
       expect(mockCodingStatisticsService.invalidateCache).toHaveBeenCalledWith(1, 'v3');
       expect(mockCodingFreshnessService.markVersionsPendingAfterReset).not.toHaveBeenCalled();
+      expect(mockCodingFreshnessService.clearVersionsAfterReset)
+        .toHaveBeenCalledWith(1, ['v2'], undefined, undefined);
       expect(mockCodingFreshnessService.markExistingAutoCodingVersionsPendingAfterResetScope)
         .toHaveBeenCalledWith(1, ['v1', 'v3'], undefined, undefined);
     });
@@ -537,6 +547,8 @@ describe('CodingVersionService', () => {
 
       await service.resetCodingVersion(workspaceId, version, unitFilters, variableFilters);
 
+      expect(mockCodingFreshnessService.clearVersionsAfterReset)
+        .toHaveBeenCalledWith(1, ['v2'], unitFilters, variableFilters);
       expect(mockResponseRepository.update).not.toHaveBeenCalled();
       expect(mockCodingFreshnessService.markExistingAutoCodingVersionsPendingAfterResetScope)
         .toHaveBeenCalledWith(1, ['v1', 'v3'], unitFilters, variableFilters);

--- a/apps/backend/src/app/database/services/coding/coding-version.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-version.service.ts
@@ -115,6 +115,12 @@ export class CodingVersionService {
             unitFilters,
             variableFilters
           );
+        await this.clearManualCodingFreshnessAfterSourceReset(
+          workspaceId,
+          version,
+          unitFilters,
+          variableFilters
+        );
         await this.markExistingAutoCodingFreshnessPendingAfterReset(
           workspaceId,
           version,
@@ -209,9 +215,15 @@ export class CodingVersionService {
       }
 
       // Invalidate caches for all affected coding views
+      await this.clearManualCodingFreshnessAfterSourceReset(
+        workspaceId,
+        version,
+        unitFilters,
+        variableFilters
+      );
       await this.codingFreshnessService?.markVersionsPendingAfterReset(
         workspaceId,
-        this.toResetUnitIdsByVersion(resetUnitIdsByVersion)
+        this.toFreshnessResetUnitIdsByVersion(resetUnitIdsByVersion, version)
       );
       await this.markExistingAutoCodingFreshnessPendingAfterReset(
         workspaceId,
@@ -500,6 +512,24 @@ export class CodingVersionService {
     );
   }
 
+  private async clearManualCodingFreshnessAfterSourceReset(
+    workspaceId: number,
+    version: ResetCodingVersion,
+    unitFilters?: string[],
+    variableFilters?: string[]
+  ): Promise<void> {
+    if (version !== 'v1' || !this.codingFreshnessService) {
+      return;
+    }
+
+    await this.codingFreshnessService.clearVersionsAfterReset(
+      workspaceId,
+      ['v2'],
+      unitFilters,
+      variableFilters
+    );
+  }
+
   private async markAppliedCodingJobsResultsClearedBeforeGeneratedResponseDelete(
     workspaceId: number,
     responseIds: number[]
@@ -524,5 +554,17 @@ export class CodingVersionService {
         .map(([version, unitIds]) => [version, Array.from(unitIds)])
         .filter(([, unitIds]) => (unitIds as number[]).length > 0)
     ) as Partial<Record<CodingFreshnessVersion, number[]>>;
+  }
+
+  private toFreshnessResetUnitIdsByVersion(
+    resetUnitIdsByVersion: ResetUnitIdsByVersion,
+    version: ResetCodingVersion
+  ): Partial<Record<CodingFreshnessVersion, number[]>> {
+    const resetUnitIds = this.toResetUnitIdsByVersion(resetUnitIdsByVersion);
+    if (version === 'v1') {
+      delete resetUnitIds.v2;
+    }
+
+    return resetUnitIds;
   }
 }

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
@@ -187,6 +187,9 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
   const mockCodingFreshnessService = {
     markUnitsStaleAfterCodingSchemeChange: jest.fn().mockResolvedValue(undefined)
   };
+  const mockCodingReadinessCacheInvalidator = {
+    invalidateWorkspaceReadinessCache: jest.fn()
+  };
 
   function makeService(): WorkspaceFilesService {
     return new WorkspaceFilesService(
@@ -203,7 +206,10 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
       { delete: jest.fn() } as unknown as CtorParams[10],
       { invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined) } as unknown as CtorParams[11],
       undefined,
-      mockCodingFreshnessService as unknown as CtorParams[13]
+      mockCodingFreshnessService as unknown as CtorParams[13],
+      undefined,
+      undefined,
+      mockCodingReadinessCacheInvalidator as unknown as CtorParams[16]
     );
   }
 
@@ -363,6 +369,15 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
     ]);
 
     expect(invalidateSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('invalidates auto-coding readiness cache when workspace file caches are invalidated', async () => {
+    const service = makeService();
+
+    await service.invalidateWorkspaceFileCaches(1);
+
+    expect(mockCodingReadinessCacheInvalidator.invalidateWorkspaceReadinessCache)
+      .toHaveBeenCalledWith(1);
   });
 });
 

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -56,6 +56,10 @@ import {
   CODING_PROCESS_CACHE_INVALIDATOR,
   CodingProcessCacheInvalidator
 } from '../coding/coding-process-cache-invalidator.token';
+import {
+  CODING_READINESS_CACHE_INVALIDATOR,
+  CodingReadinessCacheInvalidator
+} from '../coding/coding-readiness-cache-invalidator.token';
 import { WorkspaceXmlSchemaValidationService } from './workspace-xml-schema-validation.service';
 import { WorkspaceFileStorageService } from './workspace-file-storage.service';
 import { WorkspaceFileParsingService } from './workspace-file-parsing.service';
@@ -194,7 +198,10 @@ export class WorkspaceFilesService implements OnModuleInit {
     private readonly codingFileCacheService?: CodingFileCacheService,
     @Optional()
     @Inject(CODING_PROCESS_CACHE_INVALIDATOR)
-    private readonly codingProcessCacheInvalidator?: CodingProcessCacheInvalidator
+    private readonly codingProcessCacheInvalidator?: CodingProcessCacheInvalidator,
+    @Optional()
+    @Inject(CODING_READINESS_CACHE_INVALIDATOR)
+    private readonly codingReadinessCacheInvalidator?: CodingReadinessCacheInvalidator
   ) {}
 
   private normalizeFileUnitId(value: string | null | undefined): string {
@@ -3942,6 +3949,7 @@ ${bookletRefs}
     );
     this.codingFileCacheService?.clearCaches();
     this.codingProcessCacheInvalidator?.invalidateWorkspaceCaches(workspaceId);
+    this.codingReadinessCacheInvalidator?.invalidateWorkspaceReadinessCache(workspaceId);
     this.logger.log(
       `Invalidated workspace files caches for workspace ${workspaceId} in Redis`
     );

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1789,6 +1789,63 @@ describe('CodingManagementManualComponent', () => {
     }
   });
 
+  it('should wait for incomplete variables before focusing completed manual freshness work', () => {
+    jest.useFakeTimers();
+    try {
+      component.canApplyManualCodingResults = true;
+      setCompletePlanningState();
+      setCodingProgress(10, 10);
+      component.appliedResultsOverview = null;
+      component.isLoadingCodingIncompleteVariables = true;
+      component.isLoadingAppliedResultsOverview = false;
+      component.selectedManualTabIndex = 0;
+
+      const componentInternals = component as unknown as {
+        pendingManualFreshnessFocus: boolean;
+        manualFreshnessPlanningRequested: boolean;
+        requestManualFreshnessFocusIfNeeded(): void;
+        focusManualFreshnessTargetIfReady(): void;
+        loadManualTabData(tab: 'planning' | 'completion'): void;
+      };
+      componentInternals.pendingManualFreshnessFocus = true;
+      componentInternals.manualFreshnessPlanningRequested = false;
+      const loadManualTabDataSpy = jest
+        .spyOn(componentInternals, 'loadManualTabData')
+        .mockImplementation();
+      const scrollToSectionSpy = jest
+        .spyOn(component, 'scrollToSection')
+        .mockImplementation();
+
+      componentInternals.requestManualFreshnessFocusIfNeeded();
+
+      expect(component.selectedManualTabIndex).toBe(1);
+      expect(loadManualTabDataSpy).toHaveBeenCalledTimes(1);
+      expect(loadManualTabDataSpy).toHaveBeenCalledWith('planning');
+      expect(scrollToSectionSpy).not.toHaveBeenCalled();
+
+      component.isLoadingCodingIncompleteVariables = false;
+      component.isLoadingAppliedResultsOverview = true;
+      componentInternals.focusManualFreshnessTargetIfReady();
+
+      expect(component.selectedManualTabIndex).toBe(1);
+      expect(loadManualTabDataSpy).toHaveBeenCalledTimes(1);
+      expect(scrollToSectionSpy).not.toHaveBeenCalled();
+
+      setAppliedResults(10, 0, 10);
+      component.isLoadingAppliedResultsOverview = false;
+      componentInternals.focusManualFreshnessTargetIfReady();
+
+      expect(component.selectedManualTabIndex).toBe(4);
+      expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(2, 'completion');
+
+      jest.runOnlyPendingTimers();
+
+      expect(scrollToSectionSpy).toHaveBeenCalledWith('manual-completion');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('should keep coding managers away from the hidden completion tab', () => {
     jest.useFakeTimers();
     try {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -55,7 +55,7 @@ describe('CodingManagementManualComponent', () => {
   let fixture: ComponentFixture<CodingManagementManualComponent>;
 
   const fakeActivatedRoute = {
-    snapshot: { data: {} }
+    snapshot: { data: {}, queryParamMap: convertToParamMap({}) }
   } as ActivatedRoute;
 
   beforeEach(async () => {
@@ -1657,6 +1657,129 @@ describe('CodingManagementManualComponent', () => {
       expect(component.getPlanningNextStepTargetTab()).toBe('completion');
       expect(component.selectedManualTabIndex).toBe(4);
       expect(loadManualTabDataSpy).toHaveBeenCalledWith('completion');
+
+      jest.runOnlyPendingTimers();
+
+      expect(scrollToSectionSpy).toHaveBeenCalledWith('manual-completion');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should focus manual freshness work on execution when open coding cases remain', () => {
+    jest.useFakeTimers();
+    try {
+      setCompletePlanningState();
+      setCodingProgress(10, 4);
+      setAppliedResults(10, 0, 10);
+      component.selectedManualTabIndex = 0;
+
+      const componentInternals = component as unknown as {
+        pendingManualFreshnessFocus: boolean;
+        manualFreshnessPlanningRequested: boolean;
+        requestManualFreshnessFocusIfNeeded(): void;
+        loadManualTabData(tab: 'planning' | 'execution'): void;
+      };
+      componentInternals.pendingManualFreshnessFocus = true;
+      componentInternals.manualFreshnessPlanningRequested = false;
+      const loadManualTabDataSpy = jest
+        .spyOn(componentInternals, 'loadManualTabData')
+        .mockImplementation();
+      const scrollToSectionSpy = jest
+        .spyOn(component, 'scrollToSection')
+        .mockImplementation();
+
+      componentInternals.requestManualFreshnessFocusIfNeeded();
+
+      expect(component.selectedManualTabIndex).toBe(3);
+      expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(1, 'planning');
+      expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(2, 'execution');
+
+      jest.runOnlyPendingTimers();
+
+      expect(scrollToSectionSpy).toHaveBeenCalledWith('manual-execution');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should focus manual freshness work on completion when all cases are coded', () => {
+    jest.useFakeTimers();
+    try {
+      component.canApplyManualCodingResults = true;
+      setCompletePlanningState();
+      setCodingProgress(10, 10);
+      setAppliedResults(10, 0, 10);
+      component.selectedManualTabIndex = 0;
+
+      const componentInternals = component as unknown as {
+        pendingManualFreshnessFocus: boolean;
+        manualFreshnessPlanningRequested: boolean;
+        requestManualFreshnessFocusIfNeeded(): void;
+        loadManualTabData(tab: 'planning' | 'completion'): void;
+      };
+      componentInternals.pendingManualFreshnessFocus = true;
+      componentInternals.manualFreshnessPlanningRequested = false;
+      const loadManualTabDataSpy = jest
+        .spyOn(componentInternals, 'loadManualTabData')
+        .mockImplementation();
+      const scrollToSectionSpy = jest
+        .spyOn(component, 'scrollToSection')
+        .mockImplementation();
+
+      componentInternals.requestManualFreshnessFocusIfNeeded();
+
+      expect(component.selectedManualTabIndex).toBe(4);
+      expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(1, 'planning');
+      expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(2, 'completion');
+
+      jest.runOnlyPendingTimers();
+
+      expect(scrollToSectionSpy).toHaveBeenCalledWith('manual-completion');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should wait for applied results before focusing completed manual freshness work', () => {
+    jest.useFakeTimers();
+    try {
+      component.canApplyManualCodingResults = true;
+      setCompletePlanningState();
+      setCodingProgress(10, 10);
+      component.appliedResultsOverview = null;
+      component.isLoadingAppliedResultsOverview = true;
+      component.selectedManualTabIndex = 0;
+
+      const componentInternals = component as unknown as {
+        pendingManualFreshnessFocus: boolean;
+        manualFreshnessPlanningRequested: boolean;
+        requestManualFreshnessFocusIfNeeded(): void;
+        focusManualFreshnessTargetIfReady(): void;
+        loadManualTabData(tab: 'planning' | 'completion'): void;
+      };
+      componentInternals.pendingManualFreshnessFocus = true;
+      componentInternals.manualFreshnessPlanningRequested = false;
+      const loadManualTabDataSpy = jest
+        .spyOn(componentInternals, 'loadManualTabData')
+        .mockImplementation();
+      const scrollToSectionSpy = jest
+        .spyOn(component, 'scrollToSection')
+        .mockImplementation();
+
+      componentInternals.requestManualFreshnessFocusIfNeeded();
+
+      expect(component.selectedManualTabIndex).toBe(1);
+      expect(loadManualTabDataSpy).toHaveBeenCalledTimes(1);
+      expect(loadManualTabDataSpy).toHaveBeenCalledWith('planning');
+      expect(scrollToSectionSpy).not.toHaveBeenCalled();
+
+      setAppliedResults(10, 0, 10);
+      component.isLoadingAppliedResultsOverview = false;
+      componentInternals.focusManualFreshnessTargetIfReady();
+
+      expect(component.selectedManualTabIndex).toBe(4);
+      expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(2, 'completion');
 
       jest.runOnlyPendingTimers();
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -23,7 +23,7 @@ import {
   switchMap
 } from 'rxjs';
 import * as ExcelJS from 'exceljs';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { PageEvent, MatPaginatorModule } from '@angular/material/paginator';
 import { MatTabsModule } from '@angular/material/tabs';
 import { CodingJobsComponent } from '../coding-jobs/coding-jobs.component';
@@ -189,6 +189,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private exportJobService = inject(ExportJobService);
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
+  private route = inject(ActivatedRoute);
   private router = inject(Router);
   private document = inject(DOCUMENT);
   private destroy$ = new Subject<void>();
@@ -219,6 +220,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   isLoadingCaseCoverage = false;
   isLoadingCodingProgress = false;
   isLoadingManualCodeAvailability = false;
+  isLoadingAppliedResultsOverview = false;
   isLoadingKappaSummary = false;
 
   // Response matching mode configuration
@@ -388,10 +390,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private jobDefinitionsForExportWorkspaceId?: number;
   private hasLoadedJobDefinitionsForExport = false;
   private isLoadingJobDefinitionsForExport = false;
+  private readonly manualFreshnessFocusParam = 'manual-freshness';
+  private pendingManualFreshnessFocus = false;
+  private manualFreshnessPlanningRequested = false;
 
   expectedCombinations: ExpectedCombinationDto[] = [];
 
   ngOnInit(): void {
+    this.pendingManualFreshnessFocus =
+      this.route.snapshot.queryParamMap.get('focus') === this.manualFreshnessFocusParam;
+
     this.validationStateService.validationProgress$
       .pipe(takeUntil(this.destroy$))
       .subscribe((progress: ValidationProgress | null) => {
@@ -1398,6 +1406,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingVariableCoverage ||
       this.isLoadingCaseCoverage ||
       this.isLoadingManualCodeAvailability ||
+      this.isLoadingAppliedResultsOverview ||
       this.isLoadingMatchingMode;
   }
 
@@ -2256,6 +2265,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .pipe(
         finalize(() => {
           this.isLoadingMatchingMode = false;
+          this.focusManualFreshnessTargetIfReady();
         }),
         takeUntil(this.destroy$)
       )
@@ -2342,6 +2352,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.canApplyManualCodingResults = this.appService.authData.isAdmin === true;
       this.canManageManualCodingJobs = this.appService.authData.isAdmin === true;
       this.keepAvailableManualTabSelected(activeTab);
+      this.requestManualFreshnessFocusIfNeeded();
       return;
     }
 
@@ -2356,12 +2367,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.canManageManualCodingJobs = accessLevel >= 2;
           this.canApplyManualCodingResults = accessLevel >= 3;
           this.keepAvailableManualTabSelected(activeTab);
+          this.requestManualFreshnessFocusIfNeeded();
         },
         error: () => {
           const activeTab = this.activeManualTab;
           this.canManageManualCodingJobs = false;
           this.canApplyManualCodingResults = false;
           this.keepAvailableManualTabSelected(activeTab);
+          this.requestManualFreshnessFocusIfNeeded();
         }
       });
   }
@@ -2383,6 +2396,30 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const executionTabIndex = this.visibleManualCodingTabs.indexOf('execution');
     this.selectedManualTabIndex = executionTabIndex >= 0 ? executionTabIndex : 0;
     this.loadManualTabData(this.activeManualTab);
+  }
+
+  private requestManualFreshnessFocusIfNeeded(): void {
+    if (!this.pendingManualFreshnessFocus || this.manualFreshnessPlanningRequested) {
+      return;
+    }
+
+    this.manualFreshnessPlanningRequested = true;
+    this.goToManualTab('planning');
+    this.focusManualFreshnessTargetIfReady();
+  }
+
+  private focusManualFreshnessTargetIfReady(): void {
+    if (!this.pendingManualFreshnessFocus ||
+        !this.manualFreshnessPlanningRequested ||
+        this.isAnyPlanningDataLoading()) {
+      return;
+    }
+
+    this.pendingManualFreshnessFocus = false;
+    this.goToManualTab(
+      this.getPlanningNextStepTargetTab(),
+      this.getPlanningNextStepTargetSection()
+    );
   }
 
   private loadJobDefinitionsForExport(): void {
@@ -2586,6 +2623,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$),
         finalize(() => {
           this.isLoadingCodingProgress = false;
+          this.focusManualFreshnessTargetIfReady();
         })
       )
       .subscribe({
@@ -2611,6 +2649,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$),
         finalize(() => {
           this.isLoadingVariableCoverage = false;
+          this.focusManualFreshnessTargetIfReady();
         })
       )
       .subscribe({
@@ -2667,6 +2706,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$),
         finalize(() => {
           this.isLoadingCaseCoverage = false;
+          this.focusManualFreshnessTargetIfReady();
         })
       )
       .subscribe({
@@ -2774,6 +2814,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$),
         finalize(() => {
           this.isLoadingManualCodeAvailability = false;
+          this.focusManualFreshnessTargetIfReady();
         })
       )
       .subscribe({
@@ -2852,12 +2893,20 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private loadAppliedResultsOverview(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.isLoadingAppliedResultsOverview = false;
       return;
     }
 
+    this.isLoadingAppliedResultsOverview = true;
     this.testPersonCodingService
       .getAppliedResultsOverview(workspaceId)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.isLoadingAppliedResultsOverview = false;
+          this.focusManualFreshnessTargetIfReady();
+        })
+      )
       .subscribe({
         next: overview => {
           if (!overview) {
@@ -3457,6 +3506,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.responseAnalysis = analysis;
           this.responseAnalysisError = null;
           this.isLoadingResponseAnalysis = false;
+          this.focusManualFreshnessTargetIfReady();
 
           if (analysis.isCalculating) {
             // Poll every 5 seconds if calculating
@@ -3469,6 +3519,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: error => {
           this.isLoadingResponseAnalysis = false;
+          this.focusManualFreshnessTargetIfReady();
           this.responseAnalysis = null;
           this.responseAnalysisError = `Fehler beim Laden der Antwortanalyse: ${error.message || error}`;
           this.snackBar.open(

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -220,6 +220,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   isLoadingCaseCoverage = false;
   isLoadingCodingProgress = false;
   isLoadingManualCodeAvailability = false;
+  isLoadingCodingIncompleteVariables = false;
   isLoadingAppliedResultsOverview = false;
   isLoadingKappaSummary = false;
 
@@ -1406,6 +1407,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingVariableCoverage ||
       this.isLoadingCaseCoverage ||
       this.isLoadingManualCodeAvailability ||
+      this.isLoadingCodingIncompleteVariables ||
       this.isLoadingAppliedResultsOverview ||
       this.isLoadingMatchingMode;
   }
@@ -2769,13 +2771,21 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.codingIncompleteVariables = [];
       this.manualCodingScopeSummary = null;
       this.setManualCodeAvailabilityWarnings([]);
+      this.isLoadingCodingIncompleteVariables = false;
       this.isLoadingManualCodeAvailability = false;
       return;
     }
 
+    this.isLoadingCodingIncompleteVariables = true;
     this.codingJobBackendService
       .getCodingIncompleteVariables(workspaceId)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.isLoadingCodingIncompleteVariables = false;
+          this.focusManualFreshnessTargetIfReady();
+        })
+      )
       .subscribe({
         next: (
           variables: {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
@@ -154,7 +154,7 @@
       </button>
       }
       @if (hasManualCodingFreshnessAction) {
-      <button mat-stroked-button color="primary" (click)="openManualCoding()">
+      <button mat-stroked-button color="primary" (click)="openManualCoding(true)">
         <mat-icon>keyboard</mat-icon>
         {{ 'coding-management.readiness.open-manual-review' | translate }}
       </button>

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -246,7 +246,7 @@ describe('CodingManagementComponent', () => {
           'second-autocoding-waits-help': 'Der Start von Auto-Coding 2 bleibt bis dahin gesperrt. {{taskResultHelp}}',
           'second-autocoding-waits-chip': '{{version}}: {{count}} wartet',
           'second-autocoding-waits-snackbar': 'Schließen Sie zuerst die manuelle Kodierung ab und übernehmen Sie die Ergebnisse.',
-          'open-manual-review': 'Manuelle Prüfung öffnen'
+          'open-manual-review': 'Manuelle Kodierung öffnen'
         }
       }
     });
@@ -379,12 +379,15 @@ describe('CodingManagementComponent', () => {
       fixture.detectChanges();
       const actionPanel = fixture.nativeElement.querySelector('.coding-freshness-actions') as HTMLElement | null;
       const manualActionButton = Array.from(actionPanel?.querySelectorAll('button') || [])
-        .find(button => button.textContent?.includes('Manuelle Prüfung öffnen')) as HTMLButtonElement | undefined;
+        .find(button => button.textContent?.includes('Manuelle Kodierung öffnen')) as HTMLButtonElement | undefined;
       expect(manualActionButton).toBeTruthy();
 
       manualActionButton?.click();
 
-      expect(mockRouter.navigate).toHaveBeenCalledWith(['/workspace-admin/1/coding/manual']);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(
+        ['/workspace-admin/1/coding/manual'],
+        { queryParams: { focus: 'manual-freshness' } }
+      );
     });
 
     it('should keep earlier coding freshness warnings visible while second auto-coding waits', () => {
@@ -1086,9 +1089,19 @@ describe('CodingManagementComponent', () => {
     it('should navigate to manual coding route', () => {
       component.openManualCoding();
 
-      expect(mockRouter.navigate).toHaveBeenCalledWith([
-        '/workspace-admin/1/coding/manual'
-      ]);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(
+        ['/workspace-admin/1/coding/manual'],
+        undefined
+      );
+    });
+
+    it('should navigate to focused manual coding route for freshness work', () => {
+      component.openManualCoding(true);
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(
+        ['/workspace-admin/1/coding/manual'],
+        { queryParams: { focus: 'manual-freshness' } }
+      );
     });
 
     it('should navigate to test files route', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -1232,13 +1232,17 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     });
   }
 
-  openManualCoding(): void {
+  openManualCoding(focusManualFreshness = false): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
       return;
     }
 
-    this.router.navigate([`/workspace-admin/${workspaceId}/coding/manual`]);
+    const navigationExtras = focusManualFreshness ?
+      { queryParams: { focus: 'manual-freshness' } } :
+      undefined;
+
+    this.router.navigate([`/workspace-admin/${workspaceId}/coding/manual`], navigationExtras);
   }
 
   openTestFiles(): void {

--- a/apps/frontend/src/app/shared/utils/coding-freshness-text.util.spec.ts
+++ b/apps/frontend/src/app/shared/utils/coding-freshness-text.util.spec.ts
@@ -140,7 +140,7 @@ describe('coding freshness text utils', () => {
         unitCount: 1,
         affectedResponseCount: 2
       }
-    ])).toBe('Manuelle Kodierung prüfen');
+    ])).toBe('Manuelle Kodierung aktualisieren');
   });
 
   it('separates auto-coding warnings from manual review warnings', () => {
@@ -212,8 +212,8 @@ describe('coding freshness text utils', () => {
         affectedResponseCount: 10
       }
     ])).toBe(
-      'Öffnen Sie die manuelle Prüfung und wenden Sie abgeschlossene Job-Ergebnisse erneut an ' +
-      'oder kodieren Sie offene Fälle neu.'
+      'Öffnen Sie die manuelle Kodierung. Bearbeiten Sie offene Fälle im Abschnitt Durchführung ' +
+      'oder übernehmen Sie abgeschlossene Ergebnisse im Abschnitt Abschluss.'
     );
   });
 
@@ -233,7 +233,7 @@ describe('coding freshness text utils', () => {
       }
     ])).toBe(
       'Aktualisieren Sie zuerst die offenen Auto-Coding-Schritte. ' +
-      'Prüfen Sie danach die manuelle Kodierung.'
+      'Danach wird die manuelle Kodierung neu bewertet.'
     );
   });
 });

--- a/apps/frontend/src/app/shared/utils/coding-freshness-text.util.ts
+++ b/apps/frontend/src/app/shared/utils/coding-freshness-text.util.ts
@@ -37,7 +37,7 @@ export function getCodingFreshnessStateLabel(state: CodingFreshnessState): strin
     CURRENT: 'aktuell',
     PENDING: 'zu kodieren',
     STALE: 'zu aktualisieren',
-    MANUAL_REVIEW_REQUIRED: 'zu prüfen'
+    MANUAL_REVIEW_REQUIRED: 'zu aktualisieren'
   };
   return labels[state];
 }
@@ -142,7 +142,7 @@ export function getCodingFreshnessAttentionTitle(
   }
 
   if (autoCodingWarnings.length === 0 && manualReviewWarnings.length > 0) {
-    return 'Manuelle Kodierung prüfen';
+    return 'Manuelle Kodierung aktualisieren';
   }
 
   return 'Kodierstand prüfen';
@@ -156,10 +156,10 @@ export function getCodingFreshnessManualReviewGuidanceText(
   }
 
   if (getCodingFreshnessAutoCodingWarnings(items).length > 0) {
-    return 'Aktualisieren Sie zuerst die offenen Auto-Coding-Schritte. Prüfen Sie danach die manuelle Kodierung.';
+    return 'Aktualisieren Sie zuerst die offenen Auto-Coding-Schritte. Danach wird die manuelle Kodierung neu bewertet.';
   }
 
-  return 'Öffnen Sie die manuelle Prüfung und wenden Sie abgeschlossene Job-Ergebnisse erneut an oder kodieren Sie offene Fälle neu.';
+  return 'Öffnen Sie die manuelle Kodierung. Bearbeiten Sie offene Fälle im Abschnitt Durchführung oder übernehmen Sie abgeschlossene Ergebnisse im Abschnitt Abschluss.';
 }
 
 export function getCodingFreshnessSummaryText(items: CodingFreshnessSummaryItemDto[]): string {
@@ -255,8 +255,8 @@ function getManualReviewSummaryText(
     getCodingFreshnessAffectedResponseCount(items)
   );
 
-  return `Die manuelle Kodierung muss für ${taskResults} geprüft werden. ` +
-    `Das betrifft ${responses}.`;
+  return `Für ${taskResults} ist die manuelle Kodierung nicht aktuell. ` +
+    `Betroffen sind ${responses}.`;
 }
 
 function getSingleCodingFreshnessActionText(
@@ -270,7 +270,7 @@ function getSingleCodingFreshnessActionText(
   }
 
   if (item.version === 'v2' || item.state === 'MANUAL_REVIEW_REQUIRED') {
-    return `Die manuelle Kodierung muss für ${taskResults} geprüft werden`;
+    return `Für ${taskResults} ist die manuelle Kodierung nicht aktuell`;
   }
 
   return `Die Kodierung muss für ${taskResults} aktualisiert werden`;
@@ -351,7 +351,7 @@ function getChipActionText(item: CodingFreshnessSummaryItemDto): string {
   }
 
   if (item.version === 'v2' || item.state === 'MANUAL_REVIEW_REQUIRED') {
-    return 'prüfen';
+    return 'aktualisieren';
   }
 
   return getCodingFreshnessStateLabel(item.state);

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1328,7 +1328,7 @@
       "update-running": "Aktualisierung läuft: {{progress}}%",
       "retry": "Erneut prüfen",
       "check-test-files": "Testdateien prüfen",
-      "open-manual-review": "Manuelle Prüfung öffnen"
+      "open-manual-review": "Manuelle Kodierung öffnen"
     },
     "labels": {
       "geogebra-file": "GeoGebra-Datei"


### PR DESCRIPTION
## Summary

Fixes #768.

This changes the manual-coding freshness flow so the overview no longer sends users to a generic manual review entry point. The freshness action now opens manual coding with context, and the manual coding view waits for the relevant planning, progress, and applied-results data before choosing the next target section.

## Changes

- Clarify German manual-coding freshness text and action labels.
- Add focused navigation from the coding overview into manual coding via `focus=manual-freshness`.
- Route focused manual freshness work to planning, execution, or completion based on the loaded state.
- Track applied-results loading so completed manual work is not routed before completion data is available.
- Clear stale downstream v2 freshness after a v1 reset so reset flows do not leave orphaned manual-review warnings.
- Extend tests for focused navigation, applied-results timing, and v1 reset freshness cleanup.

## Validation

- `npx nx lint backend`
- `npx nx test backend --runInBand`
- `npx nx lint frontend`
- `npx nx test frontend --runInBand`
- `git diff --check`
