### PR TITLE
Fix workspace user assignment pagination

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-users.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-users.controller.spec.ts
@@ -7,18 +7,24 @@ import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
 import { AccessLevelGuard } from './access-level.guard';
 
+type WorkspaceUsersServiceMock = jest.Mocked<Pick<WorkspaceUsersService, 'setWorkspaceUsers'>>;
+
 describe('WorkspaceUsersController', () => {
   let controller: WorkspaceUsersController;
+  let workspaceUsersService: WorkspaceUsersServiceMock;
   let authService: jest.Mocked<Pick<AuthService, 'createToken' | 'createTokenForUserId'>>;
 
   beforeEach(() => {
+    workspaceUsersService = {
+      setWorkspaceUsers: jest.fn()
+    };
     authService = {
       createToken: jest.fn(),
       createTokenForUserId: jest.fn()
     };
 
     controller = new WorkspaceUsersController(
-      {} as WorkspaceUsersService,
+      workspaceUsersService as unknown as WorkspaceUsersService,
       authService as unknown as AuthService
     );
   });
@@ -88,5 +94,15 @@ describe('WorkspaceUsersController', () => {
         expect(authService.createToken).not.toHaveBeenCalled();
       }
     );
+  });
+
+  describe('setWorkspaceUsers', () => {
+    it('delegates workspace user assignment with the parsed workspace id', async () => {
+      workspaceUsersService.setWorkspaceUsers.mockResolvedValue(true);
+
+      await expect(controller.setWorkspaceUsers([7, 8], 3)).resolves.toBe(true);
+
+      expect(workspaceUsersService.setWorkspaceUsers).toHaveBeenCalledWith(3, [7, 8]);
+    });
   });
 });

--- a/apps/backend/src/app/admin/workspace/workspace-users.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-users.controller.spec.ts
@@ -1,5 +1,6 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, INestApplication, InternalServerErrorException } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { Test, TestingModule } from '@nestjs/testing';
 import { WorkspaceUsersController } from './workspace-users.controller';
 import { WorkspaceUsersService } from '../../database/services/workspace/workspace-users.service';
 import { AuthService } from '../../auth/service/auth.service';
@@ -7,7 +8,7 @@ import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
 import { AccessLevelGuard } from './access-level.guard';
 
