### PR TITLE
Fix training discussion missing codes

### DIFF
--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -41,6 +41,7 @@ describe('CoderTrainingService', () => {
     getMissingsProfileDetails: jest.Mock;
     ensureDefaultMissingsProfile: jest.Mock;
     getNegativeMissingCodesForProfileOrDefault: jest.Mock;
+    getMissingByIdForProfileOrDefault: jest.Mock;
     getMissingByCodeForProfileOrDefault: jest.Mock;
     resolveMissingsProfileId: jest.Mock;
   };
@@ -86,6 +87,19 @@ describe('CoderTrainingService', () => {
         ]
       }),
       getNegativeMissingCodesForProfileOrDefault: jest.fn().mockResolvedValue(new Set([-97, -98, -99])),
+      getMissingByIdForProfileOrDefault: jest.fn(async (_workspaceId, _profileId, missingId: string) => {
+        if (missingId === 'mir') {
+          return {
+            id: 'mir', label: 'missing invalid response', code: -98, score: 0
+          };
+        }
+        if (missingId === 'mci') {
+          return {
+            id: 'mci', label: 'missing coding impossible', code: -97, score: 0
+          };
+        }
+        throw new BadRequestException(`Missing '${missingId}' not found`);
+      }),
       getMissingByCodeForProfileOrDefault: jest.fn(async (_workspaceId, _profileId, code: number) => {
         if ([-97, -98, -99].includes(code)) {
           return {
@@ -2065,6 +2079,59 @@ describe('CoderTrainingService', () => {
         score: 0
       }));
       expect(result.score).toBe(0);
+      expect(result.source).toBe('manual');
+    });
+
+    it('should resolve MIR discussion issue option to the default profile missing code', async () => {
+      const { training } = createTrainingWithUnit();
+      (coderTrainingRepository.findOne as jest.Mock)
+        .mockResolvedValueOnce(training)
+        .mockResolvedValueOnce(null);
+      mockDiscussionSave();
+
+      const result = await service.saveDiscussionResult(1, 5, 101, 99, 'Manager', -3);
+
+      expect(missingsProfilesService.getMissingByIdForProfileOrDefault).toHaveBeenCalledWith(1, 1, 'mir');
+      expect(missingsProfilesService.getMissingByCodeForProfileOrDefault).toHaveBeenCalledWith(1, 1, -98);
+      expect(coderTrainingDiscussionResultRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+        code: -98,
+        score: 0
+      }));
+      expect(result.code).toBe(-98);
+      expect(result.score).toBe(0);
+      expect(result.source).toBe('manual');
+    });
+
+    it('should resolve MCI discussion issue option to the response job missing profile code', async () => {
+      const { training } = createTrainingWithUnit();
+      training.codingJobs[0].missings_profile_id = 77;
+      (coderTrainingRepository.findOne as jest.Mock)
+        .mockResolvedValueOnce(training)
+        .mockResolvedValueOnce(null);
+      missingsProfilesService.getMissingByIdForProfileOrDefault.mockResolvedValueOnce({
+        id: 'mci',
+        label: 'Custom technical problem',
+        code: -41,
+        score: 3
+      });
+      missingsProfilesService.getMissingByCodeForProfileOrDefault.mockResolvedValueOnce({
+        id: 'mci',
+        label: 'Custom technical problem',
+        code: -41,
+        score: 3
+      });
+      mockDiscussionSave();
+
+      const result = await service.saveDiscussionResult(1, 5, 101, 99, 'Manager', -4);
+
+      expect(missingsProfilesService.getMissingByIdForProfileOrDefault).toHaveBeenCalledWith(1, 77, 'mci');
+      expect(missingsProfilesService.getMissingByCodeForProfileOrDefault).toHaveBeenCalledWith(1, 77, -41);
+      expect(coderTrainingDiscussionResultRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+        code: -41,
+        score: 3
+      }));
+      expect(result.code).toBe(-41);
+      expect(result.score).toBe(3);
       expect(result.source).toBe('manual');
     });
 

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -885,13 +885,37 @@ export class CoderTrainingService {
     code: number,
     exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
   ): Promise<number> {
-    const jobUnits = this.findTrainingJobUnitsForResponse(training, responseId, exclusions);
-    if (jobUnits.length === 0) {
+    const profileId = await this.resolveMissingProfileIdForResponse(
+      workspaceId,
+      training,
+      responseId,
+      exclusions
+    );
+
+    try {
       return (await this.missingsProfilesService.getMissingByCodeForProfileOrDefault(
         workspaceId,
-        null,
+        profileId,
         code
       )).score;
+    } catch (error) {
+      if (error instanceof BadRequestException && error.message.includes('not found')) {
+        throw new BadRequestException(`Unsupported missing code: ${code}`);
+      }
+
+      throw error;
+    }
+  }
+
+  private async resolveMissingProfileIdForResponse(
+    workspaceId: number,
+    training: CoderTraining,
+    responseId: number,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
+  ): Promise<number | null> {
+    const jobUnits = this.findTrainingJobUnitsForResponse(training, responseId, exclusions);
+    if (jobUnits.length === 0) {
+      return null;
     }
 
     const resolvedProfileIds = await Promise.all(jobUnits.map(({ job }) => (
@@ -902,19 +926,38 @@ export class CoderTrainingService {
       throw new BadRequestException(`Conflicting missing profiles for response ${responseId} in training ${training.id}`);
     }
 
-    try {
-      return (await this.missingsProfilesService.getMissingByCodeForProfileOrDefault(
-        workspaceId,
-        resolvedProfileIds[0],
-        code
-      )).score;
-    } catch (error) {
-      if (error instanceof BadRequestException && error.message.includes('not found')) {
-        throw new BadRequestException(`Unsupported missing code: ${code}`);
-      }
+    return resolvedProfileIds[0];
+  }
 
-      throw error;
+  private async resolveManualDiscussionCode(
+    workspaceId: number,
+    training: CoderTraining,
+    responseId: number,
+    code: number,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
+  ): Promise<number> {
+    const missingIdByIssueOption = new Map<number, IqbStandardMissingId>([
+      [-3, 'mir'],
+      [-4, 'mci']
+    ]);
+    const missingId = missingIdByIssueOption.get(code);
+    if (!missingId) {
+      return code;
     }
+
+    const profileId = await this.resolveMissingProfileIdForResponse(
+      workspaceId,
+      training,
+      responseId,
+      exclusions
+    );
+    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+      workspaceId,
+      profileId,
+      missingId
+    );
+
+    return missing.code;
   }
 
   private async deriveDiscussionScore(
@@ -1025,11 +1068,19 @@ export class CoderTrainingService {
       throw new BadRequestException('Discussion code must be an integer');
     }
 
-    const derivedScore = await this.deriveDiscussionScore(
+    const resolvedCode = await this.resolveManualDiscussionCode(
       workspaceId,
       training,
       responseId,
       code,
+      exclusions
+    );
+
+    const derivedScore = await this.deriveDiscussionScore(
+      workspaceId,
+      training,
+      responseId,
+      resolvedCode,
       representativeUnit,
       exclusions
     );
@@ -1040,7 +1091,7 @@ export class CoderTrainingService {
       response_id: responseId
     });
 
-    discussionResult.code = code;
+    discussionResult.code = resolvedCode;
     discussionResult.score = derivedScore;
     discussionResult.notes = notes?.trim() || null;
     discussionResult.manager_user_id = managerUserId;


### PR DESCRIPTION
## Summary
- Resolve training discussion UI missing options `-3` and `-4` to the active `mir`/`mci` missing profile codes before persisting.
- Reuse the existing response-specific missing profile conflict checks for manual discussion results.
- Add focused backend coverage for default and job-specific missing profiles.

## Context
Refs #700. The issue remains open because the replay-note behavior still needs separate verification.

## Validation
- `npx jest --config apps/backend/jest.config.ts --runTestsByPath apps/backend/src/app/database/services/coding/coder-training.service.spec.ts --runInBand`
- `npx nx lint backend`
- `npx nx build backend`

Note: `npx nx test backend --runTestsByPath ...` unexpectedly ran the broader backend suite locally and hit the existing `libxmljs2`/Node ABI mismatch (`NODE_MODULE_VERSION 127` vs `141`), so the targeted Jest command above was used for the affected spec.
