### PR TITLE
Differentiate manual review export labels

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1498,6 +1498,84 @@ describe('CodingManagementManualComponent', () => {
     );
   });
 
+  it('should label manual review exports by their double-coding method', () => {
+    const exportJobService = TestBed.inject(ExportJobService) as unknown as {
+      startJob: jest.Mock;
+    };
+    const componentInternals = component as unknown as {
+      startManualCodingExport: (
+        context: 'training' | 'execution',
+        result: {
+          exportType: 'aggregated';
+          doubleCodingMethod?: 'most-frequent' | 'new-column-per-coder' | 'new-row-per-variable';
+          jobDefinitionIds: number[];
+        }
+      ) => void;
+      appService: {
+        selectedWorkspaceId: number;
+        updateAuthData(authData: unknown): void;
+      };
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.appService.updateAuthData({ userId: 9 });
+    exportJobService.startJob.mockClear();
+
+    [
+      {
+        method: 'most-frequent' as const,
+        displayLabelKey: 'export-toast.types.manual-review-most-frequent',
+        downloadFilePrefix: 'manual-review-most-frequent'
+      },
+      {
+        method: 'new-column-per-coder' as const,
+        displayLabelKey: 'export-toast.types.manual-review-new-column-per-coder',
+        downloadFilePrefix: 'manual-review-new-column-per-coder'
+      },
+      {
+        method: 'new-row-per-variable' as const,
+        displayLabelKey: 'export-toast.types.manual-review-new-row-per-variable',
+        downloadFilePrefix: 'manual-review-new-row-per-variable'
+      }
+    ].forEach(({ method }) => {
+      componentInternals.startManualCodingExport('execution', {
+        exportType: 'aggregated',
+        doubleCodingMethod: method,
+        jobDefinitionIds: [11]
+      });
+    });
+
+    expect(exportJobService.startJob).toHaveBeenNthCalledWith(
+      1,
+      5,
+      expect.objectContaining({
+        exportType: 'aggregated',
+        doubleCodingMethod: 'most-frequent',
+        displayLabelKey: 'export-toast.types.manual-review-most-frequent',
+        downloadFilePrefix: 'manual-review-most-frequent'
+      })
+    );
+    expect(exportJobService.startJob).toHaveBeenNthCalledWith(
+      2,
+      5,
+      expect.objectContaining({
+        exportType: 'aggregated',
+        doubleCodingMethod: 'new-column-per-coder',
+        displayLabelKey: 'export-toast.types.manual-review-new-column-per-coder',
+        downloadFilePrefix: 'manual-review-new-column-per-coder'
+      })
+    );
+    expect(exportJobService.startJob).toHaveBeenNthCalledWith(
+      3,
+      5,
+      expect.objectContaining({
+        exportType: 'aggregated',
+        doubleCodingMethod: 'new-row-per-variable',
+        displayLabelKey: 'export-toast.types.manual-review-new-row-per-variable',
+        downloadFilePrefix: 'manual-review-new-row-per-variable'
+      })
+    );
+  });
+
   it('should show a specific error when replay export auth token creation fails', () => {
     const exportJobService = TestBed.inject(ExportJobService) as unknown as {
       startJob: jest.Mock;

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -1209,6 +1209,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const exportConfig: ExportJobConfig = {
       exportType: result.exportType,
       userId: this.appService.userId,
+      ...this.getManualCodingExportDisplayMetadata(result),
       includeReplayUrl: result.includeReplayUrl ?? false,
       outputCommentsInsteadOfCodes: result.outputCommentsInsteadOfCodes,
       anonymizeCoders: result.anonymizeCoders,
@@ -1245,6 +1246,33 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.showError('Exportjob konnte nicht gestartet werden.');
         }
       });
+  }
+
+  private getManualCodingExportDisplayMetadata(
+    result: ManualCodingExportDialogResult
+  ): Pick<ExportJobConfig, 'displayLabelKey' | 'downloadFilePrefix'> {
+    if (result.exportType !== 'aggregated') {
+      return {};
+    }
+
+    switch (result.doubleCodingMethod || 'most-frequent') {
+      case 'new-column-per-coder':
+        return {
+          displayLabelKey: 'export-toast.types.manual-review-new-column-per-coder',
+          downloadFilePrefix: 'manual-review-new-column-per-coder'
+        };
+      case 'new-row-per-variable':
+        return {
+          displayLabelKey: 'export-toast.types.manual-review-new-row-per-variable',
+          downloadFilePrefix: 'manual-review-new-row-per-variable'
+        };
+      case 'most-frequent':
+      default:
+        return {
+          displayLabelKey: 'export-toast.types.manual-review-most-frequent',
+          downloadFilePrefix: 'manual-review-most-frequent'
+        };
+    }
   }
 
   private getCoderTrainingIds(): number[] {

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.html
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.html
@@ -18,7 +18,7 @@
             <mat-icon [class]="getStatusClass(job.status)" class="status-icon">
               {{ getStatusIcon(job.status) }}
             </mat-icon>
-            <span class="job-type">{{ getExportTypeLabel(job.exportType) }}</span>
+            <span class="job-type">{{ getExportTypeLabel(job) }}</span>
           </div>
 
           <div class="job-progress" *ngIf="job.status === 'waiting' || job.status === 'active'">

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.spec.ts
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.spec.ts
@@ -20,6 +20,8 @@ describe('ExportToastComponent', () => {
       jobId: 'waiting',
       workspaceId: 1,
       exportType: 'aggregated',
+      displayLabelKey: 'export-toast.types.manual-review-most-frequent',
+      downloadFilePrefix: 'manual-review-most-frequent',
       status: 'waiting',
       result: { fileName: 'export.csv', fileSize: 100 }
     },
@@ -61,6 +63,7 @@ describe('ExportToastComponent', () => {
           'by-variable-compact': 'Nach Variable, kompakt',
           detailed: 'Detailliertes Kodierprotokoll',
           'coding-times': 'Kodierzeiten-Bericht',
+          'manual-review-most-frequent': 'Kodierer: häufigster Code',
           'results-by-version': 'Finale Ergebnisdaten',
           'item-matrix': 'Itemmatrix'
         },
@@ -92,6 +95,7 @@ describe('ExportToastComponent', () => {
     expect(component.getStatusIcon('unknown' as never)).toBe('help');
     expect(component.getStatusClass('failed')).toBe('status-failed');
     expect(component.getExportTypeLabel('aggregated')).toBe('Aggregierte Ansicht');
+    expect(component.getExportTypeLabel(jobs[0])).toBe('Kodierer: häufigster Code');
     expect(component.getExportTypeLabel('detailed')).toBe('Detailliertes Kodierprotokoll');
     expect(component.getExportTypeLabel('results-by-version')).toBe('Finale Ergebnisdaten');
     expect(component.getExportTypeLabel('item-matrix')).toBe('Itemmatrix');
@@ -106,7 +110,8 @@ describe('ExportToastComponent', () => {
     component.cancelJob(jobs[1]);
     component.clearCompleted();
 
-    expect(exportJobService.downloadFile).toHaveBeenCalledWith(1, 'waiting', 'aggregated', 'export.csv');
+    expect(exportJobService.downloadFile)
+      .toHaveBeenCalledWith(1, 'waiting', 'aggregated', 'export.csv', 'manual-review-most-frequent');
     expect(exportJobService.removeJob).toHaveBeenCalledWith('waiting');
     expect(exportJobService.cancelJob).toHaveBeenCalledWith(jobs[1]);
     expect(exportJobService.removeJob).toHaveBeenCalledWith('done');

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.ts
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.ts
@@ -99,8 +99,10 @@ export class ExportToastComponent implements OnInit, OnDestroy {
     return `status-${status}`;
   }
 
-  getExportTypeLabel(exportType: string): string {
-    const translationKey = this.exportTypeLabelKeys[exportType];
+  getExportTypeLabel(jobOrExportType: ExportJob | string): string {
+    const exportType = typeof jobOrExportType === 'string' ? jobOrExportType : jobOrExportType.exportType;
+    const displayLabelKey = typeof jobOrExportType === 'string' ? undefined : jobOrExportType.displayLabelKey;
+    const translationKey = displayLabelKey || this.exportTypeLabelKeys[exportType];
     return translationKey ? this.translateService.instant(translationKey) : exportType;
   }
 
@@ -124,7 +126,13 @@ export class ExportToastComponent implements OnInit, OnDestroy {
   }
 
   downloadFile(job: ExportJob): void {
-    this.exportJobService.downloadFile(job.workspaceId, job.jobId, job.exportType, job.result?.fileName);
+    this.exportJobService.downloadFile(
+      job.workspaceId,
+      job.jobId,
+      job.exportType,
+      job.result?.fileName,
+      job.downloadFilePrefix
+    );
   }
 
   removeJob(job: ExportJob): void {

--- a/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
@@ -60,6 +60,29 @@ describe('ExportJobService', () => {
       service.ngOnDestroy(); // cleanup
     }));
 
+    it('should keep display metadata on the local job', () => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(of({ jobId: 'j1', message: 'Job started' }));
+
+      service.startJob(1, {
+        exportType: 'aggregated',
+        userId: 1,
+        displayLabelKey: 'export-toast.types.manual-review-most-frequent',
+        downloadFilePrefix: 'manual-review-most-frequent'
+      }).subscribe();
+
+      expect(service.activeJobs[0]).toEqual(expect.objectContaining({
+        displayLabelKey: 'export-toast.types.manual-review-most-frequent',
+        downloadFilePrefix: 'manual-review-most-frequent'
+      }));
+      const requestConfig = codingJobBackendServiceMock.startExportJob.mock.calls[0][1];
+      expect(requestConfig).not.toEqual(expect.objectContaining({
+        displayLabelKey: expect.any(String)
+      }));
+      expect(requestConfig).not.toEqual(expect.objectContaining({
+        downloadFilePrefix: expect.any(String)
+      }));
+    });
+
     it('should surface start errors without adding a job', () => {
       codingJobBackendServiceMock.startExportJob.mockReturnValue(
         throwError(() => new Error('start failed'))
@@ -147,6 +170,41 @@ describe('ExportJobService', () => {
 
       expect(codingJobBackendServiceMock.startExportJob).not.toHaveBeenCalled();
       expect(service.activeJobs.length).toBe(0);
+    });
+  });
+
+  describe('downloadFile', () => {
+    it('should use the display file prefix when present', () => {
+      const blob = new Blob(['xlsx'], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      });
+      const anchor = document.createElement('a');
+      const clickSpy = jest.spyOn(anchor, 'click').mockImplementation();
+      const createElementSpy = jest.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+      Object.defineProperty(window.URL, 'createObjectURL', {
+        value: jest.fn().mockReturnValue('blob:url'),
+        configurable: true
+      });
+      Object.defineProperty(window.URL, 'revokeObjectURL', {
+        value: jest.fn(),
+        configurable: true
+      });
+      codingJobBackendServiceMock.downloadExportFile.mockReturnValue(of(blob));
+      const date = new Date().toISOString().slice(0, 10);
+
+      service.downloadFile(
+        1,
+        'j1',
+        'aggregated',
+        'export.xlsx',
+        'manual-review-most-frequent'
+      );
+
+      expect(anchor.download).toBe(`export-manual-review-most-frequent-${date}.xlsx`);
+      expect(clickSpy).toHaveBeenCalled();
+
+      createElementSpy.mockRestore();
     });
   });
 });

--- a/apps/frontend/src/app/shared/services/file/export-job.service.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.ts
@@ -24,6 +24,8 @@ export interface ExportJob {
   status: 'waiting' | 'active' | 'completed' | 'failed' | 'cancelled';
   progress: number;
   exportType: string;
+  displayLabelKey?: string;
+  downloadFilePrefix?: string;
   result?: {
     fileName: string;
     fileSize: number;
@@ -68,6 +70,8 @@ export interface ExportJobConfig {
   coderIds?: number[];
   authToken?: string;
   serverUrl?: string;
+  displayLabelKey?: string;
+  downloadFilePrefix?: string;
 }
 
 export const REPLAY_AUTH_TOKEN_ERROR_CODE = 'replay-auth-token-failed';
@@ -125,13 +129,20 @@ export class ExportJobService implements OnDestroy {
 
   startJob(workspaceId: number, config: ExportJobConfig): Observable<ExportJob> {
     return this.withReplayAuthToken(workspaceId, config).pipe(
-      switchMap(preparedConfig => this.codingJobBackendService.startExportJob(workspaceId, preparedConfig)),
+      switchMap(preparedConfig => {
+        const requestConfig = { ...preparedConfig };
+        delete requestConfig.displayLabelKey;
+        delete requestConfig.downloadFilePrefix;
+        return this.codingJobBackendService.startExportJob(workspaceId, requestConfig);
+      }),
       map((response: { jobId: string }) => ({
         jobId: response.jobId,
         workspaceId,
         status: 'waiting' as const,
         progress: 0,
         exportType: config.exportType,
+        displayLabelKey: config.displayLabelKey,
+        downloadFilePrefix: config.downloadFilePrefix,
         createdAt: Date.now()
       })),
       tap(job => {
@@ -302,7 +313,13 @@ export class ExportJobService implements OnDestroy {
     });
   }
 
-  downloadFile(workspaceId: number, jobId: string, exportType: string, fileName?: string): void {
+  downloadFile(
+    workspaceId: number,
+    jobId: string,
+    exportType: string,
+    fileName?: string,
+    downloadFilePrefix?: string
+  ): void {
     this.codingJobBackendService.downloadExportFile(workspaceId, jobId).subscribe({
       next: (blob: Blob) => {
         const url = window.URL.createObjectURL(blob);
@@ -310,7 +327,7 @@ export class ExportJobService implements OnDestroy {
         a.href = url;
         const ext = this.getDownloadExtension(exportType, fileName);
         const date = new Date().toISOString().slice(0, 10);
-        a.download = `export-${exportType}-${date}.${ext}`;
+        a.download = `export-${downloadFilePrefix || exportType}-${date}.${ext}`;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -69,6 +69,9 @@
       "by-variable-compact": "Nach Variable, kompakt",
       "detailed": "Detailliertes Kodierprotokoll",
       "coding-times": "Kodierzeiten-Bericht",
+      "manual-review-most-frequent": "Kodierer: häufigster Code",
+      "manual-review-new-column-per-coder": "pro Kodierer neue Spalte",
+      "manual-review-new-row-per-variable": "pro Variable neue Zeile",
       "results-by-version": "Finale Ergebnisdaten",
       "item-matrix": "Itemmatrix"
     }


### PR DESCRIPTION
## Summary
- Show manual review export variants by their selected double-coding method in the export toast.
- Keep the backend export request payload unchanged by storing display metadata only on the frontend job state.
- Use matching download filename prefixes for manual review variants.

## Validation
- npx nx lint frontend
- npx nx test frontend --runTestsByPath=apps/frontend/src/app/shared/services/file/export-job.service.spec.ts,apps/frontend/src/app/components/export-toast/export-toast.component.spec.ts,apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
- Checked the local Docker UI at http://localhost:4200 for the manual coding export dialog and export toast labels.

Related issue: #798