### PR TITLE
Add NA scores for IQB standard missings

### DIFF
--- a/api-dto/coding/missings-profiles.dto.ts
+++ b/api-dto/coding/missings-profiles.dto.ts
@@ -3,7 +3,7 @@ export interface MissingDto {
   label: string;
   description: string;
   code: number;
-  score: number;
+  score: number | null;
 }
 
 export class MissingsProfilesDto {

--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -1996,7 +1996,7 @@ describe('CoderTrainingService', () => {
       code: number | null,
       score: number | null,
       codingIssueOption: number | null,
-      missingCodes: { mirCode: number; mciCode: number; negativeCodes: Set<number>; scoresByCode: Map<number, number> }
+      missingCodes: { mirCode: number; mciCode: number; negativeCodes: Set<number>; scoresByCode: Map<number, number | null> }
     ) => { code: string | null; score: number | null };
 
     const getMapDisplayCodeAndScore = (svc: CoderTrainingService): MapDisplayCodeAndScoreFn => {
@@ -2006,7 +2006,7 @@ describe('CoderTrainingService', () => {
 
     type GetMissingScoresByCodeFromMissingsFn = (
       missings: Array<{ id?: string; code: number; score?: unknown }>
-    ) => Map<number, number>;
+    ) => Map<number, number | null>;
 
     const getMissingScoresByCodeFromMissings = (svc: CoderTrainingService): GetMissingScoresByCodeFromMissingsFn => {
       const serviceWithPrivateMethod = svc as unknown as {
@@ -2065,7 +2065,6 @@ describe('CoderTrainingService', () => {
     });
 
     it.each([
-      ['null', null],
       ['empty string', ''],
       ['blank string', '  '],
       ['boolean false', false],
@@ -2078,6 +2077,25 @@ describe('CoderTrainingService', () => {
           score
         }
       ])).toThrow('score');
+    });
+
+    it('should keep explicit NA missing scores during display normalization', () => {
+      const scoresByCode = getMissingScoresByCodeFromMissings(service)([
+        {
+          id: 'mci',
+          code: -97,
+          score: null
+        }
+      ]);
+      const mapDisplay = getMapDisplayCodeAndScore(service);
+
+      expect(scoresByCode.get(-97)).toBeNull();
+      expect(mapDisplay(-97, null, null, {
+        mirCode: -98,
+        mciCode: -97,
+        negativeCodes: new Set([-97, -98]),
+        scoresByCode
+      })).toEqual({ code: '-97', score: null });
     });
 
     it('should reject automatic missing agreement when response jobs use different missing profiles', async () => {

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -139,7 +139,7 @@ type TrainingResponseJobUnit = {
 type MissingCodePair = { mirCode: number; mciCode: number };
 type MissingCodeDisplayContext = MissingCodePair & {
   negativeCodes: Set<number>;
-  scoresByCode: Map<number, number>;
+  scoresByCode: Map<number, number | null>;
 };
 
 const DEFAULT_MISSING_CODE_CONTEXT: MissingCodeDisplayContext = {
@@ -147,7 +147,7 @@ const DEFAULT_MISSING_CODE_CONTEXT: MissingCodeDisplayContext = {
   mciCode: IQB_STANDARD_MISSING_CODES.mci,
   negativeCodes: new Set(Object.values(IQB_STANDARD_MISSING_CODES)),
   scoresByCode: new Map(
-    (Object.entries(IQB_STANDARD_MISSING_SCORES) as Array<[IqbStandardMissingId, number]>)
+    (Object.entries(IQB_STANDARD_MISSING_SCORES) as Array<[IqbStandardMissingId, number | null]>)
       .map(([missingId, score]) => [IQB_STANDARD_MISSING_CODES[missingId], score])
   )
 };
@@ -269,9 +269,9 @@ export class CoderTrainingService {
 
   private getMissingScoresByCodeFromMissings(
     missings: Array<{ id?: string; code: number; score?: unknown }>,
-    fallbackScoresByCode?: Map<number, number>
-  ): Map<number, number> {
-    const scoresByCode = new Map<number, number>(fallbackScoresByCode);
+    fallbackScoresByCode?: Map<number, number | null>
+  ): Map<number, number | null> {
+    const scoresByCode = new Map<number, number | null>(fallbackScoresByCode);
 
     missings.forEach(missing => {
       const code = Number(missing.code);
@@ -279,17 +279,25 @@ export class CoderTrainingService {
         return;
       }
 
-      if (!this.hasExplicitFiniteScore(missing.score)) {
+      if (!this.hasExplicitScoreProperty(missing) || !this.hasExplicitValidScore(missing.score)) {
         throw new BadRequestException(`Missing profile must define a score for code ${code}`);
       }
 
-      scoresByCode.set(code, Number(missing.score));
+      scoresByCode.set(code, this.normalizeScore(missing.score));
     });
 
     return scoresByCode;
   }
 
-  private hasExplicitFiniteScore(score: unknown): boolean {
+  private hasExplicitScoreProperty(missing: { score?: unknown }): boolean {
+    return Object.prototype.hasOwnProperty.call(missing, 'score');
+  }
+
+  private hasExplicitValidScore(score: unknown): boolean {
+    if (score === null) {
+      return true;
+    }
+
     if (typeof score === 'number') {
       return Number.isFinite(score);
     }
@@ -302,10 +310,18 @@ export class CoderTrainingService {
     return false;
   }
 
+  private normalizeScore(score: unknown): number | null {
+    if (score === null) {
+      return null;
+    }
+
+    return Number(score);
+  }
+
   private getMissingScoreFromContext(
     missingCodes: MissingCodeDisplayContext,
     code: number
-  ): number {
+  ): number | null {
     const score = missingCodes.scoresByCode.get(code);
     if (score === undefined) {
       throw new BadRequestException(`Missing profile must define a score for code ${code}`);

--- a/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
@@ -815,7 +815,7 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
         id: 'mir',
         label: 'MIR',
         code: -97,
-        score: 0
+        score: null
       })
     };
 
@@ -849,7 +849,7 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
 
     expect(missingsProfilesService.getMissingByIdForProfileOrDefault).toHaveBeenCalledWith(7, 77, 'mir');
     expect(worksheet.getRow(2).getCell(codeColumn).value).toBe('-97');
-    expect(worksheet.getRow(2).getCell(scoreColumn).value).toBe(0);
+    expect(worksheet.getRow(2).getCell(scoreColumn).value).toBe('NA');
   });
 
   it('does not fall back to response scores for discussion manager rows without stored score', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.ts
@@ -192,6 +192,14 @@ export class CodingExportService {
     };
   }
 
+  private formatScoreForExport(code: number | null | undefined, score: number | null | undefined): number | string {
+    if (score !== null && score !== undefined) {
+      return score;
+    }
+
+    return code !== null && code !== undefined && code < 0 ? 'NA' : '';
+  }
+
   private async getExclusionChecker(workspaceId: number): Promise<(bookletName: string, unitName: string) => boolean> {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     return (bookletName: string, unitName: string) => !unitName || isExcludedByResolvedExclusions(exclusions, bookletName, unitName);
@@ -1590,7 +1598,9 @@ export class CodingExportService {
             row[`${displayName} Code`] = outputCommentsInsteadOfCodes ?
               (data?.comment ?? '') :
               this.formatCodeWithIssueSuffix(data?.code ?? null, data?.codingIssueOption ?? null);
-            row[`${displayName} Score`] = outputCommentsInsteadOfCodes ? '' : (data?.score ?? '');
+            row[`${displayName} Score`] = outputCommentsInsteadOfCodes ?
+              '' :
+              this.formatScoreForExport(data?.code ?? null, data?.score ?? null);
             if (includeComments) row[`${displayName} Note`] = data?.comment ?? '';
             if (data?.code !== null && data?.code !== undefined) codes.push(data.code);
             if (data?.comment) comments.push(`${displayName}: ${data.comment}`);

--- a/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.spec.ts
@@ -63,7 +63,7 @@ describe('CodingItemMatrixExportService', () => {
         id: 'mir',
         label: 'missing invalid response',
         code: -98,
-        score: 0
+        score: null
       })
     };
     const service = createService(missingsProfilesService);
@@ -91,8 +91,10 @@ describe('CodingItemMatrixExportService', () => {
       ]));
 
     const output = await collectStream(service.exportItemMatrixAsCsvStream(7, 'code', 'v2'));
+    const scoreOutput = await collectStream(service.exportItemMatrixAsCsvStream(7, 'score', 'v2'));
 
     expect(output).toContain('login-1;code-1;group-1;BOOKLET-1;-98');
+    expect(scoreOutput).toContain('login-1;code-1;group-1;BOOKLET-1;NA');
     expect(missingsProfilesService.getMissingByIdForProfileOrDefault)
       .toHaveBeenCalledWith(7, null, 'mir');
   });
@@ -123,14 +125,14 @@ describe('CodingItemMatrixExportService', () => {
     });
     (service as never as { getResponseValuesForRows: jest.Mock }).getResponseValuesForRows =
       jest.fn().mockResolvedValue(new Map([
-        [12, new Map([['UNIT1\u001FVAR1', { code: -96, score: 0 }]])]
+        [12, new Map([['UNIT1\u001FVAR1', { code: -96, score: null }]])]
       ]));
 
     const codeOutput = await collectStream(service.exportItemMatrixAsCsvStream(7, 'code', 'v2'));
     const scoreOutput = await collectStream(service.exportItemMatrixAsCsvStream(7, 'score', 'v2'));
 
     expect(codeOutput).toContain('login-1;code-1;group-1;BOOKLET-1;-96');
-    expect(scoreOutput).toContain('login-1;code-1;group-1;BOOKLET-1;0');
+    expect(scoreOutput).toContain('login-1;code-1;group-1;BOOKLET-1;NA');
     expect(missingsProfilesService.getMissingByIdForProfileOrDefault).not.toHaveBeenCalled();
     expect(missingsProfilesService.getMissingByCodeForProfileOrDefault).not.toHaveBeenCalled();
   });

--- a/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.ts
@@ -442,7 +442,13 @@ export class CodingItemMatrixExportService {
   ): Promise<string | number> {
     const missing = await this.resolveMissingValue(workspaceId, value.code);
     if (requestedValue === 'score') {
-      return value.score ?? missing?.score ?? '';
+      if (value.score !== null && value.score !== undefined) {
+        return value.score;
+      }
+      if (missing) {
+        return missing.score === null ? 'NA' : missing.score;
+      }
+      return value.code !== null && value.code < 0 ? 'NA' : '';
     }
 
     return missing?.code ?? mapCodeForExport(value.code) ?? '';

--- a/apps/backend/src/app/database/services/coding/missings-profiles.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/missings-profiles.service.spec.ts
@@ -52,23 +52,25 @@ describe('MissingsProfilesService', () => {
 
     await expect(service.getMissingsProfiles(1)).resolves.toEqual([{ id: 1, label: 'IQB-Standard' }]);
     await expect(service.getMissingsProfiles(1)).resolves.toEqual([{ id: 2, label: 'IQB-Standard' }]);
-    expect(repo.save).toHaveBeenCalledTimes(1);
+    expect(repo.save).toHaveBeenCalledTimes(2);
   });
 
-  it('creates IQB standard defaults with score 0 for all standard missings', async () => {
+  it('creates canonical IQB standard defaults with explicit NA scores', async () => {
     repo.findOne.mockResolvedValueOnce(null);
     repo.save.mockImplementationOnce(async value => ({ ...value, id: 2 }));
 
     const profile = await service.ensureDefaultMissingsProfile(1);
 
     expect(profile.parseMissings()).toEqual([
-      expect.objectContaining({ id: 'mci', code: -97, score: 0 }),
       expect.objectContaining({ id: 'mir', code: -98, score: 0 }),
-      expect.objectContaining({ id: 'mbi_mbo', code: -99, score: 0 })
+      expect.objectContaining({ id: 'mbi_mbo', code: -99, score: 0 }),
+      expect.objectContaining({ id: 'mnr', code: -96, score: null }),
+      expect.objectContaining({ id: 'mci', code: -97, score: null }),
+      expect.objectContaining({ id: 'mbd', code: -94, score: null })
     ]);
   });
 
-  it('adds score 0 to legacy IQB standard profiles', async () => {
+  it('synchronizes legacy IQB standard profiles to the canonical missings', async () => {
     repo.findOne.mockResolvedValueOnce({
       id: 7,
       label: 'IQB-Standard',
@@ -90,12 +92,18 @@ describe('MissingsProfilesService', () => {
 
     expect(repo.save).toHaveBeenCalledWith(expect.objectContaining({
       label: 'IQB-Standard',
-      missings: expect.stringContaining('"score":0')
+      missings: expect.stringContaining('"id":"mbd"')
     }));
-    expect(profile.parseMissings().map(missing => missing.score)).toEqual([0, 0, 0]);
+    expect(profile.parseMissings()).toEqual([
+      expect.objectContaining({ id: 'mir', code: -98, score: 0 }),
+      expect.objectContaining({ id: 'mbi_mbo', code: -99, score: 0 }),
+      expect.objectContaining({ id: 'mnr', code: -96, score: null }),
+      expect.objectContaining({ id: 'mci', code: -97, score: null }),
+      expect.objectContaining({ id: 'mbd', code: -94, score: null })
+    ]);
   });
 
-  it('adds score 0 to legacy IQB standard profiles resolved by explicit profile id', async () => {
+  it('synchronizes legacy IQB standard profiles resolved by explicit profile id', async () => {
     const legacyProfile = {
       id: 7,
       label: 'IQB-Standard',
@@ -114,20 +122,20 @@ describe('MissingsProfilesService', () => {
     repo.findOne.mockResolvedValue(legacyProfile);
     repo.save.mockImplementation(async value => value);
 
-    await expect(service.getMissingByIdForProfileOrDefault(1, 7, 'mir')).resolves.toEqual({
-      id: 'mir',
-      label: 'MIR',
-      code: -98,
-      score: 0
+    await expect(service.getMissingByIdForProfileOrDefault(1, 7, 'mci')).resolves.toEqual({
+      id: 'mci',
+      label: 'missing coding impossible',
+      code: -97,
+      score: null
     });
     expect(repo.save).toHaveBeenCalledWith(expect.objectContaining({
       id: 7,
       label: 'IQB-Standard',
-      missings: expect.stringContaining('"score":0')
+      missings: expect.stringContaining('"score":null')
     }));
   });
 
-  it('adds score 0 to legacy IQB standard profiles resolved by label', async () => {
+  it('synchronizes legacy IQB standard profiles resolved by label', async () => {
     repo.findOne.mockResolvedValueOnce({
       id: 7,
       label: 'IQB-Standard',
@@ -144,11 +152,13 @@ describe('MissingsProfilesService', () => {
     expect(repo.save).toHaveBeenCalledWith(expect.objectContaining({
       id: 7,
       label: 'IQB-Standard',
-      missings: expect.stringContaining('"score":0')
+      missings: expect.stringContaining('"id":"mnr"')
     }));
-    expect(profile?.parseMissings()).toEqual([
-      expect.objectContaining({ id: 'mir', code: -98, score: 0 })
-    ]);
+    expect(profile?.parseMissings()).toHaveLength(5);
+    expect(profile?.parseMissings()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'mir', code: -98, score: 0 }),
+      expect.objectContaining({ id: 'mci', code: -97, score: null })
+    ]));
   });
 
   it('loads profiles by label and id', async () => {
@@ -220,7 +230,6 @@ describe('MissingsProfilesService', () => {
 
   it.each([
     ['absent', undefined],
-    ['null', null],
     ['empty string', ''],
     ['blank string', '  '],
     ['boolean false', false],
@@ -240,6 +249,27 @@ describe('MissingsProfilesService', () => {
 
     await expect(service.createMissingsProfile(1, profile)).rejects.toThrow('score');
     expect(repo.save).not.toHaveBeenCalled();
+  });
+
+  it('accepts explicit null as a fachlicher NA score', async () => {
+    const profile = new MissingsProfilesDto();
+    profile.label = 'Profile';
+    profile.setMissings([
+      {
+        id: 'mir', label: 'MIR', description: 'Invalid response', code: -98, score: 0
+      },
+      {
+        id: 'mci', label: 'MCI', description: 'Coding impossible', code: -97, score: null
+      }
+    ]);
+    repo.findOne.mockResolvedValueOnce(null);
+
+    await expect(service.createMissingsProfile(1, profile)).resolves.toMatchObject({
+      label: 'Profile'
+    });
+    expect(repo.save).toHaveBeenCalledWith(expect.objectContaining({
+      missings: expect.stringContaining('"score":null')
+    }));
   });
 
   it('rejects malformed missings JSON', async () => {
@@ -302,13 +332,19 @@ describe('MissingsProfilesService', () => {
     profile.label = 'IQB-Standard';
     profile.setMissings([
       {
-        id: 'mci', label: 'missing coding impossible', description: '', code: -97, score: 0
+        id: 'mci', label: 'missing coding impossible', description: '', code: -97, score: null
       },
       {
         id: 'mir', label: 'missing invalid response', description: '', code: -98, score: 0
       },
       {
         id: 'mbi_mbo', label: 'mbi / mbo', description: '', code: -99, score: 0
+      },
+      {
+        id: 'mnr', label: 'missing not reached', description: '', code: -96, score: null
+      },
+      {
+        id: 'mbd', label: 'missing by design', description: '', code: -94, score: null
       }
     ]);
     repo.findOne.mockResolvedValue({
@@ -318,8 +354,8 @@ describe('MissingsProfilesService', () => {
     });
 
     await expect(service.resolveMissingsProfileId(1, undefined)).resolves.toBe(7);
-    await expect(service.getDefaultNegativeMissingCodes(1)).resolves.toEqual(new Set([-97, -98, -99]));
-    await expect(service.getNegativeMissingCodesForProfileOrDefault(1, 0)).resolves.toEqual(new Set([-97, -98, -99]));
+    await expect(service.getDefaultNegativeMissingCodes(1)).resolves.toEqual(new Set([-94, -96, -97, -98, -99]));
+    await expect(service.getNegativeMissingCodesForProfileOrDefault(1, 0)).resolves.toEqual(new Set([-94, -96, -97, -98, -99]));
   });
 
   it('resolves missing code and score by missing id', async () => {
@@ -347,7 +383,6 @@ describe('MissingsProfilesService', () => {
 
   it.each([
     ['absent', undefined],
-    ['null', null],
     ['empty string', ''],
     ['blank string', '  '],
     ['boolean false', false],
@@ -370,6 +405,27 @@ describe('MissingsProfilesService', () => {
       .mockResolvedValueOnce({ id: profile.id, label: profile.label, missings: profile.missings });
 
     await expect(service.getMissingByIdForProfileOrDefault(1, 8, 'mir')).rejects.toThrow('score');
+  });
+
+  it('resolves profile missing values with explicit null scores', async () => {
+    const profile = new MissingsProfilesDto();
+    profile.id = 8;
+    profile.label = 'NA profile';
+    profile.missings = JSON.stringify([
+      {
+        id: 'mci', label: 'missing coding impossible', description: '', code: -97, score: null
+      }
+    ]);
+    repo.findOne
+      .mockResolvedValueOnce({ id: profile.id, label: profile.label, missings: profile.missings })
+      .mockResolvedValueOnce({ id: profile.id, label: profile.label, missings: profile.missings });
+
+    await expect(service.getMissingByIdForProfileOrDefault(1, 8, 'mci')).resolves.toEqual({
+      id: 'mci',
+      label: 'missing coding impossible',
+      code: -97,
+      score: null
+    });
   });
 
   it('rejects unknown explicit profile ids', async () => {

--- a/apps/backend/src/app/database/services/coding/missings-profiles.service.ts
+++ b/apps/backend/src/app/database/services/coding/missings-profiles.service.ts
@@ -10,21 +10,25 @@ export interface ResolvedMissingValue {
   id: string;
   label: string;
   code: number;
-  score: number;
+  score: number | null;
 }
 
-export type IqbStandardMissingId = 'mci' | 'mir' | 'mbi_mbo';
+export type IqbStandardMissingId = 'mir' | 'mbi_mbo' | 'mnr' | 'mci' | 'mbd';
 
 export const IQB_STANDARD_MISSING_CODES: Record<IqbStandardMissingId, number> = {
-  mci: -97,
   mir: -98,
-  mbi_mbo: -99
+  mbi_mbo: -99,
+  mnr: -96,
+  mci: -97,
+  mbd: -94
 };
 
-export const IQB_STANDARD_MISSING_SCORES: Record<IqbStandardMissingId, number> = {
-  mci: 0,
+export const IQB_STANDARD_MISSING_SCORES: Record<IqbStandardMissingId, number | null> = {
   mir: 0,
-  mbi_mbo: 0
+  mbi_mbo: 0,
+  mnr: null,
+  mci: null,
+  mbd: null
 };
 
 @Injectable()
@@ -32,9 +36,6 @@ export class MissingsProfilesService {
   private readonly logger = new Logger(MissingsProfilesService.name);
 
   private readonly defaultProfileLabel = 'IQB-Standard';
-  private readonly iqbStandardMissingScores = new Map<string, number>(
-    Object.entries(IQB_STANDARD_MISSING_SCORES)
-  );
 
   constructor(
     @InjectRepository(MissingsProfile)
@@ -93,7 +94,7 @@ export class MissingsProfilesService {
       return profile;
     }
 
-    const enriched = this.addIqbStandardScores(profile);
+    const enriched = this.synchronizeIqbStandardProfile(profile);
     if (!enriched.changed) {
       return enriched.profile;
     }
@@ -128,7 +129,15 @@ export class MissingsProfilesService {
     return Object.assign(new MissingsProfilesDto(), profile);
   }
 
-  private hasExplicitFiniteScore(score: unknown): boolean {
+  private hasExplicitScoreProperty(missing: MissingDto): boolean {
+    return Object.prototype.hasOwnProperty.call(missing, 'score');
+  }
+
+  private hasExplicitValidScore(score: unknown): boolean {
+    if (score === null) {
+      return true;
+    }
+
     if (typeof score === 'number') {
       return Number.isFinite(score);
     }
@@ -139,6 +148,14 @@ export class MissingsProfilesService {
     }
 
     return false;
+  }
+
+  private normalizeScore(score: unknown): number | null {
+    if (score === null) {
+      return null;
+    }
+
+    return Number(score);
   }
 
   private parseMissingsForStorage(profile: MissingsProfilesDto): MissingDto[] {
@@ -176,7 +193,7 @@ export class MissingsProfilesService {
 
     const normalizedMissings = missings.map((missing, index) => {
       const code = Number(missing.code);
-      const score = Number(missing.score);
+      const score = this.normalizeScore(missing.score);
 
       if (!missing.id || typeof missing.id !== 'string' || missing.id.trim() === '') {
         throw new BadRequestException(`Missing entry ${index + 1} must define an id`);
@@ -198,7 +215,7 @@ export class MissingsProfilesService {
         throw new BadRequestException(`Missing entry '${missing.id}' must define a negative code`);
       }
 
-      if (!this.hasExplicitFiniteScore(missing.score)) {
+      if (!this.hasExplicitScoreProperty(missing) || !this.hasExplicitValidScore(missing.score)) {
         throw new BadRequestException(`Missing entry '${missing.id}' must define a score`);
       }
 
@@ -246,25 +263,30 @@ export class MissingsProfilesService {
     return profile;
   }
 
-  private addIqbStandardScores(profile: MissingsProfilesDto): { profile: MissingsProfilesDto; changed: boolean } {
-    const missings = profile.parseMissings();
-    let changed = false;
+  private areMissingsEqual(left: MissingDto[], right: MissingDto[]): boolean {
+    if (left.length !== right.length) {
+      return false;
+    }
 
-    const enrichedMissings = missings.map(missing => {
-      const score = this.iqbStandardMissingScores.get(missing.id);
-      if (score === undefined || this.hasExplicitFiniteScore(missing.score)) {
-        return missing;
-      }
-
-      changed = true;
-      return {
-        ...missing,
-        score
-      };
+    return left.every((leftMissing, index) => {
+      const rightMissing = right[index];
+      return leftMissing.id === rightMissing.id &&
+        leftMissing.label === rightMissing.label &&
+        leftMissing.description === rightMissing.description &&
+        Number(leftMissing.code) === rightMissing.code &&
+        this.hasExplicitScoreProperty(leftMissing) &&
+        this.hasExplicitValidScore(leftMissing.score) &&
+        this.normalizeScore(leftMissing.score) === rightMissing.score;
     });
+  }
+
+  private synchronizeIqbStandardProfile(profile: MissingsProfilesDto): { profile: MissingsProfilesDto; changed: boolean } {
+    const canonicalMissings = this.createIqbStandardMissings();
+    const currentMissings = profile.parseMissings();
+    const changed = !this.areMissingsEqual(currentMissings, canonicalMissings);
 
     if (changed) {
-      profile.setMissings(enrichedMissings as MissingDto[]);
+      profile.setMissings(canonicalMissings);
     }
 
     return { profile, changed };
@@ -272,13 +294,13 @@ export class MissingsProfilesService {
 
   private assertMissingHasScore(missing: MissingDto): ResolvedMissingValue {
     const code = Number(missing.code);
-    const score = Number(missing.score);
+    const score = this.normalizeScore(missing.score);
 
     if (!Number.isInteger(code)) {
       throw new BadRequestException(`Missing '${missing.id}' must define an integer code`);
     }
 
-    if (!this.hasExplicitFiniteScore(missing.score)) {
+    if (!this.hasExplicitScoreProperty(missing) || !this.hasExplicitValidScore(missing.score)) {
       throw new BadRequestException(`Missing '${missing.id}' must define a score`);
     }
 
@@ -290,33 +312,50 @@ export class MissingsProfilesService {
     };
   }
 
-  private createDefaultMissingsProfile(): MissingsProfilesDto {
-    const iqbStandardProfile = new MissingsProfilesDto();
-    iqbStandardProfile.label = this.defaultProfileLabel;
-    iqbStandardProfile.setMissings([
-      {
-        id: 'mci',
-        label: 'missing coding impossible',
-        description: '(1) Item müsste/könnte bearbeitet worden sein, aber (2) Antwort ist aufgrund technischer Probleme (z.B. Scanfehler) nicht auswertbar.',
-        code: IQB_STANDARD_MISSING_CODES.mci,
-        score: IQB_STANDARD_MISSING_SCORES.mci
-      },
+  private createIqbStandardMissings(): MissingDto[] {
+    return [
       {
         id: 'mir',
         label: 'missing invalid response',
-        description: '(1) Item wurde bearbeitet, aber (2a) leere Antwort oder (2b) ungültige (Spaß-)Antwort. Das Item wurde zwar bearbeitet, aber es wurde seitens der Testperson kein ernsthafter Lösungsversuch unternommen. Beispiel: Antworten wie "kein Plan", "egal", oder eine gemalte Sonne.',
+        description: '(1) Item wurde bearbeitet und (2a) leere Antwort oder (2b) sonstwie ungültige (Spaß-)Antwort.',
         code: IQB_STANDARD_MISSING_CODES.mir,
         score: IQB_STANDARD_MISSING_SCORES.mir
       },
       {
         id: 'mbi_mbo',
-        label: 'mbi / mbo',
-        description: 'Item wurde nicht bearbeitet aber gesehen oder Item wurde nicht gesehen, aber es gibt nachfolgend gesehene oder bearbeitete Items.',
+        label: 'missing by omission',
+        description: 'Item wurde nicht bearbeitet aber gesehen oder es wurde nicht gesehen, aber es gibt nachfolgend gesehene oder bearbeitete Items.',
         code: IQB_STANDARD_MISSING_CODES.mbi_mbo,
         score: IQB_STANDARD_MISSING_SCORES.mbi_mbo
+      },
+      {
+        id: 'mnr',
+        label: 'missing not reached',
+        description: '(1) Item wurde nicht gesehen und (2) es folgen nur nicht gesehene Items.',
+        code: IQB_STANDARD_MISSING_CODES.mnr,
+        score: IQB_STANDARD_MISSING_SCORES.mnr
+      },
+      {
+        id: 'mci',
+        label: 'missing coding impossible',
+        description: '(1) Item müsste/könnte bearbeitet worden sein und (2) Antwort ist aufgrund technischer Probleme nicht auswertbar.',
+        code: IQB_STANDARD_MISSING_CODES.mci,
+        score: IQB_STANDARD_MISSING_SCORES.mci
+      },
+      {
+        id: 'mbd',
+        label: 'missing by design',
+        description: 'Antwort liegt nicht vor, weil das Item der Testperson planmäßig nicht präsentiert wurde.',
+        code: IQB_STANDARD_MISSING_CODES.mbd,
+        score: IQB_STANDARD_MISSING_SCORES.mbd
       }
-    ]);
+    ];
+  }
 
+  private createDefaultMissingsProfile(): MissingsProfilesDto {
+    const iqbStandardProfile = new MissingsProfilesDto();
+    iqbStandardProfile.label = this.defaultProfileLabel;
+    iqbStandardProfile.setMissings(this.createIqbStandardMissings());
     return iqbStandardProfile;
   }
 
@@ -333,7 +372,7 @@ export class MissingsProfilesService {
       });
 
       if (existingProfile) {
-        const enriched = this.addIqbStandardScores(this.toDto(existingProfile));
+        const enriched = this.synchronizeIqbStandardProfile(this.toDto(existingProfile));
         if (enriched.changed) {
           existingProfile.missings = enriched.profile.missings as string;
           const savedProfile = await this.missingsProfileRepository.save(existingProfile);

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts
@@ -450,7 +450,6 @@ describe('CodingJobResultDialogComponent', () => {
   });
 
   it.each([
-    ['null', null],
     ['empty string', ''],
     ['blank string', '   ']
   ])('should block applying results when a manual missing score is %s', (_label, score) => {
@@ -505,6 +504,63 @@ describe('CodingJobResultDialogComponent', () => {
     expect(result.unresolvedMissing).toBe(true);
     expect(result.score).toBeUndefined();
     expect(component.canApplyCodingResults()).toBe(false);
+  });
+
+  it('should resolve manually selected missing codes with an explicit NA score', () => {
+    component.data.codingJob = {
+      ...component.data.codingJob,
+      status: 'completed',
+      missings_profile_id: 77
+    };
+    mockMissingsProfileService.getMissingsProfileDetails.mockReturnValue(of({
+      id: 77,
+      label: 'NA profile',
+      missings: JSON.stringify([
+        {
+          id: 'mir',
+          label: 'Custom MIR',
+          description: '',
+          code: -123,
+          score: null
+        },
+        {
+          id: 'mci',
+          label: 'Custom MCI',
+          description: '',
+          code: -124,
+          score: 8
+        }
+      ])
+    }));
+    mockCodingJobBackendService.getCodingJobUnits.mockReturnValue(of([{
+      responseId: 1,
+      unitName: 'UNIT_1',
+      unitAlias: 'UNIT_1',
+      variableId: 'VAR_1',
+      variableAnchor: 'VAR_1',
+      bookletName: 'BOOKLET_A',
+      personLogin: 'login',
+      personCode: 'code',
+      personGroup: 'group',
+      isDoubleCoded: false,
+      otherCoders: []
+    }]));
+    mockCodingJobBackendService.getCodingProgress.mockReturnValue(of({
+      'login@code@group@BOOKLET_A::BOOKLET_A::UNIT_1::VAR_1': {
+        id: -3,
+        label: 'MIR'
+      }
+    }));
+
+    component.loadCodingResults();
+
+    expect(component.dataSource.data[0]).toMatchObject({
+      code: -123,
+      score: null,
+      unresolvedMissing: false
+    });
+    expect(component.getScoreDisplay(component.dataSource.data[0])).toBe('NA');
+    expect(component.canApplyCodingResults()).toBe(true);
   });
 
   it('should identify new-code cases by stable issue option id', () => {

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.ts
@@ -54,7 +54,7 @@ interface CodingResult {
   testPersonSearch: string;
   code?: string | number | null;
   codeLabel?: string;
-  score?: number;
+  score?: number | null;
   codingIssueOption?: number;
   codingIssueOptionLabel?: string;
   givenCode?: string | number;
@@ -68,7 +68,7 @@ interface CodingResult {
 interface CodingProgressEntry {
   id?: string | number;
   label?: string;
-  score?: number;
+  score?: number | null;
   codingIssueOption?: number;
 }
 
@@ -89,7 +89,7 @@ interface CodingJobUnitResult {
 
 interface ResolvedMissingPreview {
   code: number;
-  score: number;
+  score: number | null;
   label?: string;
 }
 
@@ -357,18 +357,26 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
     }
 
     const code = Number(missing.code);
-    if (!Number.isInteger(code) || !this.hasExplicitFiniteScore(missing.score)) {
+    if (!Number.isInteger(code) || !this.hasExplicitScoreProperty(missing) || !this.hasExplicitValidScore(missing.score)) {
       return null;
     }
 
     return {
       code,
-      score: Number(missing.score),
+      score: this.normalizeScore(missing.score),
       label: missing.label
     };
   }
 
-  private hasExplicitFiniteScore(score: unknown): boolean {
+  private hasExplicitScoreProperty(missing: MissingDto): boolean {
+    return Object.prototype.hasOwnProperty.call(missing, 'score');
+  }
+
+  private hasExplicitValidScore(score: unknown): boolean {
+    if (score === null) {
+      return true;
+    }
+
     if (typeof score === 'number') {
       return Number.isFinite(score);
     }
@@ -379,6 +387,14 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
     }
 
     return false;
+  }
+
+  private normalizeScore(score: unknown): number | null {
+    if (score === null) {
+      return null;
+    }
+
+    return Number(score);
   }
 
   private getCodingProgressKey(unit: CodingJobUnitResult): string {
@@ -724,6 +740,9 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
     if (result.score !== undefined && result.score !== null) {
       return result.score.toString();
     }
+    if (result.score === null) {
+      return 'NA';
+    }
     if (this.hasCode(result)) {
       return '';
     }
@@ -771,7 +790,7 @@ export class CodingJobResultDialogComponent implements OnInit, OnDestroy, AfterV
   private getMappedResultScore(
     progress: CodingProgressEntry | undefined,
     missingPreviewLookup: MissingPreviewLookup
-  ): number | undefined {
+  ): number | null | undefined {
     const code = this.toNumericCode(progress?.id);
     const missingPreview = this.getMissingPreviewForProgressCode(code, missingPreviewLookup);
     if (missingPreview) {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/apply-empty-coding-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/apply-empty-coding-dialog.component.ts
@@ -8,7 +8,7 @@ import { TranslateModule } from '@ngx-translate/core';
 export interface ApplyEmptyCodingDialogData {
   count: number;
   code: number;
-  score: number;
+  score: number | null;
 }
 
 @Component({
@@ -34,7 +34,7 @@ export interface ApplyEmptyCodingDialogData {
         <ul>
           <li>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.status' | translate }}: <strong>CODING_COMPLETE</strong></li>
           <li>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.code' | translate }}: <strong>{{ data.code }}</strong></li>
-          <li>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.score' | translate }}: <strong>{{ data.score }}</strong></li>
+          <li>{{ 'coding-management-manual.response-analysis.apply-empty-coding-dialog.score' | translate }}: <strong>{{ getScoreDisplay(data.score) }}</strong></li>
         </ul>
       </div>
     </mat-dialog-content>
@@ -81,5 +81,9 @@ export class ApplyEmptyCodingDialogComponent {
 
   onConfirm(): void {
     this.dialogRef.close(true);
+  }
+
+  getScoreDisplay(score: number | null): string | number {
+    return score === null ? 'NA' : score;
   }
 }

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -92,7 +92,7 @@ import {
 import type {
   ManualCodeAvailabilityWarningDto
 } from '../../../../../../../api-dto/coding/manual-code-availability.dto';
-import { MissingsProfilesDto } from '../../../../../../../api-dto/coding/missings-profiles.dto';
+import { MissingDto, MissingsProfilesDto } from '../../../../../../../api-dto/coding/missings-profiles.dto';
 import {
   CODING_FRESHNESS_TASK_RESULT_HELP,
   formatCodingFreshnessResponseCount,
@@ -378,7 +378,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   isApplyingCodingResults = false;
 
   private applyingCodingResultJobIds = new Set<number>();
-  emptyResponseMissing: { code: number; score: number } | null = null;
+  emptyResponseMissing: { code: number; score: number | null } | null = null;
 
   showCoderTraining = false;
   editTraining: CoderTraining | null = null;
@@ -2536,14 +2536,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
           const missing = this.toMissingProfileDto(profile)?.parseMissings()
             .find(entry => entry.id === 'mir');
-          if (!missing || !Number.isInteger(Number(missing.code)) || !this.hasExplicitFiniteScore(missing.score)) {
+          if (!missing || !Number.isInteger(Number(missing.code)) || !this.hasExplicitScoreProperty(missing) || !this.hasExplicitValidScore(missing.score)) {
             this.emptyResponseMissing = null;
             return;
           }
 
           this.emptyResponseMissing = {
             code: Number(missing.code),
-            score: Number(missing.score)
+            score: this.normalizeScore(missing.score)
           };
         },
         error: () => {
@@ -2556,7 +2556,15 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return profile ? Object.assign(new MissingsProfilesDto(), profile) : null;
   }
 
-  private hasExplicitFiniteScore(score: unknown): boolean {
+  private hasExplicitScoreProperty(missing: MissingDto): boolean {
+    return Object.prototype.hasOwnProperty.call(missing, 'score');
+  }
+
+  private hasExplicitValidScore(score: unknown): boolean {
+    if (score === null) {
+      return true;
+    }
+
     if (typeof score === 'number') {
       return Number.isFinite(score);
     }
@@ -2569,6 +2577,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return false;
   }
 
+  private normalizeScore(score: unknown): number | null {
+    if (score === null) {
+      return null;
+    }
+
+    return Number(score);
+  }
+
   getApplyEmptyResponseCodingTooltip(): string {
     if (!this.emptyResponseMissing) {
       return this.translateService.instant(
@@ -2578,8 +2594,15 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
     return this.translateService.instant(
       'coding-management-manual.response-analysis.apply-empty-coding-tooltip',
-      this.emptyResponseMissing
+      {
+        ...this.emptyResponseMissing,
+        score: this.getScoreDisplay(this.emptyResponseMissing.score)
+      }
     );
+  }
+
+  getScoreDisplay(score: number | null): string | number {
+    return score === null ? 'NA' : score;
   }
 
   private loadCodingFreshness(): void {

--- a/apps/frontend/src/app/coding/components/edit-missings-profiles-dialog/edit-missings-profiles-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/edit-missings-profiles-dialog/edit-missings-profiles-dialog.component.html
@@ -100,9 +100,23 @@
               {{ 'workspace.missing-score' | translate }}
             </th>
             <td mat-cell *matCellDef="let missing; let i = index">
-              <mat-form-field appearance="fill">
-                <input matInput type="number" [(ngModel)]="missing.score" />
-              </mat-form-field>
+              <div class="score-editor">
+                <mat-form-field appearance="fill">
+                  <input
+                    matInput
+                    type="number"
+                    [ngModel]="missing.score"
+                    (ngModelChange)="setMissingScore(missing, $event)"
+                    [disabled]="isMissingScoreNa(missing)"
+                  />
+                </mat-form-field>
+                <mat-checkbox
+                  [checked]="isMissingScoreNa(missing)"
+                  (change)="setMissingScoreNa(missing, $event.checked)"
+                >
+                  NA
+                </mat-checkbox>
+              </div>
             </td>
           </ng-container>
 
@@ -177,7 +191,7 @@
             <th mat-header-cell *matHeaderCellDef>
               {{ 'workspace.missing-score' | translate }}
             </th>
-            <td mat-cell *matCellDef="let missing">{{ missing.score }}</td>
+            <td mat-cell *matCellDef="let missing">{{ getScoreDisplay(missing.score) }}</td>
           </ng-container>
 
           <!-- Actions Column (empty in view mode) -->

--- a/apps/frontend/src/app/coding/components/edit-missings-profiles-dialog/edit-missings-profiles-dialog.component.scss
+++ b/apps/frontend/src/app/coding/components/edit-missings-profiles-dialog/edit-missings-profiles-dialog.component.scss
@@ -87,7 +87,7 @@
     }
 
     .mat-column-description {
-      width: 35%;
+      width: 30%;
     }
 
     .mat-column-code {
@@ -95,7 +95,7 @@
     }
 
     .mat-column-score {
-      width: 10%;
+      width: 15%;
     }
 
     .mat-column-actions {
@@ -106,6 +106,16 @@
     mat-form-field {
       width: 100%;
       margin: -16px 0;
+    }
+
+    .score-editor {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      mat-form-field {
+        min-width: 80px;
+      }
     }
   }
 

--- a/apps/frontend/src/app/coding/components/edit-missings-profiles-dialog/edit-missings-profiles-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/edit-missings-profiles-dialog/edit-missings-profiles-dialog.component.spec.ts
@@ -16,7 +16,7 @@ describe('EditMissingsProfilesDialogComponent', () => {
       label: 'missing coding impossible',
       description: '',
       code: -97,
-      score: 0
+      score: null
     }
   ];
 
@@ -105,16 +105,16 @@ describe('EditMissingsProfilesDialogComponent', () => {
     expect(component.isProfileValid([
       ...createValidMissings(),
       {
-        ...createValidMissings()[0], id: 'extra', code: -96, score: null
+        ...createValidMissings()[0], id: 'extra', code: -96, score: false
       } as never
     ])).toBe(false);
 
     expect(component.isProfileValid([
       ...createValidMissings(),
       {
-        ...createValidMissings()[0], id: 'extra', code: -96, score: false
+        ...createValidMissings()[0], id: 'extra', code: -96, score: null
       } as never
-    ])).toBe(false);
+    ])).toBe(true);
   });
 
   it('rejects malformed missing ids and labels without throwing', () => {
@@ -172,6 +172,17 @@ describe('EditMissingsProfilesDialogComponent', () => {
       code: -99,
       score: 0
     }));
+  });
+
+  it('normalizes explicit NA scores for storage and display', () => {
+    const component = createComponent();
+    const missings = createValidMissings();
+
+    expect(component.normalizeMissingsForStorage(missings)[1]).toEqual(expect.objectContaining({
+      code: -97,
+      score: null
+    }));
+    expect(component.getScoreDisplay(null)).toBe('NA');
   });
 
   it('treats a null update response as a failed save', () => {

--- a/apps/frontend/src/app/coding/components/edit-missings-profiles-dialog/edit-missings-profiles-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/edit-missings-profiles-dialog/edit-missings-profiles-dialog.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import {
   MAT_DIALOG_DATA,
   MatDialogModule,
@@ -31,6 +32,7 @@ import { MissingDto, MissingsProfilesDto } from '../../../../../../../api-dto/co
     ReactiveFormsModule,
     MatButtonModule,
     MatCardModule,
+    MatCheckboxModule,
     MatDialogModule,
     MatFormFieldModule,
     MatIconModule,
@@ -139,8 +141,10 @@ export class EditMissingsProfilesDialogComponent implements OnInit {
         return;
       }
 
+      const normalizedMissings = this.normalizeMissingsForStorage(missings);
+
       if (this.editMode) {
-        this.selectedProfile.setMissings(missings);
+        this.selectedProfile.setMissings(normalizedMissings);
       }
 
       this.saving = true;
@@ -283,7 +287,7 @@ export class EditMissingsProfilesDialogComponent implements OnInit {
         missing.id.trim() !== '' && missing.label !== undefined && missing.label !== null &&
         missing.label.trim() !== '' && missing.description !== undefined && missing.description !== null &&
         this.hasExplicitFiniteNumber(missing.code) &&
-        this.hasExplicitFiniteNumber(missing.score));
+        this.hasExplicitValidScore(missing.score));
     } catch (error) {
       // Error occurred while parsing missings
       return [];
@@ -301,6 +305,22 @@ export class EditMissingsProfilesDialogComponent implements OnInit {
     }
 
     return false;
+  }
+
+  private hasExplicitValidScore(score: unknown): boolean {
+    if (score === null) {
+      return true;
+    }
+
+    return this.hasExplicitFiniteNumber(score);
+  }
+
+  private normalizeScore(score: unknown): number | null {
+    if (score === null) {
+      return null;
+    }
+
+    return Number(score);
   }
 
   private isValidMissingCode(code: unknown): boolean {
@@ -336,7 +356,7 @@ export class EditMissingsProfilesDialogComponent implements OnInit {
         label: 'missing coding impossible',
         description: '',
         code: -97,
-        score: 0
+        score: null
       }
     ];
   }
@@ -358,7 +378,7 @@ export class EditMissingsProfilesDialogComponent implements OnInit {
         !this.isNonBlankString(missing.label) ||
         missing.description === undefined || missing.description === null ||
         !this.isValidMissingCode(missing.code) ||
-        !this.hasExplicitFiniteNumber(missing.score)) {
+        !this.hasExplicitValidScore(missing.score)) {
         return false;
       }
 
@@ -372,5 +392,37 @@ export class EditMissingsProfilesDialogComponent implements OnInit {
     }
 
     return this.requiredMissingIds.every(requiredId => ids.has(requiredId));
+  }
+
+  normalizeMissingsForStorage(missings: MissingDto[]): MissingDto[] {
+    return missings.map(missing => ({
+      id: missing.id.trim(),
+      label: missing.label.trim(),
+      description: String(missing.description),
+      code: Number(missing.code),
+      score: this.normalizeScore(missing.score)
+    }));
+  }
+
+  isMissingScoreNa(missing: MissingDto): boolean {
+    return missing.score === null;
+  }
+
+  setMissingScoreNa(missing: MissingDto, isNa: boolean): void {
+    missing.score = isNa ? null : 0;
+  }
+
+  setMissingScore(missing: MissingDto, value: unknown): void {
+    if (value === null || value === undefined || value === '') {
+      (missing as { score: unknown }).score = '';
+      return;
+    }
+
+    const score = Number(value);
+    (missing as { score: unknown }).score = Number.isFinite(score) ? score : value;
+  }
+
+  getScoreDisplay(score: number | null): string | number {
+    return score === null ? 'NA' : score;
   }
 }

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -990,7 +990,7 @@
     "no-failures": "Keine Fehler vorhanden",
     "error-loading-missings-profiles": "Fehler beim Laden der Missings-Profile",
     "error-loading-missings-profile-details": "Fehler beim Laden der Details zum Missings-Profil",
-    "missing-validation-error": "Alle Missing-Einträge müssen gültige Angaben inklusive Code und Score haben",
+    "missing-validation-error": "Alle Missing-Einträge müssen gültige Angaben inklusive Code und Score oder NA haben",
     "profile-updated-successfully": "Profil erfolgreich aktualisiert",
     "error-updating-missings-profile": "Fehler beim Aktualisieren des Missings-Profils",
     "profile-created-successfully": "Profil erfolgreich erstellt",

--- a/database/changelog/coding-box.changelog-1.16.2.sql
+++ b/database/changelog/coding-box.changelog-1.16.2.sql
@@ -1,0 +1,43 @@
+-- liquibase formatted sql
+
+-- changeset jurei733:1
+-- comment: Preserve previous IQB standard missings variants and canonicalize the active profile with explicit NA scores
+
+WITH canonical_iqb_standard AS (
+  SELECT $$[{"id":"mir","label":"missing invalid response","description":"(1) Item wurde bearbeitet und (2a) leere Antwort oder (2b) sonstwie ungültige (Spaß-)Antwort.","code":-98,"score":0},{"id":"mbi_mbo","label":"missing by omission","description":"Item wurde nicht bearbeitet aber gesehen oder es wurde nicht gesehen, aber es gibt nachfolgend gesehene oder bearbeitete Items.","code":-99,"score":0},{"id":"mnr","label":"missing not reached","description":"(1) Item wurde nicht gesehen und (2) es folgen nur nicht gesehene Items.","code":-96,"score":null},{"id":"mci","label":"missing coding impossible","description":"(1) Item müsste/könnte bearbeitet worden sein und (2) Antwort ist aufgrund technischer Probleme nicht auswertbar.","code":-97,"score":null},{"id":"mbd","label":"missing by design","description":"Antwort liegt nicht vor, weil das Item der Testperson planmäßig nicht präsentiert wurde.","code":-94,"score":null}]$$::TEXT AS missings
+)
+INSERT INTO "public"."missings_profile" ("workspace_id", "label", "missings")
+SELECT w."id", 'IQB-Standard', canonical_iqb_standard."missings"
+FROM "public"."workspace" w
+CROSS JOIN canonical_iqb_standard
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "public"."missings_profile" mp
+  WHERE mp."workspace_id" = w."id"
+    AND mp."label" = 'IQB-Standard'
+);
+
+WITH canonical_iqb_standard AS (
+  SELECT $$[{"id":"mir","label":"missing invalid response","description":"(1) Item wurde bearbeitet und (2a) leere Antwort oder (2b) sonstwie ungültige (Spaß-)Antwort.","code":-98,"score":0},{"id":"mbi_mbo","label":"missing by omission","description":"Item wurde nicht bearbeitet aber gesehen oder es wurde nicht gesehen, aber es gibt nachfolgend gesehene oder bearbeitete Items.","code":-99,"score":0},{"id":"mnr","label":"missing not reached","description":"(1) Item wurde nicht gesehen und (2) es folgen nur nicht gesehene Items.","code":-96,"score":null},{"id":"mci","label":"missing coding impossible","description":"(1) Item müsste/könnte bearbeitet worden sein und (2) Antwort ist aufgrund technischer Probleme nicht auswertbar.","code":-97,"score":null},{"id":"mbd","label":"missing by design","description":"Antwort liegt nicht vor, weil das Item der Testperson planmäßig nicht präsentiert wurde.","code":-94,"score":null}]$$::TEXT AS missings
+)
+INSERT INTO "public"."missings_profile" ("workspace_id", "label", "missings")
+SELECT
+  mp."workspace_id",
+  'IQB-Standard (vor 1.16.2 #' || mp."id" || ')',
+  mp."missings"
+FROM "public"."missings_profile" mp
+CROSS JOIN canonical_iqb_standard
+WHERE mp."label" = 'IQB-Standard'
+  AND mp."missings" IS DISTINCT FROM canonical_iqb_standard."missings"
+ON CONFLICT ("workspace_id", "label") DO NOTHING;
+
+WITH canonical_iqb_standard AS (
+  SELECT $$[{"id":"mir","label":"missing invalid response","description":"(1) Item wurde bearbeitet und (2a) leere Antwort oder (2b) sonstwie ungültige (Spaß-)Antwort.","code":-98,"score":0},{"id":"mbi_mbo","label":"missing by omission","description":"Item wurde nicht bearbeitet aber gesehen oder es wurde nicht gesehen, aber es gibt nachfolgend gesehene oder bearbeitete Items.","code":-99,"score":0},{"id":"mnr","label":"missing not reached","description":"(1) Item wurde nicht gesehen und (2) es folgen nur nicht gesehene Items.","code":-96,"score":null},{"id":"mci","label":"missing coding impossible","description":"(1) Item müsste/könnte bearbeitet worden sein und (2) Antwort ist aufgrund technischer Probleme nicht auswertbar.","code":-97,"score":null},{"id":"mbd","label":"missing by design","description":"Antwort liegt nicht vor, weil das Item der Testperson planmäßig nicht präsentiert wurde.","code":-94,"score":null}]$$::TEXT AS missings
+)
+UPDATE "public"."missings_profile" mp
+SET "missings" = canonical_iqb_standard."missings"
+FROM canonical_iqb_standard
+WHERE mp."label" = 'IQB-Standard'
+  AND mp."missings" IS DISTINCT FROM canonical_iqb_standard."missings";
+
+-- rollback -- Cannot safely restore canonicalized IQB-Standard profile variants automatically; previous variants were preserved as separate backup profiles.

--- a/database/changelog/coding-box.changelog-root.xml
+++ b/database/changelog/coding-box.changelog-root.xml
@@ -40,4 +40,5 @@
   <include file="coding-box.changelog-1.15.0.sql"/>
   <include file="coding-box.changelog-1.16.0.sql"/>
   <include file="coding-box.changelog-1.16.1.sql"/>
+  <include file="coding-box.changelog-1.16.2.sql"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

Adds explicit `NA` handling for IQB-standard missing scores across missing profiles, training/result previews, and score exports.

The active `IQB-Standard` profile is canonicalized to include `mir`, `mbi_mbo`, `mnr`, `mci`, and `mbd`, with `null` scores exported and displayed as `NA` where required. Existing divergent `IQB-Standard` profiles are preserved by the migration as backup profiles before the active standard profile is overwritten.

Refs #636

## Validation

- `npx nx test backend --runTestsByPath=apps/backend/src/app/database/services/coding/coding-export.service.spec.ts` (Nx ran the broader backend suite; passed on retry)
- `npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/components/coding-jobs/coding-job-result-dialog/coding-job-result-dialog.component.spec.ts` (Nx ran the broader frontend suite; passed)
- `npx nx lint backend`
- `npx nx lint frontend`
- `git diff --check`

`make dev-db-validate-changelog` could not be rerun locally because Docker was not reachable at the configured socket.
