### PR TITLE
Filter DERIVE_ERROR source variables by manual scope

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -1054,6 +1054,152 @@ describe('CodingValidationService', () => {
       ]);
     });
 
+    it('should exclude DERIVE_ERROR-only source variables covered by derived variables with manual instructions', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'source-var', responseCount: '2' },
+        { unitName: 'unit1', variableId: 'derived-var', responseCount: '2' }
+      ]);
+      const assignedResponsesQb = createQueryBuilderMock([]);
+      const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(assignedResponsesQb);
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['source-var', 'derived-var'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['derived-var'])]])
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map([
+          [getManualCodingScopeKey('unit1', 'source-var'), new Set(['derived-var'])]
+        ])
+      );
+      mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['derived-var'])]])
+      );
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
+        createSlimResponses(
+          'unit1',
+          'derived-var',
+          2,
+          { statusV1: deriveErrorStatus }
+        ) as never
+      );
+
+      const result = await service.getCodingIncompleteVariables(
+        1,
+        undefined,
+        undefined,
+        true
+      );
+
+      expect(result.map(variable => variable.variableId)).toEqual(['derived-var']);
+      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
+        1,
+        [{ unitName: 'unit1', variableId: 'derived-var', includeDeriveError: true }]
+      );
+    });
+
+    it('should suppress DERIVE_ERROR counts for covered source variables that remain regular candidates', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'source-var', responseCount: '1' },
+        { unitName: 'unit1', variableId: 'derived-var', responseCount: '1' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'source-var', responseCount: '2' },
+        { unitName: 'unit1', variableId: 'derived-var', responseCount: '2' }
+      ]);
+      const assignedResponsesQb = createQueryBuilderMock([]);
+      const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+      const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(assignedResponsesQb);
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['source-var', 'derived-var'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['derived-var'])]])
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map([
+          [getManualCodingScopeKey('unit1', 'source-var'), new Set(['derived-var'])]
+        ])
+      );
+      mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['derived-var'])]])
+      );
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        ...createSlimResponses(
+          'unit1',
+          'source-var',
+          1,
+          { statusV1: codingIncompleteStatus }
+        ),
+        ...createSlimResponses(
+          'unit1',
+          'derived-var',
+          1,
+          { statusV1: codingIncompleteStatus }
+        ),
+        ...createSlimResponses(
+          'unit1',
+          'derived-var',
+          2,
+          { statusV1: deriveErrorStatus }
+        ).map((response, index) => ({ ...response, id: index + 10 }))
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(
+        1,
+        undefined,
+        undefined,
+        true
+      );
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          variableId: 'source-var',
+          deriveErrorResponseCount: 0
+        }),
+        expect.objectContaining({
+          variableId: 'derived-var',
+          deriveErrorResponseCount: 2
+        })
+      ]);
+      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
+        1,
+        [
+          { unitName: 'unit1', variableId: 'source-var' },
+          { unitName: 'unit1', variableId: 'derived-var', includeDeriveError: true }
+        ]
+      );
+    });
+
     it('should apply training deduplication when DERIVE_ERROR case counts are requested without aggregation', async () => {
       const codingIncompleteQb = createQueryBuilderMock([
         { unitName: 'unit1', variableId: 'var1', responseCount: '3' }

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -762,7 +762,9 @@ export class CodingValidationService {
     const variableReferences = variables.map(v => ({
       unitName: v.unitName,
       variableId: v.variableId,
-      ...(includeDeriveErrorInCaseInfo ? { includeDeriveError: true } : {})
+      ...(includeDeriveErrorInCaseInfo && v.deriveErrorResponseCount > 0 ?
+        { includeDeriveError: true } :
+        {})
     }));
     const [slimResponses, assignedResponseIdsByVariable] = await Promise.all([
       this.codingJobService.getSlimResponsesForVariables(
@@ -842,11 +844,13 @@ export class CodingValidationService {
         return { uniqueCases, casesInJobs };
       };
 
-      const regularVarResponses = includeDeriveErrorInCaseInfo ?
+      const includeDeriveErrorForVariable = includeDeriveErrorInCaseInfo &&
+        variable.deriveErrorResponseCount > 0;
+      const regularVarResponses = includeDeriveErrorForVariable ?
         varResponsesWithRequestedStatuses.filter(response => response.statusV1 !== DERIVE_ERROR_STATUS) :
         varResponsesWithRequestedStatuses;
       const regularCaseInfo = countAggregatedCases(regularVarResponses);
-      const deriveErrorCaseInfo = includeDeriveErrorInCaseInfo ?
+      const deriveErrorCaseInfo = includeDeriveErrorForVariable ?
         countAggregatedCases(varResponsesWithRequestedStatuses) :
         null;
 
@@ -1153,6 +1157,32 @@ export class CodingValidationService {
       coveredSourceKeys,
       derivedVariablesBySourceMap
     );
+    const deriveErrorCoveredSourceKeys = includeDeriveErrorOnly ?
+      getCoveredSourceKeysForManualDerivedVariables(
+        Array.from(manualInstructionSets.entries()).flatMap(([manualUnitName, variables]) => (
+          Array.from(variables)
+            .map(variableId => ({ unitName: manualUnitName, variableId }))
+            .filter(row => filterFn({
+              unitName: row.unitName,
+              variableId: row.variableId,
+              responseCount: '0'
+            }))
+        )),
+        derivedVariablesBySourceMap
+      ) :
+      new Set<string>();
+    const getScopedDeriveErrorResponseCount = (
+      responseUnitName: string,
+      variableId: string
+    ): number => (
+      includeDeriveErrorOnly &&
+      isCoveredSourceVariable(
+        { unitName: responseUnitName, variableId },
+        deriveErrorCoveredSourceKeys
+      ) ?
+        0 :
+        deriveErrorCountsByKey.get(`${responseUnitName}::${variableId}`) || 0
+    );
 
     // Merge results, summing response counts for variables that appear in both
     const mergedMap = new Map<string, {
@@ -1168,7 +1198,8 @@ export class CodingValidationService {
       const key = `${row.unitName}::${row.variableId}`;
       const existing = mergedMap.get(key);
       const count = parseInt(row.responseCount, 10);
-      const deriveErrorResponseCount = deriveErrorCountsByKey.get(key) || 0;
+      const deriveErrorResponseCount =
+        getScopedDeriveErrorResponseCount(row.unitName, row.variableId);
       const isDerived = derivedVariableSets.get(row.unitName?.toUpperCase())?.has(row.variableId) ?? false;
       const coderTrainingRequired = trainingRequiredSets.get(row.unitName?.toUpperCase())?.has(row.variableId) ?? false;
 
@@ -1193,6 +1224,14 @@ export class CodingValidationService {
         }
 
         const [deriveUnitName, variableId] = key.split('::');
+        if (
+          isCoveredSourceVariable(
+            { unitName: deriveUnitName, variableId },
+            deriveErrorCoveredSourceKeys
+          )
+        ) {
+          return;
+        }
         if (!filterFn({
           unitName: deriveUnitName,
           variableId,


### PR DESCRIPTION
Related to #711.

Summary:
- Filters DERIVE_ERROR counts for source variables covered by manual derived variables.
- Requests DERIVE_ERROR case details only for variables with scoped DERIVE_ERROR counts.
- Adds regression coverage for manual derived source scopes.

Validation:
- PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npx nx lint backend
- PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts --runInBand
- PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npx nx test backend --runInBand
- git diff --check

Issue #711 remains open for QA and follow-up.