### PR TITLE
Refresh manual coding statistics after apply

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -195,6 +195,7 @@ describe('CodingReviewService', () => {
       jobDefinitionRepository as never,
       variableBundleRepository as never,
       {} as never,
+      {} as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
       } as never,
@@ -357,6 +358,7 @@ describe('CodingReviewService', () => {
       codingJobUnitRepository as never,
       jobDefinitionRepository as never,
       variableBundleRepository as never,
+      {} as never,
       {} as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
@@ -1332,12 +1334,19 @@ describe('CodingReviewService', () => {
         ))
       }
     };
+    const codingStatisticsService = {
+      invalidateCache: jest.fn().mockResolvedValue(undefined)
+    };
+    const codingAnalysisService = {
+      invalidateCache: jest.fn().mockResolvedValue(undefined)
+    };
     const localService = new CodingReviewService(
       responseRepository as never,
       codingJobUnitRepository as never,
       jobDefinitionRepository as never,
       variableBundleRepository as never,
-      {} as never,
+      codingStatisticsService as never,
+      codingAnalysisService as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
       } as never,
@@ -1388,6 +1397,8 @@ describe('CodingReviewService', () => {
       failedCount: 0,
       skippedCount: 0
     });
+    expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(workspaceId);
+    expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(workspaceId);
   });
 
   it('skips explicit replay decisions with codes unsupported by the coding scheme', async () => {
@@ -1414,6 +1425,7 @@ describe('CodingReviewService', () => {
       codingJobUnitRepository as never,
       jobDefinitionRepository as never,
       variableBundleRepository as never,
+      {} as never,
       {} as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
@@ -1461,6 +1473,7 @@ describe('CodingReviewService', () => {
       codingJobUnitRepository as never,
       jobDefinitionRepository as never,
       variableBundleRepository as never,
+      {} as never,
       {} as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
@@ -1537,6 +1550,7 @@ describe('CodingReviewService', () => {
       jobDefinitionRepository as never,
       variableBundleRepository as never,
       codingStatisticsService as never,
+      {} as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
       } as never,

--- a/apps/backend/src/app/database/services/coding/coding-review.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.ts
@@ -19,6 +19,7 @@ import {
   isCodingIssueReviewJobType
 } from './coding-job-type.util';
 import { CodingJobService } from './coding-job.service';
+import { CodingAnalysisService } from './coding-analysis.service';
 
 type JobDefinitionBundleScope = {
   bundleIds: number[];
@@ -101,6 +102,7 @@ export class CodingReviewService {
     @InjectRepository(VariableBundle)
     private variableBundleRepository: Repository<VariableBundle>,
     private codingStatisticsService: CodingStatisticsService,
+    private codingAnalysisService: CodingAnalysisService,
     private workspaceExclusionService: WorkspaceExclusionService,
     private codingJobService: CodingJobService,
     @Optional()
@@ -1189,6 +1191,13 @@ export class CodingReviewService {
           }
         }
       });
+
+      if (appliedCount > 0 && typeof this.codingStatisticsService.invalidateCache === 'function') {
+        await this.codingStatisticsService.invalidateCache(workspaceId);
+      }
+      if (appliedCount > 0 && typeof this.codingAnalysisService.invalidateCache === 'function') {
+        await this.codingAnalysisService.invalidateCache(workspaceId);
+      }
 
       const message = `Applied ${appliedCount} resolutions successfully. ${failedCount > 0 ? `${failedCount} failed.` : ''
       } ${skippedCount > 0 ? `${skippedCount} skipped.` : ''}`;

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1206,7 +1206,15 @@ describe('CodingManagementManualComponent', () => {
       refreshAllStatistics(): void;
       loadResponseAnalysis(): void;
       reloadCodingJobsList(): void;
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        notifyTestResultsChanged: jest.Mock;
+      };
     };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    const notifyTestResultsChangedSpy = jest
+      .spyOn(componentInternals.testPersonCodingService, 'notifyTestResultsChanged')
+      .mockImplementation();
     const loadCodingFreshnessSpy = jest
       .spyOn(componentInternals, 'loadCodingFreshness')
       .mockImplementation();
@@ -1222,6 +1230,10 @@ describe('CodingManagementManualComponent', () => {
 
     componentInternals.refreshAfterApplyingCodingResults();
 
+    expect(notifyTestResultsChangedSpy).toHaveBeenCalledWith({
+      workspaceId: 5,
+      statisticsVersion: 'v2'
+    });
     expect(refreshAllStatisticsSpy).toHaveBeenCalled();
     expect(loadResponseAnalysisSpy).toHaveBeenCalled();
     expect(loadCodingFreshnessSpy).toHaveBeenCalled();

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -3070,6 +3070,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private refreshAfterApplyingCodingResults(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (workspaceId) {
+      this.testPersonCodingService.notifyTestResultsChanged({
+        workspaceId,
+        statisticsVersion: 'v2'
+      });
+    }
     this.refreshAllStatistics();
     this.loadResponseAnalysis();
     this.loadCodingFreshness();

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
@@ -237,7 +237,8 @@ describe('DoubleCodedReviewComponent', () => {
               failedCount: 0,
               skippedCount: 0,
               message: 'ok'
-            }))
+            })),
+            notifyTestResultsChanged: jest.fn()
           }
         },
         {
@@ -381,6 +382,7 @@ describe('DoubleCodedReviewComponent', () => {
   it('stores and applies a replay code selection that has no coder result', async () => {
     const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
       applyDoubleCodedResolutions: jest.Mock;
+      notifyTestResultsChanged: jest.Mock;
     };
     const replaySource = {} as MessageEventSource;
     const harness = component as unknown as ReplaySelectionHarness;
@@ -411,6 +413,10 @@ describe('DoubleCodedReviewComponent', () => {
 
     expect(testPersonCodingService.applyDoubleCodedResolutions).toHaveBeenCalledWith(1, {
       decisions: [{ responseId: 501, code: 3, score: 2 }]
+    });
+    expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalledWith({
+      workspaceId: 1,
+      statisticsVersion: 'v2'
     });
   });
 

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -1282,6 +1282,12 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
         }).subscribe(message => {
           this.showSuccess(message);
         });
+        if (response.appliedCount > 0) {
+          this.testPersonCodingService.notifyTestResultsChanged({
+            workspaceId,
+            statisticsVersion: 'v2'
+          });
+        }
         this.resultsApplied = true;
         this.loadData();
       },


### PR DESCRIPTION
## Summary

- Switch the coding overview to manual statistics after manual results are applied.
- Notify the overview after double-coded resolutions apply v2 results.
- Invalidate statistics and response-analysis caches after double-coded resolutions are written.

## Root Cause

Manual result application updated v2 response data, but the overview could remain on the first autocoder run and stale cached analysis data after related review flows.

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-results.service.spec.ts --runInBand`
- `docker compose --env-file .env.dev exec -T backend npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-review.service.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts --runInBand`
- `npx nx lint frontend`
- `npx nx lint backend`
- Browser check with workspace 47: applying six completed jobs switched the overview to `Manuelle Kodierung`, showing `CODING_COMPLETE +35` and `CODING_INCOMPLETE -35`.

Related: #707