### PR TITLE
Include code 0 in codebook export

### DIFF
--- a/apps/backend/src/app/admin/code-book/codebook-generator.class.spec.ts
+++ b/apps/backend/src/app/admin/code-book/codebook-generator.class.spec.ts
@@ -112,9 +112,46 @@ describe('CodebookGenerator', () => {
         { ...manualCode, id: 3, ruleSet: undefined }
       ],
       { ...contentSetting, codeLabelToUpper: true }
-    ) as unknown[];
+    ) as { id: string }[];
     expect(Array.isArray(codeInfos)).toBe(true);
     expect(codeInfos.length).toBeGreaterThan(0);
+    expect(codeInfos.map(codeInfo => codeInfo.id)).toContain('0');
+  });
+
+  it('includes code 0 in generated codebook output', async () => {
+    const codebookBuffer = await CodebookGenerator.generateCodebook(
+      [
+        {
+          id: 1,
+          key: 'UNIT.VOCS',
+          name: 'Unit',
+          scheme: JSON.stringify({
+            version: '3.0',
+            variableCodings: [
+              {
+                ...variableCoding,
+                codes: [
+                  {
+                    ...manualCode, id: 0, label: 'Code 0', score: 0, type: 'NO_CREDIT'
+                  },
+                  {
+                    ...manualCode, id: 1, label: 'Code 1', score: 1, type: 'FULL_CREDIT'
+                  }
+                ]
+              }
+            ]
+          })
+        }
+      ],
+      contentSetting as never,
+      []
+    );
+
+    const codebook = JSON.parse(codebookBuffer.toString('utf-8')) as Array<{
+      variables: Array<{ codes: Array<{ id: string }> }>;
+    }>;
+
+    expect(codebook[0].variables[0].codes.map(code => code.id)).toEqual(['0', '1']);
   });
 
   it('filters codes without manual instructions in manual codebooks without closed variables', () => {

--- a/apps/backend/src/app/admin/code-book/codebook-generator.class.ts
+++ b/apps/backend/src/app/admin/code-book/codebook-generator.class.ts
@@ -161,7 +161,7 @@ export class CodebookGenerator {
       if (this.shouldHideCodeInManualCodebook(code, contentSetting)) {
         return codeInfos;
       }
-      if (code.id) {
+      if (code.id !== undefined && code.id !== null) {
         try {
           const codeInfo = this.getCodeInfoFromCodeAsText(code, contentSetting);
           codeInfos.push(codeInfo);


### PR DESCRIPTION
## Summary
- Include numeric code `0` when building Codebook code entries.
- Add regression coverage for direct code extraction and generated JSON Codebook output.

## Root Cause
The Codebook generator checked `code.id` with a truthy condition, so the valid numeric code `0` was treated like a missing ID and skipped.

## Validation
- `npx nx lint backend`
- `npx nx test backend --testFile=apps/backend/src/app/admin/code-book/codebook-generator.class.spec.ts`
- `npx nx test backend --runInBand`

Related: #784
