### PR TITLE
Handle coding freshness warnings on file upload

### DIFF
--- a/api-dto/files/test-files-upload-result.dto.ts
+++ b/api-dto/files/test-files-upload-result.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { TestResultsUploadIssueDto } from './test-results-upload-result.dto';
 
 export type TestFilesUploadConflictDto = {
   fileId: string;
@@ -35,4 +36,7 @@ export class TestFilesUploadResultDto {
 
   @ApiProperty({ type: [Object], required: false })
     uploadedFiles?: TestFilesUploadUploadedDto[];
+
+  @ApiProperty({ type: [Object], required: false })
+    issues?: TestResultsUploadIssueDto[];
 }

--- a/api-dto/files/test-results-upload-result.dto.ts
+++ b/api-dto/files/test-results-upload-result.dto.ts
@@ -32,6 +32,7 @@ export type TestResultsUploadIssueCategory =
   'timestamp' |
   'missing_booklet_log' |
   'no_logs_saved' |
+  'coding_freshness' |
   'other';
 
 export type TestResultsUploadIssueDto = {

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
@@ -19,6 +19,7 @@ describe('TestCenterService', () => {
   let service: TestcenterService;
   let httpService: { put: jest.Mock; axiosRef: { get: jest.Mock } };
   let personService: DeepMocked<PersonService>;
+  let workspaceFilesService: DeepMocked<WorkspaceFilesService>;
   let cacheService: DeepMocked<CacheService>;
   let workspaceTestResultsService: DeepMocked<WorkspaceTestResultsService>;
   let codingFreshnessService: DeepMocked<CodingFreshnessService>;
@@ -95,6 +96,7 @@ describe('TestCenterService', () => {
     service = module.get<TestcenterService>(TestcenterService);
     httpService = module.get(HttpService);
     personService = module.get(PersonService);
+    workspaceFilesService = module.get(WorkspaceFilesService);
     cacheService = module.get(CacheService);
     workspaceTestResultsService = module.get(WorkspaceTestResultsService);
     codingFreshnessService = module.get(CodingFreshnessService);
@@ -320,6 +322,77 @@ describe('TestCenterService', () => {
           '',
           mockAuthToken
         )).rejects.toThrow('Unexpected Testcenter response');
+      });
+    });
+
+    describe('importWorkspaceFiles', () => {
+      it('should forward test file upload issues from Testcenter imports', async () => {
+        const codingFreshnessIssue = {
+          level: 'warning' as const,
+          category: 'coding_freshness' as const,
+          message: 'Kodierstand konnte nicht aktualisiert werden.'
+        };
+        const testcenterFile = {
+          name: 'definition.voud',
+          size: 123,
+          modificationTime: Date.now(),
+          type: 'Resource',
+          id: 'file-1',
+          report: [],
+          info: {
+            label: 'Definition',
+            description: ''
+          },
+          data: ''
+        };
+        httpService.axiosRef.get
+          .mockResolvedValueOnce({
+            data: {
+              Booklet: [],
+              Resource: [testcenterFile],
+              Unit: [],
+              Testtakers: []
+            }
+          } as AxiosResponse)
+          .mockResolvedValueOnce({ data: testcenterFile } as AxiosResponse);
+        workspaceFilesService.testCenterImport.mockResolvedValue({
+          total: 1,
+          uploaded: 1,
+          failed: 0,
+          uploadedFiles: [{
+            fileId: 'file-1',
+            filename: 'definition.voud',
+            fileType: 'Resource'
+          }],
+          failedFiles: [],
+          conflicts: [],
+          issues: [codingFreshnessIssue]
+        });
+
+        const result = await service.importWorkspaceFiles(
+          '123',
+          'ws-456',
+          'demo',
+          '',
+          'test-token',
+          {
+            responses: 'false',
+            logs: 'false',
+            definitions: 'true',
+            units: 'false',
+            player: 'false',
+            codings: 'false',
+            testTakers: 'false',
+            booklets: 'false',
+            metadata: 'false'
+          },
+          'group1'
+        );
+
+        expect(result.testFilesUploadResult?.issues).toEqual([
+          codingFreshnessIssue
+        ]);
+        expect(result.issues).toEqual([codingFreshnessIssue]);
       });
     });
   });

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.ts
@@ -815,6 +815,7 @@ export class TestcenterService {
       const uploadedFiles: TestFilesUploadUploadedDto[] = [];
       const failedFiles: TestFilesUploadFailedDto[] = [];
       const conflicts: NonNullable<TestFilesUploadResultDto['conflicts']> = [];
+      const issues: TestResultsUploadIssueDto[] = [];
 
       for (const { optionKey, file } of filesWithOption) {
         await this.setCurrentFileProgress(
@@ -868,6 +869,9 @@ export class TestcenterService {
           if ((perFileResult.conflicts || []).length > 0) {
             conflicts.push(...(perFileResult.conflicts || []));
           }
+          if ((perFileResult.issues || []).length > 0) {
+            issues.push(...(perFileResult.issues || []));
+          }
 
           await this.applyFileResultProgress(
             workspace_id,
@@ -896,7 +900,8 @@ export class TestcenterService {
         failed: failedFiles.length,
         uploadedFiles,
         failedFiles,
-        conflicts
+        conflicts,
+        issues: issues.length > 0 ? issues : undefined
       };
 
       if (importRunId) {
@@ -1096,6 +1101,7 @@ export class TestcenterService {
         result.filesTestTakers = filesResult.filesTestTakers;
         result.filesMetadata = filesResult.filesMetadata;
         result.testFilesUploadResult = filesResult.uploadResult;
+        appendIssues(filesResult.uploadResult.issues);
       }
 
       if (responses === 'true') {

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
@@ -184,6 +184,10 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
     findOne: jest.fn(),
     upsert: jest.fn().mockResolvedValue(undefined)
   };
+  const mockCodingStatisticsService = {
+    invalidateCache: jest.fn().mockResolvedValue(undefined),
+    invalidateIncompleteVariablesCache: jest.fn().mockResolvedValue(undefined)
+  };
   const mockCodingFreshnessService = {
     markUnitsStaleAfterCodingSchemeChange: jest.fn().mockResolvedValue(undefined)
   };
@@ -197,7 +201,7 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
       {} as unknown as CtorParams[1],
       {} as unknown as CtorParams[2],
       {} as unknown as CtorParams[3],
-      {} as unknown as CtorParams[4],
+      mockCodingStatisticsService as unknown as CtorParams[4],
       {} as unknown as CtorParams[5],
       {} as unknown as CtorParams[6],
       {} as unknown as CtorParams[7],
@@ -327,6 +331,37 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
 
     expect(mockCodingFreshnessService.markUnitsStaleAfterCodingSchemeChange)
       .not.toHaveBeenCalled();
+  });
+
+  it('keeps upload successful and returns a freshness warning when stale marking fails', async () => {
+    const service = makeService();
+    const oldData = createCodingScheme({ processing: [] });
+    const newData = createCodingScheme({ processing: ['IGNORE_CASE'] });
+    mockFileUploadRepository.findOne.mockResolvedValue({
+      file_id: 'UNIT_A.VOCS',
+      data: oldData
+    });
+    mockCodingFreshnessService.markUnitsStaleAfterCodingSchemeChange
+      .mockRejectedValueOnce(new Error('freshness failed'));
+
+    const result = await service.uploadTestFiles(
+      1,
+      [createVocsFile(newData)],
+      true
+    );
+
+    expect(result.uploaded).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        level: 'warning',
+        category: 'coding_freshness',
+        fileName: 'UNIT_A.VOCS',
+        message: expect.stringContaining('Datei wurde gespeichert')
+      })
+    ]);
+    expect(result.uploadedFiles?.[0]).not.toHaveProperty('issues');
+    expect(mockFileUploadRepository.upsert).toHaveBeenCalled();
   });
 
   it('invalidates workspace file caches after Testcenter import writes files', async () => {

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -27,6 +27,7 @@ import {
   TestFilesUploadResultDto,
   TestFilesUploadUploadedDto
 } from '../../../../../../../api-dto/files/test-files-upload-result.dto';
+import { TestResultsUploadIssueDto } from '../../../../../../../api-dto/files/test-results-upload-result.dto';
 import { FileValidationResultDto } from '../../../../../../../api-dto/files/file-validation-result.dto';
 import { ResponseDto } from '../../../../../../../api-dto/responses/response-dto';
 import {
@@ -483,19 +484,19 @@ export class WorkspaceFilesService implements OnModuleInit {
     fileId: unknown,
     previousData: unknown,
     nextData: unknown
-  ): Promise<void> {
+  ): Promise<TestResultsUploadIssueDto | undefined> {
     if (!this.codingFreshnessService || !this.isCodingSchemeFileId(fileId)) {
-      return;
+      return undefined;
     }
 
     const unitName = this.normalizeCodingSchemeUnitName(fileId);
     if (!unitName) {
-      return;
+      return undefined;
     }
 
     const impact = this.getCodingSchemeFreshnessImpact(previousData, nextData);
     if (!impact.autoCodingChanged && !impact.manualCodingChanged) {
-      return;
+      return undefined;
     }
 
     try {
@@ -506,11 +507,18 @@ export class WorkspaceFilesService implements OnModuleInit {
           manualCodingSchemeRefs: impact.manualCodingChanged ? [unitName] : []
         }
       );
+      return undefined;
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       this.logger.warn(
         `Could not update coding freshness after coding scheme change ${unitName}: ${detail}`
       );
+      return {
+        level: 'warning',
+        category: 'coding_freshness',
+        message: 'Datei wurde gespeichert, aber der Kodierstand konnte nicht zuverlässig aktualisiert werden. Bitte prüfen Sie den Kodierstand erneut.',
+        fileName: String(fileId || unitName)
+      };
     }
   }
 
@@ -1033,6 +1041,7 @@ ${bookletRefs}
       const conflicts: TestFilesUploadConflictDto[] = [];
       const failedFiles: TestFilesUploadFailedDto[] = [];
       const uploadedFiles: TestFilesUploadUploadedDto[] = [];
+      const issues: TestResultsUploadIssueDto[] = [];
       let uploaded = 0;
 
       const isConflict = (
@@ -1055,6 +1064,13 @@ ${bookletRefs}
           return;
         }
 
+        if (value && typeof value === 'object') {
+          const resultIssues = (value as { issues?: unknown }).issues;
+          if (Array.isArray(resultIssues)) {
+            issues.push(...(resultIssues as TestResultsUploadIssueDto[]));
+          }
+        }
+
         if (isFailedResult(value)) {
           failedFiles.push({
             filename: value.filename,
@@ -1074,7 +1090,11 @@ ${bookletRefs}
 
         if (this.isUploaded(value)) {
           uploaded += 1;
-          uploadedFiles.push(value);
+          uploadedFiles.push({
+            fileId: value.fileId,
+            filename: value.filename,
+            fileType: value.fileType
+          });
           return;
         }
 
@@ -1121,7 +1141,8 @@ ${bookletRefs}
         failed: failedFiles.length,
         conflicts: conflicts.length > 0 ? conflicts : undefined,
         failedFiles: failedFiles.length > 0 ? failedFiles : undefined,
-        uploadedFiles: uploadedFiles.length > 0 ? uploadedFiles : undefined
+        uploadedFiles: uploadedFiles.length > 0 ? uploadedFiles : undefined,
+        issues: issues.length > 0 ? issues : undefined
       };
     };
 
@@ -1720,7 +1741,7 @@ ${bookletRefs}
         'file_id',
         'workspace_id'
       ]);
-      await this.markCodingSchemeFreshnessAfterFileChange(
+      const freshnessIssue = await this.markCodingSchemeFreshnessAfterFileChange(
         workspaceId,
         fileUpload.file_id,
         existing?.data,
@@ -1732,7 +1753,8 @@ ${bookletRefs}
       return {
         fileId: fileUpload.file_id,
         filename: file.originalname,
-        fileType
+        fileType,
+        issues: freshnessIssue ? [freshnessIssue] : undefined
       };
     } catch (error) {
       this.logger.error(
@@ -1970,14 +1992,14 @@ ${bookletRefs}
           'workspace_id'
         ]);
       }
-      await Promise.all(changedCodingSchemes.map(change => (
+      const freshnessIssues = (await Promise.all(changedCodingSchemes.map(change => (
         this.markCodingSchemeFreshnessAfterFileChange(
           workspaceId,
           change.fileId,
           change.previousData,
           change.nextData
         )
-      )));
+      )))).filter((issue): issue is TestResultsUploadIssueDto => !!issue);
       if (registry.length > 0 || overwriteRegistry.length > 0) {
         await this.invalidateWorkspaceFileCaches(workspaceId);
       }
@@ -1987,7 +2009,8 @@ ${bookletRefs}
         failed: 0,
         uploadedFiles: [...insertableFiles, ...overwriteFiles],
         conflicts: remainingConflicts.length ? remainingConflicts : undefined,
-        failedFiles: undefined
+        failedFiles: undefined,
+        issues: freshnessIssues.length ? freshnessIssues : undefined
       };
     } catch (error) {
       this.logger.error('Error during test center import', error);

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import {
+  ActivatedRoute, convertToParamMap, ParamMap, Router
+} from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
@@ -39,10 +41,8 @@ describe('CodingManagementComponent', () => {
   let mockSnackBar: jest.Mocked<Partial<MatSnackBar>>;
   let autoCodingCompletedSubject: Subject<{ jobId?: string }>;
   let testResultsChangedSubject: Subject<TestResultsChangedEvent>;
-
-  const fakeActivatedRoute = {
-    snapshot: { data: {} }
-  } as ActivatedRoute;
+  let queryParamMapSubject: BehaviorSubject<ParamMap>;
+  let fakeActivatedRoute: ActivatedRoute;
 
   beforeEach(async () => {
     // Mock window.open
@@ -97,6 +97,14 @@ describe('CodingManagementComponent', () => {
     };
     autoCodingCompletedSubject = new Subject<{ jobId?: string }>();
     testResultsChangedSubject = new Subject<TestResultsChangedEvent>();
+    queryParamMapSubject = new BehaviorSubject<ParamMap>(convertToParamMap({}));
+    fakeActivatedRoute = {
+      snapshot: {
+        data: {},
+        queryParamMap: queryParamMapSubject.value
+      },
+      queryParamMap: queryParamMapSubject.asObservable()
+    } as unknown as ActivatedRoute;
 
     mockTestPersonCodingService = {
       autoCodingCompleted$: autoCodingCompletedSubject.asObservable(),
@@ -287,6 +295,22 @@ describe('CodingManagementComponent', () => {
     it('should load autocoding readiness for the first autocoder run', () => {
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
+    });
+
+    it('should refresh coding status overview when requested by query param', () => {
+      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+      queryParamMapSubject.next(convertToParamMap({
+        refreshCodingFreshness: '1'
+      }));
+
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
     });
   });
 

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -22,7 +22,7 @@ import {
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { PageEvent } from '@angular/material/paginator';
 import { Sort } from '@angular/material/sort';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AppService } from '../../../core/services/app.service';
@@ -124,6 +124,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private uiService = inject(CodingManagementUiService);
   private translateService = inject(TranslateService);
   private router = inject(Router);
+  private route = inject(ActivatedRoute);
   private readonly reviewBatchSize = 500;
   private readonly maxReviewResponses = 5000;
 
@@ -314,6 +315,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.loadCodingFreshness();
     this.loadManualAppliedResultsOverview();
     this.loadAutocodingReadiness();
+    this.route.queryParamMap
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(params => {
+        const refreshRequested = params.get('refreshCodingFreshness');
+        if (refreshRequested === '1' || refreshRequested === 'true') {
+          this.refreshCodingStatusOverview();
+        }
+      });
   }
 
   ngOnDestroy(): void {
@@ -455,6 +464,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   refreshAutocodingReadiness(): void {
     this.loadAutocodingReadiness(true);
+  }
+
+  private refreshCodingStatusOverview(): void {
+    this.fetchCodingStatistics();
+    this.loadCodingFreshness();
+    this.loadManualAppliedResultsOverview();
+    this.loadAutocodingReadiness(true);
+    this.refreshTableData();
   }
 
   startFreshnessCoding(version: 'v1' | 'v3'): void {

--- a/apps/frontend/src/app/coding/components/scheme-editor-dialog/scheme-editor-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/scheme-editor-dialog/scheme-editor-dialog.component.spec.ts
@@ -5,9 +5,10 @@ import {
   MAT_DIALOG_DATA, MatDialog, MatDialogRef
 } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
@@ -40,6 +41,8 @@ describe('SchemeEditorDialogComponent', () => {
   let mockSnackBar: Partial<MatSnackBar>;
   let mockDialog: Partial<MatDialog>;
   let mockTranslateService: Partial<TranslateService>;
+  let mockRouter: Partial<Router>;
+  let snackBarAction$: Subject<void>;
 
   const mockData: SchemeEditorDialogData = {
     workspaceId: 1,
@@ -61,12 +64,18 @@ describe('SchemeEditorDialogComponent', () => {
       close: jest.fn()
     };
 
+    snackBarAction$ = new Subject<void>();
     mockSnackBar = {
-      open: jest.fn()
+      open: jest.fn().mockReturnValue({
+        onAction: () => snackBarAction$.asObservable()
+      })
     };
 
     mockDialog = {
       open: jest.fn()
+    };
+    mockRouter = {
+      navigate: jest.fn()
     };
     mockTranslateService = {
       instant: jest.fn().mockImplementation((key: string) => key),
@@ -89,7 +98,8 @@ describe('SchemeEditorDialogComponent', () => {
         { provide: MAT_DIALOG_DATA, useValue: mockData },
         { provide: MatSnackBar, useValue: mockSnackBar },
         { provide: TranslateService, useValue: mockTranslateService },
-        { provide: MatDialog, useValue: mockDialog }
+        { provide: MatDialog, useValue: mockDialog },
+        { provide: Router, useValue: mockRouter }
       ]
     })
       .overrideComponent(SchemeEditorDialogComponent, {
@@ -158,6 +168,41 @@ describe('SchemeEditorDialogComponent', () => {
     );
     expect(mockSnackBar.open).toHaveBeenCalledWith('coding.schemer.save-success', 'Success', expect.any(Object));
     expect(mockDialogRef.close).toHaveBeenCalledWith(true);
+  }));
+
+  it('should show a freshness warning with navigation action after saving', fakeAsync(() => {
+    component.hasChanges = true;
+    component.unitScheme = { scheme: '{"updated": true}', schemeType: 'type1' };
+
+    (mockFileService.getFilesList as jest.Mock).mockReturnValueOnce(of({
+      data: [{ id: 'r1', filename: 'test-scheme.json', file_type: 'Resource' }]
+    }));
+    (mockFileService.uploadTestFiles as jest.Mock).mockReturnValueOnce(of({
+      failed: 0,
+      conflicts: [],
+      issues: [{
+        level: 'warning',
+        category: 'coding_freshness',
+        message: 'Datei wurde gespeichert'
+      }]
+    }));
+
+    component.save();
+    tick();
+
+    expect(mockSnackBar.open).toHaveBeenCalledWith(
+      'coding.schemer.save-freshness-warning',
+      'coding.schemer.check-coding-status',
+      { duration: 10000 }
+    );
+
+    snackBarAction$.next();
+    tick();
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(
+      ['/workspace-admin/1/coding/management'],
+      { queryParams: { refreshCodingFreshness: '1' } }
+    );
   }));
 
   it('should handle save error', fakeAsync(() => {

--- a/apps/frontend/src/app/coding/components/scheme-editor-dialog/scheme-editor-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/scheme-editor-dialog/scheme-editor-dialog.component.ts
@@ -7,10 +7,12 @@ import {
 import { MatButton } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 import { StandaloneUnitSchemerComponent } from '../schemer/unit-schemer.component';
 import { UnitScheme } from '../schemer/unit-scheme.interface';
 import { FileService } from '../../../shared/services/file/file.service';
 import { base64ToUtf8 } from '../../../shared/utils/common-utils';
+import { TestResultsUploadIssueDto } from '../../../../../../../api-dto/files/test-results-upload-result.dto';
 
 import { ConfirmDialogComponent } from '../../../shared/dialogs/confirm-dialog.component';
 
@@ -124,7 +126,8 @@ export class SchemeEditorDialogComponent implements OnInit {
     private snackBar: MatSnackBar,
     private fileService: FileService,
     private translate: TranslateService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private router: Router
   ) { }
 
   ngOnInit(): void {
@@ -284,11 +287,15 @@ export class SchemeEditorDialogComponent implements OnInit {
         const conflicts = result.conflicts || [];
         const ok = result.failed === 0 && conflicts.length === 0;
         if (ok) {
-          this.snackBar.open(
-            this.translate.instant('coding.schemer.save-success'),
-            'Success',
-            { duration: 3000 }
-          );
+          if (this.hasCodingFreshnessWarning(result.issues)) {
+            this.showCodingFreshnessWarning();
+          } else {
+            this.snackBar.open(
+              this.translate.instant('coding.schemer.save-success'),
+              'Success',
+              { duration: 3000 }
+            );
+          }
           this.dialogRef.close(true);
         } else {
           this.snackBar.open(
@@ -298,5 +305,26 @@ export class SchemeEditorDialogComponent implements OnInit {
           );
         }
       });
+  }
+
+  private hasCodingFreshnessWarning(
+    issues: TestResultsUploadIssueDto[] | undefined
+  ): boolean {
+    return (issues || []).some(issue => issue.category === 'coding_freshness');
+  }
+
+  private showCodingFreshnessWarning(): void {
+    const snackBarRef = this.snackBar.open(
+      this.translate.instant('coding.schemer.save-freshness-warning'),
+      this.translate.instant('coding.schemer.check-coding-status'),
+      { duration: 10000 }
+    ) as ReturnType<MatSnackBar['open']> | undefined;
+
+    snackBarRef?.onAction().subscribe(() => {
+      this.router.navigate(
+        [`/workspace-admin/${this.data.workspaceId}/coding/management`],
+        { queryParams: { refreshCodingFreshness: '1' } }
+      );
+    });
   }
 }

--- a/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.spec.ts
@@ -320,7 +320,12 @@ describe('TestCenterImportComponent', () => {
         failed: 0,
         uploadedFiles: [],
         failedFiles: [],
-        conflicts: [{ fileId: 'file1', filename: 'file1.xml', fileType: 'unit' }]
+        conflicts: [{ fileId: 'file1', filename: 'file1.xml', fileType: 'unit' }],
+        issues: [{
+          level: 'warning',
+          category: 'coding_freshness',
+          message: 'Initial warning'
+        }]
       }
     };
     importService.importWorkspaceFiles.mockReturnValueOnce(of(mockInitialResult));
@@ -348,7 +353,12 @@ describe('TestCenterImportComponent', () => {
         failed: 0,
         uploadedFiles: [{ fileId: 'file1', filename: 'file1.xml', fileType: 'unit' }],
         failedFiles: [],
-        conflicts: []
+        conflicts: [],
+        issues: [{
+          level: 'warning',
+          category: 'coding_freshness',
+          message: 'Overwrite warning'
+        }]
       }
     };
     importService.importWorkspaceFiles.mockReturnValueOnce(of(mockFinalResult));
@@ -364,6 +374,20 @@ describe('TestCenterImportComponent', () => {
       importType: 'testFiles',
       overwriteSelectedCount: 1
     }));
+    const closePayload =
+      mockDialogRef.close.mock.calls[mockDialogRef.close.mock.calls.length - 1][0];
+    expect(closePayload.result.testFilesUploadResult.issues).toEqual([
+      {
+        level: 'warning',
+        category: 'coding_freshness',
+        message: 'Initial warning'
+      },
+      {
+        level: 'warning',
+        category: 'coding_freshness',
+        message: 'Overwrite warning'
+      }
+    ]);
   });
 
   it('should render correctly when using individual URL (reproduction of crash)', async () => {

--- a/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.ts
@@ -664,6 +664,11 @@ export class TestCenterImportComponent {
                 c => !(overwriteFileIds || []).includes(c.fileId)
               );
 
+              const mergedIssues = [
+                ...(firstResult?.issues || []),
+                ...(secondResult?.issues || [])
+              ];
+
               const mergedResult: TestFilesUploadResultDto = {
                 total: Number(
                   firstResult?.total ??
@@ -673,7 +678,8 @@ export class TestCenterImportComponent {
                 failed: mergedFailedFiles.length,
                 uploadedFiles: mergedUploadedFiles,
                 failedFiles: mergedFailedFiles,
-                conflicts: remainingConflicts
+                conflicts: remainingConflicts,
+                issues: mergedIssues.length > 0 ? mergedIssues : undefined
               };
 
               const mergedData = {

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files-upload-result-dialog.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files-upload-result-dialog.component.html
@@ -110,5 +110,8 @@
 </div>
 
 <div mat-dialog-actions align="end">
+  @if (canCheckCodingStatus) {
+    <button mat-button color="primary" type="button" (click)="checkCodingStatus()">Kodierstand prüfen</button>
+  }
   <button mat-button type="button" (click)="close()">Schließen</button>
 </div>

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files-upload-result-dialog.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files-upload-result-dialog.component.spec.ts
@@ -1,32 +1,37 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
 import { TestFilesUploadResultDialogComponent, TestFilesUploadResultDialogData } from './test-files-upload-result-dialog.component';
 
 describe('TestFilesUploadResultDialogComponent', () => {
   let fixture: ComponentFixture<TestFilesUploadResultDialogComponent>;
   let component: TestFilesUploadResultDialogComponent;
   let dialogRef: { close: jest.Mock };
+  let router: { navigate: jest.Mock };
 
   const data: TestFilesUploadResultDialogData = {
+    workspaceId: 1,
     attempted: 4,
     overwriteSelectedCount: 1,
     uploadedFiles: [{ filename: 'booklet.xml', fileId: 'f1', fileType: 'Booklet' } as never],
     failedFiles: [{ filename: 'bad.xml', reason: 'Invalid XML' } as never],
     remainingConflicts: [{ filename: 'unit.xml', fileId: 'f2', fileType: 'Unit' } as never],
     issues: [{
-      level: 'warning', message: 'Missing value', fileName: 'responses.csv', rowIndex: 3
+      level: 'warning', category: 'coding_freshness', message: 'Missing value', fileName: 'responses.csv', rowIndex: 3
     } as never]
   };
 
   beforeEach(async () => {
     dialogRef = { close: jest.fn() };
+    router = { navigate: jest.fn() };
 
     await TestBed.configureTestingModule({
       imports: [TestFilesUploadResultDialogComponent, NoopAnimationsModule],
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
-        { provide: MAT_DIALOG_DATA, useValue: data }
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: Router, useValue: router }
       ]
     }).compileComponents();
 
@@ -53,6 +58,8 @@ describe('TestFilesUploadResultDialogComponent', () => {
     expect(component.filteredIssues).toHaveLength(1);
     component.filterText = 'nomatch';
     expect(component.filteredUploadedFiles).toHaveLength(0);
+    expect(component.hasCodingFreshnessWarning).toBe(true);
+    expect(component.canCheckCodingStatus).toBe(true);
 
     expect(component.trackByUploaded(0, data.uploadedFiles[0])).toContain('booklet.xml');
     expect(component.trackByFailed(0, data.failedFiles[0])).toContain('bad.xml');
@@ -63,12 +70,23 @@ describe('TestFilesUploadResultDialogComponent', () => {
     expect(dialogRef.close).toHaveBeenCalled();
   });
 
+  it('navigates to coding management when checking coding status', () => {
+    component.checkCodingStatus();
+
+    expect(dialogRef.close).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledWith(
+      ['/workspace-admin/1/coding/management'],
+      { queryParams: { refreshCodingFreshness: '1' } }
+    );
+  });
+
   it('falls back to defaults when optional data is absent', async () => {
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [TestFilesUploadResultDialogComponent, NoopAnimationsModule],
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
+        { provide: Router, useValue: router },
         {
           provide: MAT_DIALOG_DATA,
           useValue: {

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files-upload-result-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files-upload-result-dialog.component.ts
@@ -12,6 +12,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatTabsModule } from '@angular/material/tabs';
 import { ScrollingModule } from '@angular/cdk/scrolling';
+import { Router } from '@angular/router';
 import {
   TestFilesUploadConflictDto,
   TestFilesUploadFailedDto,
@@ -20,6 +21,7 @@ import {
 import { TestResultsUploadIssueDto } from '../../../../../../../api-dto/files/test-results-upload-result.dto';
 
 export type TestFilesUploadResultDialogData = {
+  workspaceId?: number;
   attempted: number;
   uploadedCount?: number;
   failedCount?: number;
@@ -53,7 +55,8 @@ export class TestFilesUploadResultDialogComponent {
 
   constructor(
     private dialogRef: MatDialogRef<TestFilesUploadResultDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: TestFilesUploadResultDialogData
+    @Inject(MAT_DIALOG_DATA) public data: TestFilesUploadResultDialogData,
+    private router: Router
   ) {}
 
   get attempted(): number {
@@ -103,6 +106,14 @@ export class TestFilesUploadResultDialogComponent {
         .map(s => String(s).toUpperCase());
       return parts.some(p => p.includes(q));
     });
+  }
+
+  get hasCodingFreshnessWarning(): boolean {
+    return this.issues.some(issue => issue.category === 'coding_freshness');
+  }
+
+  get canCheckCodingStatus(): boolean {
+    return !!this.data.workspaceId && this.hasCodingFreshnessWarning;
   }
 
   private matchesQuery(
@@ -156,5 +167,17 @@ export class TestFilesUploadResultDialogComponent {
 
   close(): void {
     this.dialogRef.close();
+  }
+
+  checkCodingStatus(): void {
+    if (!this.data.workspaceId) {
+      return;
+    }
+
+    this.dialogRef.close();
+    this.router.navigate(
+      [`/workspace-admin/${this.data.workspaceId}/coding/management`],
+      { queryParams: { refreshCodingFreshness: '1' } }
+    );
   }
 }

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files.component.ts
@@ -553,10 +553,12 @@ export class TestFilesComponent implements OnInit, OnDestroy {
     const attempted = result.total;
     if (conflicts.length === 0) {
       this.openUploadResultDialog({
+        workspaceId: this.appService.selectedWorkspaceId,
         attempted,
         uploadedFiles,
         failedFiles,
-        remainingConflicts: []
+        remainingConflicts: [],
+        issues: result.issues
       });
       this.onUploadSuccess();
       return;
@@ -605,13 +607,19 @@ export class TestFilesComponent implements OnInit, OnDestroy {
               const remainingConflicts = conflicts.filter(
                 c => !(resultChoice.overwriteFileIds || []).includes(c.fileId)
               );
+              const finalIssues = [
+                ...(result.issues || []),
+                ...(overwriteResult.issues || [])
+              ];
 
               this.openUploadResultDialog({
+                workspaceId: this.appService.selectedWorkspaceId,
                 attempted,
                 overwriteSelectedCount,
                 uploadedFiles: finalUploadedFiles,
                 failedFiles: finalFailedFiles,
-                remainingConflicts
+                remainingConflicts,
+                issues: finalIssues.length ? finalIssues : undefined
               });
               this.onUploadSuccess();
             },
@@ -625,10 +633,12 @@ export class TestFilesComponent implements OnInit, OnDestroy {
           });
       } else {
         this.openUploadResultDialog({
+          workspaceId: this.appService.selectedWorkspaceId,
           attempted,
           uploadedFiles,
           failedFiles,
-          remainingConflicts: conflicts
+          remainingConflicts: conflicts,
+          issues: result.issues
         });
         this.onUploadSuccess();
       }
@@ -710,10 +720,12 @@ export class TestFilesComponent implements OnInit, OnDestroy {
     const attempted = result.total;
     if (conflicts.length === 0) {
       this.openUploadResultDialog({
+        workspaceId,
         attempted,
         uploadedFiles,
         failedFiles,
-        remainingConflicts: []
+        remainingConflicts: [],
+        issues: result.issues
       });
       this.onUploadSuccess();
       return;
@@ -763,13 +775,19 @@ export class TestFilesComponent implements OnInit, OnDestroy {
               const remainingConflicts = conflicts.filter(
                 c => !(resultChoice.overwriteFileIds || []).includes(c.fileId)
               );
+              const finalIssues = [
+                ...(result.issues || []),
+                ...(overwriteResult.issues || [])
+              ];
 
               this.openUploadResultDialog({
+                workspaceId,
                 attempted,
                 overwriteSelectedCount,
                 uploadedFiles: finalUploadedFiles,
                 failedFiles: finalFailedFiles,
-                remainingConflicts
+                remainingConflicts,
+                issues: finalIssues.length ? finalIssues : undefined
               });
               this.onUploadSuccess();
             },
@@ -784,10 +802,12 @@ export class TestFilesComponent implements OnInit, OnDestroy {
       } else {
         // Skip overwriting, keep already uploaded (non-conflicting) files.
         this.openUploadResultDialog({
+          workspaceId,
           attempted,
           uploadedFiles,
           failedFiles,
-          remainingConflicts: conflicts
+          remainingConflicts: conflicts,
+          issues: result.issues
         });
         this.onUploadSuccess();
       }
@@ -873,6 +893,7 @@ export class TestFilesComponent implements OnInit, OnDestroy {
         const remainingConflicts = detailed?.conflicts || [];
 
         this.openUploadResultDialog({
+          workspaceId: this.appService.selectedWorkspaceId,
           attempted,
           uploadedCount: Number(detailed?.uploaded ?? uploadedFiles.length),
           failedCount: Number(detailed?.failed ?? failedFiles.length),
@@ -884,7 +905,7 @@ export class TestFilesComponent implements OnInit, OnDestroy {
           uploadedFiles,
           failedFiles,
           remainingConflicts,
-          issues: r.issues
+          issues: detailed?.issues || r.issues
         } as TestFilesUploadResultDialogData);
 
         this.onUploadSuccess();

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -664,6 +664,8 @@
     "schemer": {
       "save-success": "Antwortschema erfolgreich gespeichert",
       "save-error": "Fehler beim Speichern des Antwortschemas",
+      "save-freshness-warning": "Datei wurde gespeichert, aber der Kodierstand konnte nicht zuverlässig aktualisiert werden. Bitte prüfen Sie den Kodierstand erneut.",
+      "check-coding-status": "Kodierstand prüfen",
       "load-error": "Fehler beim Laden der Antwortschema-Informationen. Der Editor arbeitet ohne Variablen-Validierung.",
       "decode-error": "Fehler beim Dekodieren der Schemer-HTML",
       "download-error": "Fehler beim Herunterladen der Schemer-HTML",


### PR DESCRIPTION
## Summary
- return coding freshness warning issues when a coding scheme upload succeeds but freshness marking fails
- surface the warning in scheme editor and test file upload result flows with a “Kodierstand prüfen” action
- refresh the coding management overview when opened from that action
- preserve warning issues through Testcenter conflict overwrite imports

## Validation
- npx nx test backend --testFile=apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts --runInBand
- npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts --runInBand
- npx nx test frontend --testFile=apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.spec.ts --runInBand
- npx nx lint backend
- npx nx lint frontend
- git diff --check

Refs #772
