### PR TITLE
Show review tooltips for general codes

### DIFF
--- a/apps/backend/src/app/admin/workspace/dto/workspace-coding.interfaces.ts
+++ b/apps/backend/src/app/admin/workspace/dto/workspace-coding.interfaces.ts
@@ -40,6 +40,7 @@ export interface DoubleCodedReviewItem {
     trainingId: number | null;
     trainingLabel: string | null;
     code: number | null;
+    codingIssueOption: number | null;
     score: number | null;
     notes: string | null;
     supervisorComment: string | null;

--- a/apps/backend/src/app/admin/workspace/workspace-coding-review.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-review.controller.ts
@@ -138,6 +138,11 @@ export class WorkspaceCodingReviewController {
                       nullable: true,
                       description: 'Code given by the coder'
                     },
+                    codingIssueOption: {
+                      type: 'number',
+                      nullable: true,
+                      description: 'General coding issue option selected by the coder'
+                    },
                     score: {
                       type: 'number',
                       nullable: true,

--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -65,6 +65,7 @@ describe('CodingReviewService', () => {
     variable_id: 'VAR_1',
     coding_job_id: 100,
     code: 1,
+    coding_issue_option: null,
     score: 1,
     notes: null,
     supervisor_comment: null,
@@ -207,6 +208,7 @@ describe('CodingReviewService', () => {
     codingJobUnitRepository.find.mockResolvedValueOnce([
       makeCodingJobUnit({
         code: 1,
+        coding_issue_option: -3,
         score: 0
       }),
       makeCodingJobUnit({
@@ -309,7 +311,9 @@ describe('CodingReviewService', () => {
         responseId: 10,
         variableId: 'VAR_1',
         coderResults: [
-          { coderId: 1, jobId: 100, code: 1 },
+          {
+            coderId: 1, jobId: 100, code: 1, codingIssueOption: -3
+          },
           {
             coderId: 2, jobId: 101, code: 1, score: 1
           }
@@ -1583,6 +1587,7 @@ describe('CodingReviewService', () => {
                 trainingId: null,
                 trainingLabel: null,
                 code: 1,
+                codingIssueOption: null,
                 score: 1,
                 notes: null,
                 supervisorComment: null,
@@ -1597,6 +1602,7 @@ describe('CodingReviewService', () => {
                 trainingId: null,
                 trainingLabel: null,
                 code: 1,
+                codingIssueOption: null,
                 score: 1,
                 notes: null,
                 supervisorComment: null,
@@ -1611,6 +1617,7 @@ describe('CodingReviewService', () => {
                 trainingId: null,
                 trainingLabel: null,
                 code: 2,
+                codingIssueOption: null,
                 score: 1,
                 notes: null,
                 supervisorComment: null,

--- a/apps/backend/src/app/database/services/coding/coding-review.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.ts
@@ -35,6 +35,7 @@ type ReviewCoderResult = {
   trainingId: number | null;
   trainingLabel: string | null;
   code: number | null;
+  codingIssueOption?: number | null;
   score: number | null;
   notes: string | null;
   supervisorComment: string | null;
@@ -178,6 +179,7 @@ export class CodingReviewService {
           trainingId: number | null;
           trainingLabel: string | null;
           code: number | null;
+          codingIssueOption: number | null;
           score: number | null;
           notes: string | null;
           supervisorComment: string | null;
@@ -483,6 +485,7 @@ export class CodingReviewService {
           trainingId: number | null;
           trainingLabel: string | null;
           code: number | null;
+          codingIssueOption: number | null;
           score: number | null;
           notes: string | null;
           supervisorComment: string | null;
@@ -543,6 +546,7 @@ export class CodingReviewService {
             trainingId: unit.coding_job?.training_id ?? null,
             trainingLabel: unit.coding_job?.training?.label ?? null,
             code: resolvedCodeAndScore.code,
+            codingIssueOption: unit.coding_issue_option ?? null,
             score: resolvedCodeAndScore.score,
             notes: unit.notes,
             supervisorComment: unit.supervisor_comment || null,

--- a/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
@@ -604,6 +604,7 @@ export class WorkspaceCodingService {
           trainingId: number | null;
           trainingLabel: string | null;
           code: number | null;
+          codingIssueOption: number | null;
           score: number | null;
           notes: string | null;
           codedAt: Date;

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -323,6 +323,7 @@ describe('CodeSelectorComponent', () => {
     component.reviewCodeSelections = [
       { code: 1, coderNames: ['Coder A', 'Coder B'] },
       { code: 2, coderNames: ['Coder C'] },
+      { code: -3, coderNames: ['Coder F', 'Coder G'] },
       { code: -2, coderNames: ['Coder D', 'Coder E'] }
     ];
 
@@ -342,12 +343,16 @@ describe('CodeSelectorComponent', () => {
     expect(component.hasReviewCodeSelection(1)).toBe(true);
     expect(component.getReviewCodeSelectionCount(1)).toBe(2);
     expect(component.hasReviewCodeSelection(2)).toBe(true);
+    expect(component.hasReviewCodeSelection(-3)).toBe(true);
     expect(component.getReviewCodeSelectionCount(-2)).toBe(2);
     expect(component.getReviewCodeSelectionCount(99)).toBe(0);
     expect(badge.textContent).toContain('2');
     expect(codeRow).toBeTruthy();
     expect(issueBadge.textContent).toContain('2');
-    expect(issueRows).toHaveLength(1);
+    expect(issueRows).toHaveLength(2);
+    expect(component.getCodingIssueOptionRowTooltip(
+      component.codingIssueOptionCodes.find(item => item.id === -3)!
+    )).toContain('Coder F, Coder G');
     expect(component.getCodingIssueOptionRowTooltip(
       component.codingIssueOptionCodes.find(item => item.id === -2)!
     )).toContain('Coder D, Coder E');

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts
@@ -98,6 +98,7 @@ describe('DoubleCodedReviewComponent', () => {
                       jobId: 1001,
                       jobName: 'Definition 99 / A',
                       code: 1,
+                      codingIssueOption: -3,
                       score: 0,
                       notes: null,
                       supervisorComment: null,
@@ -345,7 +346,7 @@ describe('DoubleCodedReviewComponent', () => {
     );
     const reviewCodeSelections = new URLSearchParams(openedUrl.split('?')[1]).get('reviewCodeSelections');
     expect(JSON.parse(reviewCodeSelections || '[]')).toEqual([
-      { code: 1, coderNames: ['Coder A'] },
+      { code: -3, coderNames: ['Coder A'] },
       { code: 2, coderNames: ['Coder B'] }
     ]);
     expect(openSpy).toHaveBeenCalledWith(openedUrl, '_blank');

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -45,6 +45,7 @@ interface CoderResult {
   jobId: number;
   jobName: string;
   code: number | null;
+  codingIssueOption?: number | null;
   score: number | null;
   notes: string | null;
   supervisorComment: string | null;
@@ -186,6 +187,7 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
   private replayDecisionByResponseId = new Map<number, ReplayDecisionResult>();
   private replayWindowByResponseId = new Map<number, MessageEventSource>();
   private readonly replayDecisionPrefix = 'replay:';
+  private readonly standaloneCodingIssueOptionIds = new Set([-3, -4]);
 
   ngOnInit(): void {
     this.initializeForm();
@@ -795,21 +797,38 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
     const coderNamesByCode = new Map<number, string[]>();
 
     item.coderResults.forEach(result => {
-      if (result.code === null || result.code === undefined) {
-        return;
-      }
-
-      const coderNames = coderNamesByCode.get(result.code) || [];
       const coderName = this.getCoderDisplayName(result);
-      if (!coderNames.includes(coderName)) {
-        coderNames.push(coderName);
-      }
-      coderNamesByCode.set(result.code, coderNames);
+      this.getReviewSelectionCodes(result).forEach(code => {
+        const coderNames = coderNamesByCode.get(code) || [];
+        if (!coderNames.includes(coderName)) {
+          coderNames.push(coderName);
+        }
+        coderNamesByCode.set(code, coderNames);
+      });
     });
 
     return Array.from(coderNamesByCode.entries())
       .sort(([codeA], [codeB]) => codeA - codeB)
       .map(([code, coderNames]) => ({ code, coderNames }));
+  }
+
+  private getReviewSelectionCodes(result: CoderResult): number[] {
+    if (
+      result.codingIssueOption !== null &&
+      result.codingIssueOption !== undefined &&
+      this.standaloneCodingIssueOptionIds.has(result.codingIssueOption)
+    ) {
+      return [result.codingIssueOption];
+    }
+
+    const codes = new Set<number>();
+    if (result.code !== null && result.code !== undefined) {
+      codes.add(result.code);
+    }
+    if (result.codingIssueOption !== null && result.codingIssueOption !== undefined) {
+      codes.add(result.codingIssueOption);
+    }
+    return Array.from(codes);
   }
 
   private handleReplayCodeSelected(

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -1104,6 +1104,7 @@ export class TestPersonCodingService {
           jobId: number;
           jobName: string;
           code: number | null;
+          codingIssueOption: number | null;
           score: number | null;
           notes: string | null;
           supervisorComment: string | null;
@@ -1168,6 +1169,7 @@ export class TestPersonCodingService {
           jobId: number;
           jobName: string;
           code: number | null;
+          codingIssueOption: number | null;
           score: number | null;
           notes: string | null;
           supervisorComment: string | null;


### PR DESCRIPTION
## Summary
- include general coding issue options in double-coded review replay badge metadata
- keep standalone general options like `(mir)`/`(mci)` on the support-code badge only
- add focused coverage for general-code review tooltips

## Related
- https://github.com/iqb-berlin/coding-box/issues/701#issuecomment-4733277219

## Validation
- `npx nx test frontend --runInBand=true --testPathPattern=apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts --testPathPattern=apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.spec.ts`
- `npx nx lint frontend`
- `npx nx lint backend`
- `npx nx build backend`
- `npx nx build frontend`

Note: `npx nx test backend --runInBand=true --testFile=apps/backend/src/app/database/services/coding/coding-review.service.spec.ts` could not run locally because the installed `libxmljs2` native binary was built for Node module version 127 while the current Node expects 141.