### PR TITLE
Pass coder assignments to discussion replay

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -292,6 +292,58 @@ describe('CodingResultsComparisonComponent', () => {
     );
   });
 
+  it('should pass coder code assignments to the discussion replay', () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    codingStatisticsService.getReplayUrl.mockReturnValue(of({
+      replayUrl: 'https://app.test/#/replay/login%40code%40booklet/UNIT_1/2/VAR_1?workspaceId=1'
+    }));
+
+    component.openReplay({
+      responseId: 77,
+      unitName: 'UNIT_1',
+      variableId: 'VAR_1',
+      testperson: 'login@code@booklet',
+      coders: [
+        {
+          jobId: 1,
+          coderName: 'Coder A',
+          code: '2',
+          score: 1,
+          codingIssueOption: null
+        },
+        {
+          jobId: 2,
+          coderName: 'Coder B',
+          code: '2',
+          score: 1,
+          codingIssueOption: -1
+        },
+        {
+          jobId: 3,
+          coderName: 'Coder C',
+          code: null,
+          score: null,
+          codingIssueOption: -3
+        },
+        {
+          jobId: 4,
+          coderName: 'Coder D',
+          code: '2',
+          score: null,
+          codingIssueOption: -3
+        }
+      ]
+    } as never);
+
+    const openedUrl = openSpy.mock.calls[0][0] as string;
+    const reviewCodeSelections = new URLSearchParams(openedUrl.split('?')[1]).get('reviewCodeSelections');
+    expect(JSON.parse(reviewCodeSelections || '[]')).toEqual([
+      { code: -3, coderNames: ['Coder C', 'Coder D'] },
+      { code: -1, coderNames: ['Coder B'] },
+      { code: 2, coderNames: ['Coder A', 'Coder B'] }
+    ]);
+  });
+
   it('should pass selected training display options to the discussion replay', () => {
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
     codingStatisticsService.getReplayUrl.mockReturnValue(of({

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -37,6 +37,7 @@ import { CoderTraining } from '../../models/coder-training.model';
 import { CodingStatisticsService } from '../../services/coding-statistics.service';
 import { AppService } from '../../../core/services/app.service';
 import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
+import type { ReviewCodeSelection } from '../../../replay/services/units-replay.service';
 import {
   hasInvalidRegexFilter,
   matchesTextFilter
@@ -137,6 +138,7 @@ interface ReplayDisplayOptions {
   showScore?: boolean;
   allowComments?: boolean;
   suppressGeneralInstructions?: boolean;
+  reviewCodeSelections?: string;
 }
 
 interface ComparisonFilters {
@@ -320,6 +322,8 @@ export class CodingResultsComparisonComponent implements OnInit {
     [-3]: 'Spaßantwort',
     [-4]: 'Technisch'
   };
+
+  private readonly standaloneCodingIssueOptionIds = new Set([-3, -4]);
 
   tableFilters: ComparisonFilters = {
     unitName: '',
@@ -1302,7 +1306,7 @@ export class CodingResultsComparisonComponent implements OnInit {
           window.open(this.buildReplayUrl(
             result.replayUrl,
             responseId,
-            this.getReplayDisplayOptions()
+            this.getReplayDisplayOptions(comparison)
           ), '_blank');
         } else {
           this.snackBar.open('Replay-URL konnte nicht erzeugt werden.', this.translate.instant('common.close'), { duration: 3000 });
@@ -1314,21 +1318,77 @@ export class CodingResultsComparisonComponent implements OnInit {
     });
   }
 
-  private getReplayDisplayOptions(): ReplayDisplayOptions {
+  private getReplayDisplayOptions(comparison?: TrainingComparison | WithinTrainingComparison): ReplayDisplayOptions {
+    const reviewCodeSelections = comparison ? this.serializeReviewCodeSelections(comparison) : undefined;
     if (this.comparisonMode !== 'within-training') {
-      return {};
+      return { reviewCodeSelections };
     }
 
     const selectedTraining = this.getSelectedWithinTraining();
     if (!selectedTraining) {
-      return {};
+      return { reviewCodeSelections };
     }
 
     return {
       showScore: selectedTraining.show_score ?? false,
       allowComments: selectedTraining.allow_comments ?? true,
-      suppressGeneralInstructions: selectedTraining.suppress_general_instructions ?? false
+      suppressGeneralInstructions: selectedTraining.suppress_general_instructions ?? false,
+      reviewCodeSelections
     };
+  }
+
+  private serializeReviewCodeSelections(comparison: TrainingComparison | WithinTrainingComparison): string | undefined {
+    const selections = this.getReviewCodeSelections(comparison);
+    return selections.length > 0 ? JSON.stringify(selections) : undefined;
+  }
+
+  private getReviewCodeSelections(comparison: TrainingComparison | WithinTrainingComparison): ReviewCodeSelection[] {
+    const coderNamesByCode = new Map<number, string[]>();
+
+    comparison.coders.forEach(coder => {
+      const coderName = this.getCoderSourceLabel(coder);
+      this.getReviewSelectionCodes(coder).forEach(code => {
+        const coderNames = coderNamesByCode.get(code) || [];
+        if (!coderNames.includes(coderName)) {
+          coderNames.push(coderName);
+        }
+        coderNamesByCode.set(code, coderNames);
+      });
+    });
+
+    return Array.from(coderNamesByCode.entries())
+      .sort(([codeA], [codeB]) => codeA - codeB)
+      .map(([code, coderNames]) => ({ code, coderNames }));
+  }
+
+  private getReviewSelectionCodes(coder: ComparisonCoderResult): number[] {
+    if (
+      coder.codingIssueOption !== null &&
+      coder.codingIssueOption !== undefined &&
+      this.standaloneCodingIssueOptionIds.has(coder.codingIssueOption)
+    ) {
+      return [coder.codingIssueOption];
+    }
+
+    const codes = new Set<number>();
+    const code = this.parseReviewCode(coder.code);
+    if (code !== null) {
+      codes.add(code);
+    }
+    if (coder.codingIssueOption !== null && coder.codingIssueOption !== undefined) {
+      codes.add(coder.codingIssueOption);
+    }
+    return Array.from(codes);
+  }
+
+  private parseReviewCode(code: string | null): number | null {
+    const trimmedCode = code?.trim();
+    if (!trimmedCode) {
+      return null;
+    }
+
+    const parsedCode = Number(trimmedCode);
+    return Number.isFinite(parsedCode) ? parsedCode : null;
   }
 
   private buildReplayUrl(
@@ -1350,6 +1410,9 @@ export class CodingResultsComparisonComponent implements OnInit {
       }
       if (displayOptions.suppressGeneralInstructions !== undefined) {
         params.set('suppressGeneralInstructions', String(displayOptions.suppressGeneralInstructions));
+      }
+      if (displayOptions.reviewCodeSelections) {
+        params.set('reviewCodeSelections', displayOptions.reviewCodeSelections);
       }
       const serializedParams = params.toString();
       return serializedParams ? `${path}?${serializedParams}` : path;


### PR DESCRIPTION
## Summary
- add coder assignment metadata to discussion replay links via `reviewCodeSelections`
- mirror the double-coded review handling for regular codes and standalone issue options
- cover the URL serialization with a focused frontend spec

## Context
Related to #814. This intentionally does not close the issue yet.

## Validation
- `npx nx test frontend --runInBand=true --testPathPatterns=coding-results-comparison.component.spec.ts`
- `npx nx lint frontend`
- Manual UI check in the app with the existing Keycloak session: discussion replay rendered badges for `coder1` and `coder2` with matching tooltips.