### PR TITLE
Refresh coding statistics after discussion results apply

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -708,16 +708,27 @@ describe('CodingManagementComponent', () => {
     it('should switch to changed statistics version when test results change', () => {
       (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
 
-      testResultsChangedSubject.next({ statisticsVersion: 'v2' });
+      testResultsChangedSubject.next({ workspaceId: 1, statisticsVersion: 'v2' });
 
       expect(component.selectedStatisticsVersion).toBe('v2');
       expect(component.filterParams.version).toBe('v2');
       expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v2');
     });
 
+    it('should ignore changed test results from a different workspace', () => {
+      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+
+      testResultsChangedSubject.next({ workspaceId: 2, statisticsVersion: 'v2' });
+
+      expect(component.selectedStatisticsVersion).toBe('v1');
+      expect(component.filterParams.version).toBe('v1');
+      expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+    });
+
     it('should consume a pending statistics version when opened after results changed', () => {
       fixture.destroy();
       (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (mockTestPersonCodingService.consumePendingStatisticsVersion as jest.Mock).mockClear();
       (mockTestPersonCodingService.consumePendingStatisticsVersion as jest.Mock)
         .mockReturnValueOnce('v2');
 
@@ -727,6 +738,7 @@ describe('CodingManagementComponent', () => {
 
       expect(component.selectedStatisticsVersion).toBe('v2');
       expect(component.filterParams.version).toBe('v2');
+      expect(mockTestPersonCodingService.consumePendingStatisticsVersion).toHaveBeenCalledWith(1);
       expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v2');
     });
 

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -17,7 +17,10 @@ import { CodingManagementService } from '../../services/coding-management.servic
 import { CodingManagementUiService } from './services/coding-management-ui.service';
 import { AppService } from '../../../core/services/app.service';
 import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
-import { TestPersonCodingService } from '../../services/test-person-coding.service';
+import {
+  TestPersonCodingService,
+  TestResultsChangedEvent
+} from '../../services/test-person-coding.service';
 import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
 import { Success } from '../../models/success.model';
@@ -35,6 +38,7 @@ describe('CodingManagementComponent', () => {
   let mockRouter: jest.Mocked<Partial<Router>>;
   let mockSnackBar: jest.Mocked<Partial<MatSnackBar>>;
   let autoCodingCompletedSubject: Subject<{ jobId?: string }>;
+  let testResultsChangedSubject: Subject<TestResultsChangedEvent>;
 
   const fakeActivatedRoute = {
     snapshot: { data: {} }
@@ -92,10 +96,12 @@ describe('CodingManagementComponent', () => {
       getEnableRegexSearch: jest.fn().mockReturnValue(of(false))
     };
     autoCodingCompletedSubject = new Subject<{ jobId?: string }>();
+    testResultsChangedSubject = new Subject<TestResultsChangedEvent>();
 
     mockTestPersonCodingService = {
       autoCodingCompleted$: autoCodingCompletedSubject.asObservable(),
-      testResultsChanged$: of(),
+      testResultsChanged$: testResultsChangedSubject.asObservable(),
+      consumePendingStatisticsVersion: jest.fn().mockReturnValue(null),
       getCodingFreshness: jest.fn().mockReturnValue(of({
         workspaceId: 1,
         currentRevision: 0,
@@ -697,6 +703,31 @@ describe('CodingManagementComponent', () => {
       component.fetchCodingStatistics();
 
       expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v1');
+    });
+
+    it('should switch to changed statistics version when test results change', () => {
+      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+
+      testResultsChangedSubject.next({ statisticsVersion: 'v2' });
+
+      expect(component.selectedStatisticsVersion).toBe('v2');
+      expect(component.filterParams.version).toBe('v2');
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v2');
+    });
+
+    it('should consume a pending statistics version when opened after results changed', () => {
+      fixture.destroy();
+      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (mockTestPersonCodingService.consumePendingStatisticsVersion as jest.Mock)
+        .mockReturnValueOnce('v2');
+
+      fixture = TestBed.createComponent(CodingManagementComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      expect(component.selectedStatisticsVersion).toBe('v2');
+      expect(component.filterParams.version).toBe('v2');
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v2');
     });
 
     it('should handle status click from statistics card through the normal table filter', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -203,12 +203,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
-    const pendingStatisticsVersion = this.testPersonCodingService.consumePendingStatisticsVersion();
-    if (pendingStatisticsVersion) {
-      this.selectStatisticsVersion(pendingStatisticsVersion);
-    }
+    let pendingStatisticsVersion: StatisticsVersion | null = null;
 
     if (workspaceId) {
+      pendingStatisticsVersion = this.testPersonCodingService.consumePendingStatisticsVersion(workspaceId);
+      if (pendingStatisticsVersion) {
+        this.selectStatisticsVersion(pendingStatisticsVersion);
+      }
+
       this.workspaceSettingsService
         .getAutoFetchCodingStatistics(workspaceId)
         .subscribe(autoFetch => {
@@ -343,9 +345,16 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   private refreshAfterTestResultsChanged(event: TestResultsChangedEvent = {}): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (event.workspaceId && event.workspaceId !== workspaceId) {
+      return;
+    }
+
     if (event.statisticsVersion) {
       this.selectStatisticsVersion(event.statisticsVersion);
-      this.testPersonCodingService.consumePendingStatisticsVersion();
+      if (workspaceId) {
+        this.testPersonCodingService.consumePendingStatisticsVersion(workspaceId);
+      }
     }
     this.fetchCodingStatistics();
     this.loadCodingFreshness();

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -41,7 +41,8 @@ import {
 } from '../test-person-coding-dialog/test-person-coding-dialog.component';
 import {
   AppliedResultsOverview,
-  TestPersonCodingService
+  TestPersonCodingService,
+  TestResultsChangedEvent
 } from '../../services/test-person-coding.service';
 import { ExportCodingBookComponent } from '../export-coding-book/export-coding-book.component';
 import { VariableAnalysisDialogComponent } from '../variable-analysis-dialog/variable-analysis-dialog.component';
@@ -202,11 +203,16 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
+    const pendingStatisticsVersion = this.testPersonCodingService.consumePendingStatisticsVersion();
+    if (pendingStatisticsVersion) {
+      this.selectStatisticsVersion(pendingStatisticsVersion);
+    }
+
     if (workspaceId) {
       this.workspaceSettingsService
         .getAutoFetchCodingStatistics(workspaceId)
         .subscribe(autoFetch => {
-          if (autoFetch) {
+          if (autoFetch || pendingStatisticsVersion) {
             this.fetchCodingStatistics();
           }
         });
@@ -297,12 +303,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
     this.testPersonCodingService.testResultsChanged$
       .pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.fetchCodingStatistics();
-        this.loadCodingFreshness();
-        this.loadManualAppliedResultsOverview();
-        this.loadAutocodingReadiness();
-        this.refreshTableData();
+      .subscribe(event => {
+        this.refreshAfterTestResultsChanged(event);
       });
 
     // Check for active reset job (persists across navigation)
@@ -320,6 +322,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   // Statistics Card Event Handlers
   onVersionChange(version: 'v1' | 'v2' | 'v3'): void {
+    this.selectStatisticsVersion(version);
+
+    if (this.statisticsLoaded) {
+      this.fetchCodingStatistics();
+    }
+  }
+
+  private selectStatisticsVersion(version: 'v1' | 'v2' | 'v3'): void {
     this.selectedStatisticsVersion = version;
     this.filterParams = {
       ...this.filterParams,
@@ -330,10 +340,18 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.totalRecords = 0;
     this.referenceStatistics = null;
     this.referenceVersion = null;
+  }
 
-    if (this.statisticsLoaded) {
-      this.fetchCodingStatistics();
+  private refreshAfterTestResultsChanged(event: TestResultsChangedEvent = {}): void {
+    if (event.statisticsVersion) {
+      this.selectStatisticsVersion(event.statisticsVersion);
+      this.testPersonCodingService.consumePendingStatisticsVersion();
     }
+    this.fetchCodingStatistics();
+    this.loadCodingFreshness();
+    this.loadManualAppliedResultsOverview();
+    this.loadAutocodingReadiness();
+    this.refreshTableData();
   }
 
   fetchCodingStatistics(): void {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -1387,7 +1387,10 @@ describe('CodingResultsComparisonComponent', () => {
         jobConflictStrategy: 'removeFromJobs'
       }
     );
-    expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalledWith({ statisticsVersion: 'v2' });
+    expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalledWith({
+      workspaceId: 1,
+      statisticsVersion: 'v2'
+    });
     expect(component.loadComparison).toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -17,6 +17,7 @@ import { CodingStatisticsService } from '../../services/coding-statistics.servic
 import { AppService } from '../../../core/services/app.service';
 import { CoderTraining } from '../../models/coder-training.model';
 import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
+import { TestPersonCodingService } from '../../services/test-person-coding.service';
 
 describe('CodingResultsComparisonComponent', () => {
   let component: CodingResultsComparisonComponent;
@@ -46,6 +47,9 @@ describe('CodingResultsComparisonComponent', () => {
   };
   let workspaceSettingsService: {
     getEnableRegexSearch: jest.Mock;
+  };
+  let testPersonCodingService: {
+    notifyTestResultsChanged: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -82,6 +86,9 @@ describe('CodingResultsComparisonComponent', () => {
     };
     workspaceSettingsService = {
       getEnableRegexSearch: jest.fn().mockReturnValue(of(false))
+    };
+    testPersonCodingService = {
+      notifyTestResultsChanged: jest.fn()
     };
 
     await TestBed.configureTestingModule({
@@ -127,6 +134,10 @@ describe('CodingResultsComparisonComponent', () => {
         {
           provide: WorkspaceSettingsService,
           useValue: workspaceSettingsService
+        },
+        {
+          provide: TestPersonCodingService,
+          useValue: testPersonCodingService
         }
       ]
     }).compileComponents();
@@ -1376,6 +1387,7 @@ describe('CodingResultsComparisonComponent', () => {
         jobConflictStrategy: 'removeFromJobs'
       }
     );
+    expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalledWith({ statisticsVersion: 'v2' });
     expect(component.loadComparison).toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -1162,7 +1162,10 @@ export class CodingResultsComparisonComponent implements OnInit {
           { duration: 5000 }
         );
         if (result.updatedResponsesCount > 0 || result.removedJobUnitCount > 0) {
-          this.testPersonCodingService.notifyTestResultsChanged({ statisticsVersion: 'v2' });
+          this.testPersonCodingService.notifyTestResultsChanged({
+            workspaceId: this.data.workspaceId,
+            statisticsVersion: 'v2'
+          });
         }
         this.loadComparison();
       },

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -32,6 +32,7 @@ import { Subject, takeUntil } from 'rxjs';
 import { normalizeTestperson } from '../../../replay/utils/token-utils';
 import { PostMessage, PostMessageService } from '../../../core/services/post-message.service';
 import { CodingTrainingBackendService } from '../../services/coding-training-backend.service';
+import { TestPersonCodingService } from '../../services/test-person-coding.service';
 import { CoderTraining } from '../../models/coder-training.model';
 import { CodingStatisticsService } from '../../services/coding-statistics.service';
 import { AppService } from '../../../core/services/app.service';
@@ -256,6 +257,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   private workspaceSettingsService = inject(WorkspaceSettingsService);
   private postMessageService = inject(PostMessageService);
   private dialog = inject(MatDialog);
+  private testPersonCodingService = inject(TestPersonCodingService);
   private ngUnsubscribe = new Subject<void>();
 
   isLoading = false;
@@ -1159,6 +1161,9 @@ export class CodingResultsComparisonComponent implements OnInit {
           this.translate.instant('common.close'),
           { duration: 5000 }
         );
+        if (result.updatedResponsesCount > 0 || result.removedJobUnitCount > 0) {
+          this.testPersonCodingService.notifyTestResultsChanged({ statisticsVersion: 'v2' });
+        }
         this.loadComparison();
       },
       error: error => {

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -158,6 +158,12 @@ export interface AutoCodingCompletedEvent {
   jobId?: string;
 }
 
+export type CodingStatisticsVersion = 'v1' | 'v2' | 'v3';
+
+export interface TestResultsChangedEvent {
+  statisticsVersion?: CodingStatisticsVersion;
+}
+
 export interface WorkspaceGroupCodingStats {
   groupName: string;
   testPersonCount: number;
@@ -226,7 +232,8 @@ export class TestPersonCodingService {
   readonly serverUrl = inject(SERVER_URL);
   private http = inject(HttpClient);
   private autoCodingCompletedSubject = new Subject<AutoCodingCompletedEvent>();
-  private testResultsChangedSubject = new Subject<void>();
+  private testResultsChangedSubject = new Subject<TestResultsChangedEvent>();
+  private pendingStatisticsVersion: CodingStatisticsVersion | null = null;
   autoCodingCompleted$ = this.autoCodingCompletedSubject.asObservable();
   testResultsChanged$ = this.testResultsChangedSubject.asObservable();
 
@@ -242,8 +249,17 @@ export class TestPersonCodingService {
     this.autoCodingCompletedSubject.next({ jobId });
   }
 
-  notifyTestResultsChanged(): void {
-    this.testResultsChangedSubject.next();
+  notifyTestResultsChanged(event: TestResultsChangedEvent = {}): void {
+    if (event.statisticsVersion) {
+      this.pendingStatisticsVersion = event.statisticsVersion;
+    }
+    this.testResultsChangedSubject.next(event);
+  }
+
+  consumePendingStatisticsVersion(): CodingStatisticsVersion | null {
+    const version = this.pendingStatisticsVersion;
+    this.pendingStatisticsVersion = null;
+    return version;
   }
 
   codeTestPersons(workspaceId: number, testPersonIds: string, autoCoderRun: number = 1): Observable<CodingStatisticsWithJob> {

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -161,6 +161,7 @@ export interface AutoCodingCompletedEvent {
 export type CodingStatisticsVersion = 'v1' | 'v2' | 'v3';
 
 export interface TestResultsChangedEvent {
+  workspaceId?: number;
   statisticsVersion?: CodingStatisticsVersion;
 }
 
@@ -233,7 +234,7 @@ export class TestPersonCodingService {
   private http = inject(HttpClient);
   private autoCodingCompletedSubject = new Subject<AutoCodingCompletedEvent>();
   private testResultsChangedSubject = new Subject<TestResultsChangedEvent>();
-  private pendingStatisticsVersion: CodingStatisticsVersion | null = null;
+  private pendingStatisticsVersions = new Map<number, CodingStatisticsVersion>();
   autoCodingCompleted$ = this.autoCodingCompletedSubject.asObservable();
   testResultsChanged$ = this.testResultsChangedSubject.asObservable();
 
@@ -250,15 +251,15 @@ export class TestPersonCodingService {
   }
 
   notifyTestResultsChanged(event: TestResultsChangedEvent = {}): void {
-    if (event.statisticsVersion) {
-      this.pendingStatisticsVersion = event.statisticsVersion;
+    if (event.workspaceId && event.statisticsVersion) {
+      this.pendingStatisticsVersions.set(event.workspaceId, event.statisticsVersion);
     }
     this.testResultsChangedSubject.next(event);
   }
 
-  consumePendingStatisticsVersion(): CodingStatisticsVersion | null {
-    const version = this.pendingStatisticsVersion;
-    this.pendingStatisticsVersion = null;
+  consumePendingStatisticsVersion(workspaceId: number): CodingStatisticsVersion | null {
+    const version = this.pendingStatisticsVersions.get(workspaceId) ?? null;
+    this.pendingStatisticsVersions.delete(workspaceId);
     return version;
   }
 


### PR DESCRIPTION
## Summary

Relates to #694. This PR keeps the issue open intentionally.

- refreshes the coding overview after training discussion results are applied
- switches the overview to statistics version `v2`, where the applied discussion results are written
- keeps pending statistics refresh hints scoped to the originating workspace so workspace switches cannot apply the hint to the wrong workspace

## Root Cause

Applied training discussion results update the `v2` coding result fields, but the coding overview could remain on `v1` or miss the transient refresh event when navigating back after applying results.

## Validation

- `npx jest --config apps/frontend/jest.config.ts --runTestsByPath apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts --silent`
- `npx nx lint frontend`
- `npx nx test frontend`