### PR TITLE
Bump version to 1.16.2

### DIFF
--- a/apps/frontend/src/app/components/home/home.component.html
+++ b/apps/frontend/src/app/components/home/home.component.html
@@ -11,7 +11,7 @@
     [appTitle]="'Web application for coding'"
     [introHtml]="'appService.appConfig.introHtml'"
     [appName]="'IQB-Kodierbox'"
-    [appVersion]="'1.16.1'"
+    [appVersion]="'1.16.2'"
     [userName]="authData.userName"
     [userLongName]="appService.userProfile.firstName + ' ' + appService.userProfile.lastName"
     [isUserLoggedIn]="Number(authData.userId) > 0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coding-box",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coding-box",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "20.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-box",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the application version from 1.16.1 to 1.16.2 in `package.json` and `package-lock.json`
- update the displayed Home component app version to 1.16.2

## Validation
- `npx nx lint frontend`