-type WorkspaceUsersServiceMock = jest.Mocked<Pick<WorkspaceUsersService, 'setWorkspaceUsers'>>;
+type WorkspaceUsersServiceMock = jest.Mocked<Pick<WorkspaceUsersService, 'findUsers' | 'setWorkspaceUsers'>>;
 
 describe('WorkspaceUsersController', () => {
   let controller: WorkspaceUsersController;
@@ -16,6 +17,7 @@ describe('WorkspaceUsersController', () => {
 
   beforeEach(() => {
     workspaceUsersService = {
+      findUsers: jest.fn(),
       setWorkspaceUsers: jest.fn()
     };
     authService = {
@@ -28,6 +30,34 @@ describe('WorkspaceUsersController', () => {
       authService as unknown as AuthService
     );
   });
+
+  async function createTestApp(): Promise<INestApplication> {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WorkspaceUsersController],
+      providers: [
+        {
+          provide: WorkspaceUsersService,
+          useValue: workspaceUsersService
+        },
+        {
+          provide: AuthService,
+          useValue: authService
+        }
+      ]
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(WorkspaceGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(AccessLevelGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    const app = module.createNestApplication();
+    await app.init();
+    await app.listen(0);
+    return app;
+  }
 
   describe('createOwnToken', () => {
     it('requires workspace access without workspace admin access level metadata', () => {
@@ -96,13 +126,57 @@ describe('WorkspaceUsersController', () => {
     );
   });
 
+  describe('findUsers', () => {
+    it('throws when workspace users cannot be retrieved', async () => {
+      workspaceUsersService.findUsers.mockRejectedValue(new Error('database unavailable'));
+
+      await expect(controller.findUsers(3, 1, 500)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('returns an HTTP error when workspace users cannot be retrieved', async () => {
+      workspaceUsersService.findUsers.mockRejectedValue(new Error('database unavailable'));
+      let app: INestApplication | undefined;
+
+      try {
+        app = await createTestApp();
+
+        const response = await fetch(`${await app.getUrl()}/admin/workspace/3/users?page=1&limit=500`);
+
+        expect(response.status).toBe(500);
+      } finally {
+        await app?.close();
+      }
+    });
+  });
+
   describe('setWorkspaceUsers', () => {
-    it('delegates workspace user assignment with the parsed workspace id', async () => {
+    it('delegates workspace user assignment', async () => {
       workspaceUsersService.setWorkspaceUsers.mockResolvedValue(true);
 
       await expect(controller.setWorkspaceUsers([7, 8], 3)).resolves.toBe(true);
 
       expect(workspaceUsersService.setWorkspaceUsers).toHaveBeenCalledWith(3, [7, 8]);
+    });
+
+    it('parses the workspace id from the route before delegating', async () => {
+      workspaceUsersService.setWorkspaceUsers.mockResolvedValue(true);
+      let app: INestApplication | undefined;
+
+      try {
+        app = await createTestApp();
+
+        const response = await fetch(`${await app.getUrl()}/admin/workspace/3/users`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify([7, 8])
+        });
+
+        expect(response.status).toBe(201);
+        await expect(response.json()).resolves.toBe(true);
+        expect(workspaceUsersService.setWorkspaceUsers).toHaveBeenCalledWith(3, [7, 8]);
+      } finally {
+        await app?.close();
+      }
     });
   });
 });

--- a/apps/backend/src/app/admin/workspace/workspace-users.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-users.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  DefaultValuePipe,
   Get, Logger, Param, ParseIntPipe, Post, Query, Req, UseGuards
 } from '@nestjs/common';
 import {
@@ -157,8 +158,8 @@ export class WorkspaceUsersController {
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   async findUsers(
     @Param('workspace_id') workspaceId: number,
-                           @Query('page') page: number = 1,
-                           @Query('limit') limit: number = 20
+                           @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number = 1,
+                           @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number = 20
   ): Promise<{ data: WorkspaceUser[]; total: number; page: number; limit: number }> {
     try {
       const [users, total] = await this.workspaceUsersService.findUsers(workspaceId, { page, limit });
@@ -179,11 +180,11 @@ export class WorkspaceUsersController {
     }
   }
 
-  @Post(':workspaceId/users')
+  @Post(':workspace_id/users')
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   @ApiOperation({ summary: 'Set workspace users', description: 'Assigns users to a workspace' })
-  @ApiParam({ name: 'workspaceId', type: Number, description: 'ID of the workspace' })
+  @ApiParam({ name: 'workspace_id', type: Number, description: 'ID of the workspace' })
   @ApiBody({
     schema: {
       type: 'array',
@@ -200,7 +201,7 @@ export class WorkspaceUsersController {
   @ApiBadRequestResponse({ description: 'Invalid user IDs or workspace ID' })
   @ApiTags('admin users')
   async setWorkspaceUsers(@Body() userIds: number[],
-    @Param('workspaceId') workspaceId: number) {
+    @Param('workspace_id', ParseIntPipe) workspaceId: number) {
     return this.workspaceUsersService.setWorkspaceUsers(workspaceId, userIds);
   }
 

--- a/apps/backend/src/app/admin/workspace/workspace-users.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-users.controller.ts
@@ -3,7 +3,7 @@ import {
   Body,
   Controller,
   DefaultValuePipe,
-  Get, Logger, Param, ParseIntPipe, Post, Query, Req, UseGuards
+  Get, InternalServerErrorException, Logger, Param, ParseIntPipe, Post, Query, Req, UseGuards
 } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
@@ -170,13 +170,8 @@ export class WorkspaceUsersController {
         limit
       };
     } catch (error) {
-      this.logger.error(`Error retrieving users for workspace ${workspaceId}`);
-      return {
-        data: [],
-        total: 0,
-        page,
-        limit
-      };
+      this.logger.error(`Error retrieving users for workspace ${workspaceId}`, error);
+      throw new InternalServerErrorException('Could not retrieve workspace users');
     }
   }
 

--- a/apps/frontend/src/app/sys-admin/components/user-access-rights-dialog/user-access-rights-dialog.component.html
+++ b/apps/frontend/src/app/sys-admin/components/user-access-rights-dialog/user-access-rights-dialog.component.html
@@ -7,6 +7,7 @@
   <button mat-raised-button
           color="primary"
           type="submit"
+          [disabled]="isLoadingWorkspaceUsers || workspaceUsersLoadingFailed"
           [mat-dialog-close]="result">
     {{ 'save' | translate }}
   </button>

--- a/apps/frontend/src/app/sys-admin/components/user-access-rights-dialog/user-access-rights-dialog.component.spec.ts
+++ b/apps/frontend/src/app/sys-admin/components/user-access-rights-dialog/user-access-rights-dialog.component.spec.ts
@@ -3,15 +3,38 @@ import { provideHttpClient } from '@angular/common/http';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
+import { of, throwError } from 'rxjs';
 import { UserAccessRightsDialogComponent } from './user-access-rights-dialog.component';
 import { environment } from '../../../../environments/environment';
 import { SERVER_URL } from '../../../injection-tokens';
+import { WorkspaceBackendService } from '../../../workspace/services/workspace-backend.service';
+import { UserBackendService } from '../../../shared/services/user/user-backend.service';
 
 describe('UserAccessRightsDialogComponent', () => {
-  let component: UserAccessRightsDialogComponent;
-  let fixture: ComponentFixture<UserAccessRightsDialogComponent>;
+  const workspaceBackendService = {
+    getAllWorkspaceUsers: jest.fn(),
+    getAllWorkspacesList: jest.fn()
+  };
+  const userBackendService = {
+    getUsersFull: jest.fn()
+  };
+
+  function createComponent(dialogData: { selectedWorkspace?: number[] } = {}):
+  ComponentFixture<UserAccessRightsDialogComponent> {
+    TestBed.overrideProvider(MAT_DIALOG_DATA, { useValue: dialogData });
+    const fixture = TestBed.createComponent(UserAccessRightsDialogComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
 
   beforeEach(async () => {
+    workspaceBackendService.getAllWorkspaceUsers.mockReset();
+    workspaceBackendService.getAllWorkspacesList.mockReset();
+    userBackendService.getUsersFull.mockReset();
+    workspaceBackendService.getAllWorkspaceUsers.mockReturnValue(of([]));
+    workspaceBackendService.getAllWorkspacesList.mockReturnValue(of({ data: [], total: 0 }));
+    userBackendService.getUsersFull.mockReturnValue(of([]));
+
     await TestBed.configureTestingModule({
       providers: [{
         provide: MAT_DIALOG_DATA,
@@ -21,7 +44,15 @@ describe('UserAccessRightsDialogComponent', () => {
         provide: SERVER_URL,
         useValue: environment.backendUrl
       },
-      provideHttpClient()
+      provideHttpClient(),
+      {
+        provide: WorkspaceBackendService,
+        useValue: workspaceBackendService
+      },
+      {
+        provide: UserBackendService,
+        useValue: userBackendService
+      }
       ],
       imports: [
         TranslateModule.forRoot(),
@@ -29,12 +60,44 @@ describe('UserAccessRightsDialogComponent', () => {
         MatIconModule
       ]
     }).compileComponents();
-
-    fixture = TestBed.createComponent(UserAccessRightsDialogComponent);
-    component = fixture.componentInstance;
   });
 
   it('should create', () => {
+    const fixture = createComponent();
+    const component = fixture.componentInstance;
+
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize the saved result from loaded workspace users', () => {
+    workspaceBackendService.getAllWorkspaceUsers.mockReturnValue(of([
+      {
+        workspaceId: 1, userId: 7, accessLevel: 3, canCode: false
+      },
+      {
+        workspaceId: 1, userId: 8, accessLevel: 1, canCode: true
+      }
+    ]));
+
+    const fixture = createComponent({ selectedWorkspace: [1] });
+    const component = fixture.componentInstance;
+
+    expect(component.selectedUserIds).toEqual([7, 8]);
+    expect(component.result).toEqual([7, 8]);
+    expect(component.isLoadingWorkspaceUsers).toBe(false);
+    expect(component.workspaceUsersLoadingFailed).toBe(false);
+  });
+
+  it('should disable saving when loading workspace users fails', () => {
+    workspaceBackendService.getAllWorkspaceUsers.mockReturnValue(throwError(() => new Error('load failed')));
+
+    const fixture = createComponent({ selectedWorkspace: [1] });
+    const component = fixture.componentInstance;
+
+    expect(component.result).toEqual([]);
+    expect(component.isLoadingWorkspaceUsers).toBe(false);
+    expect(component.workspaceUsersLoadingFailed).toBe(true);
+    const saveButton: HTMLButtonElement = fixture.nativeElement.querySelector('button[color="primary"]');
+    expect(saveButton.disabled).toBe(true);
   });
 });

--- a/apps/frontend/src/app/sys-admin/components/user-access-rights-dialog/user-access-rights-dialog.component.ts
+++ b/apps/frontend/src/app/sys-admin/components/user-access-rights-dialog/user-access-rights-dialog.component.ts
@@ -33,10 +33,10 @@ export class UserAccessRightsDialogComponent {
   result: number[] = [];
   constructor() {
     if (this.data.selectedWorkspace?.length > 0) {
-      this.workspaceBackendService.getWorkspaceUsers(this.data.selectedWorkspace[0])
+      this.workspaceBackendService.getAllWorkspaceUsers(this.data.selectedWorkspace[0])
         .subscribe(users => {
-          if (Array.isArray(users.data)) {
-            this.selectedUserIds = users.data.map(user => user.userId);
+          if (Array.isArray(users)) {
+            this.selectedUserIds = users.map(user => user.userId);
           }
         });
     }

--- a/apps/frontend/src/app/sys-admin/components/user-access-rights-dialog/user-access-rights-dialog.component.ts
+++ b/apps/frontend/src/app/sys-admin/components/user-access-rights-dialog/user-access-rights-dialog.component.ts
@@ -29,14 +29,28 @@ export class UserAccessRightsDialogComponent {
 
   private workspaceBackendService = inject(WorkspaceBackendService);
 
-  selectedUserIds!: number[];
+  selectedUserIds: number[] = [];
+  isLoadingWorkspaceUsers = false;
+  workspaceUsersLoadingFailed = false;
   result: number[] = [];
+
   constructor() {
     if (this.data.selectedWorkspace?.length > 0) {
+      this.isLoadingWorkspaceUsers = true;
       this.workspaceBackendService.getAllWorkspaceUsers(this.data.selectedWorkspace[0])
-        .subscribe(users => {
-          if (Array.isArray(users)) {
-            this.selectedUserIds = users.map(user => user.userId);
+        .subscribe({
+          next: users => {
+            if (Array.isArray(users)) {
+              this.selectedUserIds = users.map(user => user.userId);
+              this.result = [...this.selectedUserIds];
+            }
+            this.isLoadingWorkspaceUsers = false;
+          },
+          error: () => {
+            this.selectedUserIds = [];
+            this.result = [];
+            this.workspaceUsersLoadingFailed = true;
+            this.isLoadingWorkspaceUsers = false;
           }
         });
     }

--- a/apps/frontend/src/app/workspace/services/workspace-backend.service.spec.ts
+++ b/apps/frontend/src/app/workspace/services/workspace-backend.service.spec.ts
@@ -113,6 +113,36 @@ describe('WorkspaceBackendService', () => {
         limit: 1
       });
     });
+
+    it('should fail when loading all workspace users cannot fetch a later page', () => {
+      const errorHandler = jest.fn();
+      const nextHandler = jest.fn();
+
+      service.getAllWorkspaceUsers(1).subscribe({
+        next: nextHandler,
+        error: errorHandler
+      });
+
+      const firstRequest = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/1/users?page=1&limit=500`
+      );
+      firstRequest.flush({
+        data: [{
+          workspaceId: 1, userId: 1, accessLevel: 3, canCode: false
+        }],
+        total: 2,
+        page: 1,
+        limit: 1
+      });
+
+      const secondRequest = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/1/users?page=2&limit=500`
+      );
+      secondRequest.flush('server error', { status: 500, statusText: 'Server Error' });
+
+      expect(nextHandler).not.toHaveBeenCalled();
+      expect(errorHandler).toHaveBeenCalled();
+    });
   });
 
   describe('addWorkspace', () => {

--- a/apps/frontend/src/app/workspace/services/workspace-backend.service.spec.ts
+++ b/apps/frontend/src/app/workspace/services/workspace-backend.service.spec.ts
@@ -53,6 +53,68 @@ describe('WorkspaceBackendService', () => {
     });
   });
 
+  describe('getWorkspaceUsers', () => {
+    it('should fetch workspace users with pagination parameters', () => {
+      const mockResponse = {
+        data: [{
+          workspaceId: 1, userId: 7, accessLevel: 3, canCode: false
+        }],
+        total: 1,
+        page: 2,
+        limit: 50
+      };
+
+      service.getWorkspaceUsers(1, { page: 2, limit: 50 }).subscribe(res => {
+        expect(res).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/1/users?page=2&limit=50`
+      );
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+
+    it('should fetch all workspace users across pages', () => {
+      service.getAllWorkspaceUsers(1).subscribe(res => {
+        expect(res).toEqual([
+          {
+            workspaceId: 1, userId: 1, accessLevel: 3, canCode: false
+          },
+          {
+            workspaceId: 1, userId: 2, accessLevel: 1, canCode: true
+          }
+        ]);
+      });
+
+      const firstRequest = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/1/users?page=1&limit=500`
+      );
+      expect(firstRequest.request.method).toBe('GET');
+      firstRequest.flush({
+        data: [{
+          workspaceId: 1, userId: 1, accessLevel: 3, canCode: false
+        }],
+        total: 2,
+        page: '1',
+        limit: '1'
+      });
+
+      const secondRequest = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/1/users?page=2&limit=500`
+      );
+      expect(secondRequest.request.method).toBe('GET');
+      secondRequest.flush({
+        data: [{
+          workspaceId: 1, userId: 2, accessLevel: 1, canCode: true
+        }],
+        total: 2,
+        page: 2,
+        limit: 1
+      });
+    });
+  });
+
   describe('addWorkspace', () => {
     it('should populate headers and body', () => {
       const mockDto = { name: 'New' };

--- a/apps/frontend/src/app/workspace/services/workspace-backend.service.ts
+++ b/apps/frontend/src/app/workspace/services/workspace-backend.service.ts
@@ -2,9 +2,12 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import {
   catchError,
+  EMPTY,
+  expand,
   map,
   Observable,
-  of
+  of,
+  reduce
 } from 'rxjs';
 import { WorkspaceFullDto } from '../../../../../../api-dto/workspaces/workspace-full-dto';
 import { CreateWorkspaceDto } from '../../../../../../api-dto/workspaces/create-workspace-dto';
@@ -21,6 +24,7 @@ export interface CoderDto extends WorkspaceUserDto {
   providedIn: 'root'
 })
 export class WorkspaceBackendService {
+  private readonly workspaceUsersPageLimit = 500;
   private readonly serverUrl = inject(SERVER_URL);
   private http = inject(HttpClient);
 
@@ -41,10 +45,21 @@ export class WorkspaceBackendService {
       );
   }
 
-  getWorkspaceUsers(workspaceId: number): Observable<PaginatedWorkspaceUserDto> {
+  getWorkspaceUsers(
+    workspaceId: number,
+    options?: { page?: number; limit?: number }
+  ): Observable<PaginatedWorkspaceUserDto> {
+    let params = new HttpParams();
+    if (options?.page) {
+      params = params.set('page', options.page);
+    }
+    if (options?.limit) {
+      params = params.set('limit', options.limit);
+    }
+
     return this.http
       .get<PaginatedWorkspaceUserDto>(`${this.serverUrl}admin/workspace/${workspaceId}/users`,
-      {})
+      { params })
       .pipe(
         catchError(() => of({
           data: [],
@@ -53,6 +68,21 @@ export class WorkspaceBackendService {
           limit: 0
         }))
       );
+  }
+
+  getAllWorkspaceUsers(workspaceId: number): Observable<WorkspaceUserDto[]> {
+    return this.getWorkspaceUsers(workspaceId, { page: 1, limit: this.workspaceUsersPageLimit }).pipe(
+      expand(response => {
+        const currentPage = Number(response.page);
+        const currentLimit = Number(response.limit);
+        const total = Number(response.total);
+
+        return currentPage * currentLimit < total ?
+          this.getWorkspaceUsers(workspaceId, { page: currentPage + 1, limit: this.workspaceUsersPageLimit }) :
+          EMPTY;
+      }),
+      reduce((users, response) => users.concat(response.data), [] as WorkspaceUserDto[])
+    );
   }
 
   getWorkspaceCoders(workspaceId: number): Observable<{ data: CoderDto[], total: number }> {

--- a/apps/frontend/src/app/workspace/services/workspace-backend.service.ts
+++ b/apps/frontend/src/app/workspace/services/workspace-backend.service.ts
@@ -49,17 +49,7 @@ export class WorkspaceBackendService {
     workspaceId: number,
     options?: { page?: number; limit?: number }
   ): Observable<PaginatedWorkspaceUserDto> {
-    let params = new HttpParams();
-    if (options?.page) {
-      params = params.set('page', options.page);
-    }
-    if (options?.limit) {
-      params = params.set('limit', options.limit);
-    }
-
-    return this.http
-      .get<PaginatedWorkspaceUserDto>(`${this.serverUrl}admin/workspace/${workspaceId}/users`,
-      { params })
+    return this.requestWorkspaceUsers(workspaceId, options)
       .pipe(
         catchError(() => of({
           data: [],
@@ -70,15 +60,32 @@ export class WorkspaceBackendService {
       );
   }
 
+  private requestWorkspaceUsers(
+    workspaceId: number,
+    options?: { page?: number; limit?: number }
+  ): Observable<PaginatedWorkspaceUserDto> {
+    let params = new HttpParams();
+    if (options?.page) {
+      params = params.set('page', options.page);
+    }
+    if (options?.limit) {
+      params = params.set('limit', options.limit);
+    }
+
+    return this.http
+      .get<PaginatedWorkspaceUserDto>(`${this.serverUrl}admin/workspace/${workspaceId}/users`,
+      { params });
+  }
+
   getAllWorkspaceUsers(workspaceId: number): Observable<WorkspaceUserDto[]> {
-    return this.getWorkspaceUsers(workspaceId, { page: 1, limit: this.workspaceUsersPageLimit }).pipe(
+    return this.requestWorkspaceUsers(workspaceId, { page: 1, limit: this.workspaceUsersPageLimit }).pipe(
       expand(response => {
         const currentPage = Number(response.page);
         const currentLimit = Number(response.limit);
         const total = Number(response.total);
 
         return currentPage * currentLimit < total ?
-          this.getWorkspaceUsers(workspaceId, { page: currentPage + 1, limit: this.workspaceUsersPageLimit }) :
+          this.requestWorkspaceUsers(workspaceId, { page: currentPage + 1, limit: this.workspaceUsersPageLimit }) :
           EMPTY;
       }),
       reduce((users, response) => users.concat(response.data), [] as WorkspaceUserDto[])


### PR DESCRIPTION
## Summary
- load all assigned workspace users in the workspace access-rights dialog instead of only the first paginated page
- add paginated workspace-user loading in the frontend service, including defensive numeric handling for pagination metadata
- parse workspace user endpoint pagination and workspace IDs in the backend controller

## Why
The workspace-based user assignment flow replaces the full user list for a workspace. When the dialog only preselected the first paginated page, saving could omit existing assignments and trip the study-manager invariant.

Relates to #775.

## Validation
- `npx nx test frontend --testFile=apps/frontend/src/app/workspace/services/workspace-backend.service.spec.ts`
- `npx nx test backend --testFile=apps/backend/src/app/admin/workspace/workspace-users.controller.spec.ts`
- `npx nx lint frontend`
- `npx nx lint backend`

Note: A full `npx nx test backend` run was also attempted and timed out in the existing `src/app/database/services-read-methods.spec.ts`; the changed backend controller spec passed separately.