### PR TITLE
Handle variable bundle coding cases

### DIFF
--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -425,7 +425,8 @@ describe('CoderTrainingService', () => {
         {
           caseSelectionMode: 'oldest_first',
           referenceTrainingIds: undefined,
-          referenceMode: undefined
+          referenceMode: undefined,
+          assignedVariableBundles
         }
       );
 
@@ -1346,18 +1347,22 @@ describe('CoderTrainingService', () => {
       overrides: Partial<{
         value: string | null;
         unitid: number;
+        variableid: string;
+        unitAlias: string;
+        unitName: string;
+        bookletName: string;
         personLogin: string;
         personCode: string;
         personGroup: string;
       }> = {}
     ) => ({
       id: responseId,
-      variableid: 'var1',
+      variableid: overrides.variableid ?? 'var1',
       value: overrides.value ?? `value-${responseId}`,
       unitid: overrides.unitid ?? responseId + 100,
       unit: {
-        alias: 'Alias Unit',
-        name: 'Real Unit',
+        alias: overrides.unitAlias ?? 'Alias Unit',
+        name: overrides.unitName ?? 'Real Unit',
         booklet: {
           person: {
             login: overrides.personLogin ?? `person-${responseId}`,
@@ -1365,7 +1370,7 @@ describe('CoderTrainingService', () => {
             group: overrides.personGroup ?? 'Group'
           },
           bookletinfo: {
-            name: 'Booklet'
+            name: overrides.bookletName ?? 'Booklet'
           }
         }
       }
@@ -1564,6 +1569,95 @@ describe('CoderTrainingService', () => {
         1,
         3
       ]);
+    });
+
+    it('samples bundle variables by shared case', async () => {
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockRepository.find.mockResolvedValue([{
+        id: 5,
+        name: 'Bundle',
+        workspace_id: 1,
+        variables: [
+          { unitName: 'Real Unit A', variableId: 'var1' },
+          { unitName: 'Real Unit B', variableId: 'var2' }
+        ]
+      }]);
+      const queryBuilders = [
+        {
+          leftJoinAndSelect: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          getMany: jest.fn().mockResolvedValue([
+            makeResponseEntity(1, {
+              unitName: 'Real Unit A',
+              variableid: 'var1',
+              personLogin: 'person-1',
+              personCode: '1'
+            }),
+            makeResponseEntity(3, {
+              unitName: 'Real Unit A',
+              variableid: 'var1',
+              personLogin: 'person-2',
+              personCode: '2'
+            })
+          ])
+        },
+        {
+          leftJoinAndSelect: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          getMany: jest.fn().mockResolvedValue([
+            makeResponseEntity(2, {
+              unitName: 'Real Unit B',
+              variableid: 'var2',
+              personLogin: 'person-1',
+              personCode: '1'
+            }),
+            makeResponseEntity(4, {
+              unitName: 'Real Unit B',
+              variableid: 'var2',
+              personLogin: 'person-2',
+              personCode: '2'
+            })
+          ])
+        }
+      ];
+      const responseRepository = {
+        createQueryBuilder: jest.fn()
+          .mockReturnValueOnce(queryBuilders[0])
+          .mockReturnValueOnce(queryBuilders[1])
+      };
+      const chunkRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnThis(),
+          getMany: jest.fn().mockResolvedValue([])
+        })
+      };
+
+      (service as unknown as { responseRepository: typeof responseRepository }).responseRepository = responseRepository;
+      (service as unknown as { chunkRepository: typeof chunkRepository }).chunkRepository = chunkRepository;
+
+      const result = await service.generateCoderTrainingPackages(
+        1,
+        [{ id: 10, name: 'Coder 1' }],
+        [
+          { unitId: 'Real Unit A', variableId: 'var1', sampleCount: 1 },
+          { unitId: 'Real Unit B', variableId: 'var2', sampleCount: 1 }
+        ],
+        {
+          caseSelectionMode: 'oldest_first',
+          assignedVariableBundles: [{
+            id: 5,
+            name: 'Bundle',
+            sampleCount: 1
+          }]
+        }
+      );
+
+      expect(result[0].responses.map(response => response.responseId)).toEqual([1, 2]);
+      expect(new Set(result[0].responses.map(response => response.personLogin))).toEqual(new Set(['person-1']));
     });
 
     it('should keep the same referenced cases when the training uses a unit alias', async () => {

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -97,6 +97,14 @@ type TrainingVariableConfig = {
   includeDeriveError?: boolean;
 };
 
+type TrainingBundleConfig = {
+  id: number;
+  name: string;
+  sampleCount: number;
+  caseOrderingMode?: 'continuous' | 'alternating';
+  variables: TrainingVariableConfig[];
+};
+
 type DiscussionSource = 'manual' | 'auto_agreement' | null;
 
 type SaveDiscussionResultResponse = {
@@ -595,6 +603,66 @@ export class CoderTrainingService {
       sampleCount: variable.sampleCount || 10,
       includeDeriveError: variable.includeDeriveError === true ? true : undefined
     }));
+  }
+
+  private makeTrainingConfigKey(unitName: string, variableId: string): string {
+    return `${unitName}:${variableId}`;
+  }
+
+  private async buildTrainingBundleConfigs(
+    workspaceId: number,
+    assignedVariableBundles: JobDefinitionVariableBundle[] = [],
+    variableConfigs: TrainingVariableConfig[] = []
+  ): Promise<TrainingBundleConfig[]> {
+    const bundleIds = this.getValidatedBundleIds(assignedVariableBundles);
+    const fetchedBundleById = await this.getWorkspaceVariableBundlesById(workspaceId, bundleIds);
+    const variableConfigByKey = new Map(
+      variableConfigs.map(config => [
+        this.makeTrainingVariableKey(config.unitId, config.variableId),
+        config
+      ])
+    );
+
+    return assignedVariableBundles.map(bundle => {
+      const fetchedBundle = fetchedBundleById.get(bundle.id);
+      const configuredVariablesByKey = new Map(
+        (bundle.variables || []).map(variable => [
+          this.makeTrainingVariableKey(variable.unitName, variable.variableId),
+          variable
+        ])
+      );
+      const variables = (fetchedBundle?.variables || []).map(variable => {
+        const variableKey = this.makeTrainingVariableKey(
+          variable.unitName,
+          variable.variableId
+        );
+        const configuredVariable = configuredVariablesByKey.get(variableKey);
+        const selectedConfig = variableConfigByKey.get(variableKey);
+
+        return {
+          unitId: variable.unitName,
+          variableId: variable.variableId,
+          sampleCount:
+            selectedConfig?.sampleCount ||
+            configuredVariable?.sampleCount ||
+            bundle.sampleCount ||
+            10,
+          includeDeriveError:
+            selectedConfig?.includeDeriveError === true ||
+            configuredVariable?.includeDeriveError === true ?
+              true :
+              undefined
+        };
+      });
+
+      return {
+        id: bundle.id,
+        name: fetchedBundle?.name || bundle.name || '',
+        sampleCount: bundle.sampleCount || 10,
+        caseOrderingMode: bundle.caseOrderingMode,
+        variables
+      };
+    });
   }
 
   private mapTrainingBundles(
@@ -1199,6 +1267,96 @@ export class CoderTrainingService {
     }
   }
 
+  private getTrainingBundleCaseKey(response: CoderTrainingResponse): string {
+    return [
+      response.personLogin,
+      response.personCode,
+      response.personGroup,
+      response.bookletName
+    ].join('\u0000');
+  }
+
+  private sampleBundleResponses(
+    bundle: TrainingBundleConfig,
+    responsesByConfig: Map<string, CoderTrainingResponse[]>,
+    caseSelectionMode: CaseSelectionMode
+  ): Map<string, CoderTrainingResponse[]> {
+    const responsesByCase = new Map<string, CoderTrainingResponse[]>();
+
+    bundle.variables.forEach(variable => {
+      const configKey = this.makeTrainingConfigKey(
+        variable.unitId,
+        variable.variableId
+      );
+      const responses = responsesByConfig.get(configKey) || [];
+      responses.forEach(response => {
+        const caseKey = this.getTrainingBundleCaseKey(response);
+        const caseResponses = responsesByCase.get(caseKey) || [];
+        caseResponses.push(response);
+        responsesByCase.set(caseKey, caseResponses);
+      });
+    });
+
+    const representatives = Array.from(responsesByCase.entries()).map(
+      ([caseKey, responses]) => {
+        const sortedResponses = [...responses].sort((a, b) => a.responseId - b.responseId);
+        const chunkTsValues = sortedResponses
+          .map(response => response.chunkTs)
+          .filter((chunkTs): chunkTs is number => chunkTs !== undefined);
+        return {
+          caseKey,
+          response: {
+            ...sortedResponses[0],
+            responseId: Math.min(
+              ...sortedResponses.map(response => response.responseId)
+            ),
+            chunkTs:
+              chunkTsValues.length > 0 ?
+                Math.min(...chunkTsValues) :
+                sortedResponses[0].chunkTs
+          }
+        };
+      }
+    );
+    const caseKeyByRepresentativeResponseId = new Map(
+      representatives.map(entry => [entry.response.responseId, entry.caseKey])
+    );
+    const sampledRepresentatives = this.sampleResponses(
+      representatives.map(entry => entry.response),
+      bundle.sampleCount,
+      caseSelectionMode
+    );
+    const sampledCaseKeys = new Set(
+      sampledRepresentatives
+        .map(response => caseKeyByRepresentativeResponseId.get(response.responseId))
+        .filter((caseKey): caseKey is string => !!caseKey)
+    );
+    const sampledResponsesByConfig = new Map<string, CoderTrainingResponse[]>();
+
+    bundle.variables.forEach(variable => {
+      sampledResponsesByConfig.set(
+        this.makeTrainingConfigKey(variable.unitId, variable.variableId),
+        []
+      );
+    });
+
+    sampledCaseKeys.forEach(caseKey => {
+      const caseResponses = responsesByCase.get(caseKey) || [];
+      caseResponses.forEach(response => {
+        const configKey = this.makeTrainingConfigKey(
+          response.unitName,
+          response.variableId
+        );
+        const responses = sampledResponsesByConfig.get(configKey);
+        if (responses) {
+          responses.push(response);
+        }
+      });
+    });
+
+    return sampledResponsesByConfig;
+  }
+
   private sortTrainingResponses(
     responses: CoderTrainingResponse[],
     caseOrderingMode: 'continuous' | 'alternating' = 'continuous'
@@ -1235,6 +1393,7 @@ export class CoderTrainingService {
       caseSelectionMode?: CaseSelectionMode;
       referenceTrainingIds?: number[];
       referenceMode?: ReferenceMode;
+      assignedVariableBundles?: JobDefinitionVariableBundle[];
     }
   ): Promise<TrainingPackage[]> {
     const caseSelectionMode = options?.caseSelectionMode ?? 'oldest_first';
@@ -1261,14 +1420,27 @@ export class CoderTrainingService {
       derivedVariableSets.set(unitNameKey.toUpperCase(), vars);
     });
 
+    const bundleConfigs = await this.buildTrainingBundleConfigs(
+      workspaceId,
+      options?.assignedVariableBundles || [],
+      variableConfigs
+    );
+    const bundleVariableKeys = new Set(
+      bundleConfigs.flatMap(bundle => bundle.variables.map(variable => this.makeTrainingConfigKey(
+        variable.unitId,
+        variable.variableId
+      )))
+    );
+
     // Pre-sample responses for each variable configuration to ensure consistency across all coders
     const sampledResponsesByConfig: Map<string, CoderTrainingResponse[]> = new Map();
+    const responsesForSamplingByConfig: Map<string, CoderTrainingResponse[]> = new Map();
 
     for (const config of variableConfigs) {
       const variableId = config.variableId;
       const unitId = config.unitId;
       const sampleCount = config.sampleCount;
-      const configKey = `${unitId}:${variableId}`;
+      const configKey = this.makeTrainingConfigKey(unitId, variableId);
       const includeDeriveError = config.includeDeriveError === true;
 
       this.logger.log(`Querying incomplete responses for unit ${unitId}, variable ${variableId}`);
@@ -1409,11 +1581,29 @@ export class CoderTrainingService {
         referenceResponseIdsByConfig,
         configKey
       );
+      responsesForSamplingByConfig.set(configKey, responsesForSampling);
 
-      const sampledResponses = this.sampleResponses(responsesForSampling, sampleCount, caseSelectionMode);
-      sampledResponsesByConfig.set(configKey, sampledResponses);
+      if (!bundleVariableKeys.has(configKey)) {
+        const sampledResponses = this.sampleResponses(responsesForSampling, sampleCount, caseSelectionMode);
+        sampledResponsesByConfig.set(configKey, sampledResponses);
 
-      this.logger.log(`Sampled ${sampledResponses.length} consistent responses for unit ${unitId}, variable ${variableId}`);
+        this.logger.log(`Sampled ${sampledResponses.length} consistent responses for unit ${unitId}, variable ${variableId}`);
+      }
+    }
+
+    for (const bundle of bundleConfigs) {
+      const sampledResponsesByBundleVariable = this.sampleBundleResponses(
+        bundle,
+        responsesForSamplingByConfig,
+        caseSelectionMode
+      );
+      sampledResponsesByBundleVariable.forEach((responses, configKey) => {
+        sampledResponsesByConfig.set(configKey, responses);
+      });
+
+      this.logger.log(
+        `Sampled ${bundle.sampleCount} bundled cases for training bundle ${bundle.name || bundle.id}`
+      );
     }
 
     // Create training packages for each coder using the pre-sampled responses
@@ -1427,7 +1617,10 @@ export class CoderTrainingService {
       this.logger.log(`Assigning consistent training samples to coder ${coderName} (ID: ${coderId})`);
 
       for (const config of variableConfigs) {
-        const configKey = `${config.unitId}:${config.variableId}`;
+        const configKey = this.makeTrainingConfigKey(
+          config.unitId,
+          config.variableId
+        );
         const sampledResponses = sampledResponsesByConfig.get(configKey)!;
         coderResponses.push(...sampledResponses);
       }
@@ -1528,11 +1721,26 @@ export class CoderTrainingService {
 
       this.logger.log(`Created coder training ${trainingId} with label '${trainingLabel}' and configuration`);
 
-      const trainingPackages = await this.generateCoderTrainingPackages(workspaceId, selectedCoders, trainingVariableConfigs, {
+      const trainingPackageOptions: {
+        caseSelectionMode: CaseSelectionMode;
+        referenceTrainingIds?: number[];
+        referenceMode?: ReferenceMode;
+        assignedVariableBundles?: JobDefinitionVariableBundle[];
+      } = {
         caseSelectionMode: caseSelectionMode ?? 'oldest_first',
         referenceTrainingIds,
         referenceMode
-      });
+      };
+      if (assignedVariableBundles?.length) {
+        trainingPackageOptions.assignedVariableBundles = assignedVariableBundles;
+      }
+
+      const trainingPackages = await this.generateCoderTrainingPackages(
+        workspaceId,
+        selectedCoders,
+        trainingVariableConfigs,
+        trainingPackageOptions
+      );
 
       // Build mapping from variable to bundle id and bundle sorting mode
       const variableToBundleMap = new Map<string, number>();
@@ -2373,11 +2581,26 @@ export class CoderTrainingService {
         }
 
         // Generate and create new jobs
-        const trainingPackages = await this.generateCoderTrainingPackages(workspaceId, selectedCoders, effectiveTrainingVariableConfigs, {
+        const trainingPackageOptions: {
+          caseSelectionMode: CaseSelectionMode;
+          referenceTrainingIds?: number[];
+          referenceMode?: ReferenceMode;
+          assignedVariableBundles?: JobDefinitionVariableBundle[];
+        } = {
           caseSelectionMode: newCaseSelectionMode,
           referenceTrainingIds: effectiveReferenceTrainingIds,
           referenceMode: newReferenceMode ?? undefined
-        });
+        };
+        if (effectiveAssignedVariableBundles.length > 0) {
+          trainingPackageOptions.assignedVariableBundles = effectiveAssignedVariableBundles;
+        }
+
+        const trainingPackages = await this.generateCoderTrainingPackages(
+          workspaceId,
+          selectedCoders,
+          effectiveTrainingVariableConfigs,
+          trainingPackageOptions
+        );
 
         // Build mapping from variable to bundle id and bundle sorting mode
         const variableToBundleMap = new Map<string, number>();

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -66,6 +66,20 @@ const makeResponse = (
   personGroup: 'G1'
 });
 
+const makeSameCaseResponse = (
+  id: number,
+  unitName: string,
+  variableid: string,
+  caseId: number,
+  value = `value-${id}`
+): SlimResponseForTest => ({
+  ...makeResponse(id, unitName, variableid, value),
+  personLogin: `P${caseId.toString().padStart(3, '0')}`,
+  personCode: `C${caseId.toString().padStart(3, '0')}`,
+  personGroup: 'G1',
+  bookletName: 'Booklet'
+});
+
 describe('CodingJobService distribution from job definitions', () => {
   let service: CodingJobService;
   let workspaceFilesService: { getDerivedVariableMap: jest.Mock };
@@ -237,9 +251,9 @@ describe('CodingJobService distribution from job definitions', () => {
 
     const doubleCodingSummary = Object.values(result.doubleCodingInfo);
     expect(doubleCodingSummary.reduce((sum, item) => sum + item.distinctCases, 0)).toBe(7);
-    expect(doubleCodingSummary.reduce((sum, item) => sum + item.codingTasksTotal, 0)).toBe(10);
-    expect(doubleCodingSummary.reduce((sum, item) => sum + item.doubleCodedCases, 0)).toBe(3);
-    expect(doubleCodingSummary.reduce((sum, item) => sum + item.singleCodedCasesAssigned, 0)).toBe(4);
+    expect(doubleCodingSummary.reduce((sum, item) => sum + item.codingTasksTotal, 0)).toBe(9);
+    expect(doubleCodingSummary.reduce((sum, item) => sum + item.doubleCodedCases, 0)).toBe(2);
+    expect(doubleCodingSummary.reduce((sum, item) => sum + item.singleCodedCasesAssigned, 0)).toBe(5);
 
     expect(createdJobCalls.every(call => call.dto.jobDefinitionId === 77)).toBe(true);
     expect(createdJobCalls.every(call => call.subset.length > 0)).toBe(true);
@@ -259,7 +273,7 @@ describe('CodingJobService distribution from job definitions', () => {
     createdJobCalls.flatMap(call => call.subset).forEach(response => {
       assignedResponseCounts.set(response.id, (assignedResponseCounts.get(response.id) || 0) + 1);
     });
-    expect([...assignedResponseCounts.values()].filter(count => count === 2)).toHaveLength(3);
+    expect([...assignedResponseCounts.values()].filter(count => count === 2)).toHaveLength(2);
     expect(Math.max(...assignedResponseCounts.values())).toBe(2);
   });
 
@@ -782,6 +796,78 @@ describe('CodingJobService distribution from job definitions', () => {
     expect(result.aggregationInfo).toEqual(preview.aggregationInfo);
     expect(createdJobCalls).toHaveLength(1);
     expect(createdJobCalls[0].subset.map(response => response.id).sort((a, b) => a - b)).toEqual([1, 3]);
+  });
+
+  it('assigns variables from the same bundled case across units to the same coder', async () => {
+    const responses = [
+      makeSameCaseResponse(1, 'Unit 1', 'Var 1', 1),
+      makeSameCaseResponse(2, 'Unit 2', 'Var 2', 1),
+      makeSameCaseResponse(3, 'Unit 1', 'Var 1', 2),
+      makeSameCaseResponse(4, 'Unit 2', 'Var 2', 2)
+    ];
+    const createdJobCalls: Array<{ subset: SlimResponseForTest[] }> = [];
+    const request = {
+      selectedVariables: [],
+      selectedVariableBundles: [{
+        id: 9,
+        name: 'Bundle A',
+        caseOrderingMode: 'alternating' as const,
+        variables: [
+          { unitName: 'Unit 1', variableId: 'Var 1' },
+          { unitName: 'Unit 2', variableId: 'Var 2' }
+        ]
+      }],
+      selectedCoders: [
+        { id: 1, name: 'Ada', username: 'ada' },
+        { id: 2, name: 'Bea', username: 'bea' }
+      ],
+      caseOrderingMode: 'continuous' as const,
+      maxCodingCases: 1,
+      distributionSeed: 'same-case-bundle'
+    };
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+    jest.spyOn(
+      service as unknown as {
+        createCodingJobWithUnitSubsetInManager: (
+          workspaceId: number,
+          dto: unknown,
+          subset: SlimResponseForTest[]
+        ) => Promise<CodingJob>
+      },
+      'createCodingJobWithUnitSubsetInManager'
+    ).mockImplementation(async (_workspaceId, _dto, subset) => {
+      createdJobCalls.push({ subset: subset as SlimResponseForTest[] });
+      return { id: 450 + createdJobCalls.length } as CodingJob;
+    });
+
+    const preview = await service.calculateDistribution(5, request);
+    const result = await service.createDistributedCodingJobs(5, {
+      ...request,
+      jobDefinitionId: 84
+    });
+    const usage = await service.calculateDistributionVariableUsage(5, request);
+
+    expect(preview.aggregationInfo['bundle:9']).toEqual({
+      uniqueCases: 2,
+      totalResponses: 4
+    });
+    expect(
+      Object.values(preview.distribution['bundle:9'])
+        .reduce((sum, value) => sum + value, 0)
+    ).toBe(1);
+    expect(result.distribution).toEqual(preview.distribution);
+    expect(result.tasksPerCoder).toEqual(preview.tasksPerCoder);
+    expect(Object.fromEntries(usage.entries())).toEqual({
+      'Unit 1::Var 1': 1,
+      'Unit 2::Var 2': 1
+    });
+    expect(createdJobCalls).toHaveLength(1);
+    expect(createdJobCalls[0].subset).toHaveLength(2);
+    expect(new Set(createdJobCalls[0].subset.map(response => response.personLogin)).size).toBe(1);
+    expect(createdJobCalls[0].subset.map(response => response.variableid).sort()).toEqual(['Var 1', 'Var 2']);
   });
 
   it('keeps bundles with duplicate names separate by bundle id', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -4488,4 +4488,151 @@ describe('CodingJobService', () => {
       variablePage: '1'
     });
   });
+
+  it('uses all visible bundle units for bundle context when only open units are returned', async () => {
+    const openUnit = {
+      response_id: 99,
+      unit_name: 'UNIT_A',
+      unit_alias: 'Unit A',
+      variable_id: 'VAR_A',
+      variable_anchor: 'VAR_A',
+      booklet_name: 'BOOKLET',
+      person_login: 'login',
+      person_code: 'code',
+      person_group: 'group',
+      notes: null,
+      variable_bundle_id: 9,
+      code: null,
+      score: null,
+      is_open: true
+    };
+    const closedBundleUnit = {
+      response_id: 100,
+      unit_name: 'UNIT_B',
+      unit_alias: 'Unit B',
+      variable_id: 'VAR_B',
+      variable_anchor: 'VAR_B',
+      booklet_name: 'BOOKLET',
+      person_login: 'login',
+      person_code: 'code',
+      person_group: 'group',
+      notes: null,
+      variable_bundle_id: 9,
+      code: 7,
+      score: 2,
+      is_open: false
+    };
+    const responseQueryBuilder: Record<string, jest.Mock> = {};
+    [
+      'leftJoinAndSelect',
+      'where',
+      'andWhere'
+    ].forEach(method => {
+      responseQueryBuilder[method] = jest.fn().mockReturnValue(responseQueryBuilder);
+    });
+    responseQueryBuilder.getMany = jest.fn().mockResolvedValue([
+      {
+        id: 99,
+        variableid: 'VAR_A',
+        is_autocoder_generated: false,
+        status_v1: null,
+        code_v1: null,
+        score_v1: null,
+        code_v2: null,
+        score_v2: null,
+        code_v3: null,
+        score_v3: null,
+        unit: {
+          name: 'UNIT_A',
+          booklet: {
+            bookletinfo: { name: 'BOOKLET' },
+            person: { login: 'login', code: 'code', group: 'group' }
+          }
+        }
+      },
+      {
+        id: 100,
+        variableid: 'VAR_B',
+        is_autocoder_generated: false,
+        status_v1: null,
+        code_v1: null,
+        score_v1: null,
+        code_v2: null,
+        score_v2: null,
+        code_v3: null,
+        score_v3: null,
+        unit: {
+          name: 'UNIT_B',
+          booklet: {
+            bookletinfo: { name: 'BOOKLET' },
+            person: { login: 'login', code: 'code', group: 'group' }
+          }
+        }
+      }
+    ]);
+
+    codingJobRepository.findOne.mockResolvedValue({
+      id: 10,
+      workspace_id: 3,
+      job_definition_id: 5,
+      training_id: null,
+      case_ordering_mode: 'continuous',
+      codingJobCoders: []
+    });
+    codingJobVariableBundleRepository.find.mockResolvedValue([
+      {
+        variable_bundle_id: 9,
+        case_ordering_mode: 'alternating'
+      }
+    ]);
+    variableBundleRepository.find.mockResolvedValue([
+      {
+        id: 9,
+        workspace_id: 3,
+        name: 'Bundle',
+        variables: [
+          { unitName: 'UNIT_A', variableId: 'VAR_A' },
+          { unitName: 'UNIT_B', variableId: 'VAR_B' }
+        ]
+      }
+    ]);
+    codingJobUnitRepository.find
+      .mockResolvedValueOnce([openUnit])
+      .mockResolvedValueOnce([openUnit, closedBundleUnit])
+      .mockResolvedValueOnce([]);
+    responseRepository.createQueryBuilder.mockReturnValue(responseQueryBuilder);
+    codingFileCacheService.getVariablePageMap.mockImplementation(async (unitName: string) => new Map([
+      [unitName === 'UNIT_A' ? 'VAR_A' : 'VAR_B', unitName === 'UNIT_A' ? '0' : '1']
+    ]));
+
+    const result = await service.getCodingJobUnits(10, true);
+
+    expect(result).toHaveLength(1);
+    expect(codingJobUnitRepository.find).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { coding_job_id: 10 }
+      })
+    );
+    expect(result[0].bundleContext?.caseKey).toBe('login\u0000code\u0000group\u0000BOOKLET');
+    expect(result[0].bundleContext?.variables).toEqual([
+      expect.objectContaining({
+        responseId: 99,
+        unitName: 'UNIT_A',
+        variableId: 'VAR_A',
+        status: 'manual-open',
+        source: 'manual'
+      }),
+      expect.objectContaining({
+        responseId: 100,
+        unitName: 'UNIT_B',
+        variableId: 'VAR_B',
+        status: 'manual-coded',
+        code: 7,
+        score: 2,
+        source: 'manual',
+        variablePage: '1'
+      })
+    ]);
+  });
 });

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -24,7 +24,8 @@ import { SaveCodingProgressDto } from '../../../admin/coding-job/dto/save-coding
 import { SaveCodingNotesDto } from '../../../admin/coding-job/dto/save-coding-notes.dto';
 import {
   sortUnitsContinuous,
-  sortUnitsAlternating
+  sortUnitsAlternating,
+  getLatestCode
 } from '../../../utils/coding-utils';
 import { CodingJob } from '../../entities/coding-job.entity';
 import { CodingJobCoder } from '../../entities/coding-job-coder.entity';
