### PR TITLE
Add freshness autocoding start feedback

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
@@ -110,7 +110,14 @@
       </div>
     </div>
 
-    @if (activeFreshnessJobId) {
+    @if (isStartingFreshnessCoding) {
+    <div class="coding-freshness-job">
+      <mat-spinner diameter="18"></mat-spinner>
+      <span>
+        {{ 'coding-management.readiness.starting-freshness-coding' | translate }}
+      </span>
+    </div>
+    } @else if (activeFreshnessJobId) {
     <div class="coding-freshness-job">
       <mat-spinner diameter="18"></mat-spinner>
       <span>

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -260,6 +260,7 @@ describe('CodingManagementComponent', () => {
           'second-autocoding-waits-help': 'Der Start von Auto-Coding 2 bleibt bis dahin gesperrt. {{taskResultHelp}}',
           'second-autocoding-waits-chip': '{{version}}: {{count}} wartet',
           'second-autocoding-waits-snackbar': 'Schließen Sie zuerst die manuelle Kodierung ab und übernehmen Sie die Ergebnisse.',
+          'starting-freshness-coding': 'Auto-Coding wird gestartet...',
           'open-manual-review': 'Manuelle Kodierung öffnen'
         }
       }
@@ -556,6 +557,31 @@ describe('CodingManagementComponent', () => {
         'Schließen',
         { duration: 6000 }
       );
+    });
+
+    it('should show a start indicator while the freshness coding request is pending', () => {
+      const startRequest$ = new Subject<never>();
+      (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(startRequest$);
+      component.codingFreshnessSummary = {
+        workspaceId: 1,
+        currentRevision: 2,
+        items: [
+          {
+            version: 'v1',
+            state: 'PENDING',
+            unitCount: 7,
+            affectedResponseCount: 42
+          }
+        ]
+      };
+
+      component.startFreshnessCoding('v1');
+      fixture.detectChanges();
+
+      const status = fixture.nativeElement.querySelector('.coding-freshness-job') as HTMLElement | null;
+      expect(status?.textContent).toContain('Auto-Coding wird gestartet...');
+      expect(status?.querySelector('mat-spinner')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('.coding-freshness-actions')).toBeNull();
     });
 
     it('should open the test person coding dialog with the started freshness job', () => {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1348,6 +1348,7 @@
       "second-autocoding-waits-chip": "{{version}}: {{count}} wartet",
       "second-autocoding-waits-snackbar": "Schließen Sie zuerst die manuelle Kodierung ab und übernehmen Sie die Ergebnisse.",
       "current": "Für die aktuell berücksichtigten Testergebnisse gibt es keine offenen Aktualisierungshinweise.",
+      "starting-freshness-coding": "Auto-Coding wird gestartet...",
       "update-running": "Aktualisierung läuft: {{progress}}%",
       "retry": "Erneut prüfen",
       "check-test-files": "Testdateien prüfen",


### PR DESCRIPTION
## Summary

- show a spinner/status line while the freshness auto-coding start request is pending
- add the German UI text for the pending start state
- cover the pending-request state in the coding management component test

## Context

Related: #754

This keeps the issue open for verification on the target environment.

## Validation

- `npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts`
- `npx nx lint frontend`
