### PR TITLE
Keep workspace study managers assigned

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace.controller.spec.ts
@@ -9,6 +9,7 @@ import { AccessRightsMatrixService } from './access-rights-matrix.service';
 
 describe('WorkspaceController', () => {
   let controller: WorkspaceController;
+  let workspaceCoreService: jest.Mocked<WorkspaceCoreService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -42,9 +43,21 @@ describe('WorkspaceController', () => {
     }).compile();
 
     controller = module.get<WorkspaceController>(WorkspaceController);
+    workspaceCoreService = module.get<jest.Mocked<WorkspaceCoreService>>(WorkspaceCoreService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('passes the authenticated user id when creating a workspace', async () => {
+    workspaceCoreService.create.mockResolvedValueOnce(12);
+
+    await expect(controller.create(
+      { name: 'New workspace' } as never,
+      { user: { id: '5' } } as never
+    )).resolves.toBe(12);
+
+    expect(workspaceCoreService.create).toHaveBeenCalledWith({ name: 'New workspace' }, 5);
   });
 });

--- a/apps/backend/src/app/admin/workspace/workspace.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace.controller.ts
@@ -9,6 +9,7 @@ import {
   Patch,
   Post,
   Query,
+  Req,
   UseGuards
 } from '@nestjs/common';
 import {
@@ -32,6 +33,12 @@ import { WorkspaceGuard } from './workspace.guard';
 import { AdminGuard } from '../admin.guard';
 import { AccessRightsMatrixService } from './access-rights-matrix.service';
 import { AccessRightsMatrixDto } from '../../../../../../api-dto/workspaces/access-rights-matrix-dto';
+
+interface RequestWithUser {
+  user: {
+    id: string | number;
+  };
+}
 
 @ApiTags('Admin Workspace')
 @Controller('admin/workspace')
@@ -190,7 +197,7 @@ export class WorkspaceController {
   })
   @ApiBadRequestResponse({ description: 'Invalid workspace data' })
   @ApiTags('admin workspaces')
-  async create(@Body() createWorkspaceDto: CreateWorkspaceDto) {
-    return this.workspaceCoreService.create(createWorkspaceDto);
+  async create(@Body() createWorkspaceDto: CreateWorkspaceDto, @Req() request: RequestWithUser) {
+    return this.workspaceCoreService.create(createWorkspaceDto, Number(request.user.id));
   }
 }

--- a/apps/backend/src/app/database/services/users/users.service.spec.ts
+++ b/apps/backend/src/app/database/services/users/users.service.spec.ts
@@ -1,16 +1,40 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import WorkspaceUser from '../../entities/workspace_user.entity';
 import { UsersService } from './users.service';
 
-const createRepo = () => ({
-  find: jest.fn(),
-  findOne: jest.fn(),
-  create: jest.fn(value => ({ id: 77, ...value })),
-  save: jest.fn(value => Promise.resolve({ id: 77, ...value })),
-  upsert: jest.fn(),
-  update: jest.fn(),
-  delete: jest.fn(),
-  count: jest.fn()
+const createLockedRowsQuery = (rows: unknown[] = []) => ({
+  setLock: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  getMany: jest.fn().mockResolvedValue(rows)
 });
+
+const createRepo = () => {
+  const repo = {
+    createQueryBuilder: jest.fn(() => createLockedRowsQuery()),
+    find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn(),
+    create: jest.fn(value => ({ id: 77, ...value })),
+    save: jest.fn(value => Promise.resolve(Array.isArray(value) ? value : { id: 77, ...value })),
+    upsert: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    count: jest.fn(),
+    manager: {
+      transaction: jest.fn()
+    }
+  };
+  repo.manager.transaction.mockImplementation(callback => callback({
+    getRepository: jest.fn(() => repo)
+  }));
+  return repo;
+};
+
+const mockLockedWorkspaceUsers = (
+  workspaceUserRepository: ReturnType<typeof createRepo>,
+  rows: unknown[]
+) => {
+  workspaceUserRepository.createQueryBuilder.mockReturnValueOnce(createLockedRowsQuery(rows));
+};
 
 describe('UsersService', () => {
   let usersRepository: ReturnType<typeof createRepo>;
@@ -20,6 +44,11 @@ describe('UsersService', () => {
   beforeEach(() => {
     usersRepository = createRepo();
     workspaceUserRepository = createRepo();
+    const transactionManager = {
+      getRepository: jest.fn(entity => (entity === WorkspaceUser ? workspaceUserRepository : usersRepository))
+    };
+    usersRepository.manager.transaction.mockImplementation(callback => callback(transactionManager));
+    workspaceUserRepository.manager.transaction.mockImplementation(callback => callback(transactionManager));
     service = new UsersService(usersRepository as never, workspaceUserRepository as never);
     jest.spyOn((service as unknown as { logger: { log: jest.Mock; warn: jest.Mock; error: jest.Mock } }).logger, 'log').mockImplementation(jest.fn());
     jest.spyOn((service as unknown as { logger: { log: jest.Mock; warn: jest.Mock; error: jest.Mock } }).logger, 'warn').mockImplementation(jest.fn());
@@ -83,6 +112,7 @@ describe('UsersService', () => {
   });
 
   it('updates access and checks workspace access', async () => {
+    mockLockedWorkspaceUsers(workspaceUserRepository, [{ workspaceId: 2, userId: 9, accessLevel: 3 }]);
     workspaceUserRepository.findOne
       .mockResolvedValueOnce({ userId: 1, workspaceId: 2 })
       .mockResolvedValueOnce(null);
@@ -167,6 +197,7 @@ describe('UsersService', () => {
   });
 
   it('recreates workspace access after it was removed', async () => {
+    mockLockedWorkspaceUsers(workspaceUserRepository, [{ workspaceId: 2, userId: 8, accessLevel: 3 }]);
     await expect(service.updateUsersAccess(2, [
       {
         id: 3, username: 'c', accessLevel: 0, canCode: false
@@ -180,6 +211,7 @@ describe('UsersService', () => {
 
     workspaceUserRepository.delete.mockClear();
     workspaceUserRepository.upsert.mockClear();
+    mockLockedWorkspaceUsers(workspaceUserRepository, []);
 
     await expect(service.updateUsersAccess(2, [
       {
@@ -196,6 +228,19 @@ describe('UsersService', () => {
         canCode: true
       }
     ], ['workspaceId', 'userId']);
+  });
+
+  it('rejects workspace access updates without a remaining study manager', async () => {
+    mockLockedWorkspaceUsers(workspaceUserRepository, [{ workspaceId: 2, userId: 1, accessLevel: 3 }]);
+
+    await expect(service.updateUsersAccess(2, [
+      {
+        id: 1, username: 'study-manager', accessLevel: 1, canCode: true
+      }
+    ] as never)).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(workspaceUserRepository.delete).not.toHaveBeenCalled();
+    expect(workspaceUserRepository.upsert).not.toHaveBeenCalled();
   });
 
   it('rejects invalid workspace access payloads before writing', async () => {
@@ -272,20 +317,27 @@ describe('UsersService', () => {
     await expect(service.updateUser(1, { id: 1, username: 'new', isAdmin: true } as never)).resolves.toEqual({ id: 1, username: 'new', isAdmin: true });
     await expect(service.create({ username: 'created' } as never)).resolves.toBe(77);
     await expect(service.remove(1)).resolves.toBeUndefined();
-    expect(usersRepository.delete).toHaveBeenCalledWith(1);
+    expect(usersRepository.delete).toHaveBeenCalledWith([1]);
   });
 
   it('assigns workspaces and validates deletion constraints', async () => {
-    workspaceUserRepository.findOne.mockResolvedValueOnce({ userId: 1 });
+    workspaceUserRepository.find.mockResolvedValueOnce([]);
+    mockLockedWorkspaceUsers(workspaceUserRepository, [{ workspaceId: 2, userId: 9, accessLevel: 3 }]);
     workspaceUserRepository.save.mockResolvedValueOnce([{
       userId: 1,
       workspaceId: 2,
-      accessLevel: 3,
-      canCode: false
+      accessLevel: 1,
+      canCode: true
     }]);
 
     await expect(service.assignUserWorkspaces(1, [2])).resolves.toBe(true);
-    expect(workspaceUserRepository.delete).toHaveBeenCalledWith({ userId: 1 });
+    expect(workspaceUserRepository.save).toHaveBeenCalledWith([{
+      userId: 1,
+      workspaceId: 2,
+      accessLevel: 1,
+      canCode: true
+    }]);
+    expect(workspaceUserRepository.delete).not.toHaveBeenCalled();
 
     await expect(service.removeIds([], 1)).rejects.toBeInstanceOf(BadRequestException);
     await expect(service.removeIds([1], 1)).rejects.toBeInstanceOf(ForbiddenException);
@@ -293,6 +345,159 @@ describe('UsersService', () => {
     await expect(service.removeIds([2, 3], 1)).rejects.toBeInstanceOf(ForbiddenException);
     usersRepository.count.mockResolvedValueOnce(5);
     await expect(service.removeIds([2], 1)).resolves.toBeUndefined();
+  });
+
+  it('rejects user deletions that remove the final workspace study manager', async () => {
+    usersRepository.count.mockResolvedValueOnce(5);
+    workspaceUserRepository.find.mockResolvedValueOnce([{
+      workspaceId: 2,
+      userId: 7,
+      accessLevel: 3,
+      canCode: false
+    }]);
+    mockLockedWorkspaceUsers(workspaceUserRepository, [{
+      workspaceId: 2,
+      userId: 7,
+      accessLevel: 3,
+      canCode: false
+    }]);
+
+    await expect(service.removeIds([7], 1)).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(usersRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('allows user deletions when another workspace study manager remains', async () => {
+    usersRepository.count.mockResolvedValueOnce(5);
+    workspaceUserRepository.find.mockResolvedValueOnce([{
+      workspaceId: 2,
+      userId: 7,
+      accessLevel: 3,
+      canCode: false
+    }]);
+    mockLockedWorkspaceUsers(workspaceUserRepository, [
+      {
+        workspaceId: 2,
+        userId: 7,
+        accessLevel: 3,
+        canCode: false
+      },
+      {
+        workspaceId: 2,
+        userId: 8,
+        accessLevel: 3,
+        canCode: false
+      }
+    ]);
+
+    await expect(service.removeIds([7], 1)).resolves.toBeUndefined();
+
+    expect(usersRepository.delete).toHaveBeenCalledWith([7]);
+  });
+
+  it('preserves existing workspace access when assigning workspaces to a user', async () => {
+    workspaceUserRepository.find.mockResolvedValueOnce([
+      {
+        userId: 1,
+        workspaceId: 2,
+        accessLevel: 3,
+        canCode: false
+      },
+      {
+        userId: 1,
+        workspaceId: 4,
+        accessLevel: 1,
+        canCode: true
+      }
+    ]);
+    mockLockedWorkspaceUsers(workspaceUserRepository, [
+      {
+        userId: 1,
+        workspaceId: 2,
+        accessLevel: 3,
+        canCode: false
+      },
+      {
+        userId: 1,
+        workspaceId: 4,
+        accessLevel: 1,
+        canCode: true
+      },
+      {
+        userId: 9,
+        workspaceId: 3,
+        accessLevel: 3,
+        canCode: false
+      },
+      {
+        userId: 8,
+        workspaceId: 4,
+        accessLevel: 3,
+        canCode: false
+      }
+    ]);
+    workspaceUserRepository.save.mockResolvedValueOnce([
+      {
+        userId: 1,
+        workspaceId: 2,
+        accessLevel: 3,
+        canCode: false
+      },
+      {
+        userId: 1,
+        workspaceId: 3,
+        accessLevel: 1,
+        canCode: true
+      }
+    ]);
+
+    await expect(service.assignUserWorkspaces(1, [2, 3])).resolves.toBe(true);
+
+    expect(workspaceUserRepository.delete).toHaveBeenCalledWith({
+      userId: 1,
+      workspaceId: expect.any(Object)
+    });
+    expect(workspaceUserRepository.save).toHaveBeenCalledWith([
+      {
+        userId: 1,
+        workspaceId: 2,
+        accessLevel: 3,
+        canCode: false
+      },
+      {
+        userId: 1,
+        workspaceId: 3,
+        accessLevel: 1,
+        canCode: true
+      }
+    ]);
+  });
+
+  it('rejects workspace assignment changes that remove the final study manager', async () => {
+    workspaceUserRepository.find.mockResolvedValueOnce([{
+      userId: 1,
+      workspaceId: 2,
+      accessLevel: 3,
+      canCode: false
+    }]);
+    mockLockedWorkspaceUsers(workspaceUserRepository, [
+      {
+        userId: 1,
+        workspaceId: 2,
+        accessLevel: 3,
+        canCode: false
+      },
+      {
+        userId: 9,
+        workspaceId: 3,
+        accessLevel: 3,
+        canCode: false
+      }
+    ]);
+
+    await expect(service.assignUserWorkspaces(1, [3])).rejects.toBeInstanceOf(BadRequestException);
+    expect(workspaceUserRepository.delete).not.toHaveBeenCalled();
+    expect(workspaceUserRepository.save).not.toHaveBeenCalled();
   });
 
   it('creates existing and new local users', async () => {

--- a/apps/backend/src/app/database/services/users/users.service.ts
+++ b/apps/backend/src/app/database/services/users/users.service.ts
@@ -9,10 +9,17 @@ import { CreateUserDto } from '../../../../../../../api-dto/user/create-user-dto
 import WorkspaceUser from '../../entities/workspace_user.entity';
 import { WorkspaceUserInListDto } from '../../../../../../../api-dto/user/workspace-user-in-list-dto';
 import { UserInListDto } from '../../../../../../../api-dto/user/user-in-list-dto';
+import {
+  assertStudyManagersRemain,
+  DEFAULT_WORKSPACE_USER_ACCESS,
+  lockUserRows,
+  lockWorkspaceUserRows
+} from '../workspace/workspace-user-access.util';
 
 @Injectable()
 export class UsersService {
   private readonly logger = new Logger(UsersService.name);
+
   constructor(
     @InjectRepository(User)
     private usersRepository: Repository<User>,
@@ -111,16 +118,32 @@ export class UsersService {
       });
     });
 
-    if (userIdsToDelete.length > 0) {
-      await this.workspaceUserRepository.delete({
-        workspaceId: normalizedWorkspaceId,
-        userId: In(userIdsToDelete)
-      });
-    }
+    await this.workspaceUserRepository.manager.transaction(async manager => {
+      const workspaceUsersRepository = manager.getRepository(WorkspaceUser);
+      await lockUserRows(manager, Array.from(seenUserIds));
+      const lockedWorkspaceUsers = await lockWorkspaceUserRows(manager, [normalizedWorkspaceId]);
 
-    if (usersToUpsert.length > 0) {
-      await this.workspaceUserRepository.upsert(usersToUpsert, ['workspaceId', 'userId']);
-    }
+      assertStudyManagersRemain(
+        [normalizedWorkspaceId],
+        lockedWorkspaceUsers,
+        usersToUpsert,
+        userIdsToDelete.map(userId => ({
+          workspaceId: normalizedWorkspaceId,
+          userId
+        }))
+      );
+
+      if (userIdsToDelete.length > 0) {
+        await workspaceUsersRepository.delete({
+          workspaceId: normalizedWorkspaceId,
+          userId: In(userIdsToDelete)
+        });
+      }
+
+      if (usersToUpsert.length > 0) {
+        await workspaceUsersRepository.upsert(usersToUpsert, ['workspaceId', 'userId']);
+      }
+    });
 
     return true;
   }
@@ -248,24 +271,71 @@ export class UsersService {
 
   async assignUserWorkspaces(userId: number, workspaceIds: number[]): Promise<boolean> {
     this.logger.log(`Setting workspaces for user with ID: ${userId}`);
-    const entries = workspaceIds.map(workspaceId => ({
-      userId,
-      workspaceId,
-      accessLevel: 3,
-      canCode: false
-    }));
     try {
-      const hasRights = await this.workspaceUserRepository.findOne({ where: { userId } });
-      if (hasRights) {
-        this.logger.log(`Existing workspaces found for user ${userId}, deleting...`);
-        await this.workspaceUserRepository.delete({ userId });
-      }
-      const savedEntries = await this.workspaceUserRepository.save(entries);
+      const savedEntries = await this.workspaceUserRepository.manager.transaction(async manager => {
+        const workspaceUsersRepository = manager.getRepository(WorkspaceUser);
+        await lockUserRows(manager, [userId]);
+        const existingEntries = await workspaceUsersRepository.find({ where: { userId } });
+        const affectedWorkspaceIds = Array.from(new Set([
+          ...workspaceIds,
+          ...existingEntries.map(entry => entry.workspaceId)
+        ]));
+        const lockedWorkspaceUsers = await lockWorkspaceUserRows(manager, affectedWorkspaceIds);
+        const existingByWorkspaceId = new Map(
+          lockedWorkspaceUsers
+            .filter(entry => entry.userId === userId)
+            .map(entry => [entry.workspaceId, entry])
+        );
+        const workspaceIdSet = new Set(workspaceIds);
+        const entries = workspaceIds.map(workspaceId => {
+          const existingEntry = existingByWorkspaceId.get(workspaceId);
+          if (existingEntry && existingEntry.accessLevel > 0) {
+            return {
+              userId,
+              workspaceId,
+              accessLevel: existingEntry.accessLevel,
+              canCode: existingEntry.canCode ?? (existingEntry.accessLevel === 1)
+            };
+          }
+
+          return {
+            userId,
+            workspaceId,
+            ...DEFAULT_WORKSPACE_USER_ACCESS
+          };
+        });
+        const entriesToDelete = lockedWorkspaceUsers
+          .filter(entry => entry.userId === userId && !workspaceIdSet.has(entry.workspaceId));
+
+        assertStudyManagersRemain(
+          affectedWorkspaceIds,
+          lockedWorkspaceUsers,
+          entries,
+          entriesToDelete
+        );
+
+        if (entriesToDelete.length > 0) {
+          this.logger.log(`Existing workspaces found for user ${userId}, deleting...`);
+          await workspaceUsersRepository.delete({
+            userId,
+            workspaceId: In(entriesToDelete.map(entry => entry.workspaceId))
+          });
+        }
+
+        if (entries.length === 0) {
+          return [];
+        }
+
+        return workspaceUsersRepository.save(entries);
+      });
 
       this.logger.log(`Workspaces successfully set for user with ID: ${userId}`);
       // Return true if at least one entry was saved
       return savedEntries.length > 0;
     } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       this.logger.error(
         `Error setting workspaces for user with ID: ${userId}. Details: ${error.message}`,
         error.stack
@@ -321,7 +391,7 @@ export class UsersService {
 
   async remove(id: number | number[]): Promise<void> {
     this.logger.log(`Deleting user with id: ${id}`);
-    await this.usersRepository.delete(id);
+    await this.deleteUsersWithStudyManagerInvariant(Array.isArray(id) ? id : [id]);
   }
 
   async removeIds(ids: number[], currentUserId: number): Promise<void> {
@@ -338,7 +408,44 @@ export class UsersService {
       throw new ForbiddenException('All users cannot be deleted at once.');
     }
 
-    await this.usersRepository.delete(ids);
+    await this.deleteUsersWithStudyManagerInvariant(ids);
+  }
+
+  private async deleteUsersWithStudyManagerInvariant(userIds: number[]): Promise<void> {
+    const uniqueUserIds = Array.from(new Set(userIds));
+    if (uniqueUserIds.length === 0) {
+      return;
+    }
+
+    await this.usersRepository.manager.transaction(async manager => {
+      const usersRepository = manager.getRepository(User);
+      const workspaceUsersRepository = manager.getRepository(WorkspaceUser);
+      await lockUserRows(manager, uniqueUserIds);
+      const membershipsToDelete = await workspaceUsersRepository.find({
+        where: { userId: In(uniqueUserIds) }
+      });
+      const affectedWorkspaceIds = Array.from(new Set(
+        membershipsToDelete.map(entry => entry.workspaceId)
+      ));
+      const lockedWorkspaceUsers = await lockWorkspaceUserRows(manager, affectedWorkspaceIds);
+      const userIdSet = new Set(uniqueUserIds);
+      const lockedMembershipsToDelete = lockedWorkspaceUsers
+        .filter(entry => userIdSet.has(entry.userId));
+      const affectedManagerWorkspaceIds = Array.from(new Set(
+        lockedMembershipsToDelete
+          .filter(entry => entry.accessLevel === 3)
+          .map(entry => entry.workspaceId)
+      ));
+
+      assertStudyManagersRemain(
+        affectedManagerWorkspaceIds,
+        lockedWorkspaceUsers,
+        [],
+        lockedMembershipsToDelete
+      );
+
+      await usersRepository.delete(uniqueUserIds);
+    });
   }
 
   async createKeycloakUser(keycloakUser: CreateUserDto): Promise<number> {

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
@@ -1,4 +1,7 @@
+import { BadRequestException } from '@nestjs/common';
 import { AdminWorkspaceNotFoundException } from '../../../exceptions/admin-workspace-not-found.exception';
+import Workspace from '../../entities/workspace.entity';
+import WorkspaceUser from '../../entities/workspace_user.entity';
 import { WorkspaceCoreService } from './workspace-core.service';
 
 const createRepo = () => ({
@@ -21,6 +24,7 @@ describe('WorkspaceCoreService', () => {
     release: jest.Mock;
     manager: { delete: jest.Mock };
   };
+  let managerSave: jest.Mock;
   let service: WorkspaceCoreService;
 
   beforeEach(() => {
@@ -35,9 +39,18 @@ describe('WorkspaceCoreService', () => {
       release: jest.fn(),
       manager: { delete: jest.fn().mockResolvedValue({ affected: 1 }) }
     };
+    managerSave = jest.fn((entity: unknown, value: object) => {
+      if (entity === Workspace) {
+        return Promise.resolve({ id: 9, ...value });
+      }
+      return Promise.resolve(value);
+    });
     service = new WorkspaceCoreService(
       repo as never,
-      { createQueryRunner: () => queryRunner } as never,
+      {
+        createQueryRunner: () => queryRunner,
+        transaction: (callback: (manager: { save: jest.Mock }) => Promise<unknown>) => callback({ save: managerSave })
+      } as never,
       cacheService as never,
       workspaceTestResultsService as never
     );
@@ -65,13 +78,24 @@ describe('WorkspaceCoreService', () => {
   it('creates, patches and removes workspaces', async () => {
     repo.findOne.mockResolvedValueOnce({ id: 1, name: 'Old', settings: {} });
 
-    await expect(service.create({ name: 'New' } as never)).resolves.toBe(9);
+    await expect(service.create({ name: 'New' } as never, 5)).resolves.toBe(9);
+    expect(managerSave).toHaveBeenCalledWith(WorkspaceUser, {
+      workspaceId: 9,
+      userId: 5,
+      accessLevel: 3,
+      canCode: false
+    });
     await expect(service.patch({ id: 1, name: 'Patched', settings: { a: true } } as never)).resolves.toBeUndefined();
     expect(cacheService.delete).toHaveBeenCalled();
     await expect(service.remove([])).resolves.toBeUndefined();
     await expect(service.remove([1])).resolves.toBeUndefined();
     expect(queryRunner.commitTransaction).toHaveBeenCalled();
     expect(queryRunner.release).toHaveBeenCalled();
+  });
+
+  it('rejects workspace creation without a valid creator user id', async () => {
+    await expect(service.create({ name: 'New' } as never, 0)).rejects.toBeInstanceOf(BadRequestException);
+    expect(managerSave).not.toHaveBeenCalled();
   });
 
   it('rolls back failed removals', async () => {

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
@@ -1,9 +1,10 @@
 import {
-  forwardRef, Inject, Injectable, Logger
+  BadRequestException, forwardRef, Inject, Injectable, Logger
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Connection, In, Repository } from 'typeorm';
 import Workspace from '../../entities/workspace.entity';
+import WorkspaceUser from '../../entities/workspace_user.entity';
 import { WorkspaceInListDto } from '../../../../../../../api-dto/workspaces/workspace-in-list-dto';
 import { WorkspaceFullDto } from '../../../../../../../api-dto/workspaces/workspace-full-dto';
 import { CreateWorkspaceDto } from '../../../../../../../api-dto/workspaces/create-workspace-dto';
@@ -75,11 +76,25 @@ export class WorkspaceCoreService {
     throw new AdminWorkspaceNotFoundException(id, 'GET');
   }
 
-  async create(workspace: CreateWorkspaceDto): Promise<number> {
+  async create(workspace: CreateWorkspaceDto, creatorUserId: number): Promise<number> {
     this.logger.log(`Creating workspace with name: ${workspace.name}`);
+    const normalizedCreatorUserId = Number(creatorUserId);
+    if (!Number.isInteger(normalizedCreatorUserId) || normalizedCreatorUserId < 1) {
+      throw new BadRequestException('Creator user ID must be a positive integer.');
+    }
+
     const newWorkspace = this.workspaceRepository.create({ ...workspace });
     try {
-      const savedWorkspace = await this.workspaceRepository.save(newWorkspace);
+      const savedWorkspace = await this.connection.transaction(async manager => {
+        const createdWorkspace = await manager.save(Workspace, newWorkspace);
+        await manager.save(WorkspaceUser, {
+          workspaceId: createdWorkspace.id,
+          userId: normalizedCreatorUserId,
+          accessLevel: 3,
+          canCode: false
+        });
+        return createdWorkspace;
+      });
       this.logger.log(`Workspace created successfully with ID: ${savedWorkspace.id}`);
       return savedWorkspace.id;
     } catch (error) {

--- a/apps/backend/src/app/database/services/workspace/workspace-user-access.util.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-user-access.util.ts
@@ -1,0 +1,95 @@
+import { BadRequestException } from '@nestjs/common';
+import { EntityManager, In } from 'typeorm';
+import User from '../../entities/user.entity';
+import WorkspaceUser from '../../entities/workspace_user.entity';
+
+export const STUDY_MANAGER_ACCESS_LEVEL = 3;
+
+export const DEFAULT_WORKSPACE_USER_ACCESS = {
+  accessLevel: 1,
+  canCode: true
+} as const;
+
+type WorkspaceUserAccessEntry = Pick<WorkspaceUser, 'workspaceId' | 'userId' | 'accessLevel'>;
+type WorkspaceUserDeletionEntry = Pick<WorkspaceUser, 'workspaceId' | 'userId'>;
+
+export async function lockWorkspaceUserRows(
+  manager: EntityManager,
+  workspaceIds: number[]
+): Promise<WorkspaceUser[]> {
+  const uniqueWorkspaceIds = Array.from(new Set(workspaceIds));
+  if (uniqueWorkspaceIds.length === 0) {
+    return [];
+  }
+
+  return manager
+    .getRepository(WorkspaceUser)
+    .createQueryBuilder('workspaceUser')
+    .setLock('pessimistic_write')
+    .where({ workspaceId: In(uniqueWorkspaceIds) })
+    .getMany();
+}
+
+export async function lockUserRows(
+  manager: EntityManager,
+  userIds: number[]
+): Promise<void> {
+  const uniqueUserIds = Array.from(new Set(userIds));
+  if (uniqueUserIds.length === 0) {
+    return;
+  }
+
+  await manager
+    .getRepository(User)
+    .createQueryBuilder('appUser')
+    .setLock('pessimistic_write')
+    .where({ id: In(uniqueUserIds) })
+    .getMany();
+}
+
+export function assertStudyManagersRemain(
+  workspaceIds: number[],
+  existingEntries: WorkspaceUserAccessEntry[],
+  entriesToUpsert: WorkspaceUserAccessEntry[],
+  entriesToDelete: WorkspaceUserDeletionEntry[]
+): void {
+  const uniqueWorkspaceIds = Array.from(new Set(workspaceIds));
+  if (uniqueWorkspaceIds.length === 0) {
+    return;
+  }
+
+  const studyManagersByWorkspaceId = new Map<number, Set<number>>();
+  uniqueWorkspaceIds.forEach(workspaceId => {
+    studyManagersByWorkspaceId.set(workspaceId, new Set<number>());
+  });
+
+  existingEntries
+    .filter(entry => entry.accessLevel === STUDY_MANAGER_ACCESS_LEVEL)
+    .forEach(entry => {
+      studyManagersByWorkspaceId.get(entry.workspaceId)?.add(entry.userId);
+    });
+
+  entriesToDelete.forEach(entry => {
+    studyManagersByWorkspaceId.get(entry.workspaceId)?.delete(entry.userId);
+  });
+
+  entriesToUpsert.forEach(entry => {
+    const studyManagerIds = studyManagersByWorkspaceId.get(entry.workspaceId);
+    if (!studyManagerIds) {
+      return;
+    }
+
+    if (entry.accessLevel === STUDY_MANAGER_ACCESS_LEVEL) {
+      studyManagerIds.add(entry.userId);
+    } else {
+      studyManagerIds.delete(entry.userId);
+    }
+  });
+
+  const workspaceWithoutStudyManager = uniqueWorkspaceIds.find(
+    workspaceId => (studyManagersByWorkspaceId.get(workspaceId)?.size ?? 0) === 0
+  );
+  if (workspaceWithoutStudyManager !== undefined) {
+    throw new BadRequestException('At least one study manager must remain assigned to each workspace.');
+  }
+}

--- a/apps/backend/src/app/database/services/workspace/workspace-users.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-users.service.spec.ts
@@ -1,12 +1,38 @@
+import User from '../../entities/user.entity';
+import Workspace from '../../entities/workspace.entity';
+import WorkspaceUser from '../../entities/workspace_user.entity';
 import { WorkspaceUsersService } from './workspace-users.service';
 
-const createRepo = () => ({
-  find: jest.fn(),
-  findOne: jest.fn(),
-  findAndCount: jest.fn(),
-  save: jest.fn(),
-  delete: jest.fn()
+const createLockedRowsQuery = (rows: unknown[] = []) => ({
+  setLock: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  getMany: jest.fn().mockResolvedValue(rows)
 });
+
+const createRepo = () => {
+  const repo = {
+    createQueryBuilder: jest.fn(() => createLockedRowsQuery()),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    findAndCount: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+    manager: {
+      transaction: jest.fn()
+    }
+  };
+  repo.manager.transaction.mockImplementation(callback => callback({
+    getRepository: jest.fn(() => repo)
+  }));
+  return repo;
+};
+
+const mockLockedWorkspaceUsers = (
+  workspaceUsersRepository: ReturnType<typeof createRepo>,
+  rows: unknown[]
+) => {
+  workspaceUsersRepository.createQueryBuilder.mockReturnValueOnce(createLockedRowsQuery(rows));
+};
 
 describe('WorkspaceUsersService', () => {
   let workspaceUsersRepository: ReturnType<typeof createRepo>;
@@ -18,6 +44,21 @@ describe('WorkspaceUsersService', () => {
     workspaceUsersRepository = createRepo();
     usersRepository = createRepo();
     workspacesRepository = createRepo();
+    const transactionManager = {
+      getRepository: jest.fn(entity => {
+        if (entity === WorkspaceUser) {
+          return workspaceUsersRepository;
+        }
+        if (entity === User) {
+          return usersRepository;
+        }
+        if (entity === Workspace) {
+          return workspacesRepository;
+        }
+        return workspaceUsersRepository;
+      })
+    };
+    workspaceUsersRepository.manager.transaction.mockImplementation(callback => callback(transactionManager));
     service = new WorkspaceUsersService(
       workspaceUsersRepository as never,
       usersRepository as never,
@@ -145,15 +186,56 @@ describe('WorkspaceUsersService', () => {
     }));
   });
 
-  it('creates workspace memberships without enabling coding by default', async () => {
-    workspaceUsersRepository.save.mockResolvedValue([{ userId: 11 }]);
+  it('preserves existing workspace memberships and defaults new users to coding access', async () => {
+    mockLockedWorkspaceUsers(workspaceUsersRepository, [
+      {
+        userId: 10,
+        workspaceId: 3,
+        accessLevel: 3,
+        canCode: false
+      },
+      {
+        userId: 12,
+        workspaceId: 3,
+        accessLevel: 1,
+        canCode: true
+      }
+    ]);
+    workspaceUsersRepository.save.mockResolvedValue([{ userId: 10 }, { userId: 11 }]);
 
-    await expect(service.setWorkspaceUsers(3, [11])).resolves.toBe(true);
-    expect(workspaceUsersRepository.save).toHaveBeenCalledWith([{
-      userId: 11,
+    await expect(service.setWorkspaceUsers(3, [10, 11])).resolves.toBe(true);
+    expect(workspaceUsersRepository.delete).toHaveBeenCalledWith({
       workspaceId: 3,
-      accessLevel: 3,
-      canCode: false
-    }]);
+      userId: expect.any(Object)
+    });
+    expect(workspaceUsersRepository.save).toHaveBeenCalledWith([
+      {
+        userId: 10,
+        workspaceId: 3,
+        accessLevel: 3,
+        canCode: false
+      },
+      {
+        userId: 11,
+        workspaceId: 3,
+        accessLevel: 1,
+        canCode: true
+      }
+    ]);
+  });
+
+  it('rejects workspace memberships without a remaining study manager', async () => {
+    mockLockedWorkspaceUsers(workspaceUsersRepository, [
+      {
+        userId: 10,
+        workspaceId: 3,
+        accessLevel: 3,
+        canCode: false
+      }
+    ]);
+
+    await expect(service.setWorkspaceUsers(3, [11])).rejects.toThrow('At least one study manager');
+    expect(workspaceUsersRepository.delete).not.toHaveBeenCalled();
+    expect(workspaceUsersRepository.save).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/app/database/services/workspace/workspace-users.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-users.service.ts
@@ -6,6 +6,12 @@ import User from '../../entities/user.entity';
 import Workspace from '../../entities/workspace.entity';
 import { WorkspaceFullDto } from '../../../../../../../api-dto/workspaces/workspace-full-dto';
 import { WorkspaceSettingsDto } from '../../../../../../../api-dto/workspaces/workspace-settings-dto';
+import {
+  assertStudyManagersRemain,
+  DEFAULT_WORKSPACE_USER_ACCESS,
+  lockUserRows,
+  lockWorkspaceUserRows
+} from './workspace-user-access.util';
 
 @Injectable()
 export class WorkspaceUsersService {
@@ -52,17 +58,49 @@ export class WorkspaceUsersService {
 
   async setWorkspaceUsers(workspaceId: number, userIds: number[]): Promise<boolean> {
     this.logger.log(`Setting users for workspace with id: ${workspaceId}`);
-    const entries = userIds.map(user => ({
-      userId: user,
-      workspaceId: workspaceId,
-      accessLevel: 3,
-      canCode: false
-    }));
-    const hasRights = this.workspaceUsersRepository.find({ where: { workspaceId: workspaceId } });
-    if (hasRights) {
-      await this.workspaceUsersRepository.delete({ workspaceId: workspaceId });
-    }
-    const saved = await this.workspaceUsersRepository.save(entries);
+    const saved = await this.workspaceUsersRepository.manager.transaction(async manager => {
+      const workspaceUsersRepository = manager.getRepository(WorkspaceUser);
+      await lockUserRows(manager, userIds);
+      const existingEntries = await lockWorkspaceUserRows(manager, [workspaceId]);
+      const existingByUserId = new Map(
+        existingEntries.map(entry => [entry.userId, entry])
+      );
+      const userIdSet = new Set(userIds);
+      const entries = userIds.map(userId => {
+        const existingEntry = existingByUserId.get(userId);
+        if (existingEntry && existingEntry.accessLevel > 0) {
+          return {
+            userId,
+            workspaceId: workspaceId,
+            accessLevel: existingEntry.accessLevel,
+            canCode: existingEntry.canCode ?? (existingEntry.accessLevel === 1)
+          };
+        }
+
+        return {
+          userId,
+          workspaceId: workspaceId,
+          ...DEFAULT_WORKSPACE_USER_ACCESS
+        };
+      });
+      const entriesToDelete = existingEntries.filter(entry => !userIdSet.has(entry.userId));
+
+      assertStudyManagersRemain(
+        [workspaceId],
+        existingEntries,
+        entries,
+        entriesToDelete
+      );
+
+      if (entriesToDelete.length > 0) {
+        await workspaceUsersRepository.delete({
+          workspaceId: workspaceId,
+          userId: In(entriesToDelete.map(entry => entry.userId))
+        });
+      }
+
+      return workspaceUsersRepository.save(entries);
+    });
     return !!saved;
   }
 


### PR DESCRIPTION
## Summary
- default new workspace-user assignments to coding access (`accessLevel: 1`, `canCode: true`)
- assign the workspace creator as study manager when a workspace is created
- prevent updates and user deletions from removing the final study manager of a workspace

Relates to #775.

## Validation
- `npx nx lint backend`
- `npx nx build backend`
- targeted Jest specs for users/workspace-users pass; workspace-core/controller specs are blocked locally by the existing `libxmljs2` Node binary mismatch (`NODE_MODULE_VERSION 127` vs `141`)
