### PR TITLE
Fix replay notes in double-coded review

### DIFF
--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
@@ -24,6 +24,7 @@ describe('DoubleCodedReviewComponent', () => {
     variableId: unknown;
     code: unknown;
     score?: unknown;
+    notes?: unknown;
     responseId: number;
   };
 
@@ -366,17 +367,76 @@ describe('DoubleCodedReviewComponent', () => {
       variableId: 'VAR_1',
       code: '2',
       score: 1,
+      notes: 'Replay note',
       responseId: 501
     }, replaySource);
 
     const item = component.dataSource.data.find(row => row.responseId === 501);
     expect(component.selectionForm.get('item_501')?.value).toBe('1002');
+    expect(component.selectionForm.get('comment_501')?.value).toBe('Replay note');
     expect(item?.selectedCoderResult?.jobId).toBe(1002);
     expect(snackBar.open).toHaveBeenCalledWith(
       'double-coded-review.success.replay-code-selected',
       'close',
       expect.objectContaining({ panelClass: ['success-snackbar'] })
     );
+  });
+
+  it('clears a transferred replay note when the replay sends empty notes', async () => {
+    const replaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    harness.replayWindowByResponseId.set(501, replaySource);
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '2',
+      score: 1,
+      notes: 'Replay note',
+      responseId: 501
+    }, replaySource);
+
+    expect(component.selectionForm.get('comment_501')?.value).toBe('Replay note');
+
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '2',
+      score: 1,
+      notes: '   ',
+      responseId: 501
+    }, replaySource);
+
+    expect(component.selectionForm.get('comment_501')?.value).toBe('');
+  });
+
+  it('keeps existing comments when replay selections do not include notes', async () => {
+    const replaySource = {} as MessageEventSource;
+    const harness = component as unknown as ReplaySelectionHarness;
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const item = component.dataSource.data.find(row => row.responseId === 501)!;
+    component.getCommentControl(item).setValue('Manual review comment');
+    harness.replayWindowByResponseId.set(501, replaySource);
+
+    harness.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'person-1@P001@Booklet 1',
+      unitId: 'Unit A',
+      variableId: 'VAR_1',
+      code: '2',
+      score: 1,
+      responseId: 501
+    }, replaySource);
+
+    expect(component.selectionForm.get('comment_501')?.value).toBe('Manual review comment');
   });
 
   it('stores and applies a replay code selection that has no coder result', async () => {
@@ -397,6 +457,7 @@ describe('DoubleCodedReviewComponent', () => {
       variableId: 'VAR_1',
       code: '3',
       score: 2,
+      notes: 'Replay note',
       responseId: 501
     }, replaySource);
 
@@ -412,7 +473,12 @@ describe('DoubleCodedReviewComponent', () => {
     component.applySingleDecision(item!);
 
     expect(testPersonCodingService.applyDoubleCodedResolutions).toHaveBeenCalledWith(1, {
-      decisions: [{ responseId: 501, code: 3, score: 2 }]
+      decisions: [{
+        responseId: 501,
+        code: 3,
+        score: 2,
+        resolutionComment: 'Replay note'
+      }]
     });
     expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalledWith({
       workspaceId: 1,

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -77,6 +77,7 @@ interface ReplayDecisionResult {
   source: 'replay';
   code: number;
   score: number | null;
+  notes?: string;
 }
 
 type DecisionResult = CoderResult | ReplayDecisionResult;
@@ -87,6 +88,7 @@ interface ReplayCodeSelectedMessage extends PostMessage {
   variableId: unknown;
   code: unknown;
   score?: unknown;
+  notes?: unknown;
   responseId?: number;
 }
 
@@ -836,6 +838,8 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       return;
     }
 
+    const hasReplayNotes = Object.prototype.hasOwnProperty.call(data, 'notes');
+    const replayNotes = this.normalizeReplayMessageText(data.notes);
     const selectedResult = this.findReplaySelectedResult(item, selectedCode, selectedScore);
 
     if (selectedResult) {
@@ -843,6 +847,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
       this.replayDecisionByResponseId.delete(item.responseId);
       this.getOrCreateFormControl(this.getItemControlName(item)).setValue(selectedJobId);
       this.onSelectionChange(item, selectedJobId);
+      this.applyReplayNotesToComment(item, replayNotes, hasReplayNotes);
       this.showSuccess(this.translateService.instant('double-coded-review.success.replay-code-selected'));
       return;
     }
@@ -850,13 +855,23 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     const replayDecision: ReplayDecisionResult = {
       source: 'replay',
       code: selectedCode,
-      score: selectedScore.value
+      score: selectedScore.value,
+      ...(replayNotes ? { notes: replayNotes } : {})
     };
     this.replayDecisionByResponseId.set(item.responseId, replayDecision);
     item.selectedCoderResult = undefined;
     this.getOrCreateFormControl(this.getItemControlName(item))
       .setValue(this.getReplayDecisionControlValue(item));
+    this.applyReplayNotesToComment(item, replayNotes, hasReplayNotes);
     this.showSuccess(this.translateService.instant('double-coded-review.success.replay-code-selected'));
+  }
+
+  private applyReplayNotesToComment(item: DoubleCodedItem, notes: string, hasReplayNotes: boolean): void {
+    if (!hasReplayNotes) {
+      return;
+    }
+
+    this.getOrCreateFormControl(this.getCommentControlName(item)).setValue(notes);
   }
 
   private isReplayMessageSourceAllowed(
@@ -1259,12 +1274,10 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     item: DoubleCodedItem,
     decision: DoubleCodedResolutionDecision
   ): DoubleCodedResolutionDecision {
-    if (this.hasConflict(item)) {
-      const commentControlName = this.getCommentControlName(item);
-      const comment = this.selectionForm.get(commentControlName)?.value;
-      if (comment && comment.trim()) {
-        decision.resolutionComment = comment.trim();
-      }
+    const commentControlName = this.getCommentControlName(item);
+    const comment = this.selectionForm.get(commentControlName)?.value;
+    if (comment && comment.trim()) {
+      decision.resolutionComment = comment.trim();
     }
 
     return decision;

--- a/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
@@ -698,6 +698,18 @@ describe('ReplayCodingService', () => {
       expect(codingJobBackendServiceMock.saveCodingProgress).not.toHaveBeenCalled();
     });
 
+    it('keeps decision replay notes locally when there is no coding job', async () => {
+      await service.saveNotes(1, 'login@code@group@booklet', 'UNIT', 'VAR', 'note');
+
+      expect(service.getNotes('login@code@group@booklet', 'UNIT', 'VAR')).toBe('note');
+      expect(codingJobBackendServiceMock.saveCodingNotes).not.toHaveBeenCalled();
+
+      await service.saveNotes(1, 'login@code@group@booklet', 'UNIT', 'VAR', '   ');
+
+      expect(service.getNotes('login@code@group@booklet', 'UNIT', 'VAR')).toBe('');
+      expect(codingJobBackendServiceMock.saveCodingNotes).not.toHaveBeenCalled();
+    });
+
     it('marks note saves as issue reviews in coding issue review mode', async () => {
       codingJobBackendServiceMock.saveCodingNotes.mockReturnValue(of({} as CodingJob));
       service.codingJobId = 100;

--- a/apps/frontend/src/app/replay/services/replay-coding.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.ts
@@ -517,6 +517,15 @@ export class ReplayCodingService {
     return this.notes.get(compositeKey) || '';
   }
 
+  updateLocalNotes(testPerson: string, unitId: string, variableId: string, notes: string): void {
+    const compositeKey = this.generateCompositeKey(testPerson, unitId, variableId);
+    if (notes.trim()) {
+      this.notes.set(compositeKey, notes);
+    } else {
+      this.notes.delete(compositeKey);
+    }
+  }
+
   async saveNotes(
     workspaceId: number,
     testPerson: string,
@@ -529,21 +538,21 @@ export class ReplayCodingService {
     const authToken = this.authToken;
     const authTokenArg: [string] | [] = authToken ? [authToken] : [];
     const contextSnapshot = this.captureCodingContext();
-    if (!jobId || !workspaceId) return;
     if (this.isReviewMode) return;
 
     const compositeKey = this.generateCompositeKey(testPerson, unitId, variableId);
     const selectionRevisionAtStart = this.latestSelectionRevisionByKey.get(compositeKey) ?? 0;
     const saveFailureKey = this.getSaveFailureKey('notes', compositeKey);
     const trimmedNotes = notes.trim();
+    if (!jobId || !workspaceId) {
+      this.updateLocalNotes(testPerson, unitId, variableId, notes);
+      return;
+    }
+
     await this.enqueueRowMutation(compositeKey, async () => {
       try {
         if (this.isCurrentCodingContext(contextSnapshot)) {
-          if (trimmedNotes) {
-            this.notes.set(compositeKey, notes);
-          } else {
-            this.notes.delete(compositeKey);
-          }
+          this.updateLocalNotes(testPerson, unitId, variableId, notes);
         }
 
         await firstValueFrom(


### PR DESCRIPTION
## Summary
- keep coding-decision replay notes locally when the replay has no coding job context
- transfer replay notes into the double-coded review comment field when a replay code is selected
- clear transferred comments when the replay sends empty notes, while preserving existing comments if no notes payload is sent

## Context
Related to #701. This does not close the issue.

## Validation
- npx nx lint frontend
- npx nx test frontend --runInBand=true
- external Chromium roundtrip: replay popup had window.opener, note was transferred to the review dialog, then cleared when the replay note was emptied
