### PR TITLE
Require review status for coding issue actions

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -2462,7 +2462,8 @@ describe('CodingJobService', () => {
       response_matching_flags: null,
       aggregation_settings_version: 1,
       freshness_status: 'current',
-      freshness_reason: null
+      freshness_reason: null,
+      status: 'review'
     };
     const sourceUnit = {
       coding_job_id: 1,
@@ -2550,7 +2551,8 @@ describe('CodingJobService', () => {
       response_matching_flags: null,
       aggregation_settings_version: 1,
       freshness_status: 'current',
-      freshness_reason: null
+      freshness_reason: null,
+      status: 'review'
     };
     const sourceUnit = {
       coding_job_id: 1,
@@ -2609,8 +2611,52 @@ describe('CodingJobService', () => {
     );
   });
 
+  it.each(['active', 'completed', 'open', 'paused'])(
+    'rejects coding issue review progress for %s source jobs',
+    async status => {
+      codingJobRepository.findOne.mockResolvedValueOnce({
+        id: 1,
+        workspace_id: 3,
+        status
+      });
+
+      await expect(service.saveCodingIssueReviewProgress(1, 42, {
+        testPerson: 'login@code@booklet',
+        unitId: 'UNIT',
+        variableId: 'VAR',
+        selectedCode: { id: 7 }
+      } as never)).rejects.toThrow(
+        'Coding issue review can only be saved for coding jobs submitted for review'
+      );
+      expect(codingJobUnitRepository.findOne).not.toHaveBeenCalled();
+      expect(codingJobUnitRepository.save).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['active', 'completed', 'open', 'paused'])(
+    'rejects coding issue review notes for %s source jobs',
+    async status => {
+      codingJobRepository.findOne.mockResolvedValueOnce({
+        id: 1,
+        workspace_id: 3,
+        status
+      });
+
+      await expect(service.saveCodingIssueReviewNotes(1, 42, {
+        testPerson: 'login@code@booklet',
+        unitId: 'UNIT',
+        variableId: 'VAR',
+        notes: 'note'
+      })).rejects.toThrow(
+        'Coding issue review can only be saved for coding jobs submitted for review'
+      );
+      expect(codingJobUnitRepository.findOne).not.toHaveBeenCalled();
+      expect(codingJobUnitRepository.save).not.toHaveBeenCalled();
+    }
+  );
+
   it('rejects coding issue review progress for units that do not require review', async () => {
-    const sourceJob = { id: 1, workspace_id: 3, status: 'completed' };
+    const sourceJob = { id: 1, workspace_id: 3, status: 'review' };
     const sourceUnit = {
       coding_job_id: 1,
       workspace_id: 3,
@@ -2642,7 +2688,7 @@ describe('CodingJobService', () => {
   });
 
   it('rejects coding issue review notes for units that do not require review', async () => {
-    const sourceJob = { id: 1, workspace_id: 3, status: 'completed' };
+    const sourceJob = { id: 1, workspace_id: 3, status: 'review' };
     const sourceUnit = {
       coding_job_id: 1,
       workspace_id: 3,
@@ -2674,7 +2720,7 @@ describe('CodingJobService', () => {
   });
 
   it('does not create a blank coding issue review unit for notes-only saves', async () => {
-    const sourceJob = { id: 1, workspace_id: 3, status: 'completed' };
+    const sourceJob = { id: 1, workspace_id: 3, status: 'review' };
     const sourceUnit = {
       coding_job_id: 1,
       workspace_id: 3,
@@ -2724,7 +2770,7 @@ describe('CodingJobService', () => {
       aggregation_settings_version: 1,
       freshness_status: 'current',
       freshness_reason: null,
-      status: 'completed'
+      status: 'review'
     };
     const sourceUnit = {
       coding_job_id: 1,

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -924,6 +924,16 @@ export class CodingJobService {
     }
   }
 
+  private assertCodingIssueReviewSourceJobStatus(
+    sourceCodingJob: Pick<CodingJob, 'status'>
+  ): void {
+    if (sourceCodingJob.status !== 'review') {
+      throw new BadRequestException(
+        'Coding issue review can only be saved for coding jobs submitted for review'
+      );
+    }
+  }
+
   private async getCodingIssueReviewJobsForSource(
     sourceCodingJob: Pick<CodingJob, 'id' | 'workspace_id'>
   ): Promise<CodingJob[]> {
@@ -3641,6 +3651,7 @@ export class CodingJobService {
         'Cannot save progress for a coding job whose results have already been applied'
       );
     }
+    this.assertCodingIssueReviewSourceJobStatus(sourceCodingJob);
 
     const sourceUnit = await this.getCodingJobUnitForEntry(
       sourceCodingJob,
@@ -4094,6 +4105,7 @@ export class CodingJobService {
         'Cannot save notes for a coding job whose results have already been applied'
       );
     }
+    this.assertCodingIssueReviewSourceJobStatus(sourceCodingJob);
 
     const sourceUnit = await this.getCodingJobUnitForEntry(
       sourceCodingJob,

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.html
@@ -160,15 +160,20 @@
       <ng-container matColumnDef="actions">
         <mat-header-cell *matHeaderCellDef>Aktionen</mat-header-cell>
         <mat-cell *matCellDef="let result">
-          <button *ngIf="isCodingIssueOption(result)" mat-icon-button color="primary"
-            (click)="reviewCodingResult(result)" matTooltip="Kodierungs-Hinweis überprüfen"
-            aria-label="Kodierungs-Hinweis überprüfen">
-            <mat-icon>replay</mat-icon>
-          </button>
-          <button *ngIf="isNewCodeNeeded(result)" mat-icon-button color="primary" (click)="editCodingScheme(result)"
-            matTooltip="Kodierungsschema bearbeiten" aria-label="Kodierungsschema bearbeiten">
-            <mat-icon>edit</mat-icon>
-          </button>
+          <span *ngIf="isCodingIssueOption(result)" class="action-button-wrapper"
+            [matTooltip]="getReviewCodingResultTooltip(result)">
+            <button mat-icon-button color="primary" [disabled]="!canReviewCodingResult(result)"
+              (click)="reviewCodingResult(result)" [attr.aria-label]="getReviewCodingResultTooltip(result)">
+              <mat-icon>replay</mat-icon>
+            </button>
+          </span>
+          <span *ngIf="isNewCodeNeeded(result)" class="action-button-wrapper"
+            [matTooltip]="getEditCodingSchemeTooltip(result)">
+            <button mat-icon-button color="primary" [disabled]="!canEditCodingScheme(result)"
+              (click)="editCodingScheme(result)" [attr.aria-label]="getEditCodingSchemeTooltip(result)">
+              <mat-icon>edit</mat-icon>
+            </button>
+          </span>
         </mat-cell>
       </ng-container>
 

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.scss
@@ -143,6 +143,10 @@
       max-width: 120px;
     }
 
+    .action-button-wrapper {
+      display: inline-flex;
+    }
+
     .coded {
       color: #4caf50;
       font-weight: 500;

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
@@ -519,8 +519,74 @@ describe('CodingJobResultDialogComponent', () => {
     } as never)).toBe(false);
   });
 
+  it('should only enable coding issue actions after the job was submitted for review', () => {
+    const codingIssueResult = {
+      codingIssueOption: -1,
+      codingIssueOptionLabel: 'Unsichere Kodierung'
+    } as never;
+    const newCodeResult = {
+      codingIssueOption: -2,
+      codingIssueOptionLabel: 'Neuer Code nötig'
+    } as never;
+
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      status: 'active'
+    };
+
+    expect(component.canReviewCodingResult(codingIssueResult)).toBe(false);
+    expect(component.canEditCodingScheme(newCodeResult)).toBe(false);
+    expect(component.getReviewCodingResultTooltip(codingIssueResult))
+      .toContain('Zur Überprüfung');
+
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      status: 'review'
+    };
+
+    expect(component.canReviewCodingResult(codingIssueResult)).toBe(true);
+    expect(component.canEditCodingScheme(newCodeResult)).toBe(true);
+  });
+
+  it('should not open coding issue review before the job was submitted for review', () => {
+    const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    const snackBar = TestBed.inject(MatSnackBar) as unknown as MatSnackBarMock;
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      status: 'active'
+    };
+
+    component.reviewCodingResult({
+      unitName: 'UNIT_1',
+      unitAlias: 'Unit Alias',
+      variableId: 'VAR_1',
+      variableAnchor: 'VAR_1',
+      variablePage: '2',
+      bookletName: 'BOOKLET_A',
+      personLogin: 'login',
+      personCode: 'code',
+      personGroup: 'group',
+      testPerson: 'login@code@group@BOOKLET_A',
+      codingIssueOption: -1,
+      codingIssueOptionLabel: 'Unsichere Kodierung'
+    } as never);
+
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Kodierungshinweise können erst im Status "Zur Überprüfung" geprüft werden',
+      'Schließen',
+      { duration: 3000 }
+    );
+
+    windowOpenSpy.mockRestore();
+  });
+
   it('should open replay with a valid hash route URL', () => {
     const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      status: 'review'
+    };
 
     component.reviewCodingResult({
       unitName: 'UNIT_1',

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
@@ -832,6 +832,34 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
     return result.codingIssueOption === -1 || result.codingIssueOption === -2;
   }
 
+  isCodingIssueReviewEnabled(): boolean {
+    return this.data.codingJob.status === 'review';
+  }
+
+  canReviewCodingResult(result: CodingResult): boolean {
+    return this.isCodingIssueReviewEnabled() && this.isCodingIssueOption(result);
+  }
+
+  canEditCodingScheme(result: CodingResult): boolean {
+    return this.isCodingIssueReviewEnabled() && this.isNewCodeNeeded(result);
+  }
+
+  getReviewCodingResultTooltip(result: CodingResult): string {
+    if (!this.isCodingIssueReviewEnabled() && this.isCodingIssueOption(result)) {
+      return 'Kodierungshinweise können erst im Status "Zur Überprüfung" geprüft werden';
+    }
+
+    return 'Kodierungs-Hinweis überprüfen';
+  }
+
+  getEditCodingSchemeTooltip(result: CodingResult): string {
+    if (!this.isCodingIssueReviewEnabled() && this.isNewCodeNeeded(result)) {
+      return 'Kodierungsschema kann erst im Status "Zur Überprüfung" bearbeitet werden';
+    }
+
+    return 'Kodierungsschema bearbeiten';
+  }
+
   isNewCodeNeeded(result: CodingResult): boolean {
     return result.codingIssueOption === -2;
   }
@@ -864,6 +892,15 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
   reviewCodingResult(result: CodingResult): void {
     if (!result || !this.isCodingIssueOption(result)) {
       this.snackBar.open('Nur Kodierungs-Hinweis-Fälle können überprüft werden', 'Schließen', { duration: 3000 });
+      return;
+    }
+
+    if (!this.isCodingIssueReviewEnabled()) {
+      this.snackBar.open(
+        'Kodierungshinweise können erst im Status "Zur Überprüfung" geprüft werden',
+        'Schließen',
+        { duration: 3000 }
+      );
       return;
     }
 
@@ -909,6 +946,15 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
   editCodingScheme(result: CodingResult): void {
     if (!result || !this.isNewCodeNeeded(result)) {
       this.snackBar.open('Nur "Neuer Code erforderlich" Fälle können bearbeitet werden', 'Schließen', { duration: 3000 });
+      return;
+    }
+
+    if (!this.isCodingIssueReviewEnabled()) {
+      this.snackBar.open(
+        'Kodierungsschema kann erst im Status "Zur Überprüfung" bearbeitet werden',
+        'Schließen',
+        { duration: 3000 }
+      );
       return;
     }
 


### PR DESCRIPTION
## Summary

- Disable coding issue review and coding scheme edit actions in the coding job results dialog until a job is in status `review`.
- Add backend validation so coding issue review progress and notes can only be saved for source jobs submitted for review.
- Cover the review-status gating with frontend and backend tests.

## Context

Related issue: #704. This PR intentionally does not use an auto-closing issue keyword.

## Validation

- `npx nx lint frontend`
- `npx nx lint backend`
- `npx nx test frontend --runTestsByPath=apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job.service.spec.ts`
- Local Docker UI check: completed jobs show disabled review actions; review jobs show active actions; saved issue-review decision is reflected in the results dialog.