@@ -230,14 +231,21 @@ type DistributionPlanItem = {
   itemCaseOrderingMode: 'continuous' | 'alternating';
   uniqueCases: number;
   totalResponses: number;
-  availableResponses: SlimResponse[];
+  availableCases: DistributionPlanCaseGroup[];
   caseStatusesByResponseId: Map<number, DistributionVariableUsageCaseStatus>;
-  selectedResponses: SlimResponse[];
+  selectedCases: DistributionPlanCaseGroup[];
+};
+
+type DistributionPlanCaseGroup = {
+  caseKey: string;
+  responses: SlimResponse[];
+  representativeResponse: SlimResponse;
 };
 
 type DistributionPlanCase = {
   item: DistributionPlanItem;
   response: SlimResponse;
+  allocationCaseKey: string;
   isDoubleCoded: boolean;
   assignedCoderIds: number[];
 };
@@ -280,6 +288,33 @@ type DistributionCreatedJob = {
   jobId: number;
   jobName: string;
   caseCount: number;
+};
+
+type CodingJobBundleVariableStatus =
+  | 'manual-open'
+  | 'manual-coded'
+  | 'auto-coded'
+  | 'not-coded'
+  | 'not-available';
+
+type CodingJobBundleVariableContext = {
+  responseId: number | null;
+  unitName: string;
+  variableId: string;
+  variableAnchor: string;
+  variablePage: string;
+  status: CodingJobBundleVariableStatus;
+  code: number | null;
+  score: number | null;
+  source: 'manual' | 'auto' | 'none';
+};
+
+type CodingJobBundleContext = {
+  bundleId: number;
+  bundleName: string;
+  caseKey: string;
+  caseOrderingMode: 'continuous' | 'alternating';
+  variables: CodingJobBundleVariableContext[];
 };
 
 type DistributedCodingJobsResult = {
@@ -4252,6 +4287,7 @@ export class CodingJobService {
       personGroup: string;
       notes: string | null;
       variableBundleId: number | null;
+      bundleContext: CodingJobBundleContext | null;
       isDoubleCoded: boolean;
       otherCoders: string[];
     }[]
@@ -4284,21 +4320,26 @@ export class CodingJobService {
       bundleModes.set(b.variable_bundle_id, b.case_ordering_mode || globalMode);
     }
 
+    const codingJobUnitSelect: (keyof CodingJobUnit)[] = [
+      'response_id',
+      'unit_name',
+      'unit_alias',
+      'variable_id',
+      'variable_anchor',
+      'booklet_name',
+      'person_login',
+      'person_code',
+      'person_group',
+      'notes',
+      'variable_bundle_id',
+      'code',
+      'score',
+      'is_open'
+    ];
+
     const codingJobUnits = await this.codingJobUnitRepository.find({
       where: whereClause,
-      select: [
-        'response_id',
-        'unit_name',
-        'unit_alias',
-        'variable_id',
-        'variable_anchor',
-        'booklet_name',
-        'person_login',
-        'person_code',
-        'person_group',
-        'notes',
-        'variable_bundle_id'
-      ]
+      select: codingJobUnitSelect
     });
     const exclusions =
       await this.workspaceExclusionService.resolveExclusionsForQueries(
@@ -4311,6 +4352,18 @@ export class CodingJobService {
         unit.unit_name
       )
     );
+    const visibleCodingJobUnitsForContext = onlyOpen ?
+      (await this.codingJobUnitRepository.find({
+        where: { coding_job_id: codingJobId },
+        select: codingJobUnitSelect
+      })).filter(
+        unit => !isExcludedByResolvedExclusions(
+          exclusions,
+          unit.booklet_name,
+          unit.unit_name
+        )
+      ) :
+      visibleCodingJobUnits;
 
     // Detect double coding and other coders in the same logical coding scope.
     const responseIds = visibleCodingJobUnits.map(unit => unit.response_id);
@@ -4384,13 +4437,24 @@ export class CodingJobService {
     }
 
     const variablePageMaps = await this.getVariablePageMapsForUnits(
-      visibleCodingJobUnits,
+      visibleCodingJobUnitsForContext,
       codingJob.workspace_id
     );
     const variableAnchorMaps = await this.getVariableAnchorMapsForUnits(
-      visibleCodingJobUnits,
+      visibleCodingJobUnitsForContext,
       codingJob.workspace_id
     );
+    const bundleContextByResponseId =
+      await this.getCodingJobBundleContextsForUnits(
+        sortedUnits,
+        bundles,
+        bundleModes,
+        globalMode,
+        variablePageMaps,
+        variableAnchorMaps,
+        codingJob.workspace_id,
+        visibleCodingJobUnitsForContext
+      );
 
     return sortedUnits.map(unit => {
       const otherCoders = Array.from(
@@ -4414,10 +4478,252 @@ export class CodingJobService {
         personGroup: unit.person_group,
         notes: unit.notes,
         variableBundleId: unit.variable_bundle_id,
+        bundleContext: bundleContextByResponseId.get(unit.response_id) || null,
         isDoubleCoded: otherCoders.length > 0,
         otherCoders: otherCoders
       };
     });
+  }
+
+  private getCodingJobBundleUnitCaseKey(
+    unit: Pick<
+    CodingJobUnit,
+    | 'person_login'
+    | 'person_code'
+    | 'person_group'
+    | 'booklet_name'
+    >
+  ): string {
+    return [
+      unit.person_login,
+      unit.person_code,
+      unit.person_group,
+      unit.booklet_name
+    ].join('\u0000');
+  }
+
+  private getCodingJobBundleResponseCaseKey(
+    response: ResponseEntity
+  ): string {
+    return [
+      response.unit?.booklet?.person?.login || '',
+      response.unit?.booklet?.person?.code || '',
+      response.unit?.booklet?.person?.group || '',
+      response.unit?.booklet?.bookletinfo?.name || ''
+    ].join('\u0000');
+  }
+
+  private getCodingJobBundleVariableStatus(
+    response: ResponseEntity | undefined,
+    manualUnit: CodingJobUnit | undefined
+  ): {
+      status: CodingJobBundleVariableStatus;
+      code: number | null;
+      score: number | null;
+      source: 'manual' | 'auto' | 'none';
+    } {
+    if (manualUnit) {
+      const hasManualCode =
+        manualUnit.code !== null &&
+        manualUnit.code !== undefined;
+      return {
+        status: hasManualCode || manualUnit.is_open === false ?
+          'manual-coded' :
+          'manual-open',
+        code: manualUnit.code ?? null,
+        score: manualUnit.score ?? null,
+        source: 'manual'
+      };
+    }
+
+    if (!response) {
+      return {
+        status: 'not-available',
+        code: null,
+        score: null,
+        source: 'none'
+      };
+    }
+
+    const latestCode = getLatestCode(response);
+    if (
+      response.is_autocoder_generated === true ||
+      latestCode.code !== null ||
+      response.status_v1 !== null
+    ) {
+      return {
+        status: latestCode.code !== null || response.is_autocoder_generated === true ?
+          'auto-coded' :
+          'not-coded',
+        code: latestCode.code ?? null,
+        score: latestCode.score ?? null,
+        source: latestCode.code !== null || response.is_autocoder_generated === true ?
+          'auto' :
+          'none'
+      };
+    }
+
+    return {
+      status: 'not-coded',
+      code: null,
+      score: null,
+      source: 'none'
+    };
+  }
+
+  private async getCodingJobBundleContextsForUnits(
+    units: CodingJobUnit[],
+    codingJobBundles: CodingJobVariableBundle[],
+    bundleModes: Map<number, string>,
+    globalMode: string,
+    variablePageMaps: Map<string, Map<string, string>>,
+    variableAnchorMaps: Map<string, Map<string, string>>,
+    workspaceId: number,
+    contextUnits: CodingJobUnit[] = units
+  ): Promise<Map<number, CodingJobBundleContext>> {
+    const bundledUnits = units.filter(
+      unit => unit.variable_bundle_id !== null
+    );
+    if (bundledUnits.length === 0) {
+      return new Map();
+    }
+
+    const bundleIds = Array.from(
+      new Set(
+        bundledUnits
+          .map(unit => unit.variable_bundle_id)
+          .filter((bundleId): bundleId is number => bundleId !== null)
+      )
+    );
+    const variableBundles = await this.variableBundleRepository.find({
+      where: {
+        id: In(bundleIds),
+        workspace_id: workspaceId
+      }
+    });
+    const variableBundleById = new Map(
+      variableBundles.map(bundle => [bundle.id, bundle])
+    );
+    const caseKeys = new Set(
+      bundledUnits.map(unit => this.getCodingJobBundleUnitCaseKey(unit))
+    );
+    const contextBundledUnits = contextUnits.filter(
+      unit => unit.variable_bundle_id !== null &&
+        caseKeys.has(this.getCodingJobBundleUnitCaseKey(unit))
+    );
+    const variableIds = Array.from(
+      new Set(
+        variableBundles.flatMap(bundle => (
+          bundle.variables || []
+        ).map(variable => variable.variableId))
+      )
+    );
+    const unitNames = Array.from(
+      new Set(
+        variableBundles.flatMap(bundle => (
+          bundle.variables || []
+        ).map(variable => variable.unitName))
+      )
+    );
+
+    if (variableIds.length === 0 || unitNames.length === 0) {
+      return new Map();
+    }
+
+    const personLogins = Array.from(new Set(bundledUnits.map(unit => unit.person_login)));
+    const personCodes = Array.from(new Set(bundledUnits.map(unit => unit.person_code)));
+    const personGroups = Array.from(new Set(bundledUnits.map(unit => unit.person_group)));
+    const bookletNames = Array.from(new Set(bundledUnits.map(unit => unit.booklet_name)));
+    const responses = await this.responseRepository
+      .createQueryBuilder('response')
+      .leftJoinAndSelect('response.unit', 'unit')
+      .leftJoinAndSelect('unit.booklet', 'booklet')
+      .leftJoinAndSelect('booklet.person', 'person')
+      .leftJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
+      .where('person.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('response.variableid IN (:...variableIds)', { variableIds })
+      .andWhere('unit.name IN (:...unitNames)', { unitNames })
+      .andWhere('person.login IN (:...personLogins)', { personLogins })
+      .andWhere('person.code IN (:...personCodes)', { personCodes })
+      .andWhere('person.group IN (:...personGroups)', { personGroups })
+      .andWhere("COALESCE(bookletinfo.name, '') IN (:...bookletNames)", {
+        bookletNames
+      })
+      .getMany();
+
+    const responseByCaseAndVariable = new Map<string, ResponseEntity>();
+    responses.forEach(response => {
+      const caseKey = this.getCodingJobBundleResponseCaseKey(response);
+      if (!caseKeys.has(caseKey)) {
+        return;
+      }
+
+      responseByCaseAndVariable.set(
+        `${caseKey}\u0000${response.unit?.name || ''}::${response.variableid}`,
+        response
+      );
+    });
+
+    const manualUnitByResponseId = new Map(
+      contextBundledUnits.map(unit => [unit.response_id, unit])
+    );
+    const bundleContextByResponseId = new Map<number, CodingJobBundleContext>();
+    const configuredBundleIds = new Set(
+      codingJobBundles.map(bundle => bundle.variable_bundle_id)
+    );
+
+    bundledUnits.forEach(unit => {
+      const bundleId = unit.variable_bundle_id;
+      if (bundleId === null || !configuredBundleIds.has(bundleId)) {
+        return;
+      }
+
+      const variableBundle = variableBundleById.get(bundleId);
+      if (!variableBundle) {
+        return;
+      }
+
+      const caseKey = this.getCodingJobBundleUnitCaseKey(unit);
+      const contextVariables = (variableBundle.variables || [])
+        .map(variable => {
+          const response = responseByCaseAndVariable.get(
+            `${caseKey}\u0000${variable.unitName}::${variable.variableId}`
+          );
+          const manualUnit = response ?
+            manualUnitByResponseId.get(response.id) :
+            undefined;
+          const status = this.getCodingJobBundleVariableStatus(
+            response,
+            manualUnit
+          );
+
+          return {
+            responseId: response?.id ?? null,
+            unitName: variable.unitName,
+            variableId: variable.variableId,
+            variableAnchor:
+              variableAnchorMaps.get(variable.unitName)?.get(variable.variableId) ||
+              variable.variableId,
+            variablePage:
+              variablePageMaps.get(variable.unitName)?.get(variable.variableId) ||
+              '0',
+            ...status
+          };
+        });
+
+      bundleContextByResponseId.set(unit.response_id, {
+        bundleId,
+        bundleName: variableBundle.name,
+        caseKey,
+        caseOrderingMode:
+          (bundleModes.get(bundleId) || globalMode) === 'alternating' ?
+            'alternating' :
+            'continuous',
+        variables: contextVariables
+      });
+    });
+
+    return bundleContextByResponseId;
   }
 
   private async getVariablePageMapsForUnits(
@@ -5709,25 +6015,73 @@ export class CodingJobService {
     ].join('::');
   }
 
-  private sortResponsesForDistribution(
-    responses: SlimResponse[],
+  private getResponseAllocationCaseKey(
+    response: SlimResponse,
+    itemType: 'bundle' | 'variable'
+  ): string {
+    if (itemType === 'bundle') {
+      return [
+        'bundle-case',
+        response.personLogin,
+        response.personCode,
+        response.personGroup,
+        response.bookletName
+      ].join('\u0000');
+    }
+
+    return `response:${response.id}`;
+  }
+
+  private getCaseGroupStratumKey(
+    caseGroup: DistributionPlanCaseGroup,
+    mode: 'continuous' | 'alternating',
+    itemType: 'bundle' | 'variable'
+  ): string {
+    if (itemType === 'variable') {
+      return this.getResponseStratumKey(
+        caseGroup.representativeResponse,
+        mode
+      );
+    }
+
+    const response = caseGroup.representativeResponse;
+    if (mode === 'alternating') {
+      return [
+        response.personGroup,
+        response.bookletName
+      ].join('::');
+    }
+
+    return [
+      response.bookletName,
+      response.personGroup
+    ].join('::');
+  }
+
+  private sortCaseGroupsForDistribution(
+    caseGroups: DistributionPlanCaseGroup[],
     mode: 'continuous' | 'alternating',
     seed: string,
-    itemKey: string
-  ): SlimResponse[] {
-    const groups = new Map<string, SlimResponse[]>();
+    itemKey: string,
+    itemType: 'bundle' | 'variable'
+  ): DistributionPlanCaseGroup[] {
+    const groups = new Map<string, DistributionPlanCaseGroup[]>();
 
-    for (const response of responses) {
-      const key = this.getResponseStratumKey(response, mode);
+    for (const caseGroup of caseGroups) {
+      const key = this.getCaseGroupStratumKey(caseGroup, mode, itemType);
       const group = groups.get(key) || [];
-      group.push(response);
+      group.push(caseGroup);
       groups.set(key, group);
     }
 
     const groupEntries = Array.from(groups.entries())
       .map(([key, group]) => ({
         key,
-        group: group.sort((a, b) => this.compareResponsesByMode(mode, a, b))
+        group: group.sort((a, b) => this.compareResponsesByMode(
+          mode,
+          a.representativeResponse,
+          b.representativeResponse
+        ))
       }))
       .sort((a, b) => {
         const hashA = this.stableHash(`${seed}:${itemKey}:stratum:${a.key}`);
@@ -5735,21 +6089,83 @@ export class CodingJobService {
         return hashA - hashB || a.key.localeCompare(b.key);
       });
 
-    const result: SlimResponse[] = [];
+    const result: DistributionPlanCaseGroup[] = [];
     let remaining = true;
 
     while (remaining) {
       remaining = false;
       for (const entry of groupEntries) {
-        const response = entry.group.shift();
-        if (response) {
-          result.push(response);
+        const caseGroup = entry.group.shift();
+        if (caseGroup) {
+          result.push(caseGroup);
           remaining = true;
         }
       }
     }
 
     return result;
+  }
+
+  private buildDistributionCaseGroups(
+    itemType: 'bundle' | 'variable',
+    allItemResponses: SlimResponse[],
+    filteredResponses: SlimResponse[],
+    assignedResponseIds: Set<number>,
+    mode: 'continuous' | 'alternating',
+    seed: string,
+    itemKey: string
+  ): DistributionPlanCaseGroup[] {
+    const assignedBundleCaseKeys =
+      itemType === 'bundle' ?
+        new Set(
+          allItemResponses
+            .filter(response => assignedResponseIds.has(response.id))
+            .map(response => this.getResponseAllocationCaseKey(response, itemType))
+        ) :
+        new Set<string>();
+    const casesByKey = new Map<string, SlimResponse[]>();
+
+    filteredResponses.forEach(response => {
+      const caseKey = this.getResponseAllocationCaseKey(response, itemType);
+      if (assignedBundleCaseKeys.has(caseKey)) {
+        return;
+      }
+
+      const responses = casesByKey.get(caseKey) || [];
+      responses.push(response);
+      casesByKey.set(caseKey, responses);
+    });
+
+    const caseGroups = Array.from(casesByKey.entries()).map(
+      ([caseKey, responses]) => {
+        const sortedResponses = [...responses].sort((a, b) => this.compareResponsesByMode(mode, a, b));
+        return {
+          caseKey,
+          responses: sortedResponses,
+          representativeResponse: sortedResponses[0]
+        };
+      }
+    );
+
+    return this.sortCaseGroupsForDistribution(
+      caseGroups,
+      mode,
+      seed,
+      itemKey,
+      itemType
+    );
+  }
+
+  private countDistributionCasesInResponses(
+    item: DistributionPlanItem,
+    responses: SlimResponse[]
+  ): number {
+    return new Set(
+      responses.map(response => this.getResponseAllocationCaseKey(
+        response,
+        item.type
+      ))
+    ).size;
   }
 
   private normalizeDistributionCoders(
@@ -5952,9 +6368,9 @@ export class CodingJobService {
   private selectCasesWithGlobalCap(
     planItems: DistributionPlanItem[],
     maxCodingCases?: number
-  ): { item: DistributionPlanItem; response: SlimResponse }[] {
+  ): { item: DistributionPlanItem; caseGroup: DistributionPlanCaseGroup }[] {
     const totalAvailable = planItems.reduce(
-      (sum, item) => sum + item.availableResponses.length,
+      (sum, item) => sum + item.availableCases.length,
       0
     );
     const targetCases =
@@ -5963,11 +6379,13 @@ export class CodingJobService {
         totalAvailable;
     const queues = planItems.map(item => ({
       item,
-      responses: [...item.availableResponses]
+      cases: [...item.availableCases]
     }));
-    const selected: { item: DistributionPlanItem; response: SlimResponse }[] =
-      [];
-    const selectedResponseIds = new Set<number>();
+    const selected: {
+      item: DistributionPlanItem;
+      caseGroup: DistributionPlanCaseGroup;
+    }[] = [];
+    const selectedCaseKeys = new Set<string>();
 
     while (selected.length < targetCases) {
       let progressed = false;
@@ -5977,15 +6395,22 @@ export class CodingJobService {
           break;
         }
 
-        while (queue.responses.length > 0) {
-          const response = queue.responses.shift();
-          if (!response || selectedResponseIds.has(response.id)) {
+        while (queue.cases.length > 0) {
+          const caseGroup = queue.cases.shift();
+          const selectedCaseKey = caseGroup ?
+            `${queue.item.itemKey}\u0000${caseGroup.caseKey}` :
+            null;
+          if (
+            !caseGroup ||
+            !selectedCaseKey ||
+            selectedCaseKeys.has(selectedCaseKey)
+          ) {
             continue;
           }
 
-          selected.push({ item: queue.item, response });
-          queue.item.selectedResponses.push(response);
-          selectedResponseIds.add(response.id);
+          selected.push({ item: queue.item, caseGroup });
+          queue.item.selectedCases.push(caseGroup);
+          selectedCaseKeys.add(selectedCaseKey);
           progressed = true;
           break;
         }
@@ -6042,24 +6467,18 @@ export class CodingJobService {
     return `${response.unitName}::${response.variableid}`;
   }
 
-  private getCoderLoadRatio(
-    coder: NormalizedDistributionCoder,
-    load: { tasks: number; doubleTasks: number }
-  ): number {
-    return load.tasks / coder.weight;
-  }
-
   private chooseSingleCoder(
     coders: NormalizedDistributionCoder[],
     coderLoads: Map<number, { tasks: number; doubleTasks: number }>,
     seed: string,
-    response: SlimResponse
+    response: SlimResponse,
+    taskCount = 1
   ): NormalizedDistributionCoder {
     return [...coders].sort((a, b) => {
       const loadA = coderLoads.get(a.id) || { tasks: 0, doubleTasks: 0 };
       const loadB = coderLoads.get(b.id) || { tasks: 0, doubleTasks: 0 };
-      const ratioA = this.getCoderLoadRatio(a, loadA);
-      const ratioB = this.getCoderLoadRatio(b, loadB);
+      const ratioA = (loadA.tasks + taskCount) / a.weight;
+      const ratioB = (loadB.tasks + taskCount) / b.weight;
       const tieA = this.stableHash(`${seed}:single:${response.id}:${a.id}`);
       const tieB = this.stableHash(`${seed}:single:${response.id}:${b.id}`);
 
@@ -6101,17 +6520,18 @@ export class CodingJobService {
     coderLoads: Map<number, { tasks: number; doubleTasks: number }>,
     pairCounts: Map<string, number>,
     seed: string,
-    response: SlimResponse
+    response: SlimResponse,
+    taskCount = 1
   ): NormalizedDistributionCoder[] {
     return [...coderCombinations].sort((a, b) => {
       const score = (combination: NormalizedDistributionCoder[]) => {
         const projectedRatios = combination.map(coder => {
           const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-          return (load.tasks + 1) / coder.weight;
+          return (load.tasks + taskCount) / coder.weight;
         });
         const projectedDoubleRatios = combination.map(coder => {
           const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-          return (load.doubleTasks + 1) / coder.weight;
+          return (load.doubleTasks + taskCount) / coder.weight;
         });
         const pairKey = combination
           .map(coder => coder.id)
@@ -6280,7 +6700,6 @@ export class CodingJobService {
       );
       const {
         filteredResponses,
-        uniqueCases,
         totalResponses,
         caseStatusesByResponseId
       } = this.getDistributableResponses(
@@ -6290,8 +6709,11 @@ export class CodingJobService {
         aggregationThreshold,
         response => isDerivedVariable(response.unitName, response.variableid)
       );
-      const availableResponses = this.sortResponsesForDistribution(
+      const availableCases = this.buildDistributionCaseGroups(
+        itemObj.type,
+        allItemResponses,
         filteredResponses,
+        assignedResponseIds,
         itemCaseOrderingMode,
         distributionSeed,
         itemKey
@@ -6303,16 +6725,16 @@ export class CodingJobService {
         itemLabel,
         itemVariables,
         itemCaseOrderingMode,
-        uniqueCases,
+        uniqueCases: availableCases.length,
         totalResponses,
-        availableResponses,
+        availableCases,
         caseStatusesByResponseId,
-        selectedResponses: []
+        selectedCases: []
       };
 
       planItems.push(planItem);
       aggregationInfo[itemKey] = {
-        uniqueCases,
+        uniqueCases: availableCases.length,
         totalResponses
       };
       distribution[itemKey] = {};
@@ -6332,23 +6754,22 @@ export class CodingJobService {
       request.maxCodingCases
     );
     this.getDoubleCodingSettings(request);
-    const selectedCaseCountsByVariableKey = new Map<string, number>();
+    const selectedCaseCountsByItemKey = new Map<string, number>();
     selectedCases.forEach(selectedCase => {
-      const variableKey = this.getResponseVariableKey(selectedCase.response);
-      selectedCaseCountsByVariableKey.set(
-        variableKey,
-        (selectedCaseCountsByVariableKey.get(variableKey) || 0) + 1
+      selectedCaseCountsByItemKey.set(
+        selectedCase.item.itemKey,
+        (selectedCaseCountsByItemKey.get(selectedCase.item.itemKey) || 0) + 1
       );
     });
-    const doubleCodingCountsByVariableKey = new Map<string, number>();
-    selectedCaseCountsByVariableKey.forEach((caseCount, variableKey) => {
-      doubleCodingCountsByVariableKey.set(
-        variableKey,
+    const doubleCodingCountsByItemKey = new Map<string, number>();
+    selectedCaseCountsByItemKey.forEach((caseCount, itemKey) => {
+      doubleCodingCountsByItemKey.set(
+        itemKey,
         this.getDoubleCodingCount(request, caseCount)
       );
     });
     const totalDoubleCodingCount = Array.from(
-      doubleCodingCountsByVariableKey.values()
+      doubleCodingCountsByItemKey.values()
     ).reduce((sum, count) => sum + count, 0);
 
     if (
@@ -6371,36 +6792,38 @@ export class CodingJobService {
       totalDoubleCodingCount > 0 ?
         this.getCoderCombinations(coders, codersPerDoubleCodedCase) :
         [];
-    const assignedDoubleCodingCountsByVariableKey = new Map<string, number>();
+    const assignedDoubleCodingCountsByItemKey = new Map<string, number>();
 
     selectedCases.forEach(selectedCase => {
-      const variableKey = this.getResponseVariableKey(selectedCase.response);
+      const taskCount = selectedCase.caseGroup.responses.length;
       const assignedDoubleCodingCount =
-        assignedDoubleCodingCountsByVariableKey.get(variableKey) || 0;
+        assignedDoubleCodingCountsByItemKey.get(selectedCase.item.itemKey) || 0;
       const isDoubleCoded =
         assignedDoubleCodingCount <
-        (doubleCodingCountsByVariableKey.get(variableKey) || 0);
+        (doubleCodingCountsByItemKey.get(selectedCase.item.itemKey) || 0);
       const assignedCoders = isDoubleCoded ?
         this.chooseDoubleCodingCoders(
           doubleCodingCoderCombinations,
           coderLoads,
           pairCounts,
           distributionSeed,
-          selectedCase.response
+          selectedCase.caseGroup.representativeResponse,
+          taskCount
         ) :
         [
           this.chooseSingleCoder(
             coders,
             coderLoads,
             distributionSeed,
-            selectedCase.response
+            selectedCase.caseGroup.representativeResponse,
+            taskCount
           )
         ];
       const assignedCoderIds = assignedCoders.map(coder => coder.id);
 
       if (isDoubleCoded) {
-        assignedDoubleCodingCountsByVariableKey.set(
-          variableKey,
+        assignedDoubleCodingCountsByItemKey.set(
+          selectedCase.item.itemKey,
           assignedDoubleCodingCount + 1
         );
         const pairKey = [...assignedCoderIds].sort((a, b) => a - b).join('-');
@@ -6409,9 +6832,9 @@ export class CodingJobService {
 
       assignedCoders.forEach(coder => {
         const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-        load.tasks += 1;
+        load.tasks += taskCount;
         if (isDoubleCoded) {
-          load.doubleTasks += 1;
+          load.doubleTasks += taskCount;
         }
         coderLoads.set(coder.id, load);
 
@@ -6434,16 +6857,19 @@ export class CodingJobService {
           jobsByItemAndCoder.get(selectedCase.item.itemKey) ||
           new Map<number, SlimResponse[]>();
         const coderResponses = itemJobs.get(coder.id) || [];
-        coderResponses.push(selectedCase.response);
+        coderResponses.push(...selectedCase.caseGroup.responses);
         itemJobs.set(coder.id, coderResponses);
         jobsByItemAndCoder.set(selectedCase.item.itemKey, itemJobs);
       });
 
-      plannedCases.push({
-        item: selectedCase.item,
-        response: selectedCase.response,
-        isDoubleCoded,
-        assignedCoderIds
+      selectedCase.caseGroup.responses.forEach(response => {
+        plannedCases.push({
+          item: selectedCase.item,
+          response,
+          allocationCaseKey: selectedCase.caseGroup.caseKey,
+          isDoubleCoded,
+          assignedCoderIds
+        });
       });
     });
 
@@ -6451,15 +6877,22 @@ export class CodingJobService {
       const itemCases = plannedCases.filter(
         plannedCase => plannedCase.item.itemKey === planItem.itemKey
       );
-      const doubleCases = itemCases.filter(
-        plannedCase => plannedCase.isDoubleCoded
-      ).length;
-      const singleCases = itemCases.length - doubleCases;
-      const codingTasksTotal = Object.values(
-        distributionByCoderId[planItem.itemKey]
-      ).reduce((sum, value) => sum + value, 0);
+      const distinctCaseKeys = new Set(
+        itemCases.map(plannedCase => plannedCase.allocationCaseKey)
+      );
+      const doubleCaseKeys = new Set(
+        itemCases
+          .filter(plannedCase => plannedCase.isDoubleCoded)
+          .map(plannedCase => plannedCase.allocationCaseKey)
+      );
+      const codingTasksTotal = itemCases.reduce(
+        (sum, plannedCase) => sum + plannedCase.assignedCoderIds.length,
+        0
+      );
+      const doubleCases = doubleCaseKeys.size;
+      const singleCases = distinctCaseKeys.size - doubleCases;
 
-      doubleCodingInfo[planItem.itemKey].distinctCases = itemCases.length;
+      doubleCodingInfo[planItem.itemKey].distinctCases = distinctCaseKeys.size;
       doubleCodingInfo[planItem.itemKey].codingTasksTotal = codingTasksTotal;
       doubleCodingInfo[planItem.itemKey].totalCases = codingTasksTotal;
       doubleCodingInfo[planItem.itemKey].doubleCodedCases = doubleCases;
@@ -6691,7 +7124,6 @@ export class CodingJobService {
       );
       const {
         filteredResponses,
-        uniqueCases,
         totalResponses,
         caseStatusesByResponseId
       } = this.getDistributableResponses(
@@ -6701,8 +7133,11 @@ export class CodingJobService {
         context.aggregationThreshold,
         response => isDerivedVariable(response.unitName, response.variableid)
       );
-      const availableResponses = this.sortResponsesForDistribution(
+      const availableCases = this.buildDistributionCaseGroups(
+        itemObj.type,
+        allItemResponses,
         filteredResponses,
+        assignedResponseIds,
         itemCaseOrderingMode,
         distributionSeed,
         itemKey
@@ -6715,11 +7150,11 @@ export class CodingJobService {
         itemLabel,
         itemVariables,
         itemCaseOrderingMode,
-        uniqueCases,
+        uniqueCases: availableCases.length,
         totalResponses,
-        availableResponses,
+        availableCases,
         caseStatusesByResponseId,
-        selectedResponses: []
+        selectedCases: []
       });
     }
 
@@ -6729,13 +7164,15 @@ export class CodingJobService {
     );
     const usageByVariable = new Map<string, DistributionVariableUsageByStatus>();
 
-    selectedCases.forEach(({ item, response }) => {
-      this.addResponseToVariableUsageByStatus(
-        usageByVariable,
-        response,
-        item.caseStatusesByResponseId.get(response.id) ||
-          this.getResponseUsageStatus(response)
-      );
+    selectedCases.forEach(({ item, caseGroup }) => {
+      caseGroup.responses.forEach(response => {
+        this.addResponseToVariableUsageByStatus(
+          usageByVariable,
+          response,
+          item.caseStatusesByResponseId.get(response.id) ||
+            this.getResponseUsageStatus(response)
+        );
+      });
     });
 
     return usageByVariable;
@@ -6968,7 +7405,10 @@ export class CodingJobService {
             },
         jobId: codingJob.id,
         jobName,
-        caseCount: job.unitSubset.length
+        caseCount: this.countDistributionCasesInResponses(
+          job.item,
+          job.unitSubset
+        )
       });
     }
 

--- a/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
+++ b/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
@@ -1156,7 +1156,36 @@ export class WsgCodingJobController {
           variablePage: { type: 'string' },
           bookletName: { type: 'string' },
           personLogin: { type: 'string' },
-          personCode: { type: 'string' }
+          personCode: { type: 'string' },
+          personGroup: { type: 'string' },
+          variableBundleId: { type: 'number', nullable: true },
+          bundleContext: {
+            type: 'object',
+            nullable: true,
+            properties: {
+              bundleId: { type: 'number' },
+              bundleName: { type: 'string' },
+              caseKey: { type: 'string' },
+              caseOrderingMode: { type: 'string', enum: ['continuous', 'alternating'] },
+              variables: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    responseId: { type: 'number', nullable: true },
+                    unitName: { type: 'string' },
+                    variableId: { type: 'string' },
+                    variableAnchor: { type: 'string' },
+                    variablePage: { type: 'string' },
+                    status: { type: 'string' },
+                    code: { type: 'number', nullable: true },
+                    score: { type: 'number', nullable: true },
+                    source: { type: 'string' }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1187,6 +1216,8 @@ export class WsgCodingJobController {
         personLogin: string;
         personCode: string;
         personGroup: string;
+        variableBundleId: number | null;
+        bundleContext: unknown | null;
         isDoubleCoded: boolean;
         otherCoders: string[];
       }>

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
@@ -408,6 +408,82 @@
   position: relative;
 }
 
+.bundle-variable-chips {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  gap: 4px;
+}
+
+.bundle-variable-chip {
+  min-width: 0;
+  height: 34px;
+  padding: 0 8px;
+  border: 1px solid rgba(0, 0, 0, 0.22);
+  border-radius: 4px;
+  background: #fff;
+  color: rgba(0, 0, 0, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.bundle-variable-chip:hover:not(:disabled) {
+  border-color: #1976d2;
+  background: rgba(25, 118, 210, 0.06);
+}
+
+.bundle-variable-chip.active {
+  border-color: #1976d2;
+  background: rgba(25, 118, 210, 0.12);
+  color: #0d47a1;
+  font-weight: 600;
+}
+
+.bundle-variable-chip.auto-coded {
+  border-color: rgba(97, 97, 97, 0.55);
+  background:
+    repeating-linear-gradient(
+      135deg,
+      rgba(97, 97, 97, 0.10) 0,
+      rgba(97, 97, 97, 0.10) 4px,
+      transparent 4px,
+      transparent 10px
+    ),
+    #fafafa;
+  color: rgba(0, 0, 0, 0.56);
+}
+
+.bundle-variable-chip:disabled {
+  cursor: default;
+  opacity: 1;
+}
+
+.bundle-variable-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bundle-variable-count {
+  flex-shrink: 0;
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 11px;
+}
+
+.bundle-variable-status-icon {
+  width: 14px;
+  height: 14px;
+  font-size: 14px;
+  color: #757575;
+  flex-shrink: 0;
+}
+
 .variable-trigger-btn {
   display: flex;
   align-items: center;

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
@@ -11,8 +11,29 @@
     </mat-progress-bar>
   </div>
 
-  @if (availableVariables.length > 1) {
+  @if (availableVariables.length > 1 || shouldShowBundleVariableChips) {
   <div class="variable-selector-section">
+    @if (shouldShowBundleVariableChips) {
+    <div class="bundle-variable-chips" role="tablist">
+      @for (chip of bundleVariableChips; track chip.key) {
+      <button
+        type="button"
+        class="bundle-variable-chip"
+        [class.active]="chip.active"
+        [class.auto-coded]="chip.status === 'auto-coded'"
+        [disabled]="chip.disabled"
+        [matTooltip]="chip.tooltip"
+        (click)="selectBundleVariable(chip.key, chip.disabled)">
+        <span class="bundle-variable-name">{{ chip.variableId }}</span>
+        @if (chip.status === 'auto-coded') {
+        <mat-icon class="bundle-variable-status-icon">bolt</mat-icon>
+        } @else {
+        <span class="bundle-variable-count">{{ chip.progress.coded }}/{{ chip.progress.total }}</span>
+        }
+      </button>
+      }
+    </div>
+    } @else {
     <div class="variable-dropdown-wrapper">
       <button class="variable-trigger-btn" (click)="toggleVariablePanel()" [disabled]="isNavigationDisabled" type="button">
         <span class="variable-trigger-label">
@@ -47,6 +68,7 @@
       </div>
       }
     </div>
+    }
   </div>
   }
 

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -764,4 +764,64 @@ describe('CodeSelectorComponent', () => {
     expect(unitChangedSpy).not.toHaveBeenCalled();
     expect(navigateSpy).not.toHaveBeenCalled();
   });
+
+  it('renders small alternating bundle variables as chips including auto-coded variables', () => {
+    component.showProgress = true;
+    component.codingService = {
+      isUnitCoded: jest.fn().mockReturnValue(false)
+    } as never;
+    component.unitsData = {
+      id: 1,
+      name: 'Job',
+      currentUnitIndex: 0,
+      units: [
+        {
+          id: 1,
+          name: 'UNIT_1',
+          alias: 'UNIT_1',
+          bookletId: 0,
+          variableId: 'VAR1',
+          bundleContext: {
+            bundleId: 9,
+            bundleName: 'Bundle',
+            caseKey: 'case-1',
+            caseOrderingMode: 'alternating',
+            variables: [
+              {
+                responseId: 1,
+                unitName: 'UNIT_1',
+                variableId: 'VAR1',
+                variableAnchor: 'VAR1',
+                variablePage: '0',
+                status: 'manual-open',
+                code: null,
+                score: null,
+                source: 'manual'
+              },
+              {
+                responseId: 2,
+                unitName: 'UNIT_1',
+                variableId: 'VAR2',
+                variableAnchor: 'VAR2',
+                variablePage: '0',
+                status: 'auto-coded',
+                code: 1,
+                score: 1,
+                source: 'auto'
+              }
+            ]
+          }
+        }
+      ]
+    };
+
+    fixture.detectChanges();
+
+    const chips = fixture.nativeElement.querySelectorAll('.bundle-variable-chip') as NodeListOf<HTMLButtonElement>;
+    expect(chips).toHaveLength(2);
+    expect(chips[0].classList.contains('active')).toBe(true);
+    expect(chips[1].classList.contains('auto-coded')).toBe(true);
+    expect(chips[1].disabled).toBe(true);
+    expect(fixture.nativeElement.querySelector('.variable-trigger-btn')).toBeNull();
+  });
 });

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -661,6 +661,73 @@ export class CodeSelectorComponent implements OnChanges {
     return result;
   }
 
+  get shouldShowBundleVariableChips(): boolean {
+    const context = this.currentBundleContext;
+    return !!context &&
+      context.caseOrderingMode === 'alternating' &&
+      context.variables.length > 1 &&
+      context.variables.length < 5;
+  }
+
+  get bundleVariableChips(): Array<{
+    key: string;
+    variableId: string;
+    unitName: string;
+    status: string;
+    active: boolean;
+    disabled: boolean;
+    tooltip: string;
+    progress: { coded: number; total: number; percentage: number };
+  }> {
+    const context = this.currentBundleContext;
+    if (!context) return [];
+
+    return context.variables.map(variable => {
+      const matchingUnit = this.unitsData?.units.find(unit => (
+        unit.variableId === variable.variableId &&
+        unit.name === variable.unitName
+      ));
+      const unitName = matchingUnit?.alias || matchingUnit?.name || variable.unitName;
+      const key = `${unitName}::${variable.variableId}`;
+      const hasManualUnit = this.availableVariables.some(available => available.key === key);
+      const progress = this.getProgressForKey(key);
+      const disabled =
+        this.isNavigationDisabled ||
+        !hasManualUnit ||
+        variable.status === 'auto-coded' ||
+        variable.status === 'not-available';
+
+      return {
+        key,
+        variableId: variable.variableId,
+        unitName,
+        status: variable.status,
+        active: key === this.activeVariableKey,
+        disabled,
+        tooltip: this.getBundleVariableTooltip(variable.status),
+        progress
+      };
+    });
+  }
+
+  private get currentBundleContext() {
+    const currentUnit = this.unitsData?.units[this.unitsData.currentUnitIndex];
+    return currentUnit?.bundleContext || null;
+  }
+
+  getBundleVariableTooltip(status: string): string {
+    if (status === 'auto-coded') {
+      return this.translateService.instant('code-selector.bundle-auto-coded-tooltip');
+    }
+    if (status === 'manual-coded') {
+      return this.translateService.instant('code-selector.bundle-manual-coded-tooltip');
+    }
+    if (status === 'not-available') {
+      return this.translateService.instant('code-selector.bundle-not-available-tooltip');
+    }
+    return this.translateService.instant('code-selector.bundle-open-tooltip');
+  }
+
   /** Composite key (unitName::variableId) for the unit currently being displayed. */
   get activeVariableKey(): string {
     if (!this.unitsData?.units) return '';
@@ -705,5 +772,10 @@ export class CodeSelectorComponent implements OnChanges {
     );
     const target = firstUncoded ?? variableUnits[0];
     this.unitChanged.emit(target.unit);
+  }
+
+  selectBundleVariable(key: string, disabled: boolean): void {
+    if (disabled) return;
+    this.jumpToVariable(key);
   }
 }

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -21,6 +21,24 @@ import {
   Variable,
   VariableBundle
 } from '../models/coding-job.model';
+import type { BundleContext } from '../../replay/services/units-replay.service';
+
+export interface CodingJobUnitDto {
+  responseId: number;
+  unitName: string;
+  unitAlias: string | null;
+  variableId: string;
+  variableAnchor: string;
+  variablePage: string;
+  bookletName: string;
+  personLogin: string;
+  personCode: string;
+  personGroup: string;
+  variableBundleId: number | null;
+  bundleContext: BundleContext | null;
+  isDoubleCoded: boolean;
+  otherCoders: string[];
+}
 
 export interface CodingExportConfig {
   exportType:
@@ -806,43 +824,16 @@ export class CodingJobBackendService {
     codingJobId: number,
     authToken?: string,
     onlyOpen: boolean = false
-  ): Observable<
-    Array<{
-      responseId: number;
-      unitName: string;
-      unitAlias: string | null;
-      variableId: string;
-      variableAnchor: string;
-      variablePage: string;
-      bookletName: string;
-      personLogin: string;
-      personCode: string;
-      personGroup: string;
-      isDoubleCoded: boolean;
-      otherCoders: string[];
-    }>
-    > {
+  ): Observable<CodingJobUnitDto[]> {
     const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/${codingJobId}/units`;
     let params = new HttpParams();
     if (onlyOpen) {
       params = params.set('onlyOpen', 'true');
     }
-    return this.http.get<
-    Array<{
-      responseId: number;
-      unitName: string;
-      unitAlias: string | null;
-      variableId: string;
-      variableAnchor: string;
-      variablePage: string;
-      bookletName: string;
-      personLogin: string;
-      personCode: string;
-      personGroup: string;
-      isDoubleCoded: boolean;
-      otherCoders: string[];
-    }>
-    >(url, { headers: this.getAuthHeader(authToken), params });
+    return this.http.get<CodingJobUnitDto[]>(
+      url,
+      { headers: this.getAuthHeader(authToken), params }
+    );
   }
 
   applyCodingResults(

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -602,6 +602,85 @@ describe('ReplayComponent', () => {
     jest.useRealTimers();
   });
 
+  it('should only mark auto-coded bundle variables from the current unit', () => {
+    const iframe = document.createElement('iframe');
+    const highlightedSection = document.createElement('aspect-section') as HTMLElement;
+    jest.spyOn(domUtils, 'highlightAspectSectionWithAnchor')
+      .mockReturnValue([highlightedSection]);
+    jest.spyOn(domUtils, 'scrollToElementByAlias').mockReturnValue(true);
+    const bundleMarkerSpy = jest.spyOn(domUtils, 'highlightBundleVariableMarkers')
+      .mockReturnValue([]);
+    component.anchor = 'VAR1';
+    component.page = '0';
+    component.unitPlayerComponent = {
+      hostingIframe: {
+        nativeElement: iframe
+      }
+    } as unknown as typeof component.unitPlayerComponent;
+    (component as unknown as {
+      unitsData: {
+        currentUnitIndex: number;
+        units: unknown[];
+      };
+    }).unitsData = {
+      currentUnitIndex: 0,
+      units: [{
+        id: 1,
+        name: 'UNIT_1',
+        alias: null,
+        bookletId: 0,
+        variableId: 'VAR1',
+        bundleContext: {
+          bundleId: 9,
+          bundleName: 'Bundle',
+          caseKey: 'case-1',
+          caseOrderingMode: 'alternating',
+          variables: [
+            {
+              responseId: 1,
+              unitName: 'UNIT_1',
+              variableId: 'VAR1',
+              variableAnchor: 'VAR1',
+              variablePage: '0',
+              status: 'manual-open',
+              code: null,
+              score: null,
+              source: 'manual'
+            },
+            {
+              responseId: 2,
+              unitName: 'UNIT_1',
+              variableId: 'VAR_AUTO',
+              variableAnchor: 'VAR_AUTO',
+              variablePage: '0',
+              status: 'auto-coded',
+              code: 1,
+              score: 1,
+              source: 'auto'
+            },
+            {
+              responseId: 3,
+              unitName: 'UNIT_2',
+              variableId: 'VAR_OTHER',
+              variableAnchor: 'VAR_OTHER',
+              variablePage: '0',
+              status: 'auto-coded',
+              code: 1,
+              score: 1,
+              source: 'auto'
+            }
+          ]
+        }
+      }]
+    };
+
+    component.onResponseVisible();
+
+    expect(bundleMarkerSpy).toHaveBeenCalledWith(iframe, [
+      expect.objectContaining({ anchor: 'VAR_AUTO' })
+    ]);
+  });
+
   it('should cancel stale anchor highlight retries when unit data resets', () => {
     jest.useFakeTimers();
     const iframe = document.createElement('iframe');

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -29,7 +29,11 @@ import { SpinnerComponent } from '../spinner/spinner.component';
 import { FilesDto } from '../../../../../../../api-dto/files/files.dto';
 import { ErrorMessages } from '../../models/error-messages.model';
 import { validateToken, isTestperson } from '../../utils/token-utils';
-import { scrollToElementByAlias, highlightAspectSectionWithAnchor } from '../../utils/dom-utils';
+import {
+  scrollToElementByAlias,
+  highlightAspectSectionWithAnchor,
+  highlightBundleVariableMarkers
+} from '../../utils/dom-utils';
 import { ReviewCodeSelection, UnitsReplay, UnitsReplayUnit } from '../../services/units-replay.service';
 import { UnitsReplayComponent } from '../units-replay/units-replay.component';
 import { CodeSelectorComponent } from '../../../coding/components/code-selector/code-selector.component';
@@ -435,7 +439,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
                         `${item.personLogin}@${item.personCode}@${item.bookletName}`,
                       variableId: item.variableId,
                       variableAnchor: item.variableAnchor,
-                      variablePage: item.variablePage
+                      variablePage: item.variablePage,
+                      variableBundleId: item.variableBundleId,
+                      bundleContext: item.bundleContext
                     })),
                     currentUnitIndex: 0
                   };
@@ -1050,6 +1056,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
     const iframe = this.unitPlayerComponent?.hostingIframe?.nativeElement as HTMLIFrameElement | undefined;
     const highlightedElements = iframe ? highlightAspectSectionWithAnchor(iframe, this.anchor) : [];
+    if (iframe) {
+      this.highlightCurrentBundleMarkers(iframe);
+    }
 
     if (highlightedElements.length > 0 && iframe) {
       scrollToElementByAlias(iframe, this.anchor);
@@ -1075,6 +1084,35 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       clearTimeout(this.anchorHighlightTimeout);
       this.anchorHighlightTimeout = null;
     }
+  }
+
+  private getCurrentBundleMarkers(): Array<{ anchor: string; label: string; tooltip: string }> {
+    const currentUnit = this.unitsData?.units[this.unitsData.currentUnitIndex];
+    const bundleContext = currentUnit?.bundleContext;
+    if (!bundleContext || !this.page) {
+      return [];
+    }
+
+    const label = this.translateService.instant('code-selector.bundle-auto-coded-label');
+    const tooltip = this.translateService.instant('code-selector.bundle-auto-coded-tooltip');
+
+    return bundleContext.variables
+      .filter(variable => (
+        variable.status === 'auto-coded' &&
+        variable.unitName === currentUnit.name &&
+        variable.variableAnchor &&
+        variable.variableAnchor !== this.anchor &&
+        variable.variablePage === this.page
+      ))
+      .map(variable => ({
+        anchor: variable.variableAnchor,
+        label,
+        tooltip
+      }));
+  }
+
+  private highlightCurrentBundleMarkers(iframe: HTMLIFrameElement): void {
+    highlightBundleVariableMarkers(iframe, this.getCurrentBundleMarkers());
   }
 
   async onCodeSelected(event: { variableId: string; code: any }): Promise<void> {

--- a/apps/frontend/src/app/replay/services/units-replay.service.ts
+++ b/apps/frontend/src/app/replay/services/units-replay.service.ts
@@ -13,6 +13,33 @@ export interface ReviewCodeSelection {
   coderNames: string[];
 }
 
+export type BundleVariableStatus =
+  | 'manual-open'
+  | 'manual-coded'
+  | 'auto-coded'
+  | 'not-coded'
+  | 'not-available';
+
+export interface BundleVariableContext {
+  responseId: number | null;
+  unitName: string;
+  variableId: string;
+  variableAnchor: string;
+  variablePage: string;
+  status: BundleVariableStatus;
+  code: number | null;
+  score: number | null;
+  source: 'manual' | 'auto' | 'none';
+}
+
+export interface BundleContext {
+  bundleId: number;
+  bundleName: string;
+  caseKey: string;
+  caseOrderingMode: 'continuous' | 'alternating';
+  variables: BundleVariableContext[];
+}
+
 export interface UnitsReplayUnit {
   id: number;
   name: string;
@@ -24,6 +51,8 @@ export interface UnitsReplayUnit {
   variableId?: string;
   variableAnchor?: string;
   variablePage?: string;
+  variableBundleId?: number | null;
+  bundleContext?: BundleContext | null;
   reviewCodeSelections?: ReviewCodeSelection[];
 }
 

--- a/apps/frontend/src/app/replay/utils/dom-utils.spec.ts
+++ b/apps/frontend/src/app/replay/utils/dom-utils.spec.ts
@@ -1,7 +1,13 @@
-import { highlightAspectSectionWithAnchor, scrollToElementByAlias } from './dom-utils';
+import {
+  highlightAspectSectionWithAnchor,
+  highlightBundleVariableMarkers,
+  scrollToElementByAlias
+} from './dom-utils';
 
 describe('replay dom-utils', () => {
   const highlightOverlaySelector = '[data-coding-box-anchor-highlight-overlay="true"]';
+  const bundleMarkerSelector = '[data-coding-box-bundle-marker-overlay="true"]';
+  const bundleMarkerHostSelector = '[data-coding-box-bundle-marker="true"]';
 
   function createIframe(html: string): HTMLIFrameElement {
     const iframe = document.createElement('iframe');
@@ -227,6 +233,65 @@ describe('replay dom-utils', () => {
     expect(cellA.querySelector(highlightOverlaySelector)).toBeNull();
     expect(cellB.style.position).toBe('absolute');
     expect(cellB.querySelector(highlightOverlaySelector)).not.toBeNull();
+  });
+
+  it('adds and clears bundle variable markers without removing the active highlight', () => {
+    const iframe = createIframe(`
+      <aspect-section id="section">
+        <div id="section-frame">
+          <span id="field-a" data-element-alias="01a"></span>
+          <span id="field-b" data-element-alias="01b"></span>
+        </div>
+      </aspect-section>
+    `);
+
+    highlightAspectSectionWithAnchor(iframe, '01a');
+    const markedSections = highlightBundleVariableMarkers(iframe, [{
+      anchor: '01b',
+      label: 'auto',
+      tooltip: 'Automatisch kodiert'
+    }]);
+    const sectionFrame = iframe.contentDocument?.querySelector('#section-frame') as HTMLElement;
+
+    expect(markedSections).toHaveLength(1);
+    expect(sectionFrame.style.border).toBe('3px solid #4285f4');
+    expect(sectionFrame.querySelector(bundleMarkerSelector)).not.toBeNull();
+
+    highlightBundleVariableMarkers(iframe, []);
+    expect(sectionFrame.style.border).toBe('3px solid #4285f4');
+    expect(sectionFrame.querySelector(bundleMarkerSelector)).toBeNull();
+  });
+
+  it('marks and clears auto-coded bundle variables on directly aliased native fields', () => {
+    const iframe = createIframe(`
+      <aspect-section id="section">
+        <div id="section-frame">
+          <input id="field-a" data-element-alias="01a" title="Vorheriger Titel">
+        </div>
+      </aspect-section>
+    `);
+
+    const markedSections = highlightBundleVariableMarkers(iframe, [{
+      anchor: '01a',
+      label: 'auto',
+      tooltip: 'Automatisch kodiert'
+    }]);
+    const section = iframe.contentDocument?.querySelector('#section') as HTMLElement;
+    const fieldA = iframe.contentDocument?.querySelector('#field-a') as HTMLElement;
+
+    expect(markedSections).toEqual([section]);
+    expect(fieldA.matches(bundleMarkerHostSelector)).toBe(true);
+    expect(fieldA.querySelector(bundleMarkerSelector)).toBeNull();
+    expect(fieldA.style.outline).toBe('2px dashed #757575');
+    expect(fieldA.style.outlineOffset).toBe('2px');
+    expect(fieldA.getAttribute('title')).toBe('Automatisch kodiert');
+
+    highlightBundleVariableMarkers(iframe, []);
+
+    expect(fieldA.matches(bundleMarkerHostSelector)).toBe(false);
+    expect(fieldA.style.outline).toBe('');
+    expect(fieldA.style.outlineOffset).toBe('');
+    expect(fieldA.getAttribute('title')).toBe('Vorheriger Titel');
   });
 
   it('falls back to inset field highlighting when a table target cannot host an overlay', () => {

--- a/apps/frontend/src/app/replay/utils/dom-utils.ts
+++ b/apps/frontend/src/app/replay/utils/dom-utils.ts
@@ -7,6 +7,12 @@ const HIGHLIGHT_FIELD_SHADOW = 'inset 0 0 0 2px #4285f4';
 const HIGHLIGHT_ATTR = 'data-coding-box-anchor-highlight';
 const HIGHLIGHT_OVERLAY_ATTR = 'data-coding-box-anchor-highlight-overlay';
 const HIGHLIGHT_PREVIOUS_POSITION_ATTR = 'data-coding-box-anchor-highlight-previous-position';
+const BUNDLE_MARKER_ATTR = 'data-coding-box-bundle-marker';
+const BUNDLE_MARKER_OVERLAY_ATTR = 'data-coding-box-bundle-marker-overlay';
+const BUNDLE_MARKER_PREVIOUS_POSITION_ATTR = 'data-coding-box-bundle-marker-previous-position';
+const BUNDLE_MARKER_PREVIOUS_OUTLINE_ATTR = 'data-coding-box-bundle-marker-previous-outline';
+const BUNDLE_MARKER_PREVIOUS_OUTLINE_OFFSET_ATTR = 'data-coding-box-bundle-marker-previous-outline-offset';
+const BUNDLE_MARKER_PREVIOUS_TITLE_ATTR = 'data-coding-box-bundle-marker-previous-title';
 const NATIVE_FIELD_SELECTOR = [
   'input:not([type="hidden"])',
   'textarea',
@@ -96,6 +102,110 @@ function canHighlightWithOverlay(element: HTMLElement): boolean {
 function highlightField(element: HTMLElement): void {
   element.style.boxShadow = HIGHLIGHT_FIELD_SHADOW;
   element.setAttribute(HIGHLIGHT_ATTR, 'true');
+}
+
+function clearBundleMarker(element: HTMLElement): void {
+  if (element.getAttribute(BUNDLE_MARKER_OVERLAY_ATTR) === 'true') {
+    element.remove();
+    return;
+  }
+
+  element.querySelectorAll(`[${BUNDLE_MARKER_OVERLAY_ATTR}="true"]`).forEach(el => {
+    el.remove();
+  });
+
+  if (element.hasAttribute(BUNDLE_MARKER_PREVIOUS_POSITION_ATTR)) {
+    element.style.position = element.getAttribute(BUNDLE_MARKER_PREVIOUS_POSITION_ATTR) || '';
+    element.removeAttribute(BUNDLE_MARKER_PREVIOUS_POSITION_ATTR);
+  }
+
+  if (element.hasAttribute(BUNDLE_MARKER_PREVIOUS_OUTLINE_ATTR)) {
+    element.style.outline = element.getAttribute(BUNDLE_MARKER_PREVIOUS_OUTLINE_ATTR) || '';
+    element.removeAttribute(BUNDLE_MARKER_PREVIOUS_OUTLINE_ATTR);
+  }
+
+  if (element.hasAttribute(BUNDLE_MARKER_PREVIOUS_OUTLINE_OFFSET_ATTR)) {
+    element.style.outlineOffset = element.getAttribute(BUNDLE_MARKER_PREVIOUS_OUTLINE_OFFSET_ATTR) || '';
+    element.removeAttribute(BUNDLE_MARKER_PREVIOUS_OUTLINE_OFFSET_ATTR);
+  }
+
+  if (element.hasAttribute(BUNDLE_MARKER_PREVIOUS_TITLE_ATTR)) {
+    const previousTitle = element.getAttribute(BUNDLE_MARKER_PREVIOUS_TITLE_ATTR);
+    if (previousTitle) {
+      element.setAttribute('title', previousTitle);
+    } else {
+      element.removeAttribute('title');
+    }
+    element.removeAttribute(BUNDLE_MARKER_PREVIOUS_TITLE_ATTR);
+  }
+
+  element.removeAttribute(BUNDLE_MARKER_ATTR);
+}
+
+function clearBundleMarkers(document: Document): void {
+  document.querySelectorAll(`[${BUNDLE_MARKER_ATTR}="true"]`).forEach(el => {
+    clearBundleMarker(el as HTMLElement);
+  });
+}
+
+function markWithBundleOverlay(
+  element: HTMLElement,
+  label: string,
+  tooltip: string
+): void {
+  const view = element.ownerDocument.defaultView;
+  const computedPosition = view?.getComputedStyle(element).position;
+
+  if (!computedPosition || computedPosition === 'static') {
+    element.setAttribute(BUNDLE_MARKER_PREVIOUS_POSITION_ATTR, element.style.position);
+    element.style.position = 'relative';
+  }
+
+  const overlay = element.ownerDocument.createElement('div');
+  overlay.setAttribute(BUNDLE_MARKER_ATTR, 'true');
+  overlay.setAttribute(BUNDLE_MARKER_OVERLAY_ATTR, 'true');
+  overlay.setAttribute('title', tooltip);
+  overlay.style.position = 'absolute';
+  overlay.style.inset = '0';
+  overlay.style.boxSizing = 'border-box';
+  overlay.style.border = '2px dashed #757575';
+  overlay.style.backgroundImage = 'repeating-linear-gradient(135deg, rgba(117, 117, 117, 0.10) 0, rgba(117, 117, 117, 0.10) 4px, transparent 4px, transparent 10px)';
+  overlay.style.pointerEvents = 'none';
+  overlay.style.zIndex = '2147483646';
+
+  const badge = element.ownerDocument.createElement('span');
+  badge.textContent = label;
+  badge.style.position = 'absolute';
+  badge.style.top = '2px';
+  badge.style.right = '2px';
+  badge.style.maxWidth = 'calc(100% - 4px)';
+  badge.style.overflow = 'hidden';
+  badge.style.textOverflow = 'ellipsis';
+  badge.style.whiteSpace = 'nowrap';
+  badge.style.boxSizing = 'border-box';
+  badge.style.padding = '1px 4px';
+  badge.style.borderRadius = '3px';
+  badge.style.background = 'rgba(255, 255, 255, 0.92)';
+  badge.style.color = '#616161';
+  badge.style.font = '11px/1.3 Arial, sans-serif';
+  badge.style.border = '1px solid rgba(117, 117, 117, 0.45)';
+  overlay.appendChild(badge);
+
+  element.appendChild(overlay);
+  element.setAttribute(BUNDLE_MARKER_ATTR, 'true');
+}
+
+function markWithBundleFieldOutline(
+  element: HTMLElement,
+  tooltip: string
+): void {
+  element.setAttribute(BUNDLE_MARKER_PREVIOUS_OUTLINE_ATTR, element.style.outline);
+  element.setAttribute(BUNDLE_MARKER_PREVIOUS_OUTLINE_OFFSET_ATTR, element.style.outlineOffset);
+  element.setAttribute(BUNDLE_MARKER_PREVIOUS_TITLE_ATTR, element.getAttribute('title') || '');
+  element.style.outline = '2px dashed #757575';
+  element.style.outlineOffset = '2px';
+  element.setAttribute('title', tooltip);
+  element.setAttribute(BUNDLE_MARKER_ATTR, 'true');
 }
 
 function getParentSection(element: HTMLElement): HTMLElement | null {
@@ -311,6 +421,51 @@ export function highlightAspectSectionWithAnchor(iframe: HTMLIFrameElement, anch
         result.push(element as HTMLElement);
       });
     }
+  } catch (error) {
+    // Silently handle errors
+  }
+
+  return result;
+}
+
+export function highlightBundleVariableMarkers(
+  iframe: HTMLIFrameElement,
+  markers: Array<{ anchor: string; label: string; tooltip: string }>
+): HTMLElement[] {
+  const result: HTMLElement[] = [];
+
+  try {
+    if (!iframe.contentDocument) {
+      return result;
+    }
+
+    clearBundleMarkers(iframe.contentDocument);
+    const elementsByAlias = findElementsByDataAlias(iframe);
+
+    markers.forEach(marker => {
+      const anchorElement = elementsByAlias[marker.anchor];
+      if (!anchorElement) {
+        return;
+      }
+
+      const target =
+        getTableHighlightTarget(anchorElement) ||
+        getFieldHighlightTarget(anchorElement) ||
+        anchorElement;
+      const markerTarget = canHighlightWithOverlay(target) ?
+        target :
+        anchorElement;
+
+      if (canHighlightWithOverlay(markerTarget)) {
+        markWithBundleOverlay(markerTarget, marker.label, marker.tooltip);
+      } else {
+        markWithBundleFieldOutline(target, marker.tooltip);
+      }
+      const parentSection = getParentSection(anchorElement);
+      if (parentSection) {
+        result.push(parentSection);
+      }
+    });
   } catch (error) {
     // Silently handle errors
   }

--- a/apps/frontend/src/app/services/facades/coding-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/coding-facade.service.ts
@@ -4,7 +4,12 @@ import {
   CodingJob,
   VariableBundle
 } from '../../coding/models/coding-job.model';
-import { CodingJobBackendService, CodingExportConfig, JobDefinition } from '../../coding/services/coding-job-backend.service';
+import {
+  CodingJobBackendService,
+  CodingExportConfig,
+  CodingJobUnitDto,
+  JobDefinition
+} from '../../coding/services/coding-job-backend.service';
 import {
   ReplayBackendService,
   ReplayClientTimings,
@@ -303,7 +308,7 @@ export class CodingFacadeService {
     return this.codingJobBackendService.getCodingNotes(workspaceId, codingJobId);
   }
 
-  getCodingJobUnits(workspaceId: number, codingJobId: number): Observable<Array<{ responseId: number; unitName: string; unitAlias: string | null; variableId: string; variableAnchor: string; variablePage: string; bookletName: string; personLogin: string; personCode: string; personGroup: string }>> {
+  getCodingJobUnits(workspaceId: number, codingJobId: number): Observable<CodingJobUnitDto[]> {
     return this.codingJobBackendService.getCodingJobUnits(workspaceId, codingJobId);
   }
 

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1051,6 +1051,11 @@
     "general-codes-and-notes": "Allgemeine Codes und Notiz",
     "my-coding-jobs": "Meine Kodierjobs",
     "progress-tooltip": "Kodierfortschritt {{completed}}/{{total}} ({{percentage}}%). Offen: {{open}}",
+    "bundle-auto-coded-label": "auto",
+    "bundle-auto-coded-tooltip": "Diese Bündelvariable wurde automatisch kodiert.",
+    "bundle-manual-coded-tooltip": "Diese Bündelvariable ist manuell kodiert.",
+    "bundle-open-tooltip": "Diese Bündelvariable ist offen.",
+    "bundle-not-available-tooltip": "Diese Bündelvariable ist für diesen Fall nicht verfügbar.",
     "code-assignment-uncertain-requires-code": "Code-Vergabe unsicher kann erst nach einem regulären Code ausgewählt werden.",
     "new-code-comment-required": "Bitte begründen Sie „Neuer Code nötig“ im Kommentar zu diesem Kodierfall.",
     "coding-issue-options": {


### PR DESCRIPTION
## Summary

- keep variables from the same bundle case assigned to the same coder across units
- include closed/manual-coded bundle variables in coding context when only open units are loaded
- show auto-coded bundle variables in the coding replay and variable selector
- align coder training sampling with bundled cases

## Issue

Relates to #693.

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job.service.spec.ts`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coder-training.service.spec.ts`
- `npx nx test frontend --testFile=apps/frontend/src/app/replay/components/replay/replay.component.spec.ts`
- `npx nx test frontend --testFile=apps/frontend/src/app/replay/utils/dom-utils.spec.ts`
- `npx nx lint backend`
- `npx nx build backend`
- `npx nx lint frontend`
- `npx nx build frontend`
- `git diff --check`

Note: a full backend test run was previously blocked locally by a native `libxmljs2` Node ABI mismatch, so the affected backend suites were run directly.
