### PR TITLE
Add Testcenter response import modes

### DIFF
--- a/api-dto/files/import-options.dto.ts
+++ b/api-dto/files/import-options.dto.ts
@@ -14,6 +14,8 @@ export interface ImportOptionsDto {
   metadata: string;
 }
 
+export type TestResultsOverwriteMode = 'skip' | 'merge' | 'replace';
+
 export interface ImportResultDto {
   success: boolean;
   testFiles: number;

--- a/apps/backend/src/app/admin/workspace/workspace-test-center.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-test-center.controller.ts
@@ -16,7 +16,10 @@ import {
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
 import { TestGroupsInfoDto } from '../../../../../../api-dto/files/test-groups-info.dto';
-import { ImportOptionsDto as ImportOptions } from '../../../../../../api-dto/files/import-options.dto';
+import {
+  ImportOptionsDto as ImportOptions,
+  TestResultsOverwriteMode
+} from '../../../../../../api-dto/files/import-options.dto';
 import { ImportWorkspaceFilesProgressDto } from '../../../../../../api-dto/files/import-workspace-progress.dto';
 import { TestGroupsLoadProgressDto } from '../../../../../../api-dto/files/test-groups-load-progress.dto';
 
@@ -133,6 +136,12 @@ export class WorkspaceTestCenterController {
     required: false,
     description: 'Optional run id to provide upload progress during import'
   })
+  @ApiQuery({
+    name: 'responseOverwriteMode',
+    required: false,
+    description:
+      'Overwrite mode for imported responses: skip (default), merge, or replace'
+  })
   @ApiOkResponse({ description: 'Files imported successfully', type: Object })
   @ApiBadRequestResponse({ description: 'Failed to import files' })
   async importWorkspaceFiles(
@@ -153,7 +162,8 @@ export class WorkspaceTestCenterController {
       @Query('metadata') metadata: string,
       @Query('overwriteFileIds') overwriteFileIds: string,
       @Query('overwriteExistingLogs') overwriteExistingLogs: string,
-      @Query('importRunId') importRunId: string
+      @Query('importRunId') importRunId: string,
+      @Query('responseOverwriteMode') responseOverwriteMode: string
   ): Promise<Result> {
     const importOptions: ImportOptions = {
       definitions: definitions,
@@ -172,6 +182,8 @@ export class WorkspaceTestCenterController {
       .split(';')
       .map(s => s.trim())
       .filter(Boolean);
+    const normalizedResponseOverwriteMode =
+      this.normalizeResponseOverwriteMode(responseOverwriteMode);
 
     const result = await (
       this.testCenterService as unknown as {
@@ -185,7 +197,8 @@ export class WorkspaceTestCenterController {
           groups: string,
           overwriteExistingLogs: boolean,
           overwriteFileIds?: string[],
-          importRunId?: string
+          importRunId?: string,
+          responseOverwriteMode?: TestResultsOverwriteMode
         ) => Promise<Result>;
       }
     ).importWorkspaceFiles(
@@ -198,7 +211,8 @@ export class WorkspaceTestCenterController {
       testGroups,
       overwriteLogs,
       overwriteIds.length ? overwriteIds : undefined,
-      importRunId
+      importRunId,
+      normalizedResponseOverwriteMode
     );
 
     if (result?.success) {
@@ -209,6 +223,20 @@ export class WorkspaceTestCenterController {
     }
 
     return result;
+  }
+
+  private normalizeResponseOverwriteMode(
+    responseOverwriteMode?: string
+  ): TestResultsOverwriteMode {
+    const normalized = (responseOverwriteMode || '').toLowerCase();
+    if (
+      normalized === 'merge' ||
+      normalized === 'replace' ||
+      normalized === 'skip'
+    ) {
+      return normalized;
+    }
+    return 'skip';
   }
 
   @Get(':workspace_id/importWorkspaceFiles/progress')

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.spec.ts
@@ -486,6 +486,79 @@ describe('TestCenterService', () => {
         currentRevision: 1,
         items: []
       });
+      expect(personService.processPersonBooklets).toHaveBeenCalledWith(
+        expect.any(Array),
+        123,
+        'skip',
+        'person',
+        expect.any(Array)
+      );
+    });
+
+    it('should pass the selected response overwrite mode to person processing', async () => {
+      const mockResponses: Response[] = [
+        {
+          groupname: 'group1',
+          loginname: 'user1',
+          code: 'code1',
+          bookletname: 'booklet1',
+          unitname: 'unit1',
+          originalUnitId: 'unit-1-id',
+          responses: '[]',
+          laststate: '{}'
+        }
+      ];
+      const mockPersons: Person[] = [
+        {
+          workspace_id: 123,
+          group: 'group1',
+          login: 'user1',
+          code: 'code1',
+          booklets: []
+        }
+      ];
+
+      httpService.axiosRef.get.mockResolvedValue({
+        data: mockResponses
+      } as AxiosResponse);
+      personService.createPersonList.mockResolvedValue(mockPersons);
+      personService.assignBookletsToPerson.mockResolvedValue(mockPersons[0]);
+      personService.assignUnitsToBookletAndPerson.mockResolvedValue(
+        mockPersons[0]
+      );
+      personService.processPersonBooklets.mockResolvedValue({
+        addedUnitIds: [10],
+        changedUnitIds: [],
+        addedResponseCount: 1,
+        changedResponseCount: 0
+      });
+      personService.getImportStatistics.mockResolvedValue({
+        persons: 1,
+        booklets: 1,
+        units: 1
+      });
+
+      await service.importWorkspaceFiles(
+        '123',
+        'ws-456',
+        'demo',
+        '',
+        'token',
+        mockImportOptions,
+        'group1',
+        true,
+        undefined,
+        undefined,
+        'merge'
+      );
+
+      expect(personService.processPersonBooklets).toHaveBeenCalledWith(
+        expect.any(Array),
+        123,
+        'merge',
+        'person',
+        expect.any(Array)
+      );
     });
 
     it('should keep Testcenter response imports successful when coding cache invalidation fails', async () => {

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.ts
@@ -9,7 +9,11 @@ import { TestGroupsInfoDto } from '../../../../../../../api-dto/files/test-group
 import { PersonService } from './person.service';
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import { TestResultsUploadIssueDto } from '../../../../../../../api-dto/files/test-results-upload-result.dto';
-import { ImportOptionsDto as ImportOptions, ImportResultDto as Result } from '../../../../../../../api-dto/files/import-options.dto';
+import {
+  ImportOptionsDto as ImportOptions,
+  ImportResultDto as Result,
+  TestResultsOverwriteMode
+} from '../../../../../../../api-dto/files/import-options.dto';
 
 import {
   TestFilesUploadResultDto,
@@ -347,7 +351,8 @@ export class TestcenterService {
     server: string,
     url: string,
     authToken: string,
-    testGroups: string
+    testGroups: string,
+    responseOverwriteMode: TestResultsOverwriteMode = 'skip'
   ): Promise<Promise<{ issues: TestResultsUploadIssueDto[] }>[]> {
     this.logger.log('Import response data from TC');
     const headersRequest = this.createHeaders(authToken);
@@ -438,7 +443,7 @@ export class TestcenterService {
                 const batchSummary = await this.personService.processPersonBooklets(
                   personBatch,
                   Number(workspace_id),
-                  'skip',
+                  responseOverwriteMode,
                   'person',
                   issues
                 );
@@ -1000,7 +1005,8 @@ export class TestcenterService {
     testGroups: string,
     overwriteExistingLogs: boolean = true,
     overwriteFileIds?: string[],
-    importRunId?: string
+    importRunId?: string,
+    responseOverwriteMode: TestResultsOverwriteMode = 'skip'
   ): Promise<Result> {
     const { responses, logs } = importOptions;
     const result: Result = {
@@ -1030,7 +1036,8 @@ export class TestcenterService {
           server,
           url,
           authToken,
-          testGroups
+          testGroups,
+          responseOverwriteMode
         );
         result.responses = responsePromises.length;
         const responseResults = await Promise.all(responsePromises);

--- a/apps/frontend/src/app/services/facades/workspace-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/workspace-facade.service.ts
@@ -38,6 +38,7 @@ import { UnitInfoDto } from '../../../../../../api-dto/unit-info/unit-info.dto';
 import { ResourcePackageDto } from '../../../../../../api-dto/resource-package/resource-package-dto';
 import { TestGroupsInfoDto } from '../../../../../../api-dto/files/test-groups-info.dto';
 import { TestGroupsLoadProgressDto } from '../../../../../../api-dto/files/test-groups-load-progress.dto';
+import { TestResultsOverwriteMode } from '../../../../../../api-dto/files/import-options.dto';
 import { UnitVariableDetailsDto } from '../../models/unit-variable-details.dto';
 
 interface PaginatedResponse<T> {
@@ -235,7 +236,9 @@ export class WorkspaceFacadeService {
     importOptions: ImportOptions,
     testGroups: string[],
     overwriteExistingLogs: boolean = false,
-    overwriteFileIds?: string[]
+    overwriteFileIds?: string[],
+    importRunId?: string,
+    responseOverwriteMode: TestResultsOverwriteMode = 'skip'
   ): Observable<Result> {
     return this.importService.importWorkspaceFiles(
       workspaceId,
@@ -246,7 +249,9 @@ export class WorkspaceFacadeService {
       importOptions,
       testGroups,
       overwriteExistingLogs,
-      overwriteFileIds
+      overwriteFileIds,
+      importRunId,
+      responseOverwriteMode
     );
   }
 

--- a/apps/frontend/src/app/shared/dialogs/confirm-dialog.component.ts
+++ b/apps/frontend/src/app/shared/dialogs/confirm-dialog.component.ts
@@ -26,9 +26,17 @@ import { MatButton } from '@angular/material/button';
       <button mat-raised-button color="primary" [mat-dialog-close]="true">
         {{ confirmData.confirmButtonLabel }}
       </button>
+      @if (confirmData.alternativeButtonLabel) {
+      <button
+        mat-raised-button
+        [mat-dialog-close]="confirmData.alternativeButtonValue ?? 'alternative'"
+      >
+        {{ confirmData.alternativeButtonLabel }}
+      </button>
+      }
       @if (showCancel) {
       <button mat-raised-button [mat-dialog-close]="false">
-        {{ 'workspace.cancel' | translate }}
+        {{ confirmData.cancelButtonLabel || ('workspace.cancel' | translate) }}
       </button>
       }
     </mat-dialog-actions>
@@ -74,4 +82,7 @@ export interface ConfirmDialogData {
   content: string;
   confirmButtonLabel: string;
   showCancel: boolean;
+  alternativeButtonLabel?: string;
+  alternativeButtonValue?: unknown;
+  cancelButtonLabel?: string;
 }

--- a/apps/frontend/src/app/shared/services/file/import.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/file/import.service.spec.ts
@@ -62,7 +62,44 @@ describe('ImportService', () => {
       const req = httpMock.expectOne(request => request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/importWorkspaceFiles` &&
         request.params.get('tc_workspace') === 'ws1' &&
         request.params.get('testGroups') === 'g1' &&
-        request.params.get('responses') === 'true'
+        request.params.get('responses') === 'true' &&
+        request.params.get('responseOverwriteMode') === 'skip'
+      );
+      expect(req.request.method).toBe('GET');
+      req.flush({});
+    });
+
+    it('should send the selected response overwrite mode', () => {
+      const options: ImportOptions = {
+        responses: 'true',
+        definitions: 'false',
+        units: 'false',
+        player: 'false',
+        codings: 'false',
+        logs: 'false',
+        testTakers: 'false',
+        booklets: 'false',
+        metadata: 'false'
+      };
+
+      service.importWorkspaceFiles(
+        mockWorkspaceId,
+        'ws1',
+        'srv',
+        'url',
+        'tok',
+        options,
+        ['g1'],
+        false,
+        undefined,
+        undefined,
+        'merge'
+      ).subscribe(res => {
+        expect(res).toBeDefined();
+      });
+
+      const req = httpMock.expectOne(
+        request => request.params.get('responseOverwriteMode') === 'merge'
       );
       expect(req.request.method).toBe('GET');
       req.flush({});

--- a/apps/frontend/src/app/shared/services/file/import.service.ts
+++ b/apps/frontend/src/app/shared/services/file/import.service.ts
@@ -3,7 +3,11 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { catchError, Observable, of } from 'rxjs';
 import { SERVER_URL } from '../../../injection-tokens';
 import { TestGroupsInfoDto } from '../../../../../../../api-dto/files/test-groups-info.dto';
-import { ImportOptionsDto as ImportOptions, ImportResultDto as Result } from '../../../../../../../api-dto/files/import-options.dto';
+import {
+  ImportOptionsDto as ImportOptions,
+  ImportResultDto as Result,
+  TestResultsOverwriteMode
+} from '../../../../../../../api-dto/files/import-options.dto';
 import { ImportWorkspaceFilesProgressDto } from '../../../../../../../api-dto/files/import-workspace-progress.dto';
 import { TestGroupsLoadProgressDto } from '../../../../../../../api-dto/files/test-groups-load-progress.dto';
 
@@ -26,7 +30,8 @@ export class ImportService {
     testGroups: string[],
     overwriteExistingLogs: boolean = false,
     overwriteFileIds?: string[],
-    importRunId?: string
+    importRunId?: string,
+    responseOverwriteMode: TestResultsOverwriteMode = 'skip'
   ): Observable<Result> {
     const {
       units,
@@ -57,7 +62,8 @@ export class ImportService {
       .set('testGroups', String(testGroups.join(',')))
       .set('overwriteExistingLogs', String(overwriteExistingLogs))
       .set('overwriteFileIds', String((overwriteFileIds || []).join(';')))
-      .set('importRunId', String(importRunId || ''));
+      .set('importRunId', String(importRunId || ''))
+      .set('responseOverwriteMode', responseOverwriteMode);
 
     return this.http
       .get<Result>(

--- a/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.html
@@ -145,6 +145,19 @@
                 Importiert Testergebnisse der Teilnehmenden
               </div>
             </div>
+            @if (importFilesForm.get('responses')?.value) {
+            <mat-form-field appearance="outline">
+              <mat-label>Umgang mit vorhandenen Antworten</mat-label>
+              <mat-select formControlName="responseOverwriteMode">
+                <mat-option value="skip">Vorhandene Units überspringen</mat-option>
+                <mat-option value="merge">Fehlende Antwortwerte ergänzen</mat-option>
+                <mat-option value="replace">Vorhandene Antwortwerte ersetzen</mat-option>
+              </mat-select>
+              <mat-hint>
+                Gilt für Antworten aus dem Testcenter; Logs werden separat behandelt.
+              </mat-hint>
+            </mat-form-field>
+            }
             <div class="checkbox-item">
               <mat-checkbox formControlName="logs">
                 <span class="checkbox-label">Logs</span>

--- a/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.spec.ts
@@ -189,7 +189,10 @@ describe('TestCenterImportComponent', () => {
       'fake-token',
       expect.objectContaining({ responses: true }),
       ['group1'],
-      true
+      true,
+      undefined,
+      undefined,
+      'skip'
     );
 
     expect(mockDialogRef.close).toHaveBeenCalledWith({
@@ -199,6 +202,97 @@ describe('TestCenterImportComponent', () => {
       importedLogs: false,
       uploadResult: mockImportResult
     });
+  });
+
+  it('should pass the selected response overwrite mode for testResults import', async () => {
+    component.authenticated = true;
+    component.authToken = 'fake-token';
+    component.importFilesForm.patchValue({
+      workspace: 'tc-ws-1',
+      responses: true,
+      responseOverwriteMode: 'merge'
+    });
+    component.loginForm.patchValue({ testCenter: 1 });
+
+    const mockGroup: TestGroupsInfoDto = {
+      groupName: 'group1',
+      groupLabel: 'Group 1',
+      bookletsStarted: 10,
+      numUnitsTotal: 100,
+      numUnitsMin: 1,
+      numUnitsMax: 10,
+      numUnitsAvg: 5,
+      lastChange: Date.now(),
+      existsInDatabase: true,
+      hasBookletLogs: false
+    };
+    component.selectedRows = [mockGroup];
+
+    const mockImportResult: Result = {
+      success: true,
+      testFiles: 0,
+      responses: 10,
+      logs: 0,
+      booklets: 0,
+      units: 0,
+      persons: 0,
+      importedGroups: ['group1']
+    };
+    importService.importWorkspaceFiles.mockReturnValue(of(mockImportResult));
+
+    component.getTestData();
+    await fixture.whenStable();
+
+    expect(importService.importWorkspaceFiles).toHaveBeenCalledWith(
+      1,
+      'tc-ws-1',
+      '1',
+      '',
+      'fake-token',
+      expect.objectContaining({ responses: true }),
+      ['group1'],
+      true,
+      undefined,
+      undefined,
+      'merge'
+    );
+  });
+
+  it('should not start import when log overwrite confirmation is cancelled', async () => {
+    component.authenticated = true;
+    component.authToken = 'fake-token';
+    component.importFilesForm.patchValue({
+      workspace: 'tc-ws-1',
+      responses: true,
+      logs: true
+    });
+    component.loginForm.patchValue({ testCenter: 1 });
+    component.showTestGroups = true;
+    component.selectedRows = [{
+      groupName: 'group1',
+      groupLabel: 'Group 1',
+      bookletsStarted: 10,
+      numUnitsTotal: 100,
+      numUnitsMin: 1,
+      numUnitsMax: 10,
+      numUnitsAvg: 5,
+      lastChange: Date.now(),
+      existsInDatabase: true,
+      hasBookletLogs: true
+    }];
+
+    const dialog = TestBed.inject(MatDialog);
+    const mockConfirmDialogRef = {
+      afterClosed: jest.fn().mockReturnValue(of(false))
+    } as Partial<MatDialogRef<never>>;
+    jest.spyOn(dialog, 'open').mockReturnValue(mockConfirmDialogRef as MatDialogRef<never>);
+
+    component.getTestData();
+    await fixture.whenStable();
+
+    expect(importService.importWorkspaceFiles).not.toHaveBeenCalled();
+    expect(component.isUploadingTestResults).toBe(false);
+    expect(component.showTestGroups).toBe(true);
   });
 
   it('should handle authentication error', () => {

--- a/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-center-import/test-center-import.component.ts
@@ -59,6 +59,7 @@ import {
   ImportWorkspaceOptionKey
 } from '../../../../../../../api-dto/files/import-workspace-progress.dto';
 import { TestGroupsLoadProgressDto } from '../../../../../../../api-dto/files/test-groups-load-progress.dto';
+import { TestResultsOverwriteMode } from '../../../../../../../api-dto/files/import-options.dto';
 
 export type WorkspaceAdmin = {
   label: string;
@@ -79,6 +80,7 @@ export interface ImportFormValues {
   workspace: string;
   testCenterIndividual: string;
   importOptions: ImportOptions;
+  responseOverwriteMode: TestResultsOverwriteMode;
 }
 
 @Component({
@@ -212,6 +214,7 @@ export class TestCenterImportComponent {
       player: this.fb.control(false),
       codings: this.fb.control(false),
       logs: this.fb.control(false),
+      responseOverwriteMode: this.fb.control('skip'),
       testTakers: this.fb.control(false),
       booklets: this.fb.control(false),
       metadata: this.fb.control(false)
@@ -436,28 +439,34 @@ export class TestCenterImportComponent {
     return this.selectedRows.some(group => group.hasBookletLogs);
   }
 
-  private async confirmOverwriteLogs(): Promise<boolean> {
+  private async confirmOverwriteLogs(): Promise<'overwrite' | 'skip' | 'cancel'> {
     const groupsWithLogs = this.selectedRows.filter(
       group => group.hasBookletLogs
     );
 
     if (groupsWithLogs.length === 0) {
-      return true;
+      return 'overwrite';
     }
 
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
       width: '400px',
       data: <ConfirmDialogData>{
-        title: 'Logs überschreiben',
+        title: 'Vorhandene Logs gefunden',
         content:
           `${groupsWithLogs.length} ausgewählte Testgruppe(n) haben bereits Booklet-Logs in der Datenbank. ` +
-          'Möchten Sie die vorhandenen Logs überschreiben?',
+          'Möchten Sie die vorhandenen Logs überschreiben oder vorhandene Logs überspringen?',
         confirmButtonLabel: 'Überschreiben',
+        alternativeButtonLabel: 'Ohne Überschreiben fortfahren',
+        alternativeButtonValue: 'skip',
+        cancelButtonLabel: 'Abbrechen',
         showCancel: true
       }
     });
 
-    return firstValueFrom(dialogRef.afterClosed());
+    const result = await firstValueFrom(dialogRef.afterClosed());
+    if (result === true) return 'overwrite';
+    if (result === 'skip') return 'skip';
+    return 'cancel';
   }
 
   getTestData(): void {
@@ -476,7 +485,9 @@ export class TestCenterImportComponent {
         testTakers: this.importFilesForm.get('testTakers')?.value,
         booklets: this.importFilesForm.get('booklets')?.value,
         metadata: this.importFilesForm.get('metadata')?.value
-      }
+      },
+      responseOverwriteMode:
+        this.importFilesForm.get('responseOverwriteMode')?.value || 'skip'
     };
 
     this.uploadData = null;
@@ -501,8 +512,12 @@ export class TestCenterImportComponent {
       this.isUploadingTestResults = false;
       this.resetUploadProgress();
 
-      this.confirmOverwriteLogs().then(confirmed => {
-        if (confirmed) {
+      this.confirmOverwriteLogs().then(choice => {
+        if (choice === 'cancel') {
+          this.resetUploadProgress();
+          return;
+        }
+        if (choice === 'overwrite') {
           this.isUploadingTestFiles = true;
           this.isUploadingTestResults = this.data.importType === 'testResults';
           this.initializeUploadProgress(selectedGroupNames.length);
@@ -535,7 +550,8 @@ export class TestCenterImportComponent {
     formValues: ImportFormValues,
     selectedGroupNames: string[],
     overwriteExistingLogs: boolean,
-    overwriteFileIds?: string[]
+    overwriteFileIds?: string[],
+    responseOverwriteMode: TestResultsOverwriteMode = 'skip'
   ): void {
     const importedResponses = !!formValues.importOptions.responses;
     const importedLogs = !!formValues.importOptions.logs;
@@ -573,7 +589,8 @@ export class TestCenterImportComponent {
         selectedGroupNames,
         overwriteExistingLogs,
         overwriteFileIds,
-        this.importRunId
+        this.importRunId,
+        responseOverwriteMode
       )
       .subscribe({
         next: data => {
@@ -758,7 +775,10 @@ export class TestCenterImportComponent {
             this.authToken,
             formValues.importOptions,
             [groupName],
-            overwriteExistingLogs
+            overwriteExistingLogs,
+            undefined,
+            undefined,
+            formValues.responseOverwriteMode
           )
         );
 


### PR DESCRIPTION
## Summary

Refs #796.

This PR keeps the Testcenter import fix focused on the confirmed scope:

- adds a response overwrite mode for Testcenter result imports (`skip`, `merge`, `replace`)
- forwards the selected response mode through the frontend service, backend controller, and Testcenter import service
- uses the selected mode when persisting imported responses instead of always using `skip`
- changes the existing log overwrite confirmation so `Abbrechen` cancels the import start, while a separate action continues without overwriting logs

The broader status/diff UI ideas from the issue are intentionally left for a follow-up issue: detecting incomplete groups, selecting all incomplete groups, and filtering/sorting by richer status.

## Validation

- `npx nx lint frontend`
- `npx nx lint backend`
- `npx nx test frontend --runInBand`
- `npx nx test backend --runInBand`

## Notes

This PR does not include the unrelated local changes currently present in the worktree around test file upload details and workspace file handling.