### PR TITLE
Align manual coding distribution deduplication

### DIFF
--- a/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
+++ b/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
@@ -23,6 +23,7 @@ export interface ManualCodingDeduplicationResponse extends AggregationSourceResp
   personLogin?: string | null;
   personCode?: string | null;
   personGroup?: string | null;
+  bookletName?: string | null;
 }
 
 export function normalizeAggregationValue(
@@ -67,6 +68,7 @@ export function getManualCodingDeduplicationKey(
     response.personLogin || '',
     response.personCode || '',
     response.personGroup || '',
+    response.bookletName || '',
     response.unitName,
     response.variableId,
     valueHash

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -1057,6 +1057,61 @@ describe('CodingJobService distribution from job definitions', () => {
     });
   });
 
+  it('deduplicates identical manual coding responses before calculating batched variable usage', async () => {
+    const responses = [
+      makeSameCaseResponse(1, 'Unit 1', 'Var 1', 1, 'same-value'),
+      makeSameCaseResponse(2, 'Unit 1', 'Var 1', 1, 'same-value'),
+      makeSameCaseResponse(3, 'Unit 1', 'Var 1', 2, 'other-value')
+    ];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode')
+      .mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+
+    const usageByKey = await service.calculateDistributionVariableUsageByStatusBatch(5, [
+      {
+        key: 'requested',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        caseOrderingMode: 'continuous',
+        distributionSeed: 'seed-deduplicated'
+      }
+    ]);
+
+    expect(Object.fromEntries(usageByKey.get('requested')?.entries() || [])).toEqual({
+      'Unit 1::Var 1': { regular: 2, deriveError: 0, total: 2 }
+    });
+  });
+
+  it('treats an assigned duplicate as assigned when calculating batched variable usage', async () => {
+    const responses = [
+      makeSameCaseResponse(1, 'Unit 1', 'Var 1', 1, 'same-value'),
+      makeSameCaseResponse(2, 'Unit 1', 'Var 1', 1, 'same-value'),
+      makeSameCaseResponse(3, 'Unit 1', 'Var 1', 2, 'other-value')
+    ];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode')
+      .mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+    (
+      service as unknown as { getAssignedResponseIdsForVariables: jest.Mock }
+    ).getAssignedResponseIdsForVariables.mockResolvedValue(new Set([2]));
+
+    const usageByKey = await service.calculateDistributionVariableUsageByStatusBatch(5, [
+      {
+        key: 'requested',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        caseOrderingMode: 'continuous',
+        distributionSeed: 'seed-assigned-deduplicated'
+      }
+    ]);
+
+    expect(Object.fromEntries(usageByKey.get('requested')?.entries() || [])).toEqual({
+      'Unit 1::Var 1': { regular: 1, deriveError: 0, total: 1 }
+    });
+  });
+
   it('counts mixed aggregated regular and DERIVE_ERROR cases as regular usage', async () => {
     const responses = [
       {

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -1112,6 +1112,35 @@ describe('CodingJobService distribution from job definitions', () => {
     });
   });
 
+  it('keeps assigned duplicate cases reserved after deduplication and aggregation', async () => {
+    const responses = [
+      makeSameCaseResponse(1, 'Unit 1', 'Var 1', 1, 'same-value'),
+      makeSameCaseResponse(2, 'Unit 1', 'Var 1', 1, 'same-value'),
+      makeSameCaseResponse(3, 'Unit 1', 'Var 1', 2, 'same-value'),
+      makeSameCaseResponse(4, 'Unit 1', 'Var 1', 3, 'other-value')
+    ];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(2);
+    (
+      service as unknown as { getAssignedResponseIdsForVariables: jest.Mock }
+    ).getAssignedResponseIdsForVariables.mockResolvedValue(new Set([2]));
+
+    const usageByKey = await service.calculateDistributionVariableUsageByStatusBatch(5, [
+      {
+        key: 'requested',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        caseOrderingMode: 'continuous',
+        distributionSeed: 'seed-assigned-aggregation'
+      }
+    ]);
+
+    expect(Object.fromEntries(usageByKey.get('requested')?.entries() || [])).toEqual({
+      'Unit 1::Var 1': { regular: 1, deriveError: 0, total: 1 }
+    });
+  });
+
   it('counts mixed aggregated regular and DERIVE_ERROR cases as regular usage', async () => {
     const responses = [
       {

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -1083,6 +1083,41 @@ describe('CodingJobService distribution from job definitions', () => {
     });
   });
 
+  it('does not deduplicate same-person responses from different booklets', async () => {
+    const responses = [
+      {
+        ...makeSameCaseResponse(1, 'Unit 1', 'Var 1', 1, 'same-value'),
+        bookletName: 'Booklet A'
+      },
+      {
+        ...makeSameCaseResponse(2, 'Unit 1', 'Var 1', 1, 'same-value'),
+        bookletName: 'Booklet A'
+      },
+      {
+        ...makeSameCaseResponse(3, 'Unit 1', 'Var 1', 1, 'same-value'),
+        bookletName: 'Booklet B'
+      }
+    ];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode')
+      .mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+
+    const usageByKey = await service.calculateDistributionVariableUsageByStatusBatch(5, [
+      {
+        key: 'requested',
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        caseOrderingMode: 'continuous',
+        distributionSeed: 'seed-booklet-deduplicated'
+      }
+    ]);
+
+    expect(Object.fromEntries(usageByKey.get('requested')?.entries() || [])).toEqual({
+      'Unit 1::Var 1': { regular: 2, deriveError: 0, total: 2 }
+    });
+  });
+
   it('treats an assigned duplicate as assigned when calculating batched variable usage', async () => {
     const responses = [
       makeSameCaseResponse(1, 'Unit 1', 'Var 1', 1, 'same-value'),

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -1254,6 +1254,55 @@ describe('CodingJobService', () => {
     });
   });
 
+  it('groups existing refresh tasks by the item key expression instead of the select alias', async () => {
+    const queryBuilder = createQueryBuilder([
+      {
+        responseId: '10',
+        itemKey: 'Unit 1::Var 1',
+        coderId: '3',
+        taskCount: '1'
+      }
+    ]);
+    const itemKeyExpression =
+      "CASE WHEN cju.variable_bundle_id IS NOT NULL THEN CONCAT('bundle:', cju.variable_bundle_id) ELSE CONCAT(cju.unit_name, '::', cju.variable_id) END";
+    jest
+      .spyOn(
+        service as unknown as {
+          applyCodingJobUnitExclusions: (...args: unknown[]) => Promise<void>;
+        },
+        'applyCodingJobUnitExclusions'
+      )
+      .mockResolvedValueOnce(undefined);
+    codingJobUnitRepository.createQueryBuilder.mockReturnValueOnce(
+      queryBuilder
+    );
+
+    await expect(
+      (
+        service as unknown as {
+          getJobDefinitionExistingTaskRows: (
+            workspaceId: number,
+            jobDefinitionId: number
+          ) => Promise<unknown[]>;
+        }
+      ).getJobDefinitionExistingTaskRows(3, 9)
+    ).resolves.toEqual([
+      {
+        responseId: 10,
+        itemKey: 'Unit 1::Var 1',
+        coderId: 3,
+        taskCount: 1
+      }
+    ]);
+
+    expect(queryBuilder.addSelect).toHaveBeenCalledWith(
+      itemKeyExpression,
+      'itemKey'
+    );
+    expect(queryBuilder.addGroupBy).toHaveBeenCalledWith(itemKeyExpression);
+    expect(queryBuilder.addGroupBy).not.toHaveBeenCalledWith('itemKey');
+  });
+
   it('rejects DERIVE_ERROR opt-ins in job definition refresh previews when the setting is disabled', async () => {
     const buildDistributionPlanSpy = jest.spyOn(
       service as unknown as { buildDistributionPlan: jest.Mock },

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -2003,13 +2003,12 @@ export class CodingJobService {
     const repository = manager ?
       manager.getRepository(CodingJobUnit) :
       this.codingJobUnitRepository;
+    const itemKeyExpression =
+      "CASE WHEN cju.variable_bundle_id IS NOT NULL THEN CONCAT('bundle:', cju.variable_bundle_id) ELSE CONCAT(cju.unit_name, '::', cju.variable_id) END";
     const query = repository
       .createQueryBuilder('cju')
       .select('cju.response_id', 'responseId')
-      .addSelect(
-        "CASE WHEN cju.variable_bundle_id IS NOT NULL THEN CONCAT('bundle:', cju.variable_bundle_id) ELSE CONCAT(cju.unit_name, '::', cju.variable_id) END",
-        'itemKey'
-      )
+      .addSelect(itemKeyExpression, 'itemKey')
       .addSelect('coding_job_coder.user_id', 'coderId')
       .addSelect('COUNT(cju.id)', 'taskCount')
       .innerJoin('cju.coding_job', 'coding_job')
@@ -2020,7 +2019,7 @@ export class CodingJobService {
       })
       .andWhere('coding_job.training_id IS NULL')
       .groupBy('cju.response_id')
-      .addGroupBy('itemKey')
+      .addGroupBy(itemKeyExpression)
       .addGroupBy('coding_job_coder.user_id');
     this.applyNonCodingIssueReviewJobFilter(
       query,

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -49,7 +49,12 @@ import {
   isExcludedByResolvedExclusions,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
-import { buildAggregationGroups } from './aggregation-metrics.util';
+import {
+  buildAggregationGroups,
+  deduplicateManualCodingResponses,
+  getManualCodingDeduplicationKey,
+  ManualCodingDeduplicationResponse
+} from './aggregation-metrics.util';
 import {
   formatCodingTestPersonFromUnit,
   generateCodingProgressKey,
@@ -5578,11 +5583,7 @@ export class CodingJobService {
     });
 
     return buildAggregationGroups(
-      responses.map(response => ({
-        ...response,
-        responseId: response.id,
-        variableId: response.variableid
-      })),
+      this.withManualCodingDeduplicationFields(responses),
       flags,
       threshold,
       derivedVariableMap
@@ -5593,6 +5594,47 @@ export class CodingJobService {
     }));
   }
 
+  private withManualCodingDeduplicationFields(
+    responses: SlimResponse[]
+  ): Array<SlimResponse & ManualCodingDeduplicationResponse> {
+    return responses.map(response => ({
+      ...response,
+      responseId: response.id,
+      variableId: response.variableid
+    }));
+  }
+
+  private deduplicateSlimResponsesForManualCoding(
+    responses: SlimResponse[],
+    assignedResponseIds: Set<number>
+  ): {
+      responses: SlimResponse[];
+      assignedResponseIds: Set<number>;
+    } {
+    const responsesWithCaseFields =
+      this.withManualCodingDeduplicationFields(responses);
+    const assignedDeduplicationKeys = new Set(
+      responsesWithCaseFields
+        .filter(response => assignedResponseIds.has(response.responseId))
+        .map(response => getManualCodingDeduplicationKey(response))
+    );
+    const dedupedResponses =
+      deduplicateManualCodingResponses(responsesWithCaseFields);
+    const assignedDedupedResponseIds = new Set(
+      dedupedResponses
+        .filter(response => (
+          assignedResponseIds.has(response.responseId) ||
+          assignedDeduplicationKeys.has(getManualCodingDeduplicationKey(response))
+        ))
+        .map(response => response.responseId)
+    );
+
+    return {
+      responses: dedupedResponses,
+      assignedResponseIds: assignedDedupedResponseIds
+    };
+  }
+
   private async filterSlimResponsesForAggregation(
     workspaceId: number,
     responses: SlimResponse[],
@@ -5601,12 +5643,12 @@ export class CodingJobService {
   ): Promise<SlimResponse[]> {
     const derivedVariableMap =
       await this.getDerivedVariableMapForAggregation(workspaceId);
+    const dedupedResponses = this.deduplicateSlimResponsesForManualCoding(
+      responses,
+      new Set()
+    ).responses;
     const groups = buildAggregationGroups(
-      responses.map(response => ({
-        ...response,
-        responseId: response.id,
-        variableId: response.variableid
-      })),
+      this.withManualCodingDeduplicationFields(dedupedResponses),
       matchingFlags,
       aggregationThreshold,
       derivedVariableMap
@@ -5825,6 +5867,13 @@ export class CodingJobService {
     aggregationThreshold: number | null,
     isDerivedResponse: (response: SlimResponse) => boolean
   ): DistributableResponses {
+    const {
+      responses,
+      assignedResponseIds: effectiveAssignedResponseIds
+    } = this.deduplicateSlimResponsesForManualCoding(
+      allItemResponses,
+      assignedResponseIds
+    );
     const filteredResponses: SlimResponse[] = [];
     const caseStatusesByResponseId = new Map<number, DistributionVariableUsageCaseStatus>();
     let uniqueCases = 0;
@@ -5832,7 +5881,7 @@ export class CodingJobService {
 
     if (aggregationThreshold !== null) {
       const aggregatedGroups = this.aggregateResponsesByVariableAndValue(
-        allItemResponses,
+        responses,
         matchingFlags,
         aggregationThreshold,
         isDerivedResponse
@@ -5840,7 +5889,7 @@ export class CodingJobService {
 
       aggregatedGroups.forEach(group => {
         if (group.responses.length >= aggregationThreshold) {
-          const groupAlreadyAssigned = group.responses.some(response => assignedResponseIds.has(response.id)
+          const groupAlreadyAssigned = group.responses.some(response => effectiveAssignedResponseIds.has(response.id)
           );
           if (!groupAlreadyAssigned) {
             group.responses.sort((a, b) => a.id - b.id);
@@ -5857,7 +5906,7 @@ export class CodingJobService {
         }
 
         const unassignedResponses = group.responses.filter(
-          response => !assignedResponseIds.has(response.id)
+          response => !effectiveAssignedResponseIds.has(response.id)
         );
         filteredResponses.push(...unassignedResponses);
         unassignedResponses.forEach(response => {
@@ -5878,8 +5927,8 @@ export class CodingJobService {
       };
     }
 
-    const unassignedResponses = allItemResponses.filter(
-      response => !assignedResponseIds.has(response.id)
+    const unassignedResponses = responses.filter(
+      response => !effectiveAssignedResponseIds.has(response.id)
     );
     unassignedResponses.forEach(response => {
       caseStatusesByResponseId.set(

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -1046,6 +1046,57 @@ describe('CodingValidationService', () => {
       ]);
     });
 
+    it('should not deduplicate same-person responses from different booklets when counting availability', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '3' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([]);
+      const assignedResponsesQb = createQueryBuilderMock([]);
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(assignedResponsesQb);
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        {
+          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group', bookletName: 'Booklet A'
+        },
+        {
+          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group', bookletName: 'Booklet A'
+        },
+        {
+          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group', bookletName: 'Booklet B'
+        }
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(1);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 3,
+          casesInJobs: 0,
+          availableCases: 2,
+          uniqueCasesAfterAggregation: 2
+        })
+      ]);
+    });
+
     it('should expose aggregation-aware case counts when DERIVE_ERROR is included', async () => {
       const codingIncompleteQb = createQueryBuilderMock([
         { unitName: 'unit1', variableId: 'var1', responseCount: '2' }

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -990,6 +990,62 @@ describe('CodingValidationService', () => {
       ]);
     });
 
+    it('should treat assigned duplicate responses as assigned after deduplication and aggregation', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '4' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([]);
+      const assignedResponsesQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseId: '2' }
+      ]);
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(assignedResponsesQb);
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        {
+          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group'
+        },
+        {
+          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group'
+        },
+        {
+          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-2', personCode: 'code-2', personGroup: 'group'
+        },
+        {
+          id: 4, unitName: 'unit1', variableid: 'var1', value: 'other-value', personLogin: 'person-3', personCode: 'code-3', personGroup: 'group'
+        }
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(1);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 4,
+          casesInJobs: 1,
+          availableCases: 1,
+          uniqueCasesAfterAggregation: 2
+        })
+      ]);
+    });
+
     it('should expose aggregation-aware case counts when DERIVE_ERROR is included', async () => {
       const codingIncompleteQb = createQueryBuilderMock([
         { unitName: 'unit1', variableId: 'var1', responseCount: '2' }

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -78,6 +78,7 @@ type SlimCodingResponse = {
   personLogin?: string | null;
   personCode?: string | null;
   personGroup?: string | null;
+  bookletName?: string | null;
 };
 
 type VariableCaseInfo = {

--- a/apps/backend/src/app/database/services/jobs/job-definition-realistic-scenarios.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition-realistic-scenarios.spec.ts
@@ -1,0 +1,276 @@
+import { BadRequestException } from '@nestjs/common';
+import { CodingJobService } from '../coding/coding-job.service';
+import {
+  JobDefinition,
+  JobDefinitionVariable
+} from '../../entities/job-definition.entity';
+import { JobDefinitionService } from './job-definition.service';
+
+type ScenarioResponse = {
+  id: number;
+  variableid: string;
+  value: string | null;
+  statusV1?: number | null;
+  unitName: string;
+  unitAlias: string | null;
+  bookletName: string;
+  personLogin: string;
+  personCode: string;
+  personGroup: string;
+};
+
+type ScenarioJobDefinition = Partial<JobDefinition> &
+Pick<JobDefinition, 'id' | 'workspace_id' | 'status' | 'assigned_variables' | 'assigned_variable_bundles'>;
+
+type AssignedResponseIdsOwner = {
+  getAssignedResponseIdsForVariables: (
+    workspaceId: number,
+    variables: JobDefinitionVariable[],
+    excludeJobDefinitionId?: number
+  ) => Promise<Set<number>>;
+};
+
+const createRepo = () => {
+  const repo = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(value => value),
+    save: jest.fn(value => Promise.resolve(value)),
+    remove: jest.fn(),
+    manager: {
+      transaction: jest.fn(async (callback: (manager: {
+        getRepository: jest.Mock;
+      }) => Promise<unknown>) => callback({
+        getRepository: jest.fn(() => repo)
+      }))
+    },
+    createQueryBuilder: jest.fn()
+  };
+
+  return repo;
+};
+
+const manualCodingResponse = (
+  id: number,
+  variable: JobDefinitionVariable,
+  personCase: number,
+  value: string
+): ScenarioResponse => ({
+  id,
+  variableid: variable.variableId,
+  value,
+  unitName: variable.unitName,
+  unitAlias: variable.unitName,
+  bookletName: `Booklet-${personCase}`,
+  personLogin: `P${personCase.toString().padStart(3, '0')}`,
+  personCode: `C${personCase.toString().padStart(3, '0')}`,
+  personGroup: 'G1'
+});
+
+const availability = (
+  variable: JobDefinitionVariable,
+  availableCases: number
+) => ({
+  unitName: variable.unitName,
+  variableId: variable.variableId,
+  responseCount: availableCases,
+  casesInJobs: 0,
+  availableCases,
+  uniqueCasesAfterAggregation: availableCases
+});
+
+describe('JobDefinitionService realistic manual-coding edit scenarios', () => {
+  let codingJobService: CodingJobService;
+  let service: JobDefinitionService;
+  let jobDefinitionRepository: ReturnType<typeof createRepo>;
+  let codingValidationService: { getCodingIncompleteVariables: jest.Mock };
+  let existingDefinition: ScenarioJobDefinition;
+
+  const mv14828 = { unitName: 'MV14828', variableId: '01' };
+  const mv14855 = { unitName: 'MV14855', variableId: '01' };
+  const mv14868 = { unitName: 'MV14868', variableId: '01' };
+  const mv15484 = { unitName: 'MV15484', variableId: '01' };
+
+  const scenarioResponses: ScenarioResponse[] = [
+    manualCodingResponse(1, mv14828, 1, 'same-value'),
+    manualCodingResponse(2, mv14828, 1, 'same-value'),
+    manualCodingResponse(3, mv14828, 2, 'same-value'),
+    manualCodingResponse(4, mv14828, 3, 'other-value'),
+    manualCodingResponse(5, mv14855, 4, 'value-a'),
+    manualCodingResponse(6, mv14855, 4, 'value-a'),
+    manualCodingResponse(7, mv14855, 5, 'value-b'),
+    manualCodingResponse(8, mv14868, 6, 'removed-variable-value'),
+    manualCodingResponse(9, mv15484, 7, 'added-variable-value')
+  ];
+
+  const createExistingDefinition = (): ScenarioJobDefinition => ({
+    id: 74,
+    workspace_id: 12,
+    status: 'pending_review',
+    assigned_variables: [mv14828, mv14855, mv14868],
+    assigned_variable_bundles: [],
+    assigned_coders: [4, 7, 8],
+    max_coding_cases: null,
+    case_ordering_mode: 'continuous',
+    distribution_seed: 'job-definition:12:realistic-edit'
+  });
+
+  const changedVariables = [mv14828, mv14855, mv15484];
+
+  beforeEach(() => {
+    const codingJobRepository = createRepo();
+    const codingJobCoderRepository = createRepo();
+    const codingJobVariableRepository = createRepo();
+    const codingJobVariableBundleRepository = createRepo();
+    const codingJobUnitRepository = createRepo();
+    const variableBundleRepository = createRepo();
+    const responseRepository = createRepo();
+    const fileUploadRepository = createRepo();
+    const settingRepository = createRepo();
+    const connection = { transaction: jest.fn() };
+    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const workspaceFilesService = {
+      getDerivedVariableMap: jest.fn().mockResolvedValue(new Map())
+    };
+    const workspaceExclusionService = {
+      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+        globalIgnoredUnits: [],
+        ignoredBooklets: [],
+        testletIgnoredUnits: []
+      })
+    };
+    const usersService = {
+      getUserIsAdmin: jest.fn().mockResolvedValue(false),
+      getUserAccessLevel: jest.fn().mockResolvedValue(1),
+      assertUsersCanCodeInWorkspace: jest.fn().mockResolvedValue(undefined)
+    };
+
+    existingDefinition = createExistingDefinition();
+
+    codingJobService = new CodingJobService(
+      codingJobRepository as never,
+      codingJobCoderRepository as never,
+      codingJobVariableRepository as never,
+      codingJobVariableBundleRepository as never,
+      codingJobUnitRepository as never,
+      variableBundleRepository as never,
+      responseRepository as never,
+      fileUploadRepository as never,
+      settingRepository as never,
+      connection as never,
+      cacheService as never,
+      workspaceFilesService as never,
+      workspaceExclusionService as never,
+      usersService as never
+    );
+
+    jest.spyOn(codingJobService, 'getSlimResponsesForVariables').mockImplementation(
+      async (_workspaceId, variables) => scenarioResponses.filter(response => variables.some(
+        variable => variable.unitName === response.unitName &&
+          variable.variableId === response.variableid
+      )) as never
+    );
+    jest.spyOn(codingJobService, 'getResponseMatchingMode').mockResolvedValue([]);
+    jest.spyOn(codingJobService, 'getAggregationThreshold').mockResolvedValue(2);
+    jest.spyOn(
+      codingJobService as unknown as AssignedResponseIdsOwner,
+      'getAssignedResponseIdsForVariables'
+    ).mockResolvedValue(new Set());
+    jest.spyOn(codingJobService, 'getCodingJobCountsByDefinitionIds')
+      .mockResolvedValue(new Map());
+    jest.spyOn(codingJobService, 'assertDeriveErrorManualCodingEnabled')
+      .mockResolvedValue(undefined);
+    jest.spyOn(codingJobService, 'assertCodersCanCodeInWorkspace')
+      .mockResolvedValue(undefined);
+    jest.spyOn(codingJobService, 'calculateDistributionVariableUsageByStatusBatch');
+
+    jobDefinitionRepository = createRepo();
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+
+    const variableBundleRepositoryForDefinitions = createRepo();
+    variableBundleRepositoryForDefinitions.find.mockResolvedValue([]);
+    const usersRepository = createRepo();
+    codingValidationService = {
+      getCodingIncompleteVariables: jest.fn().mockResolvedValue([
+        availability(mv14828, 2),
+        availability(mv14855, 2),
+        availability(mv15484, 1)
+      ])
+    };
+    const missingsProfilesService = {
+      resolveMissingsProfileId: jest.fn(async (_workspaceId, profileId?: number | null) => profileId || 55)
+    };
+
+    service = new JobDefinitionService(
+      jobDefinitionRepository as never,
+      variableBundleRepositoryForDefinitions as never,
+      usersRepository as never,
+      codingJobService as never,
+      codingValidationService as never,
+      missingsProfilesService as never
+    );
+  });
+
+  it('updates a definition after variable changes when duplicate raw responses still leave enough effective cases', async () => {
+    await expect(service.updateJobDefinition(74, 12, {
+      assignedVariables: changedVariables,
+      assignedVariableBundles: [],
+      maxCodingCases: null,
+      caseOrderingMode: 'continuous'
+    })).resolves.toMatchObject({
+      id: 74,
+      assigned_variables: changedVariables
+    });
+
+    expect(codingValidationService.getCodingIncompleteVariables).toHaveBeenCalledWith(
+      12,
+      undefined,
+      undefined,
+      false,
+      74
+    );
+    expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).toHaveBeenCalledWith(12, [
+      expect.objectContaining({
+        key: 'requested',
+        excludeJobDefinitionId: 74,
+        selectedVariables: changedVariables
+      })
+    ]);
+    expect(jobDefinitionRepository.save).toHaveBeenCalled();
+  });
+
+  it('still rejects the same realistic edit when another unstarted definition reserves the effective cases', async () => {
+    const competingDefinition: ScenarioJobDefinition = {
+      id: 75,
+      workspace_id: 12,
+      status: 'approved',
+      assigned_variables: [mv14828, mv14855],
+      assigned_variable_bundles: [],
+      assigned_coders: [9],
+      max_coding_cases: null,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'job-definition:12:competing'
+    };
+    jobDefinitionRepository.find.mockResolvedValue([
+      existingDefinition,
+      competingDefinition
+    ]);
+
+    let thrownError: unknown;
+    try {
+      await service.updateJobDefinition(74, 12, {
+        assignedVariables: changedVariables,
+        assignedVariableBundles: [],
+        maxCodingCases: null,
+        caseOrderingMode: 'continuous'
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(BadRequestException);
+    expect((thrownError as BadRequestException).message).toContain('MV14828:01');
+    expect(jobDefinitionRepository.save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -821,6 +821,113 @@ describe('JobDefinitionService', () => {
     });
   });
 
+  it('allows updating a pending definition when its own retained cases are excluded from reservations', async () => {
+    const retainedVariable = { unitName: 'Unit 1', variableId: 'Var 1' };
+    const addedVariable = { unitName: 'Unit 2', variableId: 'Var 2' };
+    const existingDefinition = {
+      id: 74,
+      workspace_id: 7,
+      status: 'pending_review',
+      assigned_variables: [retainedVariable],
+      assigned_variable_bundles: [],
+      assigned_coders: [1, 2],
+      duration_seconds: 1,
+      max_coding_cases: null,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'definition-74-seed'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValue([
+      { unitName: 'Unit 1', variableId: 'Var 1', availableCases: 2 },
+      { unitName: 'Unit 2', variableId: 'Var 2', availableCases: 1 }
+    ]);
+
+    await expect(service.updateJobDefinition(74, 7, {
+      assignedVariables: [retainedVariable, addedVariable],
+      assignedVariableBundles: [],
+      maxCodingCases: null,
+      caseOrderingMode: 'continuous'
+    })).resolves.toMatchObject({
+      id: 74,
+      assigned_variables: [retainedVariable, addedVariable]
+    });
+
+    expect(codingValidationService.getCodingIncompleteVariables).toHaveBeenCalledWith(
+      7,
+      undefined,
+      undefined,
+      false,
+      74
+    );
+    expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).toHaveBeenCalledWith(7, [
+      expect.objectContaining({
+        key: 'requested',
+        excludeJobDefinitionId: 74,
+        selectedVariables: [retainedVariable, addedVariable]
+      })
+    ]);
+    expect(jobDefinitionRepository.save).toHaveBeenCalled();
+  });
+
+  it('rejects updating a pending definition when another unstarted definition reserves the remaining cases', async () => {
+    const selectedVariable = { unitName: 'Unit 1', variableId: 'Var 1' };
+    const existingDefinition = {
+      id: 74,
+      workspace_id: 7,
+      status: 'pending_review',
+      assigned_variables: [selectedVariable],
+      assigned_variable_bundles: [],
+      assigned_coders: [1, 2],
+      duration_seconds: 1,
+      max_coding_cases: 1,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'definition-74-seed'
+    };
+    const otherDefinition = {
+      id: 75,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [selectedVariable],
+      assigned_variable_bundles: [],
+      assigned_coders: [3],
+      duration_seconds: 1,
+      max_coding_cases: 2,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'definition-75-seed'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition, otherDefinition]);
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValue([
+      { unitName: 'Unit 1', variableId: 'Var 1', availableCases: 3 }
+    ]);
+
+    await expect(service.updateJobDefinition(74, 7, {
+      assignedVariables: [selectedVariable],
+      assignedVariableBundles: [],
+      maxCodingCases: 2,
+      caseOrderingMode: 'continuous'
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).toHaveBeenCalledWith(7, [
+      expect.objectContaining({
+        key: 'requested',
+        excludeJobDefinitionId: 74,
+        selectedVariables: [selectedVariable],
+        maxCodingCases: 2
+      }),
+      expect.objectContaining({
+        key: 75,
+        jobDefinitionId: 75,
+        selectedVariables: [selectedVariable],
+        maxCodingCases: 2
+      })
+    ]);
+    expect(jobDefinitionRepository.save).not.toHaveBeenCalled();
+  });
+
   it('does not reserve planned cases again for definitions that already have created jobs', async () => {
     codingValidationService.getCodingIncompleteVariables.mockResolvedValue([
       { unitName: 'Unit 1', variableId: 'Var 1', availableCases: 5 }


### PR DESCRIPTION
## Summary
- Deduplicate manual coding responses before planning distribution usage.
- Keep assigned duplicate responses reserved after deduplication.
- Expand regression coverage across distribution planning, availability counting, job-definition updates, and a realistic variable-change edit scenario.

## Context
Refs #681.

The job-definition availability check compares planned distribution usage with available manual coding cases. Duplicate manual responses could make planned usage count raw responses while availability counted deduplicated cases, causing valid job-definition edits to fail.

The added tests now cover realistic follow-up scenarios from the testserver data: assigned duplicate responses, aggregation thresholds, retained cases during definition edits, another unstarted definition reserving the remaining capacity, and editing an existing definition by removing one variable and adding another while duplicate raw responses collapse to fewer effective cases.

## Validation
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts --runInBand
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts --runInBand
- npx nx test backend --testFile=apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts --runInBand
- npx nx test backend --testFile=apps/backend/src/app/database/services/jobs/job-definition-realistic-scenarios.spec.ts --runInBand
- npx nx lint backend
- npx nx test backend --runInBand
- npx nx build backend