### PR TITLE
Persist replay notes in discussion results

### DIFF
--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
@@ -207,7 +207,7 @@
 
   @if (allowComments) {
   <mat-form-field appearance="outline" class="notes-field">
-    <textarea #notesTextarea matInput [(ngModel)]="coderNotes" (input)="onNotesChanged()"
+    <textarea #notesTextarea matInput [(ngModel)]="coderNotes" (input)="onNotesChanged()" (blur)="onNotesCommitted()"
       [disabled]="isReadOnly" [attr.aria-invalid]="newCodeCommentValidationError ? 'true' : null"
       placeholder="{{ 'code-selector.coder-notes-placeholder' | translate }}" rows="3"></textarea>
   </mat-form-field>

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -62,6 +62,7 @@ export class CodeSelectorComponent implements OnChanges {
 
   @Output() codeSelected = new EventEmitter<CodeSelectedEvent>();
   @Output() notesChanged = new EventEmitter<string>();
+  @Output() notesCommitted = new EventEmitter<string>();
   @Output() openNavigateDialog = new EventEmitter<void>();
   @Output() openCommentDialog = new EventEmitter<void>();
   @Output() openCodingJobs = new EventEmitter<void>();
@@ -419,6 +420,11 @@ export class CodeSelectorComponent implements OnChanges {
     if (this.isReadOnly) return;
     this.updateNewCodeCommentValidationState();
     this.notesChanged.emit(this.coderNotes);
+  }
+
+  onNotesCommitted(): void {
+    if (this.isReadOnly) return;
+    this.notesCommitted.emit(this.coderNotes);
   }
 
   canLeaveCurrentUnit(showValidationMessage = true): boolean {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -9,7 +9,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { CodingTrainingBackendService } from '../../services/coding-training-backend.service';
 import { CodingResultsComparisonComponent } from './coding-results-comparison.component';
 import { SERVER_URL } from '../../../injection-tokens';
@@ -993,6 +993,351 @@ describe('CodingResultsComparisonComponent', () => {
     expect(row.discussionScore).toBe(2);
     expect(row.discussionNotes).toBe('Replay note');
     expect(row.discussionSource).toBe('manual');
+  });
+
+  it('should resave an existing replay discussion result when notes are committed later', () => {
+    const row = {
+      responseId: 1,
+      unitName: 'Unit1',
+      variableId: 'Var1',
+      testperson: 'login@code@booklet',
+      discussionCode: 7,
+      discussionScore: 2,
+      discussionNotes: null,
+      discussionSource: 'manual' as 'manual' | 'auto_agreement' | null,
+      coders: [
+        {
+          jobId: 1,
+          coderName: 'Coder1',
+          code: '7',
+          score: 2
+        }
+      ]
+    };
+    codingTrainingBackendService.saveDiscussionResult.mockReturnValueOnce(of({
+      success: true,
+      code: 7,
+      score: 2,
+      notes: 'Late replay note',
+      source: 'manual',
+      managerUserId: 2,
+      managerName: 'Test User'
+    }));
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.withinTrainingData = [row];
+    component.discussionCodeByResponseId[1] = '7';
+    component.discussionScoreByResponseId[1] = 2;
+
+    (component as unknown as {
+      handleReplayNotesCommitted: (data: {
+        type: 'replayNotesCommitted';
+        testPerson: string;
+        unitId: string;
+        variableId: string;
+        notes?: string | null;
+        responseId: number;
+      }) => void;
+    }).handleReplayNotesCommitted({
+      type: 'replayNotesCommitted',
+      testPerson: 'login@code@booklet',
+      unitId: 'Unit1',
+      variableId: 'Var1',
+      notes: 'Late replay note',
+      responseId: 1
+    });
+
+    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledWith(1, 5, 1, 7, 2, 'Late replay note');
+    expect(component.discussionNotesByResponseId[1]).toBe('Late replay note');
+    expect(row.discussionNotes).toBe('Late replay note');
+  });
+
+  it('should queue replay notes committed while the replay code save is still running', () => {
+    const row = {
+      responseId: 1,
+      unitName: 'Unit1',
+      variableId: 'Var1',
+      testperson: 'login@code@booklet',
+      discussionCode: null,
+      discussionScore: null,
+      discussionNotes: null,
+      discussionSource: null as 'manual' | 'auto_agreement' | null,
+      coders: [
+        {
+          jobId: 1,
+          coderName: 'Coder1',
+          code: '7',
+          score: 2
+        }
+      ]
+    };
+    const codeSave = new Subject<{
+      success: boolean;
+      code: number;
+      score: number;
+      notes: string | null;
+      source: 'manual';
+      managerUserId: number;
+      managerName: string;
+    }>();
+    const notesSave = new Subject<{
+      success: boolean;
+      code: number;
+      score: number;
+      notes: string | null;
+      source: 'manual';
+      managerUserId: number;
+      managerName: string;
+    }>();
+    codingTrainingBackendService.saveDiscussionResult
+      .mockReturnValueOnce(codeSave.asObservable())
+      .mockReturnValueOnce(notesSave.asObservable());
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.withinTrainingData = [row];
+
+    const privateComponent = component as unknown as {
+      handleReplayCodeSelected: (data: {
+        type: 'replayCodeSelected';
+        testPerson: string;
+        unitId: string;
+        variableId: string;
+        code: string;
+        score?: number | null;
+        notes?: string | null;
+        responseId: number;
+      }) => void;
+      handleReplayNotesCommitted: (data: {
+        type: 'replayNotesCommitted';
+        testPerson: string;
+        unitId: string;
+        variableId: string;
+        notes?: string | null;
+        responseId: number;
+      }) => void;
+    };
+
+    privateComponent.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'login@code@booklet',
+      unitId: 'Unit1',
+      variableId: 'Var1',
+      code: '7',
+      score: 2,
+      notes: null,
+      responseId: 1
+    });
+    privateComponent.handleReplayNotesCommitted({
+      type: 'replayNotesCommitted',
+      testPerson: 'login@code@booklet',
+      unitId: 'Unit1',
+      variableId: 'Var1',
+      notes: 'Late replay note',
+      responseId: 1
+    });
+
+    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledTimes(1);
+    expect(component.discussionNotesByResponseId[1]).toBe('Late replay note');
+
+    codeSave.next({
+      success: true,
+      code: 7,
+      score: 2,
+      notes: null,
+      source: 'manual',
+      managerUserId: 2,
+      managerName: 'Test User'
+    });
+    codeSave.complete();
+
+    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledTimes(2);
+    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenLastCalledWith(1, 5, 1, 7, 2, 'Late replay note');
+
+    notesSave.next({
+      success: true,
+      code: 7,
+      score: 2,
+      notes: 'Late replay note',
+      source: 'manual',
+      managerUserId: 2,
+      managerName: 'Test User'
+    });
+    notesSave.complete();
+
+    expect(row.discussionNotes).toBe('Late replay note');
+  });
+
+  it('should clear queued replay notes when the active discussion save fails', () => {
+    const row = {
+      responseId: 1,
+      unitName: 'Unit1',
+      variableId: 'Var1',
+      testperson: 'login@code@booklet',
+      discussionCode: null,
+      discussionScore: null,
+      discussionNotes: null,
+      discussionSource: null as 'manual' | 'auto_agreement' | null,
+      coders: [
+        {
+          jobId: 1,
+          coderName: 'Coder1',
+          code: '7',
+          score: 2
+        }
+      ]
+    };
+    const codeSave = new Subject<{
+      success: boolean;
+      code: number;
+      score: number;
+      notes: string | null;
+      source: 'manual';
+      managerUserId: number;
+      managerName: string;
+    }>();
+    codingTrainingBackendService.saveDiscussionResult
+      .mockReturnValueOnce(codeSave.asObservable())
+      .mockReturnValueOnce(of({
+        success: true,
+        code: 7,
+        score: 2,
+        notes: null,
+        source: 'manual',
+        managerUserId: 2,
+        managerName: 'Test User'
+      }));
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.withinTrainingData = [row];
+
+    const privateComponent = component as unknown as {
+      handleReplayCodeSelected: (data: {
+        type: 'replayCodeSelected';
+        testPerson: string;
+        unitId: string;
+        variableId: string;
+        code: string;
+        score?: number | null;
+        notes?: string | null;
+        responseId: number;
+      }) => void;
+      handleReplayNotesCommitted: (data: {
+        type: 'replayNotesCommitted';
+        testPerson: string;
+        unitId: string;
+        variableId: string;
+        notes?: string | null;
+        responseId: number;
+      }) => void;
+    };
+
+    privateComponent.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'login@code@booklet',
+      unitId: 'Unit1',
+      variableId: 'Var1',
+      code: '7',
+      score: 2,
+      notes: null,
+      responseId: 1
+    });
+    privateComponent.handleReplayNotesCommitted({
+      type: 'replayNotesCommitted',
+      testPerson: 'login@code@booklet',
+      unitId: 'Unit1',
+      variableId: 'Var1',
+      notes: 'Stale replay note',
+      responseId: 1
+    });
+
+    codeSave.error(new HttpErrorResponse({
+      status: 400,
+      error: { message: 'Unsupported code for variable Var1: 7' }
+    }));
+
+    component.discussionCodeByResponseId[1] = '7';
+    component.discussionNotesByResponseId[1] = '';
+    component.onDiscussionCodeBlur(row, 2);
+
+    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledTimes(2);
+    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenLastCalledWith(1, 5, 1, 7, 2, null);
+    expect(row.discussionNotes).toBeNull();
+  });
+
+  it('should keep committed replay notes until a later replay code selection is saved', () => {
+    const row = {
+      responseId: 1,
+      unitName: 'Unit1',
+      variableId: 'Var1',
+      testperson: 'login@code@booklet',
+      discussionCode: null,
+      discussionScore: null,
+      discussionNotes: null,
+      discussionSource: null as 'manual' | 'auto_agreement' | null,
+      coders: [
+        {
+          jobId: 1,
+          coderName: 'Coder1',
+          code: '7',
+          score: 2
+        }
+      ]
+    };
+    codingTrainingBackendService.saveDiscussionResult.mockReturnValueOnce(of({
+      success: true,
+      code: 7,
+      score: 2,
+      notes: 'Committed first',
+      source: 'manual',
+      managerUserId: 2,
+      managerName: 'Test User'
+    }));
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.withinTrainingData = [row];
+
+    const privateComponent = component as unknown as {
+      handleReplayNotesCommitted: (data: {
+        type: 'replayNotesCommitted';
+        testPerson: string;
+        unitId: string;
+        variableId: string;
+        notes?: string | null;
+        responseId: number;
+      }) => void;
+      handleReplayCodeSelected: (data: {
+        type: 'replayCodeSelected';
+        testPerson: string;
+        unitId: string;
+        variableId: string;
+        code: string;
+        score?: number | null;
+        responseId: number;
+      }) => void;
+    };
+
+    privateComponent.handleReplayNotesCommitted({
+      type: 'replayNotesCommitted',
+      testPerson: 'login@code@booklet',
+      unitId: 'Unit1',
+      variableId: 'Var1',
+      notes: 'Committed first',
+      responseId: 1
+    });
+    expect(codingTrainingBackendService.saveDiscussionResult).not.toHaveBeenCalled();
+
+    privateComponent.handleReplayCodeSelected({
+      type: 'replayCodeSelected',
+      testPerson: 'login@code@booklet',
+      unitId: 'Unit1',
+      variableId: 'Var1',
+      code: '7',
+      score: 2,
+      responseId: 1
+    });
+
+    expect(codingTrainingBackendService.saveDiscussionResult).toHaveBeenCalledWith(1, 5, 1, 7, 2, 'Committed first');
+    expect(row.discussionNotes).toBe('Committed first');
   });
 
   it('should show a validation message when a discussion code is not supported by the coding scheme', () => {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -62,6 +62,14 @@ interface ReplayCodeSelectedMessage extends PostMessage {
   responseId?: number;
 }
 
+interface ReplayNotesCommittedMessage extends PostMessage {
+  testPerson: string;
+  unitId: string;
+  variableId: string;
+  notes?: string | null;
+  responseId?: number;
+}
+
 export type CodingResultsComparisonMode = 'between-trainings' | 'within-training';
 
 export interface CodingResultsComparisonDialogData {
@@ -331,6 +339,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   discussionNotesByResponseId: Record<number, string> = {};
   discussionErrorByResponseId: Record<number, string> = {};
   isSavingDiscussionByResponseId: Record<number, boolean> = {};
+  private pendingDiscussionNotesByResponseId: Record<number, string> = {};
   readonly emptyModalValueDisplay: ModalValueDisplay = {
     valueText: '-',
     deviationText: '-',
@@ -382,6 +391,12 @@ export class CodingResultsComparisonComponent implements OnInit {
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(msg => {
         this.handleReplayCodeSelected(msg.message);
+      });
+
+    this.postMessageService.getMessages<ReplayNotesCommittedMessage>('replayNotesCommitted')
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe(msg => {
+        this.handleReplayNotesCommitted(msg.message);
       });
   }
 
@@ -1031,9 +1046,17 @@ export class CodingResultsComparisonComponent implements OnInit {
       notes
     ).subscribe({
       next: result => {
+        const hasPendingNotes = Object.prototype.hasOwnProperty.call(
+          this.pendingDiscussionNotesByResponseId,
+          responseId
+        );
+        const pendingNotes = hasPendingNotes ?
+          this.pendingDiscussionNotesByResponseId[responseId] :
+          '';
+
         this.discussionCodeByResponseId[responseId] = result.code !== null ? result.code.toString() : '';
         this.discussionScoreByResponseId[responseId] = result.score;
-        this.discussionNotesByResponseId[responseId] = result.notes || '';
+        this.discussionNotesByResponseId[responseId] = hasPendingNotes ? pendingNotes : result.notes || '';
         withinComparison.discussionCode = result.code;
         withinComparison.discussionScore = result.score;
         withinComparison.discussionNotes = result.notes;
@@ -1045,9 +1068,19 @@ export class CodingResultsComparisonComponent implements OnInit {
           this.discussionManagerLabel = result.managerName;
         }
         this.isSavingDiscussionByResponseId[responseId] = false;
+
+        if (hasPendingNotes) {
+          delete this.pendingDiscussionNotesByResponseId[responseId];
+          const normalizedPendingNotes = pendingNotes.trim() || null;
+          const normalizedSavedNotes = (result.notes || '').trim() || null;
+          if (normalizedPendingNotes !== normalizedSavedNotes) {
+            this.onDiscussionCodeBlur(withinComparison, result.score);
+          }
+        }
       },
       error: error => {
         this.isSavingDiscussionByResponseId[responseId] = false;
+        delete this.pendingDiscussionNotesByResponseId[responseId];
         const message = this.getDiscussionSaveErrorMessage(error);
         this.discussionErrorByResponseId[responseId] = message;
         this.snackBar.open(message, this.translate.instant('common.close'), { duration: 4000 });
@@ -1235,6 +1268,7 @@ export class CodingResultsComparisonComponent implements OnInit {
     this.discussionNotesByResponseId = {};
     this.discussionErrorByResponseId = {};
     this.isSavingDiscussionByResponseId = {};
+    this.pendingDiscussionNotesByResponseId = {};
 
     const persistedManager = data.find(item => !!item.discussionManagerName)?.discussionManagerName;
     if (persistedManager) {
@@ -1944,9 +1978,9 @@ export class CodingResultsComparisonComponent implements OnInit {
     this.loadKappaStatistics();
   }
 
-  private handleReplayCodeSelected(data: ReplayCodeSelectedMessage): void {
-    if (this.comparisonMode !== 'within-training') return;
-
+  private findWithinTrainingReplayRow(
+    data: Pick<ReplayCodeSelectedMessage, 'testPerson' | 'unitId' | 'variableId' | 'responseId'>
+  ): WithinTrainingComparison | null {
     const targetVarId = (data.variableId || '').toLowerCase();
     const targetUnitId = (data.unitId || '').toLowerCase();
     const normalizedMsgTP = normalizeTestperson(data.testPerson || '').toLowerCase();
@@ -1966,11 +2000,27 @@ export class CodingResultsComparisonComponent implements OnInit {
       });
     }
 
+    return row || null;
+  }
+
+  private getDiscussionScoreOverride(responseId: number): number | null | undefined {
+    return Object.prototype.hasOwnProperty.call(this.discussionScoreByResponseId, responseId) ?
+      this.discussionScoreByResponseId[responseId] :
+      undefined;
+  }
+
+  private handleReplayCodeSelected(data: ReplayCodeSelectedMessage): void {
+    if (this.comparisonMode !== 'within-training') return;
+
+    const row = this.findWithinTrainingReplayRow(data);
+
     if (row) {
       this.discussionCodeByResponseId[row.responseId] = this.mapCodeForDisplay(data.code);
       this.discussionScoreByResponseId[row.responseId] =
         data.score !== undefined ? data.score : this.getDiscussionScoreFromKnownCodes(row, parseInt(data.code, 10));
-      this.discussionNotesByResponseId[row.responseId] = data.notes || '';
+      if (Object.prototype.hasOwnProperty.call(data, 'notes')) {
+        this.discussionNotesByResponseId[row.responseId] = data.notes || '';
+      }
       this.onDiscussionCodeBlur(row, data.score);
 
       this.snackBar.open(
@@ -1979,5 +2029,33 @@ export class CodingResultsComparisonComponent implements OnInit {
         { duration: 3000 }
       );
     }
+  }
+
+  private handleReplayNotesCommitted(data: ReplayNotesCommittedMessage): void {
+    if (this.comparisonMode !== 'within-training') return;
+
+    const row = this.findWithinTrainingReplayRow(data);
+    if (!row) {
+      return;
+    }
+
+    const responseId = row.responseId;
+    const notes = data.notes || '';
+    this.discussionNotesByResponseId[responseId] = notes;
+    this.discussionErrorByResponseId[responseId] = '';
+
+    const currentCode = (this.discussionCodeByResponseId[responseId] || '').trim() ||
+      (row.discussionCode !== null && row.discussionCode !== undefined ? row.discussionCode.toString() : '');
+    if (!currentCode) {
+      return;
+    }
+
+    this.discussionCodeByResponseId[responseId] = currentCode;
+    if (this.isSavingDiscussionByResponseId[responseId]) {
+      this.pendingDiscussionNotesByResponseId[responseId] = notes;
+      return;
+    }
+
+    this.onDiscussionCodeBlur(row, this.getDiscussionScoreOverride(responseId));
   }
 }

--- a/apps/frontend/src/app/replay/components/replay/replay.component.html
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.html
@@ -52,7 +52,8 @@
         [clearCodingIssueOnRegularSelection]="isCodingIssueReviewMode"
         [reviewCodeSelections]="reviewCodeSelections"
         (codeSelected)="onCodeSelected($event)"
-        (notesChanged)="onNotesChanged($event)" (openNavigateDialog)="openNavigateDialog()"
+        (notesChanged)="onNotesChanged($event)" (notesCommitted)="onNotesCommitted($event)"
+        (openNavigateDialog)="openNavigateDialog()"
         (openCodingJobs)="openCodingJobs()"
         (openCommentDialog)="openCommentDialog()" (pauseCodingJob)="pauseCodingJob()"
         (unitChanged)="handleUnitChanged($event)">

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -429,6 +429,82 @@ describe('ReplayComponent', () => {
     }, '*');
   });
 
+  it('should send committed replay notes back to the comparison opener on blur', () => {
+    const postMessage = jest.fn();
+    Object.defineProperty(window, 'opener', {
+      value: { postMessage },
+      configurable: true
+    });
+    component.originResponseId = 99;
+    component.testPerson = 'valid@test@person';
+    component.unitId = 'unit-123';
+    component.codingService.currentVariableId = 'VAR1';
+
+    component.onNotesCommitted('Late replay note');
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'replayNotesCommitted',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-123',
+      variableId: 'VAR1',
+      notes: 'Late replay note',
+      responseId: 99
+    }, '*');
+  });
+
+  it('should debounce replay notes commits while typing', () => {
+    jest.useFakeTimers();
+    const postMessage = jest.fn();
+    Object.defineProperty(window, 'opener', {
+      value: { postMessage },
+      configurable: true
+    });
+    jest.spyOn(component.codingService, 'saveNotes').mockResolvedValue();
+    component.originResponseId = 99;
+    component.workspaceId = 5;
+    component.testPerson = 'valid@test@person';
+    component.unitId = 'unit-123';
+    component.codingService.currentVariableId = 'VAR1';
+
+    component.onNotesChanged('Late replay note');
+    jest.advanceTimersByTime(749);
+    expect(postMessage).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'replayNotesCommitted',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-123',
+      variableId: 'VAR1',
+      notes: 'Late replay note',
+      responseId: 99
+    }, '*');
+    jest.useRealTimers();
+  });
+
+  it('should allow retrying the same committed replay notes after the duplicate window', () => {
+    jest.useFakeTimers();
+    const postMessage = jest.fn();
+    Object.defineProperty(window, 'opener', {
+      value: { postMessage },
+      configurable: true
+    });
+    component.originResponseId = 99;
+    component.testPerson = 'valid@test@person';
+    component.unitId = 'unit-123';
+    component.codingService.currentVariableId = 'VAR1';
+
+    component.onNotesCommitted('Retry note');
+    component.onNotesCommitted('Retry note');
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1000);
+    component.onNotesCommitted('Retry note');
+
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
   it('should handle rejected note saves in the component boundary', async () => {
     const saveNotesSpy = jest.spyOn(component.codingService, 'saveNotes')
       .mockRejectedValue(new Error('save failed'));

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -12,7 +12,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import {
-  firstValueFrom, of, Subject, Subscription, catchError
+  firstValueFrom, of, Subject, Subscription, catchError, debounceTime
 } from 'rxjs';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
 import { MatSnackBar, MatSnackBarRef, TextOnlySnackBar } from '@angular/material/snack-bar';
@@ -55,6 +55,11 @@ interface ReplayUnitPayload {
   player: FilesDto[];
   vocs: FilesDto[];
   serverTimings?: ReplayServerTimings;
+}
+
+interface PendingReplayNotesCommit {
+  variableId: string;
+  notes: string;
 }
 
 @Component({
@@ -120,6 +125,8 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private codingProgressLoadedForJobKey: string | null = null;
   private activeStatusUpdatedForJobKey: string | null = null;
   private authBootstrapSubscription: Subscription | null = null;
+  private replayNotesCommitSubscription: Subscription | null = null;
+  private readonly replayNotesCommitSubject = new Subject<PendingReplayNotesCommit>();
   private replayReAuthenticationPending = false;
   private replayTokenRefreshRunning = false;
   @ViewChild(UnitPlayerComponent) unitPlayerComponent: UnitPlayerComponent | undefined;
@@ -150,6 +157,10 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private unitPayloadRunId = 0;
   private readonly ANCHOR_HIGHLIGHT_RETRY_DELAY_MS = 100;
   private readonly ANCHOR_HIGHLIGHT_MAX_ATTEMPTS = 40;
+  private readonly REPLAY_NOTES_COMMIT_DEBOUNCE_MS = 750;
+  private readonly REPLAY_NOTES_COMMIT_DEDUPE_MS = 1000;
+  private lastReplayNotesCommitKey: string | null = null;
+  private replayNotesCommitDedupeTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Resize handle state
   codePanelWidth: number = 350;
@@ -172,6 +183,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         this.refreshReplayAuthTokenAfterReAuthentication().catch(() => undefined);
       }
     });
+    this.replayNotesCommitSubscription = this.replayNotesCommitSubject
+      .pipe(debounceTime(this.REPLAY_NOTES_COMMIT_DEBOUNCE_MS))
+      .subscribe(commit => this.sendReplayNotesCommitted(commit.variableId, commit.notes));
     this.subscribeRouter();
   }
 
@@ -1030,12 +1044,15 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   ngOnDestroy(): void {
     this.routerSubscription?.unsubscribe();
     this.authBootstrapSubscription?.unsubscribe();
+    this.replayNotesCommitSubscription?.unsubscribe();
     this.routerSubscription = null;
     this.authBootstrapSubscription = null;
+    this.replayNotesCommitSubscription = null;
     this.cancelPendingAnchorHighlight();
     this.resetSnackBars();
     this.watermarkObserver?.disconnect();
     this.watermarkObserver = null;
+    this.clearReplayNotesCommitDedupeTimeout();
   }
 
   private scheduleAnchorHighlight(): void {
@@ -1152,14 +1169,63 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   onNotesChanged(notes: string): void {
     if (this.isCodingReadOnly()) return;
 
+    const variableId = this.codingService.currentVariableId;
     this.codingService.saveNotes(
       this.workspaceId,
       this.testPerson,
       this.unitId,
-      this.codingService.currentVariableId,
+      variableId,
       notes,
       this.unitsData
     ).catch(() => undefined);
+    this.replayNotesCommitSubject.next({ variableId, notes });
+  }
+
+  onNotesCommitted(notes: string): void {
+    if (this.isCodingReadOnly()) return;
+
+    this.sendReplayNotesCommitted(this.codingService.currentVariableId, notes);
+  }
+
+  private sendReplayNotesCommitted(variableId: string, notes: string): void {
+    if (!window.opener || !this.originResponseId || !variableId) {
+      return;
+    }
+
+    const commitKey = JSON.stringify({
+      testPerson: this.testPerson,
+      unitId: this.unitId,
+      variableId,
+      notes,
+      responseId: this.originResponseId
+    });
+    if (commitKey === this.lastReplayNotesCommitKey) {
+      return;
+    }
+    this.lastReplayNotesCommitKey = commitKey;
+    this.clearReplayNotesCommitDedupeTimeout();
+    this.replayNotesCommitDedupeTimeout = setTimeout(() => {
+      if (this.lastReplayNotesCommitKey === commitKey) {
+        this.lastReplayNotesCommitKey = null;
+      }
+      this.replayNotesCommitDedupeTimeout = null;
+    }, this.REPLAY_NOTES_COMMIT_DEDUPE_MS);
+
+    window.opener.postMessage({
+      type: 'replayNotesCommitted',
+      testPerson: this.testPerson,
+      unitId: this.unitId,
+      variableId,
+      notes,
+      responseId: this.originResponseId
+    }, '*');
+  }
+
+  private clearReplayNotesCommitDedupeTimeout(): void {
+    if (this.replayNotesCommitDedupeTimeout) {
+      clearTimeout(this.replayNotesCommitDedupeTimeout);
+      this.replayNotesCommitDedupeTimeout = null;
+    }
   }
 
   getCompletedCount(): number {


### PR DESCRIPTION
## Summary

Related to #700.

This change persists replay notes from the discussion replay back into the within-training comparison dialog. When a note is committed after a replay code was already selected, the comparison dialog resaves the current discussion code and score with the new note.

It also handles note commits that arrive while the code save is still in flight, and deduplicates immediate blur/debounce duplicates while still allowing later retries.

## Validation

- `npx nx lint frontend`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts`
- `npx nx test frontend --testFile=apps/frontend/src/app/replay/components/replay/replay.component.spec.ts`
- Browser-tested locally in Docker on `http://localhost:4200` with a seeded training case: selected a code in replay, added a note, verified the second save included the note, verified the note persisted in the database and appeared in the comparison dialog textarea.
