### PR TITLE
Fix bundled coding job navigation

### DIFF
--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.css
@@ -400,6 +400,8 @@
 
 /* Variable selector section */
 .variable-selector-section {
+  display: grid;
+  gap: 4px;
   margin-bottom: 6px;
   padding: 0 4px;
 }
@@ -568,6 +570,20 @@
   border-left-color: #1976d2;
 }
 
+.variable-panel-item.disabled {
+  cursor: default;
+  color: rgba(0, 0, 0, 0.52);
+}
+
+.variable-panel-item.disabled:hover {
+  background: transparent;
+}
+
+.variable-panel-item.disabled .variable-panel-name,
+.variable-panel-item.disabled .variable-panel-count {
+  color: rgba(0, 0, 0, 0.52);
+}
+
 .variable-panel-header {
   display: flex;
   justify-content: space-between;
@@ -584,6 +600,13 @@
   white-space: nowrap;
   flex: 1;
   margin-right: 8px;
+}
+
+.variable-panel-kind {
+  margin-left: 4px;
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 11px;
+  font-weight: 400;
 }
 
 .variable-panel-count {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.html
@@ -11,8 +11,49 @@
     </mat-progress-bar>
   </div>
 
-  @if (availableVariables.length > 1 || shouldShowBundleVariableChips) {
+  @if (shouldShowVariableSelectorSection) {
   <div class="variable-selector-section">
+    @if (navigationItems.length > 1) {
+    <div class="variable-dropdown-wrapper">
+      <button class="variable-trigger-btn" (click)="toggleVariablePanel()" [disabled]="isNavigationDisabled" type="button">
+        <span class="variable-trigger-label">
+          @let activeItem = activeNavigationItem;
+          @if (activeItem) {
+          @let prog = getProgressForNavigationItem(activeItem);
+          <span class="variable-trigger-name">{{ activeItem.label }}</span>
+          <span class="variable-trigger-progress">({{ prog.coded }}/{{ prog.total }})</span>
+          } @else {
+          Variable wählen
+          }
+        </span>
+        <mat-icon class="variable-trigger-icon">{{ isVariablePanelOpen ? 'expand_less' : 'expand_more' }}</mat-icon>
+      </button>
+
+      @if (isVariablePanelOpen) {
+      <div class="variable-panel" #variablePanel>
+        @for (item of navigationItems; track item.key) {
+        @let prog = getProgressForNavigationItem(item);
+        <div class="variable-panel-item" [class.active]="item.key === activeNavigationKey" (click)="selectNavigationItem(item.key)"
+          tabindex="-1">
+          <div class="variable-panel-header">
+            <span class="variable-panel-name">
+              {{ item.label }}
+              @if (item.type === 'bundle') {
+              <span class="variable-panel-kind">{{ 'code-selector.variable-bundle' | translate }}</span>
+              }
+            </span>
+            <span class="variable-panel-count">{{ prog.coded }}/{{ prog.total }}</span>
+          </div>
+          <div class="variable-panel-bar-track">
+            <div class="variable-panel-bar-fill" [style.width.%]="prog.percentage"
+              [class.complete]="prog.percentage === 100"></div>
+          </div>
+        </div>
+        }
+      </div>
+      }
+    </div>
+    }
     @if (shouldShowBundleVariableChips) {
     <div class="bundle-variable-chips" role="tablist">
       @for (chip of bundleVariableChips; track chip.key) {
@@ -33,36 +74,46 @@
       </button>
       }
     </div>
-    } @else {
-    <div class="variable-dropdown-wrapper">
-      <button class="variable-trigger-btn" (click)="toggleVariablePanel()" [disabled]="isNavigationDisabled" type="button">
+    }
+    @if (shouldShowBundleVariableDropdown) {
+    <div class="variable-dropdown-wrapper bundle-variable-dropdown-wrapper">
+      <button class="variable-trigger-btn" (click)="toggleBundleVariablePanel()" [disabled]="isNavigationDisabled" type="button">
         <span class="variable-trigger-label">
-          @if (activeVariableKey) {
-          @let prog = getProgressForKey(activeVariableKey);
-          <span class="variable-trigger-name">{{ activeVariableKey.split('::')[0] }} / {{
-            activeVariableKey.split('::')[1] }}</span>
-          <span class="variable-trigger-progress">({{ prog.coded }}/{{ prog.total }})</span>
+          @let activeBundleVariable = activeBundleVariableNavigationItem;
+          @if (activeBundleVariable) {
+          <span class="variable-trigger-name">{{ activeBundleVariable.label }}</span>
+          <span class="variable-trigger-progress">({{ activeBundleVariable.progress.coded }}/{{ activeBundleVariable.progress.total }})</span>
           } @else {
           Variable wählen
           }
         </span>
-        <mat-icon class="variable-trigger-icon">{{ isVariablePanelOpen ? 'expand_less' : 'expand_more' }}</mat-icon>
+        <mat-icon class="variable-trigger-icon">{{ isBundleVariablePanelOpen ? 'expand_less' : 'expand_more' }}</mat-icon>
       </button>
 
-      @if (isVariablePanelOpen) {
-      <div class="variable-panel" #variablePanel>
-        @for (v of availableVariables; track v.key) {
-        @let prog = getProgressForKey(v.key);
-        <div class="variable-panel-item" [class.active]="v.key === activeVariableKey" (click)="selectVariable(v.key)"
+      @if (isBundleVariablePanelOpen) {
+      <div class="variable-panel" #bundleVariablePanel>
+        @for (item of bundleVariableNavigationItems; track item.key) {
+        <div
+          class="variable-panel-item"
+          [class.active]="item.active"
+          [class.disabled]="item.disabled"
+          [matTooltip]="item.tooltip"
+          (click)="selectBundleVariable(item.key, item.disabled)"
           tabindex="-1">
           <div class="variable-panel-header">
-            <span class="variable-panel-name">{{ v.unitName }} / {{ v.variableId }}</span>
-            <span class="variable-panel-count">{{ prog.coded }}/{{ prog.total }}</span>
+            <span class="variable-panel-name">{{ item.label }}</span>
+            @if (item.status === 'auto-coded') {
+            <mat-icon class="bundle-variable-status-icon">bolt</mat-icon>
+            } @else {
+            <span class="variable-panel-count">{{ item.progress.coded }}/{{ item.progress.total }}</span>
+            }
           </div>
+          @if (item.status !== 'auto-coded') {
           <div class="variable-panel-bar-track">
-            <div class="variable-panel-bar-fill" [style.width.%]="prog.percentage"
-              [class.complete]="prog.percentage === 100"></div>
+            <div class="variable-panel-bar-fill" [style.width.%]="item.progress.percentage"
+              [class.complete]="item.progress.percentage === 100"></div>
           </div>
+          }
         </div>
         }
       </div>

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -824,4 +824,264 @@ describe('CodeSelectorComponent', () => {
     expect(chips[1].disabled).toBe(true);
     expect(fixture.nativeElement.querySelector('.variable-trigger-btn')).toBeNull();
   });
+
+  it('keeps the navigation dropdown visible for bundle jobs and lists one entry per bundle', () => {
+    component.showProgress = true;
+    component.codingService = {
+      isUnitCoded: jest.fn().mockReturnValue(false)
+    } as never;
+    const bundleContext = {
+      bundleId: 9,
+      bundleName: 'Bundle A',
+      caseKey: 'case-1',
+      caseOrderingMode: 'alternating' as const,
+      variables: [
+        {
+          responseId: 1,
+          unitName: 'UNIT_1',
+          variableId: 'VAR1',
+          variableAnchor: 'VAR1',
+          variablePage: '0',
+          status: 'manual-open' as const,
+          code: null,
+          score: null,
+          source: 'manual' as const
+        },
+        {
+          responseId: 2,
+          unitName: 'UNIT_1',
+          variableId: 'VAR2',
+          variableAnchor: 'VAR2',
+          variablePage: '0',
+          status: 'manual-open' as const,
+          code: null,
+          score: null,
+          source: 'manual' as const
+        }
+      ]
+    };
+    component.unitsData = {
+      id: 1,
+      name: 'Job',
+      currentUnitIndex: 0,
+      units: [
+        {
+          id: 1,
+          name: 'UNIT_1',
+          alias: 'UNIT_1',
+          bookletId: 0,
+          variableId: 'VAR1',
+          variableBundleId: 9,
+          bundleContext
+        },
+        {
+          id: 2,
+          name: 'UNIT_1',
+          alias: 'UNIT_1',
+          bookletId: 0,
+          variableId: 'VAR2',
+          variableBundleId: 9,
+          bundleContext
+        },
+        {
+          id: 3,
+          name: 'UNIT_2',
+          alias: 'UNIT_2',
+          bookletId: 0,
+          variableId: 'VAR3'
+        }
+      ]
+    };
+
+    fixture.detectChanges();
+
+    const trigger = fixture.nativeElement.querySelector('.variable-trigger-btn') as HTMLButtonElement;
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain('Bundle A');
+    expect(fixture.nativeElement.querySelectorAll('.bundle-variable-chip')).toHaveLength(2);
+
+    component.toggleVariablePanel();
+    fixture.detectChanges();
+
+    const panelItems = fixture.nativeElement.querySelectorAll('.variable-panel-item') as NodeListOf<HTMLElement>;
+    expect(component.navigationItems.map(item => item.label)).toEqual(['Bundle A', 'UNIT_2 / VAR3']);
+    expect(panelItems).toHaveLength(2);
+    expect(panelItems[0].textContent).toContain('Bundle A');
+    expect(panelItems[0].textContent).toContain('code-selector.variable-bundle');
+    expect(panelItems[1].textContent).toContain('UNIT_2 / VAR3');
+  });
+
+  it('shows a bundle variable dropdown for single non-chip bundle jobs', () => {
+    component.showProgress = true;
+    component.codingService = {
+      isUnitCoded: jest.fn().mockReturnValue(false)
+    } as never;
+    const variables = ['VAR1', 'VAR2', 'VAR3', 'VAR4', 'VAR5'].map((variableId, index) => ({
+      responseId: index + 1,
+      unitName: 'UNIT_1',
+      variableId,
+      variableAnchor: variableId,
+      variablePage: '0',
+      status: 'manual-open' as const,
+      code: null,
+      score: null,
+      source: 'manual' as const
+    }));
+    const bundleContext = {
+      bundleId: 9,
+      bundleName: 'Bundle A',
+      caseKey: 'case-1',
+      caseOrderingMode: 'continuous' as const,
+      variables
+    };
+    component.unitsData = {
+      id: 1,
+      name: 'Job',
+      currentUnitIndex: 0,
+      units: variables.map((variable, index) => ({
+        id: index + 1,
+        name: 'UNIT_1',
+        alias: 'UNIT_1',
+        bookletId: 0,
+        variableId: variable.variableId,
+        variableBundleId: 9,
+        bundleContext
+      }))
+    };
+
+    fixture.detectChanges();
+
+    const trigger = fixture.nativeElement.querySelector(
+      '.bundle-variable-dropdown-wrapper .variable-trigger-btn'
+    ) as HTMLButtonElement;
+    expect(component.navigationItems.map(item => item.label)).toEqual(['Bundle A']);
+    expect(component.shouldShowBundleVariableChips).toBe(false);
+    expect(component.shouldShowBundleVariableDropdown).toBe(true);
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain('UNIT_1 / VAR1');
+    expect(fixture.nativeElement.querySelectorAll('.bundle-variable-chip')).toHaveLength(0);
+
+    component.toggleBundleVariablePanel();
+    fixture.detectChanges();
+
+    const panelItems = fixture.nativeElement.querySelectorAll(
+      '.bundle-variable-dropdown-wrapper .variable-panel-item'
+    ) as NodeListOf<HTMLElement>;
+    expect(panelItems).toHaveLength(5);
+    expect(panelItems[4].textContent).toContain('UNIT_1 / VAR5');
+
+    const emitSpy = jest.spyOn(component.unitChanged, 'emit');
+    component.selectBundleVariable('UNIT_1::VAR5', false);
+
+    expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[4]);
+  });
+
+  it('keeps bundle variable navigation within the current bundle case', () => {
+    component.showProgress = true;
+    component.codingService = {
+      isUnitCoded: jest.fn().mockReturnValue(false)
+    } as never;
+    const variables = ['VAR1', 'VAR2', 'VAR3', 'VAR4', 'VAR5'].map((variableId, index) => ({
+      responseId: index + 1,
+      unitName: 'UNIT_1',
+      variableId,
+      variableAnchor: variableId,
+      variablePage: '0',
+      status: 'manual-open' as const,
+      code: null,
+      score: null,
+      source: 'manual' as const
+    }));
+    const firstCaseContext = {
+      bundleId: 9,
+      bundleName: 'Bundle A',
+      caseKey: 'case-1',
+      caseOrderingMode: 'continuous' as const,
+      variables
+    };
+    const secondCaseContext = {
+      ...firstCaseContext,
+      caseKey: 'case-2',
+      variables: variables.map((variable, index) => ({
+        ...variable,
+        responseId: index + 6
+      }))
+    };
+    const createCaseUnits = (testPerson: string, bundleContext: typeof firstCaseContext, idOffset: number) => (
+      bundleContext.variables.map((variable, index) => ({
+        id: idOffset + index,
+        name: 'UNIT_1',
+        alias: 'UNIT_1',
+        bookletId: 0,
+        testPerson,
+        variableId: variable.variableId,
+        variableBundleId: 9,
+        bundleContext
+      }))
+    );
+    component.unitsData = {
+      id: 1,
+      name: 'Job',
+      currentUnitIndex: 5,
+      units: [
+        ...createCaseUnits('person-1@code@group@booklet', firstCaseContext, 1),
+        ...createCaseUnits('person-2@code@group@booklet', secondCaseContext, 6)
+      ]
+    };
+
+    const emitSpy = jest.spyOn(component.unitChanged, 'emit');
+
+    component.selectBundleVariable('UNIT_1::VAR5', false);
+
+    expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[9]);
+    expect(emitSpy).not.toHaveBeenCalledWith(component.unitsData.units[4]);
+  });
+
+  it('navigates to the first uncoded unit of a selected bundle navigation item', () => {
+    component.codingService = {
+      isUnitCoded: jest.fn((unit: { variableId?: string }) => unit.variableId === 'VAR1')
+    } as never;
+    component.unitsData = {
+      id: 1,
+      name: 'Job',
+      currentUnitIndex: 0,
+      units: [
+        {
+          id: 1,
+          name: 'UNIT_1',
+          alias: 'UNIT_1',
+          bookletId: 0,
+          variableId: 'VAR1',
+          variableBundleId: 9,
+          bundleContext: {
+            bundleId: 9,
+            bundleName: 'Bundle A',
+            caseKey: 'case-1',
+            caseOrderingMode: 'continuous',
+            variables: []
+          }
+        },
+        {
+          id: 2,
+          name: 'UNIT_1',
+          alias: 'UNIT_1',
+          bookletId: 0,
+          variableId: 'VAR2',
+          variableBundleId: 9
+        },
+        {
+          id: 3,
+          name: 'UNIT_2',
+          alias: 'UNIT_2',
+          bookletId: 0,
+          variableId: 'VAR3'
+        }
+      ]
+    };
+    const emitSpy = jest.spyOn(component.unitChanged, 'emit');
+
+    component.jumpToNavigationItem('bundle:9');
+
+    expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[1]);
+  });
 });

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -14,7 +14,14 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { ReviewCodeSelection, UnitsReplay, UnitsReplayUnit } from '../../../replay/services/units-replay.service';
+import {
+  BundleContext,
+  BundleVariableContext,
+  BundleVariableStatus,
+  ReviewCodeSelection,
+  UnitsReplay,
+  UnitsReplayUnit
+} from '../../../replay/services/units-replay.service';
 import { ReplayCodingService } from '../../../replay/services/replay-coding.service';
 import {
   Code,
@@ -25,6 +32,28 @@ import {
   VariableCoding
 } from '../../../models/coding-interfaces';
 import { hasManualInstruction } from '../../utils/manual-coding.util';
+
+interface NavigationItem {
+  key: string;
+  type: 'variable' | 'bundle';
+  label: string;
+  variableId?: string;
+  unitName?: string;
+  bundleId?: number;
+}
+
+interface BundleVariableNavigationItem {
+  key: string;
+  label: string;
+  variableId: string;
+  unitName: string;
+  targetUnit?: UnitsReplayUnit;
+  status: BundleVariableStatus;
+  active: boolean;
+  disabled: boolean;
+  tooltip: string;
+  progress: { coded: number; total: number; percentage: number };
+}
 
 @Component({
   selector: 'app-code-selector',
@@ -69,6 +98,7 @@ export class CodeSelectorComponent implements OnChanges {
   @Output() pauseCodingJob = new EventEmitter<void>();
   @Output() unitChanged = new EventEmitter<UnitsReplayUnit>();
   @ViewChild('variablePanel') variablePanel?: ElementRef<HTMLElement>;
+  @ViewChild('bundleVariablePanel') bundleVariablePanel?: ElementRef<HTMLElement>;
   @ViewChild('notesTextarea') notesTextarea?: ElementRef<HTMLTextAreaElement>;
 
   selectableItems: SelectableItem[] = [];
@@ -97,8 +127,11 @@ export class CodeSelectorComponent implements OnChanges {
 
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
-    if (this.isVariablePanelOpen && !this.elementRef.nativeElement.contains(event.target as Node | null)) {
-      this.isVariablePanelOpen = false;
+    if (
+      (this.isVariablePanelOpen || this.isBundleVariablePanelOpen) &&
+      !this.elementRef.nativeElement.contains(event.target as Node | null)
+    ) {
+      this.closeVariablePanel();
     }
   }
 
@@ -606,27 +639,46 @@ export class CodeSelectorComponent implements OnChanges {
   }
 
   isVariablePanelOpen = false;
+  isBundleVariablePanelOpen = false;
 
   toggleVariablePanel(): void {
     if (this.isNavigationDisabled) return;
     this.isVariablePanelOpen = !this.isVariablePanelOpen;
     if (this.isVariablePanelOpen) {
-      setTimeout(() => this.focusCurrentVariableInPanel(), 0);
+      this.isBundleVariablePanelOpen = false;
+    }
+    if (this.isVariablePanelOpen) {
+      setTimeout(() => this.focusCurrentVariableInPanel(this.variablePanel?.nativeElement), 0);
+    }
+  }
+
+  toggleBundleVariablePanel(): void {
+    if (this.isNavigationDisabled) return;
+    this.isBundleVariablePanelOpen = !this.isBundleVariablePanelOpen;
+    if (this.isBundleVariablePanelOpen) {
+      this.isVariablePanelOpen = false;
+      setTimeout(() => this.focusCurrentVariableInPanel(this.bundleVariablePanel?.nativeElement), 0);
     }
   }
 
   closeVariablePanel(): void {
     this.isVariablePanelOpen = false;
+    this.isBundleVariablePanelOpen = false;
   }
 
   selectVariable(key: string): void {
     if (this.isNavigationDisabled) return;
-    this.isVariablePanelOpen = false;
+    this.closeVariablePanel();
     this.jumpToVariable(key);
   }
 
-  private focusCurrentVariableInPanel(): void {
-    const panel = this.variablePanel?.nativeElement;
+  selectNavigationItem(key: string): void {
+    if (this.isNavigationDisabled) return;
+    this.closeVariablePanel();
+    this.jumpToNavigationItem(key);
+  }
+
+  private focusCurrentVariableInPanel(panel?: HTMLElement): void {
     if (!panel) return;
 
     const activeItem = panel.querySelector<HTMLElement>('.variable-panel-item.active');
@@ -644,10 +696,64 @@ export class CodeSelectorComponent implements OnChanges {
     const units = this.unitsData.units.filter(
       u => (u.alias || u.name) === unitName && u.variableId === variableId
     );
+    return this.getProgressForUnits(units);
+  }
+
+  getProgressForNavigationItem(item: NavigationItem): { coded: number; total: number; percentage: number } {
+    if (!this.unitsData?.units || !this.codingService) return { coded: 0, total: 0, percentage: 0 };
+    if (item.type === 'bundle') {
+      const units = this.unitsData.units.filter(unit => unit.variableBundleId === item.bundleId);
+      return this.getProgressForUnits(units);
+    }
+
+    return this.getProgressForKey(`${item.unitName}::${item.variableId}`);
+  }
+
+  private getProgressForUnits(units: UnitsReplayUnit[]): { coded: number; total: number; percentage: number } {
     const total = units.length;
     const coded = units.filter(u => this.codingService.isUnitCoded(u)).length;
     const percentage = total > 0 ? Math.round((coded / total) * 100) : 0;
     return { coded, total, percentage };
+  }
+
+  get navigationItems(): NavigationItem[] {
+    if (!this.unitsData?.units) return [];
+    const seen = new Set<string>();
+    const result: NavigationItem[] = [];
+
+    for (const unit of this.unitsData.units) {
+      if (unit.variableBundleId !== null && unit.variableBundleId !== undefined) {
+        const key = this.getBundleNavigationKey(unit.variableBundleId);
+        if (!seen.has(key)) {
+          seen.add(key);
+          result.push({
+            key,
+            type: 'bundle',
+            label: unit.bundleContext?.bundleName ||
+              `${this.translateService.instant('code-selector.variable-bundle')} ${unit.variableBundleId}`,
+            bundleId: unit.variableBundleId
+          });
+        }
+        continue;
+      }
+
+      if (unit.variableId) {
+        const unitName = unit.alias || unit.name;
+        const key = this.getVariableNavigationKey(unitName, unit.variableId);
+        if (!seen.has(key)) {
+          seen.add(key);
+          result.push({
+            key,
+            type: 'variable',
+            label: `${unitName} / ${unit.variableId}`,
+            variableId: unit.variableId,
+            unitName
+          });
+        }
+      }
+    }
+
+    return result;
   }
 
   /** Unique unit+variable combinations available in the current coding job, preserving order of first appearance. */
@@ -675,38 +781,41 @@ export class CodeSelectorComponent implements OnChanges {
       context.variables.length < 5;
   }
 
-  get bundleVariableChips(): Array<{
-    key: string;
-    variableId: string;
-    unitName: string;
-    status: string;
-    active: boolean;
-    disabled: boolean;
-    tooltip: string;
-    progress: { coded: number; total: number; percentage: number };
-  }> {
+  get shouldShowBundleVariableDropdown(): boolean {
+    return !this.shouldShowBundleVariableChips && this.bundleVariableNavigationItems.length > 1;
+  }
+
+  get shouldShowVariableSelectorSection(): boolean {
+    return this.navigationItems.length > 1 ||
+      this.shouldShowBundleVariableChips ||
+      this.shouldShowBundleVariableDropdown;
+  }
+
+  get bundleVariableChips(): BundleVariableNavigationItem[] {
+    return this.bundleVariableNavigationItems;
+  }
+
+  get bundleVariableNavigationItems(): BundleVariableNavigationItem[] {
     const context = this.currentBundleContext;
     if (!context) return [];
 
     return context.variables.map(variable => {
-      const matchingUnit = this.unitsData?.units.find(unit => (
-        unit.variableId === variable.variableId &&
-        unit.name === variable.unitName
-      ));
-      const unitName = matchingUnit?.alias || matchingUnit?.name || variable.unitName;
+      const targetUnit = this.getCurrentBundleVariableUnit(context, variable);
+      const unitName = targetUnit?.alias || targetUnit?.name || variable.unitName;
       const key = `${unitName}::${variable.variableId}`;
-      const hasManualUnit = this.availableVariables.some(available => available.key === key);
       const progress = this.getProgressForKey(key);
       const disabled =
         this.isNavigationDisabled ||
-        !hasManualUnit ||
+        !targetUnit ||
         variable.status === 'auto-coded' ||
         variable.status === 'not-available';
 
       return {
         key,
+        label: `${unitName} / ${variable.variableId}`,
         variableId: variable.variableId,
         unitName,
+        targetUnit,
         status: variable.status,
         active: key === this.activeVariableKey,
         disabled,
@@ -716,9 +825,53 @@ export class CodeSelectorComponent implements OnChanges {
     });
   }
 
+  private getCurrentBundleVariableUnit(
+    context: BundleContext,
+    variable: BundleVariableContext
+  ): UnitsReplayUnit | undefined {
+    if (!this.unitsData?.units) return undefined;
+    const currentUnit = this.unitsData.units[this.unitsData.currentUnitIndex];
+
+    return this.unitsData.units.find(unit => (
+      this.isUnitInBundle(unit, context.bundleId) &&
+      unit.variableId === variable.variableId &&
+      unit.name === variable.unitName &&
+      this.isUnitInCurrentBundleCase(unit, currentUnit, context)
+    ));
+  }
+
+  private isUnitInBundle(unit: UnitsReplayUnit, bundleId: number): boolean {
+    return unit.variableBundleId === bundleId || unit.bundleContext?.bundleId === bundleId;
+  }
+
+  private isUnitInCurrentBundleCase(
+    unit: UnitsReplayUnit,
+    currentUnit: UnitsReplayUnit | undefined,
+    context: BundleContext
+  ): boolean {
+    if (unit.bundleContext?.caseKey && context.caseKey) {
+      return unit.bundleContext.caseKey === context.caseKey;
+    }
+
+    if (currentUnit?.testPerson || unit.testPerson) {
+      return unit.testPerson === currentUnit?.testPerson;
+    }
+
+    return unit === currentUnit;
+  }
+
+  get activeBundleVariableNavigationItem(): BundleVariableNavigationItem | null {
+    return this.bundleVariableNavigationItems.find(item => item.active) || null;
+  }
+
   private get currentBundleContext() {
     const currentUnit = this.unitsData?.units[this.unitsData.currentUnitIndex];
-    return currentUnit?.bundleContext || null;
+    if (currentUnit?.bundleContext) return currentUnit.bundleContext;
+    if (currentUnit?.variableBundleId === null || currentUnit?.variableBundleId === undefined) return null;
+
+    return this.unitsData?.units.find(unit => (
+      unit.variableBundleId === currentUnit.variableBundleId && !!unit.bundleContext
+    ))?.bundleContext || null;
   }
 
   getBundleVariableTooltip(status: string): string {
@@ -740,6 +893,23 @@ export class CodeSelectorComponent implements OnChanges {
     const unit = this.unitsData.units[this.unitsData.currentUnitIndex];
     if (!unit?.variableId) return '';
     return `${unit.alias || unit.name}::${unit.variableId}`;
+  }
+
+  get activeNavigationKey(): string {
+    if (!this.unitsData?.units) return '';
+    const unit = this.unitsData.units[this.unitsData.currentUnitIndex];
+    if (!unit) return '';
+    if (unit.variableBundleId !== null && unit.variableBundleId !== undefined) {
+      return this.getBundleNavigationKey(unit.variableBundleId);
+    }
+    if (unit.variableId) {
+      return this.getVariableNavigationKey(unit.alias || unit.name, unit.variableId);
+    }
+    return '';
+  }
+
+  get activeNavigationItem(): NavigationItem | null {
+    return this.navigationItems.find(item => item.key === this.activeNavigationKey) || null;
   }
 
   /** Progress (coded / total) for the unit+variable of the current unit. */
@@ -780,8 +950,43 @@ export class CodeSelectorComponent implements OnChanges {
     this.unitChanged.emit(target.unit);
   }
 
+  jumpToNavigationItem(key: string): void {
+    if (this.isNavigationDisabled) return;
+    const item = this.navigationItems.find(navItem => navItem.key === key);
+    if (!item) return;
+
+    if (item.type === 'variable' && item.unitName && item.variableId) {
+      this.jumpToVariable(`${item.unitName}::${item.variableId}`);
+      return;
+    }
+
+    if (!this.unitsData?.units || item.bundleId === undefined) return;
+    const bundleUnits = this.unitsData.units.filter(unit => unit.variableBundleId === item.bundleId);
+    if (bundleUnits.length === 0) return;
+
+    const firstUncoded = bundleUnits.find(unit => !this.codingService.isUnitCoded(unit));
+    const target = firstUncoded ?? bundleUnits[0];
+    this.unitChanged.emit(target);
+  }
+
   selectBundleVariable(key: string, disabled: boolean): void {
     if (disabled) return;
-    this.jumpToVariable(key);
+    this.closeVariablePanel();
+    this.jumpToBundleVariable(key);
+  }
+
+  private jumpToBundleVariable(key: string): void {
+    if (this.isNavigationDisabled) return;
+    const target = this.bundleVariableNavigationItems.find(item => item.key === key)?.targetUnit;
+    if (!target) return;
+    this.unitChanged.emit(target);
+  }
+
+  private getVariableNavigationKey(unitName: string, variableId: string): string {
+    return `variable:${unitName}::${variableId}`;
+  }
+
+  private getBundleNavigationKey(bundleId: number): string {
+    return `bundle:${bundleId}`;
   }
 }

--- a/apps/frontend/src/app/coding/components/my-coding-jobs/my-coding-jobs.component.scss
+++ b/apps/frontend/src/app/coding/components/my-coding-jobs/my-coding-jobs.component.scss
@@ -189,15 +189,14 @@
 }
 
 .no-data-message {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: 32px;
+  flex: 1 1 auto;
+  min-height: 220px;
+  padding: 24px 32px;
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 16px;
 
   mat-icon {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1073,6 +1073,7 @@
     "bundle-manual-coded-tooltip": "Diese Bündelvariable ist manuell kodiert.",
     "bundle-open-tooltip": "Diese Bündelvariable ist offen.",
     "bundle-not-available-tooltip": "Diese Bündelvariable ist für diesen Fall nicht verfügbar.",
+    "variable-bundle": "Bündel",
     "code-assignment-uncertain-requires-code": "Code-Vergabe unsicher kann erst nach einem regulären Code ausgewählt werden.",
     "new-code-comment-required": "Bitte begründen Sie „Neuer Code nötig“ im Kommentar zu diesem Kodierfall.",
     "coding-issue-options": {


### PR DESCRIPTION
## Summary
- Collapse bundled coding variables into a single global navigation entry per bundle.
- Add a bundle-variable selector for switching variables within the current bundle case.
- Keep bundle-variable navigation constrained to the current case and fix the empty-state overlap on narrow coding job views.

Refs #683

## Validation
- npx nx test frontend --runInBand --testPathPattern=code-selector.component.spec.ts
- npx nx lint frontend
- npx nx build frontend
- UI check in the running Docker frontend on localhost:4200

Issue is intentionally not closed by this PR.