### PR TITLE
Fix manual coding analysis freshness scope

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -491,20 +491,39 @@
 
             <div
               class="analysis-stale-note"
-              *ngIf="isResponseAnalysisOutdated()"
+              *ngIf="
+                isResponseAnalysisOutdated() ||
+                hasResponseAnalysisRestScopeDifference()
+              "
             >
               <ng-container
                 *ngIf="responseAnalysis?.aggregationSummary as aggregation"
               >
                 <mat-icon>warning</mat-icon>
-                <span>
-                  Diese Antwort-Analyse basiert auf
-                  {{ aggregation.rawCases }} Rohantworten. Der aktuelle manuelle
-                  Bestand umfasst
-                  {{ getCurrentRawManualResponses() }} Rohantworten. Bitte neu
-                  berechnen; deshalb kann die hier gezeigte Einsparung von den
-                  Fortschrittswerten abweichen.
+                <span *ngIf="isResponseAnalysisOutdated(); else restScopeDifference">
+                  {{
+                    'coding-management-manual.response-analysis.outdated-note'
+                      | translate
+                        : {
+                            analysisRawCases: aggregation.rawCases,
+                            referenceRawCases:
+                              getResponseAnalysisReferenceRawCases()
+                          }
+                  }}
                 </span>
+                <ng-template #restScopeDifference>
+                  <span>
+                    {{
+                      'coding-management-manual.response-analysis.rest-scope-note'
+                        | translate
+                          : {
+                              analysisRawCases: aggregation.rawCases,
+                              currentRawManualResponses:
+                                getCurrentRawManualResponses()
+                            }
+                    }}
+                  </span>
+                </ng-template>
               </ng-container>
             </div>
           </div>

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -130,6 +130,12 @@ describe('CodingManagementManualComponent', () => {
         'completed-jobs': {
           'readonly-note': 'Nur lesbar'
         },
+        'response-analysis': {
+          'outdated-note':
+            'Diese Antwort-Analyse basiert auf {{analysisRawCases}} Rohantworten. Der aktuelle manuelle Vorbereitungsbestand umfasst {{referenceRawCases}} Rohantworten. Bitte neu berechnen; deshalb kann die hier gezeigte Einsparung von den Fortschrittswerten abweichen.',
+          'rest-scope-note':
+            'Diese Antwort-Analyse basiert auf {{analysisRawCases}} vorbereiteten Rohantworten. Der aktuelle Restbestand umfasst {{currentRawManualResponses}} Rohantworten, weil bereits Ergebnisse angewendet wurden oder Fälle nicht mehr separat gezählt werden.'
+        },
         errors: {
           'replay-auth-token-failed':
             'Replay-Links konnten nicht vorbereitet werden, weil kein Auth-Token erstellt werden konnte. Exportjob wurde nicht gestartet.'
@@ -512,7 +518,7 @@ describe('CodingManagementManualComponent', () => {
     expect(component.isPreparationReady()).toBe(true);
   });
 
-  it('should flag response analysis as outdated when raw manual counts changed', () => {
+  it('should flag response analysis as outdated when the status pool count changed', () => {
     component.responseAnalysis = {
       emptyResponses: { total: 0, totalUncoded: 0, items: [] },
       duplicateValues: {
@@ -535,9 +541,55 @@ describe('CodingManagementManualComponent', () => {
     };
     setAppliedResults(897, 8, 889);
     component.appliedResultsOverview!.rawTotalIncompleteResponses = 973;
+    setCodingProgress(973, 8);
+    component.codingProgressOverview!.statusTotalCasesToCode = 973;
 
     expect(component.getCurrentRawManualResponses()).toBe(973);
+    expect(component.getResponseAnalysisReferenceRawCases()).toBe(973);
     expect(component.isResponseAnalysisOutdated()).toBe(true);
+  });
+
+  it('should not require preparation refresh when only the applied result rest scope is smaller', () => {
+    component.responseAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 840,
+        totalResponses: 5840,
+        groups: [],
+        isAggregationApplied: true
+      },
+      aggregationSummary: {
+        duplicateGroups: 840,
+        duplicateResponses: 5840,
+        collapsedCases: 5000,
+        rawCases: 21606,
+        effectiveCases: 16606,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: new Date().toISOString()
+    };
+    setCodingProgress(16606, 12000);
+    component.codingProgressOverview!.rawTotalCasesToCode = 17705;
+    component.codingProgressOverview!.statusTotalCasesToCode = 21606;
+    setAppliedResults(17705, 3901, 13804);
+
+    expect(component.getCurrentRawManualResponses()).toBe(17705);
+    expect(component.getResponseAnalysisReferenceRawCases()).toBe(21606);
+    expect(component.isResponseAnalysisOutdated()).toBe(false);
+    expect(component.hasResponseAnalysisRestScopeDifference()).toBe(true);
+    expect(component.hasPreparationWarnings()).toBe(false);
+    expect(component.isPreparationReady()).toBe(true);
+
+    fixture.detectChanges();
+    const pageText = fixture.nativeElement.textContent as string;
+    expect(pageText).toContain(
+      'Der aktuelle Restbestand umfasst 17705 Rohantworten'
+    );
+    expect(pageText).not.toContain(
+      'Der aktuelle manuelle Vorbereitungsbestand umfasst'
+    );
   });
 
   it('should describe completed coding jobs as ready to apply', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -1514,6 +1514,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       0;
   }
 
+  getResponseAnalysisReferenceRawCases(): number {
+    return this.getManualStatusPoolCount();
+  }
+
   getManualStatusPoolCount(): number {
     return this.codingProgressOverview?.statusTotalCasesToCode ??
       this.caseCoverageOverview?.statusTotalCasesToCode ??
@@ -1557,9 +1561,19 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   isResponseAnalysisOutdated(): boolean {
     const analysisRawCases = this.responseAnalysis?.aggregationSummary?.rawCases ?? 0;
+    const referenceRawCases = this.getResponseAnalysisReferenceRawCases();
+    return !!this.responseAnalysis &&
+      !this.responseAnalysis.isCalculating &&
+      referenceRawCases > 0 &&
+      analysisRawCases !== referenceRawCases;
+  }
+
+  hasResponseAnalysisRestScopeDifference(): boolean {
+    const analysisRawCases = this.responseAnalysis?.aggregationSummary?.rawCases ?? 0;
     const currentRawManualResponses = this.getCurrentRawManualResponses();
     return !!this.responseAnalysis &&
       !this.responseAnalysis.isCalculating &&
+      !this.isResponseAnalysisOutdated() &&
       currentRawManualResponses > 0 &&
       analysisRawCases !== currentRawManualResponses;
   }

--- a/apps/frontend/src/app/ws-admin/components/test-files/test-files-upload-result-dialog.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-files/test-files-upload-result-dialog.component.spec.ts
@@ -146,7 +146,11 @@ describe('TestFilesUploadResultDialogComponent', () => {
   it('allows checking coding status after successful coding scheme uploads without freshness warnings', async () => {
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
-      imports: [TestFilesUploadResultDialogComponent, NoopAnimationsModule],
+      imports: [
+        TestFilesUploadResultDialogComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot()
+      ],
       providers: [
         { provide: MatDialogRef, useValue: dialogRef },
         { provide: Router, useValue: router },

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1943,6 +1943,8 @@
       "more": "weitere",
       "last-updated": "Letzte Aktualisierung",
       "no-data": "Keine Analysedaten verfügbar. Bitte laden Sie die Analyse neu.",
+      "outdated-note": "Diese Antwort-Analyse basiert auf {{analysisRawCases}} Rohantworten. Der aktuelle manuelle Vorbereitungsbestand umfasst {{referenceRawCases}} Rohantworten. Bitte neu berechnen; deshalb kann die hier gezeigte Einsparung von den Fortschrittswerten abweichen.",
+      "rest-scope-note": "Diese Antwort-Analyse basiert auf {{analysisRawCases}} vorbereiteten Rohantworten. Der aktuelle Restbestand umfasst {{currentRawManualResponses}} Rohantworten, weil bereits Ergebnisse angewendet wurden oder Fälle nicht mehr separat gezählt werden.",
       "showing-first-50": "Zeige die ersten 50 von {{total}} Einträgen",
       "showing-first-20-groups": "Zeige die ersten 20 von {{total}} Gruppen",
       "table": {


### PR DESCRIPTION
## Summary

Relates to #794.

This adjusts the manual-coding preparation freshness check so the response analysis raw count is compared against the manual status/analysis pool instead of the reduced current rest/manual work pool. When the analysis is still valid but the current rest scope is smaller because results were already applied or cases are no longer counted separately, the UI now shows an explanatory rest-scope note instead of asking users to update preparation.

## Root Cause

The previous frontend freshness comparison used the current raw manual rest/work count as the reference. In workspaces where the response analysis/status pool is larger than the remaining manual work pool, this made a valid response analysis look stale and kept the "Vorbereitung aktualisieren" banner visible.

## Changes

- Compare response-analysis freshness against `statusTotalCasesToCode` / status-pool fallbacks.
- Keep a separate rest-scope difference note when the analysis is valid but the current raw rest count differs.
- Move the affected German UI strings into i18n.
- Add a regression test that models the real status-pool vs. reduced-rest-pool distinction.
- Add the missing translate module setup for the affected upload-result dialog spec.

## Validation

- `npx nx test frontend`
- `npx nx lint frontend`
- `git diff --check`
- Manual Playwright campaign against the running app: 12 scenarios, 0 findings, 0 console errors after test-harness correction.

Issue is intentionally not closed by this PR description.
