### PR TITLE
Improve manual coding performance

### DIFF
--- a/api-dto/coding/autocoding-readiness.dto.ts
+++ b/api-dto/coding/autocoding-readiness.dto.ts
@@ -1,4 +1,10 @@
-export type AutocodingReadinessStatus = 'READY' | 'BLOCKED' | 'NO_RESULTS';
+export type AutocodingReadinessStatus =
+  | 'READY'
+  | 'BLOCKED'
+  | 'NO_RESULTS'
+  | 'DIAGNOSTICS_PENDING';
+
+export type AutocodingReadinessDetailLevel = 'summary' | 'full';
 
 export type AutocodingReadinessBlocker =
   | 'NO_RELEVANT_RESPONSES'
@@ -18,6 +24,8 @@ export interface AutocodingInvalidVariableSampleDto {
 export interface AutocodingReadinessDto {
   workspaceId: number;
   autoCoderRun: 1 | 2;
+  detailLevel?: AutocodingReadinessDetailLevel;
+  detailsComplete?: boolean;
   readiness: AutocodingReadinessStatus;
   blockers: AutocodingReadinessBlocker[];
   rawResponsesTotal: number;
@@ -31,6 +39,7 @@ export interface AutocodingReadinessDto {
   invalidCodingSchemes: string[];
   validVariablePairs: number;
   validResponses: number;
+  potentialCodeableResponses?: number;
   codeableResponses: number;
   invalidVariableSamples: AutocodingInvalidVariableSampleDto[];
   computedAt?: string;

--- a/api-dto/coding/response-analysis.dto.ts
+++ b/api-dto/coding/response-analysis.dto.ts
@@ -23,6 +23,7 @@ export interface DuplicateValueGroupDto {
   variableId: string;
   normalizedValue: string;
   originalValue: string;
+  occurrenceCount?: number;
   occurrences: {
     personLogin: string;
     personCode: string;
@@ -65,6 +66,8 @@ export interface ResponseAnalysisDto {
   aggregationSummary: AggregationSummaryDto;
   matchingFlags: string[];
   analysisTimestamp: string;
+  sourceRevision?: number;
+  currentSourceRevision?: number;
   isCalculating?: boolean;
   progress?: number;
 }

--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
@@ -21,7 +21,11 @@ import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
 import { WorkspaceId } from './workspace.decorator';
 import { AccessLevelGuard, RequireAccessLevel } from './access-level.guard';
-import { CodingValidationService, CodingAnalysisService, MissingsProfilesService } from '../../database/services/coding';
+import {
+  CodingValidationService,
+  CodingAnalysisService,
+  MissingsProfilesService
+} from '../../database/services/coding';
 import { VariableAnalysisReplayService } from '../../database/services/test-results';
 import { ExportValidationResultsService } from '../../database/services/validation';
 import { VariableAnalysisItemDto } from '../../../../../../api-dto/coding/variable-analysis-item.dto';
@@ -44,7 +48,7 @@ export class WorkspaceCodingAnalysisController {
     private missingsProfilesService: MissingsProfilesService,
     @InjectRepository(Setting)
     private readonly settingRepository: Repository<Setting>
-  ) { }
+  ) {}
 
   @Get(':workspace_id/coding/variable-analysis')
   @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
@@ -96,7 +100,8 @@ export class WorkspaceCodingAnalysisController {
   @ApiQuery({
     name: 'regexSearch',
     required: false,
-    description: 'Interpret variable ID filter as a case-sensitive regular expression',
+    description:
+      'Interpret variable ID filter as a case-sensitive regular expression',
     type: Boolean
   })
   async getVariableAnalysis(
@@ -117,8 +122,12 @@ export class WorkspaceCodingAnalysisController {
       }> {
     const validPage = Math.max(1, page);
     const validLimit = Math.min(Math.max(1, limit), 500); // Set maximum limit to 500
-    const effectiveRegexSearch = regexSearch === 'true' &&
-      await getWorkspaceRegexSearchEnabled(this.settingRepository, workspace_id);
+    const effectiveRegexSearch =
+      regexSearch === 'true' &&
+      (await getWorkspaceRegexSearchEnabled(
+        this.settingRepository,
+        workspace_id
+      ));
 
     return this.variableAnalysisReplayService.getVariableAnalysis(
       workspace_id,
@@ -224,13 +233,15 @@ export class WorkspaceCodingAnalysisController {
   @ApiQuery({
     name: 'includeDeriveErrorOnly',
     required: false,
-    description: 'Also include variables that only have DERIVE_ERROR responses and expose DERIVE_ERROR-aware case counts',
+    description:
+      'Also include variables that only have DERIVE_ERROR responses and expose DERIVE_ERROR-aware case counts',
     type: Boolean
   })
   @ApiQuery({
     name: 'excludeJobDefinitionId',
     required: false,
-    description: 'Ignore coding jobs from this job definition when calculating remaining cases',
+    description:
+      'Ignore coding jobs from this job definition when calculating remaining cases',
     type: Number
   })
   @ApiOkResponse({
@@ -261,19 +272,23 @@ export class WorkspaceCodingAnalysisController {
           },
           uniqueCasesAfterAggregation: {
             type: 'number',
-            description: 'Number of unique coding cases after applying aggregation grouping (1 per duplicate group)'
+            description:
+              'Number of unique coding cases after applying aggregation grouping (1 per duplicate group)'
           },
           availableCasesWithDeriveError: {
             type: 'number',
-            description: 'Number of available cases when DERIVE_ERROR is included'
+            description:
+              'Number of available cases when DERIVE_ERROR is included'
           },
           uniqueCasesAfterAggregationWithDeriveError: {
             type: 'number',
-            description: 'Number of unique coding cases after aggregation when DERIVE_ERROR is included'
+            description:
+              'Number of unique coding cases after aggregation when DERIVE_ERROR is included'
           },
           isDerived: {
             type: 'boolean',
-            description: 'Whether this is a derived variable (computed from other variables)'
+            description:
+              'Whether this is a derived variable (computed from other variables)'
           }
         }
       }
@@ -368,7 +383,9 @@ export class WorkspaceCodingAnalysisController {
     @WorkspaceId() workspace_id: number,
       @Query('unitName') unitName?: string,
       @Query('trainingRequired') trainingRequired?: string
-  ): Promise<Awaited<ReturnType<CodingValidationService['getManualCodingScopeSummary']>>> {
+  ): Promise<
+      Awaited<ReturnType<CodingValidationService['getManualCodingScopeSummary']>>
+      > {
     let trainingRequiredParam: boolean | undefined;
     if (trainingRequired === 'true') {
       trainingRequiredParam = true;
@@ -453,8 +470,7 @@ export class WorkspaceCodingAnalysisController {
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiBody({
-    description:
-      'List of manual coding variables to check for applied results',
+    description: 'List of manual coding variables to check for applied results',
     schema: {
       type: 'object',
       properties: {
@@ -601,7 +617,8 @@ export class WorkspaceCodingAnalysisController {
             },
             duplicateResponses: {
               type: 'number',
-              description: 'Number of responses in aggregatable duplicate groups'
+              description:
+                'Number of responses in aggregatable duplicate groups'
             },
             collapsedCases: {
               type: 'number',
@@ -635,9 +652,21 @@ export class WorkspaceCodingAnalysisController {
           type: 'string',
           description: 'ISO timestamp of when the analysis was performed'
         },
+        sourceRevision: {
+          type: 'number',
+          nullable: true,
+          description:
+            'Test result revision the cached analysis was calculated from'
+        },
+        currentSourceRevision: {
+          type: 'number',
+          nullable: true,
+          description: 'Current test result revision for the workspace'
+        },
         isCalculating: {
           type: 'boolean',
-          description: 'Whether the analysis is currently being calculated in the background'
+          description:
+            'Whether the analysis is currently being calculated in the background'
         }
       }
     }
@@ -652,9 +681,14 @@ export class WorkspaceCodingAnalysisController {
   ) {
     const validThreshold = this.normalizeIntegerParam(threshold, 2, 2, 100);
     const vEmptyPage = this.normalizeIntegerParam(emptyPage, 1, 1);
-    const vEmptyLimit = this.normalizeIntegerParam(emptyLimit, 50, 1);
+    const vEmptyLimit = this.normalizeIntegerParam(emptyLimit, 50, 1, 500);
     const vDuplicatePage = this.normalizeIntegerParam(duplicatePage, 1, 1);
-    const vDuplicateLimit = this.normalizeIntegerParam(duplicateLimit, 50, 1);
+    const vDuplicateLimit = this.normalizeIntegerParam(
+      duplicateLimit,
+      50,
+      1,
+      500
+    );
 
     return this.codingAnalysisService.getResponseAnalysis(
       workspace_id,
@@ -674,9 +708,7 @@ export class WorkspaceCodingAnalysisController {
   @ApiOkResponse({
     description: 'Current response aggregation settings.'
   })
-  async getAggregationSettings(
-  @WorkspaceId() workspace_id: number
-  ) {
+  async getAggregationSettings(@WorkspaceId() workspace_id: number) {
     return this.codingAnalysisService.getAggregationSettings(workspace_id);
   }
 
@@ -692,7 +724,8 @@ export class WorkspaceCodingAnalysisController {
       properties: {
         threshold: {
           type: 'number',
-          description: 'Minimum number of duplicate occurrences to trigger aggregation',
+          description:
+            'Minimum number of duplicate occurrences to trigger aggregation',
           example: 2,
           minimum: 2,
           maximum: 100
@@ -735,7 +768,8 @@ export class WorkspaceCodingAnalysisController {
       properties: {
         threshold: {
           type: 'number',
-          description: 'Minimum number of duplicate occurrences to trigger aggregation',
+          description:
+            'Minimum number of duplicate occurrences to trigger aggregation',
           example: 2,
           minimum: 2
         },
@@ -764,7 +798,8 @@ export class WorkspaceCodingAnalysisController {
         },
         uniqueCodingCases: {
           type: 'number',
-          description: 'New total count of unique coding cases after aggregation'
+          description:
+            'New total count of unique coding cases after aggregation'
         },
         message: { type: 'string' }
       }
@@ -799,9 +834,10 @@ export class WorkspaceCodingAnalysisController {
     @WorkspaceId() workspace_id: number,
                    @Body() body: { threshold?: number } = {}
   ): Promise<void> {
-    const threshold = body.threshold === undefined ?
-      undefined :
-      this.normalizeIntegerParam(body.threshold, 2, 2, 100);
+    const threshold =
+      body.threshold === undefined ?
+        undefined :
+        this.normalizeIntegerParam(body.threshold, 2, 2, 100);
 
     await this.codingAnalysisService.startAnalysis(
       workspace_id,

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
@@ -148,11 +148,12 @@ describe('WorkspaceCodingStatisticsController', () => {
   });
 
   it('delegates autocoding readiness requests with parsed options', async () => {
-    await controller.getAutocodingReadiness(5, '2', 'true');
+    await controller.getAutocodingReadiness(5, '2', 'true', 'summary');
 
     expect(codingReadinessService.getReadiness).toHaveBeenCalledWith(5, {
       autoCoderRun: 2,
-      forceRefresh: true
+      forceRefresh: true,
+      detailLevel: 'summary'
     });
   });
 

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -45,7 +45,10 @@ import {
   CodingFreshnessVersion,
   StartCodingFreshnessJobDto
 } from '../../../../../../api-dto/coding/coding-freshness.dto';
-import { AutocodingReadinessDto } from '../../../../../../api-dto/coding/autocoding-readiness.dto';
+import {
+  AutocodingReadinessDetailLevel,
+  AutocodingReadinessDto
+} from '../../../../../../api-dto/coding/autocoding-readiness.dto';
 import { JobQueueService } from '../../job-queue/job-queue.service';
 import { sanitizeCsvText } from '../../utils/csv.util';
 
@@ -1067,17 +1070,25 @@ export class WorkspaceCodingStatisticsController {
     required: false,
     description: 'Ignore the short-lived readiness cache and recalculate.'
   })
+  @ApiQuery({
+    name: 'detailLevel',
+    required: false,
+    description: 'Return a lightweight summary or full diagnostics.',
+    enum: ['summary', 'full']
+  })
   @ApiOkResponse({
     description: 'Auto-coding readiness diagnostics retrieved successfully.'
   })
   async getAutocodingReadiness(
     @WorkspaceId() workspace_id: number,
       @Query('autoCoderRun') autoCoderRun?: string | string[],
-      @Query('forceRefresh') forceRefresh?: string | string[]
+      @Query('forceRefresh') forceRefresh?: string | string[],
+      @Query('detailLevel') detailLevel?: string | string[]
   ): Promise<AutocodingReadinessDto> {
     return this.codingReadinessService.getReadiness(workspace_id, {
       autoCoderRun: this.parseAutoCoderRun(autoCoderRun),
-      forceRefresh: this.parseBooleanQuery(forceRefresh)
+      forceRefresh: this.parseBooleanQuery(forceRefresh),
+      detailLevel: this.parseReadinessDetailLevel(detailLevel)
     });
   }
 
@@ -1244,6 +1255,22 @@ export class WorkspaceCodingStatisticsController {
       return numericValue;
     }
     throw new BadRequestException('autoCoderRun must be 1 or 2');
+  }
+
+  private parseReadinessDetailLevel(
+    value?: string | string[]
+  ): AutocodingReadinessDetailLevel {
+    const values = this.parseArrayQuery(value);
+    if (values.length === 0) {
+      return 'full';
+    }
+    if (values.length > 1) {
+      throw new BadRequestException('detailLevel must be provided only once');
+    }
+    if (values[0] === 'summary' || values[0] === 'full') {
+      return values[0];
+    }
+    throw new BadRequestException('detailLevel must be summary or full');
   }
 
   private parseBooleanQuery(value?: string | string[]): boolean {

--- a/apps/backend/src/app/cache/coding-incomplete-cache-scheduler.service.ts
+++ b/apps/backend/src/app/cache/coding-incomplete-cache-scheduler.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -7,7 +7,7 @@ import { CodingValidationService } from '../database/services/coding';
 import Persons from '../database/entities/persons.entity';
 
 @Injectable()
-export class CodingIncompleteCacheSchedulerService implements OnModuleInit {
+export class CodingIncompleteCacheSchedulerService {
   private readonly logger = new Logger(CodingIncompleteCacheSchedulerService.name);
 
   constructor(
@@ -21,6 +21,13 @@ export class CodingIncompleteCacheSchedulerService implements OnModuleInit {
    * Run on module initialization to pre-cache all manual coding variables.
    */
   async onModuleInit(): Promise<void> {
+    if (!this.isStartupWarmupEnabled()) {
+      this.logger.log(
+        'Skipping manual coding variables cache warmup on startup'
+      );
+      return;
+    }
+
     this.logger.log('Starting manual coding variables cache warmup on application startup');
 
     try {
@@ -171,5 +178,10 @@ export class CodingIncompleteCacheSchedulerService implements OnModuleInit {
     const rssMB = (memUsage.rss / 1024 / 1024).toFixed(1);
 
     return `Heap: ${heapUsedMB}MB/${heapTotalMB}MB (${heapPercent}%), RSS: ${rssMB}MB`;
+  }
+
+  private isStartupWarmupEnabled(): boolean {
+    return process.env.ENABLE_STARTUP_CACHE_WARMUP === 'true' ||
+      process.env.ENABLE_CODING_INCOMPLETE_STARTUP_WARMUP === 'true';
   }
 }

--- a/apps/backend/src/app/cache/coding-statistics-cache-scheduler.service.ts
+++ b/apps/backend/src/app/cache/coding-statistics-cache-scheduler.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -7,7 +7,7 @@ import { CodingStatisticsService } from '../database/services/coding';
 import Persons from '../database/entities/persons.entity';
 
 @Injectable()
-export class CodingStatisticsCacheSchedulerService implements OnModuleInit {
+export class CodingStatisticsCacheSchedulerService {
   private readonly logger = new Logger(CodingStatisticsCacheSchedulerService.name);
 
   constructor(
@@ -21,6 +21,13 @@ export class CodingStatisticsCacheSchedulerService implements OnModuleInit {
    * Run on module initialization to pre-cache all coding statistics
    */
   async onModuleInit(): Promise<void> {
+    if (!this.isStartupWarmupEnabled()) {
+      this.logger.log(
+        'Skipping coding statistics cache warmup on startup'
+      );
+      return;
+    }
+
     this.logger.log('Starting coding statistics cache warmup on application startup');
 
     try {
@@ -171,5 +178,10 @@ export class CodingStatisticsCacheSchedulerService implements OnModuleInit {
     const rssMB = (memUsage.rss / 1024 / 1024).toFixed(1);
 
     return `Heap: ${heapUsedMB}MB/${heapTotalMB}MB (${heapPercent}%), RSS: ${rssMB}MB`;
+  }
+
+  private isStartupWarmupEnabled(): boolean {
+    return process.env.ENABLE_STARTUP_CACHE_WARMUP === 'true' ||
+      process.env.ENABLE_CODING_STATISTICS_STARTUP_WARMUP === 'true';
   }
 }

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
@@ -5,6 +5,12 @@ import { ResponseEntity } from '../../entities/response.entity';
 import Persons from '../../entities/persons.entity';
 import { Unit } from '../../entities/unit.entity';
 import { Booklet } from '../../entities/booklet.entity';
+import {
+  createDuplicateValuePageCache,
+  createEmptyResponseChunkCaches,
+  createDuplicateValueChunkCaches,
+  RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+} from './response-analysis-page-cache.util';
 
 jest.mock('./coding-job.service', () => ({
   ResponseMatchingFlag: {
@@ -34,18 +40,22 @@ describe('CodingAnalysisService aggregation settings', () => {
     };
     const responseRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
-      update: jest.fn().mockResolvedValue(undefined)
+      update: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue([{ revision: 11 }])
     } as unknown as Repository<ResponseEntity>;
     const codingJobService = {
       getAggregationThreshold: jest.fn().mockResolvedValue(2),
       getResponseMatchingMode: jest.fn().mockResolvedValue([]),
       setAggregationThreshold: jest.fn().mockResolvedValue(undefined),
-      setResponseMatchingMode: jest.fn().mockImplementation((_workspaceId, flags) => Promise.resolve(flags)),
-      normalizeResponseMatchingFlags: jest.fn().mockImplementation(flags => (
-        flags?.includes(ResponseMatchingFlag.NO_AGGREGATION) ?
+      setResponseMatchingMode: jest
+        .fn()
+        .mockImplementation((_workspaceId, flags) => Promise.resolve(flags)),
+      normalizeResponseMatchingFlags: jest
+        .fn()
+        .mockImplementation(flags => (flags?.includes(ResponseMatchingFlag.NO_AGGREGATION) ?
           [ResponseMatchingFlag.NO_AGGREGATION] :
-          Array.from(new Set(flags ?? []))
-      ))
+          Array.from(new Set(flags ?? [])))
+        )
     };
     const codingValidationService = {
       invalidateIncompleteVariablesCache: jest.fn().mockResolvedValue(undefined)
@@ -54,12 +64,14 @@ describe('CodingAnalysisService aggregation settings', () => {
       invalidateCache: jest.fn().mockResolvedValue(undefined)
     };
     const cacheService = {
+      get: jest.fn().mockResolvedValue(null),
       delete: jest.fn().mockResolvedValue(undefined),
       set: jest.fn().mockResolvedValue(true),
       deleteByPattern: jest.fn().mockResolvedValue(undefined)
     };
     const jobQueueService = {
       getActiveCodingAnalysisJob: jest.fn().mockResolvedValue(null),
+      getCodingAnalysisJobForCacheKey: jest.fn().mockResolvedValue(null),
       addCodingAnalysisJob: jest.fn().mockResolvedValue(undefined)
     };
 
@@ -108,14 +120,23 @@ describe('CodingAnalysisService aggregation settings', () => {
       aggregationActive: true,
       revertedResponses: 2
     });
-    expect(codingJobService.setAggregationThreshold).toHaveBeenCalledWith(7, 100);
-    expect(codingJobService.setResponseMatchingMode).toHaveBeenCalledWith(7, [ResponseMatchingFlag.IGNORE_CASE]);
+    expect(codingJobService.setAggregationThreshold).toHaveBeenCalledWith(
+      7,
+      100
+    );
+    expect(codingJobService.setResponseMatchingMode).toHaveBeenCalledWith(7, [
+      ResponseMatchingFlag.IGNORE_CASE
+    ]);
     expect(responseRepository.update).toHaveBeenCalledWith(
       { id: expect.anything() },
       { code_v2: null, score_v2: null, status_v2: null }
     );
-    expect(cacheService.deleteByPattern).toHaveBeenCalledWith('response-analysis:7_*');
-    expect(codingValidationService.invalidateIncompleteVariablesCache).toHaveBeenCalledWith(7);
+    expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+      'response-analysis:7_*'
+    );
+    expect(
+      codingValidationService.invalidateIncompleteVariablesCache
+    ).toHaveBeenCalledWith(7);
     expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(7);
   });
 
@@ -135,17 +156,18 @@ describe('CodingAnalysisService aggregation settings', () => {
   });
 
   it('clears the selected analysis cache before a forced restart', async () => {
-    const {
-      service,
-      cacheService,
-      jobQueueService
-    } = createService();
+    const { service, cacheService, jobQueueService } = createService();
 
     await service.startAnalysis(7, [ResponseMatchingFlag.IGNORE_CASE], 4, {
       forceRefresh: true
     });
 
-    expect(cacheService.delete).toHaveBeenCalledWith('response-analysis:7_IGNORE_CASE_t4');
+    expect(cacheService.delete).toHaveBeenCalledWith(
+      'response-analysis:7_IGNORE_CASE_t4'
+    );
+    expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+      'response-analysis:7_IGNORE_CASE_t4:*'
+    );
     expect(cacheService.set).toHaveBeenCalledWith(
       'response-analysis:7_IGNORE_CASE_t4:run',
       expect.any(String),
@@ -156,15 +178,13 @@ describe('CodingAnalysisService aggregation settings', () => {
       matchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
       threshold: 4,
       cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
-      runId: expect.any(String)
+      runId: expect.any(String),
+      sourceRevision: 11
     });
   });
 
   it('queues a superseding forced restart even when an older workspace analysis is active', async () => {
-    const {
-      service,
-      jobQueueService
-    } = createService();
+    const { service, jobQueueService } = createService();
     jobQueueService.getActiveCodingAnalysisJob.mockResolvedValue({
       id: 'old-job',
       data: {
@@ -180,10 +200,371 @@ describe('CodingAnalysisService aggregation settings', () => {
       forceRefresh: true
     });
 
-    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith(expect.objectContaining({
-      workspaceId: 7,
-      cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
-      runId: expect.any(String)
-    }));
+    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 7,
+        cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
+        runId: expect.any(String)
+      })
+    );
+  });
+
+  it('reuses an existing matching response analysis job without resetting its run marker', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    jobQueueService.getCodingAnalysisJobForCacheKey.mockResolvedValue({
+      id: 'queued-job',
+      data: {
+        workspaceId: 7,
+        matchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
+        threshold: 4,
+        cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
+        runId: 'existing-run'
+      }
+    });
+
+    await service.startAnalysis(7, [ResponseMatchingFlag.IGNORE_CASE], 4);
+
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+    expect(cacheService.set).not.toHaveBeenCalledWith(
+      'response-analysis:7_IGNORE_CASE_t4:run',
+      expect.any(String),
+      0
+    );
+  });
+
+  it('serves response analysis from lightweight page caches without reading the full payload', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    cacheService.get.mockImplementation((key: string) => {
+      if (key === 'response-analysis:7__t2:summary') {
+        return Promise.resolve({
+          emptyResponses: { total: 12, totalUncoded: 9 },
+          duplicateValues: {
+            total: 3,
+            totalResponses: 8,
+            isAggregationApplied: false
+          },
+          aggregationSummary: {
+            duplicateGroups: 3,
+            duplicateResponses: 8,
+            collapsedCases: 5,
+            rawCases: 8,
+            effectiveCases: 3,
+            threshold: 2,
+            aggregationActive: true
+          },
+          matchingFlags: [],
+          analysisTimestamp: '2026-05-22T00:00:00.000Z',
+          sourceRevision: 11
+        });
+      }
+      if (key === 'response-analysis:7__t2:empty:p2:l5') {
+        return Promise.resolve({
+          items: [
+            {
+              responseId: 101,
+              unitName: 'u',
+              unitAlias: null,
+              variableId: 'v',
+              personLogin: 'p',
+              personCode: 'c',
+              personGroup: 'g',
+              bookletName: 'b',
+              value: null
+            }
+          ],
+          page: 2,
+          pageSize: 5
+        });
+      }
+      if (key === 'response-analysis:7__t2:duplicate:p3:l10') {
+        return Promise.resolve({
+          groups: [],
+          page: 3,
+          pageSize: 10
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await service.getResponseAnalysis(7, 2, 2, 5, 3, 10);
+
+    expect(result.emptyResponses.total).toBe(12);
+    expect(result.emptyResponses.page).toBe(2);
+    expect(result.emptyResponses.items).toHaveLength(1);
+    expect(result.duplicateValues.totalResponses).toBe(8);
+    expect(result.currentSourceRevision).toBe(11);
+    expect(result.isCalculating).toBe(false);
+    expect(cacheService.get).not.toHaveBeenCalledWith(
+      'response-analysis:7__t2'
+    );
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+  });
+
+  it('serves response analysis pages from chunk caches without reading the full payload', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    const analysis = {
+      emptyResponses: {
+        total: 2,
+        totalUncoded: 2,
+        items: [
+          {
+            responseId: 101,
+            unitName: 'u1',
+            unitAlias: null,
+            variableId: 'v',
+            personLogin: 'p1',
+            personCode: 'c1',
+            personGroup: 'g',
+            bookletName: 'b',
+            value: null
+          },
+          {
+            responseId: 102,
+            unitName: 'u2',
+            unitAlias: null,
+            variableId: 'v',
+            personLogin: 'p2',
+            personCode: 'c2',
+            personGroup: 'g',
+            bookletName: 'b',
+            value: null
+          }
+        ]
+      },
+      duplicateValues: {
+        total: 1,
+        totalResponses: 6,
+        groups: [
+          {
+            unitName: 'u',
+            unitAlias: null,
+            variableId: 'v',
+            normalizedValue: 'same',
+            originalValue: 'same',
+            occurrences: Array.from({ length: 6 }, (_, index) => ({
+              personLogin: `p${index}`,
+              personCode: `${index}`,
+              bookletName: 'b',
+              responseId: index,
+              value: 'same'
+            }))
+          }
+        ],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 1,
+        duplicateResponses: 6,
+        collapsedCases: 5,
+        rawCases: 8,
+        effectiveCases: 3,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: '2026-05-22T00:00:00.000Z',
+      sourceRevision: 11
+    };
+    const emptyChunks = createEmptyResponseChunkCaches(analysis);
+    const duplicateChunks = createDuplicateValueChunkCaches(analysis);
+    cacheService.get.mockImplementation((key: string) => {
+      if (key === 'response-analysis:7__t2:summary') {
+        return Promise.resolve({
+          emptyResponses: { total: 2, totalUncoded: 2 },
+          duplicateValues: {
+            total: 1,
+            totalResponses: 6,
+            isAggregationApplied: false
+          },
+          aggregationSummary: analysis.aggregationSummary,
+          matchingFlags: [],
+          analysisTimestamp: analysis.analysisTimestamp,
+          sourceRevision: 11
+        });
+      }
+      if (key === 'response-analysis:7__t2:empty-chunk:0') {
+        return Promise.resolve(emptyChunks[0]);
+      }
+      if (key === 'response-analysis:7__t2:duplicate-chunk:0') {
+        return Promise.resolve(duplicateChunks[0]);
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await service.getResponseAnalysis(7, 2, 1, 1, 1, 1);
+
+    expect(result.emptyResponses.items).toHaveLength(1);
+    expect(result.emptyResponses.items[0].responseId).toBe(101);
+    expect(result.duplicateValues.groups).toHaveLength(1);
+    expect(result.duplicateValues.groups[0].occurrences).toHaveLength(
+      RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+    );
+    expect(result.currentSourceRevision).toBe(11);
+    expect(result.isCalculating).toBe(false);
+    expect(cacheService.get).not.toHaveBeenCalledWith(
+      'response-analysis:7__t2'
+    );
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+  });
+
+  it('serves out-of-range response analysis pages from summary cache without recalculating', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    cacheService.get.mockImplementation((key: string) => {
+      if (key === 'response-analysis:7__t2:summary') {
+        return Promise.resolve({
+          emptyResponses: { total: 2, totalUncoded: 2 },
+          duplicateValues: {
+            total: 1,
+            totalResponses: 6,
+            isAggregationApplied: false
+          },
+          aggregationSummary: {
+            duplicateGroups: 1,
+            duplicateResponses: 6,
+            collapsedCases: 5,
+            rawCases: 8,
+            effectiveCases: 3,
+            threshold: 2,
+            aggregationActive: true
+          },
+          matchingFlags: [],
+          analysisTimestamp: '2026-05-22T00:00:00.000Z',
+          sourceRevision: 11
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await service.getResponseAnalysis(7, 2, 99, 50, 42, 50);
+
+    expect(result.emptyResponses.total).toBe(2);
+    expect(result.emptyResponses.page).toBe(99);
+    expect(result.emptyResponses.items).toEqual([]);
+    expect(result.duplicateValues.total).toBe(1);
+    expect(result.duplicateValues.page).toBe(42);
+    expect(result.duplicateValues.groups).toEqual([]);
+    expect(cacheService.get).not.toHaveBeenCalledWith(
+      'response-analysis:7__t2'
+    );
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+  });
+
+  it('marks cached response analysis stale when the test result revision changed', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    const cachedAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 0,
+        totalResponses: 0,
+        groups: [],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 0,
+        duplicateResponses: 0,
+        collapsedCases: 0,
+        rawCases: 5,
+        effectiveCases: 5,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: '2026-05-22T00:00:00.000Z',
+      sourceRevision: 10
+    };
+    cacheService.get.mockImplementation((key: string) => Promise.resolve(key === 'response-analysis:7__t2' ? cachedAnalysis : null)
+    );
+
+    const result = await service.getResponseAnalysis(7);
+
+    expect(result.sourceRevision).toBe(10);
+    expect(result.currentSourceRevision).toBe(11);
+    expect(result.isCalculating).toBe(true);
+    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 7,
+        cacheKey: 'response-analysis:7__t2',
+        sourceRevision: 11
+      })
+    );
+  });
+
+  it('keeps legacy cached response analysis without revision usable', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    const cachedAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 0,
+        totalResponses: 0,
+        groups: [],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 0,
+        duplicateResponses: 0,
+        collapsedCases: 0,
+        rawCases: 5,
+        effectiveCases: 5,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: '2026-05-22T00:00:00.000Z'
+    };
+    cacheService.get.mockImplementation((key: string) => Promise.resolve(key === 'response-analysis:7__t2' ? cachedAnalysis : null)
+    );
+
+    const result = await service.getResponseAnalysis(7);
+
+    expect(result.currentSourceRevision).toBe(11);
+    expect(result.isCalculating).toBe(false);
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+  });
+
+  it('keeps only a duplicate occurrence preview in page caches', () => {
+    const pageCache = createDuplicateValuePageCache(
+      {
+        emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+        duplicateValues: {
+          total: 1,
+          totalResponses: 12,
+          isAggregationApplied: false,
+          groups: [
+            {
+              unitName: 'u',
+              unitAlias: null,
+              variableId: 'v',
+              normalizedValue: 'same',
+              originalValue: 'same',
+              occurrences: Array.from({ length: 12 }, (_, index) => ({
+                personLogin: `person-${index}`,
+                personCode: `${index}`,
+                bookletName: 'booklet',
+                responseId: index,
+                value: 'same'
+              }))
+            }
+          ]
+        },
+        aggregationSummary: {
+          duplicateGroups: 1,
+          duplicateResponses: 12,
+          collapsedCases: 11,
+          rawCases: 12,
+          effectiveCases: 1,
+          threshold: 2,
+          aggregationActive: true
+        },
+        matchingFlags: [],
+        analysisTimestamp: '2026-05-22T00:00:00.000Z'
+      },
+      1,
+      10
+    );
+
+    expect(pageCache.groups[0].occurrenceCount).toBe(12);
+    expect(pageCache.groups[0].occurrences).toHaveLength(
+      RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+    );
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
@@ -9,14 +9,9 @@ import { ResponseEntity } from '../../entities/response.entity';
 import {
   ResponseAnalysisDto,
   EmptyResponseDto,
-  DuplicateValueGroupDto,
-  EmptyResponseAnalysisDto,
-  DuplicateValueAnalysisDto
+  DuplicateValueGroupDto
 } from '../../../../../../../api-dto/coding/response-analysis.dto';
-import {
-  CodingJobService,
-  ResponseMatchingFlag
-} from './coding-job.service';
+import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { CodingValidationService } from './coding-validation.service';
 import { CodingStatisticsService } from './coding-statistics.service';
 import { CacheService } from '../../../cache/cache.service';
@@ -27,6 +22,28 @@ import {
   getCodingAnalysisCacheKey,
   getCodingAnalysisRunMarkerKey
 } from './coding-analysis-cache-key.util';
+import {
+  createDuplicateValuePageCache,
+  createEmptyResponsePageCache,
+  createDuplicateValuePageCacheFromChunks,
+  createDuplicateValueChunkCaches,
+  createEmptyResponseChunkCaches,
+  createEmptyResponsePageCacheFromChunks,
+  createResponseAnalysisFromCachedParts,
+  createResponseAnalysisSummaryCache,
+  DuplicateValueChunkCache,
+  DuplicateValuePageCache,
+  EmptyResponseChunkCache,
+  EmptyResponsePageCache,
+  getRequiredResponseAnalysisChunkIndexes,
+  getResponseAnalysisDuplicateChunkCacheKey,
+  getResponseAnalysisDerivedCachePattern,
+  getResponseAnalysisDuplicatePageCacheKey,
+  getResponseAnalysisEmptyChunkCacheKey,
+  getResponseAnalysisEmptyPageCacheKey,
+  getResponseAnalysisSummaryCacheKey,
+  ResponseAnalysisSummaryCache
+} from './response-analysis-page-cache.util';
 
 export interface AggregationSettingsResult {
   success: boolean;
@@ -40,6 +57,7 @@ export interface AggregationSettingsResult {
 @Injectable()
 export class CodingAnalysisService {
   private readonly logger = new Logger(CodingAnalysisService.name);
+  private readonly slowResponseAnalysisThresholdMs = 3000;
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -55,7 +73,7 @@ export class CodingAnalysisService {
     private codingStatisticsService: CodingStatisticsService,
     private cacheService: CacheService,
     private jobQueueService: JobQueueService
-  ) { }
+  ) {}
 
   /**
    * Analyzes responses for a workspace to identify:
@@ -71,41 +89,157 @@ export class CodingAnalysisService {
     emptyLimit = 50,
     duplicatePage = 1,
     duplicateLimit = 50
-  ): Promise<ResponseAnalysisDto & { isCalculating?: boolean; progress?: number }> {
+  ): Promise<
+    ResponseAnalysisDto & { isCalculating?: boolean; progress?: number }
+    > {
+    const startedAt = Date.now();
+    let timingStatus = 'failed';
     try {
       const requestedThreshold = this.normalizeThreshold(threshold);
       this.logger.log(
         `Getting response analysis for workspace ${workspaceId} with threshold ${requestedThreshold}`
       );
 
-      const matchingFlags = await this.codingJobService.getResponseMatchingMode(
-        workspaceId
-      );
+      const [matchingFlags, currentSourceRevision] = await Promise.all([
+        this.codingJobService.getResponseMatchingMode(workspaceId),
+        this.getWorkspaceResultsRevision(workspaceId)
+      ]);
 
       // If NO_AGGREGATION is set, we want to see all duplicates regardless of the requested threshold
-      const effectiveThreshold = matchingFlags.includes(ResponseMatchingFlag.NO_AGGREGATION) ?
+      const effectiveThreshold = matchingFlags.includes(
+        ResponseMatchingFlag.NO_AGGREGATION
+      ) ?
         2 :
         requestedThreshold;
 
       // Check cache for the FULL analysis for this threshold
-      const cacheKey = this.getCacheKey(workspaceId, matchingFlags, effectiveThreshold);
-      const fullAnalysis = await this.cacheService.get<ResponseAnalysisDto>(cacheKey);
+      const cacheKey = this.getCacheKey(
+        workspaceId,
+        matchingFlags,
+        effectiveThreshold
+      );
+      const summaryCache =
+        await this.cacheService.get<ResponseAnalysisSummaryCache>(
+          getResponseAnalysisSummaryCacheKey(cacheKey)
+        );
 
       // Check if a job is currently running
-      const activeJob = await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
+      const activeJob =
+        await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
       const isCalculating = !!activeJob;
       let progress = 0;
       if (activeJob) {
         progress = await activeJob.progress();
       }
 
+      const chunkedPageCaches = summaryCache ?
+        await this.getResponseAnalysisPageCachesFromChunks(
+          cacheKey,
+          emptyPage,
+          emptyLimit,
+          duplicatePage,
+          duplicateLimit,
+          summaryCache
+        ) :
+        null;
+
+      if (
+        summaryCache &&
+        chunkedPageCaches?.emptyPageCache &&
+        chunkedPageCaches?.duplicatePageCache
+      ) {
+        const analysisIsStale = this.isAnalysisSourceRevisionStale(
+          summaryCache,
+          currentSourceRevision
+        );
+        if (analysisIsStale && !isCalculating) {
+          await this.startAnalysis(
+            workspaceId,
+            matchingFlags,
+            effectiveThreshold,
+            {
+              sourceRevision: currentSourceRevision
+            }
+          );
+        }
+        timingStatus = analysisIsStale ? 'stale-chunk-cache' : 'chunk-cache-hit';
+        return createResponseAnalysisFromCachedParts(
+          summaryCache,
+          chunkedPageCaches.emptyPageCache,
+          chunkedPageCaches.duplicatePageCache,
+          currentSourceRevision,
+          isCalculating || analysisIsStale,
+          progress
+        );
+      }
+
+      const [emptyPageCache, duplicatePageCache] = summaryCache ?
+        await Promise.all([
+          this.cacheService.get<EmptyResponsePageCache>(
+            getResponseAnalysisEmptyPageCacheKey(
+              cacheKey,
+              emptyPage,
+              emptyLimit
+            )
+          ),
+          this.cacheService.get<DuplicateValuePageCache>(
+            getResponseAnalysisDuplicatePageCacheKey(
+              cacheKey,
+              duplicatePage,
+              duplicateLimit
+            )
+          )
+        ]) :
+        [null, null];
+
+      if (summaryCache && emptyPageCache && duplicatePageCache) {
+        const analysisIsStale = this.isAnalysisSourceRevisionStale(
+          summaryCache,
+          currentSourceRevision
+        );
+        if (analysisIsStale && !isCalculating) {
+          await this.startAnalysis(
+            workspaceId,
+            matchingFlags,
+            effectiveThreshold,
+            {
+              sourceRevision: currentSourceRevision
+            }
+          );
+        }
+        timingStatus = analysisIsStale ? 'stale-page-cache' : 'page-cache-hit';
+        return createResponseAnalysisFromCachedParts(
+          summaryCache,
+          emptyPageCache,
+          duplicatePageCache,
+          currentSourceRevision,
+          isCalculating || analysisIsStale,
+          progress
+        );
+      }
+
+      const fullAnalysis =
+        await this.cacheService.get<ResponseAnalysisDto>(cacheKey);
+
       if (fullAnalysis && !fullAnalysis.aggregationSummary) {
         await this.invalidateCache(workspaceId);
         if (!isCalculating) {
-          await this.startAnalysis(workspaceId, matchingFlags, effectiveThreshold);
+          await this.startAnalysis(
+            workspaceId,
+            matchingFlags,
+            effectiveThreshold,
+            {
+              sourceRevision: currentSourceRevision
+            }
+          );
         }
+        timingStatus = 'legacy-cache-missing-summary';
         return {
-          ...this.createEmptyAnalysisResult(matchingFlags, effectiveThreshold),
+          ...this.createEmptyAnalysisResult(
+            matchingFlags,
+            effectiveThreshold,
+            currentSourceRevision
+          ),
           isCalculating: true,
           progress
         };
@@ -115,56 +249,86 @@ export class CodingAnalysisService {
         if (!isCalculating) {
           // If no analysis and no job running, trigger one (or return empty with isCalculating=false and let frontend trigger)
           // For better UX, let's trigger it automatically if missing
-          await this.startAnalysis(workspaceId, matchingFlags, effectiveThreshold);
+          await this.startAnalysis(
+            workspaceId,
+            matchingFlags,
+            effectiveThreshold,
+            {
+              sourceRevision: currentSourceRevision
+            }
+          );
+          timingStatus = 'cache-miss-started';
           return {
-            ...this.createEmptyAnalysisResult(matchingFlags, effectiveThreshold),
+            ...this.createEmptyAnalysisResult(
+              matchingFlags,
+              effectiveThreshold,
+              currentSourceRevision
+            ),
             isCalculating: true,
             progress
           };
         }
+        timingStatus = 'cache-miss-existing-job';
         return {
-          ...this.createEmptyAnalysisResult(matchingFlags, effectiveThreshold),
+          ...this.createEmptyAnalysisResult(
+            matchingFlags,
+            effectiveThreshold,
+            currentSourceRevision
+          ),
           isCalculating: true,
           progress
         };
       }
 
-      // Slice the results for pagination
-      const emptyStart = (emptyPage - 1) * emptyLimit;
-      const emptyItems = fullAnalysis.emptyResponses.items.slice(
-        emptyStart,
-        emptyStart + emptyLimit
+      const analysisIsStale = this.isAnalysisSourceRevisionStale(
+        fullAnalysis,
+        currentSourceRevision
+      );
+      if (analysisIsStale && !isCalculating) {
+        await this.startAnalysis(
+          workspaceId,
+          matchingFlags,
+          effectiveThreshold,
+          {
+            sourceRevision: currentSourceRevision
+          }
+        );
+      }
+      timingStatus = analysisIsStale ? 'stale-cache' : 'cache-hit';
+      await this.writeResponseAnalysisDerivedCaches(
+        cacheKey,
+        fullAnalysis,
+        emptyPage,
+        emptyLimit,
+        duplicatePage,
+        duplicateLimit
       );
 
-      const duplicateStart = (duplicatePage - 1) * duplicateLimit;
-      const duplicateGroups = fullAnalysis.duplicateValues.groups.slice(
-        duplicateStart,
-        duplicateStart + duplicateLimit
-      );
-
-      return {
-        ...fullAnalysis,
-        emptyResponses: {
-          ...fullAnalysis.emptyResponses,
-          items: emptyItems,
-          page: emptyPage,
-          pageSize: emptyLimit
-        } as EmptyResponseAnalysisDto,
-        duplicateValues: {
-          ...fullAnalysis.duplicateValues,
-          groups: duplicateGroups,
-          page: duplicatePage,
-          pageSize: duplicateLimit
-        } as DuplicateValueAnalysisDto,
-        isCalculating,
+      return createResponseAnalysisFromCachedParts(
+        createResponseAnalysisSummaryCache(fullAnalysis),
+        createEmptyResponsePageCache(fullAnalysis, emptyPage, emptyLimit),
+        createDuplicateValuePageCache(
+          fullAnalysis,
+          duplicatePage,
+          duplicateLimit
+        ),
+        currentSourceRevision,
+        isCalculating || analysisIsStale,
         progress
-      };
+      );
     } catch (error) {
       this.logger.error(
         `Error analyzing responses for workspace ${workspaceId}: ${error.message}`,
         error.stack
       );
       throw new Error(`Failed to analyze responses: ${error.message}`);
+    } finally {
+      this.logResponseAnalysisTiming(
+        'getResponseAnalysis',
+        workspaceId,
+        startedAt,
+        timingStatus
+      );
     }
   }
 
@@ -172,31 +336,64 @@ export class CodingAnalysisService {
     workspaceId: number,
     matchingFlags?: ResponseMatchingFlag[],
     threshold?: number,
-    options: { forceRefresh?: boolean } = {}
+    options: { forceRefresh?: boolean; sourceRevision?: number } = {}
   ): Promise<void> {
-    const activeMatchingFlags = matchingFlags ||
-      await this.codingJobService.getResponseMatchingMode(workspaceId);
-    const savedThreshold = threshold === undefined ?
-      await this.codingJobService.getAggregationThreshold(workspaceId) :
-      threshold;
+    const activeMatchingFlags =
+      matchingFlags ||
+      (await this.codingJobService.getResponseMatchingMode(workspaceId));
+    const savedThreshold =
+      threshold === undefined ?
+        await this.codingJobService.getAggregationThreshold(workspaceId) :
+        threshold;
     const activeThreshold = this.normalizeThreshold(savedThreshold ?? 2);
 
     // If NO_AGGREGATION is set, we want to see all duplicates regardless of the requested threshold
-    const effectiveThreshold = activeMatchingFlags.includes(ResponseMatchingFlag.NO_AGGREGATION) ?
+    const effectiveThreshold = activeMatchingFlags.includes(
+      ResponseMatchingFlag.NO_AGGREGATION
+    ) ?
       2 :
       activeThreshold;
 
-    const cacheKey = this.getCacheKey(workspaceId, activeMatchingFlags, effectiveThreshold);
+    const cacheKey = this.getCacheKey(
+      workspaceId,
+      activeMatchingFlags,
+      effectiveThreshold
+    );
+    const sourceRevision =
+      options.sourceRevision ??
+      (await this.getWorkspaceResultsRevision(workspaceId));
 
     if (options.forceRefresh) {
-      await this.cacheService.delete(cacheKey);
-      this.logger.log(`Invalidated response analysis cache before restart for workspace ${workspaceId}`);
+      await Promise.all([
+        this.cacheService.delete(cacheKey),
+        this.cacheService.deleteByPattern(
+          getResponseAnalysisDerivedCachePattern(cacheKey)
+        )
+      ]);
+      this.logger.log(
+        `Invalidated response analysis cache before restart for workspace ${workspaceId}`
+      );
     }
 
-    // Check if job already running
-    const activeJob = await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
+    const reusableJob =
+      await this.jobQueueService.getCodingAnalysisJobForCacheKey(
+        workspaceId,
+        cacheKey
+      );
+    if (reusableJob && !options.forceRefresh) {
+      this.logger.log(
+        `Reusing queued response analysis for workspace ${workspaceId} (Job ID: ${reusableJob.id})`
+      );
+      return;
+    }
+
+    // Check if another analysis for this workspace is already running.
+    const activeJob =
+      await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
     if (activeJob && !options.forceRefresh) {
-      this.logger.log(`Analysis job already running for workspace ${workspaceId} (Job ID: ${activeJob.id})`);
+      this.logger.log(
+        `Analysis job already running for workspace ${workspaceId} (Job ID: ${activeJob.id})`
+      );
       return;
     }
 
@@ -207,16 +404,38 @@ export class CodingAnalysisService {
     }
 
     const runId = randomUUID();
-    await this.cacheService.set(getCodingAnalysisRunMarkerKey(cacheKey), runId, 0);
+    await this.cacheService.set(
+      getCodingAnalysisRunMarkerKey(cacheKey),
+      runId,
+      0
+    );
 
     await this.jobQueueService.addCodingAnalysisJob({
       workspaceId,
       matchingFlags: activeMatchingFlags as unknown as string[],
       threshold: effectiveThreshold,
       cacheKey,
-      runId
+      runId,
+      sourceRevision
     });
-    this.logger.log(`Triggered background response analysis for workspace ${workspaceId}`);
+    this.logger.log(
+      `Triggered background response analysis for workspace ${workspaceId}`
+    );
+  }
+
+  private logResponseAnalysisTiming(
+    operation: string,
+    workspaceId: number,
+    startedAt: number,
+    status: string
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    const message = `${operation} for workspace ${workspaceId} finished in ${durationMs}ms (${status})`;
+    if (durationMs >= this.slowResponseAnalysisThresholdMs) {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.debug(message);
   }
 
   private analyzeBatch(
@@ -304,19 +523,24 @@ export class CodingAnalysisService {
     }
   }
 
-  async getAggregationSettings(workspaceId: number): Promise<AggregationSettingsResult> {
+  async getAggregationSettings(
+    workspaceId: number
+  ): Promise<AggregationSettingsResult> {
     const [threshold, flags] = await Promise.all([
       this.codingJobService.getAggregationThreshold(workspaceId),
       this.codingJobService.getResponseMatchingMode(workspaceId)
     ]);
     const normalizedThreshold = this.normalizeThreshold(threshold ?? 2);
-    const normalizedFlags = this.codingJobService.normalizeResponseMatchingFlags(flags);
+    const normalizedFlags =
+      this.codingJobService.normalizeResponseMatchingFlags(flags);
 
     return {
       success: true,
       threshold: normalizedThreshold,
       flags: normalizedFlags,
-      aggregationActive: !normalizedFlags.includes(ResponseMatchingFlag.NO_AGGREGATION),
+      aggregationActive: !normalizedFlags.includes(
+        ResponseMatchingFlag.NO_AGGREGATION
+      ),
       revertedResponses: 0,
       message: 'Aggregation settings loaded.'
     };
@@ -328,24 +552,37 @@ export class CodingAnalysisService {
     flags?: ResponseMatchingFlag[]
   ): Promise<AggregationSettingsResult> {
     const validThreshold = this.normalizeThreshold(threshold);
-    const currentFlags = flags ?? await this.codingJobService.getResponseMatchingMode(workspaceId);
-    const normalizedFlags = this.codingJobService.normalizeResponseMatchingFlags(currentFlags);
+    const currentFlags =
+      flags ??
+      (await this.codingJobService.getResponseMatchingMode(workspaceId));
+    const normalizedFlags =
+      this.codingJobService.normalizeResponseMatchingFlags(currentFlags);
 
     try {
-      await this.codingJobService.setAggregationThreshold(workspaceId, validThreshold);
-      const savedFlags = await this.codingJobService.setResponseMatchingMode(workspaceId, normalizedFlags);
-      const revertedCount = await this.revertMaterializedDuplicateAggregation(workspaceId);
+      await this.codingJobService.setAggregationThreshold(
+        workspaceId,
+        validThreshold
+      );
+      const savedFlags = await this.codingJobService.setResponseMatchingMode(
+        workspaceId,
+        normalizedFlags
+      );
+      const revertedCount =
+        await this.revertMaterializedDuplicateAggregation(workspaceId);
       await this.invalidateAggregationDependentCaches(workspaceId);
 
       return {
         success: true,
         threshold: validThreshold,
         flags: savedFlags,
-        aggregationActive: !savedFlags.includes(ResponseMatchingFlag.NO_AGGREGATION),
+        aggregationActive: !savedFlags.includes(
+          ResponseMatchingFlag.NO_AGGREGATION
+        ),
         revertedResponses: revertedCount,
-        message: revertedCount > 0 ?
-          `Aggregation settings saved. Reverted ${revertedCount} materialized duplicate responses.` :
-          'Aggregation settings saved.'
+        message:
+          revertedCount > 0 ?
+            `Aggregation settings saved. Reverted ${revertedCount} materialized duplicate responses.` :
+            'Aggregation settings saved.'
       };
     } catch (error) {
       this.logger.error(
@@ -357,7 +594,9 @@ export class CodingAnalysisService {
         success: false,
         threshold: validThreshold,
         flags: normalizedFlags,
-        aggregationActive: !normalizedFlags.includes(ResponseMatchingFlag.NO_AGGREGATION),
+        aggregationActive: !normalizedFlags.includes(
+          ResponseMatchingFlag.NO_AGGREGATION
+        ),
         revertedResponses: 0,
         message: `Error saving aggregation settings: ${error.message}`
       };
@@ -379,11 +618,18 @@ export class CodingAnalysisService {
       uniqueCodingCases: number;
       message: string;
     }> {
-    const currentFlags = await this.codingJobService.getResponseMatchingMode(workspaceId);
+    const currentFlags =
+      await this.codingJobService.getResponseMatchingMode(workspaceId);
     const nextFlags = aggregateMode ?
-      currentFlags.filter(flag => flag !== ResponseMatchingFlag.NO_AGGREGATION) :
+      currentFlags.filter(
+        flag => flag !== ResponseMatchingFlag.NO_AGGREGATION
+      ) :
       [ResponseMatchingFlag.NO_AGGREGATION];
-    const result = await this.saveAggregationSettings(workspaceId, threshold, nextFlags);
+    const result = await this.saveAggregationSettings(
+      workspaceId,
+      threshold,
+      nextFlags
+    );
 
     return {
       success: result.success,
@@ -396,7 +642,8 @@ export class CodingAnalysisService {
 
   private createEmptyAnalysisResult(
     matchingFlags: ResponseMatchingFlag[],
-    threshold: number | null = null
+    threshold: number | null = null,
+    sourceRevision?: number
   ): ResponseAnalysisDto {
     const result: ResponseAnalysisDto = {
       emptyResponses: {
@@ -418,26 +665,210 @@ export class CodingAnalysisService {
         matchingFlags
       ),
       matchingFlags: matchingFlags as unknown as string[],
-      analysisTimestamp: new Date().toISOString()
+      analysisTimestamp: new Date().toISOString(),
+      sourceRevision,
+      currentSourceRevision: sourceRevision
     };
 
     return result;
+  }
+
+  private isAnalysisSourceRevisionStale(
+    analysis: Pick<ResponseAnalysisDto, 'sourceRevision'>,
+    currentSourceRevision: number
+  ): boolean {
+    return (
+      analysis.sourceRevision !== undefined &&
+      analysis.sourceRevision !== currentSourceRevision
+    );
+  }
+
+  private async getWorkspaceResultsRevision(
+    workspaceId: number
+  ): Promise<number> {
+    try {
+      const rows = (await this.responseRepository.query(
+        'SELECT revision FROM workspace_test_results_revision WHERE workspace_id = $1',
+        [workspaceId]
+      )) as Array<{ revision: number | string }>;
+      return Number(rows[0]?.revision || 0);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve test result revision for response analysis: ${message}`
+      );
+      return 0;
+    }
   }
 
   /**
    * Invalidates all cached analysis results for a given workspace
    */
   async invalidateCache(workspaceId: number): Promise<void> {
-    this.logger.log(`Invalidating response analysis cache for workspace ${workspaceId}`);
+    this.logger.log(
+      `Invalidating response analysis cache for workspace ${workspaceId}`
+    );
     // "response-analysis:1_*" matches all variations (flags, thresholds) for workspace 1
     const pattern = `${CODING_ANALYSIS_CACHE_KEY_PREFIX}:${workspaceId}_*`;
     await this.cacheService.deleteByPattern(pattern);
   }
 
-  private async invalidateAggregationDependentCaches(workspaceId: number): Promise<void> {
+  private async invalidateAggregationDependentCaches(
+    workspaceId: number
+  ): Promise<void> {
     await this.invalidateCache(workspaceId);
-    await this.codingValidationService.invalidateIncompleteVariablesCache(workspaceId);
+    await this.codingValidationService.invalidateIncompleteVariablesCache(
+      workspaceId
+    );
     await this.codingStatisticsService.invalidateCache(workspaceId);
+  }
+
+  private async writeResponseAnalysisDerivedCaches(
+    cacheKey: string,
+    analysis: ResponseAnalysisDto,
+    emptyPage: number,
+    emptyLimit: number,
+    duplicatePage: number,
+    duplicateLimit: number
+  ): Promise<void> {
+    const writes: Promise<boolean>[] = [
+      this.cacheService.set(
+        getResponseAnalysisSummaryCacheKey(cacheKey),
+        createResponseAnalysisSummaryCache(analysis)
+      ),
+      this.cacheService.set(
+        getResponseAnalysisEmptyPageCacheKey(cacheKey, emptyPage, emptyLimit),
+        createEmptyResponsePageCache(analysis, emptyPage, emptyLimit)
+      ),
+      this.cacheService.set(
+        getResponseAnalysisDuplicatePageCacheKey(
+          cacheKey,
+          duplicatePage,
+          duplicateLimit
+        ),
+        createDuplicateValuePageCache(analysis, duplicatePage, duplicateLimit)
+      )
+    ];
+
+    for (const chunk of createEmptyResponseChunkCaches(analysis)) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisEmptyChunkCacheKey(cacheKey, chunk.chunkIndex),
+          chunk
+        )
+      );
+    }
+
+    for (const chunk of createDuplicateValueChunkCaches(analysis)) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisDuplicateChunkCacheKey(cacheKey, chunk.chunkIndex),
+          chunk
+        )
+      );
+    }
+
+    await Promise.all(writes);
+  }
+
+  private async getResponseAnalysisPageCachesFromChunks(
+    cacheKey: string,
+    emptyPage: number,
+    emptyLimit: number,
+    duplicatePage: number,
+    duplicateLimit: number,
+    summaryCache: ResponseAnalysisSummaryCache
+  ): Promise<{
+      emptyPageCache: EmptyResponsePageCache | null;
+      duplicatePageCache: DuplicateValuePageCache | null;
+    }> {
+    const emptyOutOfRangePageCache =
+      this.createOutOfRangeEmptyResponsePageCache(
+        summaryCache.emptyResponses.total,
+        emptyPage,
+        emptyLimit
+      );
+    const duplicateOutOfRangePageCache =
+      this.createOutOfRangeDuplicateValuePageCache(
+        summaryCache.duplicateValues.total,
+        duplicatePage,
+        duplicateLimit
+      );
+    const emptyChunkIndexes = emptyOutOfRangePageCache ?
+      [] :
+      getRequiredResponseAnalysisChunkIndexes(emptyPage, emptyLimit);
+    const duplicateChunkIndexes = duplicateOutOfRangePageCache ?
+      [] :
+      getRequiredResponseAnalysisChunkIndexes(duplicatePage, duplicateLimit);
+    const emptyChunkReads: Promise<EmptyResponseChunkCache | null>[] = [];
+    for (const chunkIndex of emptyChunkIndexes) {
+      emptyChunkReads.push(
+        this.cacheService.get<EmptyResponseChunkCache>(
+          getResponseAnalysisEmptyChunkCacheKey(cacheKey, chunkIndex)
+        )
+      );
+    }
+
+    const duplicateChunkReads: Promise<DuplicateValueChunkCache | null>[] = [];
+    for (const chunkIndex of duplicateChunkIndexes) {
+      duplicateChunkReads.push(
+        this.cacheService.get<DuplicateValueChunkCache>(
+          getResponseAnalysisDuplicateChunkCacheKey(cacheKey, chunkIndex)
+        )
+      );
+    }
+
+    const [emptyChunks, duplicateChunks] = await Promise.all([
+      Promise.all(emptyChunkReads),
+      Promise.all(duplicateChunkReads)
+    ]);
+
+    if (
+      emptyChunks.some(chunk => chunk === null) ||
+      duplicateChunks.some(chunk => chunk === null)
+    ) {
+      return {
+        emptyPageCache: null,
+        duplicatePageCache: null
+      };
+    }
+
+    return {
+      emptyPageCache:
+        emptyOutOfRangePageCache ??
+        createEmptyResponsePageCacheFromChunks(
+          emptyChunks as EmptyResponseChunkCache[],
+          emptyPage,
+          emptyLimit
+        ),
+      duplicatePageCache:
+        duplicateOutOfRangePageCache ??
+        createDuplicateValuePageCacheFromChunks(
+          duplicateChunks as DuplicateValueChunkCache[],
+          duplicatePage,
+          duplicateLimit
+        )
+    };
+  }
+
+  private createOutOfRangeEmptyResponsePageCache(
+    total: number,
+    page: number,
+    pageSize: number
+  ): EmptyResponsePageCache | null {
+    return (page - 1) * pageSize >= total ?
+      { items: [], page, pageSize } :
+      null;
+  }
+
+  private createOutOfRangeDuplicateValuePageCache(
+    total: number,
+    page: number,
+    pageSize: number
+  ): DuplicateValuePageCache | null {
+    return (page - 1) * pageSize >= total ?
+      { groups: [], page, pageSize } :
+      null;
   }
 
   private getCacheKey(
@@ -456,7 +887,9 @@ export class CodingAnalysisService {
     return Math.min(100, Math.max(2, Math.round(parsed)));
   }
 
-  private async revertMaterializedDuplicateAggregation(workspaceId: number): Promise<number> {
+  private async revertMaterializedDuplicateAggregation(
+    workspaceId: number
+  ): Promise<number> {
     const aggregatedResponses = await this.responseRepository
       .createQueryBuilder('response')
       .select('response.id', 'id')

--- a/apps/backend/src/app/database/services/coding/coding-applied-results-overview-cache-key.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-applied-results-overview-cache-key.util.ts
@@ -1,0 +1,13 @@
+export const getCodingAppliedResultsOverviewCacheKey = (
+  workspaceId: number,
+  testResultsRevision: number,
+  codingRevision: number
+): string => `coding_applied_results_overview:${workspaceId}:r${testResultsRevision}:c${codingRevision}`;
+
+export const getCodingAppliedResultsOverviewCachePattern = (
+  workspaceId: number
+): string => `coding_applied_results_overview:${workspaceId}:*`;
+
+export const getCodingAppliedResultsOverviewVersionKey = (
+  workspaceId: number
+): string => `coding_applied_results_overview:version:${workspaceId}`;

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -99,7 +99,11 @@ describe('CodingJobService', () => {
   let fileUploadRepository: ReturnType<typeof createRepo>;
   let settingRepository: ReturnType<typeof createRepo>;
   let connection: { transaction: jest.Mock };
-  let cacheService: { delete: jest.Mock };
+  let cacheService: {
+    delete: jest.Mock;
+    incr: jest.Mock;
+    deleteByPattern: jest.Mock;
+  };
   let codingFreshnessService: { reconcileAppliedManualCodingJobs: jest.Mock };
   let codingFileCacheService: { getVariablePageMap: jest.Mock };
   let missingsProfilesService: {
@@ -198,7 +202,11 @@ describe('CodingJobService', () => {
       })
       )
     };
-    cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
     jobDefinitionRepository.createQueryBuilder.mockReturnValue({
       setLock: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
@@ -1756,6 +1764,12 @@ describe('CodingJobService', () => {
     );
     expect(cacheService.delete).toHaveBeenCalledWith(
       'coding_incomplete_variables_v8:7'
+    );
+    expect(cacheService.incr).toHaveBeenCalledWith(
+      'coding_applied_results_overview:version:7'
+    );
+    expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+      'coding_applied_results_overview:7:*'
     );
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -69,6 +69,10 @@ import {
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
 import { CodingFreshnessService } from './coding-freshness.service';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 import { CodingFileCacheService } from './coding-file-cache.service';
 import { CodingReplayAnchorService } from './coding-replay-anchor.service';
 import {
@@ -2940,9 +2944,17 @@ export class CodingJobService {
     workspaceId: number
   ): Promise<void> {
     const cacheKey = getCodingIncompleteVariablesCacheKey(workspaceId);
-    await this.cacheService.delete(cacheKey);
+    await Promise.all([
+      this.cacheService.delete(cacheKey),
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspaceId)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspaceId)
+      )
+    ]);
     this.logger.log(
-      `Invalidated manual coding variables cache for workspace ${workspaceId}`
+      `Invalidated manual coding variables and applied results overview cache for workspace ${workspaceId}`
     );
   }
 
@@ -3267,22 +3279,16 @@ export class CodingJobService {
       })
       .andWhere('person.consider = :consider', { consider: true });
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    allVariables.forEach((variable, index) => {
-      const unitParam = `unitName${index}`;
-      const variableParam = `variableId${index}`;
-      conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unit_name;
-      parameters[variableParam] = variable.variable_id;
-    });
-
-    if (conditions.length > 0) {
-      queryBuilder.andWhere(`(${conditions.join(' OR ')})`, parameters);
-    }
+    this.applyVariablePairFilter(
+      queryBuilder,
+      allVariables.map(variable => ({
+        unitName: variable.unit_name,
+        variableId: variable.variable_id
+      })),
+      'unit.name',
+      'response.variableid',
+      'codingJobResponses'
+    );
 
     // Exclude aggregated duplicates (marked with code_v2 = -111)
     queryBuilder.andWhere(
@@ -4906,20 +4912,16 @@ export class CodingJobService {
       .andWhere('person.consider = :consider', { consider: true });
     this.applyManualCodingCandidateStatusFilter(queryBuilder);
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    allVariables.forEach((variable, index) => {
-      const unitParam = `cjUnitName${index}`;
-      const variableParam = `cjVariableId${index}`;
-      conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unit_name;
-      parameters[variableParam] = variable.variable_id;
-    });
-
-    queryBuilder.andWhere(`(${conditions.join(' OR ')})`, parameters);
+    this.applyVariablePairFilter(
+      queryBuilder,
+      allVariables.map(variable => ({
+        unitName: variable.unit_name,
+        variableId: variable.variable_id
+      })),
+      'unit.name',
+      'response.variableid',
+      'codingJobSlimResponses'
+    );
     queryBuilder.andWhere(
       '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
       {
@@ -5693,22 +5695,13 @@ export class CodingJobService {
       );
     applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `unitName${index}`;
-      const variableParam = `variableId${index}`;
-      conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    if (conditions.length > 0) {
-      queryBuilder.andWhere(`(${conditions.join(' OR ')})`, parameters);
-    }
+    this.applyVariablePairFilter(
+      queryBuilder,
+      variables,
+      'unit.name',
+      'response.variableid',
+      'responsesForVariables'
+    );
 
     return queryBuilder.orderBy('response.id', 'ASC').getMany();
   }
@@ -5760,22 +5753,13 @@ export class CodingJobService {
       );
     applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `slimUnitName${index}`;
-      const variableParam = `slimVariableId${index}`;
-      conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    if (conditions.length > 0) {
-      queryBuilder.andWhere(`(${conditions.join(' OR ')})`, parameters);
-    }
+    this.applyVariablePairFilter(
+      queryBuilder,
+      variables,
+      'unit.name',
+      'response.variableid',
+      'slimResponsesForVariables'
+    );
 
     const raw = await queryBuilder.orderBy('response.id', 'ASC').getRawMany();
 
@@ -5831,20 +5815,11 @@ export class CodingJobService {
       );
     }
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `assignedUnitName${index}`;
-      const variableParam = `assignedVariableId${index}`;
-      conditions.push(
-        `(cju.unit_name = :${unitParam} AND cju.variable_id = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    query.andWhere(`(${conditions.join(' OR ')})`, parameters);
+    this.applyCodingJobUnitVariablePairFilter(
+      query,
+      variables,
+      'assignedResponseIdsForVariables'
+    );
     await this.applyCodingJobUnitExclusions(
       query,
       workspaceId,
@@ -5856,6 +5831,56 @@ export class CodingJobService {
       rawResults
         .map(row => Number(row.responseId))
         .filter(responseId => Number.isFinite(responseId))
+    );
+  }
+
+  private applyVariablePairFilter(
+    queryBuilder: SelectQueryBuilder<ResponseEntity>,
+    variables: VariableReference[],
+    unitColumn: string,
+    variableColumn: string,
+    parameterPrefix: string
+  ): void {
+    if (variables.length === 0) {
+      return;
+    }
+
+    const parameters: Record<string, string> = {};
+    const pairs = variables.map((variable, index) => {
+      const unitParam = `${parameterPrefix}UnitName${index}`;
+      const variableParam = `${parameterPrefix}VariableId${index}`;
+      parameters[unitParam] = variable.unitName;
+      parameters[variableParam] = variable.variableId;
+      return `(:${unitParam}, :${variableParam})`;
+    });
+
+    queryBuilder.andWhere(
+      `(${unitColumn}, ${variableColumn}) IN (${pairs.join(', ')})`,
+      parameters
+    );
+  }
+
+  private applyCodingJobUnitVariablePairFilter(
+    queryBuilder: SelectQueryBuilder<CodingJobUnit>,
+    variables: VariableReference[],
+    parameterPrefix: string
+  ): void {
+    if (variables.length === 0) {
+      return;
+    }
+
+    const parameters: Record<string, string> = {};
+    const pairs = variables.map((variable, index) => {
+      const unitParam = `${parameterPrefix}UnitName${index}`;
+      const variableParam = `${parameterPrefix}VariableId${index}`;
+      parameters[unitParam] = variable.unitName;
+      parameters[variableParam] = variable.variableId;
+      return `(:${unitParam}, :${variableParam})`;
+    });
+
+    queryBuilder.andWhere(
+      `(cju.unit_name, cju.variable_id) IN (${pairs.join(', ')})`,
+      parameters
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -10,8 +10,19 @@ jest.mock('../workspace/workspace-files.service', () => ({
 const createRepository = () => ({
   createQueryBuilder: jest.fn(),
   find: jest.fn(),
-  findOne: jest.fn()
+  findOne: jest.fn(),
+  query: jest.fn().mockResolvedValue([])
 });
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
 
 type MockQueryBuilder = Record<string, jest.Mock> & {
   subQueryProbes: Record<string, jest.Mock>[];
@@ -67,26 +78,47 @@ const createQueryBuilder = (rawResults: unknown[] = []) => {
     'orderBy'
   ].forEach(method => {
     queryBuilder[method] = jest.fn((condition?: unknown) => {
+      if (method === 'leftJoin' && typeof condition === 'function') {
+        condition(createSubQueryProbe(queryBuilder));
+      }
       executeBrackets(condition, queryBuilder);
       return queryBuilder;
     });
   });
   queryBuilder.getRawMany = jest.fn().mockResolvedValue(rawResults);
+  queryBuilder.getRawOne = jest.fn().mockResolvedValue({
+    count: rawResults.length.toString()
+  });
   queryBuilder.getCount = jest.fn().mockResolvedValue(0);
   return queryBuilder;
 };
 
 const expectProductiveManualPoolExists = (queryBuilder: MockQueryBuilder) => {
-  expect(queryBuilder.subQueryProbes).toHaveLength(1);
-  const [existsBuilder] = queryBuilder.subQueryProbes;
-  expect(existsBuilder.from).toHaveBeenCalledWith('coding_job_unit', 'manual_cju');
-  expect(existsBuilder.innerJoin).toHaveBeenCalledWith(
+  const assignedResponsesBuilder = queryBuilder.subQueryProbes.find(
+    probe => probe.select.mock.calls.some(
+      call => call[0] === 'DISTINCT manual_cju.response_id'
+    )
+  );
+  expect(assignedResponsesBuilder).toBeDefined();
+  expect(assignedResponsesBuilder.select).toHaveBeenCalledWith(
+    'DISTINCT manual_cju.response_id',
+    'response_id'
+  );
+  expect(assignedResponsesBuilder.from).toHaveBeenCalledWith(
+    'coding_job_unit',
+    'manual_cju'
+  );
+  expect(assignedResponsesBuilder.innerJoin).toHaveBeenCalledWith(
     'coding_job',
     'manual_cj',
     'manual_cj.id = manual_cju.coding_job_id'
   );
-  expect(existsBuilder.where).toHaveBeenCalledWith('manual_cju.response_id = response.id');
-  expect(existsBuilder.andWhere).toHaveBeenCalledWith('manual_cj.training_id IS NULL');
+  expect(assignedResponsesBuilder.where).toHaveBeenCalledWith(
+    'manual_cj.training_id IS NULL'
+  );
+  expect(assignedResponsesBuilder.andWhere).toHaveBeenCalledWith(
+    expect.stringContaining('coding_issue_review')
+  );
 };
 
 describe('CodingProgressService variable coverage conflicts', () => {
@@ -102,6 +134,15 @@ describe('CodingProgressService variable coverage conflicts', () => {
     getManualInstructionVariableMap: jest.Mock;
   };
   let service: CodingProgressService;
+
+  const mockCoverageResponseCounts = (...counts: number[]) => {
+    responseRepository.query.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT COUNT(response.id) AS count')) {
+        return Promise.resolve([{ count: String(counts.shift() ?? 0) }]);
+      }
+      return Promise.resolve([]);
+    });
+  };
 
   beforeEach(() => {
     responseRepository = createRepository();
@@ -139,6 +180,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
   it('keeps covered source responses in status totals but excludes them from progress totals', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    mockCoverageResponseCounts(3);
 
     responseRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([
       {
@@ -201,6 +243,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
   it('does not let unassigned pre-coded derived responses cover source responses in manual totals', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    mockCoverageResponseCounts(3, 3);
     const allResponses = [
       {
         responseId: '100',
@@ -233,9 +276,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
     const manualPoolResponses = allResponses.slice(1);
 
     responseRepository.createQueryBuilder
-      .mockReturnValueOnce(createQueryBuilder(allResponses))
       .mockReturnValueOnce(createQueryBuilder(manualPoolResponses))
-      .mockReturnValueOnce(createQueryBuilder(allResponses))
       .mockReturnValueOnce(createQueryBuilder(manualPoolResponses));
     codingJobUnitRepository.createQueryBuilder
       .mockReturnValueOnce(createQueryBuilder([]))
@@ -281,6 +322,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
     const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
+    mockCoverageResponseCounts(2);
     const responses = [
       {
         responseId: '100',
@@ -303,7 +345,6 @@ describe('CodingProgressService variable coverage conflicts', () => {
     ];
 
     responseRepository.createQueryBuilder
-      .mockReturnValueOnce(createQueryBuilder(responses))
       .mockReturnValueOnce(createQueryBuilder(responses));
     settingRepository.findOne.mockResolvedValue({ content: 'disabled' });
     workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
@@ -326,15 +367,287 @@ describe('CodingProgressService variable coverage conflicts', () => {
     });
   });
 
-  it('limits manual pool existence checks to non-training coding jobs', async () => {
-    const allResponsesQuery = createQueryBuilder([]);
-    const manualPoolQuery = createQueryBuilder([]);
-    const variableCoverageQuery = createQueryBuilder([]);
+  it('returns cached applied result overview by test results revision', async () => {
+    const cachedOverview = {
+      totalIncompleteResponses: 2,
+      appliedResponses: 1,
+      remainingResponses: 1,
+      completionPercentage: 50,
+      rawTotalIncompleteResponses: 2,
+      rawAppliedResponses: 1,
+      rawCompletionPercentage: 50,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0,
+      statusTotalIncompleteResponses: 2,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0,
+      deriveErrorTotalResponses: 0,
+      deriveErrorAppliedResponses: 0,
+      deriveErrorRemainingResponses: 0,
+      deriveErrorRawTotalResponses: 0,
+      deriveErrorRawAppliedResponses: 0
+    };
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(cachedOverview),
+      set: jest.fn(),
+      getNumber: jest.fn().mockResolvedValue(3),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
+    };
+    responseRepository.query.mockResolvedValue([{ revision: 9 }]);
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
 
-    responseRepository.createQueryBuilder
-      .mockReturnValueOnce(allResponsesQuery)
-      .mockReturnValueOnce(manualPoolQuery)
-      .mockReturnValueOnce(variableCoverageQuery);
+    const result = await cachedService.getAppliedResultsOverview(5);
+
+    expect(result).toBe(cachedOverview);
+    expect(cacheService.get).toHaveBeenCalledWith(
+      'coding_applied_results_overview:5:r9:c3'
+    );
+    expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('reuses an in-flight applied result overview query for the same revision', async () => {
+    const overview = {
+      totalIncompleteResponses: 1,
+      appliedResponses: 0,
+      remainingResponses: 1,
+      completionPercentage: 0,
+      rawTotalIncompleteResponses: 1,
+      rawAppliedResponses: 0,
+      rawCompletionPercentage: 0,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0,
+      statusTotalIncompleteResponses: 1,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0,
+      deriveErrorTotalResponses: 0,
+      deriveErrorAppliedResponses: 0,
+      deriveErrorRemainingResponses: 0,
+      deriveErrorRawTotalResponses: 0,
+      deriveErrorRawAppliedResponses: 0
+    };
+    const overviewDeferred = createDeferred<typeof overview>();
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+      getNumber: jest.fn().mockResolvedValue(4),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
+    };
+    responseRepository.query.mockResolvedValue([{ revision: 10 }]);
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
+    const internals = cachedService as unknown as {
+      computeAndCacheAppliedResultsOverview: (
+        workspaceId: number,
+        testResultsRevision: number,
+        codingRevision: number,
+        cacheKey: string
+      ) => Promise<typeof overview>;
+    };
+    const computeSpy = jest
+      .spyOn(internals, 'computeAndCacheAppliedResultsOverview')
+      .mockReturnValue(overviewDeferred.promise);
+
+    const firstRequest = cachedService.getAppliedResultsOverview(5);
+    const secondRequest = cachedService.getAppliedResultsOverview(5);
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+
+    expect(computeSpy).toHaveBeenCalledTimes(1);
+    expect(computeSpy).toHaveBeenCalledWith(
+      5,
+      10,
+      4,
+      'coding_applied_results_overview:5:r10:c4'
+    );
+
+    overviewDeferred.resolve(overview);
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual(
+      [overview, overview]
+    );
+  });
+
+  it('does not cache stale applied result overview when revision changes while computing', async () => {
+    const overview = {
+      totalIncompleteResponses: 1,
+      appliedResponses: 1,
+      remainingResponses: 0,
+      completionPercentage: 100,
+      rawTotalIncompleteResponses: 1,
+      rawAppliedResponses: 1,
+      rawCompletionPercentage: 100,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0,
+      statusTotalIncompleteResponses: 1,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0,
+      deriveErrorTotalResponses: 0,
+      deriveErrorAppliedResponses: 0,
+      deriveErrorRemainingResponses: 0,
+      deriveErrorRawTotalResponses: 0,
+      deriveErrorRawAppliedResponses: 0
+    };
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+      getNumber: jest.fn().mockResolvedValue(0),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
+    };
+    responseRepository.query
+      .mockResolvedValueOnce([{ revision: 11 }])
+      .mockResolvedValueOnce([{ revision: 12 }]);
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
+    const internals = cachedService as unknown as {
+      computeAppliedResultsOverview: (
+        workspaceId: number
+      ) => Promise<typeof overview>;
+    };
+    jest
+      .spyOn(internals, 'computeAppliedResultsOverview')
+      .mockResolvedValue(overview);
+
+    await cachedService.getAppliedResultsOverview(5);
+
+    expect(cacheService.set).not.toHaveBeenCalledWith(
+      'coding_applied_results_overview:5:r11:c0',
+      expect.anything(),
+      0
+    );
+  });
+
+  it('does not cache stale applied result overview when coding revision changes while computing', async () => {
+    const overview = {
+      totalIncompleteResponses: 1,
+      appliedResponses: 1,
+      remainingResponses: 0,
+      completionPercentage: 100,
+      rawTotalIncompleteResponses: 1,
+      rawAppliedResponses: 1,
+      rawCompletionPercentage: 100,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0,
+      statusTotalIncompleteResponses: 1,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0,
+      deriveErrorTotalResponses: 0,
+      deriveErrorAppliedResponses: 0,
+      deriveErrorRemainingResponses: 0,
+      deriveErrorRawTotalResponses: 0,
+      deriveErrorRawAppliedResponses: 0
+    };
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+      getNumber: jest.fn()
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(3),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
+    };
+    responseRepository.query.mockResolvedValue([{ revision: 11 }]);
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
+    const internals = cachedService as unknown as {
+      computeAppliedResultsOverview: (
+        workspaceId: number
+      ) => Promise<typeof overview>;
+    };
+    jest
+      .spyOn(internals, 'computeAppliedResultsOverview')
+      .mockResolvedValue(overview);
+
+    await cachedService.getAppliedResultsOverview(5);
+
+    expect(cacheService.set).not.toHaveBeenCalledWith(
+      'coding_applied_results_overview:5:r11:c2',
+      expect.anything(),
+      0
+    );
+  });
+
+  it('invalidates applied result overview keys and bumps the coding revision', async () => {
+    const cacheService = {
+      get: jest.fn(),
+      set: jest.fn(),
+      getNumber: jest.fn(),
+      incr: jest.fn().mockResolvedValue(8),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
+
+    await cachedService.invalidateAppliedResultsOverviewCache(5);
+
+    expect(cacheService.incr).toHaveBeenCalledWith(
+      'coding_applied_results_overview:version:5'
+    );
+    expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+      'coding_applied_results_overview:5:*'
+    );
+  });
+
+  it('limits manual pool existence checks to non-training coding jobs', async () => {
+    mockCoverageResponseCounts(0);
+    const responseQueries: MockQueryBuilder[] = [];
+    responseRepository.createQueryBuilder.mockImplementation(() => {
+      const query = createQueryBuilder([]);
+      responseQueries.push(query);
+      return query;
+    });
     codingJobUnitRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([]));
     settingRepository.findOne.mockResolvedValue({ content: 'disabled' });
     jobDefinitionRepository.find.mockResolvedValue([]);
@@ -342,13 +655,17 @@ describe('CodingProgressService variable coverage conflicts', () => {
     await service.getCodingProgressOverview(5);
     await service.getVariableCoverageOverview(5);
 
-    expectProductiveManualPoolExists(manualPoolQuery);
-    expectProductiveManualPoolExists(variableCoverageQuery);
+    const manualPoolQueries = responseQueries.filter(query => query.subQueryProbes.some(probe => probe.select.mock.calls.some(
+      call => call[0] === 'DISTINCT manual_cju.response_id'
+    )));
+    expect(manualPoolQueries.length).toBeGreaterThanOrEqual(1);
+    manualPoolQueries.forEach(expectProductiveManualPoolExists);
   });
 
   it('excludes covered source responses from case coverage while preserving status totals', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    mockCoverageResponseCounts(3);
 
     responseRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([
       {
@@ -523,6 +840,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
   it('excludes intended-incomplete variables without manual instructions from case coverage', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    mockCoverageResponseCounts(2);
     const responses = [
       {
         responseId: '100',
@@ -545,7 +863,6 @@ describe('CodingProgressService variable coverage conflicts', () => {
     ];
 
     responseRepository.createQueryBuilder
-      .mockReturnValueOnce(createQueryBuilder(responses))
       .mockReturnValueOnce(createQueryBuilder(responses));
     codingJobUnitRepository.createQueryBuilder
       .mockReturnValueOnce(createQueryBuilder([]))

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -12,6 +12,9 @@ import { Setting } from '../../entities/setting.entity';
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import {
   applyResolvedExclusionsToQuery,
+  normalizeExclusionBookletId,
+  normalizeExclusionUnitId,
+  ResolvedWorkspaceExclusions,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
 import {
@@ -32,6 +35,12 @@ import {
   applyNonCodingIssueReviewJobFilter,
   getNonCodingIssueReviewJobSqlCondition
 } from './coding-job-type.util';
+import { CacheService } from '../../../cache/cache.service';
+import {
+  getCodingAppliedResultsOverviewCacheKey,
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 
 type ResponseMatchingFlag =
   | 'NO_AGGREGATION'
@@ -53,7 +62,7 @@ interface CoverageResponse {
 }
 
 interface CoverageResponseScope {
-  allResponses: CoverageResponse[];
+  statusTotalResponseCount: number;
   manualResponses: CoverageResponse[];
   excludedSourceSummary: ManualCodingExcludedSourceSummary;
 }
@@ -81,6 +90,27 @@ interface EffectiveVariableCaseCoverage {
 }
 
 interface DeriveErrorManualProgress {
+  deriveErrorTotalResponses: number;
+  deriveErrorAppliedResponses: number;
+  deriveErrorRemainingResponses: number;
+  deriveErrorRawTotalResponses: number;
+  deriveErrorRawAppliedResponses: number;
+}
+
+interface AppliedResultsOverview {
+  totalIncompleteResponses: number;
+  appliedResponses: number;
+  remainingResponses: number;
+  completionPercentage: number;
+  rawTotalIncompleteResponses: number;
+  rawAppliedResponses: number;
+  rawCompletionPercentage: number;
+  aggregationActive: boolean;
+  aggregationThreshold: number | null;
+  aggregatedDuplicateCases: number;
+  statusTotalIncompleteResponses: number;
+  coveredSourceVariableCount: number;
+  coveredSourceResponseCount: number;
   deriveErrorTotalResponses: number;
   deriveErrorAppliedResponses: number;
   deriveErrorRemainingResponses: number;
@@ -123,6 +153,15 @@ interface ManualCodingVariableLookups {
 @Injectable()
 export class CodingProgressService {
   private readonly logger = new Logger(CodingProgressService.name);
+  private readonly appliedResultsOverviewInFlight = new Map<
+  string,
+  Promise<AppliedResultsOverview>
+  >();
+
+  private readonly appliedResultsOverviewPrewarmTimers = new Map<
+  number,
+  NodeJS.Timeout
+  >();
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -138,7 +177,9 @@ export class CodingProgressService {
     private workspaceFilesService: WorkspaceFilesService,
     private workspaceExclusionService: WorkspaceExclusionService,
     @Optional()
-    private missingsProfilesService?: MissingsProfilesService
+    private missingsProfilesService?: MissingsProfilesService,
+    @Optional()
+    private cacheService?: CacheService
   ) { }
 
   private async getDefaultMirCode(workspaceId: number): Promise<number> {
@@ -152,6 +193,112 @@ export class CodingProgressService {
       'mir'
     );
     return missing.code;
+  }
+
+  private async createAppliedResultsOverviewCacheKey(
+    workspaceId: number
+  ): Promise<string> {
+    const [testResultsRevision, codingRevision] = await Promise.all([
+      this.resolveTestResultsRevision(workspaceId),
+      this.resolveAppliedResultsOverviewRevision(workspaceId)
+    ]);
+    return this.getAppliedResultsOverviewCacheKey(
+      workspaceId,
+      testResultsRevision,
+      codingRevision
+    );
+  }
+
+  private getAppliedResultsOverviewCacheKey(
+    workspaceId: number,
+    testResultsRevision: number,
+    codingRevision: number
+  ): string {
+    return getCodingAppliedResultsOverviewCacheKey(
+      workspaceId,
+      testResultsRevision,
+      codingRevision
+    );
+  }
+
+  async invalidateAppliedResultsOverviewCache(
+    workspaceId: number,
+    options: { prewarm?: boolean } = {}
+  ): Promise<void> {
+    if (!this.cacheService) {
+      return;
+    }
+
+    this.dropAppliedResultsOverviewInFlight(workspaceId);
+    await Promise.all([
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspaceId)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspaceId)
+      )
+    ]);
+
+    if (options.prewarm) {
+      this.scheduleAppliedResultsOverviewPrewarm(workspaceId);
+    }
+  }
+
+  private dropAppliedResultsOverviewInFlight(workspaceId: number): void {
+    const prefix = `coding_applied_results_overview:${workspaceId}:`;
+    Array.from(this.appliedResultsOverviewInFlight.keys())
+      .filter(cacheKey => cacheKey.startsWith(prefix))
+      .forEach(cacheKey => this.appliedResultsOverviewInFlight.delete(cacheKey));
+  }
+
+  private scheduleAppliedResultsOverviewPrewarm(workspaceId: number): void {
+    if (!this.cacheService || process.env.NODE_ENV === 'test') {
+      return;
+    }
+
+    const existingTimer = this.appliedResultsOverviewPrewarmTimers.get(workspaceId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
+    const timer = setTimeout(() => {
+      this.appliedResultsOverviewPrewarmTimers.delete(workspaceId);
+      this.getAppliedResultsOverview(workspaceId).catch(error => {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `Could not prewarm applied results overview for workspace ${workspaceId}: ${message}`
+        );
+      });
+    }, 500);
+
+    timer.unref?.();
+    this.appliedResultsOverviewPrewarmTimers.set(workspaceId, timer);
+  }
+
+  private async resolveTestResultsRevision(workspaceId: number): Promise<number> {
+    try {
+      const rows = (await this.responseRepository.query(
+        'SELECT revision FROM workspace_test_results_revision WHERE workspace_id = $1',
+        [workspaceId]
+      )) as Array<{ revision: number | string }>;
+      return Number(rows[0]?.revision || 0);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve test result revision for applied results overview cache: ${message}`
+      );
+      return 0;
+    }
+  }
+
+  private async resolveAppliedResultsOverviewRevision(workspaceId: number): Promise<number> {
+    if (!this.cacheService) {
+      return 0;
+    }
+    return this.cacheService.getNumber(
+      getCodingAppliedResultsOverviewVersionKey(workspaceId),
+      0
+    );
   }
 
   async getCodingProgressOverview(workspaceId: number): Promise<{
@@ -200,7 +347,7 @@ export class CodingProgressService {
       aggregationActive: effectiveProgress.aggregationActive,
       aggregationThreshold: effectiveProgress.aggregationThreshold,
       aggregatedDuplicateCases: effectiveProgress.aggregatedDuplicateCases,
-      statusTotalCasesToCode: responseScope.allResponses.length,
+      statusTotalCasesToCode: responseScope.statusTotalResponseCount,
       coveredSourceVariableCount:
         responseScope.excludedSourceSummary.coveredSourceVariableCount,
       coveredSourceResponseCount:
@@ -208,26 +355,77 @@ export class CodingProgressService {
     };
   }
 
-  async getAppliedResultsOverview(workspaceId: number): Promise<{
-    totalIncompleteResponses: number;
-    appliedResponses: number;
-    remainingResponses: number;
-    completionPercentage: number;
-    rawTotalIncompleteResponses: number;
-    rawAppliedResponses: number;
-    rawCompletionPercentage: number;
-    aggregationActive: boolean;
-    aggregationThreshold: number | null;
-    aggregatedDuplicateCases: number;
-    statusTotalIncompleteResponses: number;
-    coveredSourceVariableCount: number;
-    coveredSourceResponseCount: number;
-    deriveErrorTotalResponses: number;
-    deriveErrorAppliedResponses: number;
-    deriveErrorRemainingResponses: number;
-    deriveErrorRawTotalResponses: number;
-    deriveErrorRawAppliedResponses: number;
-  }> {
+  async getAppliedResultsOverview(workspaceId: number): Promise<AppliedResultsOverview> {
+    if (!this.cacheService) {
+      return this.computeAppliedResultsOverview(workspaceId);
+    }
+
+    const [testResultsRevision, codingRevision] = await Promise.all([
+      this.resolveTestResultsRevision(workspaceId),
+      this.resolveAppliedResultsOverviewRevision(workspaceId)
+    ]);
+    const cacheKey = this.getAppliedResultsOverviewCacheKey(
+      workspaceId,
+      testResultsRevision,
+      codingRevision
+    );
+    const cached = await this.cacheService.get<AppliedResultsOverview>(
+      cacheKey
+    );
+    if (cached) {
+      return cached;
+    }
+
+    const inFlightOverview = this.appliedResultsOverviewInFlight.get(cacheKey);
+    if (inFlightOverview) {
+      return inFlightOverview;
+    }
+
+    const overviewPromise = this.computeAndCacheAppliedResultsOverview(
+      workspaceId,
+      testResultsRevision,
+      codingRevision,
+      cacheKey
+    );
+    this.appliedResultsOverviewInFlight.set(cacheKey, overviewPromise);
+    try {
+      return await overviewPromise;
+    } finally {
+      if (this.appliedResultsOverviewInFlight.get(cacheKey) === overviewPromise) {
+        this.appliedResultsOverviewInFlight.delete(cacheKey);
+      }
+    }
+  }
+
+  private async computeAndCacheAppliedResultsOverview(
+    workspaceId: number,
+    testResultsRevision: number,
+    codingRevision: number,
+    cacheKey: string
+  ): Promise<AppliedResultsOverview> {
+    const overview = await this.computeAppliedResultsOverview(workspaceId);
+    const [currentTestResultsRevision, currentCodingRevision] = await Promise.all([
+      this.resolveTestResultsRevision(workspaceId),
+      this.resolveAppliedResultsOverviewRevision(workspaceId)
+    ]);
+    if (
+      currentTestResultsRevision === testResultsRevision &&
+      currentCodingRevision === codingRevision
+    ) {
+      await this.cacheService?.set(cacheKey, overview, 0);
+    } else {
+      this.logger.log(
+        `Skipped caching stale applied results overview for workspace ${workspaceId} ` +
+        `(planned test revision ${testResultsRevision}, current test revision ${currentTestResultsRevision}; ` +
+        `planned coding revision ${codingRevision}, current coding revision ${currentCodingRevision})`
+      );
+    }
+    return overview;
+  }
+
+  private async computeAppliedResultsOverview(
+    workspaceId: number
+  ): Promise<AppliedResultsOverview> {
     const responseScope = await this.getCoverageResponseScope(workspaceId);
     const responses = responseScope.manualResponses;
     const appliedResponseIds = new Set(
@@ -252,7 +450,7 @@ export class CodingProgressService {
       appliedResponseIds
     );
 
-    return {
+    const overview = {
       totalIncompleteResponses: effectiveProgress.effectiveTotalCasesToCode,
       appliedResponses: effectiveProgress.effectiveCompletedCases,
       remainingResponses: Math.max(
@@ -266,13 +464,14 @@ export class CodingProgressService {
       aggregationActive: effectiveProgress.aggregationActive,
       aggregationThreshold: effectiveProgress.aggregationThreshold,
       aggregatedDuplicateCases: effectiveProgress.aggregatedDuplicateCases,
-      statusTotalIncompleteResponses: responseScope.allResponses.length,
+      statusTotalIncompleteResponses: responseScope.statusTotalResponseCount,
       coveredSourceVariableCount:
         responseScope.excludedSourceSummary.coveredSourceVariableCount,
       coveredSourceResponseCount:
         responseScope.excludedSourceSummary.coveredSourceResponseCount,
       ...deriveErrorProgress
     };
+    return overview;
   }
 
   async getCaseCoverageOverview(workspaceId: number): Promise<{
@@ -334,7 +533,7 @@ export class CodingProgressService {
       aggregationActive: effectiveCoverage.aggregationActive,
       aggregationThreshold: effectiveCoverage.aggregationThreshold,
       aggregatedDuplicateCases: effectiveCoverage.aggregatedDuplicateCases,
-      statusTotalCasesToCode: responseScope.allResponses.length,
+      statusTotalCasesToCode: responseScope.statusTotalResponseCount,
       coveredSourceVariableCount:
         responseScope.excludedSourceSummary.coveredSourceVariableCount,
       coveredSourceResponseCount:
@@ -366,8 +565,8 @@ export class CodingProgressService {
   }
 
   private async getCoverageResponseScope(workspaceId: number): Promise<CoverageResponseScope> {
-    const [allResponses, manualPoolResponses] = await Promise.all([
-      this.getCoverageResponses(workspaceId),
+    const [statusTotalResponseCount, manualPoolResponses] = await Promise.all([
+      this.getCoverageResponseCount(workspaceId),
       this.getCoverageResponses(workspaceId, true)
     ]);
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
@@ -417,7 +616,7 @@ export class CodingProgressService {
     );
 
     return {
-      allResponses,
+      statusTotalResponseCount,
       manualResponses,
       excludedSourceSummary
     };
@@ -568,25 +767,27 @@ export class CodingProgressService {
       .leftJoin('booklet.bookletinfo', 'bookletinfo')
       .leftJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('person.consider = :consider', { consider: true })
-      .orderBy('response.id', 'ASC');
+      .andWhere('person.consider = :consider', { consider: true });
     this.applyManualProgressStatusFilter(query, 'andWhere');
 
     if (manualPoolOnly) {
+      query.leftJoin(
+        subQuery => subQuery
+          .select('DISTINCT manual_cju.response_id', 'response_id')
+          .from('coding_job_unit', 'manual_cju')
+          .innerJoin(
+            'coding_job',
+            'manual_cj',
+            'manual_cj.id = manual_cju.coding_job_id'
+          )
+          .where('manual_cj.training_id IS NULL')
+          .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj')),
+        'assigned_manual_response',
+        'assigned_manual_response.response_id = response.id'
+      );
       query.andWhere(new Brackets(qb => {
         qb.where('response.code_v2 IS NULL')
-          .orWhere(subQuery => {
-            const exists = subQuery
-              .subQuery()
-              .select('1')
-              .from('coding_job_unit', 'manual_cju')
-              .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
-              .where('manual_cju.response_id = response.id')
-              .andWhere('manual_cj.training_id IS NULL')
-              .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
-              .getQuery();
-            return `EXISTS (${exists})`;
-          });
+          .orWhere('assigned_manual_response.response_id IS NOT NULL');
       }));
     } else {
       query.andWhere(
@@ -619,6 +820,108 @@ export class CodingProgressService {
       personCode: row.personCode ?? '',
       personGroup: row.personGroup ?? ''
     }));
+  }
+
+  private async getCoverageResponseCount(workspaceId: number): Promise<number> {
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
+    const params: unknown[] = [
+      workspaceId,
+      true,
+      statusStringToNumber('CODING_INCOMPLETE'),
+      statusStringToNumber('INTENDED_INCOMPLETE'),
+      statusStringToNumber('DERIVE_ERROR'),
+      -111,
+      defaultMirCode
+    ];
+    const exclusionSql = this.buildCoverageResponseCountExclusionSql(
+      exclusions,
+      params
+    );
+    const rows = await this.responseRepository.query(
+      `
+        WITH scoped_units AS MATERIALIZED (
+          SELECT unit.id
+          FROM persons person
+          INNER JOIN booklet booklet
+            ON booklet.personid = person.id
+          INNER JOIN unit unit
+            ON unit.bookletid = booklet.id
+          LEFT JOIN bookletinfo bookletinfo
+            ON bookletinfo.id = booklet.infoid
+          WHERE person.workspace_id = $1
+            AND person.consider = $2
+            ${exclusionSql}
+        ),
+        manual_derive_responses AS MATERIALIZED (
+          SELECT DISTINCT manual_derive_cju.response_id
+          FROM coding_job_unit manual_derive_cju
+          INNER JOIN coding_job manual_derive_cj
+            ON manual_derive_cj.id = manual_derive_cju.coding_job_id
+          WHERE manual_derive_cj.training_id IS NULL
+            AND ${getNonCodingIssueReviewJobSqlCondition('manual_derive_cj')}
+        )
+        SELECT COUNT(response.id) AS count
+        FROM scoped_units
+        INNER JOIN response response
+          ON response.unitid = scoped_units.id
+        LEFT JOIN manual_derive_responses
+          ON manual_derive_responses.response_id = response.id
+        WHERE (
+          response.status_v1 IN ($3, $4)
+          OR (
+            response.status_v1 = $5
+            AND manual_derive_responses.response_id IS NOT NULL
+          )
+        )
+          AND (
+            response.code_v2 IS NULL
+            OR (response.code_v2 != $6 AND response.code_v2 != $7)
+          )
+      `,
+      params
+    ) as Array<{ count?: number | string }>;
+    return Number(rows[0]?.count || 0);
+  }
+
+  private buildCoverageResponseCountExclusionSql(
+    exclusions: ResolvedWorkspaceExclusions,
+    params: unknown[]
+  ): string {
+    const conditions: string[] = [];
+    const unitNameSql = 'REGEXP_REPLACE(UPPER(unit.name), \'\\.XML$\', \'\', \'i\')';
+    const bookletNameSql = 'UPPER(bookletinfo.name)';
+
+    if (exclusions.globalIgnoredUnits.length > 0) {
+      const placeholders = exclusions.globalIgnoredUnits.map(value => {
+        params.push(normalizeExclusionUnitId(value));
+        return `$${params.length}`;
+      });
+      conditions.push(`${unitNameSql} NOT IN (${placeholders.join(', ')})`);
+    }
+
+    if (exclusions.ignoredBooklets.length > 0) {
+      const placeholders = exclusions.ignoredBooklets.map(value => {
+        params.push(normalizeExclusionBookletId(value));
+        return `$${params.length}`;
+      });
+      conditions.push(`${bookletNameSql} NOT IN (${placeholders.join(', ')})`);
+    }
+
+    if (exclusions.testletIgnoredUnits.length > 0) {
+      const pairConditions = exclusions.testletIgnoredUnits.map(exclusion => {
+        params.push(normalizeExclusionBookletId(exclusion.bookletId));
+        const bookletPlaceholder = `$${params.length}`;
+        params.push(normalizeExclusionUnitId(exclusion.unitId));
+        const unitPlaceholder = `$${params.length}`;
+        return `(${bookletNameSql} = ${bookletPlaceholder} AND ${unitNameSql} = ${unitPlaceholder})`;
+      });
+      conditions.push(`NOT (${pairConditions.join(' OR ')})`);
+    }
+
+    return conditions.length > 0 ?
+      `AND ${conditions.join('\n            AND ')}` :
+      '';
   }
 
   private async getAssignedCoverageResponseRows(workspaceId: number): Promise<number[]> {

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
@@ -21,11 +21,13 @@ type QueryBuilderMock = {
 type ReadinessFixture = {
   units: Unit[];
   rawResponsesTotal: number;
+  activePersonHash?: string;
   candidateRows: Array<{
     unitid: number | string;
     variableid: string;
     response_count: number | string;
   }>;
+  candidateResponsesTotal?: number;
   unitFiles: FileUpload[];
   codingSchemeFiles?: FileUpload[];
   unitVariableMap: Map<string, Set<string>>;
@@ -35,6 +37,16 @@ type ReadinessQueryMocks = {
   unitQuery: QueryBuilderMock;
   countQuery: QueryBuilderMock;
   candidateQuery: QueryBuilderMock;
+  fileUploadRepository: {
+    find: jest.Mock;
+  };
+  responseRepository: {
+    createQueryBuilder: jest.Mock;
+    query: jest.Mock;
+  };
+  workspaceFilesService: {
+    getUnitVariableMap: jest.Mock;
+  };
 };
 
 const createQueryBuilderMock = (): QueryBuilderMock => {
@@ -109,9 +121,25 @@ const createService = (
 
   const countQuery = createQueryBuilderMock();
   countQuery.getCount.mockResolvedValue(fixture.rawResponsesTotal);
+  countQuery.getRawOne.mockResolvedValue({
+    raw_responses_total: fixture.rawResponsesTotal,
+    raw_responses_with_relevant_status:
+      fixture.candidateResponsesTotal ??
+      fixture.candidateRows.reduce(
+        (sum, row) => sum + Number(row.response_count || 0),
+        0
+      )
+  });
 
   const candidateQuery = createQueryBuilderMock();
   candidateQuery.getRawMany.mockResolvedValue(fixture.candidateRows);
+  candidateQuery.getCount.mockResolvedValue(
+    fixture.candidateResponsesTotal ??
+      fixture.candidateRows.reduce(
+        (sum, row) => sum + Number(row.response_count || 0),
+        0
+      )
+  );
 
   const fileRevisionQuery = createQueryBuilderMock();
   fileRevisionQuery.getRawOne.mockResolvedValue({
@@ -119,17 +147,19 @@ const createService = (
     max_created_at: '2026-05-20T08:00:00.000Z'
   });
 
-  Object.assign(queryMocks || {}, {
-    unitQuery,
-    countQuery,
-    candidateQuery
-  });
-
   const responseRepository = {
     createQueryBuilder: jest.fn()
       .mockReturnValueOnce(countQuery)
       .mockReturnValueOnce(candidateQuery),
-    query: jest.fn().mockResolvedValue([{ revision: 1 }])
+    query: jest.fn().mockImplementation((query: string) => {
+      if (query.includes('FROM persons')) {
+        return Promise.resolve([{
+          active_count: '1',
+          active_hash: fixture.activePersonHash || 'active-person-hash'
+        }]);
+      }
+      return Promise.resolve([{ revision: 1 }]);
+    })
   };
   const unitRepository = {
     createQueryBuilder: jest.fn().mockReturnValue(unitQuery)
@@ -150,6 +180,15 @@ const createService = (
       testletIgnoredUnits: []
     })
   };
+
+  Object.assign(queryMocks || {}, {
+    unitQuery,
+    countQuery,
+    candidateQuery,
+    fileUploadRepository,
+    responseRepository,
+    workspaceFilesService
+  });
 
   return new CodingReadinessService(
     responseRepository as never,
@@ -235,6 +274,150 @@ describe('CodingReadinessService', () => {
     expect(internals.readinessCache.has('2|1|1|files|0|scope')).toBe(true);
     expect(internals.readinessInFlight.has('1|1|1|files|0|scope')).toBe(false);
     expect(internals.cacheRevisionByWorkspace.get(1)).toBe(5);
+  });
+
+  it('returns summary readiness without loading units, variables or files', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 3,
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 3 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+
+    const readiness = await service.getReadiness(1, {
+      forceRefresh: true,
+      detailLevel: 'summary'
+    });
+
+    expect(readiness).toMatchObject({
+      detailLevel: 'summary',
+      detailsComplete: false,
+      readiness: 'DIAGNOSTICS_PENDING',
+      rawResponsesTotal: 3,
+      rawResponsesWithRelevantStatus: 3,
+      validResponses: 0,
+      potentialCodeableResponses: 3,
+      codeableResponses: 0,
+      matchedUnitFiles: 0,
+      matchedCodingSchemes: 0
+    });
+    expect(queryMocks.unitQuery?.getMany).not.toHaveBeenCalled();
+    expect(queryMocks.countQuery?.getRawOne).toHaveBeenCalledTimes(1);
+    expect(queryMocks.candidateQuery?.getCount).not.toHaveBeenCalled();
+    expect(queryMocks.candidateQuery?.getRawMany).not.toHaveBeenCalled();
+    expect(queryMocks.fileUploadRepository?.find).not.toHaveBeenCalled();
+    expect(
+      queryMocks.workspaceFilesService?.getUnitVariableMap
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse workspace-wide summary readiness when active persons changed', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 3,
+      activePersonHash: 'first-active-set',
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 3 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+    queryMocks.responseRepository?.createQueryBuilder.mockReturnValue(
+      queryMocks.countQuery
+    );
+
+    await service.getReadiness(1, {
+      detailLevel: 'summary'
+    });
+    queryMocks.responseRepository?.createQueryBuilder.mockReset();
+    queryMocks.responseRepository?.createQueryBuilder.mockReturnValue(
+      queryMocks.countQuery
+    );
+    queryMocks.responseRepository?.query.mockImplementation((query: string) => {
+      if (query.includes('FROM persons')) {
+        return Promise.resolve([{
+          active_count: '2',
+          active_hash: 'second-active-set'
+        }]);
+      }
+      return Promise.resolve([{ revision: 1 }]);
+    });
+    queryMocks.countQuery?.getRawOne.mockReset();
+    queryMocks.countQuery?.getRawOne.mockResolvedValue({
+      raw_responses_total: 7,
+      raw_responses_with_relevant_status: 5
+    });
+
+    const readiness = await service.getReadiness(1, {
+      detailLevel: 'summary'
+    });
+
+    expect(readiness.rawResponsesTotal).toBe(7);
+    expect(readiness.rawResponsesWithRelevantStatus).toBe(5);
+    expect(readiness.fromCache).toBe(false);
+    expect(queryMocks.countQuery?.getRawOne).toHaveBeenCalledTimes(1);
+  });
+
+  it('can block from summary readiness when no relevant candidate responses exist', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 2,
+      candidateResponsesTotal: 0,
+      candidateRows: [],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+
+    const readiness = await service.getReadiness(1, {
+      forceRefresh: true,
+      detailLevel: 'summary'
+    });
+
+    expect(readiness).toMatchObject({
+      detailLevel: 'summary',
+      detailsComplete: true,
+      readiness: 'BLOCKED',
+      validResponses: 0,
+      codeableResponses: 0
+    });
+    expect(readiness.blockers).toEqual(['NO_RELEVANT_RESPONSES']);
+    expect(queryMocks.fileUploadRepository?.find).not.toHaveBeenCalled();
+    expect(
+      queryMocks.workspaceFilesService?.getUnitVariableMap
+    ).not.toHaveBeenCalled();
   });
 
   it('keeps missing files as diagnostics without blocking partially codeable data', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
@@ -1,4 +1,6 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException, Injectable, Logger, Optional
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   Brackets, In, Repository, SelectQueryBuilder
@@ -17,6 +19,7 @@ import {
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import {
   AutocodingInvalidVariableSampleDto,
+  AutocodingReadinessDetailLevel,
   AutocodingReadinessBlocker,
   AutocodingReadinessDto,
   AutocodingReadinessStatus
@@ -25,18 +28,21 @@ import {
   getCodingVariableIdCandidateSql,
   isCodingVariableIdCandidate
 } from './coding-response-candidate.util';
+import { CacheService } from '../../../cache/cache.service';
 
 export type AutocodingReadinessOptions = {
   personIds?: string[];
   unitIds?: number[];
   autoCoderRun?: 1 | 2;
   forceRefresh?: boolean;
+  detailLevel?: AutocodingReadinessDetailLevel;
 };
 
 type ReadinessCacheSignature = {
   sourceRevision: number;
   fileRevision: string;
   cacheRevision: number;
+  activePersonHash: string;
   scopedUnitHash: string;
 };
 
@@ -49,6 +55,11 @@ type CandidateVariableCountRow = {
   unitid: string | number;
   variableid: string;
   response_count: string | number;
+};
+
+type SummaryReadinessCountRow = {
+  raw_responses_total: string | number;
+  raw_responses_with_relevant_status: string | number;
 };
 
 type CandidateVariableCount = {
@@ -88,7 +99,8 @@ export class CodingReadinessService {
   private readonly logger = new Logger(CodingReadinessService.name);
   private readonly maxSamplesPerUnit = 8;
   private readonly maxSampleUnits = 10;
-  private readonly cacheTtlMs = 60_000;
+  private readonly cacheTtlMs = 10 * 60_000;
+  private readonly distributedCacheTtlSeconds = 60 * 60;
   private readonly readinessCache = new Map<string, ReadinessCacheEntry>();
   private readonly readinessInFlight = new Map<string, Promise<AutocodingReadinessDto>>();
   private readonly cacheRevisionByWorkspace = new Map<number, number>();
@@ -101,7 +113,9 @@ export class CodingReadinessService {
     @InjectRepository(FileUpload)
     private readonly fileUploadRepository: Repository<FileUpload>,
     private readonly workspaceFilesService: WorkspaceFilesService,
-    private readonly workspaceExclusionService: WorkspaceExclusionService
+    private readonly workspaceExclusionService: WorkspaceExclusionService,
+    @Optional()
+    private readonly cacheService?: CacheService
   ) {}
 
   async getReadiness(
@@ -110,29 +124,41 @@ export class CodingReadinessService {
   ): Promise<AutocodingReadinessDto> {
     const startedAt = Date.now();
     const autoCoderRun = options.autoCoderRun || 1;
-    const units = await this.getScopedUnits(workspaceId, options);
-    const unitIds = units.map(unit => unit.id);
+    const detailLevel = options.detailLevel || 'full';
+    const workspaceWide = this.isWorkspaceWideReadiness(options);
+    const scopedUnits = workspaceWide ?
+      null :
+      await this.getScopedUnits(workspaceId, options);
+    const unitIds = scopedUnits?.map(unit => unit.id) || [];
 
-    if (unitIds.length === 0) {
-      return this.withComputationMetadata(
-        this.emptyReadiness(workspaceId, autoCoderRun, 'NO_RESULTS'),
-        startedAt,
-        false,
-        {
-          sourceRevision: 0,
-          fileRevision: '0:',
-          cacheRevision: this.getWorkspaceCacheRevision(workspaceId),
-          scopedUnitHash: ''
-        }
-      );
-    }
-
-    const cacheSignature = await this.getCacheSignature(workspaceId, unitIds, options);
-    const cacheKey = this.buildCacheKey(workspaceId, autoCoderRun, cacheSignature);
+    const cacheSignature = await this.getCacheSignature(
+      workspaceId,
+      unitIds,
+      options,
+      workspaceWide
+    );
+    const cacheKey = this.buildCacheKey(
+      workspaceId,
+      autoCoderRun,
+      detailLevel,
+      cacheSignature
+    );
     if (!options.forceRefresh) {
       const cached = this.getCachedReadiness(cacheKey);
       if (cached) {
         return cached;
+      }
+      const distributedCached = await this.getDistributedCachedReadiness(
+        workspaceId,
+        autoCoderRun,
+        cacheKey
+      );
+      if (distributedCached) {
+        this.setCachedReadiness(cacheKey, distributedCached);
+        return {
+          ...distributedCached,
+          fromCache: true
+        };
       }
     }
 
@@ -144,8 +170,9 @@ export class CodingReadinessService {
     const readinessPromise = this.computeReadiness(
       workspaceId,
       autoCoderRun,
+      detailLevel,
       options,
-      units,
+      scopedUnits,
       startedAt,
       cacheSignature,
       cacheKey
@@ -235,12 +262,42 @@ export class CodingReadinessService {
   private async computeReadiness(
     workspaceId: number,
     autoCoderRun: 1 | 2,
+    detailLevel: AutocodingReadinessDetailLevel,
     options: AutocodingReadinessOptions,
-    units: Unit[],
+    scopedUnits: Unit[] | null,
     startedAt: number,
     cacheSignature: ReadinessCacheSignature,
     cacheKey: string
   ): Promise<AutocodingReadinessDto> {
+    if (detailLevel === 'summary') {
+      return this.computeSummaryReadiness(
+        workspaceId,
+        autoCoderRun,
+        options,
+        scopedUnits,
+        startedAt,
+        cacheSignature,
+        cacheKey
+      );
+    }
+
+    const units = scopedUnits ?? await this.getScopedUnits(workspaceId, options);
+    if (units.length === 0) {
+      const emptyReadiness = this.withComputationMetadata(
+        this.emptyReadiness(
+          workspaceId,
+          autoCoderRun,
+          'NO_RESULTS',
+          detailLevel
+        ),
+        startedAt,
+        false,
+        cacheSignature
+      );
+      this.setCachedReadiness(cacheKey, emptyReadiness);
+      return emptyReadiness;
+    }
+
     const [rawResponsesTotal, candidateVariableCounts] = await Promise.all([
       this.countRawResponses(workspaceId, options, autoCoderRun),
       this.getCandidateVariableCounts(workspaceId, options, autoCoderRun)
@@ -279,6 +336,8 @@ export class CodingReadinessService {
     const readiness = this.withComputationMetadata({
       workspaceId,
       autoCoderRun,
+      detailLevel: 'full',
+      detailsComplete: true,
       readiness: this.getReadinessStatus(
         rawResponsesTotal,
         codeableResponses,
@@ -304,6 +363,61 @@ export class CodingReadinessService {
     this.logger.debug(
       `Computed autocoding readiness for workspace ${workspaceId}, run ${autoCoderRun} ` +
       `in ${readiness.computationMs}ms: ${readiness.readiness}.`
+    );
+    return readiness;
+  }
+
+  private async computeSummaryReadiness(
+    workspaceId: number,
+    autoCoderRun: 1 | 2,
+    options: AutocodingReadinessOptions,
+    scopedUnits: Unit[] | null,
+    startedAt: number,
+    cacheSignature: ReadinessCacheSignature,
+    cacheKey: string
+  ): Promise<AutocodingReadinessDto> {
+    const {
+      rawResponsesTotal,
+      rawResponsesWithRelevantStatus
+    } = await this.countSummaryResponses(workspaceId, options, autoCoderRun);
+    const potentialCodeableResponses = rawResponsesWithRelevantStatus;
+    const blockers = this.getSummaryBlockers({
+      rawResponsesTotal,
+      rawResponsesWithRelevantStatus
+    });
+    const needsFullDiagnostics =
+      rawResponsesTotal > 0 &&
+      rawResponsesWithRelevantStatus > 0;
+
+    const readiness = this.withComputationMetadata({
+      workspaceId,
+      autoCoderRun,
+      detailLevel: 'summary',
+      detailsComplete: !needsFullDiagnostics,
+      readiness: needsFullDiagnostics ?
+        'DIAGNOSTICS_PENDING' :
+        this.getReadinessStatus(rawResponsesTotal, 0, blockers),
+      blockers,
+      rawResponsesTotal,
+      rawResponsesWithRelevantStatus,
+      resultUnitsTotal: scopedUnits?.length || 0,
+      resultUnitKeysTotal: 0,
+      matchedUnitFiles: 0,
+      missingUnitFiles: [],
+      matchedCodingSchemes: 0,
+      missingCodingSchemes: [],
+      invalidCodingSchemes: [],
+      validVariablePairs: 0,
+      validResponses: 0,
+      potentialCodeableResponses,
+      codeableResponses: 0,
+      invalidVariableSamples: []
+    }, startedAt, false, cacheSignature);
+
+    this.setCachedReadiness(cacheKey, readiness);
+    this.logger.debug(
+      `Computed summary autocoding readiness for workspace ${workspaceId}, ` +
+      `run ${autoCoderRun} in ${readiness.computationMs}ms: ${readiness.readiness}.`
     );
     return readiness;
   }
@@ -344,6 +458,36 @@ export class CodingReadinessService {
     const query = await this.createScopedResponseQuery(workspaceId, options);
     this.applyAutocoderGeneratedFilter(query, autoCoderRun);
     return query.getCount();
+  }
+
+  private async countSummaryResponses(
+    workspaceId: number,
+    options: AutocodingReadinessOptions,
+    autoCoderRun: 1 | 2
+  ): Promise<{
+      rawResponsesTotal: number;
+      rawResponsesWithRelevantStatus: number;
+    }> {
+    const query = await this.createScopedResponseQuery(workspaceId, options);
+    this.applyAutocoderGeneratedFilter(query, autoCoderRun);
+    const derivePending = statusStringToNumber('DERIVE_PENDING') as number;
+    const candidateCondition =
+      `((response.status IN (3, 2, 1) OR response.status_v1 = ${derivePending}) ` +
+      `AND ${getCodingVariableIdCandidateSql('response')})`;
+    const row = await query
+      .select('COUNT(response.id)', 'raw_responses_total')
+      .addSelect(
+        `COUNT(response.id) FILTER (WHERE ${candidateCondition})`,
+        'raw_responses_with_relevant_status'
+      )
+      .getRawOne<SummaryReadinessCountRow>();
+
+    return {
+      rawResponsesTotal: Number(row?.raw_responses_total || 0),
+      rawResponsesWithRelevantStatus: Number(
+        row?.raw_responses_with_relevant_status || 0
+      )
+    };
   }
 
   private async getCandidateVariableCounts(
@@ -753,6 +897,21 @@ export class CodingReadinessService {
     return blockers;
   }
 
+  private getSummaryBlockers(input: {
+    rawResponsesTotal: number;
+    rawResponsesWithRelevantStatus: number;
+  }): AutocodingReadinessBlocker[] {
+    if (input.rawResponsesTotal === 0) {
+      return [];
+    }
+
+    const blockers: AutocodingReadinessBlocker[] = [];
+    if (input.rawResponsesWithRelevantStatus === 0) {
+      blockers.push('NO_RELEVANT_RESPONSES');
+    }
+    return blockers;
+  }
+
   private getReadinessStatus(
     rawResponsesTotal: number,
     codeableResponses: number,
@@ -800,11 +959,14 @@ export class CodingReadinessService {
   private emptyReadiness(
     workspaceId: number,
     autoCoderRun: 1 | 2,
-    readiness: AutocodingReadinessStatus
+    readiness: AutocodingReadinessStatus,
+    detailLevel: AutocodingReadinessDetailLevel = 'full'
   ): AutocodingReadinessDto {
     return {
       workspaceId,
       autoCoderRun,
+      detailLevel,
+      detailsComplete: true,
       readiness,
       blockers: [],
       rawResponsesTotal: 0,
@@ -847,19 +1009,35 @@ export class CodingReadinessService {
   private async getCacheSignature(
     workspaceId: number,
     unitIds: number[],
-    options: AutocodingReadinessOptions
+    options: AutocodingReadinessOptions,
+    workspaceWide: boolean
   ): Promise<ReadinessCacheSignature> {
-    const [sourceRevision, fileRevision] = await Promise.all([
+    const [sourceRevision, fileRevision, activePersonHash] = await Promise.all([
       this.getWorkspaceResultsRevision(workspaceId),
-      this.getWorkspaceFileRevision(workspaceId)
+      this.getWorkspaceFileRevision(workspaceId),
+      workspaceWide ?
+        this.getWorkspaceActivePersonHash(workspaceId) :
+        Promise.resolve('scoped')
     ]);
 
     return {
       sourceRevision,
       fileRevision,
       cacheRevision: this.getWorkspaceCacheRevision(workspaceId),
-      scopedUnitHash: this.hashScope(unitIds, options)
+      activePersonHash,
+      scopedUnitHash: workspaceWide ?
+        this.hashValues(['workspace-wide']) :
+        this.hashScope(unitIds, options)
     };
+  }
+
+  private isWorkspaceWideReadiness(
+    options: AutocodingReadinessOptions
+  ): boolean {
+    return (
+      this.uniquePositiveIds((options.personIds || []).map(id => Number(id))).length === 0 &&
+      this.uniquePositiveIds(options.unitIds || []).length === 0
+    );
   }
 
   private getWorkspaceCacheRevision(workspaceId: number): number {
@@ -917,17 +1095,44 @@ export class CodingReadinessService {
     }
   }
 
+  private async getWorkspaceActivePersonHash(workspaceId: number): Promise<string> {
+    try {
+      const rows = await this.responseRepository.query(
+        `
+          SELECT
+            COUNT(id)::text AS active_count,
+            COALESCE(md5(string_agg(id::text, ',' ORDER BY id)), '') AS active_hash
+          FROM persons
+          WHERE workspace_id = $1
+            AND consider = true
+        `,
+        [workspaceId]
+      ) as Array<{ active_count: string; active_hash: string }>;
+      const row = rows[0];
+      return `${row?.active_count || '0'}:${row?.active_hash || ''}`;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve active person signature for readiness cache: ${message}`
+      );
+      return '0:';
+    }
+  }
+
   private buildCacheKey(
     workspaceId: number,
     autoCoderRun: 1 | 2,
+    detailLevel: AutocodingReadinessDetailLevel,
     signature: ReadinessCacheSignature
   ): string {
     return [
       workspaceId,
       autoCoderRun,
+      detailLevel,
       signature.sourceRevision,
       signature.fileRevision,
       signature.cacheRevision,
+      signature.activePersonHash,
       signature.scopedUnitHash
     ].join('|');
   }
@@ -956,6 +1161,52 @@ export class CodingReadinessService {
     this.readinessCache.set(cacheKey, {
       expiresAt: Date.now() + this.cacheTtlMs,
       readiness
+    });
+    this.setDistributedCachedReadiness(cacheKey, readiness);
+  }
+
+  private getDistributedReadinessCacheKey(
+    workspaceId: number,
+    autoCoderRun: 1 | 2,
+    cacheKey: string
+  ): string {
+    return `coding_readiness:${workspaceId}:run${autoCoderRun}:${this.hashValues([cacheKey])}`;
+  }
+
+  private async getDistributedCachedReadiness(
+    workspaceId: number,
+    autoCoderRun: 1 | 2,
+    cacheKey: string
+  ): Promise<AutocodingReadinessDto | null> {
+    if (!this.cacheService) {
+      return null;
+    }
+    return this.cacheService.get<AutocodingReadinessDto>(
+      this.getDistributedReadinessCacheKey(workspaceId, autoCoderRun, cacheKey)
+    );
+  }
+
+  private setDistributedCachedReadiness(
+    cacheKey: string,
+    readiness: AutocodingReadinessDto
+  ): void {
+    if (!this.cacheService) {
+      return;
+    }
+    const distributedCacheKey = this.getDistributedReadinessCacheKey(
+      readiness.workspaceId,
+      readiness.autoCoderRun,
+      cacheKey
+    );
+    this.cacheService.set(
+      distributedCacheKey,
+      readiness,
+      this.distributedCacheTtlSeconds
+    ).catch(error => {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not store autocoding readiness cache ${distributedCacheKey}: ${message}`
+      );
     });
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
@@ -36,7 +36,9 @@ describe('CodingStatisticsService', () => {
     mockCacheService = {
       get: jest.fn(),
       set: jest.fn(),
-      delete: jest.fn()
+      delete: jest.fn(),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
     } as unknown as jest.Mocked<CacheService>;
 
     mockJobQueueService = {
@@ -334,11 +336,19 @@ describe('CodingStatisticsService', () => {
 
     it('should invalidate incomplete variables cache', async () => {
       mockCacheService.delete.mockResolvedValue(true);
+      mockCacheService.incr.mockResolvedValue(1);
+      mockCacheService.deleteByPattern.mockResolvedValue(undefined);
 
       await service.invalidateIncompleteVariablesCache(1);
 
       expect(mockCacheService.delete).toHaveBeenCalledWith(
         'coding_incomplete_variables_v8:1'
+      );
+      expect(mockCacheService.incr).toHaveBeenCalledWith(
+        'coding_applied_results_overview:version:1'
+      );
+      expect(mockCacheService.deleteByPattern).toHaveBeenCalledWith(
+        'coding_applied_results_overview:1:*'
       );
     });
 
@@ -786,21 +796,10 @@ describe('CodingStatisticsService', () => {
   });
 
   describe('Application bootstrap', () => {
-    it('should preload statistics for all workspaces on bootstrap', async () => {
-      mockResponseRepository.query.mockResolvedValue([
-        { workspace_id: '1' },
-        { workspace_id: '2' }
-      ]);
-      mockWorkspaceCoreService.getIgnoredUnits.mockResolvedValue([]);
-      mockFileUploadRepository.find.mockResolvedValue([]);
-      mockResponseRepository.query.mockResolvedValue([]);
-
+    it('should leave workspace preload to the sequential cache scheduler', async () => {
       await service.onApplicationBootstrap();
 
-      expect(mockResponseRepository.query).toHaveBeenCalledWith(
-        expect.stringContaining('SELECT DISTINCT person.workspace_id'),
-        expect.any(Array)
-      );
+      expect(mockResponseRepository.query).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
@@ -1,5 +1,5 @@
 import {
-  Inject, Injectable, Logger, OnApplicationBootstrap, forwardRef
+  Inject, Injectable, Logger, forwardRef
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -28,6 +28,10 @@ import {
   type CodingStatisticsVersion
 } from './coding-statistics-cache-key.util';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 import { getEffectiveCodingStatusExpression } from '../../utils/effective-coding-status-expression.util';
 
 export interface KappaCalculationResult {
@@ -52,7 +56,7 @@ export interface KappaVariableSummary {
 }
 
 @Injectable()
-export class CodingStatisticsService implements OnApplicationBootstrap {
+export class CodingStatisticsService {
   private readonly logger = new Logger(CodingStatisticsService.name);
   private readonly CACHE_TTL_SECONDS = 0; // No expiration (TTL=0 means no EX flag in Redis) - persist until explicitly invalidated
 
@@ -74,21 +78,9 @@ export class CodingStatisticsService implements OnApplicationBootstrap {
       return;
     }
 
-    this.logger.log('Application bootstrap: Loading coding statistics for all workspaces...');
-    try {
-      const workspaceIds = await this.getWorkspaceIdsWithResponses();
-      this.logger.log(`Found ${workspaceIds.length} workspaces with responses, preloading statistics...`);
-
-      const preloadPromises = workspaceIds.map(workspaceId => this.getCodingStatistics(workspaceId).catch(error => {
-        this.logger.error(`Failed to preload statistics for workspace ${workspaceId}: ${error.message}`);
-      })
-      );
-
-      await Promise.allSettled(preloadPromises);
-      this.logger.log('Finished preloading coding statistics for all workspaces');
-    } catch (error) {
-      this.logger.error(`Error during application bootstrap: ${error.message}`);
-    }
+    this.logger.log(
+      'Skipping coding statistics service preload; cache scheduler handles warmup sequentially.'
+    );
   }
 
   private async getWorkspaceIdsWithResponses(): Promise<number[]> {
@@ -305,8 +297,16 @@ export class CodingStatisticsService implements OnApplicationBootstrap {
 
   async invalidateIncompleteVariablesCache(workspace_id: number): Promise<void> {
     const cacheKey = getCodingIncompleteVariablesCacheKey(workspace_id);
-    await this.cacheService.delete(cacheKey);
-    this.logger.log(`Invalidated incomplete variables cache for workspace ${workspace_id}`);
+    await Promise.all([
+      this.cacheService.delete(cacheKey),
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspace_id)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspace_id)
+      )
+    ]);
+    this.logger.log(`Invalidated incomplete variables and applied results overview cache for workspace ${workspace_id}`);
   }
 
   async refreshStatistics(workspace_id: number, version: CodingStatisticsVersion = 'v1'): Promise<CodingStatistics> {

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -72,9 +72,11 @@ describe('CodingValidationService', () => {
       }
     },
     ...overrides
-  } as unknown as ResponseEntity);
+  }) as unknown as ResponseEntity;
 
-  const createQueryBuilderMock = <T extends Record<string, unknown>>(rawResults: T[] = []) => ({
+  const createQueryBuilderMock = <T extends Record<string, unknown>>(
+    rawResults: T[] = []
+  ) => ({
     innerJoin: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
     leftJoinAndSelect: jest.fn().mockReturnThis(),
@@ -101,11 +103,23 @@ describe('CodingValidationService', () => {
     unitName,
     variableid,
     value: overrides.value ?? `value-${index + 1}`,
-    ...(overrides.statusV1 !== undefined ? { statusV1: overrides.statusV1 } : {}),
+    ...(overrides.statusV1 !== undefined ?
+      { statusV1: overrides.statusV1 } :
+      {}),
     personLogin: `${variableid}-person-${index + 1}`,
     personCode: `${index + 1}`,
     personGroup: 'group'
   }));
+
+  const createDeferred = <T>() => {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  };
 
   beforeEach(async () => {
     mockResponseRepository = {
@@ -123,7 +137,9 @@ describe('CodingValidationService', () => {
       storeValidationResults: jest.fn(),
       get: jest.fn(),
       set: jest.fn(),
-      delete: jest.fn()
+      delete: jest.fn(),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
     } as unknown as jest.Mocked<CacheService>;
 
     mockWorkspaceFilesService = {
@@ -138,10 +154,12 @@ describe('CodingValidationService', () => {
 
     mockWorkspacePlayerService = {
       findUnitDef: jest.fn().mockResolvedValue([{ file_id: 'UNIT1.VOUD' }]),
-      findUnit: jest.fn().mockResolvedValue([{
-        file_id: 'UNIT1',
-        data: '<Unit><DefinitionRef player="VERONA-1.0.0"/></Unit>'
-      }]),
+      findUnit: jest.fn().mockResolvedValue([
+        {
+          file_id: 'UNIT1',
+          data: '<Unit><DefinitionRef player="VERONA-1.0.0"/></Unit>'
+        }
+      ]),
       findPlayer: jest.fn().mockResolvedValue([{ file_id: 'VERONA-1.0.0' }])
     } as unknown as jest.Mocked<WorkspacePlayerService>;
 
@@ -153,7 +171,9 @@ describe('CodingValidationService', () => {
     } as unknown as jest.Mocked<CodingJobService>;
     mockQueryBuilder.getRawMany.mockResolvedValue([]);
     mockQueryBuilder.getCount.mockResolvedValue(0);
-    mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(new Map());
+    mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
+      new Map()
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -501,7 +521,8 @@ describe('CodingValidationService', () => {
         mockCacheService.storeValidationResults.mock.calls[0][1][0].combination
       ).not.toHaveProperty('url');
       expect(
-        mockCacheService.storeValidationResults.mock.calls[0][1][0].responseFound
+        mockCacheService.storeValidationResults.mock.calls[0][1][0]
+          .responseFound
       ).toBe(true);
     });
 
@@ -545,6 +566,116 @@ describe('CodingValidationService', () => {
       );
     });
 
+    it('should reuse an in-flight uncached variables query for the same workspace', async () => {
+      const dbVariables = [
+        {
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 5,
+          deriveErrorResponseCount: 0,
+          isDerived: false,
+          coderTrainingRequired: false
+        }
+      ];
+      const enrichedVariables = [
+        {
+          ...dbVariables[0],
+          casesInJobs: 0,
+          availableCases: 5,
+          uniqueCasesAfterAggregation: 5
+        }
+      ];
+      const dbVariablesDeferred = createDeferred<typeof dbVariables>();
+      const serviceInternals = service as unknown as {
+        fetchCodingIncompleteVariablesFromDb: (
+          workspaceId: number,
+          unitName?: string,
+          trainingRequired?: boolean,
+          includeDeriveErrorOnly?: boolean
+        ) => Promise<typeof dbVariables>;
+        enrichVariablesWithCaseInfo: (
+          workspaceId: number,
+          variables: typeof dbVariables
+        ) => Promise<typeof enrichedVariables>;
+      };
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      const fetchSpy = jest
+        .spyOn(serviceInternals, 'fetchCodingIncompleteVariablesFromDb')
+        .mockReturnValue(dbVariablesDeferred.promise);
+      const enrichSpy = jest
+        .spyOn(serviceInternals, 'enrichVariablesWithCaseInfo')
+        .mockResolvedValue(enrichedVariables);
+
+      const firstRequest = service.getCodingIncompleteVariables(1);
+      const secondRequest = service.getCodingIncompleteVariables(1);
+      await Promise.resolve();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      dbVariablesDeferred.resolve(dbVariables);
+
+      await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual(
+        [enrichedVariables, enrichedVariables]
+      );
+      expect(enrichSpy).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not cache stale variables when the cache is invalidated while a query is running', async () => {
+      const dbVariables = [
+        {
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 5,
+          deriveErrorResponseCount: 0,
+          isDerived: false,
+          coderTrainingRequired: false
+        }
+      ];
+      const enrichedVariables = [
+        {
+          ...dbVariables[0],
+          casesInJobs: 0,
+          availableCases: 5,
+          uniqueCasesAfterAggregation: 5
+        }
+      ];
+      const dbVariablesDeferred = createDeferred<typeof dbVariables>();
+      const serviceInternals = service as unknown as {
+        fetchCodingIncompleteVariablesFromDb: (
+          workspaceId: number,
+          unitName?: string,
+          trainingRequired?: boolean,
+          includeDeriveErrorOnly?: boolean
+        ) => Promise<typeof dbVariables>;
+        enrichVariablesWithCaseInfo: (
+          workspaceId: number,
+          variables: typeof dbVariables
+        ) => Promise<typeof enrichedVariables>;
+      };
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockCacheService.delete.mockResolvedValue(true);
+      jest
+        .spyOn(serviceInternals, 'fetchCodingIncompleteVariablesFromDb')
+        .mockReturnValue(dbVariablesDeferred.promise);
+      jest
+        .spyOn(serviceInternals, 'enrichVariablesWithCaseInfo')
+        .mockResolvedValue(enrichedVariables);
+
+      const request = service.getCodingIncompleteVariables(1);
+      await Promise.resolve();
+
+      await service.invalidateIncompleteVariablesCache(1);
+      dbVariablesDeferred.resolve(dbVariables);
+
+      await expect(request).resolves.toEqual(enrichedVariables);
+      expect(mockCacheService.set).not.toHaveBeenCalled();
+    });
+
     it('should include INTENDED_INCOMPLETE variables even when they are defined in the scheme', async () => {
       const codingIncompleteQb = createQueryBuilderMock([
         { unitName: 'unit1', variableId: 'var1', responseCount: '5' }
@@ -556,11 +687,14 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
@@ -570,9 +704,15 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getIntendedIncompleteSchemeVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1', 'intended-only'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1', 'intended-only'])]])
       );
@@ -616,20 +756,29 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['manual-var', 'auto-only-var'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['manual-var'])]])
       );
@@ -640,7 +789,9 @@ describe('CodingValidationService', () => {
 
       const result = await service.getCodingIncompleteVariables(1);
 
-      expect(result.map(variable => variable.variableId)).toEqual(['manual-var']);
+      expect(result.map(variable => variable.variableId)).toEqual([
+        'manual-var'
+      ]);
     });
 
     it('should expose DERIVE_ERROR response counts per manual coding variable', async () => {
@@ -654,20 +805,29 @@ describe('CodingValidationService', () => {
       ]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1', 'var2'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         ...createSlimResponses('unit1', 'var1', 5),
@@ -696,32 +856,58 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const assignedResponsesQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'other', personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'other',
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         }
       ] as never);
 
@@ -749,32 +935,50 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb)
-        .mockReturnValueOnce(createQueryBuilderMock([
-          { unitName: 'unit1', variableId: 'derived-var', responseCount: '3' }
-        ]))
-        .mockReturnValueOnce(createQueryBuilderMock([
-          { unitName: 'unit1', variableId: 'base-var', responseCount: '3' },
-          { unitName: 'unit1', variableId: 'standalone-var', responseCount: '2' }
-        ]))
+        .mockReturnValueOnce(
+          createQueryBuilderMock([
+            { unitName: 'unit1', variableId: 'derived-var', responseCount: '3' }
+          ])
+        )
+        .mockReturnValueOnce(
+          createQueryBuilderMock([
+            { unitName: 'unit1', variableId: 'base-var', responseCount: '3' },
+            {
+              unitName: 'unit1',
+              variableId: 'standalone-var',
+              responseCount: '2'
+            }
+          ])
+        )
         .mockReturnValueOnce(createQueryBuilderMock([]));
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
-        new Map([['UNIT1', new Set(['base-var', 'derived-var', 'standalone-var'])]])
+        new Map([
+          ['UNIT1', new Set(['base-var', 'derived-var', 'standalone-var'])]
+        ])
       );
       mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['derived-var'])]])
       );
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
         new Map([
-          [getManualCodingScopeKey('unit1', 'base-var'), new Set(['derived-var'])]
+          [
+            getManualCodingScopeKey('unit1', 'base-var'),
+            new Set(['derived-var'])
+          ]
         ])
       );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
@@ -817,20 +1021,29 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
@@ -885,11 +1098,14 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
@@ -899,8 +1115,12 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['derived-var'])]])
       );
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
@@ -919,10 +1139,11 @@ describe('CodingValidationService', () => {
           isDerived: true
         })
       ]);
-      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
-        1,
-        [{ unitName: 'unit1', variableId: 'derived-var' }]
-      );
+      expect(
+        mockCodingJobService.getSlimResponsesForVariables
+      ).toHaveBeenCalledWith(1, [
+        { unitName: 'unit1', variableId: 'derived-var' }
+      ]);
     });
 
     it('should calculate availability on aggregation groups instead of raw job response counts', async () => {
@@ -938,41 +1159,73 @@ describe('CodingValidationService', () => {
         { unitName: 'unit1', variableId: 'var1', responseId: '5' }
       ]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(4);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-1'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person-1'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-2'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person-2'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-3'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person-3'
         },
         {
-          id: 4, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-4'
+          id: 4,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person-4'
         },
         {
-          id: 5, unitName: 'unit1', variableid: 'var1', value: 'single', personLogin: 'person-5'
+          id: 5,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'single',
+          personLogin: 'person-5'
         },
         {
-          id: 6, unitName: 'unit1', variableid: 'var1', value: 'single', personLogin: 'person-6'
+          id: 6,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'single',
+          personLogin: 'person-6'
         }
       ] as never);
 
@@ -1000,35 +1253,67 @@ describe('CodingValidationService', () => {
         { unitName: 'unit1', variableId: 'var1', responseId: '2' }
       ]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-2', personCode: 'code-2', personGroup: 'group'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-2',
+          personCode: 'code-2',
+          personGroup: 'group'
         },
         {
-          id: 4, unitName: 'unit1', variableid: 'var1', value: 'other-value', personLogin: 'person-3', personCode: 'code-3', personGroup: 'group'
+          id: 4,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'other-value',
+          personLogin: 'person-3',
+          personCode: 'code-3',
+          personGroup: 'group'
         }
       ] as never);
 
@@ -1054,32 +1339,61 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const assignedResponsesQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group', bookletName: 'Booklet A'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group',
+          bookletName: 'Booklet A'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group', bookletName: 'Booklet A'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group',
+          bookletName: 'Booklet A'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group', bookletName: 'Booklet B'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group',
+          bookletName: 'Booklet B'
         }
       ] as never);
 
@@ -1109,32 +1423,52 @@ describe('CodingValidationService', () => {
       const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
       const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: codingIncompleteStatus
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: codingIncompleteStatus
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: deriveErrorStatus
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: deriveErrorStatus
         }
       ] as never);
 
@@ -1145,10 +1479,11 @@ describe('CodingValidationService', () => {
         true
       );
 
-      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
-        1,
-        [{ unitName: 'unit1', variableId: 'var1', includeDeriveError: true }]
-      );
+      expect(
+        mockCodingJobService.getSlimResponsesForVariables
+      ).toHaveBeenCalledWith(1, [
+        { unitName: 'unit1', variableId: 'var1', includeDeriveError: true }
+      ]);
       expect(result).toEqual([
         expect.objectContaining({
           unitName: 'unit1',
@@ -1171,12 +1506,14 @@ describe('CodingValidationService', () => {
       const assignedResponsesQb = createQueryBuilderMock([]);
       const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
@@ -1186,10 +1523,15 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['derived-var'])]])
       );
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
         new Map([
-          [getManualCodingScopeKey('unit1', 'source-var'), new Set(['derived-var'])]
+          [
+            getManualCodingScopeKey('unit1', 'source-var'),
+            new Set(['derived-var'])
+          ]
         ])
       );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
@@ -1198,12 +1540,9 @@ describe('CodingValidationService', () => {
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
-        createSlimResponses(
-          'unit1',
-          'derived-var',
-          2,
-          { statusV1: deriveErrorStatus }
-        ) as never
+        createSlimResponses('unit1', 'derived-var', 2, {
+          statusV1: deriveErrorStatus
+        }) as never
       );
 
       const result = await service.getCodingIncompleteVariables(
@@ -1213,11 +1552,18 @@ describe('CodingValidationService', () => {
         true
       );
 
-      expect(result.map(variable => variable.variableId)).toEqual(['derived-var']);
-      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
-        1,
-        [{ unitName: 'unit1', variableId: 'derived-var', includeDeriveError: true }]
-      );
+      expect(result.map(variable => variable.variableId)).toEqual([
+        'derived-var'
+      ]);
+      expect(
+        mockCodingJobService.getSlimResponsesForVariables
+      ).toHaveBeenCalledWith(1, [
+        {
+          unitName: 'unit1',
+          variableId: 'derived-var',
+          includeDeriveError: true
+        }
+      ]);
     });
 
     it('should suppress DERIVE_ERROR counts for covered source variables that remain regular candidates', async () => {
@@ -1234,12 +1580,14 @@ describe('CodingValidationService', () => {
       const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
       const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
@@ -1249,10 +1597,15 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['derived-var'])]])
       );
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
         new Map([
-          [getManualCodingScopeKey('unit1', 'source-var'), new Set(['derived-var'])]
+          [
+            getManualCodingScopeKey('unit1', 'source-var'),
+            new Set(['derived-var'])
+          ]
         ])
       );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
@@ -1261,24 +1614,15 @@ describe('CodingValidationService', () => {
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
-        ...createSlimResponses(
-          'unit1',
-          'source-var',
-          1,
-          { statusV1: codingIncompleteStatus }
-        ),
-        ...createSlimResponses(
-          'unit1',
-          'derived-var',
-          1,
-          { statusV1: codingIncompleteStatus }
-        ),
-        ...createSlimResponses(
-          'unit1',
-          'derived-var',
-          2,
-          { statusV1: deriveErrorStatus }
-        ).map((response, index) => ({ ...response, id: index + 10 }))
+        ...createSlimResponses('unit1', 'source-var', 1, {
+          statusV1: codingIncompleteStatus
+        }),
+        ...createSlimResponses('unit1', 'derived-var', 1, {
+          statusV1: codingIncompleteStatus
+        }),
+        ...createSlimResponses('unit1', 'derived-var', 2, {
+          statusV1: deriveErrorStatus
+        }).map((response, index) => ({ ...response, id: index + 10 }))
       ] as never);
 
       const result = await service.getCodingIncompleteVariables(
@@ -1298,13 +1642,16 @@ describe('CodingValidationService', () => {
           deriveErrorResponseCount: 2
         })
       ]);
-      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
-        1,
-        [
-          { unitName: 'unit1', variableId: 'source-var' },
-          { unitName: 'unit1', variableId: 'derived-var', includeDeriveError: true }
-        ]
-      );
+      expect(
+        mockCodingJobService.getSlimResponsesForVariables
+      ).toHaveBeenCalledWith(1, [
+        { unitName: 'unit1', variableId: 'source-var' },
+        {
+          unitName: 'unit1',
+          variableId: 'derived-var',
+          includeDeriveError: true
+        }
+      ]);
     });
 
     it('should apply training deduplication when DERIVE_ERROR case counts are requested without aggregation', async () => {
@@ -1320,7 +1667,8 @@ describe('CodingValidationService', () => {
       const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
       const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
@@ -1333,23 +1681,57 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: codingIncompleteStatus,
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: codingIncompleteStatus,
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'other', statusV1: codingIncompleteStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'other',
+          statusV1: codingIncompleteStatus,
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 4, unitName: 'unit1', variableid: 'var1', value: 'other', statusV1: deriveErrorStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 4,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'other',
+          statusV1: deriveErrorStatus,
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         }
       ] as never);
 
@@ -1443,9 +1825,7 @@ describe('CodingValidationService', () => {
   });
 
   describe('validateManualCodeAvailability', () => {
-    const mockManualScopeQueries = (
-      variableId = 'var1'
-    ): void => {
+    const mockManualScopeQueries = (variableId = 'var1'): void => {
       const codingIncompleteQb = createQueryBuilderMock([
         { unitName: 'unit1', variableId, responseCount: '5' }
       ]);
@@ -1453,21 +1833,29 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set([variableId])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
         createSlimResponses('unit1', variableId, 5) as never
@@ -1500,7 +1888,8 @@ describe('CodingValidationService', () => {
                 {
                   id: 3,
                   label: 'Visually empty HTML',
-                  manualInstruction: '<p style="margin-top: 0; min-height: 1em"></p>'
+                  manualInstruction:
+                    '<p style="margin-top: 0; min-height: 1em"></p>'
                 }
               ]
             }
@@ -1647,13 +2036,24 @@ describe('CodingValidationService', () => {
   });
 
   describe('invalidateIncompleteVariablesCache', () => {
-    it('should delete cache key for workspace', async () => {
+    it('should delete manual coding cache keys for workspace', async () => {
       mockCacheService.delete.mockResolvedValue(true);
+      mockCacheService.incr.mockResolvedValue(1);
+      mockCacheService.deleteByPattern.mockResolvedValue(undefined);
 
       await service.invalidateIncompleteVariablesCache(1);
 
       expect(mockCacheService.delete).toHaveBeenCalledWith(
         'coding_incomplete_variables_v8:1'
+      );
+      expect(mockCacheService.delete).toHaveBeenCalledWith(
+        'coding_incomplete_variables_v8:1:scope-summary'
+      );
+      expect(mockCacheService.incr).toHaveBeenCalledWith(
+        'coding_applied_results_overview:version:1'
+      );
+      expect(mockCacheService.deleteByPattern).toHaveBeenCalledWith(
+        'coding_applied_results_overview:1:*'
       );
     });
   });
@@ -1706,7 +2106,10 @@ describe('CodingValidationService', () => {
       ]);
       mockQueryBuilder.getCount.mockResolvedValueOnce(1);
 
-      const result = await service.getAppliedResultsCount(1, undefined as never);
+      const result = await service.getAppliedResultsCount(
+        1,
+        undefined as never
+      );
 
       expect(result).toBe(1);
       expect(mockQueryBuilder.getCount).toHaveBeenCalledTimes(1);
@@ -1722,7 +2125,9 @@ describe('CodingValidationService', () => {
 
       await service.getAppliedResultsCount(1, incompleteVariables);
 
-      expect(mockResponseRepository.createQueryBuilder).toHaveBeenCalledTimes(2);
+      expect(mockResponseRepository.createQueryBuilder).toHaveBeenCalledTimes(
+        2
+      );
       expect(mockQueryBuilder.getCount).toHaveBeenCalledTimes(2);
     });
 

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -45,6 +45,10 @@ import {
   applyNonCodingIssueReviewJobFilter,
   getNonCodingIssueReviewJobSqlCondition
 } from './coding-job-type.util';
+import {
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 
 interface NormalizedExpectedCombination {
   unitKey: string;
@@ -115,6 +119,25 @@ type ManualCodingVariableWithCaseInfo = {
 export class CodingValidationService {
   private readonly logger = new Logger(CodingValidationService.name);
 
+  private readonly manualCodingCacheTtlSeconds = 300;
+
+  private readonly slowManualCodingQueryThresholdMs = 3000;
+
+  private readonly manualCodingVariablesInFlight = new Map<
+  string,
+  Promise<ManualCodingVariableWithCaseInfo[]>
+  >();
+
+  private readonly manualCodingScopeSummaryInFlight = new Map<
+  string,
+  Promise<ManualCodingScopeSummary>
+  >();
+
+  private readonly manualCodingCacheGenerationByWorkspace = new Map<
+  number,
+  number
+  >();
+
   constructor(
     @InjectRepository(ResponseEntity)
     private responseRepository: Repository<ResponseEntity>,
@@ -126,7 +149,7 @@ export class CodingValidationService {
     @Inject(forwardRef(() => CodingJobService))
     private codingJobService: CodingJobService,
     private workspacePlayerService: WorkspacePlayerService
-  ) { }
+  ) {}
 
   async validateCodingCompleteness(
     workspaceId: number,
@@ -140,7 +163,8 @@ export class CodingValidationService {
       );
       const startTime = Date.now();
 
-      const combinationsHash = generateExpectedCombinationsHash(expectedCombinations);
+      const combinationsHash =
+        generateExpectedCombinationsHash(expectedCombinations);
       const cacheKey = this.cacheService.generateValidationCacheKey(
         workspaceId,
         combinationsHash
@@ -173,7 +197,10 @@ export class CodingValidationService {
       const allResults: ValidationResultDto[] = [];
       let totalMissingCount = 0;
       const replayAssetIssueCache = new Map<string, Promise<string[]>>();
-      const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+      const exclusions =
+        await this.workspaceExclusionService.resolveExclusionsForQueries(
+          workspaceId
+        );
 
       const batchSize = 100;
       for (let i = 0; i < expectedCombinations.length; i += batchSize) {
@@ -185,13 +212,12 @@ export class CodingValidationService {
         );
 
         for (const expected of batch) {
-          const normalizedExpected = this.normalizeExpectedCombination(expected);
-          const safeCombination = this.buildSafeExpectedCombination(
-            normalizedExpected
-          );
-          const inputIssues = this.getExpectedCombinationInputIssues(
-            normalizedExpected
-          );
+          const normalizedExpected =
+            this.normalizeExpectedCombination(expected);
+          const safeCombination =
+            this.buildSafeExpectedCombination(normalizedExpected);
+          const inputIssues =
+            this.getExpectedCombinationInputIssues(normalizedExpected);
 
           if (inputIssues.length > 0) {
             totalMissingCount += 1;
@@ -215,7 +241,10 @@ export class CodingValidationService {
             .andWhere('response.value IS NOT NULL')
             .andWhere('response.value != :empty', { empty: '' });
 
-          this.applyExpectedCombinationFilters(queryBuilder, normalizedExpected);
+          this.applyExpectedCombinationFilters(
+            queryBuilder,
+            normalizedExpected
+          );
           applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
           const response = await queryBuilder.getOne();
@@ -224,15 +253,16 @@ export class CodingValidationService {
           if (!response) {
             issues.push('Keine passende Antwort gefunden.');
           } else {
-            const unitName = response.unit?.name ||
+            const unitName =
+              response.unit?.name ||
               normalizedExpected.unitKey ||
               normalizedExpected.unitAlias;
             issues.push(
-              ...await this.getReplayAssetIssues(
+              ...(await this.getReplayAssetIssues(
                 workspaceId,
                 unitName,
                 replayAssetIssueCache
-              )
+              ))
             );
           }
 
@@ -280,7 +310,8 @@ export class CodingValidationService {
 
       const endTime = Date.now();
       this.logger.log(
-        `Validation completed in ${endTime - startTime}ms. Processed all ${expectedCombinations.length
+        `Validation completed in ${endTime - startTime}ms. Processed all ${
+          expectedCombinations.length
         } combinations with ${totalMissingCount} missing responses.`
       );
 
@@ -374,8 +405,12 @@ export class CodingValidationService {
       ...(expected.personGroup ? { person_group: expected.personGroup } : {}),
       booklet_id: expected.bookletId,
       variable_id: expected.variableId,
-      ...(expected.variablePage ? { variable_page: expected.variablePage } : {}),
-      ...(expected.variableAnchor ? { variable_anchor: expected.variableAnchor } : {})
+      ...(expected.variablePage ?
+        { variable_page: expected.variablePage } :
+        {}),
+      ...(expected.variableAnchor ?
+        { variable_anchor: expected.variableAnchor } :
+        {})
     };
   }
 
@@ -388,17 +423,19 @@ export class CodingValidationService {
     ) as string[];
 
     queryBuilder
-      .andWhere(new Brackets(qb => {
-        unitCandidates.forEach((unitCandidate, index) => {
-          const parameterName = `unitCandidate${index}`;
-          const condition = `(unit.name = :${parameterName} OR unit.alias = :${parameterName})`;
-          if (index === 0) {
-            qb.where(condition, { [parameterName]: unitCandidate });
-          } else {
-            qb.orWhere(condition, { [parameterName]: unitCandidate });
-          }
-        });
-      }))
+      .andWhere(
+        new Brackets(qb => {
+          unitCandidates.forEach((unitCandidate, index) => {
+            const parameterName = `unitCandidate${index}`;
+            const condition = `(unit.name = :${parameterName} OR unit.alias = :${parameterName})`;
+            if (index === 0) {
+              qb.where(condition, { [parameterName]: unitCandidate });
+            } else {
+              qb.orWhere(condition, { [parameterName]: unitCandidate });
+            }
+          });
+        })
+      )
       .andWhere('person.login = :loginName', {
         loginName: expected.loginName
       })
@@ -447,7 +484,10 @@ export class CodingValidationService {
 
     try {
       const [unitDef, unitFile] = await Promise.all([
-        this.workspacePlayerService.findUnitDef(workspaceId, normalizedUnitName),
+        this.workspacePlayerService.findUnitDef(
+          workspaceId,
+          normalizedUnitName
+        ),
         this.workspacePlayerService.findUnit(workspaceId, normalizedUnitName)
       ]);
 
@@ -500,8 +540,14 @@ export class CodingValidationService {
 
     const module = matches[1] || '';
     const major = parseInt(matches[3], 10) || 0;
-    const minor = typeof matches[4] === 'string' ? parseInt(matches[4].substring(1), 10) : 0;
-    const patch = typeof matches[5] === 'string' ? parseInt(matches[5].substring(1), 10) : 0;
+    const minor =
+      typeof matches[4] === 'string' ?
+        parseInt(matches[4].substring(1), 10) :
+        0;
+    const patch =
+      typeof matches[5] === 'string' ?
+        parseInt(matches[5].substring(1), 10) :
+        0;
     return `${module}-${major}.${minor}.${patch}`.toUpperCase();
   }
 
@@ -526,6 +572,7 @@ export class CodingValidationService {
       coderTrainingRequired: boolean;
     }[]
     > {
+    const startedAt = Date.now();
     try {
       if (
         unitName ||
@@ -535,8 +582,12 @@ export class CodingValidationService {
       ) {
         const queryDetails = [
           unitName ? ` and unit ${unitName}` : '',
-          trainingRequired !== undefined ? ` (trainingRequired: ${trainingRequired})` : '',
-          excludeJobDefinitionId !== undefined ? ` excluding job definition ${excludeJobDefinitionId}` : ''
+          trainingRequired !== undefined ?
+            ` (trainingRequired: ${trainingRequired})` :
+            '',
+          excludeJobDefinitionId !== undefined ?
+            ` excluding job definition ${excludeJobDefinitionId}` :
+            ''
         ].join('');
         this.logger.log(
           `Querying manual coding variables for workspace ${workspaceId}${queryDetails} (not cached)`
@@ -576,31 +627,32 @@ export class CodingValidationService {
         );
         return cachedResult;
       }
+      const inFlightResult = this.manualCodingVariablesInFlight.get(cacheKey);
+      if (inFlightResult) {
+        this.logger.log(
+          `Reusing in-flight manual coding variables query for workspace ${workspaceId}`
+        );
+        return await inFlightResult;
+      }
+
       this.logger.log(
         `Cache miss: Querying manual coding variables for workspace ${workspaceId}`
       );
-      const variables = await this.fetchCodingIncompleteVariablesFromDb(
+      const cacheGeneration =
+        this.getManualCodingCacheGeneration(workspaceId);
+      const queryPromise = this.fetchAndCacheCodingIncompleteVariables(
         workspaceId,
-        undefined,
-        undefined,
-        includeDeriveErrorOnly
+        cacheKey,
+        cacheGeneration
       );
-      const result = await this.enrichVariablesWithCaseInfo(
-        workspaceId,
-        variables
-      );
-
-      const cacheSet = await this.cacheService.set(cacheKey, result, 300); // Cache for 5 minutes
-      if (cacheSet) {
-        this.logger.log(
-          `Cached ${result.length} manual coding variables for workspace ${workspaceId}`
-        );
-      } else {
-        this.logger.warn(
-          `Failed to cache manual coding variables for workspace ${workspaceId}`
-        );
+      this.manualCodingVariablesInFlight.set(cacheKey, queryPromise);
+      try {
+        return await queryPromise;
+      } finally {
+        if (this.manualCodingVariablesInFlight.get(cacheKey) === queryPromise) {
+          this.manualCodingVariablesInFlight.delete(cacheKey);
+        }
       }
-      return result;
     } catch (error) {
       this.logger.error(
         `Error getting manual coding variables: ${error.message}`,
@@ -608,6 +660,12 @@ export class CodingValidationService {
       );
       throw new Error(
         'Could not get manual coding variables. Please check the database connection.'
+      );
+    } finally {
+      this.logSlowManualCodingQuery(
+        'getCodingIncompleteVariables',
+        workspaceId,
+        startedAt
       );
     }
   }
@@ -617,21 +675,60 @@ export class CodingValidationService {
     unitName?: string,
     trainingRequired?: boolean
   ): Promise<ManualCodingScopeSummary> {
+    const startedAt = Date.now();
     try {
+      const canUseCache = !unitName && trainingRequired === undefined;
+      const cacheKey =
+        this.generateManualCodingScopeSummaryCacheKey(workspaceId);
+
+      if (canUseCache) {
+        const cachedSummary =
+          await this.cacheService.get<ManualCodingScopeSummary>(cacheKey);
+        if (cachedSummary) {
+          this.logger.log(
+            `Retrieved manual coding scope summary from cache for workspace ${workspaceId}`
+          );
+          return cachedSummary;
+        }
+      }
+
+      if (canUseCache) {
+        const inFlightSummary =
+          this.manualCodingScopeSummaryInFlight.get(cacheKey);
+        if (inFlightSummary) {
+          this.logger.log(
+            `Reusing in-flight manual coding scope summary query for workspace ${workspaceId}`
+          );
+          return await inFlightSummary;
+        }
+
+        const cacheGeneration =
+          this.getManualCodingCacheGeneration(workspaceId);
+        const summaryPromise = this.fetchAndCacheManualCodingScopeSummary(
+          workspaceId,
+          cacheKey,
+          cacheGeneration
+        );
+        this.manualCodingScopeSummaryInFlight.set(cacheKey, summaryPromise);
+        try {
+          return await summaryPromise;
+        } finally {
+          if (
+            this.manualCodingScopeSummaryInFlight.get(cacheKey) ===
+            summaryPromise
+          ) {
+            this.manualCodingScopeSummaryInFlight.delete(cacheKey);
+          }
+        }
+      }
+
       const scope = await this.fetchManualCodingScopeFromDb(
         workspaceId,
         unitName,
         trainingRequired
       );
 
-      return {
-        manualVariableCount: scope.variables.length,
-        manualResponseCount: scope.variables.reduce(
-          (sum, variable) => sum + variable.responseCount,
-          0
-        ),
-        ...scope.excludedSourceSummary
-      };
+      return this.createManualCodingScopeSummary(scope);
     } catch (error) {
       this.logger.error(
         `Error getting manual coding scope summary: ${error.message}`,
@@ -639,6 +736,12 @@ export class CodingValidationService {
       );
       throw new Error(
         'Could not get manual coding scope summary. Please check the database connection.'
+      );
+    } finally {
+      this.logSlowManualCodingQuery(
+        'getManualCodingScopeSummary',
+        workspaceId,
+        startedAt
       );
     }
   }
@@ -648,6 +751,7 @@ export class CodingValidationService {
     unitName?: string,
     trainingRequired?: boolean
   ): Promise<ManualCodeAvailabilityValidationDto> {
+    const startedAt = Date.now();
     try {
       const [variables, variableDetailsByKey] = await Promise.all([
         this.getCodingIncompleteVariables(
@@ -678,8 +782,7 @@ export class CodingValidationService {
             responseCount: variable.responseCount,
             casesInJobs: variable.casesInJobs,
             availableCases: variable.availableCases,
-            uniqueCasesAfterAggregation:
-              variable.uniqueCasesAfterAggregation,
+            uniqueCasesAfterAggregation: variable.uniqueCasesAfterAggregation,
             regularCodeCount: counts.regularCodeCount,
             selectableRegularCodeCount: counts.selectableRegularCodeCount,
             onlySpecialOptionsAvailable: true,
@@ -704,12 +807,18 @@ export class CodingValidationService {
       throw new Error(
         'Could not validate manual code availability. Please check the coding schemes.'
       );
+    } finally {
+      this.logSlowManualCodingQuery(
+        'validateManualCodeAvailability',
+        workspaceId,
+        startedAt
+      );
     }
   }
 
   /**
-     * Enrich variables with case information (cases in jobs, available cases, and unique cases after aggregation)
-     */
+   * Enrich variables with case information (cases in jobs, available cases, and unique cases after aggregation)
+   */
   private async enrichVariablesWithCaseInfo(
     workspaceId: number,
     variables: ManualCodingVariableCaseCounts[],
@@ -755,9 +864,11 @@ export class CodingValidationService {
       return result;
     }
 
-    const aggregationThreshold = await this.codingJobService.getAggregationThreshold(workspaceId);
+    const aggregationThreshold =
+      await this.codingJobService.getAggregationThreshold(workspaceId);
 
-    const matchingFlags = await this.codingJobService.getResponseMatchingMode(workspaceId);
+    const matchingFlags =
+      await this.codingJobService.getResponseMatchingMode(workspaceId);
     const variableReferences = variables.map(v => ({
       unitName: v.unitName,
       variableId: v.variableId,
@@ -782,17 +893,24 @@ export class CodingValidationService {
       .filter(variable => variable.isDerived)
       .forEach(variable => {
         const unitKey = variable.unitName.toUpperCase();
-        const derivedVariables = derivedVariableMap.get(unitKey) || new Set<string>();
+        const derivedVariables =
+          derivedVariableMap.get(unitKey) || new Set<string>();
         derivedVariables.add(variable.variableId);
         derivedVariableMap.set(unitKey, derivedVariables);
       });
+    const responsesByVariable = new Map<string, SlimCodingResponse[]>();
+    slimResponses.forEach(response => {
+      const key = `${response.unitName}::${response.variableid}`;
+      const responses = responsesByVariable.get(key) || [];
+      responses.push(response);
+      responsesByVariable.set(key, responses);
+    });
 
     for (const variable of variables) {
       const key = `${variable.unitName}::${variable.variableId}`;
 
-      const varResponsesWithRequestedStatuses = slimResponses.filter(
-        r => r.unitName === variable.unitName && r.variableid === variable.variableId
-      );
+      const varResponsesWithRequestedStatuses =
+        responsesByVariable.get(key) || [];
 
       const countAggregatedCases = (responses: SlimCodingResponse[]) => {
         const responsesWithCaseFields: ManualCodingDeduplicationResponse[] =
@@ -801,7 +919,8 @@ export class CodingValidationService {
             responseId: response.id,
             variableId: response.variableid
           }));
-        const assignedResponseIds = assignedResponseIdsByVariable.get(key) || new Set<number>();
+        const assignedResponseIds =
+          assignedResponseIdsByVariable.get(key) || new Set<number>();
 
         return countEffectiveManualCodingCases(
           responsesWithCaseFields,
@@ -812,10 +931,12 @@ export class CodingValidationService {
         );
       };
 
-      const includeDeriveErrorForVariable = includeDeriveErrorInCaseInfo &&
-        variable.deriveErrorResponseCount > 0;
+      const includeDeriveErrorForVariable =
+        includeDeriveErrorInCaseInfo && variable.deriveErrorResponseCount > 0;
       const regularVarResponses = includeDeriveErrorForVariable ?
-        varResponsesWithRequestedStatuses.filter(response => response.statusV1 !== DERIVE_ERROR_STATUS) :
+        varResponsesWithRequestedStatuses.filter(
+          response => response.statusV1 !== DERIVE_ERROR_STATUS
+        ) :
         varResponsesWithRequestedStatuses;
       const regularCaseInfo = countAggregatedCases(regularVarResponses);
       const deriveErrorCaseInfo = includeDeriveErrorForVariable ?
@@ -824,15 +945,22 @@ export class CodingValidationService {
 
       result.set(key, {
         casesInJobs: regularCaseInfo.casesInJobs,
-        availableCases: Math.max(0, regularCaseInfo.uniqueCases - regularCaseInfo.casesInJobs),
+        availableCases: Math.max(
+          0,
+          regularCaseInfo.uniqueCases - regularCaseInfo.casesInJobs
+        ),
         uniqueCasesAfterAggregation: regularCaseInfo.uniqueCases,
-        ...(deriveErrorCaseInfo ? {
-          availableCasesWithDeriveError: Math.max(
-            0,
-            deriveErrorCaseInfo.uniqueCases - deriveErrorCaseInfo.casesInJobs
-          ),
-          uniqueCasesAfterAggregationWithDeriveError: deriveErrorCaseInfo.uniqueCases
-        } : {})
+        ...(deriveErrorCaseInfo ?
+          {
+            availableCasesWithDeriveError: Math.max(
+              0,
+              deriveErrorCaseInfo.uniqueCases -
+                  deriveErrorCaseInfo.casesInJobs
+            ),
+            uniqueCasesAfterAggregationWithDeriveError:
+                deriveErrorCaseInfo.uniqueCases
+          } :
+          {})
       });
     }
 
@@ -851,22 +979,16 @@ export class CodingValidationService {
     const variableDetailsByKey = new Map<string, VariableDetailDto>();
 
     unitVariableDetails.forEach(unitDetails => {
-      const unitKeys = [
-        unitDetails.unitName,
-        unitDetails.unitId
-      ].filter(Boolean);
+      const unitKeys = [unitDetails.unitName, unitDetails.unitId].filter(
+        Boolean
+      );
 
       unitDetails.variables.forEach(variable => {
-        const variableIds = [
-          variable.alias || variable.id
-        ].filter(Boolean);
+        const variableIds = [variable.alias || variable.id].filter(Boolean);
 
         unitKeys.forEach(unitKey => {
           variableIds.forEach(variableId => {
-            const key = this.getManualCodeAvailabilityKey(
-              unitKey,
-              variableId
-            );
+            const key = this.getManualCodeAvailabilityKey(unitKey, variableId);
             if (!variableDetailsByKey.has(key)) {
               variableDetailsByKey.set(key, variable);
             }
@@ -887,15 +1009,14 @@ export class CodingValidationService {
 
     return {
       regularCodeCount: regularCodes.length,
-      selectableRegularCodeCount: regularCodes.filter(
-        code => this.hasManualInstruction(code)
+      selectableRegularCodeCount: regularCodes.filter(code => this.hasManualInstruction(code)
       ).length
     };
   }
 
-  private hasManualInstruction(
-    code: { manualInstruction?: string | null }
-  ): boolean {
+  private hasManualInstruction(code: {
+    manualInstruction?: string | null;
+  }): boolean {
     return hasVisibleManualInstruction(code);
   }
 
@@ -903,7 +1024,9 @@ export class CodingValidationService {
     unitName: string | null | undefined,
     variableId: string | null | undefined
   ): string {
-    return `${String(unitName || '').trim().toUpperCase()}::${String(variableId || '').trim()}`;
+    return `${String(unitName || '')
+      .trim()
+      .toUpperCase()}::${String(variableId || '').trim()}`;
   }
 
   private async getAssignedResponseIdsByVariable(
@@ -917,7 +1040,10 @@ export class CodingValidationService {
       return result;
     }
 
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     const query = this.codingJobUnitRepository
       .createQueryBuilder('cju')
       .select('cju.unit_name', 'unitName')
@@ -937,18 +1063,7 @@ export class CodingValidationService {
       );
     }
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `assignedUnitName${index}`;
-      const variableParam = `assignedVariableId${index}`;
-      conditions.push(`(cju.unit_name = :${unitParam} AND cju.variable_id = :${variableParam})`);
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    query.andWhere(`(${conditions.join(' OR ')})`, parameters);
+    this.applyAssignedVariablePairFilter(query, variables);
     applyNonCodingIssueReviewJobFilter(
       query,
       'coding_job',
@@ -983,7 +1098,14 @@ export class CodingValidationService {
     trainingRequired?: boolean,
     includeDeriveErrorOnly = false
   ): Promise<
-    { unitName: string; variableId: string; responseCount: number; deriveErrorResponseCount: number; isDerived: boolean; coderTrainingRequired: boolean }[]
+    {
+      unitName: string;
+      variableId: string;
+      responseCount: number;
+      deriveErrorResponseCount: number;
+      isDerived: boolean;
+      coderTrainingRequired: boolean;
+    }[]
     > {
     const scope = await this.fetchManualCodingScopeFromDb(
       workspaceId,
@@ -994,13 +1116,54 @@ export class CodingValidationService {
     return scope.variables;
   }
 
+  private applyAssignedVariablePairFilter(
+    query: SelectQueryBuilder<CodingJobUnit>,
+    variables: { unitName: string; variableId: string }[]
+  ): void {
+    const parameters: Record<string, string> = {};
+    const pairs = variables.map((variable, index) => {
+      const unitParam = `assignedUnitName${index}`;
+      const variableParam = `assignedVariableId${index}`;
+      parameters[unitParam] = variable.unitName;
+      parameters[variableParam] = variable.variableId;
+      return `(:${unitParam}, :${variableParam})`;
+    });
+
+    query.andWhere(
+      `(cju.unit_name, cju.variable_id) IN (${pairs.join(', ')})`,
+      parameters
+    );
+  }
+
+  private createResponseVariablePairCondition(
+    variables: { unitName: string; variableId: string }[],
+    parameterPrefix: string
+  ): { condition: string; parameters: Record<string, string> } {
+    const parameters: Record<string, string> = {};
+    const pairs = variables.map((variable, index) => {
+      const unitParam = `${parameterPrefix}UnitName${index}`;
+      const variableParam = `${parameterPrefix}VariableId${index}`;
+      parameters[unitParam] = variable.unitName;
+      parameters[variableParam] = variable.variableId;
+      return `(:${unitParam}, :${variableParam})`;
+    });
+
+    return {
+      condition: `(unit.name, response.variableid) IN (${pairs.join(', ')})`,
+      parameters
+    };
+  }
+
   private async fetchManualCodingScopeFromDb(
     workspaceId: number,
     unitName?: string,
     trainingRequired?: boolean,
     includeDeriveErrorOnly = false
   ): Promise<ManualCodingScopeFromDb> {
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     // Helper to build the base query for a given status
     const buildQuery = (status: number) => {
       const qb = this.responseRepository
@@ -1013,7 +1176,9 @@ export class CodingValidationService {
         .leftJoin('booklet.bookletinfo', 'bookletinfo')
         .leftJoin('booklet.person', 'person')
         .where('response.status_v1 = :status', { status })
-        .andWhere('person.workspace_id = :workspace_id', { workspace_id: workspaceId })
+        .andWhere('person.workspace_id = :workspace_id', {
+          workspace_id: workspaceId
+        })
         .andWhere('person.consider = :consider', { consider: true })
         // Exclude special/auto codes represented as negative code_v2 values.
         .andWhere('(response.code_v2 IS NULL OR response.code_v2 >= 0)')
@@ -1028,19 +1193,34 @@ export class CodingValidationService {
     };
 
     // Run both queries in parallel
-    const [codingIncompleteRaw, intendedIncompleteRaw, deriveErrorCountsByKey] = await Promise.all([
-      buildQuery(statusStringToNumber('CODING_INCOMPLETE')).getRawMany(),
-      buildQuery(statusStringToNumber('INTENDED_INCOMPLETE')).getRawMany(),
-      this.getDeriveErrorResponseCountsByVariable(workspaceId, unitName)
-    ]);
+    const [codingIncompleteRaw, intendedIncompleteRaw, deriveErrorCountsByKey] =
+      await Promise.all([
+        buildQuery(statusStringToNumber('CODING_INCOMPLETE')).getRawMany(),
+        buildQuery(statusStringToNumber('INTENDED_INCOMPLETE')).getRawMany(),
+        this.getDeriveErrorResponseCountsByVariable(workspaceId, unitName)
+      ]);
 
     this.logger.debug(
-      `[DEBUG] CODING_INCOMPLETE raw results (${codingIncompleteRaw.length}): ${
-        codingIncompleteRaw.map((r: { unitName: string; variableId: string; responseCount: string }) => `${r.unitName}::${r.variableId}(${r.responseCount})`).join(', ')}`
+      `[DEBUG] CODING_INCOMPLETE raw results (${codingIncompleteRaw.length}): ${codingIncompleteRaw
+        .map(
+          (r: {
+            unitName: string;
+            variableId: string;
+            responseCount: string;
+          }) => `${r.unitName}::${r.variableId}(${r.responseCount})`
+        )
+        .join(', ')}`
     );
     this.logger.debug(
-      `[DEBUG] INTENDED_INCOMPLETE raw results (${intendedIncompleteRaw.length}): ${
-        intendedIncompleteRaw.map((r: { unitName: string; variableId: string; responseCount: string }) => `${r.unitName}::${r.variableId}(${r.responseCount})`).join(', ')}`
+      `[DEBUG] INTENDED_INCOMPLETE raw results (${intendedIncompleteRaw.length}): ${intendedIncompleteRaw
+        .map(
+          (r: {
+            unitName: string;
+            variableId: string;
+            responseCount: string;
+          }) => `${r.unitName}::${r.variableId}(${r.responseCount})`
+        )
+        .join(', ')}`
     );
 
     // Load both lookup maps from the file service
@@ -1053,7 +1233,9 @@ export class CodingValidationService {
     ] = await Promise.all([
       this.workspaceFilesService.getUnitVariableMap(workspaceId),
       this.workspaceFilesService.getDerivedVariableMap(workspaceId),
-      this.workspaceFilesService.getCoderTrainingRequiredVariableMap(workspaceId),
+      this.workspaceFilesService.getCoderTrainingRequiredVariableMap(
+        workspaceId
+      ),
       this.workspaceFilesService.getDerivedVariablesBySourceMap(workspaceId),
       this.workspaceFilesService.getManualInstructionVariableMap(workspaceId)
     ]);
@@ -1065,25 +1247,35 @@ export class CodingValidationService {
     });
 
     const derivedVariableSets = new Map<string, Set<string>>();
-    derivedVariableMap.forEach((variables: Set<string>, unitNameKey: string) => {
-      derivedVariableSets.set(unitNameKey.toUpperCase(), variables);
-    });
+    derivedVariableMap.forEach(
+      (variables: Set<string>, unitNameKey: string) => {
+        derivedVariableSets.set(unitNameKey.toUpperCase(), variables);
+      }
+    );
 
     const trainingRequiredSets = new Map<string, Set<string>>();
-    trainingRequiredMap.forEach((variables: Set<string>, unitNameKey: string) => {
-      trainingRequiredSets.set(unitNameKey.toUpperCase(), variables);
-    });
+    trainingRequiredMap.forEach(
+      (variables: Set<string>, unitNameKey: string) => {
+        trainingRequiredSets.set(unitNameKey.toUpperCase(), variables);
+      }
+    );
 
     const manualInstructionSets = new Map<string, Set<string>>();
-    manualInstructionMap.forEach((variables: Set<string>, unitNameKey: string) => {
-      manualInstructionSets.set(unitNameKey.toUpperCase(), variables);
-    });
+    manualInstructionMap.forEach(
+      (variables: Set<string>, unitNameKey: string) => {
+        manualInstructionSets.set(unitNameKey.toUpperCase(), variables);
+      }
+    );
 
     this.logger.debug(
       `[DEBUG] unitVariableMap units: [${Array.from(validVariableSets.keys()).join(', ')}]`
     );
     // Filter results, applying trainingRequired filter if provided
-    const filterFn = (row: { unitName: string; variableId: string; responseCount: string }) => {
+    const filterFn = (row: {
+      unitName: string;
+      variableId: string;
+      responseCount: string;
+    }) => {
       const unitKey = row.unitName?.toUpperCase();
       const variableId = row.variableId;
 
@@ -1092,7 +1284,8 @@ export class CodingValidationService {
       if (!validVars?.has(variableId)) return false;
 
       // Filter by trainingRequired
-      const isRequired = trainingRequiredSets.get(unitKey)?.has(variableId) || false;
+      const isRequired =
+        trainingRequiredSets.get(unitKey)?.has(variableId) || false;
       if (trainingRequired !== undefined) {
         if (isRequired !== trainingRequired) {
           return false;
@@ -1126,49 +1319,62 @@ export class CodingValidationService {
     );
     const deriveErrorCoveredSourceKeys = includeDeriveErrorOnly ?
       getCoveredSourceKeysForManualDerivedVariables(
-        Array.from(manualInstructionSets.entries()).flatMap(([manualUnitName, variables]) => (
-          Array.from(variables)
+        Array.from(manualInstructionSets.entries()).flatMap(
+          ([manualUnitName, variables]) => Array.from(variables)
             .map(variableId => ({ unitName: manualUnitName, variableId }))
             .filter(row => filterFn({
               unitName: row.unitName,
               variableId: row.variableId,
               responseCount: '0'
-            }))
-        )),
+            })
+            )
+        ),
         derivedVariablesBySourceMap
       ) :
       new Set<string>();
     const getScopedDeriveErrorResponseCount = (
       responseUnitName: string,
       variableId: string
-    ): number => (
-      includeDeriveErrorOnly &&
+    ): number => (includeDeriveErrorOnly &&
       isCoveredSourceVariable(
         { unitName: responseUnitName, variableId },
         deriveErrorCoveredSourceKeys
       ) ?
-        0 :
-        deriveErrorCountsByKey.get(`${responseUnitName}::${variableId}`) || 0
-    );
+      0 :
+      deriveErrorCountsByKey.get(`${responseUnitName}::${variableId}`) || 0);
 
     // Merge results, summing response counts for variables that appear in both
-    const mergedMap = new Map<string, {
+    const mergedMap = new Map<
+    string,
+    {
       unitName: string;
       variableId: string;
       responseCount: number;
       deriveErrorResponseCount: number;
       isDerived: boolean;
       coderTrainingRequired: boolean;
-    }>();
+    }
+    >();
 
-    for (const row of [...filteredCodingIncomplete, ...filteredIntendedIncomplete]) {
+    for (const row of [
+      ...filteredCodingIncomplete,
+      ...filteredIntendedIncomplete
+    ]) {
       const key = `${row.unitName}::${row.variableId}`;
       const existing = mergedMap.get(key);
       const count = parseInt(row.responseCount, 10);
-      const deriveErrorResponseCount =
-        getScopedDeriveErrorResponseCount(row.unitName, row.variableId);
-      const isDerived = derivedVariableSets.get(row.unitName?.toUpperCase())?.has(row.variableId) ?? false;
-      const coderTrainingRequired = trainingRequiredSets.get(row.unitName?.toUpperCase())?.has(row.variableId) ?? false;
+      const deriveErrorResponseCount = getScopedDeriveErrorResponseCount(
+        row.unitName,
+        row.variableId
+      );
+      const isDerived =
+        derivedVariableSets
+          .get(row.unitName?.toUpperCase())
+          ?.has(row.variableId) ?? false;
+      const coderTrainingRequired =
+        trainingRequiredSets
+          .get(row.unitName?.toUpperCase())
+          ?.has(row.variableId) ?? false;
 
       if (existing) {
         existing.responseCount += count;
@@ -1199,11 +1405,13 @@ export class CodingValidationService {
         ) {
           return;
         }
-        if (!filterFn({
-          unitName: deriveUnitName,
-          variableId,
-          responseCount: String(deriveErrorResponseCount)
-        })) {
+        if (
+          !filterFn({
+            unitName: deriveUnitName,
+            variableId,
+            responseCount: String(deriveErrorResponseCount)
+          })
+        ) {
           return;
         }
 
@@ -1212,8 +1420,14 @@ export class CodingValidationService {
           variableId,
           responseCount: 0,
           deriveErrorResponseCount,
-          isDerived: derivedVariableSets.get(deriveUnitName?.toUpperCase())?.has(variableId) ?? false,
-          coderTrainingRequired: trainingRequiredSets.get(deriveUnitName?.toUpperCase())?.has(variableId) ?? false
+          isDerived:
+            derivedVariableSets
+              .get(deriveUnitName?.toUpperCase())
+              ?.has(variableId) ?? false,
+          coderTrainingRequired:
+            trainingRequiredSets
+              .get(deriveUnitName?.toUpperCase())
+              ?.has(variableId) ?? false
         });
       });
     }
@@ -1222,7 +1436,7 @@ export class CodingValidationService {
 
     this.logger.log(
       `Found ${codingIncompleteRaw.length} CODING_INCOMPLETE + ${intendedIncompleteRaw.length} INTENDED_INCOMPLETE variable groups, ` +
-      `filtered to ${result.length} valid variables${unitName ? ` for unit ${unitName}` : ''}`
+        `filtered to ${result.length} valid variables${unitName ? ` for unit ${unitName}` : ''}`
     );
 
     return {
@@ -1235,7 +1449,10 @@ export class CodingValidationService {
     workspaceId: number,
     unitName?: string
   ): Promise<Map<string, number>> {
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     const query = this.responseRepository
       .createQueryBuilder('response')
       .select('unit.name', 'unitName')
@@ -1248,7 +1465,9 @@ export class CodingValidationService {
       .where('response.status_v1 = :status', {
         status: statusStringToNumber('DERIVE_ERROR')
       })
-      .andWhere('person.workspace_id = :workspace_id', { workspace_id: workspaceId })
+      .andWhere('person.workspace_id = :workspace_id', {
+        workspace_id: workspaceId
+      })
       .andWhere('person.consider = :consider', { consider: true })
       .andWhere('(response.code_v2 IS NULL OR response.code_v2 >= 0)')
       .groupBy('unit.name')
@@ -1270,7 +1489,10 @@ export class CodingValidationService {
 
     return rawResults.reduce((counts, row) => {
       if (row.unitName && row.variableId) {
-        counts.set(`${row.unitName}::${row.variableId}`, parseInt(row.responseCount, 10) || 0);
+        counts.set(
+          `${row.unitName}::${row.variableId}`,
+          parseInt(row.responseCount, 10) || 0
+        );
       }
       return counts;
     }, new Map<string, number>());
@@ -1281,21 +1503,146 @@ export class CodingValidationService {
   }
 
   async invalidateIncompleteVariablesCache(workspaceId: number): Promise<void> {
+    this.bumpManualCodingCacheGeneration(workspaceId);
     const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
-    await this.cacheService.delete(cacheKey);
+    const scopeSummaryCacheKey =
+      this.generateManualCodingScopeSummaryCacheKey(workspaceId);
+    this.manualCodingVariablesInFlight.delete(cacheKey);
+    this.manualCodingScopeSummaryInFlight.delete(scopeSummaryCacheKey);
+    await Promise.all([
+      this.cacheService.delete(cacheKey),
+      this.cacheService.delete(scopeSummaryCacheKey),
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspaceId)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspaceId)
+      )
+    ]);
     this.logger.log(
-      `Invalidated manual coding variables cache for workspace ${workspaceId}`
+      `Invalidated manual coding variables and applied results overview cache for workspace ${workspaceId}`
+    );
+  }
+
+  private async fetchAndCacheCodingIncompleteVariables(
+    workspaceId: number,
+    cacheKey: string,
+    cacheGeneration: number
+  ): Promise<ManualCodingVariableWithCaseInfo[]> {
+    const variables = await this.fetchCodingIncompleteVariablesFromDb(
+      workspaceId,
+      undefined,
+      undefined,
+      false
+    );
+    const result = await this.enrichVariablesWithCaseInfo(
+      workspaceId,
+      variables
+    );
+
+    if (this.getManualCodingCacheGeneration(workspaceId) !== cacheGeneration) {
+      this.logger.log(
+        `Skipped caching stale manual coding variables for workspace ${workspaceId}`
+      );
+      return result;
+    }
+
+    const cacheSet = await this.cacheService.set(
+      cacheKey,
+      result,
+      this.manualCodingCacheTtlSeconds
+    );
+    if (cacheSet) {
+      this.logger.log(
+        `Cached ${result.length} manual coding variables for workspace ${workspaceId}`
+      );
+    } else {
+      this.logger.warn(
+        `Failed to cache manual coding variables for workspace ${workspaceId}`
+      );
+    }
+    return result;
+  }
+
+  private async fetchAndCacheManualCodingScopeSummary(
+    workspaceId: number,
+    cacheKey: string,
+    cacheGeneration: number
+  ): Promise<ManualCodingScopeSummary> {
+    const scope = await this.fetchManualCodingScopeFromDb(workspaceId);
+    const summary = this.createManualCodingScopeSummary(scope);
+
+    if (this.getManualCodingCacheGeneration(workspaceId) !== cacheGeneration) {
+      this.logger.log(
+        `Skipped caching stale manual coding scope summary for workspace ${workspaceId}`
+      );
+      return summary;
+    }
+
+    await this.cacheService.set(
+      cacheKey,
+      summary,
+      this.manualCodingCacheTtlSeconds
+    );
+    return summary;
+  }
+
+  private createManualCodingScopeSummary(
+    scope: ManualCodingScopeFromDb
+  ): ManualCodingScopeSummary {
+    return {
+      manualVariableCount: scope.variables.length,
+      manualResponseCount: scope.variables.reduce(
+        (sum, variable) => sum + variable.responseCount,
+        0
+      ),
+      ...scope.excludedSourceSummary
+    };
+  }
+
+  private getManualCodingCacheGeneration(workspaceId: number): number {
+    return this.manualCodingCacheGenerationByWorkspace.get(workspaceId) || 0;
+  }
+
+  private bumpManualCodingCacheGeneration(workspaceId: number): void {
+    this.manualCodingCacheGenerationByWorkspace.set(
+      workspaceId,
+      this.getManualCodingCacheGeneration(workspaceId) + 1
+    );
+  }
+
+  private generateManualCodingScopeSummaryCacheKey(
+    workspaceId: number
+  ): string {
+    return `${this.generateIncompleteVariablesCacheKey(workspaceId)}:scope-summary`;
+  }
+
+  private logSlowManualCodingQuery(
+    operation: string,
+    workspaceId: number,
+    startedAt: number
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    if (durationMs < this.slowManualCodingQueryThresholdMs) {
+      return;
+    }
+
+    this.logger.warn(
+      `${operation} for workspace ${workspaceId} took ${durationMs} ms`
     );
   }
 
   /**
-     * Get the number of unique cases (response_ids) already assigned to coding jobs for each variable
-     * This counts distinct response_ids to properly handle double-coding scenarios
-     */
+   * Get the number of unique cases (response_ids) already assigned to coding jobs for each variable
+   * This counts distinct response_ids to properly handle double-coding scenarios
+   */
   async getVariableCasesInJobs(
     workspaceId: number
   ): Promise<Map<string, number>> {
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     const query = this.codingJobUnitRepository
       .createQueryBuilder('cju')
       .select('cju.unit_name', 'unitName')
@@ -1335,7 +1682,10 @@ export class CodingValidationService {
   private async getDeriveErrorManualJobVariables(
     workspaceId: number
   ): Promise<Array<{ unitName: string; variableId: string }>> {
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     const query = this.codingJobUnitRepository
       .createQueryBuilder('cju')
       .select('cju.unit_name', 'unitName')
@@ -1360,7 +1710,10 @@ export class CodingValidationService {
       parameterPrefix: 'appliedResultsDeriveErrorVariables'
     });
 
-    const rawResults = await query.getRawMany<{ unitName: string; variableId: string }>();
+    const rawResults = await query.getRawMany<{
+      unitName: string;
+      variableId: string;
+    }>();
     return rawResults.filter(row => row.unitName && row.variableId);
   }
 
@@ -1371,7 +1724,8 @@ export class CodingValidationService {
     const providedVariables = Array.isArray(incompleteVariables) ?
       incompleteVariables :
       [];
-    const deriveErrorManualVariables = await this.getDeriveErrorManualJobVariables(workspaceId);
+    const deriveErrorManualVariables =
+      await this.getDeriveErrorManualJobVariables(workspaceId);
     return createManualCodingVariableReferences([
       ...providedVariables,
       ...deriveErrorManualVariables
@@ -1400,11 +1754,18 @@ export class CodingValidationService {
       }
 
       let totalAppliedCount = 0;
-      const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+      const exclusions =
+        await this.workspaceExclusionService.resolveExclusionsForQueries(
+          workspaceId
+        );
       const batchSize = 50;
       for (let i = 0; i < appliedResultsVariables.length; i += batchSize) {
         const batch = appliedResultsVariables.slice(i, i + batchSize);
 
+        const variablePairCondition = this.createResponseVariablePairCondition(
+          batch,
+          `appliedResults${i}`
+        );
         const query = this.responseRepository
           .createQueryBuilder('response')
           .innerJoin('response.unit', 'unit')
@@ -1413,14 +1774,15 @@ export class CodingValidationService {
           .innerJoin('booklet.person', 'person')
           .where('person.workspace_id = :workspaceId', { workspaceId })
           .andWhere('person.consider = :consider', { consider: true })
-          .andWhere(new Brackets(qb => {
-            qb.where('response.status_v1 IN (:...sourceStatuses)', {
-              sourceStatuses: [
-                statusStringToNumber('CODING_INCOMPLETE'),
-                statusStringToNumber('INTENDED_INCOMPLETE')
-              ]
-            }).orWhere(
-              `response.status_v1 = :deriveErrorStatus
+          .andWhere(
+            new Brackets(qb => {
+              qb.where('response.status_v1 IN (:...sourceStatuses)', {
+                sourceStatuses: [
+                  statusStringToNumber('CODING_INCOMPLETE'),
+                  statusStringToNumber('INTENDED_INCOMPLETE')
+                ]
+              }).orWhere(
+                `response.status_v1 = :deriveErrorStatus
                 AND EXISTS (
                   SELECT 1
                   FROM coding_job_unit manual_derive_cju
@@ -1430,9 +1792,10 @@ export class CodingValidationService {
                     AND manual_derive_cj.training_id IS NULL
                     AND ${getNonCodingIssueReviewJobSqlCondition('manual_derive_cj')}
                 )`,
-              { deriveErrorStatus: statusStringToNumber('DERIVE_ERROR') }
-            );
-          }))
+                { deriveErrorStatus: statusStringToNumber('DERIVE_ERROR') }
+              );
+            })
+          )
           .andWhere('response.status_v2 IN (:...targetStatuses)', {
             targetStatuses: [
               statusStringToNumber('CODING_COMPLETE'),
@@ -1441,28 +1804,21 @@ export class CodingValidationService {
             ]
           })
           .andWhere('(response.code_v2 IS NULL OR response.code_v2 >= 0)')
-          .andWhere(new Brackets(qb => {
-            batch.forEach((variable, index) => {
-              const parameters = {
-                [`appliedUnitName${index}`]: variable.unitName,
-                [`appliedVariableId${index}`]: variable.variableId
-              };
-              const condition = `(unit.name = :appliedUnitName${index} AND response.variableid = :appliedVariableId${index})`;
-              if (index === 0) {
-                qb.where(condition, parameters);
-              } else {
-                qb.orWhere(condition, parameters);
-              }
-            });
-          }));
+          .andWhere(
+            variablePairCondition.condition,
+            variablePairCondition.parameters
+          );
 
-        applyResolvedExclusionsToQuery(query, exclusions, { parameterPrefix: `appliedResults${i}` });
+        applyResolvedExclusionsToQuery(query, exclusions, {
+          parameterPrefix: `appliedResults${i}`
+        });
 
         const batchCount = await query.getCount();
         totalAppliedCount += batchCount;
 
         this.logger.debug(
-          `Batch ${Math.floor(i / batchSize) + 1
+          `Batch ${
+            Math.floor(i / batchSize) + 1
           }: ${batchCount} applied results`
         );
       }

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -51,7 +51,11 @@ describe('ExternalCodingImportService', () => {
         }
       }
     };
-    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
     const codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };
@@ -140,7 +144,11 @@ describe('ExternalCodingImportService', () => {
         }
       }
     };
-    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
     const codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };
@@ -221,7 +229,11 @@ describe('ExternalCodingImportService', () => {
         }
       }
     };
-    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
     const codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
@@ -15,6 +15,10 @@ import FileUpload from '../../entities/file_upload.entity';
 import { CodingFreshnessService } from './coding-freshness.service';
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 
 interface ExternalCodingRow {
   unit_key?: string;
@@ -1251,7 +1255,15 @@ export class ExternalCodingImportService {
    */
   async invalidateIncompleteVariablesCache(workspaceId: number): Promise<void> {
     const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
-    await this.cacheService.delete(cacheKey);
-    this.logger.log(`Invalidated manual coding variables cache for workspace ${workspaceId}`);
+    await Promise.all([
+      this.cacheService.delete(cacheKey),
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspaceId)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspaceId)
+      )
+    ]);
+    this.logger.log(`Invalidated manual coding variables and applied results overview cache for workspace ${workspaceId}`);
   }
 }

--- a/apps/backend/src/app/database/services/coding/response-analysis-page-cache.util.ts
+++ b/apps/backend/src/app/database/services/coding/response-analysis-page-cache.util.ts
@@ -1,0 +1,297 @@
+import {
+  AggregationSummaryDto,
+  DuplicateValueAnalysisDto,
+  DuplicateValueGroupDto,
+  EmptyResponseAnalysisDto,
+  EmptyResponseDto,
+  ResponseAnalysisDto
+} from '../../../../../../../api-dto/coding/response-analysis.dto';
+
+export interface ResponseAnalysisSummaryCache {
+  emptyResponses: Omit<EmptyResponseAnalysisDto, 'items' | 'page' | 'pageSize'>;
+  duplicateValues: Omit<
+  DuplicateValueAnalysisDto,
+  'groups' | 'page' | 'pageSize'
+  >;
+  aggregationSummary: AggregationSummaryDto;
+  matchingFlags: string[];
+  analysisTimestamp: string;
+  sourceRevision?: number;
+}
+
+export interface EmptyResponsePageCache {
+  items: EmptyResponseDto[];
+  page: number;
+  pageSize: number;
+}
+
+export interface DuplicateValuePageCache {
+  groups: DuplicateValueGroupDto[];
+  page: number;
+  pageSize: number;
+}
+
+export interface EmptyResponseChunkCache {
+  items: EmptyResponseDto[];
+  chunkIndex: number;
+  chunkSize: number;
+}
+
+export interface DuplicateValueChunkCache {
+  groups: DuplicateValueGroupDto[];
+  chunkIndex: number;
+  chunkSize: number;
+}
+
+export const RESPONSE_ANALYSIS_EMPTY_PAGE_LIMITS = [5, 10, 25, 50, 100];
+export const RESPONSE_ANALYSIS_DUPLICATE_PAGE_LIMITS = [5, 10, 20, 50, 100];
+export const RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT = 5;
+export const RESPONSE_ANALYSIS_CHUNK_SIZE = 500;
+
+export function getResponseAnalysisSummaryCacheKey(cacheKey: string): string {
+  return `${cacheKey}:summary`;
+}
+
+export function getResponseAnalysisEmptyPageCacheKey(
+  cacheKey: string,
+  page: number,
+  pageSize: number
+): string {
+  return `${cacheKey}:empty:p${page}:l${pageSize}`;
+}
+
+export function getResponseAnalysisDuplicatePageCacheKey(
+  cacheKey: string,
+  page: number,
+  pageSize: number
+): string {
+  return `${cacheKey}:duplicate:p${page}:l${pageSize}`;
+}
+
+export function getResponseAnalysisEmptyChunkCacheKey(
+  cacheKey: string,
+  chunkIndex: number
+): string {
+  return `${cacheKey}:empty-chunk:${chunkIndex}`;
+}
+
+export function getResponseAnalysisDuplicateChunkCacheKey(
+  cacheKey: string,
+  chunkIndex: number
+): string {
+  return `${cacheKey}:duplicate-chunk:${chunkIndex}`;
+}
+
+export function getResponseAnalysisDerivedCachePattern(
+  cacheKey: string
+): string {
+  return `${cacheKey}:*`;
+}
+
+export function createResponseAnalysisSummaryCache(
+  analysis: ResponseAnalysisDto
+): ResponseAnalysisSummaryCache {
+  return {
+    emptyResponses: {
+      total: analysis.emptyResponses.total,
+      totalUncoded: analysis.emptyResponses.totalUncoded
+    },
+    duplicateValues: {
+      total: analysis.duplicateValues.total,
+      totalResponses: analysis.duplicateValues.totalResponses,
+      isAggregationApplied: analysis.duplicateValues.isAggregationApplied
+    },
+    aggregationSummary: analysis.aggregationSummary,
+    matchingFlags: analysis.matchingFlags,
+    analysisTimestamp: analysis.analysisTimestamp,
+    sourceRevision: analysis.sourceRevision
+  };
+}
+
+export function createEmptyResponsePageCache(
+  analysis: ResponseAnalysisDto,
+  page: number,
+  pageSize: number
+): EmptyResponsePageCache {
+  const start = (page - 1) * pageSize;
+  return {
+    items: analysis.emptyResponses.items.slice(start, start + pageSize),
+    page,
+    pageSize
+  };
+}
+
+export function createDuplicateValuePageCache(
+  analysis: ResponseAnalysisDto,
+  page: number,
+  pageSize: number
+): DuplicateValuePageCache {
+  const start = (page - 1) * pageSize;
+  return {
+    groups: analysis.duplicateValues.groups
+      .slice(start, start + pageSize)
+      .map(group => ({
+        ...group,
+        occurrenceCount: group.occurrenceCount ?? group.occurrences.length,
+        occurrences: group.occurrences.slice(
+          0,
+          RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+        )
+      })),
+    page,
+    pageSize
+  };
+}
+
+export function createEmptyResponseChunkCaches(
+  analysis: ResponseAnalysisDto,
+  chunkSize = RESPONSE_ANALYSIS_CHUNK_SIZE
+): EmptyResponseChunkCache[] {
+  return chunkArray(analysis.emptyResponses.items, chunkSize).map(
+    (items, chunkIndex) => ({
+      items,
+      chunkIndex,
+      chunkSize
+    })
+  );
+}
+
+export function createDuplicateValueChunkCaches(
+  analysis: ResponseAnalysisDto,
+  chunkSize = RESPONSE_ANALYSIS_CHUNK_SIZE
+): DuplicateValueChunkCache[] {
+  return chunkArray(
+    analysis.duplicateValues.groups.map(group => ({
+      ...group,
+      occurrenceCount: group.occurrenceCount ?? group.occurrences.length,
+      occurrences: group.occurrences.slice(
+        0,
+        RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+      )
+    })),
+    chunkSize
+  ).map((groups, chunkIndex) => ({
+    groups,
+    chunkIndex,
+    chunkSize
+  }));
+}
+
+export function getRequiredResponseAnalysisChunkIndexes(
+  page: number,
+  pageSize: number,
+  chunkSize = RESPONSE_ANALYSIS_CHUNK_SIZE
+): number[] {
+  const start = Math.max(0, (page - 1) * pageSize);
+  const end = Math.max(start, start + pageSize - 1);
+  const firstChunk = Math.floor(start / chunkSize);
+  const lastChunk = Math.floor(end / chunkSize);
+  return Array.from(
+    { length: lastChunk - firstChunk + 1 },
+    (_, index) => firstChunk + index
+  );
+}
+
+export function createEmptyResponsePageCacheFromChunks(
+  chunks: EmptyResponseChunkCache[],
+  page: number,
+  pageSize: number
+): EmptyResponsePageCache | null {
+  const items = slicePageFromChunks(chunks, page, pageSize, chunk => chunk.items);
+  return items ? { items, page, pageSize } : null;
+}
+
+export function createDuplicateValuePageCacheFromChunks(
+  chunks: DuplicateValueChunkCache[],
+  page: number,
+  pageSize: number
+): DuplicateValuePageCache | null {
+  const groups = slicePageFromChunks(chunks, page, pageSize, chunk => chunk.groups);
+  return groups ? { groups, page, pageSize } : null;
+}
+
+export function createResponseAnalysisFromCachedParts(
+  summary: ResponseAnalysisSummaryCache,
+  emptyPage: EmptyResponsePageCache,
+  duplicatePage: DuplicateValuePageCache,
+  currentSourceRevision: number,
+  isCalculating: boolean,
+  progress: number
+): ResponseAnalysisDto {
+  return {
+    emptyResponses: {
+      ...summary.emptyResponses,
+      items: emptyPage.items,
+      page: emptyPage.page,
+      pageSize: emptyPage.pageSize
+    },
+    duplicateValues: {
+      ...summary.duplicateValues,
+      groups: duplicatePage.groups,
+      page: duplicatePage.page,
+      pageSize: duplicatePage.pageSize
+    },
+    aggregationSummary: summary.aggregationSummary,
+    matchingFlags: summary.matchingFlags,
+    analysisTimestamp: summary.analysisTimestamp,
+    sourceRevision: summary.sourceRevision,
+    currentSourceRevision,
+    isCalculating,
+    progress
+  };
+}
+
+function chunkArray<T>(items: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let start = 0; start < items.length; start += chunkSize) {
+    chunks.push(items.slice(start, start + chunkSize));
+  }
+  if (chunks.length === 0) {
+    chunks.push([]);
+  }
+  return chunks;
+}
+
+function slicePageFromChunks<T, TChunk>(
+  chunks: TChunk[],
+  page: number,
+  pageSize: number,
+  getItems: (chunk: TChunk) => T[]
+): T[] | null {
+  if (chunks.length === 0 || chunks.some(chunk => !chunk)) {
+    return null;
+  }
+  const chunkSize = getChunkSize(chunks[0]);
+  if (!chunkSize) {
+    return null;
+  }
+  const orderedChunks = [...chunks].sort(
+    (a, b) => getChunkIndex(a) - getChunkIndex(b)
+  );
+  const firstChunkStart = getChunkIndex(orderedChunks[0]) * chunkSize;
+  const pageStart = Math.max(0, (page - 1) * pageSize);
+  const relativeStart = pageStart - firstChunkStart;
+  if (relativeStart < 0) {
+    return null;
+  }
+
+  return orderedChunks
+    .flatMap(chunk => getItems(chunk))
+    .slice(relativeStart, relativeStart + pageSize);
+}
+
+function getChunkIndex(chunk: unknown): number {
+  return typeof chunk === 'object' && chunk !== null &&
+    'chunkIndex' in chunk &&
+    typeof chunk.chunkIndex === 'number' ?
+    chunk.chunkIndex :
+    0;
+}
+
+function getChunkSize(chunk: unknown): number | null {
+  return typeof chunk === 'object' && chunk !== null &&
+    'chunkSize' in chunk &&
+    typeof chunk.chunkSize === 'number' ?
+    chunk.chunkSize :
+    null;
+}

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.ts
@@ -29,6 +29,7 @@ import { CacheService } from '../../../cache/cache.service';
 import { WorkspaceTestResultsService } from './workspace-test-results.service';
 import { CodingFreshnessService } from '../coding/coding-freshness.service';
 import { CodingAnalysisService } from '../coding/coding-analysis.service';
+import { CodingProgressService } from '../coding/coding-progress.service';
 import { TestResultsMutationSummary } from './person-persistence.service';
 import { withWorkspaceTestResultsMutationLock } from '../shared/workspace-test-results-lock.util';
 
@@ -73,7 +74,9 @@ export class TestcenterService {
     @Optional()
     private readonly codingFreshnessService?: CodingFreshnessService,
     @Optional()
-    private readonly codingAnalysisService?: CodingAnalysisService
+    private readonly codingAnalysisService?: CodingAnalysisService,
+    @Optional()
+    private readonly codingProgressService?: CodingProgressService
   ) {}
 
   persons: Person[] = [];
@@ -1169,7 +1172,11 @@ export class TestcenterService {
       await Promise.all([
         this.codingAnalysisService?.invalidateCache(workspaceId),
         this.workspaceTestResultsService.invalidateCodingStatisticsCache(workspaceId),
-        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId)
+        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId),
+        this.codingProgressService?.invalidateAppliedResultsOverviewCache(
+          workspaceId,
+          { prewarm: true }
+        )
       ]);
     } catch (error) {
       const detail = error instanceof Error ? error.message : 'Unknown error';

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.ts
@@ -25,6 +25,7 @@ import { JobQueueService, TestResultsUploadJobData } from '../../../job-queue/jo
 import { WorkspaceTestResultsService } from './workspace-test-results.service';
 import { CodingFreshnessService } from '../coding/coding-freshness.service';
 import { CodingAnalysisService } from '../coding/coding-analysis.service';
+import { CodingProgressService } from '../coding/coding-progress.service';
 import { withWorkspaceTestResultsMutationLock } from '../shared/workspace-test-results-lock.util';
 
 type PersonWithoutBooklets = Omit<Person, 'booklets'>;
@@ -63,7 +64,9 @@ export class UploadResultsService {
     @Optional()
     private readonly codingFreshnessService?: CodingFreshnessService,
     @Optional()
-    private readonly codingAnalysisService?: CodingAnalysisService
+    private readonly codingAnalysisService?: CodingAnalysisService,
+    @Optional()
+    private readonly codingProgressService?: CodingProgressService
   ) {
   }
 
@@ -132,7 +135,11 @@ export class UploadResultsService {
       await Promise.all([
         this.codingAnalysisService?.invalidateCache(workspaceId),
         this.workspaceTestResultsService.invalidateCodingStatisticsCache(workspaceId),
-        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId)
+        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId),
+        this.codingProgressService?.invalidateAppliedResultsOverviewCache(
+          workspaceId,
+          { prewarm: true }
+        )
       ]);
     } catch (error) {
       const detail = error instanceof Error ? error.message : 'Unknown error';

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -62,6 +62,16 @@ const mockQueryBuilder = () => ({
   execute: jest.fn().mockResolvedValue({ affected: 0 })
 });
 
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
 type WorkspaceTestResultsServiceWithLogAnomalyLookup = {
   findLogAnomaliesForBooklets: (
     bookletIds: number[],
@@ -1254,6 +1264,97 @@ describe('WorkspaceTestResultsService', () => {
   });
 
   describe('getWorkspaceTestResultsOverview', () => {
+    it('should return cached overview by test results revision without querying aggregates', async () => {
+      const workspaceId = 1;
+      const cachedOverview = {
+        testPersons: 10,
+        testGroups: 2,
+        uniqueBooklets: 3,
+        uniqueUnits: 4,
+        uniqueResponses: 5,
+        responseStatusCounts: { DISPLAYED: 5 },
+        sessionBrowserCounts: { Chrome: 1 },
+        sessionOsCounts: { Windows: 1 },
+        sessionScreenCounts: { '1920x1080': 1 }
+      };
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 7 }]);
+      cacheService.get.mockResolvedValue(cachedOverview);
+
+      const result = await service.getWorkspaceTestResultsOverview(workspaceId);
+
+      expect(result).toBe(cachedOverview);
+      expect(cacheService.get).toHaveBeenCalledWith(
+        'workspace-overview-stats-1:v7'
+      );
+      expect(personsRepository.count).not.toHaveBeenCalled();
+      expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should reuse an in-flight overview query for the same workspace revision', async () => {
+      const workspaceId = 1;
+      const overview = {
+        testPersons: 1,
+        testGroups: 1,
+        uniqueBooklets: 1,
+        uniqueUnits: 1,
+        uniqueResponses: 1,
+        responseStatusCounts: {},
+        sessionBrowserCounts: {},
+        sessionOsCounts: {},
+        sessionScreenCounts: {}
+      };
+      const overviewDeferred = createDeferred<typeof overview>();
+      const serviceInternals = service as unknown as {
+        computeAndCacheWorkspaceTestResultsOverview: (
+          workspaceId: number,
+          revision: number,
+          cacheKey: string,
+          cacheGeneration: number
+        ) => Promise<typeof overview>;
+      };
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 8 }]);
+      cacheService.get.mockResolvedValue(null);
+      const computeSpy = jest
+        .spyOn(serviceInternals, 'computeAndCacheWorkspaceTestResultsOverview')
+        .mockReturnValue(overviewDeferred.promise);
+
+      const firstRequest = service.getWorkspaceTestResultsOverview(workspaceId);
+      const secondRequest = service.getWorkspaceTestResultsOverview(workspaceId);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(computeSpy).toHaveBeenCalledTimes(1);
+      expect(computeSpy).toHaveBeenCalledWith(
+        workspaceId,
+        8,
+        'workspace-overview-stats-1:v8',
+        0
+      );
+
+      overviewDeferred.resolve(overview);
+      await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual(
+        [overview, overview]
+      );
+    });
+
+    it('should not cache an overview if the test results revision changes while computing', async () => {
+      const workspaceId = 1;
+      (dataSource.query as jest.Mock)
+        .mockResolvedValueOnce([{ revision: 1 }])
+        .mockResolvedValueOnce([{ revision: 2 }]);
+      cacheService.get.mockResolvedValue(null);
+      (personsRepository.count as jest.Mock).mockResolvedValue(10);
+
+      await service.getWorkspaceTestResultsOverview(workspaceId);
+
+      expect(cacheService.set).not.toHaveBeenCalledWith(
+        'workspace-overview-stats-1:v1',
+        expect.anything(),
+        0
+      );
+    });
+
     it('should return correct statistics', async () => {
       const workspaceId = 1;
 
@@ -1274,15 +1375,12 @@ describe('WorkspaceTestResultsService', () => {
       unitQb.getRawMany.mockResolvedValue(['unit1', 'unit2']);
       unitQb.getRawOne.mockResolvedValue({ count: 2 });
 
-      const responseCountQb = mockQueryBuilder();
       const responseStatusQb = mockQueryBuilder();
       (responseRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(responseCountQb)
         .mockReturnValueOnce(responseStatusQb);
-      responseCountQb.getCount.mockResolvedValue(100);
       responseStatusQb.getRawMany.mockResolvedValue([
-        { status: '0', count: '5' },
-        { status: '1', count: '10' }
+        { status: '0', count: '55' },
+        { status: '1', count: '45' }
       ]);
 
       const sessionBrowserQb = mockQueryBuilder();
@@ -1304,13 +1402,22 @@ describe('WorkspaceTestResultsService', () => {
       expect(result.uniqueBooklets).toBe(1); // 1 booklet row mock
       expect(result.uniqueUnits).toBe(2);
       expect(result.uniqueResponses).toBe(100);
-      expect(result.responseStatusCounts).toEqual({ UNSET: 5, NOT_REACHED: 10 });
+      expect(result.responseStatusCounts).toEqual({ UNSET: 55, NOT_REACHED: 45 });
       expect(result.sessionBrowserCounts).toEqual({ Chrome: 20 });
-      expect(responseCountQb.andWhere).toHaveBeenCalledWith(
-        'response.is_autocoder_generated IS NOT TRUE'
-      );
+      expect(responseRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
       expect(responseStatusQb.andWhere).toHaveBeenCalledWith(
         'response.is_autocoder_generated IS NOT TRUE'
+      );
+      expect(cacheService.set).toHaveBeenCalledWith(
+        'workspace-overview-stats-1:v0',
+        expect.objectContaining({
+          testPersons: 10,
+          testGroups: 2,
+          uniqueBooklets: 1,
+          uniqueUnits: 2,
+          uniqueResponses: 100
+        }),
+        0
       );
     });
 
@@ -1349,6 +1456,112 @@ describe('WorkspaceTestResultsService', () => {
       expect(unitQb.andWhere).toHaveBeenCalledWith(
         expect.stringContaining("REGEXP_REPLACE(UPPER(unit.name), '\\.XML$', '', 'i') NOT IN"),
         expect.objectContaining({ workspaceExclusionIgnoredUnits: ['UNIT1'] }) // .XML stripped and uppercase
+      );
+    });
+
+    it('should invalidate legacy and revisioned overview cache entries', async () => {
+      const workspaceId = 1;
+
+      await service.invalidateWorkspaceStatsCache(workspaceId);
+
+      expect(cacheService.delete).toHaveBeenCalledWith(
+        'workspace-overview-stats-1'
+      );
+      expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+        'workspace-overview-stats-1:*'
+      );
+    });
+  });
+
+  describe('hasGeogebraResponses', () => {
+    it('uses a revisioned cache and stops the database query after the first match', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getRawOne.mockResolvedValue({ exists: 1 });
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 4 }]);
+
+      await expect(service.hasGeogebraResponses(1)).resolves.toBe(true);
+
+      expect(cacheService.get).toHaveBeenCalledWith(
+        'geogebra-existence:1:v4'
+      );
+      expect(qb.select).toHaveBeenCalledWith('1', 'exists');
+      expect(qb.limit).toHaveBeenCalledWith(1);
+      expect(qb.getCount).not.toHaveBeenCalled();
+      expect(qb.innerJoin).not.toHaveBeenCalledWith(
+        'booklet.bookletinfo',
+        'bookletinfo'
+      );
+      expect(cacheService.set).toHaveBeenCalledWith(
+        'geogebra-existence:1:v4',
+        true,
+        0
+      );
+    });
+
+    it('joins bookletinfo for geogebra existence only when booklet exclusions need it', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getRawOne.mockResolvedValue(null);
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 4 }]);
+      (workspaceExclusionService.resolveExclusionsForQueries as jest.Mock)
+        .mockResolvedValue({
+          globalIgnoredUnits: [],
+          ignoredBooklets: ['BOOKLET1'],
+          testletIgnoredUnits: []
+        });
+
+      await expect(service.hasGeogebraResponses(1)).resolves.toBe(false);
+
+      expect(qb.innerJoin).toHaveBeenCalledWith(
+        'booklet.bookletinfo',
+        'bookletinfo'
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'UPPER(bookletinfo.name) NOT IN (:...workspaceExclusionIgnoredBooklets)',
+        { workspaceExclusionIgnoredBooklets: ['BOOKLET1'] }
+      );
+    });
+
+    it('returns cached geogebra existence without querying responses', async () => {
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 4 }]);
+      cacheService.get.mockResolvedValueOnce(false);
+
+      await expect(service.hasGeogebraResponses(1)).resolves.toBe(false);
+
+      expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('reuses an in-flight geogebra existence query for the same workspace revision', async () => {
+      const geogebraDeferred = createDeferred<boolean>();
+      const serviceInternals = service as unknown as {
+        computeAndCacheGeoGebraExistence: (
+          workspaceId: number,
+          revision: number,
+          cacheKey: string
+        ) => Promise<boolean>;
+      };
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 4 }]);
+      const computeSpy = jest
+        .spyOn(serviceInternals, 'computeAndCacheGeoGebraExistence')
+        .mockReturnValue(geogebraDeferred.promise);
+
+      const firstRequest = service.hasGeogebraResponses(1);
+      const secondRequest = service.hasGeogebraResponses(1);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(computeSpy).toHaveBeenCalledTimes(1);
+      expect(computeSpy).toHaveBeenCalledWith(
+        1,
+        4,
+        'geogebra-existence:1:v4'
+      );
+
+      geogebraDeferred.resolve(true);
+      await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual(
+        [true, true]
       );
     });
   });

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -14,6 +14,7 @@ import {
 import { Response } from 'express';
 import * as csv from 'fast-csv';
 import * as fs from 'fs';
+import { createHash } from 'node:crypto';
 import { Writable } from 'stream';
 import { ResponseValueType } from '@iqbspecs/response/response.interface';
 import Persons from '../../entities/persons.entity';
@@ -294,6 +295,26 @@ interface LogDeleteCounts {
 @Injectable()
 export class WorkspaceTestResultsService {
   private readonly logger = new Logger(WorkspaceTestResultsService.name);
+  private readonly workspaceOverviewStatsInFlight = new Map<
+  string,
+  Promise<WorkspaceOverviewStats>
+  >();
+
+  private readonly workspaceOverviewCacheGenerationByWorkspace = new Map<
+  number,
+  number
+  >();
+
+  private readonly workspaceOverviewPrewarmTimers = new Map<
+  number,
+  ReturnType<typeof setTimeout>
+  >();
+
+  private readonly geoGebraExistenceInFlight = new Map<string, Promise<boolean>>();
+
+  private readonly slowWorkspaceOverviewThresholdMs = 1000;
+  private readonly slowGeoGebraExistenceThresholdMs = 1000;
+  private readonly workspaceOverviewPrewarmDelayMs = 500;
   private static readonly codingResponseStatuses = [
     statusStringToNumber('NOT_REACHED') || 1,
     statusStringToNumber('DISPLAYED') || 2,
@@ -1628,12 +1649,17 @@ export class WorkspaceTestResultsService {
   }
 
   async invalidateWorkspaceStatsCache(workspaceId: number): Promise<void> {
+    this.bumpWorkspaceOverviewCacheGeneration(workspaceId);
+    this.dropWorkspaceOverviewInFlight(workspaceId);
     await Promise.all([
       this.cacheService.delete(`${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}`),
+      this.cacheService.deleteByPattern(`${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}:*`),
+      this.cacheService.deleteByPattern(`geogebra-existence:${workspaceId}:*`),
       this.cacheService.deleteByPattern(`${FLAT_FREQUENCIES_CACHE_PREFIX}${workspaceId}-*`),
       this.cacheService.delete(`flat_response_filter_options:version:${workspaceId}`),
       this.cacheService.deleteByPattern(`flat_response_filter_options:${workspaceId}:*`)
     ]);
+    this.scheduleWorkspaceOverviewPrewarm(workspaceId);
   }
 
   async invalidateCodingStatisticsCache(workspaceId: number): Promise<void> {
@@ -1657,12 +1683,49 @@ export class WorkspaceTestResultsService {
       throw new Error('Invalid workspaceId provided');
     }
 
-    const cacheKey = `${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}`;
+    const revision = await this.resolveTestResultsRevision(workspaceId);
+    const cacheKey = this.getWorkspaceOverviewStatsCacheKey(
+      workspaceId,
+      revision
+    );
     const cachedOverview = await this.cacheService.get<WorkspaceOverviewStats>(cacheKey);
     if (cachedOverview) {
       return cachedOverview;
     }
 
+    const inFlightOverview = this.workspaceOverviewStatsInFlight.get(cacheKey);
+    if (inFlightOverview) {
+      this.logger.log(
+        `Reusing in-flight workspace overview query for workspace ${workspaceId} (revision ${revision})`
+      );
+      return inFlightOverview;
+    }
+
+    const cacheGeneration =
+      this.getWorkspaceOverviewCacheGeneration(workspaceId);
+    const overviewPromise = this.computeAndCacheWorkspaceTestResultsOverview(
+      workspaceId,
+      revision,
+      cacheKey,
+      cacheGeneration
+    );
+    this.workspaceOverviewStatsInFlight.set(cacheKey, overviewPromise);
+    try {
+      return await overviewPromise;
+    } finally {
+      if (this.workspaceOverviewStatsInFlight.get(cacheKey) === overviewPromise) {
+        this.workspaceOverviewStatsInFlight.delete(cacheKey);
+      }
+    }
+  }
+
+  private async computeAndCacheWorkspaceTestResultsOverview(
+    workspaceId: number,
+    revision: number,
+    cacheKey: string,
+    cacheGeneration: number
+  ): Promise<WorkspaceOverviewStats> {
+    const startedAt = Date.now();
     const testPersonsPromise = this.personsRepository.count({
       where: { workspace_id: workspaceId, consider: true }
     });
@@ -1704,19 +1767,6 @@ export class WorkspaceTestResultsService {
       .getRawOne()
       .then(res => Number(res?.count || 0));
 
-    const uniqueResponsesQuery = this.responseRepository
-      .createQueryBuilder('response')
-      .innerJoin('response.unit', 'unit')
-      .innerJoin('unit.booklet', 'booklet')
-      .innerJoin('booklet.bookletinfo', 'bookletinfo')
-      .innerJoin('booklet.person', 'person')
-      .where('person.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('person.consider = :consider', { consider: true });
-
-    this.applyExclusionsToQuery(uniqueResponsesQuery, exclusions);
-    this.excludeAutocoderGeneratedResponses(uniqueResponsesQuery);
-    const uniqueResponsesPromise = uniqueResponsesQuery.getCount();
-
     const statusRowsQuery = this.responseRepository
       .createQueryBuilder('response')
       .innerJoin('response.unit', 'unit')
@@ -1738,7 +1788,6 @@ export class WorkspaceTestResultsService {
       testGroups,
       uniqueBooklets,
       uniqueUnits,
-      uniqueResponses,
       statusRows,
       browserRows,
       osRows,
@@ -1748,7 +1797,6 @@ export class WorkspaceTestResultsService {
       testGroupsPromise,
       uniqueBookletsPromise,
       uniqueUnitsPromise,
-      uniqueResponsesPromise,
       statusRowsPromise,
       this.sessionRepository
         .createQueryBuilder('session')
@@ -1795,10 +1843,13 @@ export class WorkspaceTestResultsService {
     ]);
 
     const responseStatusCounts: Record<string, number> = {};
+    let uniqueResponses = 0;
     (statusRows || []).forEach(r => {
       const num = Number(r.status);
       const label = statusNumberToString(num) || String(num);
-      responseStatusCounts[label] = Number(r.count) || 0;
+      const count = Number(r.count) || 0;
+      responseStatusCounts[label] = count;
+      uniqueResponses += count;
     });
 
     const mapSessionCounts = (
@@ -1828,7 +1879,18 @@ export class WorkspaceTestResultsService {
       sessionScreenCounts
     };
 
-    await this.cacheService.set(cacheKey, result, 60); // Cache for 1 minute
+    const currentRevision = await this.resolveTestResultsRevision(workspaceId);
+    if (
+      currentRevision === revision &&
+      this.getWorkspaceOverviewCacheGeneration(workspaceId) === cacheGeneration
+    ) {
+      await this.cacheService.set(cacheKey, result, 0);
+    } else {
+      this.logger.log(
+        `Skipped caching stale workspace overview for workspace ${workspaceId} (planned revision ${revision}, current revision ${currentRevision})`
+      );
+    }
+    this.logWorkspaceOverviewTiming(workspaceId, revision, startedAt);
     return result;
   }
 
@@ -2431,6 +2493,131 @@ export class WorkspaceTestResultsService {
     );
   }
 
+  private async findTagsByUnitId(unitIds: number[]): Promise<Map<number, string[]>> {
+    const uniqueUnitIds = Array.from(
+      new Set(unitIds.filter(unitId => Number.isFinite(unitId) && unitId > 0))
+    );
+    if (uniqueUnitIds.length === 0) {
+      return new Map();
+    }
+
+    const tags = await this.unitTagService.findAllByUnitIds(uniqueUnitIds);
+    const tagsByUnitId = new Map<number, string[]>();
+
+    tags.forEach(tag => {
+      if (!tagsByUnitId.has(tag.unitId)) {
+        tagsByUnitId.set(tag.unitId, []);
+      }
+      tagsByUnitId.get(tag.unitId)!.push(tag.tag);
+    });
+
+    return tagsByUnitId;
+  }
+
+  private async createFlatResponseCountCacheKey(
+    workspaceId: number,
+    signature: Record<string, unknown>
+  ): Promise<string> {
+    const revision = await this.resolveTestResultsRevision(workspaceId);
+    const hash = createHash('sha1')
+      .update(JSON.stringify(signature))
+      .digest('hex')
+      .slice(0, 16);
+
+    return `flat_responses_count:${workspaceId}:v${revision}:${hash}`;
+  }
+
+  private getWorkspaceOverviewStatsCacheKey(
+    workspaceId: number,
+    revision: number
+  ): string {
+    return `${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}:v${revision}`;
+  }
+
+  private getGeoGebraExistenceCacheKey(
+    workspaceId: number,
+    revision: number
+  ): string {
+    return `geogebra-existence:${workspaceId}:v${revision}`;
+  }
+
+  private getWorkspaceOverviewCacheGeneration(workspaceId: number): number {
+    return this.workspaceOverviewCacheGenerationByWorkspace.get(workspaceId) ?? 0;
+  }
+
+  private bumpWorkspaceOverviewCacheGeneration(workspaceId: number): void {
+    this.workspaceOverviewCacheGenerationByWorkspace.set(
+      workspaceId,
+      this.getWorkspaceOverviewCacheGeneration(workspaceId) + 1
+    );
+  }
+
+  private dropWorkspaceOverviewInFlight(workspaceId: number): void {
+    const baseKey = `${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}`;
+    Array.from(this.workspaceOverviewStatsInFlight.keys())
+      .filter(key => key === baseKey || key.startsWith(`${baseKey}:`))
+      .forEach(key => this.workspaceOverviewStatsInFlight.delete(key));
+  }
+
+  private scheduleWorkspaceOverviewPrewarm(workspaceId: number): void {
+    if (process.env.NODE_ENV === 'test') {
+      return;
+    }
+    const existingTimer = this.workspaceOverviewPrewarmTimers.get(workspaceId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+    const timer = setTimeout(() => {
+      this.workspaceOverviewPrewarmTimers.delete(workspaceId);
+      this.getWorkspaceTestResultsOverview(workspaceId)
+        .then(() => {
+          this.logger.debug(
+            `Prewarmed workspace overview cache for workspace ${workspaceId}`
+          );
+        })
+        .catch(error => {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.warn(
+            `Workspace overview cache prewarm failed for workspace ${workspaceId}: ${message}`
+          );
+        });
+    }, this.workspaceOverviewPrewarmDelayMs);
+    timer.unref?.();
+    this.workspaceOverviewPrewarmTimers.set(workspaceId, timer);
+  }
+
+  private logWorkspaceOverviewTiming(
+    workspaceId: number,
+    revision: number,
+    startedAt: number
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    const message =
+      `Workspace test results overview for workspace ${workspaceId} ` +
+      `(revision ${revision}) computed in ${durationMs}ms.`;
+    if (durationMs >= this.slowWorkspaceOverviewThresholdMs) {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.debug(message);
+  }
+
+  private async resolveTestResultsRevision(workspaceId: number): Promise<number> {
+    try {
+      const rows = (await this.connection.query(
+        'SELECT revision FROM workspace_test_results_revision WHERE workspace_id = $1',
+        [workspaceId]
+      )) as Array<{ revision: number | string }>;
+      return Number(rows[0]?.revision || 0);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve test result revision for flat response count cache: ${message}`
+      );
+      return 0;
+    }
+  }
+
   async findFlatResponses(
     workspaceId: number,
     options: {
@@ -2665,7 +2852,6 @@ export class WorkspaceTestResultsService {
       .innerJoin('unit.booklet', 'bookletEntity')
       .innerJoin('bookletEntity.person', 'person')
       .innerJoin('bookletEntity.bookletinfo', 'bookletinfo')
-      .leftJoin('unit.tags', 'unitTag')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true });
 
@@ -2712,7 +2898,14 @@ export class WorkspaceTestResultsService {
       });
     }
     if (tags) {
-      qb.andWhere('unitTag.tag ILIKE :tags', { tags: `%${tags}%` });
+      qb.andWhere(
+        `EXISTS (
+          SELECT 1 FROM unit_tag unit_tag_filter
+          WHERE unit_tag_filter."unitId" = unit.id
+            AND unit_tag_filter.tag ILIKE :tags
+        )`,
+        { tags: `%${tags}%` }
+      );
     }
 
     if (geogebraOnly) {
@@ -2963,8 +3156,14 @@ export class WorkspaceTestResultsService {
       });
     }
     if (tags) {
-      countQb.leftJoin('unit.tags', 'unitTag');
-      countQb.andWhere('unitTag.tag ILIKE :tags', { tags: `%${tags}%` });
+      countQb.andWhere(
+        `EXISTS (
+          SELECT 1 FROM unit_tag unit_tag_filter
+          WHERE unit_tag_filter."unitId" = unit.id
+            AND unit_tag_filter.tag ILIKE :tags
+        )`,
+        { tags: `%${tags}%` }
+      );
     }
 
     if (geogebraOnly) {
@@ -3128,10 +3327,49 @@ export class WorkspaceTestResultsService {
 
     // Note: Session filters above are applied as separate EXISTS per dimension.
 
-    const total = await countQb
-      .select('COUNT(DISTINCT response.id)', 'cnt')
-      .getRawOne()
-      .then(r => Number(r?.cnt || 0));
+    const countCacheKey = await this.createFlatResponseCountCacheKey(
+      workspaceId,
+      {
+        code,
+        group,
+        login,
+        booklet,
+        unit,
+        response,
+        responseStatus,
+        responseValue,
+        tags,
+        geogebraOnly,
+        audioLowOnly,
+        hasValueOnly,
+        audioLowThreshold,
+        shortProcessingOnly,
+        shortProcessingThresholdMs,
+        longLoadingOnly,
+        longLoadingThresholdMs,
+        processingDurations,
+        processingDurationThresholdMs,
+        processingDurationMinMs,
+        processingDurationMaxMs,
+        unitProgress,
+        sessionBrowsers,
+        sessionOs,
+        sessionScreens,
+        sessionIds,
+        logAnomalyCodes,
+        logAnomalyThresholds,
+        exclusions
+      }
+    );
+    const cachedTotal = await this.cacheService.get<number>(countCacheKey);
+    let total = cachedTotal;
+    if (total === null) {
+      total = await countQb
+        .select('COUNT(response.id)', 'cnt')
+        .getRawOne()
+        .then(r => Number(r?.cnt || 0));
+      await this.cacheService.set(countCacheKey, total, 3600);
+    }
 
     const raw = await qb
       .select([
@@ -3146,22 +3384,9 @@ export class WorkspaceTestResultsService {
         'COALESCE(unit.alias, unit.name) AS "unit"',
         'response.variableid AS "response"',
         'response.status AS "responseStatus"',
-        'SUBSTRING(response.value, 1, :maxResponseValueLen) AS "responseValue"',
-        "COALESCE(string_agg(DISTINCT unitTag.tag, ','), '') AS \"tags\""
+        'SUBSTRING(response.value, 1, :maxResponseValueLen) AS "responseValue"'
       ])
       .setParameter('maxResponseValueLen', MAX_RESPONSE_VALUE_LEN)
-      .groupBy('response.id')
-      .addGroupBy('unit.id')
-      .addGroupBy('bookletEntity.id')
-      .addGroupBy('person.id')
-      .addGroupBy('bookletinfo.name')
-      .addGroupBy('unit.alias')
-      .addGroupBy('unit.name')
-      .addGroupBy('person.code')
-      .addGroupBy('person.group')
-      .addGroupBy('person.login')
-      .addGroupBy('response.variableid')
-      .addGroupBy('response.status')
       .orderBy('person.code', 'ASC')
       .addOrderBy('bookletinfo.name', 'ASC')
       .addOrderBy('unit.alias', 'ASC')
@@ -3170,21 +3395,18 @@ export class WorkspaceTestResultsService {
       .limit(validLimit)
       .getRawMany();
 
-    const mapped = (raw || []).map(r => {
-      const tagsStr = String(r.tags || '');
-      const tagList = tagsStr ?
-        tagsStr
-          .split(',')
-          .map(t => t.trim())
-          .filter(Boolean) :
-        [];
+    const tagsByUnitId = await this.findTagsByUnitId(
+      raw.map(r => Number(r.unitId))
+    );
 
+    const mapped = (raw || []).map(r => {
       const statusNum = Number(r.responseStatus);
       const statusLabel = statusNumberToString(statusNum);
+      const unitId = Number(r.unitId);
       return {
         bookletId: Number(r.bookletId),
         responseId: Number(r.responseId),
-        unitId: Number(r.unitId),
+        unitId,
         personId: Number(r.personId),
         code: String(r.code || ''),
         group: String(r.group || ''),
@@ -3194,7 +3416,7 @@ export class WorkspaceTestResultsService {
         response: String(r.response || ''),
         responseStatus: statusLabel || String(r.responseStatus ?? ''),
         responseValue: String(r.responseValue ?? ''),
-        tags: tagList,
+        tags: tagsByUnitId.get(unitId) || [],
         logAnomalies: []
       };
     });
@@ -7967,12 +8189,54 @@ export class WorkspaceTestResultsService {
   }
 
   async hasGeogebraResponses(workspaceId: number): Promise<boolean> {
+    const revision = await this.resolveTestResultsRevision(workspaceId);
+    const cacheKey = this.getGeoGebraExistenceCacheKey(workspaceId, revision);
+    const cached = await this.cacheService.get<boolean>(cacheKey);
+    if (cached !== null && cached !== undefined) {
+      return cached;
+    }
+
+    const inFlight = this.geoGebraExistenceInFlight.get(cacheKey);
+    if (inFlight) {
+      this.logger.log(
+        `Reusing in-flight GeoGebra existence query for workspace ${workspaceId} (revision ${revision})`
+      );
+      return inFlight;
+    }
+
+    const promise = this.computeAndCacheGeoGebraExistence(
+      workspaceId,
+      revision,
+      cacheKey
+    );
+    this.geoGebraExistenceInFlight.set(cacheKey, promise);
+    try {
+      return await promise;
+    } finally {
+      if (this.geoGebraExistenceInFlight.get(cacheKey) === promise) {
+        this.geoGebraExistenceInFlight.delete(cacheKey);
+      }
+    }
+  }
+
+  private async computeAndCacheGeoGebraExistence(
+    workspaceId: number,
+    revision: number,
+    cacheKey: string
+  ): Promise<boolean> {
+    const startedAt = Date.now();
+    const exclusionsStartedAt = Date.now();
+
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusionsDurationMs = Date.now() - exclusionsStartedAt;
+    const queryStartedAt = Date.now();
+    const needsBookletInfoForExclusions =
+      exclusions.ignoredBooklets.length > 0 ||
+      exclusions.testletIgnoredUnits.length > 0;
     const query = this.responseRepository
       .createQueryBuilder('response')
       .innerJoin('response.unit', 'unit')
       .innerJoin('unit.booklet', 'booklet')
-      .innerJoin('booklet.bookletinfo', 'bookletinfo')
       .innerJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
@@ -7980,10 +8244,51 @@ export class WorkspaceTestResultsService {
         WorkspaceTestResultsService.createGeoGebraValueCondition('response'),
         WorkspaceTestResultsService.geoGebraValueParams
       );
-    this.applyExclusionsToQuery(query, exclusions);
-    const count = await query
-      .getCount();
+    if (needsBookletInfoForExclusions) {
+      query.innerJoin('booklet.bookletinfo', 'bookletinfo');
+    }
+    this.applyExclusionsToQuery(query, exclusions, {
+      bookletInfoAlias: needsBookletInfoForExclusions ? 'bookletinfo' : null
+    });
+    const row = await query
+      .select('1', 'exists')
+      .limit(1)
+      .getRawOne();
+    const queryDurationMs = Date.now() - queryStartedAt;
+    const result = Boolean(row);
+    const currentRevision = await this.resolveTestResultsRevision(workspaceId);
+    if (currentRevision === revision) {
+      await this.cacheService.set(cacheKey, result, 0);
+    }
+    this.logGeoGebraExistenceTiming(
+      workspaceId,
+      revision,
+      result,
+      startedAt,
+      exclusionsDurationMs,
+      queryDurationMs
+    );
 
-    return count > 0;
+    return result;
+  }
+
+  private logGeoGebraExistenceTiming(
+    workspaceId: number,
+    revision: number,
+    result: boolean,
+    startedAt: number,
+    exclusionsDurationMs: number,
+    queryDurationMs: number
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    const message =
+      `GeoGebra existence for workspace ${workspaceId} ` +
+      `(revision ${revision}, result ${result}) computed in ${durationMs}ms ` +
+      `(exclusions ${exclusionsDurationMs}ms, query ${queryDurationMs}ms).`;
+    if (durationMs >= this.slowGeoGebraExistenceThresholdMs) {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.debug(message);
   }
 }

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -2519,10 +2519,10 @@ export class WorkspaceTestResultsService {
     signature: Record<string, unknown>
   ): Promise<string> {
     const revision = await this.resolveTestResultsRevision(workspaceId);
-    const hash = createHash('sha1')
+    const hash = createHash('sha256')
       .update(JSON.stringify(signature))
       .digest('hex')
-      .slice(0, 16);
+      .slice(0, 32);
 
     return `flat_responses_count:${workspaceId}:v${revision}:${hash}`;
   }

--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -1,7 +1,10 @@
 import { ConflictException } from '@nestjs/common';
 import { JobQueueService } from './job-queue.service';
 
-const createJob = (data: Record<string, unknown> = { workspaceId: 1, taskId: 7 }, state = 'waiting') => ({
+const createJob = (
+  data: Record<string, unknown> = { workspaceId: 1, taskId: 7 },
+  state = 'waiting'
+) => ({
   id: 'job-1',
   data,
   failedReason: undefined,
@@ -20,7 +23,11 @@ const createQueue = (job = createJob()) => ({
   getJob: jest.fn().mockResolvedValue(job),
   getJobs: jest.fn().mockResolvedValue([job]),
   getJobCounts: jest.fn().mockResolvedValue({
-    waiting: 1, active: 0, completed: 0, failed: 0, delayed: 0
+    waiting: 1,
+    active: 0,
+    completed: 0,
+    failed: 0,
+    delayed: 0
   }),
   isReady: jest.fn().mockResolvedValue(undefined),
   client: { ping: jest.fn().mockResolvedValue('PONG') }
@@ -57,98 +64,182 @@ describe('JobQueueService', () => {
     queues[0].getJobs.mockResolvedValue([]);
     queues[6].getJobs.mockResolvedValue([]);
 
-    await expect(service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })).resolves.toMatchObject({ data: { workspaceId: 1 } });
-    await expect(service.getTestPersonCodingJob('job-1')).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.addUploadJob({
-      workspaceId: 1,
-      file: { originalname: 'results.xml' } as never,
-      resultType: 'responses',
-      overwriteExisting: false
-    })).resolves.toHaveProperty('data.resultType', 'responses');
-    await expect(service.getUploadJob('job-1')).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).resolves.toHaveProperty('data.version', 'v1');
-    await expect(service.getResetCodingVersionJob('job-1')).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.addCodingAnalysisJob({
-      workspaceId: 1, matchingFlags: [], threshold: 0, cacheKey: 'k'
-    })).resolves.toHaveProperty('data.cacheKey', 'k');
-    await expect(service.getCodingAnalysisJob('job-1')).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.addVariableAnalysisJob({ workspaceId: 1, unitId: 2 })).resolves.toHaveProperty('data.unitId', 2);
-    await expect(service.getVariableAnalysisJob('job-1')).resolves.toHaveProperty('id', 'job-1');
+    await expect(
+      service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })
+    ).resolves.toMatchObject({ data: { workspaceId: 1 } });
+    await expect(
+      service.getTestPersonCodingJob('job-1')
+    ).resolves.toHaveProperty('id', 'job-1');
+    await expect(
+      service.addUploadJob({
+        workspaceId: 1,
+        file: { originalname: 'results.xml' } as never,
+        resultType: 'responses',
+        overwriteExisting: false
+      })
+    ).resolves.toHaveProperty('data.resultType', 'responses');
+    await expect(service.getUploadJob('job-1')).resolves.toHaveProperty(
+      'id',
+      'job-1'
+    );
+    await expect(
+      service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })
+    ).resolves.toHaveProperty('data.version', 'v1');
+    await expect(
+      service.getResetCodingVersionJob('job-1')
+    ).resolves.toHaveProperty('id', 'job-1');
+    await expect(
+      service.addCodingAnalysisJob({
+        workspaceId: 1,
+        matchingFlags: [],
+        threshold: 0,
+        cacheKey: 'k'
+      })
+    ).resolves.toHaveProperty('data.cacheKey', 'k');
+    await expect(service.getCodingAnalysisJob('job-1')).resolves.toHaveProperty(
+      'id',
+      'job-1'
+    );
+    await expect(
+      service.addVariableAnalysisJob({ workspaceId: 1, unitId: 2 })
+    ).resolves.toHaveProperty('data.unitId', 2);
+    await expect(
+      service.getVariableAnalysisJob('job-1')
+    ).resolves.toHaveProperty('id', 'job-1');
     queues[10].getJobs.mockResolvedValue([]);
-    await expect(service.addExternalCodingImportJob({ workspaceId: 1, tempFilePath: '/tmp/a', fileName: 'a.csv' })).resolves.toHaveProperty('data.fileName', 'a.csv');
-    await expect(service.getExternalCodingImportJob('job-1')).resolves.toHaveProperty('id', 'job-1');
+    await expect(
+      service.addExternalCodingImportJob({
+        workspaceId: 1,
+        tempFilePath: '/tmp/a',
+        fileName: 'a.csv'
+      })
+    ).resolves.toHaveProperty('data.fileName', 'a.csv');
+    await expect(
+      service.getExternalCodingImportJob('job-1')
+    ).resolves.toHaveProperty('id', 'job-1');
   });
 
   it('prevents duplicate active jobs where required', async () => {
-    await expect(service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addCodingStatisticsJob(1, 'v2')).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addFlatResponseFilterOptionsJob(1, 250)).resolves.toBeNull();
-    await expect(service.addCodebookGenerationJob({
-      workspaceId: 1,
-      missingsProfile: 1,
-      contentOptions: {
-        exportFormat: 'docx',
-        missingsProfile: 'default',
-        hasOnlyManualCoding: false,
-        hasGeneralInstructions: false,
-        hasDerivedVars: false,
-        hasOnlyVarsWithCodes: false,
-        hasClosedVars: false,
-        codeLabelToUpper: false,
-        showScore: false,
-        hideItemVarRelation: false
-      },
-      unitIds: [1]
-    })).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addValidationTaskJob({ taskId: 7 })).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addExternalCodingImportJob({ workspaceId: 1, tempFilePath: '/tmp/a', fileName: 'a.csv' })).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addCodingStatisticsJob(1, 'v2')
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addFlatResponseFilterOptionsJob(1, 250)
+    ).resolves.toBeNull();
+    await expect(
+      service.addCodebookGenerationJob({
+        workspaceId: 1,
+        missingsProfile: 1,
+        contentOptions: {
+          exportFormat: 'docx',
+          missingsProfile: 'default',
+          hasOnlyManualCoding: false,
+          hasGeneralInstructions: false,
+          hasDerivedVars: false,
+          hasOnlyVarsWithCodes: false,
+          hasClosedVars: false,
+          codeLabelToUpper: false,
+          showScore: false,
+          hideItemVarRelation: false
+        },
+        unitIds: [1]
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addValidationTaskJob({ taskId: 7 })
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addExternalCodingImportJob({
+        workspaceId: 1,
+        tempFilePath: '/tmp/a',
+        fileName: 'a.csv'
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 
   it('allows jobs when no duplicate active job exists', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
 
-    await expect(service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })).resolves.toHaveProperty('data.workspaceId', 1);
-    await expect(service.addCodingStatisticsJob(1, 'v1')).resolves.toHaveProperty('data.version', 'v1');
-    await expect(service.addFlatResponseFilterOptionsJob(1, 100)).resolves.toHaveProperty('data.processingDurationThresholdMs', 100);
-    await expect(service.addCodebookGenerationJob({
-      workspaceId: 1,
-      missingsProfile: 1,
-      contentOptions: {
-        exportFormat: 'docx',
-        missingsProfile: 'default',
-        hasOnlyManualCoding: false,
-        hasGeneralInstructions: false,
-        hasDerivedVars: false,
-        hasOnlyVarsWithCodes: false,
-        hasClosedVars: false,
-        codeLabelToUpper: false,
-        showScore: false,
-        hideItemVarRelation: false
-      },
-      unitIds: [1]
-    })).resolves.toHaveProperty('data.workspaceId', 1);
-    await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).resolves.toHaveProperty('data.version', 'v1');
-    await expect(service.addValidationTaskJob({ taskId: 8 })).resolves.toHaveProperty('data.taskId', 8);
-    await expect(service.addExportJob({ workspaceId: 1, userId: 2, exportType: 'coding-list' })).resolves.toHaveProperty('data.exportType', 'coding-list');
+    await expect(
+      service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })
+    ).resolves.toHaveProperty('data.workspaceId', 1);
+    await expect(
+      service.addCodingStatisticsJob(1, 'v1')
+    ).resolves.toHaveProperty('data.version', 'v1');
+    await expect(
+      service.addFlatResponseFilterOptionsJob(1, 100)
+    ).resolves.toHaveProperty('data.processingDurationThresholdMs', 100);
+    await expect(
+      service.addCodebookGenerationJob({
+        workspaceId: 1,
+        missingsProfile: 1,
+        contentOptions: {
+          exportFormat: 'docx',
+          missingsProfile: 'default',
+          hasOnlyManualCoding: false,
+          hasGeneralInstructions: false,
+          hasDerivedVars: false,
+          hasOnlyVarsWithCodes: false,
+          hasClosedVars: false,
+          codeLabelToUpper: false,
+          showScore: false,
+          hideItemVarRelation: false
+        },
+        unitIds: [1]
+      })
+    ).resolves.toHaveProperty('data.workspaceId', 1);
+    await expect(
+      service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })
+    ).resolves.toHaveProperty('data.version', 'v1');
+    await expect(
+      service.addValidationTaskJob({ taskId: 8 })
+    ).resolves.toHaveProperty('data.taskId', 8);
+    await expect(
+      service.addExportJob({
+        workspaceId: 1,
+        userId: 2,
+        exportType: 'coding-list'
+      })
+    ).resolves.toHaveProperty('data.exportType', 'coding-list');
   });
 
   it('cancels and deletes jobs across queues', async () => {
-    await expect(service.cancelJob('test-person-coding', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelJob('test-person-coding', 'job-1')
+    ).resolves.toBe(true);
     await expect(service.cancelJob('unknown', 'job-1')).resolves.toBe(false);
-    await expect(service.deleteJob('test-person-coding', 'job-1')).resolves.toBe(true);
-    await expect(service.cancelTestPersonCodingJob('job-1')).resolves.toBe(true);
-    await expect(service.deleteTestPersonCodingJob('job-1')).resolves.toBe(true);
+    await expect(
+      service.deleteJob('test-person-coding', 'job-1')
+    ).resolves.toBe(true);
+    await expect(service.cancelTestPersonCodingJob('job-1')).resolves.toBe(
+      true
+    );
+    await expect(service.deleteTestPersonCodingJob('job-1')).resolves.toBe(
+      true
+    );
     await expect(service.cancelExportJob('job-1')).resolves.toBe(true);
     await expect(service.markExportJobCancelled('job-1')).resolves.toBe(true);
     await expect(service.isExportJobCancelled('job-1')).resolves.toBe(false);
     await expect(service.deleteExportJob('job-1')).resolves.toBe(true);
-    await expect(service.deleteVariableAnalysisJob('job-1')).resolves.toBe(true);
-    await expect(service.cancelVariableAnalysisJob('job-1')).resolves.toBe(true);
+    await expect(service.deleteVariableAnalysisJob('job-1')).resolves.toBe(
+      true
+    );
+    await expect(service.cancelVariableAnalysisJob('job-1')).resolves.toBe(
+      true
+    );
   });
 
   it('aborts registered export cancellation signals when an export job is marked cancelled', async () => {
-    const exportJob = createJob({ workspaceId: 1, exportType: 'coding-list' }, 'active');
+    const exportJob = createJob(
+      { workspaceId: 1, exportType: 'coding-list' },
+      'active'
+    );
     queues[2].getJob.mockResolvedValue(exportJob);
     const signal = service.createExportJobCancellationSignal('job-1');
 
@@ -158,7 +249,10 @@ describe('JobQueueService', () => {
   });
 
   it('aborts registered export cancellation signals when cancelling an active export job directly', async () => {
-    const exportJob = createJob({ workspaceId: 1, exportType: 'coding-list' }, 'active');
+    const exportJob = createJob(
+      { workspaceId: 1, exportType: 'coding-list' },
+      'active'
+    );
     queues[2].getJob.mockResolvedValue(exportJob);
     const signal = service.createExportJobCancellationSignal('job-1');
 
@@ -172,11 +266,15 @@ describe('JobQueueService', () => {
     const otherWorkspaceJob = createJob({ workspaceId: 2 }, 'waiting');
 
     queues[0].getJob.mockResolvedValueOnce(otherWorkspaceJob);
-    await expect(service.cancelWorkspaceJob(1, 'test-person-coding', 'job-1')).resolves.toBe(false);
+    await expect(
+      service.cancelWorkspaceJob(1, 'test-person-coding', 'job-1')
+    ).resolves.toBe(false);
     expect(otherWorkspaceJob.remove).not.toHaveBeenCalled();
 
     queues[0].getJob.mockResolvedValueOnce(ownJob);
-    await expect(service.cancelWorkspaceJob(1, 'test-person-coding', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'test-person-coding', 'job-1')
+    ).resolves.toBe(true);
     expect(ownJob.remove).toHaveBeenCalled();
   });
 
@@ -184,20 +282,33 @@ describe('JobQueueService', () => {
     const validationJob = createJob({ taskId: 7 }, 'waiting');
     queues[7].getJob.mockResolvedValue(validationJob);
 
-    validationTaskRepository.find.mockResolvedValueOnce([{ id: 7, workspace_id: 2 }]);
-    await expect(service.cancelWorkspaceJob(1, 'validation-task', 'job-1')).resolves.toBe(false);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      { id: 7, workspace_id: 2 }
+    ]);
+    await expect(
+      service.cancelWorkspaceJob(1, 'validation-task', 'job-1')
+    ).resolves.toBe(false);
     expect(validationJob.remove).not.toHaveBeenCalled();
 
-    validationTaskRepository.find.mockResolvedValueOnce([{ id: 7, workspace_id: 1 }]);
-    await expect(service.cancelWorkspaceJob(1, 'validation-task', 'job-1')).resolves.toBe(true);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      { id: 7, workspace_id: 1 }
+    ]);
+    await expect(
+      service.cancelWorkspaceJob(1, 'validation-task', 'job-1')
+    ).resolves.toBe(true);
     expect(validationJob.remove).toHaveBeenCalled();
   });
 
   it('marks supported active jobs for cancellation without removing locked jobs', async () => {
-    const exportJob = createJob({ workspaceId: 1, exportType: 'test-results' }, 'active');
+    const exportJob = createJob(
+      { workspaceId: 1, exportType: 'test-results' },
+      'active'
+    );
     queues[2].getJob.mockResolvedValue(exportJob);
 
-    await expect(service.cancelWorkspaceJob(1, 'data-export', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'data-export', 'job-1')
+    ).resolves.toBe(true);
     expect(exportJob.update).toHaveBeenCalledWith({
       workspaceId: 1,
       exportType: 'test-results',
@@ -206,13 +317,18 @@ describe('JobQueueService', () => {
     expect(exportJob.discard).toHaveBeenCalled();
     expect(exportJob.remove).not.toHaveBeenCalled();
 
-    const databaseExportJob = createJob({
-      requestedByUserId: 3,
-      scope: 'workspace',
-      workspaceId: 1
-    }, 'active');
+    const databaseExportJob = createJob(
+      {
+        requestedByUserId: 3,
+        scope: 'workspace',
+        workspaceId: 1
+      },
+      'active'
+    );
     queues[11].getJob.mockResolvedValue(databaseExportJob);
-    await expect(service.cancelWorkspaceJob(1, 'database-export', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'database-export', 'job-1')
+    ).resolves.toBe(true);
     expect(databaseExportJob.update).toHaveBeenCalledWith({
       requestedByUserId: 3,
       scope: 'workspace',
@@ -224,7 +340,9 @@ describe('JobQueueService', () => {
 
     const unsupportedActiveJob = createJob({ workspaceId: 1 }, 'active');
     queues[1].getJob.mockResolvedValue(unsupportedActiveJob);
-    await expect(service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')).resolves.toBe(false);
+    await expect(
+      service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')
+    ).resolves.toBe(false);
     expect(unsupportedActiveJob.remove).not.toHaveBeenCalled();
   });
 
@@ -232,41 +350,107 @@ describe('JobQueueService', () => {
     const pausedJob = createJob({ workspaceId: 1 }, 'paused');
     queues[1].getJob.mockResolvedValue(pausedJob);
 
-    await expect(service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')
+    ).resolves.toBe(true);
     expect(pausedJob.remove).toHaveBeenCalled();
 
     const cancelledJob = createJob({ workspaceId: 1 }, 'cancelled');
     queues[1].getJob.mockResolvedValue(cancelledJob);
 
-    await expect(service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')
+    ).resolves.toBe(true);
     expect(cancelledJob.remove).toHaveBeenCalled();
   });
 
   it('handles missing jobs and failing queue operations', async () => {
     queues.forEach(queue => queue.getJob.mockResolvedValue(null));
 
-    await expect(service.cancelJob('test-person-coding', 'missing')).resolves.toBe(false);
-    await expect(service.deleteJob('test-person-coding', 'missing')).resolves.toBe(false);
-    await expect(service.cancelTestPersonCodingJob('missing')).resolves.toBe(false);
-    await expect(service.deleteTestPersonCodingJob('missing')).resolves.toBe(false);
+    await expect(
+      service.cancelJob('test-person-coding', 'missing')
+    ).resolves.toBe(false);
+    await expect(
+      service.deleteJob('test-person-coding', 'missing')
+    ).resolves.toBe(false);
+    await expect(service.cancelTestPersonCodingJob('missing')).resolves.toBe(
+      false
+    );
+    await expect(service.deleteTestPersonCodingJob('missing')).resolves.toBe(
+      false
+    );
     await expect(service.cancelExportJob('missing')).resolves.toBe(false);
-    await expect(service.markExportJobCancelled('missing')).resolves.toBe(false);
+    await expect(service.markExportJobCancelled('missing')).resolves.toBe(
+      false
+    );
     await expect(service.isExportJobCancelled('missing')).resolves.toBe(false);
     await expect(service.deleteExportJob('missing')).resolves.toBe(false);
-    await expect(service.deleteVariableAnalysisJob('missing')).resolves.toBe(false);
-    await expect(service.cancelVariableAnalysisJob('missing')).resolves.toBe(false);
+    await expect(service.deleteVariableAnalysisJob('missing')).resolves.toBe(
+      false
+    );
+    await expect(service.cancelVariableAnalysisJob('missing')).resolves.toBe(
+      false
+    );
   });
 
   it('lists workspace jobs and queue-specific jobs', async () => {
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
     expect(workspaceJobs.length).toBeGreaterThan(0);
-    expect(workspaceJobs[0]).toMatchObject({ queueName: expect.any(String), status: 'waiting' });
+    expect(workspaceJobs[0]).toMatchObject({
+      queueName: expect.any(String),
+      status: 'waiting'
+    });
 
     await expect(service.getTestPersonCodingJobs(1)).resolves.toHaveLength(1);
     await expect(service.getExportJobs(1)).resolves.toHaveLength(1);
     await expect(service.getVariableAnalysisJobs(1)).resolves.toHaveLength(1);
-    await expect(service.getActiveCodingAnalysisJob(1)).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.getActiveResetCodingVersionJob(1)).resolves.toHaveProperty('id', 'job-1');
+    await expect(service.getActiveCodingAnalysisJob(1)).resolves.toHaveProperty(
+      'id',
+      'job-1'
+    );
+    await expect(
+      service.getActiveResetCodingVersionJob(1)
+    ).resolves.toHaveProperty('id', 'job-1');
+  });
+
+  it('finds queued response analysis jobs by workspace and cache key', async () => {
+    const matchingJob = createJob({
+      workspaceId: 1,
+      cacheKey: 'response-analysis:1__t2'
+    });
+    const otherJob = createJob({
+      workspaceId: 1,
+      cacheKey: 'response-analysis:1_IGNORE_CASE_t2'
+    });
+    queues[8].getJobs.mockResolvedValue([otherJob, matchingJob]);
+
+    await expect(
+      service.getCodingAnalysisJobForCacheKey(1, 'response-analysis:1__t2')
+    ).resolves.toBe(matchingJob);
+  });
+
+  it('expires large completed response analysis queue jobs', async () => {
+    queues[8].add.mockResolvedValue(createJob());
+
+    await service.addCodingAnalysisJob({
+      workspaceId: 1,
+      matchingFlags: [],
+      threshold: 2,
+      cacheKey: 'response-analysis:1__t2'
+    });
+
+    expect(queues[8].add).toHaveBeenCalledWith(
+      {
+        workspaceId: 1,
+        matchingFlags: [],
+        threshold: 2,
+        cacheKey: 'response-analysis:1__t2'
+      },
+      {
+        removeOnComplete: { age: 3600, count: 10 },
+        removeOnFail: { age: 86400, count: 50 }
+      }
+    );
   });
 
   it('covers all registered process overview queues', async () => {
@@ -290,18 +474,18 @@ describe('JobQueueService', () => {
 
   it('uses validation task progress and metadata from the task entity in the process overview', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
-    queues[7].getJobs.mockResolvedValue([
-      createJob({ taskId: 7 }, 'active')
+    queues[7].getJobs.mockResolvedValue([createJob({ taskId: 7 }, 'active')]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'processing',
+        progress: 65,
+        progress_message: 'Testdateien werden geprüft...',
+        error: 'Schema validation failed'
+      }
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'processing',
-      progress: 65,
-      progress_message: 'Testdateien werden geprüft...',
-      error: 'Schema validation failed'
-    }]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -325,15 +509,17 @@ describe('JobQueueService', () => {
     queues[7].getJobs.mockResolvedValue([
       createJob({ taskId: 7 }, 'completed')
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'cancelled',
-      progress: 30,
-      progress_message: 'Validierung abgebrochen.',
-      error: 'Cancelled by user'
-    }]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'cancelled',
+        progress: 30,
+        progress_message: 'Validierung abgebrochen.',
+        error: 'Cancelled by user'
+      }
+    ]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -354,18 +540,18 @@ describe('JobQueueService', () => {
 
   it('keeps active Bull validation tasks active even when the task entity is cancelled', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
-    queues[7].getJobs.mockResolvedValue([
-      createJob({ taskId: 7 }, 'active')
+    queues[7].getJobs.mockResolvedValue([createJob({ taskId: 7 }, 'active')]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'cancelled',
+        progress: 30,
+        progress_message: 'Validierung abgebrochen.',
+        error: 'Cancelled by user'
+      }
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'cancelled',
-      progress: 30,
-      progress_message: 'Validierung abgebrochen.',
-      error: 'Cancelled by user'
-    }]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -389,15 +575,17 @@ describe('JobQueueService', () => {
     queues[7].getJobs.mockResolvedValue([
       createJob({ taskId: 7 }, 'completed')
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'failed',
-      progress: 100,
-      progress_message: 'Validierung fehlgeschlagen.',
-      error: 'Schema validation failed'
-    }]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'failed',
+        progress: 100,
+        progress_message: 'Validierung fehlgeschlagen.',
+        error: 'Schema validation failed'
+      }
+    ]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -486,7 +674,9 @@ describe('JobQueueService', () => {
         isCancelled: false
       }
     });
-    expect(JSON.stringify(workspaceJobs[0].data)).not.toContain('requestedByUserId');
+    expect(JSON.stringify(workspaceJobs[0].data)).not.toContain(
+      'requestedByUserId'
+    );
   });
 
   it('ignores stale null jobs returned by Bull when listing workspace jobs', async () => {
@@ -509,20 +699,34 @@ describe('JobQueueService', () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
     queues[1].getJobs.mockResolvedValue([null] as never);
 
-    await expect(service.assertNoDependencyConflicts('data-export', 1)).resolves.toBeUndefined();
+    await expect(
+      service.assertNoDependencyConflicts('data-export', 1)
+    ).resolves.toBeUndefined();
   });
 
   it('checks dependency conflicts and redis status', async () => {
-    await expect(service.assertNoActiveUploadForWorkspace(1)).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.assertNoDependencyConflicts('data-export', 1)).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.assertNoActiveUploadForWorkspace(1)
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.assertNoDependencyConflicts('data-export', 1)
+    ).rejects.toBeInstanceOf(ConflictException);
 
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
-    await expect(service.assertNoActiveUploadForWorkspace(1)).resolves.toBeUndefined();
-    await expect(service.assertNoDependencyConflicts('data-export', 1)).resolves.toBeUndefined();
+    await expect(
+      service.assertNoActiveUploadForWorkspace(1)
+    ).resolves.toBeUndefined();
+    await expect(
+      service.assertNoDependencyConflicts('data-export', 1)
+    ).resolves.toBeUndefined();
 
-    await expect(service.checkRedisConnection()).resolves.toMatchObject({ connected: true });
+    await expect(service.checkRedisConnection()).resolves.toMatchObject({
+      connected: true
+    });
     queues[0].client = null;
-    await expect(service.checkRedisConnection()).resolves.toMatchObject({ connected: false });
+    await expect(service.checkRedisConnection()).resolves.toMatchObject({
+      connected: false
+    });
   });
 
   it('deletes all variable analysis jobs including active ones', async () => {

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  Logger,
-  ConflictException
-} from '@nestjs/common';
+import { Injectable, Logger, ConflictException } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
@@ -17,7 +13,13 @@ import {
 
 type ProcessOverviewValidationTask = Pick<
 ValidationTask,
-'id' | 'workspace_id' | 'validation_type' | 'status' | 'progress' | 'progress_message' | 'error'
+| 'id'
+| 'workspace_id'
+| 'validation_type'
+| 'status'
+| 'progress'
+| 'progress_message'
+| 'error'
 >;
 
 export interface TestResultsUploadJobData {
@@ -28,7 +30,13 @@ export interface TestResultsUploadJobData {
   personMatchMode?: 'strict' | 'loose';
   overwriteMode?: 'skip' | 'merge' | 'replace';
   scope?: 'person' | 'workspace' | 'group' | 'booklet' | 'unit' | 'response';
-  scopeFilters?: { groupName?: string; bookletName?: string; unitNameOrAlias?: string; variableId?: string; subform?: string };
+  scopeFilters?: {
+    groupName?: string;
+    bookletName?: string;
+    unitNameOrAlias?: string;
+    variableId?: string;
+    subform?: string;
+  };
 }
 
 export interface TestPersonCodingJobData {
@@ -97,6 +105,7 @@ export interface CodingAnalysisJobData {
   threshold: number;
   cacheKey: string;
   runId?: string;
+  sourceRevision?: number;
 }
 
 export interface VariableAnalysisJobData {
@@ -168,9 +177,7 @@ export interface ExportJobData {
   anonymizeCoders?: boolean;
   usePseudoCoders?: boolean;
   doubleCodingMethod?:
-  | 'new-row-per-variable'
-  | 'new-column-per-coder'
-  | 'most-frequent';
+  'new-row-per-variable' | 'new-column-per-coder' | 'most-frequent';
   includeComments?: boolean;
   includeModalValue?: boolean;
   includeDoubleCoded?: boolean;
@@ -192,11 +199,7 @@ export interface ExportJobData {
 }
 
 export type ExportJobProgressPhase =
-  | 'preparing'
-  | 'counting'
-  | 'writing'
-  | 'finalizing'
-  | 'completed';
+  'preparing' | 'counting' | 'writing' | 'finalizing' | 'completed';
 
 export interface ExportJobProgress {
   percentage: number;
@@ -241,31 +244,106 @@ export interface RedisConnectionStatus {
 export class JobQueueService {
   private readonly logger = new Logger(JobQueueService.name);
 
-  private readonly exportCancellationControllers = new Map<string, AbortController>();
+  private readonly exportCancellationControllers = new Map<
+  string,
+  AbortController
+  >();
 
   private readonly DEPENDENCY_RULES: ReadonlyArray<{
     target: string;
     blockedBy: string;
     label: string;
   }> = [
-      { target: 'test-results-upload', blockedBy: 'validation-task', label: 'validation' },
-      { target: 'test-results-upload', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'test-results-upload', blockedBy: 'reset-coding-version', label: 'reset coding version' },
-      { target: 'test-results-upload', blockedBy: 'external-coding-import', label: 'external coding import' },
-      { target: 'test-person-coding', blockedBy: 'test-results-upload', label: 'test results upload' },
-      { target: 'test-person-coding', blockedBy: 'reset-coding-version', label: 'reset coding version' },
-      { target: 'test-person-coding', blockedBy: 'external-coding-import', label: 'external coding import' },
-      { target: 'validation-task', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'validation-task', blockedBy: 'test-results-upload', label: 'test results upload' },
-      { target: 'validation-task', blockedBy: 'reset-coding-version', label: 'reset coding version' },
-      { target: 'coding-statistics', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'coding-statistics', blockedBy: 'external-coding-import', label: 'external coding import' },
-      { target: 'data-export', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'reset-coding-version', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'reset-coding-version', blockedBy: 'external-coding-import', label: 'external coding import' },
-      { target: 'external-coding-import', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'external-coding-import', blockedBy: 'test-results-upload', label: 'test results upload' },
-      { target: 'external-coding-import', blockedBy: 'reset-coding-version', label: 'reset coding version' }
+      {
+        target: 'test-results-upload',
+        blockedBy: 'validation-task',
+        label: 'validation'
+      },
+      {
+        target: 'test-results-upload',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'test-results-upload',
+        blockedBy: 'reset-coding-version',
+        label: 'reset coding version'
+      },
+      {
+        target: 'test-results-upload',
+        blockedBy: 'external-coding-import',
+        label: 'external coding import'
+      },
+      {
+        target: 'test-person-coding',
+        blockedBy: 'test-results-upload',
+        label: 'test results upload'
+      },
+      {
+        target: 'test-person-coding',
+        blockedBy: 'reset-coding-version',
+        label: 'reset coding version'
+      },
+      {
+        target: 'test-person-coding',
+        blockedBy: 'external-coding-import',
+        label: 'external coding import'
+      },
+      {
+        target: 'validation-task',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'validation-task',
+        blockedBy: 'test-results-upload',
+        label: 'test results upload'
+      },
+      {
+        target: 'validation-task',
+        blockedBy: 'reset-coding-version',
+        label: 'reset coding version'
+      },
+      {
+        target: 'coding-statistics',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'coding-statistics',
+        blockedBy: 'external-coding-import',
+        label: 'external coding import'
+      },
+      {
+        target: 'data-export',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'reset-coding-version',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'reset-coding-version',
+        blockedBy: 'external-coding-import',
+        label: 'external coding import'
+      },
+      {
+        target: 'external-coding-import',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'external-coding-import',
+        blockedBy: 'test-results-upload',
+        label: 'test results upload'
+      },
+      {
+        target: 'external-coding-import',
+        blockedBy: 'reset-coding-version',
+        label: 'reset coding version'
+      }
     ];
 
   constructor(
@@ -280,11 +358,13 @@ export class JobQueueService {
     @InjectQueue('validation-task') private validationTaskQueue: Queue,
     @InjectQueue('response-analysis') private responseAnalysisQueue: Queue,
     @InjectQueue('variable-analysis') private variableAnalysisQueue: Queue,
-    @InjectQueue('external-coding-import') private externalCodingImportQueue: Queue,
-    @InjectQueue('database-export') private databaseExportQueue: Queue<DatabaseExportJobData>,
+    @InjectQueue('external-coding-import')
+    private externalCodingImportQueue: Queue,
+    @InjectQueue('database-export')
+    private databaseExportQueue: Queue<DatabaseExportJobData>,
     @InjectRepository(ValidationTask)
     private readonly validationTaskRepository: Repository<ValidationTask>
-  ) { }
+  ) {}
 
   private getQueue(name: string): Queue {
     return this.getAllQueues().get(name);
@@ -376,24 +456,37 @@ export class JobQueueService {
     workspaceId: number
   ): Promise<boolean> {
     if (queueName === 'validation-task') {
-      const taskId = Number((job.data as ValidationTaskJobData | undefined)?.taskId);
+      const taskId = Number(
+        (job.data as ValidationTaskJobData | undefined)?.taskId
+      );
       if (!taskId) return false;
 
       const tasks = await this.validationTaskRepository.find({
         where: { id: In([taskId]) },
         select: ['id', 'workspace_id']
       });
-      return tasks.some(task => Number(task.workspace_id) === Number(workspaceId));
+      return tasks.some(
+        task => Number(task.workspace_id) === Number(workspaceId)
+      );
     }
 
-    const jobWorkspaceId = Number((job.data as { workspaceId?: number } | undefined)?.workspaceId);
+    const jobWorkspaceId = Number(
+      (job.data as { workspaceId?: number } | undefined)?.workspaceId
+    );
     return Boolean(jobWorkspaceId) && jobWorkspaceId === Number(workspaceId);
   }
 
   private async cancelKnownJob(queueName: string, job: Job): Promise<boolean> {
     try {
       const state = await job.getState();
-      const removableStates = ['waiting', 'delayed', 'paused', 'completed', 'failed', 'cancelled'];
+      const removableStates = [
+        'waiting',
+        'delayed',
+        'paused',
+        'completed',
+        'failed',
+        'cancelled'
+      ];
       if (removableStates.includes(state)) {
         await job.remove();
         return true;
@@ -433,13 +526,21 @@ export class JobQueueService {
     return this.cancelKnownJob(queueName, job);
   }
 
-  async cancelWorkspaceJob(workspaceId: number, queueName: string, jobId: string): Promise<boolean> {
+  async cancelWorkspaceJob(
+    workspaceId: number,
+    queueName: string,
+    jobId: string
+  ): Promise<boolean> {
     const queue = this.getQueue(queueName);
     if (!queue) return false;
     const job = await queue.getJob(jobId);
     if (!job) return false;
 
-    const belongsToWorkspace = await this.jobBelongsToWorkspace(queueName, job, workspaceId);
+    const belongsToWorkspace = await this.jobBelongsToWorkspace(
+      queueName,
+      job,
+      workspaceId
+    );
     if (!belongsToWorkspace) return false;
 
     return this.cancelKnownJob(queueName, job);
@@ -465,75 +566,99 @@ export class JobQueueService {
 
     for (const [queueName, queue] of queues.entries()) {
       processPromises.push(
-        queue.getJobs(['active', 'waiting', 'delayed', 'completed', 'failed', 'paused']).then(async jobs => {
-          const existingJobs = jobs.filter(Boolean);
-          let matchedJobs = existingJobs;
-          let validationTaskMap = new Map<number, ProcessOverviewValidationTask>();
-          if (queueName === 'validation-task') {
-            const taskIds = existingJobs.map(j => j.data?.taskId as number).filter(Boolean);
-            if (taskIds.length === 0) return [];
-            const tasks = await this.validationTaskRepository.find({
-              where: { id: In(taskIds) },
-              select: [
-                'id',
-                'workspace_id',
-                'validation_type',
-                'status',
-                'progress',
-                'progress_message',
-                'error'
-              ]
-            }) as ProcessOverviewValidationTask[];
-            validationTaskMap = new Map(tasks.map(t => [Number(t.id), t]));
-            matchedJobs = existingJobs.filter(j => (
-              Number(validationTaskMap.get(Number(j.data?.taskId))?.workspace_id) === Number(workspaceId)
-            ));
-          } else {
-            matchedJobs = existingJobs.filter(j => j.data && j.data.workspaceId === workspaceId);
-          }
-
-          const mappedPromises = matchedJobs.map(async job => {
-            const bullState = await job.getState();
-            const validationTask = queueName === 'validation-task' ?
-              validationTaskMap.get(Number(job.data?.taskId)) :
-              undefined;
-            const status = this.getProcessOverviewStatus(
-              queueName,
-              bullState,
-              job.data,
-              validationTask
-            );
-            let progress: unknown = typeof validationTask?.progress === 'number' ?
-              validationTask.progress :
-              job.progress();
-
-            // For completed jobs, ensure progress shows as 100% if it's numeric/empty
-            if (status === 'completed') {
-              if (typeof progress !== 'object' || progress === null) {
-                progress = 100;
-              }
-            } else if (progress === undefined || progress === null) {
-              progress = 0;
+        queue
+          .getJobs([
+            'active',
+            'waiting',
+            'delayed',
+            'completed',
+            'failed',
+            'paused'
+          ])
+          .then(async jobs => {
+            const existingJobs = jobs.filter(Boolean);
+            let matchedJobs = existingJobs;
+            let validationTaskMap = new Map<
+            number,
+            ProcessOverviewValidationTask
+            >();
+            if (queueName === 'validation-task') {
+              const taskIds = existingJobs
+                .map(j => j.data?.taskId as number)
+                .filter(Boolean);
+              if (taskIds.length === 0) return [];
+              const tasks = (await this.validationTaskRepository.find({
+                where: { id: In(taskIds) },
+                select: [
+                  'id',
+                  'workspace_id',
+                  'validation_type',
+                  'status',
+                  'progress',
+                  'progress_message',
+                  'error'
+                ]
+              })) as ProcessOverviewValidationTask[];
+              validationTaskMap = new Map(tasks.map(t => [Number(t.id), t]));
+              matchedJobs = existingJobs.filter(
+                j => Number(
+                  validationTaskMap.get(Number(j.data?.taskId))?.workspace_id
+                ) === Number(workspaceId)
+              );
+            } else {
+              matchedJobs = existingJobs.filter(
+                j => j.data && j.data.workspaceId === workspaceId
+              );
             }
 
-            return {
-              id: job.id,
-              queueName: queueName,
-              status: status,
-              progress: progress,
-              data: this.sanitizeJobData({
-                ...job.data,
-                validationType: validationTask?.validation_type,
-                progressMessage: validationTask?.progress_message
-              }),
-              failedReason: this.getProcessFailedReason(status, job, validationTask),
-              timestamp: job.timestamp,
-              processedOn: job.processedOn,
-              finishedOn: job.finishedOn
-            } as ProcessDto;
-          });
-          return Promise.all(mappedPromises);
-        })
+            const mappedPromises = matchedJobs.map(async job => {
+              const bullState = await job.getState();
+              const validationTask =
+                queueName === 'validation-task' ?
+                  validationTaskMap.get(Number(job.data?.taskId)) :
+                  undefined;
+              const status = this.getProcessOverviewStatus(
+                queueName,
+                bullState,
+                job.data,
+                validationTask
+              );
+              let progress: unknown =
+                typeof validationTask?.progress === 'number' ?
+                  validationTask.progress :
+                  job.progress();
+
+              // For completed jobs, ensure progress shows as 100% if it's numeric/empty
+              if (status === 'completed') {
+                if (typeof progress !== 'object' || progress === null) {
+                  progress = 100;
+                }
+              } else if (progress === undefined || progress === null) {
+                progress = 0;
+              }
+
+              return {
+                id: job.id,
+                queueName: queueName,
+                status: status,
+                progress: progress,
+                data: this.sanitizeJobData({
+                  ...job.data,
+                  validationType: validationTask?.validation_type,
+                  progressMessage: validationTask?.progress_message
+                }),
+                failedReason: this.getProcessFailedReason(
+                  status,
+                  job,
+                  validationTask
+                ),
+                timestamp: job.timestamp,
+                processedOn: job.processedOn,
+                finishedOn: job.finishedOn
+              } as ProcessDto;
+            });
+            return Promise.all(mappedPromises);
+          })
       );
     }
 
@@ -614,7 +739,9 @@ export class JobQueueService {
     workspaceId: number
   ): Promise<Job | undefined> {
     const queue = this.getQueue(queueName);
-    const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(Boolean);
+    const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(
+      Boolean
+    );
 
     if (queueName === 'validation-task') {
       const taskIds = jobs.map(j => j.data?.taskId as number).filter(Boolean);
@@ -623,8 +750,12 @@ export class JobQueueService {
         where: { id: In(taskIds) },
         select: ['id', 'workspace_id']
       });
-      const taskWorkspaceMap = new Map(tasks.map(t => [t.id, t.workspace_id]));
-      return jobs.find(j => taskWorkspaceMap.get(j.data?.taskId) === workspaceId);
+      const taskWorkspaceMap = new Map(
+        tasks.map(t => [t.id, t.workspace_id])
+      );
+      return jobs.find(
+        j => taskWorkspaceMap.get(j.data?.taskId) === workspaceId
+      );
     }
 
     return jobs.find(j => j.data?.workspaceId === workspaceId);
@@ -636,7 +767,10 @@ export class JobQueueService {
   ): Promise<void> {
     const rules = this.DEPENDENCY_RULES.filter(r => r.target === targetQueue);
     for (const rule of rules) {
-      const blockingJob = await this.hasActiveJobForWorkspace(rule.blockedBy, workspaceId);
+      const blockingJob = await this.hasActiveJobForWorkspace(
+        rule.blockedBy,
+        workspaceId
+      );
       if (blockingJob) {
         throw new ConflictException(
           `Cannot start: a ${rule.label} job is still active for this workspace (job ${blockingJob.id}). Please wait until it completes.`
@@ -649,7 +783,9 @@ export class JobQueueService {
     queue: Queue,
     matchFn: (data: T) => boolean
   ): Promise<Job<T> | undefined> {
-    const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(Boolean);
+    const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(
+      Boolean
+    );
     return jobs.find(job => matchFn(job.data));
   }
 
@@ -866,7 +1002,7 @@ export class JobQueueService {
       'delayed'
     ]);
     this.logger.log(`Found ${jobs.length} export jobs in total`);
-    return jobs.filter(job => job.data.workspaceId === workspaceId);
+    return jobs.filter(job => job?.data?.workspaceId === workspaceId);
   }
 
   createExportJobCancellationSignal(jobId: string): AbortSignal {
@@ -1017,7 +1153,9 @@ export class JobQueueService {
     return this.codebookGenerationQueue.add(data, options);
   }
 
-  async getCodebookGenerationJob(jobId: string): Promise<Job<CodebookGenerationJobData>> {
+  async getCodebookGenerationJob(
+    jobId: string
+  ): Promise<Job<CodebookGenerationJobData>> {
     return this.codebookGenerationQueue.getJob(jobId);
   }
 
@@ -1075,8 +1213,14 @@ export class JobQueueService {
     data: CodingAnalysisJobData,
     options?: JobOptions
   ): Promise<Job<CodingAnalysisJobData>> {
-    this.logger.log(`Adding coding analysis job for workspace ${data.workspaceId}`);
-    return this.responseAnalysisQueue.add(data, options);
+    this.logger.log(
+      `Adding coding analysis job for workspace ${data.workspaceId}`
+    );
+    return this.responseAnalysisQueue.add(data, {
+      removeOnComplete: { age: 3600, count: 10 },
+      removeOnFail: { age: 86400, count: 50 },
+      ...options
+    });
   }
 
   async getCodingAnalysisJob(
@@ -1088,19 +1232,38 @@ export class JobQueueService {
   async getActiveCodingAnalysisJob(
     workspaceId: number
   ): Promise<Job<CodingAnalysisJobData> | null> {
+    return this.findCodingAnalysisJob(
+      job => job.data.workspaceId === workspaceId
+    );
+  }
+
+  async getCodingAnalysisJobForCacheKey(
+    workspaceId: number,
+    cacheKey: string
+  ): Promise<Job<CodingAnalysisJobData> | null> {
+    return this.findCodingAnalysisJob(
+      job => job.data.workspaceId === workspaceId && job.data.cacheKey === cacheKey
+    );
+  }
+
+  private async findCodingAnalysisJob(
+    predicate: (job: Job<CodingAnalysisJobData>) => boolean
+  ): Promise<Job<CodingAnalysisJobData> | null> {
     const jobs = await this.responseAnalysisQueue.getJobs([
       'active',
       'waiting',
       'delayed'
     ]);
-    return jobs.find(job => job.data.workspaceId === workspaceId) || null;
+    return jobs.find(predicate) || null;
   }
 
   async addVariableAnalysisJob(
     data: VariableAnalysisJobData,
     options?: JobOptions
   ): Promise<Job<VariableAnalysisJobData>> {
-    this.logger.log(`Adding variable analysis job for workspace ${data.workspaceId}`);
+    this.logger.log(
+      `Adding variable analysis job for workspace ${data.workspaceId}`
+    );
     return this.variableAnalysisQueue.add(data, {
       removeOnComplete: { age: 86400 },
       removeOnFail: { age: 604800 },
@@ -1117,7 +1280,9 @@ export class JobQueueService {
   async getVariableAnalysisJobs(
     workspaceId: number
   ): Promise<Job<VariableAnalysisJobData>[]> {
-    this.logger.log(`Fetching all variable analysis jobs for workspace ${workspaceId}`);
+    this.logger.log(
+      `Fetching all variable analysis jobs for workspace ${workspaceId}`
+    );
     const jobs = await this.variableAnalysisQueue.getJobs([
       'completed',
       'failed',
@@ -1139,14 +1304,19 @@ export class JobQueueService {
       this.logger.log(`Variable analysis job ${jobId} has been deleted`);
       return true;
     } catch (error) {
-      this.logger.error(`Error deleting variable analysis job: ${error.message}`, error.stack);
+      this.logger.error(
+        `Error deleting variable analysis job: ${error.message}`,
+        error.stack
+      );
       return false;
     }
   }
 
   async deleteVariableAnalysisJobs(workspaceId: number): Promise<void> {
     const jobs = await this.getVariableAnalysisJobs(workspaceId);
-    this.logger.log(`Deleting all ${jobs.length} variable analysis jobs for workspace ${workspaceId}`);
+    this.logger.log(
+      `Deleting all ${jobs.length} variable analysis jobs for workspace ${workspaceId}`
+    );
 
     for (const job of jobs) {
       try {
@@ -1154,12 +1324,14 @@ export class JobQueueService {
         if (state === 'active') {
           await job.discard();
           // If removal fails for an active job, we at least discarded it to prevent retries
-          await job.remove().catch(() => { });
+          await job.remove().catch(() => {});
         } else {
           await job.remove();
         }
       } catch (error) {
-        this.logger.warn(`Failed to remove variable analysis job ${job.id}: ${error.message}`);
+        this.logger.warn(
+          `Failed to remove variable analysis job ${job.id}: ${error.message}`
+        );
       }
     }
   }
@@ -1176,19 +1348,26 @@ export class JobQueueService {
 
       if (state === 'waiting' || state === 'delayed') {
         await job.remove();
-        this.logger.log(`Variable analysis job ${jobId} has been cancelled and removed from queue`);
+        this.logger.log(
+          `Variable analysis job ${jobId} has been cancelled and removed from queue`
+        );
         return true;
       }
 
       if (state === 'active') {
         await job.discard();
-        this.logger.log(`Variable analysis job ${jobId} is active, marked for discard`);
+        this.logger.log(
+          `Variable analysis job ${jobId} is active, marked for discard`
+        );
         return true;
       }
 
       return true; // Already finished or failed
     } catch (error) {
-      this.logger.error(`Error cancelling variable analysis job: ${error.message}`, error.stack);
+      this.logger.error(
+        `Error cancelling variable analysis job: ${error.message}`,
+        error.stack
+      );
       return false;
     }
   }

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.spec.ts
@@ -11,7 +11,8 @@ describe('CodingAnalysisProcessor', () => {
       {} as never,
       cacheService as CacheService,
       {} as WorkspaceExclusionService,
-      {} as WorkspaceFilesService
+      {} as WorkspaceFilesService,
+      { getCodingIncompleteVariables: jest.fn() } as never
     );
     const analysis: ResponseAnalysisDto = {
       emptyResponses: {
@@ -71,23 +72,77 @@ describe('CodingAnalysisProcessor', () => {
       get: jest.fn().mockResolvedValue('newer-run'),
       set: jest.fn().mockResolvedValue(true)
     };
-    const { processor, analysis } = createProcessor(cacheService);
+    const { processor } = createProcessor(cacheService);
 
-    await expect(processor.handleResponseAnalysis(createJob('old-run'))).resolves.toBe(analysis);
+    await expect(processor.handleResponseAnalysis(createJob('old-run'))).resolves.toMatchObject({
+      cacheKey: 'response-analysis:7__t2',
+      status: 'stale-skip',
+      workspaceId: 7
+    });
 
     expect(cacheService.get).toHaveBeenCalledWith('response-analysis:7__t2:run');
     expect(cacheService.set).not.toHaveBeenCalled();
   });
 
-  it('caches analysis results for the latest marked run', async () => {
+  it('caches lightweight analysis pages for the latest marked run', async () => {
     const cacheService = {
       get: jest.fn().mockResolvedValue('current-run'),
       set: jest.fn().mockResolvedValue(true)
     };
     const { processor, analysis } = createProcessor(cacheService);
 
-    await expect(processor.handleResponseAnalysis(createJob('current-run'))).resolves.toBe(analysis);
+    await expect(processor.handleResponseAnalysis(createJob('current-run'))).resolves.toMatchObject({
+      cacheKey: 'response-analysis:7__t2',
+      status: 'cached',
+      workspaceId: 7
+    });
 
-    expect(cacheService.set).toHaveBeenCalledWith('response-analysis:7__t2', analysis);
+    expect(cacheService.set).not.toHaveBeenCalledWith(
+      'response-analysis:7__t2',
+      analysis
+    );
+    expect(cacheService.set.mock.calls[0][0]).toBe(
+      'response-analysis:7__t2:summary'
+    );
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'response-analysis:7__t2:empty-chunk:0',
+      expect.objectContaining({ chunkIndex: 0 })
+    );
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'response-analysis:7__t2:duplicate-chunk:0',
+      expect.objectContaining({ chunkIndex: 0 })
+    );
+  });
+
+  it('normalizes manual analysis variable keys for query filters', async () => {
+    const codingValidationService = {
+      getCodingIncompleteVariables: jest.fn().mockResolvedValue([
+        { unitName: ' unit-a.XML ', variableId: 'var1' },
+        { unitName: 'UNIT-A', variableId: 'var1' },
+        { unitName: 'unit-b', variableId: ' var2 ' },
+        { unitName: '', variableId: 'ignored' },
+        { unitName: 'unit-c', variableId: '' }
+      ])
+    };
+    const processor = new CodingAnalysisProcessor(
+      {} as never,
+      {} as CacheService,
+      {} as WorkspaceExclusionService,
+      {} as WorkspaceFilesService,
+      codingValidationService as never
+    );
+
+    const variables = await (processor as unknown as {
+      getManualAnalysisVariables: (workspaceId: number) => Promise<
+      { unitName: string; variableId: string }[]
+      >;
+    }).getManualAnalysisVariables(7);
+
+    expect(codingValidationService.getCodingIncompleteVariables)
+      .toHaveBeenCalledWith(7);
+    expect(variables).toEqual([
+      { unitName: 'UNIT-A', variableId: 'var1' },
+      { unitName: 'UNIT-B', variableId: 'var2' }
+    ]);
   });
 });

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
@@ -2,9 +2,10 @@ import { Processor, Process } from '@nestjs/bull';
 import { Logger, Optional } from '@nestjs/common';
 import { Job } from 'bull';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Brackets } from 'typeorm';
+import { Repository, Brackets, SelectQueryBuilder } from 'typeorm';
 import { ResponseEntity } from '../../database/entities/response.entity';
 import { ResponseMatchingFlag } from '../../database/services/coding/coding-job.service';
+import { CodingValidationService } from '../../database/services/coding';
 import {
   ResponseAnalysisDto,
   EmptyResponseDto,
@@ -26,13 +27,57 @@ import {
 } from '../../database/services/coding/aggregation-metrics.util';
 import { getCodingAnalysisRunMarkerKey } from '../../database/services/coding/coding-analysis-cache-key.util';
 import {
+  createDuplicateValueChunkCaches,
+  createDuplicateValuePageCache,
+  createEmptyResponseChunkCaches,
+  createEmptyResponsePageCache,
+  createResponseAnalysisSummaryCache,
+  getResponseAnalysisDuplicateChunkCacheKey,
+  getResponseAnalysisDuplicatePageCacheKey,
+  getResponseAnalysisEmptyChunkCacheKey,
+  getResponseAnalysisEmptyPageCacheKey,
+  getResponseAnalysisSummaryCacheKey,
+  RESPONSE_ANALYSIS_DUPLICATE_PAGE_LIMITS,
+  RESPONSE_ANALYSIS_EMPTY_PAGE_LIMITS
+} from '../../database/services/coding/response-analysis-page-cache.util';
+import {
   IQB_STANDARD_MISSING_CODES,
   MissingsProfilesService
 } from '../../database/services/coding/missings-profiles.service';
 
+interface ManualAnalysisVariable {
+  unitName: string;
+  variableId: string;
+}
+
+interface AnalysisResponseRow {
+  responseId: number | string;
+  value: string | null;
+  variableId: string;
+  statusV2: number | string | null;
+  codeV2: number | string | null;
+  unitName: string | null;
+  unitAlias: string | null;
+  personLogin: string | null;
+  personCode: string | null;
+  personGroup: string | null;
+  bookletName: string | null;
+}
+
+interface CodingAnalysisJobResult {
+  workspaceId: number;
+  cacheKey: string;
+  status: 'cached' | 'stale-skip';
+  sourceRevision?: number;
+  completedAt: string;
+}
+
 @Processor('response-analysis')
 export class CodingAnalysisProcessor {
   private readonly logger = new Logger(CodingAnalysisProcessor.name);
+  private readonly slowResponseAnalysisThresholdMs = 3000;
+  private readonly normalizedUnitNameExpression =
+    "regexp_replace(UPPER(unit.name), '\\.XML$', '', 'i')";
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -40,32 +85,44 @@ export class CodingAnalysisProcessor {
     private cacheService: CacheService,
     private workspaceExclusionService: WorkspaceExclusionService,
     private workspaceFilesService: WorkspaceFilesService,
+    private codingValidationService: CodingValidationService,
     @Optional()
     private missingsProfilesService?: MissingsProfilesService
-  ) { }
+  ) {}
 
   private async getDefaultMirCode(workspaceId: number): Promise<number> {
     if (!this.missingsProfilesService) {
       return IQB_STANDARD_MISSING_CODES.mir;
     }
 
-    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
-      workspaceId,
-      null,
-      'mir'
-    );
+    const missing =
+      await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+        workspaceId,
+        null,
+        'mir'
+      );
     return missing.code;
   }
 
   @Process()
-  async handleResponseAnalysis(job: Job<CodingAnalysisJobData>) {
+  async handleResponseAnalysis(
+    job: Job<CodingAnalysisJobData>
+  ): Promise<CodingAnalysisJobResult> {
     const {
       workspaceId, matchingFlags, threshold, cacheKey
     } = job.data;
-    this.logger.log(`Processing response analysis for workspace ${workspaceId}...`);
+    const startedAt = Date.now();
+    this.logger.log(
+      `Processing response analysis for workspace ${workspaceId}...`
+    );
 
     try {
-      const analysis = await this.computeResponseAnalysis(workspaceId, matchingFlags as ResponseMatchingFlag[], threshold, job);
+      const analysis = await this.computeResponseAnalysis(
+        workspaceId,
+        matchingFlags as ResponseMatchingFlag[],
+        threshold,
+        job
+      );
       if (job.data.runId) {
         const currentRunId = await this.cacheService.get<string>(
           getCodingAnalysisRunMarkerKey(cacheKey)
@@ -74,18 +131,108 @@ export class CodingAnalysisProcessor {
           this.logger.log(
             `Skipping stale response analysis cache write for workspace ${workspaceId} (job ${job.id})`
           );
-          return analysis;
+          this.logResponseAnalysisTiming(
+            workspaceId,
+            startedAt,
+            'completed-stale-skip'
+          );
+          return this.createJobResult(job.data, 'stale-skip');
         }
       }
 
-      await this.cacheService.set(cacheKey, analysis);
+      await this.writeResponseAnalysisPageCaches(cacheKey, analysis);
 
-      this.logger.log(`Response analysis for workspace ${workspaceId} completed and cached.`);
-      return analysis;
+      this.logResponseAnalysisTiming(
+        workspaceId,
+        startedAt,
+        'completed-and-cached'
+      );
+      return this.createJobResult(job.data, 'cached');
     } catch (error) {
-      this.logger.error(`Response analysis failed: ${error.message}`, error.stack);
+      this.logResponseAnalysisTiming(workspaceId, startedAt, 'failed');
+      this.logger.error(
+        `Response analysis failed: ${error.message}`,
+        error.stack
+      );
       throw error;
     }
+  }
+
+  private async writeResponseAnalysisPageCaches(
+    cacheKey: string,
+    analysis: ResponseAnalysisDto
+  ): Promise<void> {
+    const writes: Promise<boolean>[] = [
+      this.cacheService.set(
+        getResponseAnalysisSummaryCacheKey(cacheKey),
+        createResponseAnalysisSummaryCache(analysis)
+      )
+    ];
+
+    for (const limit of RESPONSE_ANALYSIS_EMPTY_PAGE_LIMITS) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisEmptyPageCacheKey(cacheKey, 1, limit),
+          createEmptyResponsePageCache(analysis, 1, limit)
+        )
+      );
+    }
+
+    for (const limit of RESPONSE_ANALYSIS_DUPLICATE_PAGE_LIMITS) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisDuplicatePageCacheKey(cacheKey, 1, limit),
+          createDuplicateValuePageCache(analysis, 1, limit)
+        )
+      );
+    }
+
+    for (const chunk of createEmptyResponseChunkCaches(analysis)) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisEmptyChunkCacheKey(cacheKey, chunk.chunkIndex),
+          chunk
+        )
+      );
+    }
+
+    for (const chunk of createDuplicateValueChunkCaches(analysis)) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisDuplicateChunkCacheKey(cacheKey, chunk.chunkIndex),
+          chunk
+        )
+      );
+    }
+
+    await Promise.all(writes);
+  }
+
+  private createJobResult(
+    data: CodingAnalysisJobData,
+    status: CodingAnalysisJobResult['status']
+  ): CodingAnalysisJobResult {
+    return {
+      workspaceId: data.workspaceId,
+      cacheKey: data.cacheKey,
+      status,
+      sourceRevision: data.sourceRevision,
+      completedAt: new Date().toISOString()
+    };
+  }
+
+  private logResponseAnalysisTiming(
+    workspaceId: number,
+    startedAt: number,
+    status: string
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    const message = `Response analysis for workspace ${workspaceId} ${status} in ${durationMs}ms.`;
+    if (durationMs >= this.slowResponseAnalysisThresholdMs) {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.log(message);
   }
 
   private async computeResponseAnalysis(
@@ -95,16 +242,45 @@ export class CodingAnalysisProcessor {
     job?: Job<CodingAnalysisJobData>
   ): Promise<ResponseAnalysisDto> {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
-    const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
-    const derivedVariableMap = await this.getDerivedVariableMap(workspaceId);
+    const intendedIncompleteStatus = statusStringToNumber(
+      'INTENDED_INCOMPLETE'
+    );
+    const [
+      exclusions,
+      defaultMirCode,
+      derivedVariableMap,
+      sourceRevision,
+      manualVariables
+    ] = await Promise.all([
+      this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId),
+      this.getDefaultMirCode(workspaceId),
+      this.getDerivedVariableMap(workspaceId),
+      this.resolveSourceRevision(workspaceId, job?.data.sourceRevision),
+      this.getManualAnalysisVariables(workspaceId)
+    ]);
 
-    // 1. Identify relevant Unit+Variable combinations
-    this.logger.log(`Identifying relevant variables for analysis in workspace ${workspaceId}...`);
+    if (manualVariables.length === 0) {
+      this.logger.warn(
+        `No manual coding variables found for analysis in workspace ${workspaceId}`
+      );
+      return this.createEmptyAnalysisResult(
+        matchingFlags,
+        threshold,
+        sourceRevision
+      );
+    }
+
+    this.logger.log(
+      `Restricting response analysis for workspace ${workspaceId} to ${manualVariables.length} manual coding variables.`
+    );
+
+    // 1. Identify relevant UnitName+Variable combinations
+    this.logger.log(
+      `Identifying relevant variables for analysis in workspace ${workspaceId}...`
+    );
     const relevantVariablesQuery = this.responseRepository
       .createQueryBuilder('response')
-      .select('response.unitid', 'unitId')
+      .select(this.normalizedUnitNameExpression, 'unitName')
       .addSelect('response.variableid', 'variableId')
       .distinct(true)
       .innerJoin('response.unit', 'unit')
@@ -113,17 +289,32 @@ export class CodingAnalysisProcessor {
       .innerJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('response.status_v1 IN (:...statuses)', { statuses: [codingIncompleteStatus, intendedIncompleteStatus] });
+      .andWhere('response.status_v1 IN (:...statuses)', {
+        statuses: [codingIncompleteStatus, intendedIncompleteStatus]
+      });
+    this.applyManualVariableFilter(
+      relevantVariablesQuery,
+      manualVariables,
+      'relevantManualVariable'
+    );
     applyResolvedExclusionsToQuery(relevantVariablesQuery, exclusions);
-    const relevantVariables = await relevantVariablesQuery
-      .getRawMany();
+    const relevantVariables =
+      await relevantVariablesQuery.getRawMany<ManualAnalysisVariable>();
 
     if (relevantVariables.length === 0) {
-      this.logger.warn(`No relevant variables found for analysis in workspace ${workspaceId}`);
-      return this.createEmptyAnalysisResult(matchingFlags, threshold);
+      this.logger.warn(
+        `No relevant variables found for analysis in workspace ${workspaceId}`
+      );
+      return this.createEmptyAnalysisResult(
+        matchingFlags,
+        threshold,
+        sourceRevision
+      );
     }
 
-    this.logger.log(`Found ${relevantVariables.length} variable groups to analyze. Processing in chunks...`);
+    this.logger.log(
+      `Found ${relevantVariables.length} variable groups to analyze. Processing in chunks...`
+    );
 
     const emptyResponses: EmptyResponseDto[] = [];
     const duplicateValueGroups: DuplicateValueGroupDto[] = [];
@@ -139,23 +330,41 @@ export class CodingAnalysisProcessor {
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
       .andWhere('response.code_v2 = :aggregatedCode', { aggregatedCode: -111 });
+    this.applyManualVariableFilter(
+      aggregationAppliedQuery,
+      manualVariables,
+      'aggregationManualVariable'
+    );
     applyResolvedExclusionsToQuery(aggregationAppliedQuery, exclusions);
-    const isAggregationApplied = await aggregationAppliedQuery
-      .getCount() > 0;
+    const isAggregationApplied = (await aggregationAppliedQuery.getCount()) > 0;
 
     // 2. Process in chunks
-    const chunkSize = 50; // Number of variable groups per query
+    const chunkSize = 25; // Number of unit-name variable groups per query
     for (let i = 0; i < relevantVariables.length; i += chunkSize) {
       const chunk = relevantVariables.slice(i, i + chunkSize);
 
-      const qb = this.responseRepository.createQueryBuilder('response')
-        .leftJoinAndSelect('response.unit', 'unit')
-        .leftJoinAndSelect('unit.booklet', 'booklet')
-        .leftJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
-        .leftJoinAndSelect('booklet.person', 'person')
+      const qb = this.responseRepository
+        .createQueryBuilder('response')
+        .select('response.id', 'responseId')
+        .addSelect('response.value', 'value')
+        .addSelect('response.variableid', 'variableId')
+        .addSelect('response.status_v2', 'statusV2')
+        .addSelect('response.code_v2', 'codeV2')
+        .addSelect('unit.name', 'unitName')
+        .addSelect('unit.alias', 'unitAlias')
+        .addSelect('person.login', 'personLogin')
+        .addSelect('person.code', 'personCode')
+        .addSelect('person.group', 'personGroup')
+        .addSelect('bookletinfo.name', 'bookletName')
+        .leftJoin('response.unit', 'unit')
+        .leftJoin('unit.booklet', 'booklet')
+        .leftJoin('booklet.bookletinfo', 'bookletinfo')
+        .leftJoin('booklet.person', 'person')
         .where('person.workspace_id = :workspaceId', { workspaceId })
         .andWhere('person.consider = :consider', { consider: true })
-        .andWhere('response.status_v1 IN (:...statuses)', { statuses: [codingIncompleteStatus, intendedIncompleteStatus] })
+        .andWhere('response.status_v1 IN (:...statuses)', {
+          statuses: [codingIncompleteStatus, intendedIncompleteStatus]
+        })
         // Exclude already-aggregated responses (non-master duplicates) so they don't reappear after aggregation
         .andWhere(
           '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :emptyCode))',
@@ -163,18 +372,29 @@ export class CodingAnalysisProcessor {
         );
       applyResolvedExclusionsToQuery(qb, exclusions);
 
-      qb.andWhere(new Brackets(qbInside => {
-        chunk.forEach((item, index) => {
-          const params = { [`uid${index}`]: item.unitId, [`vid${index}`]: item.variableId };
-          if (index === 0) {
-            qbInside.where(`response.unitid = :uid${index} AND response.variableid = :vid${index}`, params);
-          } else {
-            qbInside.orWhere(`response.unitid = :uid${index} AND response.variableid = :vid${index}`, params);
-          }
-        });
-      }));
+      qb.andWhere(
+        new Brackets(qbInside => {
+          chunk.forEach((item, index) => {
+            const params = {
+              [`unitName${index}`]: item.unitName,
+              [`vid${index}`]: item.variableId
+            };
+            if (index === 0) {
+              qbInside.where(
+                `${this.normalizedUnitNameExpression} = :unitName${index} AND response.variableid = :vid${index}`,
+                params
+              );
+            } else {
+              qbInside.orWhere(
+                `${this.normalizedUnitNameExpression} = :unitName${index} AND response.variableid = :vid${index}`,
+                params
+              );
+            }
+          });
+        })
+      );
 
-      const responsesBatch = await qb.getMany();
+      const responsesBatch = await qb.getRawMany<AnalysisResponseRow>();
       totalProcessed += responsesBatch.length;
 
       this.analyzeBatch(
@@ -186,14 +406,23 @@ export class CodingAnalysisProcessor {
       );
 
       // Explicitly free memory if possible (though GC handles function scope)
-      if ((i + chunkSize) % 500 === 0 || (i + chunkSize) >= relevantVariables.length) {
+      if (
+        (i + chunkSize) % 500 === 0 ||
+        i + chunkSize >= relevantVariables.length
+      ) {
         const processed = Math.min(i + chunkSize, relevantVariables.length);
-        const progress = Math.round((processed / relevantVariables.length) * 100);
+        const progress = Math.round(
+          (processed / relevantVariables.length) * 100
+        );
         if (job) {
           await job.progress(progress);
         }
-        this.logger.log(`Processed ${processed}/${relevantVariables.length} variable groups...`);
-        if (global.gc) { global.gc(); }
+        this.logger.log(
+          `Processed ${processed}/${relevantVariables.length} variable groups...`
+        );
+        if (global.gc) {
+          global.gc();
+        }
       }
     }
 
@@ -204,13 +433,17 @@ export class CodingAnalysisProcessor {
         // Merge occurrences into the existing group
         mergedGroupsMap.get(key)!.occurrences.push(...group.occurrences);
       } else {
-        mergedGroupsMap.set(key, { ...group, occurrences: [...group.occurrences] });
+        mergedGroupsMap.set(key, {
+          ...group,
+          occurrences: [...group.occurrences]
+        });
       }
     }
 
     // Apply threshold filter on merged groups and build the final list
-    const mergedGroups = Array.from(mergedGroupsMap.values())
-      .filter(group => group.occurrences.length >= threshold);
+    const mergedGroups = Array.from(mergedGroupsMap.values()).filter(
+      group => group.occurrences.length >= threshold
+    );
 
     // Sort results
     emptyResponses.sort((a, b) => {
@@ -236,7 +469,9 @@ export class CodingAnalysisProcessor {
       matchingFlags
     );
 
-    this.logger.log(`Analysis complete. Processed ${totalProcessed} responses. Found ${mergedGroups.length} duplicate groups.`);
+    this.logger.log(
+      `Analysis complete. Processed ${totalProcessed} responses. Found ${mergedGroups.length} duplicate groups.`
+    );
 
     return {
       emptyResponses: {
@@ -252,12 +487,13 @@ export class CodingAnalysisProcessor {
       },
       aggregationSummary,
       matchingFlags: matchingFlags as unknown as string[],
-      analysisTimestamp: new Date().toISOString()
+      analysisTimestamp: new Date().toISOString(),
+      sourceRevision
     };
   }
 
   private analyzeBatch(
-    responses: ResponseEntity[],
+    responses: AnalysisResponseRow[],
     matchingFlags: ResponseMatchingFlag[],
     emptyResponses: EmptyResponseDto[],
     duplicateValueGroups: DuplicateValueGroupDto[],
@@ -267,7 +503,7 @@ export class CodingAnalysisProcessor {
     // Since our query chunked by Unit+Variable, we can treat this batch as a collection of complete groups
 
     // Group responses by unit+variable
-    const responsesByUnitVariable = new Map<string, ResponseEntity[]>();
+    const responsesByUnitVariable = new Map<string, AnalysisResponseRow[]>();
 
     for (const response of responses) {
       // Empty Check - IMPROVED LOGIC
@@ -275,30 +511,36 @@ export class CodingAnalysisProcessor {
 
       if (!isAggregatableValue(value)) {
         emptyResponses.push({
-          unitName: response.unit?.name || '',
-          unitAlias: response.unit?.alias || null,
-          variableId: response.variableid,
-          personLogin: response.unit?.booklet?.person?.login || '',
-          personCode: response.unit?.booklet?.person?.code || '',
-          personGroup: response.unit?.booklet?.person?.group || '',
-          bookletName: response.unit?.booklet?.bookletinfo?.name || 'Unknown',
-          responseId: response.id,
+          unitName: response.unitName || '',
+          unitAlias: response.unitAlias || null,
+          variableId: response.variableId,
+          personLogin: response.personLogin || '',
+          personCode: response.personCode || '',
+          personGroup: response.personGroup || '',
+          bookletName: response.bookletName || 'Unknown',
+          responseId: Number(response.responseId),
           value: response.value,
-          isCoded: response.status_v2 !== null,
-          assignedCode: response.code_v2
+          isCoded:
+            response.statusV2 !== null && response.statusV2 !== undefined,
+          assignedCode:
+            response.codeV2 === null || response.codeV2 === undefined ?
+              null :
+              Number(response.codeV2)
         });
         continue; // Skip empty for duplicates
       }
 
-      if (isDerivedAggregationVariable(
-        derivedVariableMap,
-        response.unit?.name || '',
-        response.variableid
-      )) {
+      if (
+        isDerivedAggregationVariable(
+          derivedVariableMap,
+          response.unitName || '',
+          response.variableId
+        )
+      ) {
         continue;
       }
 
-      const key = `${response.unit?.name || response.unitid}_${response.variableid}`;
+      const key = `${response.unitName || ''}_${response.variableId}`;
       if (!responsesByUnitVariable.has(key)) {
         responsesByUnitVariable.set(key, []);
       }
@@ -306,7 +548,7 @@ export class CodingAnalysisProcessor {
     }
 
     for (const [, groupResponses] of responsesByUnitVariable.entries()) {
-      const valueGroups = new Map<string, ResponseEntity[]>();
+      const valueGroups = new Map<string, AnalysisResponseRow[]>();
       for (const response of groupResponses) {
         const normalizedValue = normalizeAggregationValue(
           response.value,
@@ -321,16 +563,16 @@ export class CodingAnalysisProcessor {
       for (const [normalizedValue, valGroup] of valueGroups.entries()) {
         const first = valGroup[0];
         duplicateValueGroups.push({
-          unitName: first.unit?.name || '',
-          unitAlias: first.unit?.alias || null,
-          variableId: first.variableid,
+          unitName: first.unitName || '',
+          unitAlias: first.unitAlias || null,
+          variableId: first.variableId,
           normalizedValue,
           originalValue: first.value || '',
           occurrences: valGroup.map(r => ({
-            personLogin: r.unit?.booklet?.person?.login || 'Unknown',
-            personCode: r.unit?.booklet?.person?.code || '',
-            bookletName: r.unit?.booklet?.bookletinfo?.name || 'Unknown',
-            responseId: r.id,
+            personLogin: r.personLogin || 'Unknown',
+            personCode: r.personCode || '',
+            bookletName: r.bookletName || 'Unknown',
+            responseId: Number(r.responseId),
             value: r.value || ''
           }))
         });
@@ -340,7 +582,8 @@ export class CodingAnalysisProcessor {
 
   private createEmptyAnalysisResult(
     matchingFlags: ResponseMatchingFlag[],
-    threshold: number | null = null
+    threshold: number | null = null,
+    sourceRevision?: number
   ): ResponseAnalysisDto {
     const result: ResponseAnalysisDto = {
       emptyResponses: {
@@ -362,20 +605,107 @@ export class CodingAnalysisProcessor {
         matchingFlags
       ),
       matchingFlags: matchingFlags as unknown as string[],
-      analysisTimestamp: new Date().toISOString()
+      analysisTimestamp: new Date().toISOString(),
+      sourceRevision
     };
 
     return result;
+  }
+
+  private async getManualAnalysisVariables(
+    workspaceId: number
+  ): Promise<ManualAnalysisVariable[]> {
+    const variables =
+      await this.codingValidationService.getCodingIncompleteVariables(
+        workspaceId
+      );
+    const uniqueVariables = new Map<string, ManualAnalysisVariable>();
+
+    variables.forEach(variable => {
+      const unitName = this.normalizeUnitName(variable.unitName);
+      const variableId = String(variable.variableId || '').trim();
+      if (!unitName || !variableId) {
+        return;
+      }
+      uniqueVariables.set(`${unitName}::${variableId}`, {
+        unitName,
+        variableId
+      });
+    });
+
+    return Array.from(uniqueVariables.values());
+  }
+
+  private normalizeUnitName(unitName: string | null | undefined): string {
+    return String(unitName || '')
+      .trim()
+      .replace(/\.XML$/i, '')
+      .toUpperCase();
+  }
+
+  private applyManualVariableFilter(
+    query: SelectQueryBuilder<ResponseEntity>,
+    variables: ManualAnalysisVariable[],
+    parameterPrefix: string
+  ): void {
+    query.andWhere(
+      new Brackets(qbInside => {
+        variables.forEach((variable, index) => {
+          const unitParam = `${parameterPrefix}Unit${index}`;
+          const variableParam = `${parameterPrefix}Variable${index}`;
+          const params = {
+            [unitParam]: variable.unitName,
+            [variableParam]: variable.variableId
+          };
+          const condition =
+            `${this.normalizedUnitNameExpression} = :${unitParam} ` +
+            `AND response.variableid = :${variableParam}`;
+
+          if (index === 0) {
+            qbInside.where(condition, params);
+            return;
+          }
+          qbInside.orWhere(condition, params);
+        });
+      })
+    );
+  }
+
+  private async resolveSourceRevision(
+    workspaceId: number,
+    plannedRevision?: number
+  ): Promise<number> {
+    if (plannedRevision !== undefined) {
+      return plannedRevision;
+    }
+
+    try {
+      const rows = (await this.responseRepository.query(
+        'SELECT revision FROM workspace_test_results_revision WHERE workspace_id = $1',
+        [workspaceId]
+      )) as Array<{ revision: number | string }>;
+      return Number(rows[0]?.revision || 0);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve test result revision for response analysis: ${message}`
+      );
+      return 0;
+    }
   }
 
   private async getDerivedVariableMap(
     workspaceId: number
   ): Promise<Map<string, Set<string>>> {
     try {
-      return await this.workspaceFilesService.getDerivedVariableMap(workspaceId);
+      return await this.workspaceFilesService.getDerivedVariableMap(
+        workspaceId
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      this.logger.warn(`Could not load derived variable map for workspace ${workspaceId}: ${message}`);
+      this.logger.warn(
+        `Could not load derived variable map for workspace ${workspaceId}: ${message}`
+      );
       return new Map<string, Set<string>>();
     }
   }

--- a/apps/backend/src/app/prototype-methods.spec.ts
+++ b/apps/backend/src/app/prototype-methods.spec.ts
@@ -205,5 +205,5 @@ describe('backend controller prototype method smoke coverage', () => {
     }
 
     expect(invoked).toBeGreaterThan(300);
-  }, 60000);
+  }, 120000);
 });

--- a/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.spec.ts
@@ -110,6 +110,26 @@ describe('CoderTrainingsListComponent', () => {
     expect(component.coderTrainings.map(training => training.id)).toEqual([10, 11]);
   });
 
+  it('reuses an in-flight training list request', async () => {
+    const service = TestBed.inject(CodingTrainingBackendService) as unknown as {
+      getCoderTrainings: jest.Mock;
+    };
+    const trainings$ = new Subject<CoderTraining[]>();
+    service.getCoderTrainings.mockReturnValue(trainings$.asObservable());
+
+    const firstLoad = component.loadCoderTrainings();
+    const secondLoad = component.loadCoderTrainings();
+
+    expect(secondLoad).toBe(firstLoad);
+    expect(service.getCoderTrainings).toHaveBeenCalledTimes(1);
+
+    trainings$.next(trainings);
+    trainings$.complete();
+
+    await firstLoad;
+    await secondLoad;
+  });
+
   it('builds descriptive action labels for training rows', () => {
     const actionTarget = component.getTrainingActionTarget(trainings[0]);
 

--- a/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.ts
+++ b/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.ts
@@ -95,6 +95,8 @@ export class CoderTrainingsListComponent implements OnInit, OnChanges, OnDestroy
   duplicateTrainingLabels = new Set<string>();
   selectedTrainingName: string | null = null;
   isLoading = false;
+  private loadCoderTrainingsPromise?: Promise<void>;
+  private loadCoderTrainingsWorkspaceId?: number;
   displayedColumns: string[] = ['actions', 'label', 'jobsCount', 'selectionStrategy', 'created_at'];
 
   ngOnInit(): void {
@@ -141,47 +143,72 @@ export class CoderTrainingsListComponent implements OnInit, OnChanges, OnDestroy
   }
 
   loadCoderTrainings(options: { resetFilters?: boolean } = {}): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const workspaceId = this.getCurrentWorkspaceId();
-      if (!workspaceId) {
-        this.clearTrainingState({ resetFilters: true });
-        reject();
-        return;
-      }
-
+    const workspaceId = this.getCurrentWorkspaceId();
+    if (!workspaceId) {
       this.loadRequestId += 1;
-      const requestId = this.loadRequestId;
-      this.isLoading = true;
-      this.clearTrainingState({ resetFilters: options.resetFilters });
+      this.clearTrainingState({ resetFilters: true });
+      this.isLoading = false;
+      this.loadCoderTrainingsPromise = undefined;
+      this.loadCoderTrainingsWorkspaceId = undefined;
+      return Promise.reject();
+    }
 
-      this.codingTrainingBackendService.getCoderTrainings(workspaceId)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: (trainings: CoderTraining[]) => {
-            if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
-              resolve();
-              return;
-            }
+    if (
+      !options.resetFilters &&
+      this.isLoading &&
+      this.loadCoderTrainingsPromise &&
+      this.loadCoderTrainingsWorkspaceId === workspaceId
+    ) {
+      return this.loadCoderTrainingsPromise;
+    }
 
-            this.originalData = trainings;
-            this.rebuildTrainingNameFilterOptions();
-            this.clearUnavailableTrainingNameFilter();
-            this.applyAllFilters();
-            this.isLoading = false;
-            resolve();
-          },
-          error: () => {
-            if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
-              resolve();
-              return;
-            }
+    this.loadRequestId += 1;
+    const requestId = this.loadRequestId;
+    this.isLoading = true;
+    this.loadCoderTrainingsWorkspaceId = workspaceId;
+    this.clearTrainingState({ resetFilters: options.resetFilters });
 
-            this.clearTrainingState({ resetFilters: options.resetFilters });
-            this.isLoading = false;
-            reject();
-          }
-        });
+    let resolveLoad: () => void = () => {};
+    let rejectLoad: () => void = () => {};
+    const loadPromise = new Promise<void>((resolve, reject) => {
+      resolveLoad = resolve;
+      rejectLoad = reject;
     });
+    this.loadCoderTrainingsPromise = loadPromise;
+
+    this.codingTrainingBackendService.getCoderTrainings(workspaceId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (trainings: CoderTraining[]) => {
+          if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
+            resolveLoad();
+            return;
+          }
+
+          this.originalData = trainings;
+          this.rebuildTrainingNameFilterOptions();
+          this.clearUnavailableTrainingNameFilter();
+          this.applyAllFilters();
+          this.isLoading = false;
+          this.loadCoderTrainingsPromise = undefined;
+          this.loadCoderTrainingsWorkspaceId = undefined;
+          resolveLoad();
+        },
+        error: () => {
+          if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
+            resolveLoad();
+            return;
+          }
+
+          this.clearTrainingState({ resetFilters: options.resetFilters });
+          this.isLoading = false;
+          this.loadCoderTrainingsPromise = undefined;
+          this.loadCoderTrainingsWorkspaceId = undefined;
+          rejectLoad();
+        }
+      });
+
+    return loadPromise;
   }
 
   requestFullEdit(training: CoderTraining): void {

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
@@ -36,16 +36,12 @@ import {
   CodingJobDefinitionDialogComponent,
   CodingJobDefinitionDialogData
 } from '../coding-job-definition-dialog/coding-job-definition-dialog.component';
-import {
-  JobDefinitionRefreshDialogComponent
-} from './job-definition-refresh-dialog.component';
+import { JobDefinitionRefreshDialogComponent } from './job-definition-refresh-dialog.component';
 import {
   CodingJobBulkCreationDialogComponent,
   BulkCreationData
 } from '../coding-job-bulk-creation-dialog/coding-job-bulk-creation-dialog.component';
-import {
-  JobDefinitionDistributionSummaryDialogComponent
-} from './job-definition-distribution-summary-dialog.component';
+import { JobDefinitionDistributionSummaryDialogComponent } from './job-definition-distribution-summary-dialog.component';
 
 interface JobDefinition {
   id?: number;
@@ -162,6 +158,10 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
   }
 
   private loadJobDefinitions(): void {
+    if (this.isLoading) {
+      return;
+    }
+
     this.isLoading = true;
     const workspaceId = this.appService.selectedWorkspaceId;
 
@@ -230,17 +230,21 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
   }
 
   getVariableItems(definition: JobDefinition): string[] {
-    if (!definition.assignedVariables || definition.assignedVariables.length === 0) {
+    if (
+      !definition.assignedVariables ||
+      definition.assignedVariables.length === 0
+    ) {
       return [];
     }
-    return definition.assignedVariables.map(
-      variable => this.getVariableDisplayName(variable)
+    return definition.assignedVariables.map(variable => this.getVariableDisplayName(variable)
     );
   }
 
   private getVariableDisplayName(variable: Variable): string {
     const displayName = `${variable.unitName}.${variable.variableId}`;
-    return variable.includeDeriveError ? `${displayName} (DERIVE_ERROR)` : displayName;
+    return variable.includeDeriveError ?
+      `${displayName} (DERIVE_ERROR)` :
+      displayName;
   }
 
   getVisibleVariableItems(definition: JobDefinition): string[] {
@@ -256,7 +260,10 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
   }
 
   getHiddenVariableCount(definition: JobDefinition): number {
-    return Math.max(0, this.getVariableItems(definition).length - this.variablePreviewLimit);
+    return Math.max(
+      0,
+      this.getVariableItems(definition).length - this.variablePreviewLimit
+    );
   }
 
   isVariableListExpanded(definition: JobDefinition): boolean {
@@ -289,12 +296,14 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
   getDefinitionCountByStatus(
     status: NonNullable<JobDefinition['status']>
   ): number {
-    return this.jobDefinitions.filter(definition => definition.status === status)
-      .length;
+    return this.jobDefinitions.filter(
+      definition => definition.status === status
+    ).length;
   }
 
   getDefinitionsReadyForJobsCount(): number {
-    return this.jobDefinitions.filter(definition => this.canCreateCodingJobs(definition)).length;
+    return this.jobDefinitions.filter(definition => this.canCreateCodingJobs(definition)
+    ).length;
   }
 
   getStatusHint(status?: JobDefinition['status']): string {
@@ -316,7 +325,11 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       );
     }
 
-    if (definition.status === 'approved' && createdJobsCount !== undefined && createdJobsCount > 0) {
+    if (
+      definition.status === 'approved' &&
+      createdJobsCount !== undefined &&
+      createdJobsCount > 0
+    ) {
       return this.translateService.instant(
         'coding-job-definitions.status-hints.approved_created',
         { count: createdJobsCount }
@@ -364,12 +377,14 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
 
   getActionAriaLabel(action: string, definition: JobDefinition): string {
     const createdJobsCount = this.getCreatedJobsCount(definition);
-    const actionKey = action === 'jobs-already-created' && createdJobsCount === undefined ?
-      'jobs-count-unavailable' :
-      action;
-    const params = actionKey === 'jobs-already-created' && createdJobsCount !== undefined ?
-      { count: createdJobsCount } :
-      undefined;
+    const actionKey =
+      action === 'jobs-already-created' && createdJobsCount === undefined ?
+        'jobs-count-unavailable' :
+        action;
+    const params =
+      actionKey === 'jobs-already-created' && createdJobsCount !== undefined ?
+        { count: createdJobsCount } :
+        undefined;
     const actionLabel = this.translateService.instant(
       `coding-job-definitions.actions.${actionKey}`,
       params
@@ -403,7 +418,10 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
   }
 
   canCreateCodingJobs(definition: JobDefinition): boolean {
-    return definition.status === 'approved' && this.getCreatedJobsCount(definition) === 0;
+    return (
+      definition.status === 'approved' &&
+      this.getCreatedJobsCount(definition) === 0
+    );
   }
 
   canModifyDefinition(definition: JobDefinition): boolean {
@@ -416,13 +434,19 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
 
   canRefreshDefinition(definition: JobDefinition): boolean {
     const createdJobsCount = this.getCreatedJobsCount(definition);
-    return definition.status === 'approved' && createdJobsCount !== undefined && createdJobsCount > 0;
+    return (
+      definition.status === 'approved' &&
+      createdJobsCount !== undefined &&
+      createdJobsCount > 0
+    );
   }
 
   canViewDistributionSummary(definition: JobDefinition): boolean {
     const createdJobsCount = this.getCreatedJobsCount(definition);
-    return this.hasDistributionSnapshots(definition) ||
-      (createdJobsCount !== undefined && createdJobsCount > 0);
+    return (
+      this.hasDistributionSnapshots(definition) ||
+      (createdJobsCount !== undefined && createdJobsCount > 0)
+    );
   }
 
   canExportDistributionCsv(definition: JobDefinition): boolean {
@@ -430,8 +454,10 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
   }
 
   hasDistributionSnapshots(definition: JobDefinition): boolean {
-    return Array.isArray(definition.distributionSnapshots) &&
-      definition.distributionSnapshots.length > 0;
+    return (
+      Array.isArray(definition.distributionSnapshots) &&
+      definition.distributionSnapshots.length > 0
+    );
   }
 
   getLatestDistributionSnapshot(
@@ -441,7 +467,9 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       return undefined;
     }
 
-    return definition.distributionSnapshots![definition.distributionSnapshots!.length - 1];
+    return definition.distributionSnapshots![
+      definition.distributionSnapshots!.length - 1
+    ];
   }
 
   isRefreshingDefinition(definition: JobDefinition): boolean {
@@ -449,7 +477,10 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
   }
 
   isExportingDistribution(definition: JobDefinition): boolean {
-    return !!definition.id && this.exportingDistributionDefinitionIds.has(definition.id);
+    return (
+      !!definition.id &&
+      this.exportingDistributionDefinitionIds.has(definition.id)
+    );
   }
 
   getEditDefinitionLabel(definition: JobDefinition): string {
@@ -466,10 +497,14 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
 
   getEditDefinitionTooltip(definition: JobDefinition): string {
     if (this.canModifyDefinition(definition)) {
-      return this.translateService.instant('coding-job-definitions.actions.edit');
+      return this.translateService.instant(
+        'coding-job-definitions.actions.edit'
+      );
     }
 
-    return this.translateService.instant('coding-job-definitions.actions.view-readonly');
+    return this.translateService.instant(
+      'coding-job-definitions.actions.view-readonly'
+    );
   }
 
   getCreateCodingJobsTooltip(definition: JobDefinition): string {
@@ -488,7 +523,9 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       );
     }
 
-    return this.translateService.instant('coding-job-definitions.actions.create-coding-jobs');
+    return this.translateService.instant(
+      'coding-job-definitions.actions.create-coding-jobs'
+    );
   }
 
   getCreateCodingJobsActionLabel(definition: JobDefinition): string {
@@ -508,10 +545,13 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
 
   getDeleteDefinitionTooltip(definition: JobDefinition): string {
     if (this.canDeleteDefinition(definition)) {
-      return this.translateService.instant('coding-job-definitions.actions.delete');
+      return this.translateService.instant(
+        'coding-job-definitions.actions.delete'
+      );
     }
 
-    const blockingCreatedJobsCount = this.getBlockingCreatedJobsCount(definition);
+    const blockingCreatedJobsCount =
+      this.getBlockingCreatedJobsCount(definition);
     if (blockingCreatedJobsCount === undefined) {
       return this.translateService.instant(
         'coding-job-definitions.actions.jobs-count-unavailable'
@@ -957,7 +997,9 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const selectedCoders = this.mapPreviewSelectedCoders(preview.selectedCoders);
+    const selectedCoders = this.mapPreviewSelectedCoders(
+      preview.selectedCoders
+    );
     if (selectedCoders.length === 0) {
       this.showError(
         this.translateService.instant(
@@ -988,7 +1030,8 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       displayOptions: {
         showScore: definition.showScore ?? false,
         allowComments: definition.allowComments ?? true,
-        suppressGeneralInstructions: definition.suppressGeneralInstructions ?? false
+        suppressGeneralInstructions:
+          definition.suppressGeneralInstructions ?? false
       },
       displayOptionsLocked: true
     };
@@ -1000,10 +1043,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
     const result = await firstValueFrom(dialogRef.afterClosed());
 
     if (result && result.confirmed) {
-      await this.createBulkJobsFromDefinition(
-        workspaceId,
-        definition.id
-      );
+      await this.createBulkJobsFromDefinition(workspaceId, definition.id);
     }
   }
 
@@ -1106,7 +1146,10 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
 
   private getErrorMessage(error: unknown): string {
     if (error && typeof error === 'object' && 'error' in error) {
-      const httpError = error as { error?: { message?: string } | string; message?: string };
+      const httpError = error as {
+        error?: { message?: string } | string;
+        message?: string;
+      };
       if (typeof httpError.error === 'string') {
         return httpError.error;
       }

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.html
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.html
@@ -100,10 +100,12 @@
         </div>
 
         <div class="actions-group utility-actions">
-          <button mat-button (click)="loadCodingJobs()">
-            <mat-icon>refresh</mat-icon>
-            Aktualisieren
-          </button>
+          @if (showRefreshAction) {
+            <button mat-button (click)="loadCodingJobs()">
+              <mat-icon>refresh</mat-icon>
+              Aktualisieren
+            </button>
+          }
           @if (canManageCodingJobs && showBulkDeleteAction) {
             <button
               mat-raised-button
@@ -368,7 +370,9 @@
       </ng-container>
 
       <ng-container matColumnDef="assignedCoders">
-        <mat-header-cell *matHeaderCellDef>Zugewiesene Kodierer</mat-header-cell>
+        <mat-header-cell *matHeaderCellDef
+          >Zugewiesene Kodierer</mat-header-cell
+        >
         <mat-cell
           *matCellDef="let element"
           class="assigned-coders-cell"

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
@@ -10,7 +10,7 @@ import { ActivatedRoute } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { CodingJobsComponent } from './coding-jobs.component';
 import { CodingJobBackendService } from '../../services/coding-job-backend.service';
@@ -240,6 +240,25 @@ describe('CodingJobsComponent', () => {
     expect(component.dataSource.data.length).toBe(2);
     expect(component.allCoders.length).toBe(2);
     expect(component.jobsTotal).toBe(2);
+  });
+
+  it('should load coder trainings only once during initial job load', () => {
+    expect(codingTrainingBackendServiceMock.getCoderTrainings).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not start duplicate coder training loads while one is in flight', () => {
+    const trainings$ = new Subject<never[]>();
+    (codingTrainingBackendServiceMock.getCoderTrainings as jest.Mock)
+      .mockClear()
+      .mockReturnValue(trainings$.asObservable());
+
+    component.loadCoderTrainings();
+    component.loadCoderTrainings();
+
+    expect(codingTrainingBackendServiceMock.getCoderTrainings).toHaveBeenCalledTimes(1);
+
+    trainings$.next([]);
+    trainings$.complete();
   });
 
   it('should not emit jobsChanged for a plain reload', fakeAsync(() => {

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
@@ -19,10 +19,7 @@ import {
   Subscription
 } from 'rxjs';
 import { MatSortModule, Sort } from '@angular/material/sort';
-import {
-  MatPaginatorModule,
-  PageEvent
-} from '@angular/material/paginator';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import {
   MatFormField,
   MatLabel,
@@ -96,10 +93,7 @@ interface BulkApplyResultItem {
   jobName: string;
   hasIssues: boolean;
   skipped: boolean;
-  skippedReason?:
-  | 'training-job'
-  | 'not-completed'
-  | 'freshness-stale';
+  skippedReason?: 'training-job' | 'not-completed' | 'freshness-stale';
   result?: {
     success: boolean;
     updatedResponsesCount: number;
@@ -111,11 +105,7 @@ interface BulkApplyResultItem {
 }
 
 type JobPrimaryAction =
-  | 'start'
-  | 'review'
-  | 'results'
-  | 'apply'
-  | 'notAssigned';
+  'start' | 'review' | 'results' | 'apply' | 'notAssigned';
 type CodingJobScope = 'all' | 'training' | 'productive';
 
 @Component({
@@ -198,6 +188,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
   dataSource = new MatTableDataSource<CodingJob>([]);
   selection = new SelectionModel<CodingJob>(true, []);
   isLoading = false;
+  private isLoadingCoderTrainings = false;
 
   coderTrainings: CoderTraining[] = [];
   selectedTrainingId: number | string | null = null;
@@ -227,6 +218,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
   @Input() showApplyActions = true;
   @Input() showBulkDeleteAction = true;
   @Input() autoReloadOnFocus = true;
+  @Input() showRefreshAction = true;
 
   private handleWindowFocus = () => {
     if (!this.autoReloadOnFocus || this.isLoading) {
@@ -254,7 +246,6 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
       });
 
     this.updateCodingJobPermissions();
-    this.loadCoderTrainings();
     this.loadCodingJobs();
     window.addEventListener('focus', this.handleWindowFocus);
   }
@@ -332,9 +323,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
       jobName: this.normalizeJobNameFilter(),
       trainingId: this.showTrainingFilter ?
         ((this.selectedTrainingId ?? undefined) as
-            | number
-            | 'none'
-            | undefined) :
+            number | 'none' | undefined) :
         undefined,
       includeIssueSummary: true,
       sortBy: this.sortBy,
@@ -445,13 +434,9 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
   private isSupportedServerSort(
     sortBy: string
   ): sortBy is 'name' | 'description' | 'status' | 'createdAt' | 'updatedAt' {
-    return [
-      'name',
-      'description',
-      'status',
-      'createdAt',
-      'updatedAt'
-    ].includes(sortBy);
+    return ['name', 'description', 'status', 'createdAt', 'updatedAt'].includes(
+      sortBy
+    );
   }
 
   private reloadCurrentOrPreviousPageAfterDelete(deletedCount: number): void {
@@ -1093,16 +1078,19 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
 
   loadCoderTrainings(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
-    if (!workspaceId) {
+    if (!workspaceId || this.isLoadingCoderTrainings) {
       return;
     }
 
+    this.isLoadingCoderTrainings = true;
     this.codingTrainingBackendService.getCoderTrainings(workspaceId).subscribe({
       next: trainings => {
         this.coderTrainings = trainings;
+        this.isLoadingCoderTrainings = false;
       },
       error: () => {
         this.coderTrainings = [];
+        this.isLoadingCoderTrainings = false;
       }
     });
   }
@@ -1169,7 +1157,9 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
                     }
 
                     const replayUrl = appendReplayUrlParams(
-                      normalizeReplayUrlToCurrentOrigin(restartResult.firstReplayUrl),
+                      normalizeReplayUrlToCurrentOrigin(
+                        restartResult.firstReplayUrl
+                      ),
                       {
                         mode: 'coding',
                         codingJobId: restartedJob.id,
@@ -1233,7 +1223,8 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
       dialogRef.componentInstance.closeDialog();
     });
 
-    dialogRef.keydownEvents()
+    dialogRef
+      .keydownEvents()
       .pipe(filter(event => event.key === 'Escape'))
       .subscribe(() => {
         dialogRef.componentInstance.closeDialog();

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -118,9 +118,10 @@
                   ? ('coding-management-manual.buttons.show-fewer-manual-code-warnings'
                     | translate)
                   : ('coding-management-manual.buttons.show-more-manual-code-warnings'
-                    | translate: {
-                      count: hiddenManualCodeAvailabilityWarningCount
-                    })
+                    | translate
+                      : {
+                          count: hiddenManualCodeAvailabilityWarningCount
+                        })
               }}
             </button>
           </div>
@@ -245,9 +246,7 @@
           <h3
             class="subsection-title"
             [matTooltip]="
-              responseAnalysis?.isCalculating
-                ? 'Analyse läuft'
-                : ''
+              responseAnalysis?.isCalculating ? 'Analyse läuft' : ''
             "
           >
             <mat-icon>settings</mat-icon>
@@ -406,7 +405,9 @@
                       <div class="matching-actions">
                         <span
                           class="matching-state"
-                          *ngIf="hasPendingAggregationOptionsWithoutAggregation()"
+                          *ngIf="
+                            hasPendingAggregationOptionsWithoutAggregation()
+                          "
                         >
                           <mat-icon>pending_actions</mat-icon>
                           {{
@@ -500,7 +501,9 @@
                 *ngIf="responseAnalysis?.aggregationSummary as aggregation"
               >
                 <mat-icon>warning</mat-icon>
-                <span *ngIf="isResponseAnalysisOutdated(); else restScopeDifference">
+                <span
+                  *ngIf="isResponseAnalysisOutdated(); else restScopeDifference"
+                >
                   {{
                     'coding-management-manual.response-analysis.outdated-note'
                       | translate
@@ -854,7 +857,7 @@
                       }}"</span
                     >
                     <span class="occurrence-count"
-                      >({{ group.occurrences.length }}x)</span
+                      >({{ group.occurrenceCount || group.occurrences.length }}x)</span
                     >
                   </div>
                   <ul class="occurrence-list">
@@ -866,10 +869,14 @@
                       - {{ occ.bookletName }}
                     </li>
                     <li
-                      *ngIf="group.occurrences.length > 5"
+                      *ngIf="
+                        (group.occurrenceCount || group.occurrences.length) > 5
+                      "
                       class="more-occurrences"
                     >
-                      +{{ group.occurrences.length - 5 }}
+                      +{{
+                        (group.occurrenceCount || group.occurrences.length) - 5
+                      }}
                       {{
                         'coding-management-manual.response-analysis.more'
                           | translate
@@ -1146,11 +1153,15 @@
         </div>
 
         <div
-          *ngIf="isManualTab('planning')"
+          *ngIf="shouldRenderManualTabContent('planning')"
+          [hidden]="!isManualTab('planning')"
           id="manual-planning"
           class="job-definitions-container"
         >
-          <div class="manual-tab-actions">
+          <div
+            *ngIf="shouldShowManualRefreshControls()"
+            class="manual-tab-actions"
+          >
             <button
               mat-stroked-button
               color="primary"
@@ -1176,227 +1187,230 @@
             [class.blurred-content]="isLoadingVariableCoverage"
           >
             <div class="statistics-card">
-            <h2 class="section-title section-title-with-action">
-              Variablenabdeckung
-              <button
-                mat-icon-button
-                (click)="showVariableCoverageInfo = !showVariableCoverageInfo"
-                [matTooltip]="
-                  'coding-management-manual.variable-coverage.info-tooltip'
-                    | translate
-                "
-                [attr.aria-label]="
-                  'coding-management-manual.variable-coverage.info-tooltip'
-                    | translate
-                "
-                class="section-info-button"
-              >
-                <mat-icon class="section-info-icon">info</mat-icon>
-              </button>
-              <button
-                mat-icon-button
-                (click)="refreshAllStatistics()"
-                matTooltip="Statistiken manuell aktualisieren"
-                aria-label="Statistiken manuell aktualisieren"
-              >
-                <mat-icon>refresh</mat-icon>
-              </button>
-              <span
-                *ngIf="variableCoverageOverview.conflictedVariables > 0"
-                class="conflict-badge"
-                matTooltip="Es gibt Konflikte bei der Variablenzuordnung"
-              >
-                <mat-icon>warning</mat-icon>
-                {{ variableCoverageOverview.conflictedVariables }} Konflikte
-              </span>
-            </h2>
-
-            <div
-              *ngIf="showVariableCoverageInfo"
-              class="info-alert variable-coverage-info"
-            >
-              <mat-icon class="info-alert-icon">help_outline</mat-icon>
-              <div class="info-alert-content">
-                <strong>{{
-                  'coding-management-manual.variable-coverage.info-total-title'
-                    | translate
-                }}</strong>
-                <span class="info-alert-text-spaced">{{
-                  'coding-management-manual.variable-coverage.info-total-desc'
-                    | translate
-                }}</span>
-                <strong>{{
-                  'coding-management-manual.variable-coverage.info-covered-title'
-                    | translate
-                }}</strong>
-                <span class="info-alert-text-spaced">{{
-                  'coding-management-manual.variable-coverage.info-covered-desc'
-                    | translate
-                }}</span>
-                <strong>{{
-                  'coding-management-manual.variable-coverage.info-completeness-title'
-                    | translate
-                }}</strong>
-                <span>{{
-                  'coding-management-manual.variable-coverage.info-completeness-desc'
-                    | translate
-                }}</span>
-              </div>
-            </div>
-
-            <!-- Overall Coverage Stats -->
-            <div class="coverage-stats">
-              <div class="stat-item">
-                <span class="stat-label">Gesamt Variablen:</span>
-                <span class="stat-value">{{
-                  variableCoverageOverview.totalVariables
-                }}</span>
-              </div>
-              <div class="stat-item">
-                <span class="stat-label">Abgedeckte Variablen:</span>
-                <span class="stat-value covered">{{
-                  variableCoverageOverview.coveredVariables
-                }}</span>
-              </div>
-              <div class="stat-item">
-                <span class="stat-label">Fehlende Variablen:</span>
-                <span class="stat-value missing">{{
-                  variableCoverageOverview.missingVariables
-                }}</span>
-              </div>
-              <div class="stat-item">
-                <span class="stat-label">Vollständig abgedeckt:</span>
-                <span class="stat-value covered">{{
-                  variableCoverageOverview.fullyAbgedeckteVariablen
-                }}</span>
-              </div>
-              <div class="stat-item">
-                <span class="stat-label">Partiell abgedeckt:</span>
-                <span class="stat-value partial">{{
-                  variableCoverageOverview.partiallyAbgedeckteVariablen
-                }}</span>
-              </div>
-              <div class="stat-item">
-                <span class="stat-label">Abdeckungsrate:</span>
-                <span class="stat-value percentage"
-                  >{{
-                    variableCoverageOverview.coveragePercentage
-                      | number: '1.1-1'
-                  }}%</span
-                >
-              </div>
-            </div>
-
-            <!-- Status Breakdown -->
-            <div class="status-breakdown">
-              <h3 class="breakdown-title">Abdeckung nach Status</h3>
-              <div class="status-stats">
-                <div class="status-item draft">
-                  <mat-icon class="status-icon">edit</mat-icon>
-                  <div class="status-content">
-                    <span class="status-label">Entwurf:</span>
-                    <span class="status-value">{{
-                      variableCoverageOverview.coveredByDraft
-                    }}</span>
-                  </div>
-                </div>
-                <div class="status-item pending">
-                  <mat-icon class="status-icon">schedule</mat-icon>
-                  <div class="status-content">
-                    <span class="status-label">Warten auf Genehmigung:</span>
-                    <span class="status-value">{{
-                      variableCoverageOverview.coveredByPendingReview
-                    }}</span>
-                  </div>
-                </div>
-                <div class="status-item approved">
-                  <mat-icon class="status-icon">check_circle</mat-icon>
-                  <div class="status-content">
-                    <span class="status-label">Genehmigt:</span>
-                    <span class="status-value">{{
-                      variableCoverageOverview.coveredByApproved
-                    }}</span>
-                  </div>
-                </div>
-                <div
-                  class="status-item conflict"
-                  *ngIf="variableCoverageOverview.conflictedVariables > 0"
-                >
-                  <mat-icon class="status-icon">error</mat-icon>
-                  <div class="status-content">
-                    <span class="status-label">Konflikte:</span>
-                    <span class="status-value">{{
-                      variableCoverageOverview.conflictedVariables
-                    }}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Conflicts Details -->
-            <div
-              class="conflicts-section"
-              *ngIf="
-                variableCoverageOverview.coverageByStatus.conflicted.length > 0
-              "
-            >
-              <h3 class="conflicts-title">
-                <mat-icon>warning</mat-icon>
-                Variablenkonflikte
-              </h3>
-              <div class="conflicts-list">
-                <div
-                  *ngFor="
-                    let conflict of variableCoverageOverview.coverageByStatus
-                      .conflicted
+              <h2 class="section-title section-title-with-action">
+                Variablenabdeckung
+                <button
+                  mat-icon-button
+                  (click)="showVariableCoverageInfo = !showVariableCoverageInfo"
+                  [matTooltip]="
+                    'coding-management-manual.variable-coverage.info-tooltip'
+                      | translate
                   "
-                  class="conflict-item"
+                  [attr.aria-label]="
+                    'coding-management-manual.variable-coverage.info-tooltip'
+                      | translate
+                  "
+                  class="section-info-button"
                 >
-                  <div class="conflict-variable">
-                    <mat-icon>code</mat-icon>
-                    <span>{{ conflict.variableKey }}</span>
+                  <mat-icon class="section-info-icon">info</mat-icon>
+                </button>
+                <button
+                  *ngIf="shouldShowManualRefreshControls()"
+                  mat-icon-button
+                  (click)="refreshAllStatistics()"
+                  matTooltip="Statistiken manuell aktualisieren"
+                  aria-label="Statistiken manuell aktualisieren"
+                >
+                  <mat-icon>refresh</mat-icon>
+                </button>
+                <span
+                  *ngIf="variableCoverageOverview.conflictedVariables > 0"
+                  class="conflict-badge"
+                  matTooltip="Es gibt Konflikte bei der Variablenzuordnung"
+                >
+                  <mat-icon>warning</mat-icon>
+                  {{ variableCoverageOverview.conflictedVariables }} Konflikte
+                </span>
+              </h2>
+
+              <div
+                *ngIf="showVariableCoverageInfo"
+                class="info-alert variable-coverage-info"
+              >
+                <mat-icon class="info-alert-icon">help_outline</mat-icon>
+                <div class="info-alert-content">
+                  <strong>{{
+                    'coding-management-manual.variable-coverage.info-total-title'
+                      | translate
+                  }}</strong>
+                  <span class="info-alert-text-spaced">{{
+                    'coding-management-manual.variable-coverage.info-total-desc'
+                      | translate
+                  }}</span>
+                  <strong>{{
+                    'coding-management-manual.variable-coverage.info-covered-title'
+                      | translate
+                  }}</strong>
+                  <span class="info-alert-text-spaced">{{
+                    'coding-management-manual.variable-coverage.info-covered-desc'
+                      | translate
+                  }}</span>
+                  <strong>{{
+                    'coding-management-manual.variable-coverage.info-completeness-title'
+                      | translate
+                  }}</strong>
+                  <span>{{
+                    'coding-management-manual.variable-coverage.info-completeness-desc'
+                      | translate
+                  }}</span>
+                </div>
+              </div>
+
+              <!-- Overall Coverage Stats -->
+              <div class="coverage-stats">
+                <div class="stat-item">
+                  <span class="stat-label">Gesamt Variablen:</span>
+                  <span class="stat-value">{{
+                    variableCoverageOverview.totalVariables
+                  }}</span>
+                </div>
+                <div class="stat-item">
+                  <span class="stat-label">Abgedeckte Variablen:</span>
+                  <span class="stat-value covered">{{
+                    variableCoverageOverview.coveredVariables
+                  }}</span>
+                </div>
+                <div class="stat-item">
+                  <span class="stat-label">Fehlende Variablen:</span>
+                  <span class="stat-value missing">{{
+                    variableCoverageOverview.missingVariables
+                  }}</span>
+                </div>
+                <div class="stat-item">
+                  <span class="stat-label">Vollständig abgedeckt:</span>
+                  <span class="stat-value covered">{{
+                    variableCoverageOverview.fullyAbgedeckteVariablen
+                  }}</span>
+                </div>
+                <div class="stat-item">
+                  <span class="stat-label">Partiell abgedeckt:</span>
+                  <span class="stat-value partial">{{
+                    variableCoverageOverview.partiallyAbgedeckteVariablen
+                  }}</span>
+                </div>
+                <div class="stat-item">
+                  <span class="stat-label">Abdeckungsrate:</span>
+                  <span class="stat-value percentage"
+                    >{{
+                      variableCoverageOverview.coveragePercentage
+                        | number: '1.1-1'
+                    }}%</span
+                  >
+                </div>
+              </div>
+
+              <!-- Status Breakdown -->
+              <div class="status-breakdown">
+                <h3 class="breakdown-title">Abdeckung nach Status</h3>
+                <div class="status-stats">
+                  <div class="status-item draft">
+                    <mat-icon class="status-icon">edit</mat-icon>
+                    <div class="status-content">
+                      <span class="status-label">Entwurf:</span>
+                      <span class="status-value">{{
+                        variableCoverageOverview.coveredByDraft
+                      }}</span>
+                    </div>
                   </div>
-                  <div class="conflict-definitions">
-                    <span class="conflict-label">Zugeordnet zu:</span>
-                    <span
-                      *ngFor="
-                        let def of conflict.conflictingDefinitions;
-                        let last = last
-                      "
-                      class="conflict-definition"
-                    >
-                      Definition #{{ def.id }} ({{
-                        getStatusLabel(def.status)
-                      }}){{ !last ? ', ' : '' }}
-                    </span>
+                  <div class="status-item pending">
+                    <mat-icon class="status-icon">schedule</mat-icon>
+                    <div class="status-content">
+                      <span class="status-label">Warten auf Genehmigung:</span>
+                      <span class="status-value">{{
+                        variableCoverageOverview.coveredByPendingReview
+                      }}</span>
+                    </div>
+                  </div>
+                  <div class="status-item approved">
+                    <mat-icon class="status-icon">check_circle</mat-icon>
+                    <div class="status-content">
+                      <span class="status-label">Genehmigt:</span>
+                      <span class="status-value">{{
+                        variableCoverageOverview.coveredByApproved
+                      }}</span>
+                    </div>
+                  </div>
+                  <div
+                    class="status-item conflict"
+                    *ngIf="variableCoverageOverview.conflictedVariables > 0"
+                  >
+                    <mat-icon class="status-icon">error</mat-icon>
+                    <div class="status-content">
+                      <span class="status-label">Konflikte:</span>
+                      <span class="status-value">{{
+                        variableCoverageOverview.conflictedVariables
+                      }}</span>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
 
-            <div class="coverage-bar">
+              <!-- Conflicts Details -->
               <div
-                class="coverage-fill"
-                [style.width.%]="variableCoverageOverview.coveragePercentage"
-              ></div>
-            </div>
-          </div>
-          <div *ngIf="isLoadingVariableCoverage" class="loading-overlay">
-            <div class="loading-content">
-              <mat-spinner diameter="40"></mat-spinner>
-              <div class="loading-text">
-                {{
-                  'coding-management-manual.loading.variable-coverage'
-                    | translate
-                }}
+                class="conflicts-section"
+                *ngIf="
+                  variableCoverageOverview.coverageByStatus.conflicted.length >
+                  0
+                "
+              >
+                <h3 class="conflicts-title">
+                  <mat-icon>warning</mat-icon>
+                  Variablenkonflikte
+                </h3>
+                <div class="conflicts-list">
+                  <div
+                    *ngFor="
+                      let conflict of variableCoverageOverview.coverageByStatus
+                        .conflicted
+                    "
+                    class="conflict-item"
+                  >
+                    <div class="conflict-variable">
+                      <mat-icon>code</mat-icon>
+                      <span>{{ conflict.variableKey }}</span>
+                    </div>
+                    <div class="conflict-definitions">
+                      <span class="conflict-label">Zugeordnet zu:</span>
+                      <span
+                        *ngFor="
+                          let def of conflict.conflictingDefinitions;
+                          let last = last
+                        "
+                        class="conflict-definition"
+                      >
+                        Definition #{{ def.id }} ({{
+                          getStatusLabel(def.status)
+                        }}){{ !last ? ', ' : '' }}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="coverage-bar">
+                <div
+                  class="coverage-fill"
+                  [style.width.%]="variableCoverageOverview.coveragePercentage"
+                ></div>
               </div>
             </div>
-          </div>
+            <div *ngIf="isLoadingVariableCoverage" class="loading-overlay">
+              <div class="loading-content">
+                <mat-spinner diameter="40"></mat-spinner>
+                <div class="loading-text">
+                  {{
+                    'coding-management-manual.loading.variable-coverage'
+                      | translate
+                  }}
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 
         <div
-          *ngIf="isManualTab('execution')"
+          *ngIf="shouldRenderManualTabContent('execution')"
+          [hidden]="!isManualTab('execution')"
           id="manual-execution"
           class="coding-jobs-container manual-section-block"
         >
@@ -1471,12 +1485,14 @@
           </div>
 
           <coding-box-coding-jobs
+            #productiveCodingJobs
             [jobScope]="'productive'"
             [showTrainingFilter]="false"
             [showComparisonActions]="false"
             [showTransferAction]="false"
             [showApplyActions]="false"
             [autoReloadOnFocus]="autoRefreshManualCodingJobs"
+            [showRefreshAction]="shouldShowManualRefreshControls()"
             (jobsChanged)="onJobDefinitionChanged()"
           ></coding-box-coding-jobs>
         </div>
@@ -1881,7 +1897,8 @@
         </div>
 
         <div
-          *ngIf="isManualTab('training')"
+          *ngIf="shouldRenderManualTabContent('training')"
+          [hidden]="!isManualTab('training')"
           id="manual-support"
           class="coder-training-list-container manual-section-block"
         >
@@ -1977,12 +1994,14 @@
           <div class="coding-jobs-container manual-section-block">
             <h3 class="manual-section-title">Kodierjobs</h3>
             <coding-box-coding-jobs
+              #trainingCodingJobs
               [jobScope]="'training'"
               [showTrainingFilter]="true"
               [showComparisonActions]="false"
               [showTransferAction]="false"
               [showApplyActions]="false"
               [autoReloadOnFocus]="autoRefreshManualCodingJobs"
+              [showRefreshAction]="shouldShowManualRefreshControls()"
               (jobsChanged)="onJobDefinitionChanged()"
             ></coding-box-coding-jobs>
           </div>

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -5,7 +5,12 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
-import { Observable, of, throwError } from 'rxjs';
+import {
+  Observable,
+  Subject,
+  of,
+  throwError
+} from 'rxjs';
 import { CodingManagementManualComponent } from './coding-management-manual.component';
 import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
@@ -17,9 +22,7 @@ import {
 } from '../../../shared/services/file/export-job.service';
 import { CohensKappaStatisticsComponent } from '../cohens-kappa-statistics/cohens-kappa-statistics.component';
 import { ManualCodingExportDialogComponent } from '../manual-coding-export-dialog/manual-coding-export-dialog.component';
-import type {
-  ManualCodeAvailabilityWarningDto
-} from '../../../../../../../api-dto/coding/manual-code-availability.dto';
+import type { ManualCodeAvailabilityWarningDto } from '../../../../../../../api-dto/coding/manual-code-availability.dto';
 import { DoubleCodedReviewComponent } from '../double-coded-review/double-coded-review.component';
 
 type VariableCoverageOverview = NonNullable<
@@ -77,7 +80,11 @@ describe('CodingManagementManualComponent', () => {
         },
         {
           provide: MatDialog,
-          useValue: { open: jest.fn().mockReturnValue({ afterClosed: () => of(undefined) }) }
+          useValue: {
+            open: jest
+              .fn()
+              .mockReturnValue({ afterClosed: () => of(undefined) })
+          }
         },
         {
           provide: CoderService,
@@ -90,12 +97,14 @@ describe('CodingManagementManualComponent', () => {
           provide: ExportJobService,
           useValue: {
             startJob: jest.fn().mockReturnValue(of({ jobId: 'export-1' })),
-            estimateJob: jest.fn().mockReturnValue(of({
-              exportType: 'by-variable',
-              unitVariableCount: 12,
-              worksheetLimit: 1000,
-              exceedsWorksheetLimit: false
-            }))
+            estimateJob: jest.fn().mockReturnValue(
+              of({
+                exportType: 'by-variable',
+                unitVariableCount: 12,
+                worksheetLimit: 1000,
+                exceedsWorksheetLimit: false
+              })
+            )
           }
         },
         {
@@ -223,7 +232,9 @@ describe('CodingManagementManualComponent', () => {
       ResponseMatchingFlag.IGNORE_CASE,
       ResponseMatchingFlag.IGNORE_WHITESPACE
     ]);
-    expect(component.hasPendingAggregationOptionsWithoutAggregation()).toBe(true);
+    expect(component.hasPendingAggregationOptionsWithoutAggregation()).toBe(
+      true
+    );
     expect(saveSpy).not.toHaveBeenCalled();
     expect(triggerSpy).not.toHaveBeenCalled();
   });
@@ -242,7 +253,8 @@ describe('CodingManagementManualComponent', () => {
         ) => void;
       };
       const appService = componentInternals.appService;
-      const testPersonCodingService = componentInternals.testPersonCodingService;
+      const testPersonCodingService =
+        componentInternals.testPersonCodingService;
 
       appService.selectedWorkspaceId = 5;
       component.duplicateAggregationThreshold = 2;
@@ -285,7 +297,9 @@ describe('CodingManagementManualComponent', () => {
       expect(componentInternals.persistedResponseMatchingFlags).toEqual([
         ResponseMatchingFlag.NO_AGGREGATION
       ]);
-      expect(component.hasPendingAggregationOptionsWithoutAggregation()).toBe(true);
+      expect(component.hasPendingAggregationOptionsWithoutAggregation()).toBe(
+        true
+      );
     } finally {
       jest.useRealTimers();
     }
@@ -526,7 +540,68 @@ describe('CodingManagementManualComponent', () => {
     expect(component.isPreparationReady()).toBe(true);
   });
 
-  it('should flag response analysis as outdated when the status pool count changed', () => {
+  it('uses duplicate occurrence counts instead of preview length for aggregation checks', () => {
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      dialog: MatDialog;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    component.duplicateAggregationThreshold = 10;
+    component.responseAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 1,
+        totalResponses: 12,
+        groups: [
+          {
+            unitName: 'u',
+            unitAlias: null,
+            variableId: 'v',
+            normalizedValue: 'same',
+            originalValue: 'same',
+            occurrenceCount: 12,
+            occurrences: Array.from({ length: 5 }, (_, index) => ({
+              personLogin: `person-${index}`,
+              personCode: `${index}`,
+              bookletName: 'booklet',
+              responseId: index,
+              value: 'same'
+            }))
+          }
+        ],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 1,
+        duplicateResponses: 12,
+        collapsedCases: 11,
+        rawCases: 12,
+        effectiveCases: 1,
+        threshold: 10,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: new Date().toISOString()
+    };
+    const dialogSpy = jest
+      .spyOn(componentInternals.dialog, 'open')
+      .mockReturnValue({ afterClosed: () => of(undefined) } as never);
+
+    component.onApplyDuplicateAggregation();
+
+    expect(dialogSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          duplicateGroups: 1,
+          totalResponses: 12,
+          threshold: 10
+        })
+      })
+    );
+  });
+
+  it('should flag response analysis as outdated when the source revision changed', () => {
     component.responseAnalysis = {
       emptyResponses: { total: 0, totalUncoded: 0, items: [] },
       duplicateValues: {
@@ -545,7 +620,9 @@ describe('CodingManagementManualComponent', () => {
         aggregationActive: true
       },
       matchingFlags: [],
-      analysisTimestamp: new Date().toISOString()
+      analysisTimestamp: new Date().toISOString(),
+      sourceRevision: 3,
+      currentSourceRevision: 4
     };
     setAppliedResults(897, 8, 889);
     component.appliedResultsOverview!.rawTotalIncompleteResponses = 973;
@@ -555,6 +632,38 @@ describe('CodingManagementManualComponent', () => {
     expect(component.getCurrentRawManualResponses()).toBe(973);
     expect(component.getResponseAnalysisReferenceRawCases()).toBe(973);
     expect(component.isResponseAnalysisOutdated()).toBe(true);
+  });
+
+  it('should not flag response analysis as outdated when only the status pool count changed', () => {
+    component.responseAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 16,
+        totalResponses: 49,
+        groups: [],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 16,
+        duplicateResponses: 49,
+        collapsedCases: 33,
+        rawCases: 628,
+        effectiveCases: 595,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: new Date().toISOString(),
+      sourceRevision: 4,
+      currentSourceRevision: 4
+    };
+    setAppliedResults(897, 8, 889);
+    component.appliedResultsOverview!.rawTotalIncompleteResponses = 973;
+    setCodingProgress(973, 8);
+    component.codingProgressOverview!.statusTotalCasesToCode = 973;
+
+    expect(component.getResponseAnalysisReferenceRawCases()).toBe(973);
+    expect(component.isResponseAnalysisOutdated()).toBe(false);
   });
 
   it('should not require preparation refresh when only the applied result rest scope is smaller', () => {
@@ -576,7 +685,9 @@ describe('CodingManagementManualComponent', () => {
         aggregationActive: true
       },
       matchingFlags: [],
-      analysisTimestamp: new Date().toISOString()
+      analysisTimestamp: new Date().toISOString(),
+      sourceRevision: 7,
+      currentSourceRevision: 7
     };
     setCodingProgress(16606, 12000);
     component.codingProgressOverview!.rawTotalCasesToCode = 17705;
@@ -638,15 +749,15 @@ describe('CodingManagementManualComponent', () => {
         codedUnits: 5
       }
     ];
-    component.codingJobsComponent = {
+    component.productiveCodingJobsComponent = {
       canApplyResults: false
-    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
 
     expect(component.canShowCompletedJobApplyActions()).toBe(false);
 
-    component.codingJobsComponent = {
+    component.productiveCodingJobsComponent = {
       canApplyResults: true
-    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
 
     expect(component.canShowCompletedJobApplyActions()).toBe(true);
   });
@@ -736,27 +847,35 @@ describe('CodingManagementManualComponent', () => {
     componentInternals.appService.selectedWorkspaceId = 5;
     componentInternals.codingJobBackendService = {
       getCodingJobs: jest.fn().mockReturnValue(of({ data: jobs })),
-      getBulkCodingProgress: jest.fn().mockReturnValue(of({
-        1: {
-          'person@code@booklet::booklet::UNIT::VAR': {
-            id: -2
+      getBulkCodingProgress: jest.fn().mockReturnValue(
+        of({
+          1: {
+            'person@code@booklet::booklet::UNIT::VAR': {
+              id: -2
+            }
+          },
+          2: {
+            'person@code@booklet::booklet::UNIT::VAR': {
+              id: 1
+            }
           }
-        },
-        2: {
-          'person@code@booklet::booklet::UNIT::VAR': {
-            id: 1
-          }
-        }
-      }))
+        })
+      )
     };
 
     componentInternals.loadCompletedJobsReadyForApply();
 
     expect(component.completedJobsReadyForApply).toHaveLength(2);
-    expect(component.completedJobsReadyForApply.map(job => job.id)).toEqual([1, 2]);
+    expect(component.completedJobsReadyForApply.map(job => job.id)).toEqual([
+      1, 2
+    ]);
     expect(component.completedJobsReadyForApply[0].hasIssues).toBe(true);
-    expect(component.completedJobsBlockedForReview.map(job => job.id)).toEqual([1]);
-    expect(component.getCompletionActionTitle()).toContain('1 mit offenen Hinweisen');
+    expect(
+      component.completedJobsBlockedForReview.map(job => job.id)
+    ).toEqual([1]);
+    expect(component.getCompletionActionTitle()).toContain(
+      '1 mit offenen Hinweisen'
+    );
   });
 
   it('should use parent apply permission when the coding jobs table is not rendered', () => {
@@ -773,13 +892,35 @@ describe('CodingManagementManualComponent', () => {
         codedUnits: 5
       }
     ];
-    component.codingJobsComponent = undefined;
+    component.productiveCodingJobsComponent = undefined;
 
     component.canApplyManualCodingResults = false;
     expect(component.canShowCompletedJobApplyActions()).toBe(false);
 
     component.canApplyManualCodingResults = true;
     expect(component.canShowCompletedJobApplyActions()).toBe(true);
+  });
+
+  it('should reload all mounted manual coding job lists', () => {
+    const loadProductiveCodingJobs = jest.fn();
+    const loadTrainingCodingJobs = jest.fn();
+    const loadCoderTrainings = jest.fn();
+
+    component.productiveCodingJobsComponent = {
+      loadCodingJobs: loadProductiveCodingJobs
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
+    component.trainingCodingJobsComponent = {
+      loadCodingJobs: loadTrainingCodingJobs
+    } as unknown as CodingManagementManualComponent['trainingCodingJobsComponent'];
+    component.coderTrainingsListComponent = {
+      loadCoderTrainings
+    } as unknown as CodingManagementManualComponent['coderTrainingsListComponent'];
+
+    component.reloadCodingJobsList();
+
+    expect(loadProductiveCodingJobs).toHaveBeenCalledTimes(1);
+    expect(loadTrainingCodingJobs).toHaveBeenCalledTimes(1);
+    expect(loadCoderTrainings).toHaveBeenCalledTimes(1);
   });
 
   it('should hide the completion tab without study-manager permission', () => {
@@ -832,9 +973,9 @@ describe('CodingManagementManualComponent', () => {
     (snackBar.open as jest.Mock).mockClear();
     component.canApplyManualCodingResults = false;
     component.canManageManualCodingJobs = false;
-    component.codingJobsComponent = {
+    component.productiveCodingJobsComponent = {
       openTransferCodingCasesDialog
-    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
 
     component.openExecutionTransferCases();
 
@@ -871,9 +1012,9 @@ describe('CodingManagementManualComponent', () => {
     (snackBar.open as jest.Mock).mockClear();
     component.canManageManualCodingJobs = true;
     component.canApplyManualCodingResults = false;
-    component.codingJobsComponent = {
+    component.productiveCodingJobsComponent = {
       openTransferCodingCasesDialog
-    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
 
     component.openExecutionTransferCases();
 
@@ -949,7 +1090,9 @@ describe('CodingManagementManualComponent', () => {
 
     expect(component.getPlanningStatusClass()).toBe('status-attention');
     expect(component.getPlanningStatusIcon()).toBe('published_with_changes');
-    expect(component.getPlanningStatusTitle()).toBe('Kodierfälle abgeschlossen');
+    expect(component.getPlanningStatusTitle()).toBe(
+      'Kodierfälle abgeschlossen'
+    );
     expect(component.getPlanningStatusDescription()).toBe(
       'Alle Kodierfälle sind abgeschlossen. Die Übernahme der Ergebnisse in den Datenbestand bleibt Studienmanager:innen vorbehalten.'
     );
@@ -1012,7 +1155,9 @@ describe('CodingManagementManualComponent', () => {
     expect(component.getPlanningStatusTitle()).toBe(
       'Reguläre Codes für manuelle Kodierung prüfen'
     );
-    expect(component.getPlanningNextStepTitle()).toBe('Reguläre Codes ergänzen');
+    expect(component.getPlanningNextStepTitle()).toBe(
+      'Reguläre Codes ergänzen'
+    );
     expect(component.getPlanningNextStepActionLabel()).toBe(
       'Betroffene Variablen ansehen'
     );
@@ -1072,7 +1217,8 @@ describe('CodingManagementManualComponent', () => {
   });
 
   it('should keep the affected variables scroll target while coverage is loading', () => {
-    component.selectedManualTabIndex = component.manualCodingTabs.indexOf('planning');
+    component.selectedManualTabIndex =
+      component.manualCodingTabs.indexOf('planning');
     component.variableCoverageOverview = null;
     component.manualCodeAvailabilityWarnings = [
       createManualCodeAvailabilityWarning('UNIT1', 'VAR1')
@@ -1274,7 +1420,10 @@ describe('CodingManagementManualComponent', () => {
     };
     componentInternals.appService.selectedWorkspaceId = 5;
     const notifyTestResultsChangedSpy = jest
-      .spyOn(componentInternals.testPersonCodingService, 'notifyTestResultsChanged')
+      .spyOn(
+        componentInternals.testPersonCodingService,
+        'notifyTestResultsChanged'
+      )
       .mockImplementation();
     const loadCodingFreshnessSpy = jest
       .spyOn(componentInternals, 'loadCodingFreshness')
@@ -1299,6 +1448,21 @@ describe('CodingManagementManualComponent', () => {
     expect(loadResponseAnalysisSpy).toHaveBeenCalled();
     expect(loadCodingFreshnessSpy).toHaveBeenCalled();
     expect(reloadCodingJobsListSpy).toHaveBeenCalled();
+  });
+
+  it('should not refresh manual state on focus when automatic refresh is disabled', () => {
+    component.selectedManualTabIndex = 1;
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      refreshManualStateAfterExternalChange(): void;
+    };
+    const refreshSpy = jest
+      .spyOn(componentInternals, 'refreshManualStateAfterExternalChange')
+      .mockImplementation();
+
+    window.dispatchEvent(new Event('focus'));
+
+    expect(refreshSpy).not.toHaveBeenCalled();
   });
 
   it('should load all planning metrics when the planning tab is opened', () => {
@@ -1340,6 +1504,368 @@ describe('CodingManagementManualComponent', () => {
     expect(loadResponseAnalysisSpy).toHaveBeenCalled();
   });
 
+  it('should not load coding freshness when planning is opened in manual refresh mode', () => {
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      loadManualTabData(
+        tab: 'planning',
+        options?: { forceRefresh?: boolean }
+      ): void;
+      loadVariableCoverageOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadCodingProgressOverview(): void;
+      loadCodingIncompleteVariables(): void;
+      loadManualFreshnessDecisionData(): void;
+      loadCodingFreshness(options?: { force?: boolean }): void;
+      loadResponseAnalysisForPlanningIfNeeded(): void;
+    };
+    jest
+      .spyOn(componentInternals, 'loadVariableCoverageOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCaseCoverageOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCodingProgressOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCodingIncompleteVariables')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadManualFreshnessDecisionData')
+      .mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadResponseAnalysisForPlanningIfNeeded')
+      .mockImplementation();
+
+    componentInternals.loadManualTabData('planning');
+
+    expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
+  });
+
+  it('should load coding freshness when planning is force-refreshed in manual refresh mode', () => {
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      loadManualTabData(
+        tab: 'planning',
+        options?: { forceRefresh?: boolean }
+      ): void;
+      loadVariableCoverageOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadCodingProgressOverview(): void;
+      loadCodingIncompleteVariables(): void;
+      loadManualFreshnessDecisionData(): void;
+      loadCodingFreshness(options?: { force?: boolean }): void;
+      loadResponseAnalysisForPlanningIfNeeded(): void;
+    };
+    jest
+      .spyOn(componentInternals, 'loadVariableCoverageOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCaseCoverageOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCodingProgressOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCodingIncompleteVariables')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadManualFreshnessDecisionData')
+      .mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadResponseAnalysisForPlanningIfNeeded')
+      .mockImplementation();
+
+    componentInternals.loadManualTabData('planning', { forceRefresh: true });
+
+    expect(loadCodingFreshnessSpy).toHaveBeenCalledWith({ force: true });
+  });
+
+  it('should keep already visited manual tab content renderable in manual refresh mode', () => {
+    component.selectedManualTabIndex = 0;
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      loadedManualTabs: Set<'planning'>;
+    };
+
+    componentInternals.loadedManualTabs.add('planning');
+
+    expect(component.shouldRenderManualTabContent('planning')).toBe(true);
+
+    component.autoRefreshManualCodingJobs = true;
+
+    expect(component.shouldRenderManualTabContent('planning')).toBe(false);
+  });
+
+  it('should reuse an in-flight response analysis request with identical parameters', () => {
+    const responseAnalysis$ = new Subject<unknown>();
+    const getResponseAnalysis = jest.fn().mockReturnValue(
+      responseAnalysis$.asObservable()
+    );
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        getResponseAnalysis: jest.Mock;
+      };
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.testPersonCodingService = {
+      getResponseAnalysis
+    };
+
+    component.loadResponseAnalysis();
+    component.loadResponseAnalysis();
+
+    expect(getResponseAnalysis).toHaveBeenCalledTimes(1);
+
+    responseAnalysis$.next({
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: { total: 0, totalResponses: 0, groups: [] },
+      aggregationSummary: {
+        aggregationActive: false,
+        rawCases: 0,
+        effectiveCases: 0,
+        collapsedCases: 0
+      },
+      isCalculating: false
+    });
+    responseAnalysis$.complete();
+
+    expect(component.isLoadingResponseAnalysis).toBe(false);
+  });
+
+  it('should ignore stale response analysis when a forced refresh supersedes it', () => {
+    const firstResponseAnalysis$ = new Subject<unknown>();
+    const secondResponseAnalysis$ = new Subject<unknown>();
+    const getResponseAnalysis = jest
+      .fn()
+      .mockReturnValueOnce(firstResponseAnalysis$.asObservable())
+      .mockReturnValueOnce(secondResponseAnalysis$.asObservable());
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        getResponseAnalysis: jest.Mock;
+      };
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.testPersonCodingService = {
+      getResponseAnalysis
+    };
+
+    component.loadResponseAnalysis();
+    component.loadResponseAnalysis({ force: true });
+
+    expect(getResponseAnalysis).toHaveBeenCalledTimes(2);
+
+    firstResponseAnalysis$.next({
+      emptyResponses: { total: 99, totalUncoded: 99, items: [] },
+      duplicateValues: { total: 0, totalResponses: 0, groups: [] },
+      aggregationSummary: {
+        aggregationActive: false,
+        rawCases: 99,
+        effectiveCases: 99,
+        collapsedCases: 0
+      },
+      isCalculating: false
+    });
+    firstResponseAnalysis$.complete();
+
+    expect(component.responseAnalysis).toBeNull();
+    expect(component.isLoadingResponseAnalysis).toBe(true);
+
+    secondResponseAnalysis$.next({
+      emptyResponses: { total: 1, totalUncoded: 1, items: [] },
+      duplicateValues: { total: 0, totalResponses: 0, groups: [] },
+      aggregationSummary: {
+        aggregationActive: false,
+        rawCases: 1,
+        effectiveCases: 1,
+        collapsedCases: 0
+      },
+      isCalculating: false
+    });
+    secondResponseAnalysis$.complete();
+
+    expect(component.responseAnalysis?.emptyResponses.total).toBe(1);
+    expect(component.isLoadingResponseAnalysis).toBe(false);
+  });
+
+  it('should reuse an in-flight applied results overview request for the same workspace', () => {
+    const appliedResultsOverview$ = new Subject<unknown>();
+    const getAppliedResultsOverview = jest.fn().mockReturnValue(
+      appliedResultsOverview$.asObservable()
+    );
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        getAppliedResultsOverview: jest.Mock;
+      };
+      loadAppliedResultsOverview(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.testPersonCodingService = {
+      getAppliedResultsOverview
+    };
+
+    componentInternals.loadAppliedResultsOverview();
+    componentInternals.loadAppliedResultsOverview();
+
+    expect(getAppliedResultsOverview).toHaveBeenCalledTimes(1);
+
+    appliedResultsOverview$.next({
+      totalIncompleteResponses: 10,
+      appliedResponses: 4,
+      remainingResponses: 6,
+      completionPercentage: 40,
+      rawTotalIncompleteResponses: 10,
+      rawAppliedResponses: 4,
+      rawCompletionPercentage: 40,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0
+    });
+    appliedResultsOverview$.complete();
+
+    expect(component.appliedResultsOverview?.totalIncompleteResponses).toBe(10);
+    expect(component.isLoadingAppliedResultsOverview).toBe(false);
+  });
+
+  it('should ignore stale applied results overview when the workspace changes', () => {
+    const firstAppliedResultsOverview$ = new Subject<unknown>();
+    const secondAppliedResultsOverview$ = new Subject<unknown>();
+    const getAppliedResultsOverview = jest
+      .fn()
+      .mockReturnValueOnce(firstAppliedResultsOverview$.asObservable())
+      .mockReturnValueOnce(secondAppliedResultsOverview$.asObservable());
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        getAppliedResultsOverview: jest.Mock;
+      };
+      loadAppliedResultsOverview(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.testPersonCodingService = {
+      getAppliedResultsOverview
+    };
+
+    componentInternals.loadAppliedResultsOverview();
+    componentInternals.appService.selectedWorkspaceId = 6;
+    componentInternals.loadAppliedResultsOverview();
+
+    expect(getAppliedResultsOverview).toHaveBeenCalledTimes(2);
+
+    firstAppliedResultsOverview$.next({
+      totalIncompleteResponses: 99,
+      appliedResponses: 99,
+      remainingResponses: 0,
+      completionPercentage: 100,
+      rawTotalIncompleteResponses: 99,
+      rawAppliedResponses: 99,
+      rawCompletionPercentage: 100,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0
+    });
+    firstAppliedResultsOverview$.complete();
+
+    expect(component.appliedResultsOverview).toBeNull();
+    expect(component.isLoadingAppliedResultsOverview).toBe(true);
+
+    secondAppliedResultsOverview$.next({
+      totalIncompleteResponses: 1,
+      appliedResponses: 0,
+      remainingResponses: 1,
+      completionPercentage: 0,
+      rawTotalIncompleteResponses: 1,
+      rawAppliedResponses: 0,
+      rawCompletionPercentage: 0,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0
+    });
+    secondAppliedResultsOverview$.complete();
+
+    expect(component.appliedResultsOverview?.totalIncompleteResponses).toBe(1);
+    expect(component.isLoadingAppliedResultsOverview).toBe(false);
+  });
+
+  it('should ignore stale coding freshness responses when a newer refresh supersedes them', () => {
+    const firstFreshness$ = new Subject<{
+      workspaceId: number;
+      currentRevision: number;
+      items: {
+        version: 'v1';
+        state: 'PENDING';
+        unitCount: number;
+        affectedResponseCount: number;
+      }[];
+    }>();
+    const secondFreshness$ = new Subject<{
+      workspaceId: number;
+      currentRevision: number;
+      items: [];
+    }>();
+    const getCodingFreshness = jest
+      .fn()
+      .mockReturnValueOnce(firstFreshness$.asObservable())
+      .mockReturnValueOnce(secondFreshness$.asObservable());
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        getCodingFreshness: jest.Mock;
+      };
+      loadCodingFreshness(options?: { force?: boolean }): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.testPersonCodingService = {
+      getCodingFreshness
+    };
+    component.autoRefreshManualCodingJobs = true;
+    component.codingFreshnessSummary = null;
+
+    componentInternals.loadCodingFreshness({ force: true });
+    componentInternals.loadCodingFreshness({ force: true });
+
+    firstFreshness$.next({
+      workspaceId: 5,
+      currentRevision: 1,
+      items: [
+        {
+          version: 'v1',
+          state: 'PENDING',
+          unitCount: 99,
+          affectedResponseCount: 99
+        }
+      ]
+    });
+    firstFreshness$.complete();
+
+    expect(component.codingFreshnessSummary).toBeNull();
+    expect(component.isLoadingCodingFreshness).toBe(true);
+
+    secondFreshness$.next({
+      workspaceId: 5,
+      currentRevision: 2,
+      items: []
+    });
+    secondFreshness$.complete();
+
+    expect(component.codingFreshnessSummary).toEqual({
+      workspaceId: 5,
+      currentRevision: 2,
+      items: []
+    });
+    expect(component.isLoadingCodingFreshness).toBe(false);
+  });
+
   it('should ignore duplicate tab change events for the active manual tab', () => {
     component.selectedManualTabIndex = 1;
     const componentInternals = component as unknown as {
@@ -1373,12 +1899,11 @@ describe('CodingManagementManualComponent', () => {
 
     window.dispatchEvent(new Event('focus'));
 
-    expect(loadManualTabDataSpy).toHaveBeenCalledWith(
-      'planning',
-      { reloadCodingJobs: false }
-    );
+    expect(loadManualTabDataSpy).toHaveBeenCalledWith('planning', {
+      reloadCodingJobs: false
+    });
     expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
-    expect(reloadCodingJobsListSpy).toHaveBeenCalled();
+    expect(reloadCodingJobsListSpy).not.toHaveBeenCalled();
   });
 
   it('should not reload coding jobs twice when execution regains focus', () => {
@@ -1568,7 +2093,8 @@ describe('CodingManagementManualComponent', () => {
         context: 'training' | 'execution',
         result: {
           exportType: 'aggregated';
-          doubleCodingMethod?: 'most-frequent' | 'new-column-per-coder' | 'new-row-per-variable';
+          doubleCodingMethod?:
+          'most-frequent' | 'new-column-per-coder' | 'new-row-per-variable';
           jobDefinitionIds: number[];
         }
       ) => void;
@@ -1589,12 +2115,14 @@ describe('CodingManagementManualComponent', () => {
       },
       {
         method: 'new-column-per-coder' as const,
-        displayLabelKey: 'export-toast.types.manual-review-new-column-per-coder',
+        displayLabelKey:
+          'export-toast.types.manual-review-new-column-per-coder',
         downloadFilePrefix: 'manual-review-new-column-per-coder'
       },
       {
         method: 'new-row-per-variable' as const,
-        displayLabelKey: 'export-toast.types.manual-review-new-row-per-variable',
+        displayLabelKey:
+          'export-toast.types.manual-review-new-row-per-variable',
         downloadFilePrefix: 'manual-review-new-row-per-variable'
       }
     ].forEach(({ method }) => {
@@ -1621,7 +2149,8 @@ describe('CodingManagementManualComponent', () => {
       expect.objectContaining({
         exportType: 'aggregated',
         doubleCodingMethod: 'new-column-per-coder',
-        displayLabelKey: 'export-toast.types.manual-review-new-column-per-coder',
+        displayLabelKey:
+          'export-toast.types.manual-review-new-column-per-coder',
         downloadFilePrefix: 'manual-review-new-column-per-coder'
       })
     );
@@ -1641,7 +2170,8 @@ describe('CodingManagementManualComponent', () => {
       expect.objectContaining({
         exportType: 'aggregated',
         doubleCodingMethod: 'new-row-per-variable',
-        displayLabelKey: 'export-toast.types.manual-review-new-row-per-variable',
+        displayLabelKey:
+          'export-toast.types.manual-review-new-row-per-variable',
         downloadFilePrefix: 'manual-review-new-row-per-variable'
       })
     );
@@ -1671,12 +2201,14 @@ describe('CodingManagementManualComponent', () => {
     componentInternals.dialog = dialog;
     componentInternals.appService.selectedWorkspaceId = 5;
     componentInternals.appService.updateAuthData({ userId: 9 });
-    exportJobService.estimateJob.mockReturnValue(of({
-      exportType: 'by-variable',
-      unitVariableCount: 2791,
-      worksheetLimit: 1000,
-      exceedsWorksheetLimit: true
-    }));
+    exportJobService.estimateJob.mockReturnValue(
+      of({
+        exportType: 'by-variable',
+        unitVariableCount: 2791,
+        worksheetLimit: 1000,
+        exceedsWorksheetLimit: true
+      })
+    );
     dialog.open.mockReturnValue({ afterClosed: () => of(false) });
     exportJobService.startJob.mockClear();
 
@@ -1721,12 +2253,14 @@ describe('CodingManagementManualComponent', () => {
     componentInternals.dialog = dialog;
     componentInternals.appService.selectedWorkspaceId = 5;
     componentInternals.appService.updateAuthData({ userId: 9 });
-    exportJobService.estimateJob.mockReturnValue(of({
-      exportType: 'by-variable',
-      unitVariableCount: 2791,
-      worksheetLimit: 1000,
-      exceedsWorksheetLimit: true
-    }));
+    exportJobService.estimateJob.mockReturnValue(
+      of({
+        exportType: 'by-variable',
+        unitVariableCount: 2791,
+        worksheetLimit: 1000,
+        exceedsWorksheetLimit: true
+      })
+    );
     dialog.open.mockReturnValue({ afterClosed: () => of('compact') });
     exportJobService.startJob.mockClear();
 
@@ -2114,12 +2648,15 @@ describe('CodingManagementManualComponent', () => {
     setCompletePlanningState();
     setCodingProgress(10, 10);
     setAppliedResults(10, 0, 10);
-    setManualFreshnessJobSummary({
-      activeTrainingJobs: 1,
-      openProductiveJobs: 1,
-      completedProductiveJobs: 1,
-      staleSourceJobs: 1
-    }, 3);
+    setManualFreshnessJobSummary(
+      {
+        activeTrainingJobs: 1,
+        openProductiveJobs: 1,
+        completedProductiveJobs: 1,
+        staleSourceJobs: 1
+      },
+      3
+    );
     component.responseAnalysis = {
       emptyResponses: { total: 0, totalUncoded: 0, items: [] },
       duplicateValues: {
@@ -2142,7 +2679,9 @@ describe('CodingManagementManualComponent', () => {
     };
 
     expect(component.getPlanningNextStepTargetTab()).toBe('preparation');
-    expect(component.getPlanningNextStepTargetSection()).toBe('manual-preparation');
+    expect(component.getPlanningNextStepTargetSection()).toBe(
+      'manual-preparation'
+    );
 
     component.responseAnalysis = null;
     component.caseCoverageOverview = {
@@ -2151,7 +2690,9 @@ describe('CodingManagementManualComponent', () => {
     };
 
     expect(component.getPlanningNextStepTargetTab()).toBe('planning');
-    expect(component.getPlanningNextStepTargetSection()).toBe('manual-planning');
+    expect(component.getPlanningNextStepTargetSection()).toBe(
+      'manual-planning'
+    );
 
     component.caseCoverageOverview = {
       ...component.caseCoverageOverview!,
@@ -2161,49 +2702,65 @@ describe('CodingManagementManualComponent', () => {
     expect(component.getPlanningNextStepTargetTab()).toBe('training');
     expect(component.getPlanningNextStepTargetSection()).toBe('manual-support');
 
-    setManualFreshnessJobSummary({
-      activeTrainingJobs: 0,
-      openProductiveJobs: 1,
-      completedProductiveJobs: 1,
-      staleSourceJobs: 1
-    }, 3);
+    setManualFreshnessJobSummary(
+      {
+        activeTrainingJobs: 0,
+        openProductiveJobs: 1,
+        completedProductiveJobs: 1,
+        staleSourceJobs: 1
+      },
+      3
+    );
 
     expect(component.getPlanningNextStepTargetTab()).toBe('execution');
-    expect(component.getPlanningNextStepActionLabel()).toBe('Zu den Kodierjobs');
+    expect(component.getPlanningNextStepActionLabel()).toBe(
+      'Zu den Kodierjobs'
+    );
 
-    setManualFreshnessJobSummary({
-      activeTrainingJobs: 0,
-      openProductiveJobs: 0,
-      completedProductiveJobs: 1,
-      staleSourceJobs: 1
-    }, 3);
+    setManualFreshnessJobSummary(
+      {
+        activeTrainingJobs: 0,
+        openProductiveJobs: 0,
+        completedProductiveJobs: 1,
+        staleSourceJobs: 1
+      },
+      3
+    );
 
     expect(component.getPlanningNextStepTargetTab()).toBe('execution');
     expect(component.getPlanningNextStepActionLabel()).toBe(
       'Doppelkodierungsreview öffnen'
     );
 
-    setManualFreshnessJobSummary({
-      activeTrainingJobs: 0,
-      openProductiveJobs: 0,
-      completedProductiveJobs: 1,
-      staleSourceJobs: 1
-    }, 0);
+    setManualFreshnessJobSummary(
+      {
+        activeTrainingJobs: 0,
+        openProductiveJobs: 0,
+        completedProductiveJobs: 1,
+        staleSourceJobs: 1
+      },
+      0
+    );
 
     expect(component.getPlanningNextStepTargetTab()).toBe('execution');
     expect(component.getPlanningNextStepActionLabel()).toBe(
       'Veraltete Jobs prüfen'
     );
 
-    setManualFreshnessJobSummary({
-      activeTrainingJobs: 0,
-      openProductiveJobs: 0,
-      completedProductiveJobs: 1,
-      staleSourceJobs: 0
-    }, 0);
+    setManualFreshnessJobSummary(
+      {
+        activeTrainingJobs: 0,
+        openProductiveJobs: 0,
+        completedProductiveJobs: 1,
+        staleSourceJobs: 0
+      },
+      0
+    );
 
     expect(component.getPlanningNextStepTargetTab()).toBe('completion');
-    expect(component.getPlanningNextStepTargetSection()).toBe('manual-completion');
+    expect(component.getPlanningNextStepTargetSection()).toBe(
+      'manual-completion'
+    );
   });
 
   it('should open the double-coding review dialog for the freshness target', () => {
@@ -2213,13 +2770,17 @@ describe('CodingManagementManualComponent', () => {
       setCompletePlanningState();
       setCodingProgress(10, 10);
       setAppliedResults(10, 0, 10);
-      setManualFreshnessJobSummary({
-        activeTrainingJobs: 0,
-        openProductiveJobs: 0,
-        completedProductiveJobs: 1,
-        staleSourceJobs: 0
-      }, 2);
-      component.selectedManualTabIndex = component.manualCodingTabs.indexOf('planning');
+      setManualFreshnessJobSummary(
+        {
+          activeTrainingJobs: 0,
+          openProductiveJobs: 0,
+          completedProductiveJobs: 1,
+          staleSourceJobs: 0
+        },
+        2
+      );
+      component.selectedManualTabIndex =
+        component.manualCodingTabs.indexOf('planning');
 
       const dialog = {
         open: jest.fn().mockReturnValue({ afterClosed: () => of(undefined) })
@@ -2280,12 +2841,15 @@ describe('CodingManagementManualComponent', () => {
       expect(loadManualTabDataSpy).toHaveBeenCalledTimes(1);
       expect(scrollToSectionSpy).not.toHaveBeenCalled();
 
-      setManualFreshnessJobSummary({
-        activeTrainingJobs: 1,
-        openProductiveJobs: 0,
-        completedProductiveJobs: 0,
-        staleSourceJobs: 0
-      }, 0);
+      setManualFreshnessJobSummary(
+        {
+          activeTrainingJobs: 1,
+          openProductiveJobs: 0,
+          completedProductiveJobs: 0,
+          staleSourceJobs: 0
+        },
+        0
+      );
       component.isLoadingManualFreshnessJobSummary = false;
       componentInternals.focusManualFreshnessTargetIfReady();
 
@@ -2301,10 +2865,12 @@ describe('CodingManagementManualComponent', () => {
   });
 
   it('should skip double-coding summary while productive manual jobs are open', () => {
-    const getDoubleCodedVariablesForReview = jest.fn().mockReturnValue(of({
-      data: [],
-      total: 5
-    }));
+    const getDoubleCodedVariablesForReview = jest.fn().mockReturnValue(
+      of({
+        data: [],
+        total: 5
+      })
+    );
     const componentInternals = component as unknown as {
       appService: { selectedWorkspaceId: number };
       codingJobBackendService: {
@@ -2318,20 +2884,24 @@ describe('CodingManagementManualComponent', () => {
     };
     componentInternals.appService.selectedWorkspaceId = 5;
     componentInternals.codingJobBackendService = {
-      getCodingJobs: jest.fn().mockReturnValue(of({
-        data: [{
-          id: 1,
-          workspace_id: 5,
-          name: 'Offener produktiver Job',
-          status: 'open',
-          created_at: new Date(),
-          updated_at: new Date(),
-          assignedCoders: [],
-          totalUnits: 10,
-          openUnits: 2,
-          codedUnits: 8
-        }]
-      }))
+      getCodingJobs: jest.fn().mockReturnValue(
+        of({
+          data: [
+            {
+              id: 1,
+              workspace_id: 5,
+              name: 'Offener produktiver Job',
+              status: 'open',
+              created_at: new Date(),
+              updated_at: new Date(),
+              assignedCoders: [],
+              totalUnits: 10,
+              openUnits: 2,
+              codedUnits: 8
+            }
+          ]
+        })
+      )
     };
     componentInternals.testPersonCodingService = {
       getDoubleCodedVariablesForReview
@@ -2354,14 +2924,19 @@ describe('CodingManagementManualComponent', () => {
         getAggregationSettings: jest.Mock;
       };
       loadInitialManualCodingState(): void;
-      loadManualTabData(tab: 'preparation' | 'planning' | 'training' | 'execution' | 'completion'): void;
+      loadManualTabData(
+        tab:
+        'preparation' | 'planning' | 'training' | 'execution' | 'completion'
+      ): void;
     };
     componentInternals.appService.selectedWorkspaceId = 5;
     componentInternals.testPersonCodingService = {
-      getAggregationSettings: jest.fn().mockReturnValue(of({
-        flags: [ResponseMatchingFlag.NO_AGGREGATION],
-        threshold: 2
-      }))
+      getAggregationSettings: jest.fn().mockReturnValue(
+        of({
+          flags: [ResponseMatchingFlag.NO_AGGREGATION],
+          threshold: 2
+        })
+      )
     };
     jest.spyOn(componentInternals, 'loadManualTabData').mockImplementation();
 
@@ -2375,13 +2950,15 @@ describe('CodingManagementManualComponent', () => {
   it('should count pending jobs with assigned units as active manual freshness jobs', () => {
     const buildManualFreshnessJobSummary = (
       component as unknown as {
-        buildManualFreshnessJobSummary(jobs: Array<{
-          status: string;
-          totalUnits?: number;
-          openUnits?: number;
-          codedUnits?: number;
-          training_id?: number;
-        }>): {
+        buildManualFreshnessJobSummary(
+          jobs: Array<{
+            status: string;
+            totalUnits?: number;
+            openUnits?: number;
+            codedUnits?: number;
+            training_id?: number;
+          }>
+        ): {
           activeTrainingJobs: number;
           openProductiveJobs: number;
           completedProductiveJobs: number;
@@ -2441,7 +3018,9 @@ describe('CodingManagementManualComponent', () => {
 
       expect(component.visibleManualCodingTabs).not.toContain('completion');
       expect(component.getPlanningNextStepTargetTab()).toBe('execution');
-      expect(component.getPlanningNextStepActionLabel()).toBe('Zu den Kodierjobs');
+      expect(component.getPlanningNextStepActionLabel()).toBe(
+        'Zu den Kodierjobs'
+      );
 
       component.performPlanningNextStep();
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -16,7 +16,13 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import {
-  Subject, takeUntil, debounceTime, finalize, Observable, of, tap,
+  Subject,
+  takeUntil,
+  debounceTime,
+  finalize,
+  Observable,
+  of,
+  tap,
   distinctUntilChanged,
   firstValueFrom,
   map,
@@ -89,10 +95,11 @@ import {
   CodingFreshnessSummaryDto,
   CodingFreshnessSummaryItemDto
 } from '../../../../../../../api-dto/coding/coding-freshness.dto';
-import type {
-  ManualCodeAvailabilityWarningDto
-} from '../../../../../../../api-dto/coding/manual-code-availability.dto';
-import { MissingDto, MissingsProfilesDto } from '../../../../../../../api-dto/coding/missings-profiles.dto';
+import type { ManualCodeAvailabilityWarningDto } from '../../../../../../../api-dto/coding/manual-code-availability.dto';
+import {
+  MissingDto,
+  MissingsProfilesDto
+} from '../../../../../../../api-dto/coding/missings-profiles.dto';
 import {
   CODING_FRESHNESS_TASK_RESULT_HELP,
   formatCodingFreshnessResponseCount,
@@ -128,20 +135,25 @@ interface SavedCodeProgress {
 }
 
 type PlanningStatusState =
-  'loading' |
-  'preparation-required' |
-  'warning' |
-  'planning-incomplete' |
-  'planning-ready' |
-  'training-ready' |
-  'execution-ready' |
-  'double-coding-review-ready' |
-  'stale-source-review' |
-  'completion-ready' |
-  'progress-unavailable' |
-  'complete';
+  | 'loading'
+  | 'preparation-required'
+  | 'warning'
+  | 'planning-incomplete'
+  | 'planning-ready'
+  | 'training-ready'
+  | 'execution-ready'
+  | 'double-coding-review-ready'
+  | 'stale-source-review'
+  | 'completion-ready'
+  | 'progress-unavailable'
+  | 'complete';
 
-type ManualCodingTab = 'preparation' | 'planning' | 'training' | 'execution' | 'completion';
+type ManualCodingTab =
+  'preparation' | 'planning' | 'training' | 'execution' | 'completion';
+
+interface ResponseAnalysisLoadOptions {
+  force?: boolean;
+}
 
 interface ManualFreshnessJobSummary {
   activeTrainingJobs: number;
@@ -187,7 +199,12 @@ interface ManualFreshnessTarget {
   ]
 })
 export class CodingManagementManualComponent implements OnInit, OnDestroy {
-  @ViewChild(CodingJobsComponent) codingJobsComponent?: CodingJobsComponent;
+  @ViewChild('productiveCodingJobs')
+    productiveCodingJobsComponent?: CodingJobsComponent;
+
+  @ViewChild('trainingCodingJobs')
+    trainingCodingJobsComponent?: CodingJobsComponent;
+
   @ViewChild(CodingJobDefinitionsComponent)
     codingJobDefinitionsComponent?: CodingJobDefinitionsComponent;
 
@@ -275,15 +292,27 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   duplicateAggregationThreshold = 2;
   isApplyingDuplicateAggregation = false;
   private analysisPollingTimer?: ReturnType<typeof setTimeout>;
-  private readonly windowFocusRefreshThrottleMs = 1000;
+  private responseAnalysisRequestKey?: string;
+  private responseAnalysisRequestGeneration = 0;
+  private readonly responseAnalysisPollingDelayMs = 1500;
+  private appliedResultsOverviewRequestKey?: string;
+  private appliedResultsOverviewRequestGeneration = 0;
+  private readonly windowFocusRefreshThrottleMs = 30000;
+  private readonly codingFreshnessRefreshThrottleMs = 30000;
   private lastWindowFocusRefreshAt = 0;
+  private lastCodingFreshnessRefreshAt = 0;
+  private codingFreshnessRequestGeneration = 0;
+  private readonly loadedManualTabs = new Set<ManualCodingTab>();
   private readonly handleWindowFocus = () => {
     if (!this.shouldRefreshManualStateOnFocus()) {
       return;
     }
 
     const now = Date.now();
-    if (now - this.lastWindowFocusRefreshAt < this.windowFocusRefreshThrottleMs) {
+    if (
+      now - this.lastWindowFocusRefreshAt <
+      this.windowFocusRefreshThrottleMs
+    ) {
       return;
     }
 
@@ -376,7 +405,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   statusDistribution: { [status: string]: number } = {};
   statusDistributionV2: { [status: string]: number } = {};
-  appliedResultsOverview: (AppliedResultsOverview & {
+  appliedResultsOverview:
+  | (AppliedResultsOverview & {
     totalIncompleteVariables: number;
     finalStatusBreakdown: {
       codingComplete: number;
@@ -384,7 +414,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       codingError: number;
       other: number;
     };
-  }) | null = null;
+  })
+  | null = null;
 
   completedJobsReadyForApply: CodingJob[] = [];
   completedJobsBlockedForReview: CodingJob[] = [];
@@ -421,7 +452,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.pendingManualFreshnessFocus =
-      this.route.snapshot.queryParamMap.get('focus') === this.manualFreshnessFocusParam;
+      this.route.snapshot.queryParamMap.get('focus') ===
+      this.manualFreshnessFocusParam;
 
     this.validationStateService.validationProgress$
       .pipe(takeUntil(this.destroy$))
@@ -438,9 +470,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         if (progress.status === 'error') {
           this.showError(
             progress.error ||
-            this.translateService.instant(
-              'coding-management-manual.errors.validation-failed'
-            )
+              this.translateService.instant(
+                'coding-management-manual.errors.validation-failed'
+              )
           );
         }
       });
@@ -458,8 +490,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.jobDefinitionChangeSubject
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(() => {
-        this.loadJobDefinitionsForExport();
-        this.loadManualTabData(this.activeManualTab);
+        this.loadJobDefinitionsForExport({ force: true });
+        this.loadManualTabData(this.activeManualTab, { forceRefresh: true });
         if (this.coderTrainingsListComponent) {
           this.coderTrainingsListComponent.loadCoderTrainings();
         }
@@ -476,7 +508,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         const workspaceId = this.appService.selectedWorkspaceId;
         if (workspaceId) {
           const localFlagsAfterSave = [...this.responseMatchingFlags];
-          const flagsToPersist = this.getPersistableResponseMatchingFlags(localFlagsAfterSave);
+          const flagsToPersist =
+            this.getPersistableResponseMatchingFlags(localFlagsAfterSave);
           this.isApplyingDuplicateAggregation = true;
           this.testPersonCodingService
             .saveAggregationSettings(workspaceId, threshold, flagsToPersist)
@@ -493,15 +526,19 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
                   return;
                 }
                 this.persistedResponseMatchingFlags = [...result.flags];
-                this.responseMatchingFlags = this.buildResponseMatchingFlagsAfterSettingsSave(
-                  result.flags,
-                  localFlagsAfterSave
-                );
-                this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(result.threshold);
+                this.responseMatchingFlags =
+                  this.buildResponseMatchingFlagsAfterSettingsSave(
+                    result.flags,
+                    localFlagsAfterSave
+                  );
+                this.duplicateAggregationThreshold =
+                  this.normalizeAggregationThreshold(result.threshold);
                 this.refreshAggregationDependentViews();
               },
               error: () => {
-                this.showError('Fehler beim Speichern der Aggregationseinstellungen');
+                this.showError(
+                  'Fehler beim Speichern der Aggregationseinstellungen'
+                );
               }
             });
         }
@@ -510,28 +547,45 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.testPersonCodingService.autoCodingCompleted$
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
+        if (!this.autoRefreshManualCodingJobs) {
+          return;
+        }
+
+        this.loadedManualTabs.clear();
         this.refreshAllStatistics();
-        this.loadCodingFreshness();
-        this.loadResponseAnalysis();
+        this.loadCodingFreshness({ force: true });
+        this.loadResponseAnalysis({ force: true });
         this.reloadCodingJobsList();
-        this.loadJobDefinitionsForExport();
+        this.loadJobDefinitionsForExport({ force: true });
         if (this.codingJobDefinitionsComponent) {
           this.codingJobDefinitionsComponent.refresh();
         }
       });
 
-    this.loadInitialManualCodingState();
-    this.loadManualCodingJobRefreshSetting();
-    this.loadManualCodingApplyPermission();
-    this.loadCodingFreshness();
-    this.document.defaultView?.addEventListener('focus', this.handleWindowFocus);
+    this.loadManualCodingJobRefreshSetting(() => {
+      this.loadManualCodingApplyPermission();
+      this.loadInitialManualCodingState();
+      if (
+        this.autoRefreshManualCodingJobs &&
+        this.activeManualTab !== 'planning'
+      ) {
+        this.loadCodingFreshness();
+      }
+    });
+    this.document.defaultView?.addEventListener(
+      'focus',
+      this.handleWindowFocus
+    );
   }
 
   ngOnDestroy(): void {
     if (this.analysisPollingTimer) {
       clearTimeout(this.analysisPollingTimer);
     }
-    this.document.defaultView?.removeEventListener('focus', this.handleWindowFocus);
+    this.document.defaultView?.removeEventListener(
+      'focus',
+      this.handleWindowFocus
+    );
     this.destroy$.next();
     this.destroy$.complete();
 
@@ -540,7 +594,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   get activeManualTab(): ManualCodingTab {
-    return this.visibleManualCodingTabs[this.selectedManualTabIndex] || 'preparation';
+    return (
+      this.visibleManualCodingTabs[this.selectedManualTabIndex] || 'preparation'
+    );
   }
 
   get workspaceId(): number {
@@ -574,6 +630,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   isManualTab(tab: ManualCodingTab): boolean {
     return this.activeManualTab === tab;
+  }
+
+  shouldRenderManualTabContent(tab: ManualCodingTab): boolean {
+    return (
+      this.isManualTab(tab) ||
+      (!this.autoRefreshManualCodingJobs && this.loadedManualTabs.has(tab))
+    );
   }
 
   onManualTabChanged(index: number): void {
@@ -653,7 +716,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
       const detection = await this.detectCodingImportFormat(file);
       const dialogResult = await firstValueFrom(
-        this.dialog.open<
+        this.dialog
+          .open<
         CodingImportFormatDialogComponent,
         CodingImportFormatDialogData,
         CodingImportFormatDialogResult | undefined
@@ -661,7 +725,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           width: '720px',
           maxWidth: '95vw',
           data: detection
-        }).afterClosed()
+        })
+          .afterClosed()
       );
 
       if (!dialogResult) {
@@ -766,7 +831,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async detectCodingImportFormat(file: File): Promise<CodingImportFormatDialogData> {
+  private async detectCodingImportFormat(
+    file: File
+  ): Promise<CodingImportFormatDialogData> {
     let headers: string[] = [];
     const fileName = file.name;
 
@@ -800,60 +867,75 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
       const headers: string[] = [];
       worksheet.getRow(1).eachCell(cell => {
-        headers.push(this.normalizeImportHeader(cell.text || cell.value?.toString() || ''));
+        headers.push(
+          this.normalizeImportHeader(cell.text || cell.value?.toString() || '')
+        );
       });
       return headers.filter(Boolean);
     }
 
     const sample = await file.slice(0, 65536).text();
-    const firstLine = sample.split(/\r?\n/).find(line => line.trim().length > 0) || '';
+    const firstLine =
+      sample.split(/\r?\n/).find(line => line.trim().length > 0) || '';
     const delimiter = this.detectCsvDelimiter(firstLine);
     return this.splitCsvHeaderLine(firstLine, delimiter)
       .map(header => this.normalizeImportHeader(header))
       .filter(Boolean);
   }
 
-  private detectFormatFromHeaders(headers: string[]): CodingImportDetectedFormat {
+  private detectFormatFromHeaders(
+    headers: string[]
+  ): CodingImportDetectedFormat {
     const has = (header: string): boolean => headers.includes(header);
     const hasAny = (candidates: string[]): boolean => candidates.some(candidate => has(candidate));
 
     if (
       has('groupname') &&
-        has('loginname') &&
-        has('code') &&
-        has('bookletname') &&
-        has('unitname') &&
-        has('timestamp') &&
-        has('logentry')
+      has('loginname') &&
+      has('code') &&
+      has('bookletname') &&
+      has('unitname') &&
+      has('timestamp') &&
+      has('logentry')
     ) {
       return 'test-logs';
     }
 
     if (
       has('groupname') &&
-        has('loginname') &&
-        has('code') &&
-        has('bookletname') &&
-        has('unitname') &&
-        has('responses')
+      has('loginname') &&
+      has('code') &&
+      has('bookletname') &&
+      has('unitname') &&
+      has('responses')
     ) {
       return 'test-results';
     }
 
     if (
       has('variable_id') &&
-        hasAny([
-          'status_v1', 'code_v1', 'score_v1',
-          'status_v2', 'code_v2', 'score_v2',
-          'status_v3', 'code_v3', 'score_v3'
-        ])
+      hasAny([
+        'status_v1',
+        'code_v1',
+        'score_v1',
+        'status_v2',
+        'code_v2',
+        'score_v2',
+        'status_v3',
+        'code_v3',
+        'score_v3'
+      ])
     ) {
       return 'coding-results';
     }
 
     if (has('variable_id') && (has('unit_key') || has('unit_alias'))) {
-      if (hasAny(['status', 'code', 'score', 'variable_page', 'variable_anchor'])) {
-        return hasAny(['variable_page', 'variable_anchor']) ? 'coding-list' : 'external-coding';
+      if (
+        hasAny(['status', 'code', 'score', 'variable_page', 'variable_anchor'])
+      ) {
+        return hasAny(['variable_page', 'variable_anchor']) ?
+          'coding-list' :
+          'external-coding';
       }
     }
 
@@ -868,7 +950,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   ): CodingImportFormatDialogData {
     const availableVersions = this.getAvailableCodingVersions(headers);
     const sharedDescription =
-        'Für Testfälle, die außerhalb der Kodierbox bereits mit Code und Score kodiert wurden.';
+      'Für Testfälle, die außerhalb der Kodierbox bereits mit Code und Score kodiert wurden.';
 
     if (detectedFormat === 'external-coding') {
       return {
@@ -886,7 +968,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     if (detectedFormat === 'coding-list') {
-      const hasCodingValues = ['status', 'code', 'score'].some(header => headers.includes(header));
+      const hasCodingValues = ['status', 'code', 'score'].some(header => headers.includes(header)
+      );
       return {
         fileName,
         detectedFormat,
@@ -911,11 +994,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         fileName,
         detectedFormat,
         title: 'Kodierungen aus Datei importieren',
-        description: 'Die Datei sieht nach einem Kodierergebnis-Export aus dem Coding Management aus.',
+        description:
+          'Die Datei sieht nach einem Kodierergebnis-Export aus dem Coding Management aus.',
         canImport: availableVersions.length > 0,
         headers,
         availableVersions,
-        selectedVersion: availableVersions.includes('v2') ? 'v2' : availableVersions[0],
+        selectedVersion: availableVersions.includes('v2') ?
+          'v2' :
+          availableVersions[0],
         helpItems: [
           'Wählen Sie aus, welche Version aus der Datei übernommen werden soll.',
           'Die ausgewählten Werte werden als manuelle Kodierung (v2) importiert.'
@@ -928,7 +1014,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         fileName,
         detectedFormat,
         title: 'Testergebnisse-Export erkannt',
-        description: 'Diese Datei enthält vollständige Testergebnisse mit Antworten und Zuständen, nicht nur Code-/Score-Kodierungen.',
+        description:
+          'Diese Datei enthält vollständige Testergebnisse mit Antworten und Zuständen, nicht nur Code-/Score-Kodierungen.',
         canImport: false,
         headers,
         helpItems: [
@@ -943,7 +1030,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         fileName,
         detectedFormat,
         title: 'Testlogs-Export erkannt',
-        description: 'Diese Datei enthält Testlogs und kann nicht als Code-/Score-Kodierung übernommen werden.',
+        description:
+          'Diese Datei enthält Testlogs und kann nicht als Code-/Score-Kodierung übernommen werden.',
         canImport: false,
         headers,
         helpItems: [
@@ -969,13 +1057,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     };
   }
 
-  private getAvailableCodingVersions(headers: string[]): Array<'v1' | 'v2' | 'v3'> {
-    return (['v1', 'v2', 'v3'] as Array<'v1' | 'v2' | 'v3'>)
-      .filter(version => (
-        headers.includes(`status_${version}`) ||
-          headers.includes(`code_${version}`) ||
-          headers.includes(`score_${version}`)
-      ));
+  private getAvailableCodingVersions(
+    headers: string[]
+  ): Array<'v1' | 'v2' | 'v3'> {
+    return (['v1', 'v2', 'v3'] as Array<'v1' | 'v2' | 'v3'>).filter(
+      version => headers.includes(`status_${version}`) ||
+        headers.includes(`code_${version}`) ||
+        headers.includes(`score_${version}`)
+    );
   }
 
   private normalizeImportHeader(header: string): string {
@@ -1074,11 +1163,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   openTrainingComparison(): void {
     if (this.coderTrainingsListComponent) {
-      this.coderTrainingsListComponent.openResultsComparison(undefined, 'between-trainings');
+      this.coderTrainingsListComponent.openResultsComparison(
+        undefined,
+        'between-trainings'
+      );
       return;
     }
 
-    this.showError('Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+    this.showError(
+      'Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.'
+    );
   }
 
   openTrainingDiscussion(): void {
@@ -1089,7 +1183,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const coderTrainings = this.getCoderTrainingsForExport();
 
     if (coderTrainings.length === 0) {
-      this.showError('Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+      this.showError(
+        'Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.'
+      );
       return;
     }
 
@@ -1106,11 +1202,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private openTrainingWithinComparison(): void {
     if (this.coderTrainingsListComponent) {
-      this.coderTrainingsListComponent.openResultsComparison(undefined, 'within-training');
+      this.coderTrainingsListComponent.openResultsComparison(
+        undefined,
+        'within-training'
+      );
       return;
     }
 
-    this.showError('Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+    this.showError(
+      'Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.'
+    );
   }
 
   openExecutionTransferCases(): void {
@@ -1119,12 +1220,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (this.codingJobsComponent) {
-      this.codingJobsComponent.openTransferCodingCasesDialog();
+    if (this.productiveCodingJobsComponent) {
+      this.productiveCodingJobsComponent.openTransferCodingCasesDialog();
       return;
     }
 
-    this.showError('Die Kodierjobs werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+    this.showError(
+      'Die Kodierjobs werden noch geladen. Bitte versuchen Sie es gleich erneut.'
+    );
   }
 
   openExecutionReliability(): void {
@@ -1153,7 +1256,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const coderTrainingIds = this.getCoderTrainingIds();
 
     if (coderTrainingIds.length === 0) {
-      this.showError('Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+      this.showError(
+        'Die Schulungen werden noch geladen. Bitte versuchen Sie es gleich erneut.'
+      );
       return;
     }
 
@@ -1176,19 +1281,31 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.openManualCodingExportDialog('execution');
   }
 
-  private openManualCodingExportDialog(context: 'training' | 'execution'): void {
-    this.dialog.open(ManualCodingExportDialogComponent, {
-      width: '680px',
-      maxWidth: '95vw',
-      data: {
-        context,
-        coders: this.coders,
-        jobDefinitions: context === 'execution' ? this.getJobDefinitionExportOptions() : undefined,
-        coderTrainings: context === 'training' ? this.getCoderTrainingsForExport() : undefined,
-        defaultJobDefinitionIds: context === 'execution' ? this.getJobDefinitionIds() : undefined,
-        defaultCoderTrainingIds: context === 'training' ? this.getCoderTrainingIds() : undefined
-      }
-    }).afterClosed()
+  private openManualCodingExportDialog(
+    context: 'training' | 'execution'
+  ): void {
+    this.dialog
+      .open(ManualCodingExportDialogComponent, {
+        width: '680px',
+        maxWidth: '95vw',
+        data: {
+          context,
+          coders: this.coders,
+          jobDefinitions:
+            context === 'execution' ?
+              this.getJobDefinitionExportOptions() :
+              undefined,
+          coderTrainings:
+            context === 'training' ?
+              this.getCoderTrainingsForExport() :
+              undefined,
+          defaultJobDefinitionIds:
+            context === 'execution' ? this.getJobDefinitionIds() : undefined,
+          defaultCoderTrainingIds:
+            context === 'training' ? this.getCoderTrainingIds() : undefined
+        }
+      })
+      .afterClosed()
       .pipe(takeUntil(this.destroy$))
       .subscribe((result?: ManualCodingExportDialogResult) => {
         if (!result) {
@@ -1223,12 +1340,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       includeModalValue: result.includeModalValue,
       excludeAutoCoded: true,
       coderIds: result.coderIds,
-      coderTrainingIds: context === 'training' ?
-        result.coderTrainingIds ?? this.getCoderTrainingIds() :
-        undefined,
-      jobDefinitionIds: context === 'execution' ?
-        result.jobDefinitionIds ?? this.getJobDefinitionIds() :
-        undefined
+      coderTrainingIds:
+        context === 'training' ?
+          (result.coderTrainingIds ?? this.getCoderTrainingIds()) :
+          undefined,
+      jobDefinitionIds:
+        context === 'execution' ?
+          (result.jobDefinitionIds ?? this.getJobDefinitionIds()) :
+          undefined
     };
 
     if (this.requiresByVariableWorksheetEstimate(result)) {
@@ -1244,10 +1363,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     exportConfig: ExportJobConfig
   ): void {
     this.isStartingManualExport = true;
-    this.exportJobService.startJob(workspaceId, exportConfig)
-      .pipe(finalize(() => {
-        this.isStartingManualExport = false;
-      }))
+    this.exportJobService
+      .startJob(workspaceId, exportConfig)
+      .pipe(
+        finalize(() => {
+          this.isStartingManualExport = false;
+        })
+      )
       .subscribe({
         next: () => {
           this.showSuccess('Exportjob wurde gestartet.');
@@ -1255,7 +1377,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         error: error => {
           if (isReplayAuthTokenError(error)) {
             this.showError(
-              this.translateService.instant('coding-management-manual.errors.replay-auth-token-failed')
+              this.translateService.instant(
+                'coding-management-manual.errors.replay-auth-token-failed'
+              )
             );
             return;
           }
@@ -1264,9 +1388,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       });
   }
 
-  private requiresByVariableWorksheetEstimate(result: ManualCodingExportDialogResult): boolean {
-    return result.exportType === 'aggregated' &&
-      result.doubleCodingMethod === 'new-row-per-variable';
+  private requiresByVariableWorksheetEstimate(
+    result: ManualCodingExportDialogResult
+  ): boolean {
+    return (
+      result.exportType === 'aggregated' &&
+      result.doubleCodingMethod === 'new-row-per-variable'
+    );
   }
 
   private estimateManualByVariableExport(
@@ -1280,10 +1408,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     };
 
     this.isStartingManualExport = true;
-    this.exportJobService.estimateJob(workspaceId, estimateConfig)
-      .pipe(
-        takeUntil(this.destroy$)
-      )
+    this.exportJobService
+      .estimateJob(workspaceId, estimateConfig)
+      .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: estimate => {
           this.isStartingManualExport = false;
@@ -1302,7 +1429,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         error: () => {
           this.isStartingManualExport = false;
           this.showError(
-            this.translateService.instant('manual-coding-export.worksheet-estimate-failed')
+            this.translateService.instant(
+              'manual-coding-export.worksheet-estimate-failed'
+            )
           );
         }
       });
@@ -1317,19 +1446,26 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
       width: '560px',
       data: {
-        title: this.translateService.instant('manual-coding-export.too-many-worksheets-title'),
+        title: this.translateService.instant(
+          'manual-coding-export.too-many-worksheets-title'
+        ),
         message: this.translateService.instant(
           'manual-coding-export.too-many-worksheets-message',
           { actual: actualWorksheetCount, max: worksheetLimit }
         ),
-        confirmButtonText: this.translateService.instant('manual-coding-export.too-many-worksheets-continue'),
-        alternativeButtonText: this.translateService.instant('manual-coding-export.too-many-worksheets-compact'),
+        confirmButtonText: this.translateService.instant(
+          'manual-coding-export.too-many-worksheets-continue'
+        ),
+        alternativeButtonText: this.translateService.instant(
+          'manual-coding-export.too-many-worksheets-compact'
+        ),
         alternativeButtonValue: 'compact',
         cancelButtonText: this.translateService.instant('cancel')
       }
     });
 
-    dialogRef.afterClosed()
+    dialogRef
+      .afterClosed()
       .pipe(takeUntil(this.destroy$))
       .subscribe(decision => {
         if (decision === true) {
@@ -1346,7 +1482,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       });
   }
 
-  private createCompactByVariableExportConfig(exportConfig: ExportJobConfig): ExportJobConfig {
+  private createCompactByVariableExportConfig(
+    exportConfig: ExportJobConfig
+  ): ExportJobConfig {
     return {
       ...exportConfig,
       exportType: 'by-variable-compact',
@@ -1366,12 +1504,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     switch (result.doubleCodingMethod || 'most-frequent') {
       case 'new-column-per-coder':
         return {
-          displayLabelKey: 'export-toast.types.manual-review-new-column-per-coder',
+          displayLabelKey:
+            'export-toast.types.manual-review-new-column-per-coder',
           downloadFilePrefix: 'manual-review-new-column-per-coder'
         };
       case 'new-row-per-variable':
         return {
-          displayLabelKey: 'export-toast.types.manual-review-new-row-per-variable',
+          displayLabelKey:
+            'export-toast.types.manual-review-new-row-per-variable',
           downloadFilePrefix: 'manual-review-new-row-per-variable'
         };
       case 'most-frequent':
@@ -1398,7 +1538,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private getCoderTrainingsForExport(): CoderTraining[] {
     return this.coderTrainingsListComponent?.originalData.length ?
       this.coderTrainingsListComponent.originalData :
-      this.coderTrainingsListComponent?.coderTrainings ?? [];
+      (this.coderTrainingsListComponent?.coderTrainings ?? []);
   }
 
   private getJobDefinitionExportOptions(): { id: number; label: string }[] {
@@ -1416,12 +1556,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private getJobDefinitionsForManualScope(): JobDefinition[] {
-    const renderedDefinitions = this.codingJobDefinitionsComponent?.jobDefinitions;
+    const renderedDefinitions =
+      this.codingJobDefinitionsComponent?.jobDefinitions;
     if (renderedDefinitions?.length) {
       return renderedDefinitions;
     }
 
-    return this.jobDefinitionsForExportWorkspaceId === this.appService.selectedWorkspaceId ?
+    return this.jobDefinitionsForExportWorkspaceId ===
+      this.appService.selectedWorkspaceId ?
       this.jobDefinitionsForExport :
       [];
   }
@@ -1445,7 +1587,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.loadJobDefinitionsForExport();
     }
 
-    this.showError('Die Jobdefinitionen werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+    this.showError(
+      'Die Jobdefinitionen werden noch geladen. Bitte versuchen Sie es gleich erneut.'
+    );
     return false;
   }
 
@@ -1467,7 +1611,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.loadCodersForExport();
     }
 
-    this.showError('Die Kodierer werden noch geladen. Bitte versuchen Sie es gleich erneut.');
+    this.showError(
+      'Die Kodierer werden noch geladen. Bitte versuchen Sie es gleich erneut.'
+    );
     return false;
   }
 
@@ -1505,9 +1651,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   reloadCodingJobsList(): void {
-    if (this.codingJobsComponent) {
-      this.codingJobsComponent.loadCodingJobs();
-    }
+    [
+      this.productiveCodingJobsComponent,
+      this.trainingCodingJobsComponent
+    ].forEach(component => component?.loadCodingJobs());
     if (this.coderTrainingsListComponent) {
       this.coderTrainingsListComponent.loadCoderTrainings();
     }
@@ -1515,10 +1662,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   refreshManualCodingPlanning(): void {
     const activeTab = this.activeManualTab;
-    this.loadManualTabData(activeTab);
-    this.loadJobDefinitionsForExport();
+    this.loadManualTabData(activeTab, { forceRefresh: true });
+    if (!this.codingJobDefinitionsComponent) {
+      this.loadJobDefinitionsForExport({ force: true });
+    }
     if (activeTab !== 'planning') {
-      this.loadCodingFreshness();
+      this.loadCodingFreshness({ force: true });
     }
     if (this.shouldReloadCodingJobsAfterManualTabData(activeTab)) {
       this.reloadCodingJobsList();
@@ -1530,33 +1679,34 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private shouldRefreshManualStateOnFocus(): boolean {
-    return this.activeManualTab === 'planning' ||
-      this.activeManualTab === 'execution' ||
-      this.activeManualTab === 'completion';
+    return (
+      this.autoRefreshManualCodingJobs &&
+      (this.activeManualTab === 'planning' ||
+        this.activeManualTab === 'execution' ||
+        this.activeManualTab === 'completion')
+    );
   }
 
   private refreshManualStateAfterExternalChange(): void {
     const activeTab = this.activeManualTab;
     this.loadManualTabData(activeTab, { reloadCodingJobs: false });
-    this.loadJobDefinitionsForExport();
     if (activeTab !== 'planning') {
       this.loadCodingFreshness();
     }
     if (this.shouldReloadCodingJobsAfterManualTabData(activeTab)) {
       this.reloadCodingJobsList();
     }
-
-    if (this.codingJobDefinitionsComponent) {
-      this.codingJobDefinitionsComponent.refresh();
-    }
   }
 
-  private shouldReloadCodingJobsAfterManualTabData(tab: ManualCodingTab): boolean {
-    return tab !== 'training' && tab !== 'execution' && tab !== 'completion';
+  private shouldReloadCodingJobsAfterManualTabData(
+    tab: ManualCodingTab
+  ): boolean {
+    return tab === 'preparation';
   }
 
   isAnyPlanningDataLoading(): boolean {
-    return this.isLoadingResponseAnalysis ||
+    return (
+      this.isLoadingResponseAnalysis ||
       this.isLoadingCodingProgress ||
       this.isLoadingVariableCoverage ||
       this.isLoadingCaseCoverage ||
@@ -1565,7 +1715,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingAppliedResultsOverview ||
       this.isLoadingManualFreshnessJobSummary ||
       this.isLoadingDoubleCodingConflictSummary ||
-      this.isLoadingMatchingMode;
+      this.isLoadingMatchingMode
+    );
+  }
+
+  shouldShowManualRefreshControls(): boolean {
+    return !this.autoRefreshManualCodingJobs;
   }
 
   getOpenCodingCases(): number {
@@ -1573,7 +1728,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return Math.max(
         0,
         this.codingProgressOverview.totalCasesToCode -
-        this.codingProgressOverview.completedCases
+          this.codingProgressOverview.completedCases
       );
     }
 
@@ -1582,12 +1737,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   getAvailableCasesForNewJobs(): number {
     const availableCases = this.codingIncompleteVariables.reduce(
-      (sum, variable) => sum + (
-        variable.availableCases ??
-        variable.uniqueCasesAfterAggregation ??
-        variable.responseCount ??
-        0
-      ),
+      (sum, variable) => sum +
+        (variable.availableCases ??
+          variable.uniqueCasesAfterAggregation ??
+          variable.responseCount ??
+          0),
       0
     );
 
@@ -1604,7 +1758,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       0
     );
 
-    return Math.max(0, totalEffectiveCases - this.getAvailableCasesForNewJobs());
+    return Math.max(
+      0,
+      totalEffectiveCases - this.getAvailableCasesForNewJobs()
+    );
   }
 
   getVariableCoveragePercentage(): number {
@@ -1616,10 +1773,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   getCurrentRawManualResponses(): number {
-    return this.appliedResultsOverview?.rawTotalIncompleteResponses ??
+    return (
+      this.appliedResultsOverview?.rawTotalIncompleteResponses ??
       this.codingProgressOverview?.rawTotalCasesToCode ??
       this.caseCoverageOverview?.totalCasesToCode ??
-      0;
+      0
+    );
   }
 
   getResponseAnalysisReferenceRawCases(): number {
@@ -1627,20 +1786,24 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   getManualStatusPoolCount(): number {
-    return this.codingProgressOverview?.statusTotalCasesToCode ??
+    return (
+      this.codingProgressOverview?.statusTotalCasesToCode ??
       this.caseCoverageOverview?.statusTotalCasesToCode ??
       this.appliedResultsOverview?.statusTotalIncompleteResponses ??
       (this.manualCodingScopeSummary ?
         this.manualCodingScopeSummary.manualResponseCount +
-        this.manualCodingScopeSummary.coveredSourceResponseCount :
-        0);
+          this.manualCodingScopeSummary.coveredSourceResponseCount :
+        0)
+    );
   }
 
   getEffectiveManualCaseCount(): number {
-    return this.codingProgressOverview?.totalCasesToCode ??
+    return (
+      this.codingProgressOverview?.totalCasesToCode ??
       this.caseCoverageOverview?.effectiveTotalCasesToCode ??
       this.appliedResultsOverview?.totalIncompleteResponses ??
-      0;
+      0
+    );
   }
 
   getManualCaseScopeSummaryText(): string {
@@ -1657,33 +1820,40 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     const difference = statusPoolCount - effectiveCaseCount;
-    const reason = difference > 0 ?
-      `${difference} Rohantworten werden durch abgeleitete Variablen, Vorverarbeitung oder Aggregation nicht separat verteilt.` :
-      'Die effektive Fallzahl kann durch Mehrfachkodierung oder manuelle Nacharbeit abweichen.';
-    const openCaseHint = openCaseCount !== effectiveCaseCount ?
-      `, davon ${openCaseCount} offen` :
-      '';
+    const reason =
+      difference > 0 ?
+        `${difference} Rohantworten werden durch abgeleitete Variablen, Vorverarbeitung oder Aggregation nicht separat verteilt.` :
+        'Die effektive Fallzahl kann durch Mehrfachkodierung oder manuelle Nacharbeit abweichen.';
+    const openCaseHint =
+      openCaseCount !== effectiveCaseCount ?
+        `, davon ${openCaseCount} offen` :
+        '';
 
     return `${statusPoolCount} Rohantworten im Statuspool -> ${effectiveCaseCount} effektive Arbeitsfälle${openCaseHint}. ${reason}`;
   }
 
   isResponseAnalysisOutdated(): boolean {
-    const analysisRawCases = this.responseAnalysis?.aggregationSummary?.rawCases ?? 0;
-    const referenceRawCases = this.getResponseAnalysisReferenceRawCases();
-    return !!this.responseAnalysis &&
+    return (
+      !!this.responseAnalysis &&
       !this.responseAnalysis.isCalculating &&
-      referenceRawCases > 0 &&
-      analysisRawCases !== referenceRawCases;
+      this.responseAnalysis.sourceRevision !== undefined &&
+      this.responseAnalysis.currentSourceRevision !== undefined &&
+      this.responseAnalysis.sourceRevision !==
+        this.responseAnalysis.currentSourceRevision
+    );
   }
 
   hasResponseAnalysisRestScopeDifference(): boolean {
-    const analysisRawCases = this.responseAnalysis?.aggregationSummary?.rawCases ?? 0;
+    const analysisRawCases =
+      this.responseAnalysis?.aggregationSummary?.rawCases ?? 0;
     const currentRawManualResponses = this.getCurrentRawManualResponses();
-    return !!this.responseAnalysis &&
+    return (
+      !!this.responseAnalysis &&
       !this.responseAnalysis.isCalculating &&
       !this.isResponseAnalysisOutdated() &&
       currentRawManualResponses > 0 &&
-      analysisRawCases !== currentRawManualResponses;
+      analysisRawCases !== currentRawManualResponses
+    );
   }
 
   private shouldLoadResponseAnalysisForPlanning(): boolean {
@@ -1703,7 +1873,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private loadResponseAnalysisForPlanningIfNeeded(): void {
-    if (!this.isLoadingResponseAnalysis && this.shouldLoadResponseAnalysisForPlanning()) {
+    if (
+      !this.isLoadingResponseAnalysis &&
+      this.shouldLoadResponseAnalysisForPlanning()
+    ) {
       this.loadResponseAnalysis();
     }
   }
@@ -1716,21 +1889,27 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   hasPreparationWarnings(): boolean {
-    return this.hasUncodedEmptyResponses() ||
-      this.hasDuplicateFindingsWithoutAggregation;
+    return (
+      this.hasUncodedEmptyResponses() ||
+      this.hasDuplicateFindingsWithoutAggregation
+    );
   }
 
   isPreparationReady(): boolean {
-    return !!this.responseAnalysis &&
+    return (
+      !!this.responseAnalysis &&
       !this.responseAnalysis.isCalculating &&
-      !this.hasPreparationWarnings();
+      !this.hasPreparationWarnings()
+    );
   }
 
   hasPlanningWarnings(): boolean {
-    return this.hasManualCodeAvailabilityWarnings ||
+    return (
+      this.hasManualCodeAvailabilityWarnings ||
       (this.variableCoverageOverview?.conflictedVariables || 0) > 0 ||
       (this.variableCoverageOverview?.missingVariables || 0) > 0 ||
-      (this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0;
+      (this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0
+    );
   }
 
   hasVariableCoverageConflicts(): boolean {
@@ -1738,9 +1917,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   isPlanningReady(): boolean {
-    return !!this.variableCoverageOverview &&
+    return (
+      !!this.variableCoverageOverview &&
       !!this.caseCoverageOverview &&
-      !this.hasPlanningWarnings();
+      !this.hasPlanningWarnings()
+    );
   }
 
   hasExecutionOpenWork(): boolean {
@@ -1748,8 +1929,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private hasPreparationRefreshTarget(): boolean {
-    return this.hasPreparationWarnings() ||
-      this.isResponseAnalysisOutdated();
+    return this.hasPreparationWarnings() || this.isResponseAnalysisOutdated();
   }
 
   private hasActiveTrainingCodingJobs(): boolean {
@@ -1789,25 +1969,31 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return this.hasCompletedProductiveManualJobs();
     }
 
-    return this.hasManualCodingProgressScope() &&
+    return (
+      this.hasManualCodingProgressScope() &&
       !!this.codingProgressOverview &&
       !!this.appliedResultsOverview &&
-      !this.hasExecutionOpenWork();
+      !this.hasExecutionOpenWork()
+    );
   }
 
   isCompletionComplete(): boolean {
-    return this.hasManualCodingProgressScope() &&
+    return (
+      this.hasManualCodingProgressScope() &&
       this.getAppliedResultsPercentage() >= 100 &&
-      this.getOpenCodingCases() === 0;
+      this.getOpenCodingCases() === 0
+    );
   }
 
   hasManualCodingProgressScope(): boolean {
-    return ((this.codingProgressOverview?.totalCasesToCode ?? 0) > 0) ||
-      ((this.codingProgressOverview?.rawTotalCasesToCode ?? 0) > 0) ||
-      ((this.appliedResultsOverview?.totalIncompleteResponses ?? 0) > 0) ||
-      ((this.appliedResultsOverview?.rawTotalIncompleteResponses ?? 0) > 0) ||
-      ((this.appliedResultsOverview?.appliedResponses ?? 0) > 0) ||
-      ((this.appliedResultsOverview?.remainingResponses ?? 0) > 0);
+    return (
+      (this.codingProgressOverview?.totalCasesToCode ?? 0) > 0 ||
+      (this.codingProgressOverview?.rawTotalCasesToCode ?? 0) > 0 ||
+      (this.appliedResultsOverview?.totalIncompleteResponses ?? 0) > 0 ||
+      (this.appliedResultsOverview?.rawTotalIncompleteResponses ?? 0) > 0 ||
+      (this.appliedResultsOverview?.appliedResponses ?? 0) > 0 ||
+      (this.appliedResultsOverview?.remainingResponses ?? 0) > 0
+    );
   }
 
   hasCompletedJobsReadyForApply(): boolean {
@@ -1819,13 +2005,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   canApplyCompletedJobResults(): boolean {
-    return this.codingJobsComponent?.canApplyResults ??
-      this.canApplyManualCodingResults;
+    return (
+      this.productiveCodingJobsComponent?.canApplyResults ??
+      this.canApplyManualCodingResults
+    );
   }
 
   canShowCompletedJobApplyActions(): boolean {
-    return this.hasCompletedJobsReadyForApply() &&
-      this.canApplyCompletedJobResults();
+    return (
+      this.hasCompletedJobsReadyForApply() && this.canApplyCompletedJobResults()
+    );
   }
 
   getCompletionActionTitle(): string {
@@ -1928,54 +2117,56 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       }
     });
 
-    dialogRef.afterClosed().subscribe((dialogResult?: ApplyCodingResultsDialogResult | false) => {
-      if (!dialogResult) {
-        return;
-      }
+    dialogRef
+      .afterClosed()
+      .subscribe((dialogResult?: ApplyCodingResultsDialogResult | false) => {
+        if (!dialogResult) {
+          return;
+        }
 
-      this.isApplyingCodingResults = true;
-      this.applyingCodingResultJobIds.add(job.id);
-      const loadingSnack = this.snackBar.open(
-        `Wende Ergebnisse für Kodierjob "${job.name}" an...`,
-        '',
-        { duration: 3000 }
-      );
+        this.isApplyingCodingResults = true;
+        this.applyingCodingResultJobIds.add(job.id);
+        const loadingSnack = this.snackBar.open(
+          `Wende Ergebnisse für Kodierjob "${job.name}" an...`,
+          '',
+          { duration: 3000 }
+        );
 
-      this.codingJobBackendService
-        .applyCodingResults(workspaceId, job.id, {
-          overwriteExisting: dialogResult.overwriteExisting
-        })
-        .pipe(
-          finalize(() => {
-            this.applyingCodingResultJobIds.delete(job.id);
-            this.isApplyingCodingResults =
-              this.applyingCodingResultJobIds.size > 0;
-            loadingSnack.dismiss();
-          }),
-          takeUntil(this.destroy$)
-        )
-        .subscribe({
-          next: result => {
-            if (result.success) {
-              this.showSuccess(this.formatApplyCodingResultsMessage(result));
-              this.refreshAfterApplyingCodingResults();
-              return;
+        this.codingJobBackendService
+          .applyCodingResults(workspaceId, job.id, {
+            overwriteExisting: dialogResult.overwriteExisting
+          })
+          .pipe(
+            finalize(() => {
+              this.applyingCodingResultJobIds.delete(job.id);
+              this.isApplyingCodingResults =
+                this.applyingCodingResultJobIds.size > 0;
+              loadingSnack.dismiss();
+            }),
+            takeUntil(this.destroy$)
+          )
+          .subscribe({
+            next: result => {
+              if (result.success) {
+                this.showSuccess(this.formatApplyCodingResultsMessage(result));
+                this.refreshAfterApplyingCodingResults();
+                return;
+              }
+
+              this.showError(
+                `Fehler beim Anwenden der Ergebnisse: ${this.translateService.instant(
+                  result.messageKey,
+                  result.messageParams || {}
+                )}`
+              );
+            },
+            error: error => {
+              this.showError(
+                `Fehler beim Anwenden der Ergebnisse: ${error.message || 'Unbekannter Fehler'}`
+              );
             }
-
-            this.showError(
-              `Fehler beim Anwenden der Ergebnisse: ${this.translateService.instant(
-                result.messageKey,
-                result.messageParams || {}
-              )}`
-            );
-          },
-          error: error => {
-            this.showError(
-              `Fehler beim Anwenden der Ergebnisse: ${error.message || 'Unbekannter Fehler'}`
-            );
-          }
-        });
-    });
+          });
+      });
   }
 
   applyAllCompletedJobResults(): void {
@@ -2061,8 +2252,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return 'warning';
     }
 
-    if ((this.variableCoverageOverview?.missingVariables || 0) > 0 ||
-        (this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0) {
+    if (
+      (this.variableCoverageOverview?.missingVariables || 0) > 0 ||
+      (this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0
+    ) {
       return 'planning-incomplete';
     }
 
@@ -2070,9 +2263,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return 'training-ready';
     }
 
-    if (this.isPlanningReady() &&
-        !!this.codingProgressOverview &&
-        this.hasExecutionOpenWorkForFreshness()) {
+    if (
+      this.isPlanningReady() &&
+      !!this.codingProgressOverview &&
+      this.hasExecutionOpenWorkForFreshness()
+    ) {
       return 'execution-ready';
     }
 
@@ -2088,10 +2283,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return 'complete';
     }
 
-    if (this.isPlanningReady() &&
-        !!this.codingProgressOverview &&
-        !!this.appliedResultsOverview &&
-        this.hasCompletionReadyWorkForFreshness()) {
+    if (
+      this.isPlanningReady() &&
+      !!this.codingProgressOverview &&
+      !!this.appliedResultsOverview &&
+      this.hasCompletionReadyWorkForFreshness()
+    ) {
       return 'completion-ready';
     }
 
@@ -2202,14 +2399,15 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return 'Alle manuellen Kodierungen sind abgeschlossen und final übernommen.';
     }
 
-    if (this.isPlanningReady() &&
-        this.hasActiveTrainingCodingJobs()) {
+    if (this.isPlanningReady() && this.hasActiveTrainingCodingJobs()) {
       return `${this.manualFreshnessJobSummary?.activeTrainingJobs || 0} aktive Schulungskodierjob(s) sollten vor der produktiven Durchführung geprüft werden.`;
     }
 
-    if (this.isPlanningReady() &&
-        !!this.codingProgressOverview &&
-        this.hasExecutionOpenWorkForFreshness()) {
+    if (
+      this.isPlanningReady() &&
+      !!this.codingProgressOverview &&
+      this.hasExecutionOpenWorkForFreshness()
+    ) {
       return 'Die Planung ist vollständig. Bearbeiten Sie nun die offenen Kodierfälle im Abschnitt Durchführung.';
     }
 
@@ -2221,10 +2419,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return `${this.manualFreshnessJobSummary?.staleSourceJobs || 0} Kodierjob(s) enthalten veraltete Quellfälle. Prüfen Sie diese Jobs in der Durchführung, bevor Ergebnisse angewendet oder weitergeführt werden.`;
     }
 
-    if (this.isPlanningReady() &&
-        !!this.codingProgressOverview &&
-        !!this.appliedResultsOverview &&
-        this.hasCompletionReadyWorkForFreshness()) {
+    if (
+      this.isPlanningReady() &&
+      !!this.codingProgressOverview &&
+      !!this.appliedResultsOverview &&
+      this.hasCompletionReadyWorkForFreshness()
+    ) {
       return this.canShowManualCompletionTab() ?
         'Alle Kodierfälle sind abgeschlossen. Übernehmen Sie nun die Kodierergebnisse in den Datenbestand.' :
         'Alle Kodierfälle sind abgeschlossen. Die Übernahme der Ergebnisse in den Datenbestand bleibt Studienmanager:innen vorbehalten.';
@@ -2284,9 +2484,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           'Klären Sie offene Vorbereitungsbefunde wie leere Antworten oder Duplikate ohne aktive Aggregation.';
       case 'planning-incomplete':
         if ((this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0) {
-          const unavailableHint = unavailableCases > 0 ?
-            ` ${unavailableCases} Fälle sind bereits in Jobs verteilt oder durch andere Definitionen reserviert.` :
-            '';
+          const unavailableHint =
+            unavailableCases > 0 ?
+              ` ${unavailableCases} Fälle sind bereits in Jobs verteilt oder durch andere Definitionen reserviert.` :
+              '';
           return `${this.caseCoverageOverview?.effectiveUnassignedCases || 0} Fälle sind noch nicht in Kodierjobs. Für neue Jobdefinitionen sind aktuell ${availableCases} Fälle verfügbar.${unavailableHint} Danach Definition freigeben und Jobs erstellen.`;
         }
         return 'Ordnen Sie die fehlenden Variablen einer Jobdefinition zu. Danach Definition freigeben und Jobs erstellen.';
@@ -2328,9 +2529,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'stale-source-review':
         return 'Veraltete Jobs prüfen';
       case 'completion-ready':
-        return this.canShowManualCompletionTab() ? 'Zum Abschluss' : 'Zu den Kodierjobs';
+        return this.canShowManualCompletionTab() ?
+          'Zum Abschluss' :
+          'Zu den Kodierjobs';
       case 'complete':
-        return this.canShowManualCompletionTab() ? 'Abschluss ansehen' : 'Zu den Kodierjobs';
+        return this.canShowManualCompletionTab() ?
+          'Abschluss ansehen' :
+          'Zu den Kodierjobs';
       case 'loading':
       case 'progress-unavailable':
         return 'Aktualisieren';
@@ -2393,7 +2598,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'complete':
         return {
           tab: this.canShowManualCompletionTab() ? 'completion' : 'execution',
-          sectionId: this.canShowManualCompletionTab() ? 'manual-completion' : 'manual-execution',
+          sectionId: this.canShowManualCompletionTab() ?
+            'manual-completion' :
+            'manual-execution',
           action: 'navigate'
         };
       default:
@@ -2407,7 +2614,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   performPlanningNextStep(): void {
     const planningStatusState = this.getPlanningStatusState();
-    if (planningStatusState === 'loading' || planningStatusState === 'progress-unavailable') {
+    if (
+      planningStatusState === 'loading' ||
+      planningStatusState === 'progress-unavailable'
+    ) {
       this.refreshManualCodingPlanning();
       return;
     }
@@ -2452,10 +2662,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private get allCodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
     return (this.codingFreshnessSummary?.items || [])
       .filter(isCodingFreshnessOpenWarning)
-      .sort((a, b) => (
-        a.version.localeCompare(b.version) ||
-        a.state.localeCompare(b.state)
-      ));
+      .sort(
+        (a, b) => a.version.localeCompare(b.version) || a.state.localeCompare(b.state)
+      );
   }
 
   get hasCodingFreshnessWarnings(): boolean {
@@ -2571,13 +2780,18 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private get hasOnlySecondAutocodingWarnings(): boolean {
-    return this.codingFreshnessWarnings.length > 0 &&
-      this.codingFreshnessWarnings.every(item => item.version === 'v3');
+    return (
+      this.codingFreshnessWarnings.length > 0 &&
+      this.codingFreshnessWarnings.every(item => item.version === 'v3')
+    );
   }
 
-  private refreshAggregationDependentViews(includeResponseAnalysis = true): void {
+  private refreshAggregationDependentViews(
+    includeResponseAnalysis = true
+  ): void {
+    this.loadedManualTabs.clear();
     if (includeResponseAnalysis) {
-      this.loadResponseAnalysis();
+      this.loadResponseAnalysis({ force: true });
     }
     this.loadVariableCoverageOverview();
     this.loadCaseCoverageOverview();
@@ -2585,7 +2799,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.loadCodingIncompleteVariables();
     this.loadStatusDistributionV2();
     this.reloadCodingJobsList();
-    this.loadJobDefinitionsForExport();
+    this.loadJobDefinitionsForExport({ force: true });
 
     if (this.codingJobDefinitionsComponent) {
       this.codingJobDefinitionsComponent.refresh();
@@ -2615,7 +2829,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         next: settings => {
           this.responseMatchingFlags = settings.flags;
           this.persistedResponseMatchingFlags = [...settings.flags];
-          this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(settings.threshold);
+          this.duplicateAggregationThreshold =
+            this.normalizeAggregationThreshold(settings.threshold);
           this.loadManualTabData(this.activeManualTab);
         },
         error: () => {
@@ -2629,12 +2844,22 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private loadManualTabData(
     tab: ManualCodingTab,
-    options: { reloadCodingJobs?: boolean } = {}
+    options: { reloadCodingJobs?: boolean; forceRefresh?: boolean } = {}
   ): void {
     if (!this.isManualTabAvailable(tab)) {
       return;
     }
 
+    const forceRefresh = options.forceRefresh ?? false;
+    if (
+      !forceRefresh &&
+      !this.autoRefreshManualCodingJobs &&
+      this.loadedManualTabs.has(tab)
+    ) {
+      return;
+    }
+
+    this.loadedManualTabs.add(tab);
     const reloadCodingJobs = options.reloadCodingJobs ?? true;
     switch (tab) {
       case 'preparation':
@@ -2646,7 +2871,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.loadCodingProgressOverview();
         this.loadCodingIncompleteVariables();
         this.loadManualFreshnessDecisionData();
-        this.loadCodingFreshness();
+        if (this.autoRefreshManualCodingJobs || forceRefresh) {
+          this.loadCodingFreshness({ force: forceRefresh });
+        }
         this.loadResponseAnalysisForPlanningIfNeeded();
         return;
       case 'training':
@@ -2671,10 +2898,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
   }
 
-  private loadManualCodingJobRefreshSetting(): void {
+  private loadManualCodingJobRefreshSetting(
+    afterSettingLoaded?: () => void
+  ): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
       this.autoRefreshManualCodingJobs = true;
+      afterSettingLoaded?.();
       return;
     }
 
@@ -2683,6 +2913,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(enabled => {
         this.autoRefreshManualCodingJobs = enabled;
+        if (!enabled) {
+          this.codingFreshnessRequestGeneration += 1;
+          this.isLoadingCodingFreshness = false;
+        }
+        afterSettingLoaded?.();
       });
   }
 
@@ -2692,8 +2927,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
     if (this.appService.authData.isAdmin || !workspaceId || userId <= 0) {
       const activeTab = this.activeManualTab;
-      this.canApplyManualCodingResults = this.appService.authData.isAdmin === true;
-      this.canManageManualCodingJobs = this.appService.authData.isAdmin === true;
+      this.canApplyManualCodingResults =
+        this.appService.authData.isAdmin === true;
+      this.canManageManualCodingJobs =
+        this.appService.authData.isAdmin === true;
       this.keepAvailableManualTabSelected(activeTab);
       this.requestManualFreshnessFocusIfNeeded();
       return;
@@ -2730,19 +2967,26 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return this.visibleManualCodingTabs.includes(tab);
   }
 
-  private keepAvailableManualTabSelected(previousActiveTab: ManualCodingTab): void {
+  private keepAvailableManualTabSelected(
+    previousActiveTab: ManualCodingTab
+  ): void {
     if (this.isManualTabAvailable(previousActiveTab)) {
-      this.selectedManualTabIndex = this.visibleManualCodingTabs.indexOf(previousActiveTab);
+      this.selectedManualTabIndex =
+        this.visibleManualCodingTabs.indexOf(previousActiveTab);
       return;
     }
 
     const executionTabIndex = this.visibleManualCodingTabs.indexOf('execution');
-    this.selectedManualTabIndex = executionTabIndex >= 0 ? executionTabIndex : 0;
+    this.selectedManualTabIndex =
+      executionTabIndex >= 0 ? executionTabIndex : 0;
     this.loadManualTabData(this.activeManualTab);
   }
 
   private requestManualFreshnessFocusIfNeeded(): void {
-    if (!this.pendingManualFreshnessFocus || this.manualFreshnessPlanningRequested) {
+    if (
+      !this.pendingManualFreshnessFocus ||
+      this.manualFreshnessPlanningRequested
+    ) {
       return;
     }
 
@@ -2752,9 +2996,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private focusManualFreshnessTargetIfReady(): void {
-    if (!this.pendingManualFreshnessFocus ||
-        !this.manualFreshnessPlanningRequested ||
-        this.isAnyPlanningDataLoading()) {
+    if (
+      !this.pendingManualFreshnessFocus ||
+      !this.manualFreshnessPlanningRequested ||
+      this.isAnyPlanningDataLoading()
+    ) {
       return;
     }
 
@@ -2788,7 +3034,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     });
   }
 
-  private loadJobDefinitionsForExport(): void {
+  private loadJobDefinitionsForExport(options: { force?: boolean } = {}): void {
     const workspaceId = this.appService.selectedWorkspaceId;
 
     if (!workspaceId) {
@@ -2803,6 +3049,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.jobDefinitionsForExport = [];
       this.hasLoadedJobDefinitionsForExport = false;
       this.jobDefinitionsForExportWorkspaceId = workspaceId;
+    }
+
+    if (
+      !options.force &&
+      (this.isLoadingJobDefinitionsForExport ||
+        this.hasLoadedJobDefinitionsForExport)
+    ) {
+      return;
     }
 
     this.isLoadingJobDefinitionsForExport = true;
@@ -2856,7 +3110,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     this.isLoadingCodersForExport = true;
-    this.coderService.getCodersForExport()
+    this.coderService
+      .getCodersForExport()
       .pipe(
         takeUntil(this.destroy$),
         finalize(() => {
@@ -2898,9 +3153,15 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
             return;
           }
 
-          const missing = this.toMissingProfileDto(profile)?.parseMissings()
+          const missing = this.toMissingProfileDto(profile)
+            ?.parseMissings()
             .find(entry => entry.id === 'mir');
-          if (!missing || !Number.isInteger(Number(missing.code)) || !this.hasExplicitScoreProperty(missing) || !this.hasExplicitValidScore(missing.score)) {
+          if (
+            !missing ||
+            !Number.isInteger(Number(missing.code)) ||
+            !this.hasExplicitScoreProperty(missing) ||
+            !this.hasExplicitValidScore(missing.score)
+          ) {
             this.emptyResponseMissing = null;
             return;
           }
@@ -2916,7 +3177,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       });
   }
 
-  private toMissingProfileDto(profile: MissingsProfilesDto | null): MissingsProfilesDto | null {
+  private toMissingProfileDto(
+    profile: MissingsProfilesDto | null
+  ): MissingsProfilesDto | null {
     return profile ? Object.assign(new MissingsProfilesDto(), profile) : null;
   }
 
@@ -2969,24 +3232,59 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return score === null ? 'NA' : score;
   }
 
-  private loadCodingFreshness(): void {
+  private loadCodingFreshness(options: { force?: boolean } = {}): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.codingFreshnessRequestGeneration += 1;
       this.codingFreshnessSummary = null;
+      this.isLoadingCodingFreshness = false;
       return;
     }
 
+    if (!options.force && !this.autoRefreshManualCodingJobs) {
+      this.codingFreshnessRequestGeneration += 1;
+      this.isLoadingCodingFreshness = false;
+      return;
+    }
+
+    const now = Date.now();
+    if (
+      !options.force &&
+      (this.isLoadingCodingFreshness ||
+        (this.codingFreshnessSummary &&
+          now - this.lastCodingFreshnessRefreshAt <
+            this.codingFreshnessRefreshThrottleMs))
+    ) {
+      return;
+    }
+
+    const requestGeneration = this.codingFreshnessRequestGeneration + 1;
+    this.codingFreshnessRequestGeneration = requestGeneration;
     this.isLoadingCodingFreshness = true;
     this.testPersonCodingService
       .getCodingFreshness(workspaceId)
       .pipe(
         takeUntil(this.destroy$),
         finalize(() => {
-          this.isLoadingCodingFreshness = false;
+          if (
+            this.codingFreshnessRequestGeneration === requestGeneration &&
+            this.appService.selectedWorkspaceId === workspaceId
+          ) {
+            this.isLoadingCodingFreshness = false;
+          }
         })
       )
       .subscribe(summary => {
+        if (
+          this.codingFreshnessRequestGeneration !== requestGeneration ||
+          this.appService.selectedWorkspaceId !== workspaceId ||
+          (!options.force && !this.autoRefreshManualCodingJobs)
+        ) {
+          return;
+        }
+
         this.codingFreshnessSummary = summary;
+        this.lastCodingFreshnessRefreshAt = Date.now();
       });
   }
 
@@ -3058,8 +3356,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       )
       .subscribe({
         next: response => {
-          this.manualFreshnessJobSummary =
-            this.buildManualFreshnessJobSummary(response.data || []);
+          this.manualFreshnessJobSummary = this.buildManualFreshnessJobSummary(
+            response.data || []
+          );
         },
         error: () => {
           this.manualFreshnessJobSummary = null;
@@ -3072,8 +3371,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return false;
     }
 
-    return !this.hasActiveTrainingCodingJobs() &&
-      !this.hasOpenProductiveManualJobs();
+    return (
+      !this.hasActiveTrainingCodingJobs() && !this.hasOpenProductiveManualJobs()
+    );
   }
 
   private loadOpenDoubleCodingConflictSummary(): void {
@@ -3115,7 +3415,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       });
   }
 
-  private buildManualFreshnessJobSummary(jobs: CodingJob[]): ManualFreshnessJobSummary {
+  private buildManualFreshnessJobSummary(
+    jobs: CodingJob[]
+  ): ManualFreshnessJobSummary {
     return jobs.reduce<ManualFreshnessJobSummary>(
       (summary, job) => {
         if (job.freshnessStatus === 'stale_source') {
@@ -3134,8 +3436,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           return summary;
         }
 
-        if (this.isCompletedManualCodingJob(job) &&
-            job.freshnessStatus !== 'stale_source') {
+        if (
+          this.isCompletedManualCodingJob(job) &&
+          job.freshnessStatus !== 'stale_source'
+        ) {
           summary.completedProductiveJobs += 1;
         }
 
@@ -3159,9 +3463,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return false;
     }
 
-    return job.status === 'open' ||
+    return (
+      job.status === 'open' ||
       (job.openUnits ?? 0) > 0 ||
-      (job.totalUnits ?? 0) > 0;
+      (job.totalUnits ?? 0) > 0
+    );
   }
 
   private isCompletedManualCodingJob(job: CodingJob): boolean {
@@ -3174,9 +3480,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     const totalUnits = job.totalUnits ?? 0;
-    return totalUnits > 0 &&
+    return (
+      totalUnits > 0 &&
       (job.openUnits ?? 0) === 0 &&
-      (job.codedUnits ?? 0) >= totalUnits;
+      (job.codedUnits ?? 0) >= totalUnits
+    );
   }
 
   private loadVariableCoverageOverview(): void {
@@ -3196,38 +3504,40 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         })
       )
       .subscribe({
-        next: (overview: {
-          totalVariables: number;
-          coveredVariables: number;
-          coveredByDraft: number;
-          coveredByPendingReview: number;
-          coveredByApproved: number;
-          conflictedVariables: number;
-          missingVariables: number;
-          partiallyAbgedeckteVariablen?: number;
-          fullyAbgedeckteVariablen?: number;
-          coveragePercentage: number;
-          variableCaseCounts: {
-            unitName: string;
-            variableId: string;
-            caseCount: number;
-          }[];
-          coverageByStatus: {
-            draft: string[];
-            pending_review: string[];
-            approved: string[];
-            conflicted: Array<{
-              variableKey: string;
-              conflictingDefinitions: Array<{
-                id: number;
-                status: string;
+        next: (
+          overview: {
+            totalVariables: number;
+            coveredVariables: number;
+            coveredByDraft: number;
+            coveredByPendingReview: number;
+            coveredByApproved: number;
+            conflictedVariables: number;
+            missingVariables: number;
+            partiallyAbgedeckteVariablen?: number;
+            fullyAbgedeckteVariablen?: number;
+            coveragePercentage: number;
+            variableCaseCounts: {
+              unitName: string;
+              variableId: string;
+              caseCount: number;
+            }[];
+            coverageByStatus: {
+              draft: string[];
+              pending_review: string[];
+              approved: string[];
+              conflicted: Array<{
+                variableKey: string;
+                conflictingDefinitions: Array<{
+                  id: number;
+                  status: string;
+                }>;
               }>;
-            }>;
-          };
-          statusTotalVariables?: number;
-          coveredSourceVariableCount?: number;
-          coveredSourceResponseCount?: number;
-        } | null) => {
+            };
+            statusTotalVariables?: number;
+            coveredSourceVariableCount?: number;
+            coveredSourceResponseCount?: number;
+          } | null
+        ) => {
           this.variableCoverageOverview = overview;
         },
         error: () => {
@@ -3278,26 +3588,28 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         })
       )
       .subscribe({
-        next: (summary: {
-          coderPairs: Array<{
-            coder1Id: number;
-            coder1Name: string;
-            coder2Id: number;
-            coder2Name: string;
-            kappa: number | null;
-            agreement: number;
-            totalSharedResponses: number;
-            validPairs: number;
-            interpretation: string;
-          }>;
-          workspaceSummary: {
-            totalDoubleCodedResponses: number;
-            totalCoderPairs: number;
-            averageKappa: number | null;
-            variablesIncluded: number;
-            codersIncluded: number;
-          };
-        } | null) => {
+        next: (
+          summary: {
+            coderPairs: Array<{
+              coder1Id: number;
+              coder1Name: string;
+              coder2Id: number;
+              coder2Name: string;
+              kappa: number | null;
+              agreement: number;
+              totalSharedResponses: number;
+              validPairs: number;
+              interpretation: string;
+            }>;
+            workspaceSummary: {
+              totalDoubleCodedResponses: number;
+              totalCoderPairs: number;
+              averageKappa: number | null;
+              variablesIncluded: number;
+              codersIncluded: number;
+            };
+          } | null
+        ) => {
           this.workspaceKappaSummary = summary;
         },
         error: () => {
@@ -3444,22 +3756,54 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private loadAppliedResultsOverview(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.appliedResultsOverviewRequestGeneration += 1;
+      this.appliedResultsOverviewRequestKey = undefined;
       this.isLoadingAppliedResultsOverview = false;
       return;
     }
 
+    const requestKey = `${workspaceId}`;
+    if (
+      this.isLoadingAppliedResultsOverview &&
+      this.appliedResultsOverviewRequestKey === requestKey
+    ) {
+      return;
+    }
+
+    const requestGeneration = this.appliedResultsOverviewRequestGeneration + 1;
+    this.appliedResultsOverviewRequestGeneration = requestGeneration;
+    this.appliedResultsOverviewRequestKey = requestKey;
     this.isLoadingAppliedResultsOverview = true;
     this.testPersonCodingService
       .getAppliedResultsOverview(workspaceId)
       .pipe(
         takeUntil(this.destroy$),
         finalize(() => {
-          this.isLoadingAppliedResultsOverview = false;
-          this.focusManualFreshnessTargetIfReady();
+          if (
+            this.isCurrentAppliedResultsOverviewRequest(
+              requestKey,
+              requestGeneration,
+              workspaceId
+            )
+          ) {
+            this.isLoadingAppliedResultsOverview = false;
+            this.appliedResultsOverviewRequestKey = undefined;
+            this.focusManualFreshnessTargetIfReady();
+          }
         })
       )
       .subscribe({
         next: overview => {
+          if (
+            !this.isCurrentAppliedResultsOverviewRequest(
+              requestKey,
+              requestGeneration,
+              workspaceId
+            )
+          ) {
+            return;
+          }
+
           if (!overview) {
             this.appliedResultsOverview = null;
             return;
@@ -3477,9 +3821,31 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           };
         },
         error: () => {
+          if (
+            !this.isCurrentAppliedResultsOverviewRequest(
+              requestKey,
+              requestGeneration,
+              workspaceId
+            )
+          ) {
+            return;
+          }
+
           this.appliedResultsOverview = null;
         }
       });
+  }
+
+  private isCurrentAppliedResultsOverviewRequest(
+    requestKey: string,
+    requestGeneration: number,
+    workspaceId: number
+  ): boolean {
+    return (
+      this.appliedResultsOverviewRequestKey === requestKey &&
+      this.appliedResultsOverviewRequestGeneration === requestGeneration &&
+      this.appService.selectedWorkspaceId === workspaceId
+    );
   }
 
   private loadCompletedJobsReadyForApply(): void {
@@ -3496,8 +3862,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: response => {
-          const completedJobs = (response.data || [])
-            .filter(job => this.isCodingJobReadyForApply(job));
+          const completedJobs = (response.data || []).filter(job => this.isCodingJobReadyForApply(job)
+          );
 
           if (completedJobs.length === 0) {
             this.completedJobsReadyForApply = [];
@@ -3507,26 +3873,31 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           }
 
           this.codingJobBackendService
-            .getBulkCodingProgress(workspaceId, completedJobs.map(job => job.id))
+            .getBulkCodingProgress(
+              workspaceId,
+              completedJobs.map(job => job.id)
+            )
             .pipe(takeUntil(this.destroy$))
             .subscribe({
               next: progressByJobId => {
-                this.completedJobsReadyForApply = completedJobs
-                  .map(job => ({
-                    ...job,
-                    hasIssues: this.hasCodingIssuesForCompletedJob(
-                      job,
-                      progressByJobId[job.id]
-                    )
-                  }));
-                this.completedJobsBlockedForReview = this.completedJobsReadyForApply
-                  .filter(job => job.hasIssues === true);
+                this.completedJobsReadyForApply = completedJobs.map(job => ({
+                  ...job,
+                  hasIssues: this.hasCodingIssuesForCompletedJob(
+                    job,
+                    progressByJobId[job.id]
+                  )
+                }));
+                this.completedJobsBlockedForReview =
+                  this.completedJobsReadyForApply.filter(
+                    job => job.hasIssues === true
+                  );
                 this.isLoadingCompletedJobsReadyForApply = false;
               },
               error: () => {
                 this.completedJobsReadyForApply = completedJobs;
-                this.completedJobsBlockedForReview = completedJobs
-                  .filter(job => job.hasIssues === true);
+                this.completedJobsBlockedForReview = completedJobs.filter(
+                  job => job.hasIssues === true
+                );
                 this.isLoadingCompletedJobsReadyForApply = false;
               }
             });
@@ -3550,10 +3921,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       }
 
       const savedCode = value as SavedCodeProgress;
-      return savedCode.id === -1 ||
+      return (
+        savedCode.id === -1 ||
         savedCode.id === -2 ||
         savedCode.codingIssueOption === -1 ||
-        savedCode.codingIssueOption === -2;
+        savedCode.codingIssueOption === -2
+      );
     });
   }
 
@@ -3569,10 +3942,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private isCodingJobReadyForApply(job: CodingJob): boolean {
-    return ['completed', 'review'].includes(job.status) &&
+    return (
+      ['completed', 'review'].includes(job.status) &&
       job.freshnessStatus !== 'stale_source' &&
       !job.training?.id &&
-      !job.training_id;
+      !job.training_id
+    );
   }
 
   private performBulkApplyCompletedJobResults(workspaceId: number): void {
@@ -3618,9 +3993,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         statisticsVersion: 'v2'
       });
     }
+    this.loadedManualTabs.clear();
     this.refreshAllStatistics();
-    this.loadResponseAnalysis();
-    this.loadCodingFreshness();
+    this.loadResponseAnalysis({ force: true });
+    this.loadCodingFreshness({ force: true });
     this.reloadCodingJobsList();
   }
 
@@ -3716,6 +4092,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
             `Schulung erfolgreich generiert: ${packages.length} Kodierer-Pakete mit insgesamt ${totalResponses} Antworten erstellt`
           );
           this.closeCoderTraining();
+          this.loadedManualTabs.clear();
           this.refreshAllStatistics();
           this.reloadCodingJobsList();
         },
@@ -3739,8 +4116,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   get hasDeriveErrorManualCases(): boolean {
-    return (this.appliedResultsOverview?.deriveErrorRawTotalResponses ?? 0) > 0 ||
-      (this.appliedResultsOverview?.deriveErrorTotalResponses ?? 0) > 0;
+    return (
+      (this.appliedResultsOverview?.deriveErrorRawTotalResponses ?? 0) > 0 ||
+      (this.appliedResultsOverview?.deriveErrorTotalResponses ?? 0) > 0
+    );
   }
 
   get deriveErrorManualCases(): number {
@@ -3764,9 +4143,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   get hasDuplicateFindingsWithoutAggregation(): boolean {
-    return !!this.responseAnalysis &&
+    return (
+      !!this.responseAnalysis &&
       !this.responseAnalysis.aggregationSummary.aggregationActive &&
-      this.responseAnalysis.duplicateValues.total > 0;
+      this.responseAnalysis.duplicateValues.total > 0
+    );
   }
 
   getVariableEffectiveCaseCount(variable: {
@@ -3784,7 +4165,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return Math.max(
       0,
       this.caseCoverageOverview.effectiveCasesInJobs -
-      this.caseCoverageOverview.doubleCodedCases
+        this.caseCoverageOverview.doubleCodedCases
     );
   }
 
@@ -3815,7 +4196,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         next: settings => {
           this.responseMatchingFlags = settings.flags;
           this.persistedResponseMatchingFlags = [...settings.flags];
-          this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(settings.threshold);
+          this.duplicateAggregationThreshold =
+            this.normalizeAggregationThreshold(settings.threshold);
           this.isLoadingMatchingMode = false;
         },
         error: () => {
@@ -3841,7 +4223,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         next: settings => {
           this.responseMatchingFlags = settings.flags;
           this.persistedResponseMatchingFlags = [...settings.flags];
-          this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(settings.threshold);
+          this.duplicateAggregationThreshold =
+            this.normalizeAggregationThreshold(settings.threshold);
           this.loadResponseAnalysis();
         },
         error: () => {
@@ -3863,8 +4246,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   hasPendingAggregationOptionsWithoutAggregation(): boolean {
-    return this.hasMatchingFlag(ResponseMatchingFlag.NO_AGGREGATION) &&
-      this.getSelectedAggregationOptionFlags().length > 0;
+    return (
+      this.hasMatchingFlag(ResponseMatchingFlag.NO_AGGREGATION) &&
+      this.getSelectedAggregationOptionFlags().length > 0
+    );
   }
 
   onAggregationModeChanged(aggregateResponses: boolean): void {
@@ -3931,7 +4316,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     aggregateResponses: boolean,
     optionFlags: ResponseMatchingFlag[]
   ): ResponseMatchingFlag[] {
-    const selectedOptionFlags = this.getSelectedAggregationOptionFlags(optionFlags);
+    const selectedOptionFlags =
+      this.getSelectedAggregationOptionFlags(optionFlags);
     return aggregateResponses ?
       selectedOptionFlags :
       [ResponseMatchingFlag.NO_AGGREGATION, ...selectedOptionFlags];
@@ -3995,7 +4381,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           next: result => {
             this.persistedResponseMatchingFlags = [...result.flags];
             this.responseMatchingFlags = localFlagsAfterSave ?? result.flags;
-            this.duplicateAggregationThreshold = this.normalizeAggregationThreshold(result.threshold);
+            this.duplicateAggregationThreshold =
+              this.normalizeAggregationThreshold(result.threshold);
             if (showSuccessMessage) {
               this.showSuccess(
                 this.translateService.instant(
@@ -4036,10 +4423,21 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return previous.every(flag => current.includes(flag));
   }
 
-  loadResponseAnalysis(): void {
+  loadResponseAnalysis(options: ResponseAnalysisLoadOptions = {}): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.responseAnalysisRequestGeneration += 1;
       this.isLoadingResponseAnalysis = false;
+      this.responseAnalysisRequestKey = undefined;
+      return;
+    }
+
+    const requestKey = this.getResponseAnalysisRequestKey(workspaceId);
+    if (
+      !options.force &&
+      this.isLoadingResponseAnalysis &&
+      this.responseAnalysisRequestKey === requestKey
+    ) {
       return;
     }
 
@@ -4048,6 +4446,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.analysisPollingTimer = undefined;
     }
 
+    const requestGeneration = this.responseAnalysisRequestGeneration + 1;
+    this.responseAnalysisRequestGeneration = requestGeneration;
+    this.responseAnalysisRequestKey = requestKey;
     this.isLoadingResponseAnalysis = true;
     this.responseAnalysisError = null;
     this.testPersonCodingService
@@ -4059,38 +4460,81 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.duplicatePageIndex + 1,
         this.duplicatePageSize
       )
-      .pipe(takeUntil(this.destroy$))
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          if (this.isCurrentResponseAnalysisRequest(
+            requestKey,
+            requestGeneration
+          )) {
+            this.isLoadingResponseAnalysis = false;
+            this.responseAnalysisRequestKey = undefined;
+          }
+        })
+      )
       .subscribe({
         next: (analysis: ResponseAnalysisDto & { isCalculating?: boolean }) => {
+          if (!this.isCurrentResponseAnalysisRequest(
+            requestKey,
+            requestGeneration
+          )) {
+            return;
+          }
+
           this.responseAnalysis = analysis;
           this.responseAnalysisError = null;
-          this.isLoadingResponseAnalysis = false;
           this.focusManualFreshnessTargetIfReady();
 
           if (analysis.isCalculating) {
-            // Poll every 5 seconds if calculating
             this.analysisPollingTimer = setTimeout(() => {
               if (this.responseAnalysis?.isCalculating) {
                 this.loadResponseAnalysis();
               }
-            }, 5000);
+            }, this.responseAnalysisPollingDelayMs);
           }
         },
         error: error => {
-          this.isLoadingResponseAnalysis = false;
+          if (!this.isCurrentResponseAnalysisRequest(
+            requestKey,
+            requestGeneration
+          )) {
+            return;
+          }
+
           this.focusManualFreshnessTargetIfReady();
           this.responseAnalysis = null;
           this.responseAnalysisError = `Fehler beim Laden der Antwortanalyse: ${error.message || error}`;
-          this.snackBar.open(
-            this.responseAnalysisError,
-            'OK',
-            { duration: 3000 }
-          );
+          this.snackBar.open(this.responseAnalysisError, 'OK', {
+            duration: 3000
+          });
         }
       });
   }
 
-  restartAnalysis(rollbackResponseMatchingFlags?: ResponseMatchingFlag[]): void {
+  private isCurrentResponseAnalysisRequest(
+    requestKey: string,
+    requestGeneration: number
+  ): boolean {
+    return (
+      this.responseAnalysisRequestKey === requestKey &&
+      this.responseAnalysisRequestGeneration === requestGeneration
+    );
+  }
+
+  private getResponseAnalysisRequestKey(workspaceId: number): string {
+    return [
+      workspaceId,
+      this.normalizeAggregationThreshold(this.duplicateAggregationThreshold),
+      this.emptyPageIndex + 1,
+      this.emptyPageSize,
+      this.duplicatePageIndex + 1,
+      this.duplicatePageSize
+    ].join(':');
+  }
+
+  restartAnalysis(
+    rollbackResponseMatchingFlags?: ResponseMatchingFlag[]
+  ): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) return;
 
@@ -4103,17 +4547,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const shouldRefreshAggregationDependentViews = shouldSaveMatchingMode;
     let settingsReadyForAnalysis = !shouldSaveMatchingMode;
 
+    this.responseAnalysisRequestGeneration += 1;
+    this.responseAnalysisRequestKey = undefined;
     this.isLoadingResponseAnalysis = true;
     this.responseAnalysisError = null;
     const saveMatchingMode$ = shouldSaveMatchingMode ?
-      this.saveResponseMatchingMode(
-        targetMatchingFlags,
-        {
-          localFlagsAfterSave,
-          rollbackFlags: rollbackResponseMatchingFlags,
-          showSuccessMessage: false
-        }
-      ) :
+      this.saveResponseMatchingMode(targetMatchingFlags, {
+        localFlagsAfterSave,
+        rollbackFlags: rollbackResponseMatchingFlags,
+        showSuccessMessage: false
+      }) :
       of(undefined);
 
     saveMatchingMode$
@@ -4121,20 +4564,24 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         tap(() => {
           settingsReadyForAnalysis = true;
         }),
-        switchMap(() => this.codingJobBackendService
-          .triggerResponseAnalysis(
-            workspaceId,
-            this.normalizeAggregationThreshold(this.duplicateAggregationThreshold)
-          )),
+        switchMap(() => this.codingJobBackendService.triggerResponseAnalysis(
+          workspaceId,
+          this.normalizeAggregationThreshold(
+            this.duplicateAggregationThreshold
+          )
+        )
+        ),
         takeUntil(this.destroy$)
       )
       .subscribe({
         next: () => {
-          this.snackBar.open('Antwortanalyse wurde gestartet.', 'OK', { duration: 3000 });
+          this.snackBar.open('Antwortanalyse wurde gestartet.', 'OK', {
+            duration: 3000
+          });
           if (shouldRefreshAggregationDependentViews) {
             this.refreshAggregationDependentViews(false);
           }
-          this.loadResponseAnalysis(); // Start polling
+          this.loadResponseAnalysis({ force: true }); // Start polling
         },
         error: error => {
           this.isLoadingResponseAnalysis = false;
@@ -4150,7 +4597,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   refreshResponseAnalysis(): void {
-    this.loadResponseAnalysis();
+    this.loadResponseAnalysis({ force: true });
   }
 
   toggleEmptyResponsesDetails(): void {
@@ -4184,51 +4631,58 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       }
     });
 
-    dialogRef.afterClosed().pipe(takeUntil(this.destroy$)).subscribe((confirmed: unknown) => {
-      if (!confirmed) {
-        return;
-      }
+    dialogRef
+      .afterClosed()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((confirmed: unknown) => {
+        if (!confirmed) {
+          return;
+        }
 
-      this.isApplyingEmptyCoding = true;
+        this.isApplyingEmptyCoding = true;
 
-      this.testPersonCodingService
-        .applyEmptyResponseCoding(workspaceId)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: (result: { success: boolean; updatedCount: number; message: string; }) => {
-            this.isApplyingEmptyCoding = false;
+        this.testPersonCodingService
+          .applyEmptyResponseCoding(workspaceId)
+          .pipe(takeUntil(this.destroy$))
+          .subscribe({
+            next: (result: {
+              success: boolean;
+              updatedCount: number;
+              message: string;
+            }) => {
+              this.isApplyingEmptyCoding = false;
 
-            if (result.success) {
-              this.showSuccess(
-                this.translateService.instant(
-                  'coding-management-manual.response-analysis.apply-empty-coding-success',
-                  { count: result.updatedCount }
-                )
-              );
+              if (result.success) {
+                this.showSuccess(
+                  this.translateService.instant(
+                    'coding-management-manual.response-analysis.apply-empty-coding-success',
+                    { count: result.updatedCount }
+                  )
+                );
 
-              // Refresh analysis and statistics
-              this.restartAnalysis();
-              this.refreshAllStatistics();
-            } else {
+                // Refresh analysis and statistics
+                this.restartAnalysis();
+                this.refreshAllStatistics();
+              } else {
+                this.showError(
+                  this.translateService.instant(
+                    'coding-management-manual.response-analysis.apply-empty-coding-error',
+                    { error: result.message }
+                  )
+                );
+              }
+            },
+            error: () => {
+              this.isApplyingEmptyCoding = false;
               this.showError(
                 this.translateService.instant(
                   'coding-management-manual.response-analysis.apply-empty-coding-error',
-                  { error: result.message }
+                  { error: 'Unbekannter Fehler' }
                 )
               );
             }
-          },
-          error: () => {
-            this.isApplyingEmptyCoding = false;
-            this.showError(
-              this.translateService.instant(
-                'coding-management-manual.response-analysis.apply-empty-coding-error',
-                { error: 'Unbekannter Fehler' }
-              )
-            );
-          }
-        });
-    });
+          });
+      });
   }
 
   onApplyDuplicateAggregation(): void {
@@ -4238,9 +4692,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     // Filter groups that meet the threshold
-    const groupsMeetingThreshold = this.responseAnalysis.duplicateValues.groups.filter(
-      group => group.occurrences.length >= this.duplicateAggregationThreshold
-    );
+    const groupsMeetingThreshold =
+      this.responseAnalysis.duplicateValues.groups.filter(
+        group => (group.occurrenceCount ?? group.occurrences.length) >=
+          this.duplicateAggregationThreshold
+      );
 
     if (groupsMeetingThreshold.length === 0) {
       this.showError(
@@ -4253,7 +4709,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     const totalResponsesInGroups = groupsMeetingThreshold.reduce(
-      (sum, group) => sum + group.occurrences.length,
+      (sum, group) => sum + (group.occurrenceCount ?? group.occurrences.length),
       0
     );
 
@@ -4264,69 +4720,77 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       threshold: this.duplicateAggregationThreshold
     };
 
-    const dialogRef = this.dialog.open(ApplyDuplicateAggregationDialogComponent, {
-      width: '550px',
-      data: dialogData
-    });
-
-    dialogRef.afterClosed().pipe(takeUntil(this.destroy$)).subscribe((confirmed: unknown) => {
-      if (!confirmed) {
-        return;
+    const dialogRef = this.dialog.open(
+      ApplyDuplicateAggregationDialogComponent,
+      {
+        width: '550px',
+        data: dialogData
       }
+    );
 
-      this.isApplyingDuplicateAggregation = true;
+    dialogRef
+      .afterClosed()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((confirmed: unknown) => {
+        if (!confirmed) {
+          return;
+        }
 
-      this.testPersonCodingService
-        .applyDuplicateAggregation(
-          workspaceId,
-          this.duplicateAggregationThreshold,
-          true
-        )
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: result => {
-            this.isApplyingDuplicateAggregation = false;
+        this.isApplyingDuplicateAggregation = true;
 
-            if (result.success) {
-              this.showSuccess(
-                this.translateService.instant(
-                  'coding-management-manual.duplicate-aggregation.success',
-                  {
-                    aggregatedResponses: result.aggregatedResponses,
-                    aggregatedGroups: result.aggregatedGroups,
-                    uniqueCases: result.uniqueCodingCases
-                  }
+        this.testPersonCodingService
+          .applyDuplicateAggregation(
+            workspaceId,
+            this.duplicateAggregationThreshold,
+            true
+          )
+          .pipe(takeUntil(this.destroy$))
+          .subscribe({
+            next: result => {
+              this.isApplyingDuplicateAggregation = false;
+
+              if (result.success) {
+                this.showSuccess(
+                  this.translateService.instant(
+                    'coding-management-manual.duplicate-aggregation.success',
+                    {
+                      aggregatedResponses: result.aggregatedResponses,
+                      aggregatedGroups: result.aggregatedGroups,
+                      uniqueCases: result.uniqueCodingCases
+                    }
+                  )
+                );
+
+                // Sync with matching flag: Clear 'NO_AGGREGATION' when applying
+                this.saveResponseMatchingMode(
+                  this.responseMatchingFlags.filter(
+                    f => f !== ResponseMatchingFlag.NO_AGGREGATION
+                  )
                 )
-              );
-
-              // Sync with matching flag: Clear 'NO_AGGREGATION' when applying
-              this.saveResponseMatchingMode(
-                this.responseMatchingFlags.filter(f => f !== ResponseMatchingFlag.NO_AGGREGATION)
-              )
-                .pipe(takeUntil(this.destroy$))
-                .subscribe(() => {
-                  this.onResponseMatchingModeChanged();
-                });
-            } else {
+                  .pipe(takeUntil(this.destroy$))
+                  .subscribe(() => {
+                    this.onResponseMatchingModeChanged();
+                  });
+              } else {
+                this.showError(
+                  this.translateService.instant(
+                    'coding-management-manual.duplicate-aggregation.error',
+                    { error: result.message }
+                  )
+                );
+              }
+            },
+            error: () => {
+              this.isApplyingDuplicateAggregation = false;
               this.showError(
                 this.translateService.instant(
                   'coding-management-manual.duplicate-aggregation.error',
-                  { error: result.message }
+                  { error: 'Unbekannter Fehler' }
                 )
               );
             }
-          },
-          error: () => {
-            this.isApplyingDuplicateAggregation = false;
-            this.showError(
-              this.translateService.instant(
-                'coding-management-manual.duplicate-aggregation.error',
-                { error: 'Unbekannter Fehler' }
-              )
-            );
-          }
-        });
-    });
+          });
+      });
   }
 
   onDeactivateDuplicateAggregation(): void {
@@ -4338,50 +4802,63 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
       width: '400px',
       data: {
-        title: this.translateService.instant('coding-management-manual.duplicate-aggregation.deactivate-dialog-title'),
-        message: this.translateService.instant('coding-management-manual.duplicate-aggregation.deactivate-confirm'),
-        confirmButtonText: this.translateService.instant('coding-management-manual.duplicate-aggregation.deactivate-confirm-button'),
-        cancelButtonText: this.translateService.instant('coding-management-manual.duplicate-aggregation.cancel')
-      }
-    });
-
-    dialogRef.afterClosed().pipe(takeUntil(this.destroy$)).subscribe((confirmed: unknown) => {
-      if (!confirmed) {
-        return;
-      }
-
-      this.isApplyingDuplicateAggregation = true;
-
-      this.testPersonCodingService
-        .applyDuplicateAggregation(
-          workspaceId,
-          this.duplicateAggregationThreshold,
-          false // Deactivate
+        title: this.translateService.instant(
+          'coding-management-manual.duplicate-aggregation.deactivate-dialog-title'
+        ),
+        message: this.translateService.instant(
+          'coding-management-manual.duplicate-aggregation.deactivate-confirm'
+        ),
+        confirmButtonText: this.translateService.instant(
+          'coding-management-manual.duplicate-aggregation.deactivate-confirm-button'
+        ),
+        cancelButtonText: this.translateService.instant(
+          'coding-management-manual.duplicate-aggregation.cancel'
         )
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: result => {
-            this.isApplyingDuplicateAggregation = false;
-
-            if (result.success) {
-              this.showSuccess(result.message);
-
-              // Sync with matching flag: Set 'NO_AGGREGATION' when deactivating
-              this.saveResponseMatchingMode([ResponseMatchingFlag.NO_AGGREGATION])
-                .pipe(takeUntil(this.destroy$))
-                .subscribe(() => {
-                  this.onResponseMatchingModeChanged();
-                });
-            } else {
-              this.showError(result.message);
-            }
-          },
-          error: () => {
-            this.isApplyingDuplicateAggregation = false;
-            this.showError('Fehler beim Deaktivieren der Aggregation');
-          }
-        });
+      }
     });
+
+    dialogRef
+      .afterClosed()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((confirmed: unknown) => {
+        if (!confirmed) {
+          return;
+        }
+
+        this.isApplyingDuplicateAggregation = true;
+
+        this.testPersonCodingService
+          .applyDuplicateAggregation(
+            workspaceId,
+            this.duplicateAggregationThreshold,
+            false // Deactivate
+          )
+          .pipe(takeUntil(this.destroy$))
+          .subscribe({
+            next: result => {
+              this.isApplyingDuplicateAggregation = false;
+
+              if (result.success) {
+                this.showSuccess(result.message);
+
+                // Sync with matching flag: Set 'NO_AGGREGATION' when deactivating
+                this.saveResponseMatchingMode([
+                  ResponseMatchingFlag.NO_AGGREGATION
+                ])
+                  .pipe(takeUntil(this.destroy$))
+                  .subscribe(() => {
+                    this.onResponseMatchingModeChanged();
+                  });
+              } else {
+                this.showError(result.message);
+              }
+            },
+            error: () => {
+              this.isApplyingDuplicateAggregation = false;
+              this.showError('Fehler beim Deaktivieren der Aggregation');
+            }
+          });
+      });
   }
 
   onThresholdChanged(newValue: number | string | null): void {
@@ -4417,7 +4894,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return this.responseAnalysis?.emptyResponses?.totalUncoded || 0;
   }
 
-  private normalizeAggregationThreshold(value: number | string | null | undefined): number {
+  private normalizeAggregationThreshold(
+    value: number | string | null | undefined
+  ): number {
     const numericValue = Number(value);
     if (!Number.isFinite(numericValue)) {
       return 2;

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
@@ -1,176 +1,291 @@
 <div class="coding-main-container">
   @if (!hideActionButtons) {
-  <div>
-    <div class="action-buttons-toolbar">
-      <a mat-raised-button color="primary" (click)="onAutoCode()">
-        <mat-icon>auto_fix_high</mat-icon>
-        {{ 'coding-management.buttons.auto-code' | translate }}
-      </a>
-      <a mat-raised-button color="primary" (click)="openManualCoding()">
-        <mat-icon>keyboard</mat-icon>
-        {{ 'coding-management.buttons.manual-code' | translate }}
-      </a>
+    <div>
+      <div class="action-buttons-toolbar">
+        <a mat-raised-button color="primary" (click)="onAutoCode()">
+          <mat-icon>auto_fix_high</mat-icon>
+          {{ 'coding-management.buttons.auto-code' | translate }}
+        </a>
+        <a mat-raised-button color="primary" (click)="openManualCoding()">
+          <mat-icon>keyboard</mat-icon>
+          {{ 'coding-management.buttons.manual-code' | translate }}
+        </a>
 
-      @if (codingListDownloadProgress !== null) {
-      <button mat-raised-button disabled class="progress-button">
-        <mat-spinner diameter="20" class="inline-spinner"></mat-spinner>
-        {{ 'coding-management.descriptions.coding-list-progress' | translate:{progress: codingListDownloadProgress} }}
-      </button>
-      <button mat-icon-button color="warn" (click)="cancelCodingListDownload()"
-        [matTooltip]="'coding-management.download-dialog.cancel-tooltip' | translate">
-        <mat-icon>cancel</mat-icon>
-      </button>
-      } @else {
-      <a mat-raised-button color="primary" (click)="fetchCodingList()">
-        <mat-icon>list</mat-icon>
-        {{ 'coding-management.buttons.coding-list' | translate }}
-      </a>
-      }
-      <a mat-raised-button color="primary" (click)="openExportCodingBook()">
-        <mat-icon>book</mat-icon>
-        {{ 'coding-management.buttons.codebook' | translate }}
-      </a>
-      <a mat-raised-button color="primary" (click)="openItemListDialog()">
-        <mat-icon>list_alt</mat-icon>
-        {{ 'Itemliste' }}
-      </a>
-      <a mat-raised-button color="primary" (click)="fetchVariableAnalysis()">
-        <mat-icon>analytics</mat-icon>
-        {{ 'coding-management.buttons.item-variable-analysis' | translate }}
-      </a>
-      <a mat-raised-button color="primary" (click)="fetchUnitVariables()">
-        <mat-icon>list_alt</mat-icon>
-        {{ 'coding-management.buttons.coding-variables' | translate }}
-      </a>
+        @if (codingListDownloadProgress !== null) {
+          <button mat-raised-button disabled class="progress-button">
+            <mat-spinner diameter="20" class="inline-spinner"></mat-spinner>
+            {{
+              'coding-management.descriptions.coding-list-progress'
+                | translate: { progress: codingListDownloadProgress }
+            }}
+          </button>
+          <button
+            mat-icon-button
+            color="warn"
+            (click)="cancelCodingListDownload()"
+            [matTooltip]="
+              'coding-management.download-dialog.cancel-tooltip' | translate
+            "
+          >
+            <mat-icon>cancel</mat-icon>
+          </button>
+        } @else {
+          <a mat-raised-button color="primary" (click)="fetchCodingList()">
+            <mat-icon>list</mat-icon>
+            {{ 'coding-management.buttons.coding-list' | translate }}
+          </a>
+        }
+        <a mat-raised-button color="primary" (click)="openExportCodingBook()">
+          <mat-icon>book</mat-icon>
+          {{ 'coding-management.buttons.codebook' | translate }}
+        </a>
+        <a mat-raised-button color="primary" (click)="openItemListDialog()">
+          <mat-icon>list_alt</mat-icon>
+          {{ 'Itemliste' }}
+        </a>
+        <a mat-raised-button color="primary" (click)="fetchVariableAnalysis()">
+          <mat-icon>analytics</mat-icon>
+          {{ 'coding-management.buttons.item-variable-analysis' | translate }}
+        </a>
+        <a mat-raised-button color="primary" (click)="fetchUnitVariables()">
+          <mat-icon>list_alt</mat-icon>
+          {{ 'coding-management.buttons.coding-variables' | translate }}
+        </a>
+      </div>
     </div>
-  </div>
   }
 
-  <section class="coding-freshness-panel" [class.is-current]="!hasCodingFreshnessAttention">
+  <section
+    class="coding-freshness-panel"
+    [class.is-current]="!hasCodingFreshnessAttention"
+  >
     <div class="coding-freshness-main">
-      @if (isLoadingCodingFreshness || isLoadingAutocodingReadiness || isLoadingManualAppliedResultsOverview) {
-      <mat-spinner diameter="22" class="coding-freshness-state-spinner"></mat-spinner>
+      @if (
+        isLoadingCodingFreshness ||
+        isLoadingAutocodingReadiness ||
+        isLoadingManualAppliedResultsOverview
+      ) {
+        <mat-spinner
+          diameter="22"
+          class="coding-freshness-state-spinner"
+        ></mat-spinner>
       } @else {
-      <mat-icon>{{ hasCodingFreshnessAttention ? 'warning' : 'check_circle' }}</mat-icon>
+        <mat-icon>{{
+          hasCodingFreshnessAttention ? 'warning' : 'check_circle'
+        }}</mat-icon>
       }
       <div class="coding-freshness-copy">
         <div class="coding-freshness-title">
           {{ codingFreshnessPanelTitle }}
         </div>
         <div class="coding-freshness-text">
-          @if (isLoadingCodingFreshness || isLoadingAutocodingReadiness || isLoadingManualAppliedResultsOverview) {
-          {{ 'coding-management.readiness.checking' | translate }}
+          @if (
+            isLoadingCodingFreshness ||
+            isLoadingAutocodingReadiness ||
+            isLoadingManualAppliedResultsOverview
+          ) {
+            {{ 'coding-management.readiness.checking' | translate }}
+          } @else if (!hasRequestedCodingStatusOverview) {
+            {{ 'coding-management.readiness.not-checked' | translate }}
           } @else if (hasAutocodingReadinessLoadFailed) {
-          {{ 'coding-management.readiness.load-failed' | translate }}
+            {{ 'coding-management.readiness.load-failed' | translate }}
+          } @else if (isAutocodingReadinessDiagnosticsPending) {
+            <div>{{ autocodingReadinessSummaryPendingText }}</div>
+            <div class="coding-freshness-help">
+              {{
+                'coding-management.readiness.pending-diagnostics-help'
+                  | translate
+              }}
+            </div>
           } @else if (isAutocodingReadinessBlocked) {
-          <div>{{ autocodingReadinessSummaryText }}</div>
-          <div class="coding-freshness-help">{{ autocodingReadinessDetailsText }}</div>
-          @if (autocodingReadinessMissingUnitPreview) {
-          <div>
-            {{ 'coding-management.readiness.missing-unit-files' | translate:{items: autocodingReadinessMissingUnitPreview} }}
-          </div>
-          }
-          @if (autocodingReadinessMissingCodingSchemePreview) {
-          <div>
-            {{ 'coding-management.readiness.missing-coding-schemes' | translate:{items: autocodingReadinessMissingCodingSchemePreview} }}
-          </div>
-          }
-          @if (autocodingReadinessInvalidCodingSchemePreview) {
-          <div>
-            {{ 'coding-management.readiness.invalid-coding-schemes' | translate:{items: autocodingReadinessInvalidCodingSchemePreview} }}
-          </div>
-          }
-          @if (autocodingReadinessInvalidVariablePreview) {
-          <div>
-            {{ 'coding-management.readiness.invalid-variables' | translate:{items: autocodingReadinessInvalidVariablePreview} }}
-          </div>
-          }
+            <div>{{ autocodingReadinessSummaryText }}</div>
+            <div class="coding-freshness-help">
+              {{ autocodingReadinessDetailsText }}
+            </div>
+            @if (autocodingReadinessMissingUnitPreview) {
+              <div>
+                {{
+                  'coding-management.readiness.missing-unit-files'
+                    | translate
+                      : { items: autocodingReadinessMissingUnitPreview }
+                }}
+              </div>
+            }
+            @if (autocodingReadinessMissingCodingSchemePreview) {
+              <div>
+                {{
+                  'coding-management.readiness.missing-coding-schemes'
+                    | translate
+                      : { items: autocodingReadinessMissingCodingSchemePreview }
+                }}
+              </div>
+            }
+            @if (autocodingReadinessInvalidCodingSchemePreview) {
+              <div>
+                {{
+                  'coding-management.readiness.invalid-coding-schemes'
+                    | translate
+                      : { items: autocodingReadinessInvalidCodingSchemePreview }
+                }}
+              </div>
+            }
+            @if (autocodingReadinessInvalidVariablePreview) {
+              <div>
+                {{
+                  'coding-management.readiness.invalid-variables'
+                    | translate
+                      : { items: autocodingReadinessInvalidVariablePreview }
+                }}
+              </div>
+            }
           } @else if (hasCodingFreshnessWarnings) {
-          <div>{{ codingFreshnessSummaryText }}</div>
-          @if (manualCodingFreshnessGuidanceText) {
-          <div>{{ manualCodingFreshnessGuidanceText }}</div>
-          }
-          <div class="coding-freshness-help">{{ codingFreshnessExplanationText }}</div>
-          @if (codingFreshnessGroupPreview) {
-          <div>
-            {{ 'coding-management.readiness.affected-groups' | translate:{groups: codingFreshnessGroupPreview} }}
-          </div>
-          }
+            <div>{{ codingFreshnessSummaryText }}</div>
+            @if (manualCodingFreshnessGuidanceText) {
+              <div>{{ manualCodingFreshnessGuidanceText }}</div>
+            }
+            <div class="coding-freshness-help">
+              {{ codingFreshnessExplanationText }}
+            </div>
+            @if (codingFreshnessGroupPreview) {
+              <div>
+                {{
+                  'coding-management.readiness.affected-groups'
+                    | translate: { groups: codingFreshnessGroupPreview }
+                }}
+              </div>
+            }
           } @else if (hasImportedResultsWithoutCoding) {
-          {{ 'coding-management.readiness.imported-results-without-coding' | translate }}
+            {{
+              'coding-management.readiness.imported-results-without-coding'
+                | translate
+            }}
           } @else {
-          {{ 'coding-management.readiness.current' | translate }}
+            {{ 'coding-management.readiness.current' | translate }}
           }
         </div>
         @if (hasCodingFreshnessWarnings) {
-        <div class="coding-freshness-chip-row">
-          @for (item of codingFreshnessChipWarnings; track item.version + item.state) {
-          <span class="coding-freshness-chip">
-            {{ getFreshnessChipLabel(item) }}
-          </span>
-          }
-        </div>
+          <div class="coding-freshness-chip-row">
+            @for (
+              item of codingFreshnessChipWarnings;
+              track item.version + item.state
+            ) {
+              <span class="coding-freshness-chip">
+                {{ getFreshnessChipLabel(item) }}
+              </span>
+            }
+          </div>
         }
       </div>
     </div>
 
+    @if (shouldShowManualCodingStatusRefresh()) {
+      <div class="coding-freshness-actions">
+        <button
+          mat-stroked-button
+          color="primary"
+          [disabled]="isCodingStatusOverviewLoading()"
+          (click)="refreshCodingStatusOverview()"
+        >
+          <mat-icon>refresh</mat-icon>
+          {{ 'coding-management.readiness.refresh-status' | translate }}
+        </button>
+      </div>
+    }
+
     @if (isStartingFreshnessCoding) {
-    <div class="coding-freshness-job">
-      <mat-spinner diameter="18"></mat-spinner>
-      <span>
-        {{ 'coding-management.readiness.starting-freshness-coding' | translate }}
-      </span>
-    </div>
+      <div class="coding-freshness-job">
+        <mat-spinner diameter="18"></mat-spinner>
+        <span>
+          {{
+            'coding-management.readiness.starting-freshness-coding' | translate
+          }}
+        </span>
+      </div>
     } @else if (activeFreshnessJobId) {
-    <div class="coding-freshness-job">
-      <mat-spinner diameter="18"></mat-spinner>
-      <span>
-        {{ 'coding-management.readiness.update-running' | translate:{progress: activeFreshnessJobProgress || 0} }}
-      </span>
-    </div>
+      <div class="coding-freshness-job">
+        <mat-spinner diameter="18"></mat-spinner>
+        <span>
+          {{
+            'coding-management.readiness.update-running'
+              | translate: { progress: activeFreshnessJobProgress || 0 }
+          }}
+        </span>
+      </div>
     } @else if (hasAutocodingReadinessLoadFailed) {
-    <div class="coding-freshness-actions">
-      <button mat-stroked-button color="primary" [disabled]="isLoadingAutocodingReadiness"
-        (click)="refreshAutocodingReadiness()">
-        <mat-icon>refresh</mat-icon>
-        {{ 'coding-management.readiness.retry' | translate }}
-      </button>
-    </div>
+      <div class="coding-freshness-actions">
+        <button
+          mat-stroked-button
+          color="primary"
+          [disabled]="isLoadingAutocodingReadiness"
+          (click)="retryAutocodingReadiness()"
+        >
+          <mat-icon>refresh</mat-icon>
+          {{ 'coding-management.readiness.retry' | translate }}
+        </button>
+      </div>
+    } @else if (isAutocodingReadinessDiagnosticsPending) {
+      <div class="coding-freshness-actions">
+        <button
+          mat-stroked-button
+          color="primary"
+          [disabled]="isLoadingAutocodingReadiness"
+          (click)="loadAutocodingReadinessDetails()"
+        >
+          <mat-icon>fact_check</mat-icon>
+          {{ 'coding-management.readiness.check-details' | translate }}
+        </button>
+      </div>
     } @else if (isAutocodingReadinessBlocked) {
-    <div class="coding-freshness-actions">
-      <button mat-stroked-button color="primary" [disabled]="isLoadingAutocodingReadiness"
-        (click)="refreshAutocodingReadiness()">
-        <mat-icon>refresh</mat-icon>
-        {{ 'coding-management.readiness.retry' | translate }}
-      </button>
-      <button mat-stroked-button color="primary" (click)="openTestFiles()">
-        <mat-icon>folder_open</mat-icon>
-        {{ 'coding-management.readiness.check-test-files' | translate }}
-      </button>
-    </div>
+      <div class="coding-freshness-actions">
+        <button
+          mat-stroked-button
+          color="primary"
+          [disabled]="isLoadingAutocodingReadiness"
+          (click)="refreshAutocodingReadiness()"
+        >
+          <mat-icon>refresh</mat-icon>
+          {{ 'coding-management.readiness.retry' | translate }}
+        </button>
+        <button mat-stroked-button color="primary" (click)="openTestFiles()">
+          <mat-icon>folder_open</mat-icon>
+          {{ 'coding-management.readiness.check-test-files' | translate }}
+        </button>
+      </div>
     } @else if (hasCodingFreshnessWarnings) {
-    <div class="coding-freshness-actions">
-      @if (hasFreshnessAutoCodingWork('v1')) {
-      <button mat-stroked-button color="primary" [disabled]="isStartingFreshnessCoding"
-        (click)="startFreshnessCoding('v1')">
-        <mat-icon>auto_fix_high</mat-icon>
-        {{ getFreshnessAutoCodingButtonLabel('v1') }}
-      </button>
-      }
-      @if (hasFreshnessAutoCodingWork('v3')) {
-      <button mat-stroked-button color="primary" [disabled]="isStartingFreshnessCoding"
-        (click)="startFreshnessCoding('v3')">
-        <mat-icon>auto_fix_high</mat-icon>
-        {{ getFreshnessAutoCodingButtonLabel('v3') }}
-      </button>
-      }
-      @if (hasManualCodingFreshnessAction) {
-      <button mat-stroked-button color="primary" (click)="openManualCoding(true)">
-        <mat-icon>keyboard</mat-icon>
-        {{ 'coding-management.readiness.open-manual-review' | translate }}
-      </button>
-      }
-    </div>
+      <div class="coding-freshness-actions">
+        @if (hasFreshnessAutoCodingWork('v1')) {
+          <button
+            mat-stroked-button
+            color="primary"
+            [disabled]="isStartingFreshnessCoding"
+            (click)="startFreshnessCoding('v1')"
+          >
+            <mat-icon>auto_fix_high</mat-icon>
+            {{ getFreshnessAutoCodingButtonLabel('v1') }}
+          </button>
+        }
+        @if (hasFreshnessAutoCodingWork('v3')) {
+          <button
+            mat-stroked-button
+            color="primary"
+            [disabled]="isStartingFreshnessCoding"
+            (click)="startFreshnessCoding('v3')"
+          >
+            <mat-icon>auto_fix_high</mat-icon>
+            {{ getFreshnessAutoCodingButtonLabel('v3') }}
+          </button>
+        }
+        @if (hasManualCodingFreshnessAction) {
+          <button
+            mat-stroked-button
+            color="primary"
+            (click)="openManualCoding(true)"
+          >
+            <mat-icon>keyboard</mat-icon>
+            {{ 'coding-management.readiness.open-manual-review' | translate }}
+          </button>
+        }
+      </div>
     }
   </section>
 
@@ -178,36 +293,68 @@
     <div class="content-row-container">
       <!-- Statistics Section -->
       <div class="statistics-section">
-        <app-statistics-card [codingStatistics]="codingStatistics" [referenceStatistics]="referenceStatistics"
-          [referenceVersion]="referenceVersion" [selectedVersion]="selectedStatisticsVersion"
-          [isLoading]="isLoadingStatistics" [isDownloadInProgress]="isDownloadInProgress"
-          [statisticsLoaded]="statisticsLoaded" [resetProgress]="resetProgress" [downloadProgress]="downloadProgress"
+        <app-statistics-card
+          [codingStatistics]="codingStatistics"
+          [referenceStatistics]="referenceStatistics"
+          [referenceVersion]="referenceVersion"
+          [selectedVersion]="selectedStatisticsVersion"
+          [isLoading]="isLoadingStatistics"
+          [isDownloadInProgress]="isDownloadInProgress"
+          [statisticsLoaded]="statisticsLoaded"
+          [resetProgress]="resetProgress"
+          [downloadProgress]="downloadProgress"
           [hideResetButton]="hideActionButtons"
-          (versionChange)="onVersionChange($event)" (loadStatistics)="fetchCodingStatistics()"
-          (downloadResults)="onDownloadResults()" (cancelDownloadResults)="onCancelDownloadResults()" (resetVersion)="onResetVersion()"
-          (statusClick)="onStatusClick($event)" (derivedClick)="onDerivedClick()">
+          (versionChange)="onVersionChange($event)"
+          (loadStatistics)="fetchCodingStatistics()"
+          (downloadResults)="onDownloadResults()"
+          (cancelDownloadResults)="onCancelDownloadResults()"
+          (resetVersion)="onResetVersion()"
+          (statusClick)="onStatusClick($event)"
+          (derivedClick)="onDerivedClick()"
+        >
         </app-statistics-card>
       </div>
 
       <!-- Filter Section -->
       <div class="filters-section">
-        <app-response-filters [filterParams]="filterParams" [availableStatuses]="getAvailableStatuses()"
-          [isLoading]="isLoading" [isGeogebraAvailable]="isGeogebraAvailable"
-          [enableRegexSearch]="enableRegexSearch" (filterChange)="onFilterChange($event)"
-          (clearFilters)="onClearFilters()">
+        <app-response-filters
+          [filterParams]="filterParams"
+          [availableStatuses]="getAvailableStatuses()"
+          [isLoading]="isLoading"
+          [isGeogebraAvailable]="isGeogebraAvailable"
+          [enableRegexSearch]="enableRegexSearch"
+          (filterChange)="onFilterChange($event)"
+          (clearFilters)="onClearFilters()"
+        >
         </app-response-filters>
       </div>
 
       <!-- Data Section -->
       <div class="data-section">
-        <app-response-table [data]="data" [displayedColumns]="displayedColumns" [totalRecords]="totalRecords"
-          [pageSize]="pageSize" [pageIndex]="pageIndex" [pageSizeOptions]="pageSizeOptions" [isLoading]="isLoading"
-          [currentStatusFilter]="filterParams.codedStatus || currentStatusFilter" [selectedVersion]="selectedStatisticsVersion"
-          [isGeogebraFilterActive]="filterParams.geogebra" [isDerivedFilterActive]="filterParams.responseSource === 'derived'"
-          [isReviewLoading]="isLoadingReview" [sortBy]="sortBy" [sortDirection]="sortDirection"
+        <app-response-table
+          [data]="data"
+          [displayedColumns]="displayedColumns"
+          [totalRecords]="totalRecords"
+          [pageSize]="pageSize"
+          [pageIndex]="pageIndex"
+          [pageSizeOptions]="pageSizeOptions"
+          [isLoading]="isLoading"
+          [currentStatusFilter]="
+            filterParams.codedStatus || currentStatusFilter
+          "
+          [selectedVersion]="selectedStatisticsVersion"
+          [isGeogebraFilterActive]="filterParams.geogebra"
+          [isDerivedFilterActive]="filterParams.responseSource === 'derived'"
+          [isReviewLoading]="isLoadingReview"
+          [sortBy]="sortBy"
+          [sortDirection]="sortDirection"
           (pageChange)="onPageChange($event)"
-          (replayClick)="onReplayClick($event)" (showCodingScheme)="onShowCodingScheme($event)"
-          (showUnitXml)="onShowUnitXml($event)" (reviewClick)="onReviewClick()" (sortChange)="onSortChange($event)">
+          (replayClick)="onReplayClick($event)"
+          (showCodingScheme)="onShowCodingScheme($event)"
+          (showUnitXml)="onShowUnitXml($event)"
+          (reviewClick)="onReviewClick()"
+          (sortChange)="onSortChange($event)"
+        >
         </app-response-table>
       </div>
     </div>

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -1,17 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  ActivatedRoute, convertToParamMap, ParamMap, Router
+  ActivatedRoute,
+  convertToParamMap,
+  ParamMap,
+  Router
 } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
-  BehaviorSubject,
-  of,
-  Subject,
-  throwError
+  BehaviorSubject, of, Subject, throwError
 } from 'rxjs';
 import { PageEvent } from '@angular/material/paginator';
 import { CodingManagementComponent } from './coding-management.component';
@@ -31,12 +31,18 @@ import { TestPersonCodingDialogComponent } from '../test-person-coding-dialog/te
 describe('CodingManagementComponent', () => {
   let component: CodingManagementComponent;
   let fixture: ComponentFixture<CodingManagementComponent>;
-  let mockCodingManagementService: jest.Mocked<Partial<CodingManagementService>>;
+  let mockCodingManagementService: jest.Mocked<
+  Partial<CodingManagementService>
+  >;
   let mockUiService: jest.Mocked<Partial<CodingManagementUiService>>;
   let mockDialog: jest.Mocked<Partial<MatDialog>>;
   let mockAppService: jest.Mocked<Partial<AppService>>;
-  let mockWorkspaceSettingsService: jest.Mocked<Partial<WorkspaceSettingsService>>;
-  let mockTestPersonCodingService: jest.Mocked<Partial<TestPersonCodingService>>;
+  let mockWorkspaceSettingsService: jest.Mocked<
+  Partial<WorkspaceSettingsService>
+  >;
+  let mockTestPersonCodingService: jest.Mocked<
+  Partial<TestPersonCodingService>
+  >;
   let mockRouter: jest.Mocked<Partial<Router>>;
   let mockSnackBar: jest.Mocked<Partial<MatSnackBar>>;
   let autoCodingCompletedSubject: Subject<{ jobId?: string }>;
@@ -50,7 +56,10 @@ describe('CodingManagementComponent', () => {
 
     // Create mocks
     mockCodingManagementService = {
-      codingStatistics$: of({ totalResponses: 100, statusCounts: { 200: 50, 300: 50 } }),
+      codingStatistics$: of({
+        totalResponses: 100,
+        statusCounts: { 200: 50, 300: 50 }
+      }),
       referenceStatistics$: of(null),
       referenceVersion$: of(null),
       isLoadingStatistics$: of(false),
@@ -58,7 +67,9 @@ describe('CodingManagementComponent', () => {
       downloadProgress$: new BehaviorSubject<number | null>(null),
       codingListDownloadProgress$: new BehaviorSubject<number | null>(null),
       fetchCodingStatistics: jest.fn(),
-      fetchResponsesByStatus: jest.fn().mockReturnValue(of({ data: [], total: 0 })),
+      fetchResponsesByStatus: jest
+        .fn()
+        .mockReturnValue(of({ data: [], total: 0 })),
       searchResponses: jest.fn().mockReturnValue(of({ data: [], total: 0 })),
       resetCodingVersion: jest.fn().mockReturnValue(of({ message: 'Success' })),
       downloadCodingResults: jest.fn().mockReturnValue(Promise.resolve()),
@@ -93,7 +104,8 @@ describe('CodingManagementComponent', () => {
 
     mockWorkspaceSettingsService = {
       getAutoFetchCodingStatistics: jest.fn().mockReturnValue(of(false)),
-      getEnableRegexSearch: jest.fn().mockReturnValue(of(false))
+      getEnableRegexSearch: jest.fn().mockReturnValue(of(false)),
+      getAutoRefreshManualCodingJobs: jest.fn().mockReturnValue(of(true))
     };
     autoCodingCompletedSubject = new Subject<{ jobId?: string }>();
     testResultsChangedSubject = new Subject<TestResultsChangedEvent>();
@@ -110,63 +122,73 @@ describe('CodingManagementComponent', () => {
       autoCodingCompleted$: autoCodingCompletedSubject.asObservable(),
       testResultsChanged$: testResultsChangedSubject.asObservable(),
       consumePendingStatisticsVersion: jest.fn().mockReturnValue(null),
-      getCodingFreshness: jest.fn().mockReturnValue(of({
-        workspaceId: 1,
-        currentRevision: 0,
-        items: []
-      })),
-      getAutocodingReadiness: jest.fn().mockReturnValue(of({
-        workspaceId: 1,
-        autoCoderRun: 1,
-        readiness: 'READY',
-        blockers: [],
-        rawResponsesTotal: 0,
-        rawResponsesWithRelevantStatus: 0,
-        resultUnitsTotal: 0,
-        resultUnitKeysTotal: 0,
-        matchedUnitFiles: 0,
-        missingUnitFiles: [],
-        matchedCodingSchemes: 0,
-        missingCodingSchemes: [],
-        invalidCodingSchemes: [],
-        validVariablePairs: 0,
-        validResponses: 0,
-        codeableResponses: 0,
-        invalidVariableSamples: []
-      })),
-      getCodingFreshnessScope: jest.fn().mockReturnValue(of({
-        workspaceId: 1,
-        currentRevision: 0,
-        versions: ['v1', 'v2', 'v3'],
-        states: ['PENDING', 'STALE', 'MANUAL_REVIEW_REQUIRED'],
-        unitCount: 0,
-        personCount: 0,
-        groupCount: 0,
-        affectedResponseCount: 0,
-        unitIds: [],
-        personIds: [],
-        groupNames: [],
-        groups: []
-      })),
-      getAppliedResultsOverview: jest.fn().mockReturnValue(of({
-        totalIncompleteResponses: 0,
-        appliedResponses: 0,
-        remainingResponses: 0,
-        completionPercentage: 0,
-        rawTotalIncompleteResponses: 0,
-        rawAppliedResponses: 0,
-        rawCompletionPercentage: 0,
-        aggregationActive: false,
-        aggregationThreshold: null,
-        aggregatedDuplicateCases: 0
-      })),
-      startFreshnessCoding: jest.fn().mockReturnValue(of({
-        totalResponses: 0,
-        statusCounts: {},
-        unitCount: 0,
-        personCount: 0,
-        groupNames: []
-      })),
+      getCodingFreshness: jest.fn().mockReturnValue(
+        of({
+          workspaceId: 1,
+          currentRevision: 0,
+          items: []
+        })
+      ),
+      getAutocodingReadiness: jest.fn().mockReturnValue(
+        of({
+          workspaceId: 1,
+          autoCoderRun: 1,
+          readiness: 'READY',
+          blockers: [],
+          rawResponsesTotal: 0,
+          rawResponsesWithRelevantStatus: 0,
+          resultUnitsTotal: 0,
+          resultUnitKeysTotal: 0,
+          matchedUnitFiles: 0,
+          missingUnitFiles: [],
+          matchedCodingSchemes: 0,
+          missingCodingSchemes: [],
+          invalidCodingSchemes: [],
+          validVariablePairs: 0,
+          validResponses: 0,
+          codeableResponses: 0,
+          invalidVariableSamples: []
+        })
+      ),
+      getCodingFreshnessScope: jest.fn().mockReturnValue(
+        of({
+          workspaceId: 1,
+          currentRevision: 0,
+          versions: ['v1', 'v2', 'v3'],
+          states: ['PENDING', 'STALE', 'MANUAL_REVIEW_REQUIRED'],
+          unitCount: 0,
+          personCount: 0,
+          groupCount: 0,
+          affectedResponseCount: 0,
+          unitIds: [],
+          personIds: [],
+          groupNames: [],
+          groups: []
+        })
+      ),
+      getAppliedResultsOverview: jest.fn().mockReturnValue(
+        of({
+          totalIncompleteResponses: 0,
+          appliedResponses: 0,
+          remainingResponses: 0,
+          completionPercentage: 0,
+          rawTotalIncompleteResponses: 0,
+          rawAppliedResponses: 0,
+          rawCompletionPercentage: 0,
+          aggregationActive: false,
+          aggregationThreshold: null,
+          aggregatedDuplicateCases: 0
+        })
+      ),
+      startFreshnessCoding: jest.fn().mockReturnValue(
+        of({
+          totalResponses: 0,
+          statusCounts: {},
+          unitCount: 0,
+          personCount: 0,
+          groupNames: []
+        })
+      ),
       getJobStatus: jest.fn(),
       notifyAutoCodingCompleted: jest.fn()
     };
@@ -244,22 +266,36 @@ describe('CodingManagementComponent', () => {
           'uncoded-responses-title': 'Unkodierte Antworten'
         },
         readiness: {
+          'title-not-checked': 'Kodierstatus nicht geprüft',
           'title-load-failed': 'Auto-Coding-Prüfung nicht verfügbar',
           'title-blocked': 'Auto-Coding 1 nicht möglich',
+          'title-diagnostics-pending':
+            'Auto-Coding-Basisprüfung abgeschlossen',
           'title-not-started': 'Kodierung noch nicht gestartet',
           'title-manual-coding-open': 'Manuelle Kodierung abschließen',
-          summary: '{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus, aber {{codeableResponses}} kodierbare Antworten.',
+          summary:
+            '{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus, aber {{codeableResponses}} kodierbare Antworten.',
+          'summary-pending-diagnostics':
+            '{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus und {{potentialCodeableResponses}} potenziell kodierbare Antworten.',
+          'pending-diagnostics-help':
+            'Für Unit-Dateien und Kodierschemata liegt noch keine Detailprüfung vor.',
           'details-result-units': '{{count}} Ergebnis-Units',
           'details-unit-files': '{{count}} passende Unit-Dateien',
           'details-coding-schemes': '{{count}} passende Kodierschemata',
-          'details-valid-responses': '{{count}} Antworten mit passender Kodier-Variable',
+          'details-valid-responses':
+            '{{count}} Antworten mit passender Kodier-Variable',
           'additional-items': '+{{count}} weitere',
-          'second-autocoding-waits-summary': 'Auto-Coding 2 ist der nächste Schritt, sobald die manuelle Kodierung abgeschlossen ist. Schließen Sie zuerst die offenen manuellen Kodierfälle ab und übernehmen Sie die Ergebnisse.{{remaining}}',
-          'second-autocoding-waits-remaining': ' Es sind noch {{count}} manuelle Kodierergebnisse offen.',
-          'manual-results-overview-load-failed': 'Der Stand der manuellen Kodierung konnte nicht geprüft werden. Auto-Coding 2 bleibt gesperrt, bis die Prüfung erfolgreich aktualisiert wurde.',
-          'second-autocoding-waits-help': 'Der Start von Auto-Coding 2 bleibt bis dahin gesperrt. {{taskResultHelp}}',
+          'second-autocoding-waits-summary':
+            'Auto-Coding 2 ist der nächste Schritt, sobald die manuelle Kodierung abgeschlossen ist. Schließen Sie zuerst die offenen manuellen Kodierfälle ab und übernehmen Sie die Ergebnisse.{{remaining}}',
+          'second-autocoding-waits-remaining':
+            ' Es sind noch {{count}} manuelle Kodierergebnisse offen.',
+          'manual-results-overview-load-failed':
+            'Der Stand der manuellen Kodierung konnte nicht geprüft werden. Auto-Coding 2 bleibt gesperrt, bis die Prüfung erfolgreich aktualisiert wurde.',
+          'second-autocoding-waits-help':
+            'Der Start von Auto-Coding 2 bleibt bis dahin gesperrt. {{taskResultHelp}}',
           'second-autocoding-waits-chip': '{{version}}: {{count}} wartet',
-          'second-autocoding-waits-snackbar': 'Schließen Sie zuerst die manuelle Kodierung ab und übernehmen Sie die Ergebnisse.',
+          'second-autocoding-waits-snackbar':
+            'Schließen Sie zuerst die manuelle Kodierung ab und übernehmen Sie die Ergebnisse.',
           'starting-freshness-coding': 'Auto-Coding wird gestartet...',
           'open-manual-review': 'Manuelle Kodierung öffnen'
         }
@@ -270,6 +306,11 @@ describe('CodingManagementComponent', () => {
     fixture = TestBed.createComponent(CodingManagementComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    jest.useRealTimers();
   });
 
   it('should create', () => {
@@ -286,32 +327,101 @@ describe('CodingManagementComponent', () => {
     });
 
     it('should check auto-fetch setting on init', () => {
-      expect(mockWorkspaceSettingsService.getAutoFetchCodingStatistics).toHaveBeenCalledWith(1);
+      expect(
+        mockWorkspaceSettingsService.getAutoFetchCodingStatistics
+      ).toHaveBeenCalledWith(1);
     });
 
     it('should check regex search setting on init', () => {
-      expect(mockWorkspaceSettingsService.getEnableRegexSearch).toHaveBeenCalledWith(1);
+      expect(
+        mockWorkspaceSettingsService.getEnableRegexSearch
+      ).toHaveBeenCalledWith(1);
     });
 
-    it('should load autocoding readiness for the first autocoder run', () => {
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
+    it('should check manual coding auto-refresh setting on init', () => {
+      expect(
+        mockWorkspaceSettingsService.getAutoRefreshManualCodingJobs
+      ).toHaveBeenCalledWith(1);
+    });
+
+    it('should defer autocoding readiness on automatic status overview loads', () => {
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).not.toHaveBeenCalled();
+      expect(component.isLoadingAutocodingReadiness).toBe(false);
+    });
+
+    it('should load deferred autocoding readiness after the idle delay', () => {
+      jest.useFakeTimers();
+      (
+        mockTestPersonCodingService.getAutocodingReadiness as jest.Mock
+      ).mockClear();
+
+      component.loadCodingStatusOverview();
+
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(249);
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).toHaveBeenCalledWith(1, 1, false, 'summary');
+    });
+
+    it('should cancel a deferred readiness load when readiness is refreshed explicitly', () => {
+      jest.useFakeTimers();
+      (
+        mockTestPersonCodingService.getAutocodingReadiness as jest.Mock
+      ).mockClear();
+
+      component.loadCodingStatusOverview();
+      component.refreshAutocodingReadiness();
+      jest.advanceTimersByTime(250);
+
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).toHaveBeenCalledWith(1, 1, true, 'full');
     });
 
     it('should refresh coding status overview when requested by query param', () => {
-      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (
+        mockCodingManagementService.fetchCodingStatistics as jest.Mock
+      ).mockClear();
       (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
-      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
-      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+      (
+        mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock
+      ).mockClear();
+      (
+        mockTestPersonCodingService.getAutocodingReadiness as jest.Mock
+      ).mockClear();
 
-      queryParamMapSubject.next(convertToParamMap({
-        refreshCodingFreshness: '1'
-      }));
+      queryParamMapSubject.next(
+        convertToParamMap({
+          refreshCodingFreshness: '1'
+        })
+      );
 
-      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalled();
-      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
-      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+      expect(
+        mockCodingManagementService.fetchCodingStatistics
+      ).toHaveBeenCalled();
+      expect(
+        mockTestPersonCodingService.getCodingFreshness
+      ).toHaveBeenCalledWith(1);
+      expect(
+        mockTestPersonCodingService.getAppliedResultsOverview
+      ).toHaveBeenCalledWith(1);
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).toHaveBeenCalledWith(1, 1, true, 'full');
     });
   });
 
@@ -327,49 +437,196 @@ describe('CodingManagementComponent', () => {
         resultUnitsTotal: 33,
         resultUnitKeysTotal: 33,
         matchedUnitFiles: 6,
-        missingUnitFiles: ['UNIT_A', 'UNIT_B', 'UNIT_C', 'UNIT_D', 'UNIT_E', 'UNIT_F'],
+        missingUnitFiles: [
+          'UNIT_A',
+          'UNIT_B',
+          'UNIT_C',
+          'UNIT_D',
+          'UNIT_E',
+          'UNIT_F'
+        ],
         matchedCodingSchemes: 2,
         missingCodingSchemes: ['SCHEME_A'],
         invalidCodingSchemes: ['SCHEME_B'],
         validVariablePairs: 0,
         validResponses: 0,
         codeableResponses: 0,
-        invalidVariableSamples: [{
-          unitName: 'UNIT_A',
-          responseCount: 12,
-          sampleVariableIds: ['VAR_A', 'VAR_B', 'VAR_C', 'VAR_D', 'VAR_E'],
-          knownVariableIds: ['KNOWN_A']
-        }]
+        invalidVariableSamples: [
+          {
+            unitName: 'UNIT_A',
+            responseCount: 12,
+            sampleVariableIds: ['VAR_A', 'VAR_B', 'VAR_C', 'VAR_D', 'VAR_E'],
+            knownVariableIds: ['KNOWN_A']
+          }
+        ]
       };
 
       expect(component.hasCodingFreshnessAttention).toBe(true);
-      expect(component.codingFreshnessPanelTitle).toBe('Auto-Coding 1 nicht möglich');
-      expect(component.autocodingReadinessSummaryText).toContain('18787 Rohantworten vorhanden');
-      expect(component.autocodingReadinessDetailsText).toContain('0 Antworten mit passender Kodier-Variable');
-      expect(component.autocodingReadinessMissingUnitPreview).toBe('UNIT_A, UNIT_B, UNIT_C, UNIT_D, UNIT_E +1');
-      expect(component.autocodingReadinessInvalidCodingSchemePreview).toBe('SCHEME_B');
-      expect(component.autocodingReadinessInvalidVariablePreview).toBe('UNIT_A: VAR_A, VAR_B, VAR_C, VAR_D +1');
+      expect(component.codingFreshnessPanelTitle).toBe(
+        'Auto-Coding 1 nicht möglich'
+      );
+      expect(component.autocodingReadinessSummaryText).toContain(
+        '18787 Rohantworten vorhanden'
+      );
+      expect(component.autocodingReadinessDetailsText).toContain(
+        '0 Antworten mit passender Kodier-Variable'
+      );
+      expect(component.autocodingReadinessMissingUnitPreview).toBe(
+        'UNIT_A, UNIT_B, UNIT_C, UNIT_D, UNIT_E +1'
+      );
+      expect(component.autocodingReadinessInvalidCodingSchemePreview).toBe(
+        'SCHEME_B'
+      );
+      expect(component.autocodingReadinessInvalidVariablePreview).toBe(
+        'UNIT_A: VAR_A, VAR_B, VAR_C, VAR_D +1'
+      );
     });
 
     it('should expose readiness load failures as attention', () => {
-      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock)
-        .mockReturnValueOnce(throwError(() => new Error('readiness failed')));
+      (
+        mockTestPersonCodingService.getAutocodingReadiness as jest.Mock
+      ).mockReturnValueOnce(throwError(() => new Error('readiness failed')));
 
       component.loadAutocodingReadiness();
 
       expect(component.hasAutocodingReadinessLoadFailed).toBe(true);
       expect(component.hasCodingFreshnessAttention).toBe(true);
-      expect(component.codingFreshnessPanelTitle).toBe('Auto-Coding-Prüfung nicht verfügbar');
+      expect(component.codingFreshnessPanelTitle).toBe(
+        'Auto-Coding-Prüfung nicht verfügbar'
+      );
+    });
+
+    it('should expose summary readiness as pending diagnostics', () => {
+      component.autocodingReadiness = {
+        workspaceId: 1,
+        autoCoderRun: 1,
+        detailLevel: 'summary',
+        detailsComplete: false,
+        readiness: 'DIAGNOSTICS_PENDING',
+        blockers: [],
+        rawResponsesTotal: 100,
+        rawResponsesWithRelevantStatus: 80,
+        resultUnitsTotal: 12,
+        resultUnitKeysTotal: 10,
+        matchedUnitFiles: 0,
+        missingUnitFiles: [],
+        matchedCodingSchemes: 0,
+        missingCodingSchemes: [],
+        invalidCodingSchemes: [],
+        validVariablePairs: 6,
+        validResponses: 70,
+        potentialCodeableResponses: 70,
+        codeableResponses: 70,
+        invalidVariableSamples: []
+      };
+
+      expect(component.isAutocodingReadinessDiagnosticsPending).toBe(true);
+      expect(component.hasCodingFreshnessAttention).toBe(true);
+      expect(component.codingFreshnessPanelTitle).toBe(
+        'Auto-Coding-Basisprüfung abgeschlossen'
+      );
+      expect(component.autocodingReadinessSummaryPendingText).toContain(
+        '70 potenziell kodierbare Antworten'
+      );
+    });
+
+    it('should load full diagnostics without bypassing the cache when details are requested', () => {
+      component.loadAutocodingReadinessDetails();
+
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).toHaveBeenLastCalledWith(1, 1, false, 'full');
+    });
+
+    it('should retry autocoding readiness with the lightweight summary check', () => {
+      component.retryAutocodingReadiness();
+
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).toHaveBeenLastCalledWith(1, 1, true, 'summary');
     });
 
     it('should force-refresh autocoding readiness when requested', () => {
       component.refreshAutocodingReadiness();
 
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenLastCalledWith(1, 1, true);
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).toHaveBeenLastCalledWith(1, 1, true, 'full');
     });
   });
 
   describe('Coding Freshness', () => {
+    it('should ignore stale coding freshness responses when a newer request supersedes them', () => {
+      const firstFreshness$ = new Subject<{
+        workspaceId: number;
+        currentRevision: number;
+        items: {
+          version: 'v1';
+          state: 'PENDING';
+          unitCount: number;
+          affectedResponseCount: number;
+        }[];
+      }>();
+      const secondFreshness$ = new Subject<{
+        workspaceId: number;
+        currentRevision: number;
+        items: [];
+      }>();
+      (
+        mockTestPersonCodingService.getCodingFreshness as jest.Mock
+      ).mockReturnValueOnce(firstFreshness$.asObservable())
+        .mockReturnValueOnce(secondFreshness$.asObservable());
+      component.codingFreshnessSummary = null;
+
+      component.loadCodingFreshness();
+      component.loadCodingFreshness();
+
+      firstFreshness$.next({
+        workspaceId: 1,
+        currentRevision: 1,
+        items: [
+          {
+            version: 'v1',
+            state: 'PENDING',
+            unitCount: 99,
+            affectedResponseCount: 99
+          }
+        ]
+      });
+      firstFreshness$.complete();
+
+      expect(component.codingFreshnessSummary).toBeNull();
+      expect(component.isLoadingCodingFreshness).toBe(true);
+
+      secondFreshness$.next({
+        workspaceId: 1,
+        currentRevision: 2,
+        items: []
+      });
+      secondFreshness$.complete();
+
+      expect(component.codingFreshnessSummary).toEqual({
+        workspaceId: 1,
+        currentRevision: 2,
+        items: []
+      });
+      expect(component.isLoadingCodingFreshness).toBe(false);
+    });
+
+    it('should show a neutral coding status title while the status overview is loading', () => {
+      component.hasRequestedCodingStatusOverview = true;
+      component.codingFreshnessSummary = {
+        workspaceId: 1,
+        currentRevision: 2,
+        items: []
+      };
+      component.isLoadingCodingFreshness = true;
+
+      expect(component.codingFreshnessPanelTitle).toBe(
+        'Kodierstatus nicht geprüft'
+      );
+    });
+
     it('should keep second auto-coding waiting while manual coding results are still open', () => {
       component.codingFreshnessSummary = {
         workspaceId: 1,
@@ -397,20 +654,32 @@ describe('CodingManagementComponent', () => {
       };
 
       expect(component.hasCodingFreshnessWarnings).toBe(true);
-      expect(component.codingFreshnessPanelTitle).toBe('Manuelle Kodierung abschließen');
-      expect(component.codingFreshnessSummaryText).toContain('Auto-Coding 2 ist der nächste Schritt');
-      expect(component.codingFreshnessSummaryText).toContain('461 manuelle Kodierergebnisse offen');
+      expect(component.codingFreshnessPanelTitle).toBe(
+        'Manuelle Kodierung abschließen'
+      );
+      expect(component.codingFreshnessSummaryText).toContain(
+        'Auto-Coding 2 ist der nächste Schritt'
+      );
+      expect(component.codingFreshnessSummaryText).toContain(
+        '461 manuelle Kodierergebnisse offen'
+      );
       expect(component.hasFreshnessAutoCodingWork('v3')).toBe(false);
       expect(component.hasManualCodingFreshnessAction).toBe(true);
       expect(component.codingFreshnessChipWarnings).toHaveLength(1);
-      expect(component.getFreshnessChipLabel(component.codingFreshnessChipWarnings[0])).toBe(
-        'Auto-Coding 2: 671 Aufgabenbearbeitungen wartet'
-      );
+      expect(
+        component.getFreshnessChipLabel(
+          component.codingFreshnessChipWarnings[0]
+        )
+      ).toBe('Auto-Coding 2: 671 Aufgabenbearbeitungen wartet');
 
       fixture.detectChanges();
-      const actionPanel = fixture.nativeElement.querySelector('.coding-freshness-actions') as HTMLElement | null;
-      const manualActionButton = Array.from(actionPanel?.querySelectorAll('button') || [])
-        .find(button => button.textContent?.includes('Manuelle Kodierung öffnen')) as HTMLButtonElement | undefined;
+      const actionPanel = fixture.nativeElement.querySelector(
+        '.coding-freshness-actions'
+      ) as HTMLElement | null;
+      const manualActionButton = Array.from(
+        actionPanel?.querySelectorAll('button') || []
+      ).find(button => button.textContent?.includes('Manuelle Kodierung öffnen')
+      ) as HTMLButtonElement | undefined;
       expect(manualActionButton).toBeTruthy();
 
       manualActionButton?.click();
@@ -456,7 +725,7 @@ describe('CodingManagementComponent', () => {
       expect(component.codingFreshnessPanelTitle).toBe('Auto-Coding starten');
       expect(component.codingFreshnessSummaryText).toBe(
         '10 Aufgabenbearbeitungen benötigen Auto-Coding 1. ' +
-        'Dabei werden 50 Antwortwerte berücksichtigt.'
+          'Dabei werden 50 Antwortwerte berücksichtigt.'
       );
       expect(component.hasFreshnessAutoCodingWork('v1')).toBe(true);
       expect(component.hasFreshnessAutoCodingWork('v3')).toBe(false);
@@ -495,7 +764,7 @@ describe('CodingManagementComponent', () => {
       expect(component.hasFreshnessAutoCodingWork('v3')).toBe(true);
       expect(component.codingFreshnessSummaryText).toBe(
         '671 Aufgabenbearbeitungen benötigen Auto-Coding 2. ' +
-        'Dabei werden 5098 Antwortwerte berücksichtigt.'
+          'Dabei werden 5098 Antwortwerte berücksichtigt.'
       );
     });
 
@@ -512,14 +781,18 @@ describe('CodingManagementComponent', () => {
           }
         ]
       };
-      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockReturnValueOnce(of(null));
+      (
+        mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock
+      ).mockReturnValueOnce(of(null));
 
       component.loadManualAppliedResultsOverview();
 
       expect(component.manualAppliedResultsOverview).toBeNull();
       expect(component.manualAppliedResultsOverviewLoadFailed).toBe(true);
       expect(component.hasFreshnessAutoCodingWork('v3')).toBe(false);
-      expect(component.codingFreshnessSummaryText).toContain('konnte nicht geprüft werden');
+      expect(component.codingFreshnessSummaryText).toContain(
+        'konnte nicht geprüft werden'
+      );
     });
 
     it('should not start second auto-coding while manual coding results are still open', () => {
@@ -547,11 +820,15 @@ describe('CodingManagementComponent', () => {
         aggregationThreshold: null,
         aggregatedDuplicateCases: 0
       };
-      (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockClear();
+      (
+        mockTestPersonCodingService.startFreshnessCoding as jest.Mock
+      ).mockClear();
 
       component.startFreshnessCoding('v3');
 
-      expect(mockTestPersonCodingService.startFreshnessCoding).not.toHaveBeenCalled();
+      expect(
+        mockTestPersonCodingService.startFreshnessCoding
+      ).not.toHaveBeenCalled();
       expect(mockSnackBar.open).toHaveBeenCalledWith(
         'Schließen Sie zuerst die manuelle Kodierung ab und übernehmen Sie die Ergebnisse.',
         'Schließen',
@@ -561,7 +838,9 @@ describe('CodingManagementComponent', () => {
 
     it('should show a start indicator while the freshness coding request is pending', () => {
       const startRequest$ = new Subject<never>();
-      (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(startRequest$);
+      (
+        mockTestPersonCodingService.startFreshnessCoding as jest.Mock
+      ).mockReturnValueOnce(startRequest$);
       component.codingFreshnessSummary = {
         workspaceId: 1,
         currentRevision: 2,
@@ -578,24 +857,32 @@ describe('CodingManagementComponent', () => {
       component.startFreshnessCoding('v1');
       fixture.detectChanges();
 
-      const status = fixture.nativeElement.querySelector('.coding-freshness-job') as HTMLElement | null;
+      const status = fixture.nativeElement.querySelector(
+        '.coding-freshness-job'
+      ) as HTMLElement | null;
       expect(status?.textContent).toContain('Auto-Coding wird gestartet...');
       expect(status?.querySelector('mat-spinner')).toBeTruthy();
-      expect(fixture.nativeElement.querySelector('.coding-freshness-actions')).toBeNull();
+      expect(
+        fixture.nativeElement.querySelector('.coding-freshness-actions')
+      ).toBeNull();
     });
 
     it('should open the test person coding dialog with the started freshness job', () => {
       jest.useFakeTimers();
       try {
-        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
-          totalResponses: 42,
-          statusCounts: {},
-          jobId: 'freshness-job-1',
-          message: 'Processing in background',
-          unitCount: 7,
-          personCount: 3,
-          groupNames: ['TG1']
-        }));
+        (
+          mockTestPersonCodingService.startFreshnessCoding as jest.Mock
+        ).mockReturnValueOnce(
+          of({
+            totalResponses: 42,
+            statusCounts: {},
+            jobId: 'freshness-job-1',
+            message: 'Processing in background',
+            unitCount: 7,
+            personCount: 3,
+            groupNames: ['TG1']
+          })
+        );
 
         component.startFreshnessCoding('v1');
 
@@ -627,15 +914,19 @@ describe('CodingManagementComponent', () => {
 
       try {
         (mockDialog.open as jest.Mock).mockReturnValueOnce(dialogRef);
-        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
-          totalResponses: 42,
-          statusCounts: {},
-          jobId: 'freshness-job-1',
-          message: 'Processing in background',
-          unitCount: 7,
-          personCount: 3,
-          groupNames: ['TG1']
-        }));
+        (
+          mockTestPersonCodingService.startFreshnessCoding as jest.Mock
+        ).mockReturnValueOnce(
+          of({
+            totalResponses: 42,
+            statusCounts: {},
+            jobId: 'freshness-job-1',
+            message: 'Processing in background',
+            unitCount: 7,
+            personCount: 3,
+            groupNames: ['TG1']
+          })
+        );
 
         component.startFreshnessCoding('v1');
 
@@ -653,7 +944,11 @@ describe('CodingManagementComponent', () => {
 
     it('should not resume parent freshness polling when the dialog reports a terminal status for the started job', () => {
       jest.useFakeTimers();
-      const afterClosed$ = new Subject<{ initialJobId: string; jobId: string; jobStatus: 'failed' }>();
+      const afterClosed$ = new Subject<{
+        initialJobId: string;
+        jobId: string;
+        jobStatus: 'failed';
+      }>();
       const dialogRef = {
         afterClosed: jest.fn().mockReturnValue(afterClosed$),
         close: jest.fn()
@@ -661,15 +956,19 @@ describe('CodingManagementComponent', () => {
 
       try {
         (mockDialog.open as jest.Mock).mockReturnValueOnce(dialogRef);
-        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
-          totalResponses: 42,
-          statusCounts: {},
-          jobId: 'freshness-job-1',
-          message: 'Processing in background',
-          unitCount: 7,
-          personCount: 3,
-          groupNames: ['TG1']
-        }));
+        (
+          mockTestPersonCodingService.startFreshnessCoding as jest.Mock
+        ).mockReturnValueOnce(
+          of({
+            totalResponses: 42,
+            statusCounts: {},
+            jobId: 'freshness-job-1',
+            message: 'Processing in background',
+            unitCount: 7,
+            personCount: 3,
+            groupNames: ['TG1']
+          })
+        );
 
         component.startFreshnessCoding('v1');
         afterClosed$.next({
@@ -689,7 +988,11 @@ describe('CodingManagementComponent', () => {
 
     it('should resume parent freshness polling when the dialog reports a status for another job', () => {
       jest.useFakeTimers();
-      const afterClosed$ = new Subject<{ initialJobId: string; jobId: string; jobStatus: 'failed' }>();
+      const afterClosed$ = new Subject<{
+        initialJobId: string;
+        jobId: string;
+        jobStatus: 'failed';
+      }>();
       const dialogRef = {
         afterClosed: jest.fn().mockReturnValue(afterClosed$),
         close: jest.fn()
@@ -697,15 +1000,19 @@ describe('CodingManagementComponent', () => {
 
       try {
         (mockDialog.open as jest.Mock).mockReturnValueOnce(dialogRef);
-        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
-          totalResponses: 42,
-          statusCounts: {},
-          jobId: 'freshness-job-1',
-          message: 'Processing in background',
-          unitCount: 7,
-          personCount: 3,
-          groupNames: ['TG1']
-        }));
+        (
+          mockTestPersonCodingService.startFreshnessCoding as jest.Mock
+        ).mockReturnValueOnce(
+          of({
+            totalResponses: 42,
+            statusCounts: {},
+            jobId: 'freshness-job-1',
+            message: 'Processing in background',
+            unitCount: 7,
+            personCount: 3,
+            groupNames: ['TG1']
+          })
+        );
 
         component.startFreshnessCoding('v1');
         afterClosed$.next({
@@ -736,6 +1043,35 @@ describe('CodingManagementComponent', () => {
       expect(component.activeFreshnessJobId).toBeNull();
       expect(component.activeFreshnessJobProgress).toBeNull();
     });
+
+    it('should not refresh status overview after auto-coding completes when automatic refresh is disabled', () => {
+      component.autoRefreshManualCodingJobs = false;
+      (
+        mockCodingManagementService.fetchCodingStatistics as jest.Mock
+      ).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (
+        mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock
+      ).mockClear();
+      (
+        mockTestPersonCodingService.getAutocodingReadiness as jest.Mock
+      ).mockClear();
+
+      autoCodingCompletedSubject.next({ jobId: 'other-job' });
+
+      expect(
+        mockCodingManagementService.fetchCodingStatistics
+      ).not.toHaveBeenCalled();
+      expect(
+        mockTestPersonCodingService.getCodingFreshness
+      ).not.toHaveBeenCalled();
+      expect(
+        mockTestPersonCodingService.getAppliedResultsOverview
+      ).not.toHaveBeenCalled();
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).not.toHaveBeenCalled();
+    });
   });
 
   describe('Statistics Card Integration', () => {
@@ -752,35 +1088,119 @@ describe('CodingManagementComponent', () => {
     it('should fetch statistics when statistics card emits loadStatistics', () => {
       component.fetchCodingStatistics();
 
-      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v1');
+      expect(
+        mockCodingManagementService.fetchCodingStatistics
+      ).toHaveBeenCalledWith('v1');
     });
 
     it('should switch to changed statistics version when test results change', () => {
-      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (
+        mockCodingManagementService.fetchCodingStatistics as jest.Mock
+      ).mockClear();
 
-      testResultsChangedSubject.next({ workspaceId: 1, statisticsVersion: 'v2' });
+      testResultsChangedSubject.next({
+        workspaceId: 1,
+        statisticsVersion: 'v2'
+      });
 
       expect(component.selectedStatisticsVersion).toBe('v2');
       expect(component.filterParams.version).toBe('v2');
-      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v2');
+      expect(
+        mockCodingManagementService.fetchCodingStatistics
+      ).toHaveBeenCalledWith('v2');
+    });
+
+    it('should not refresh status overview after test results changed when automatic refresh is disabled', () => {
+      component.autoRefreshManualCodingJobs = false;
+      (
+        mockCodingManagementService.fetchCodingStatistics as jest.Mock
+      ).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (
+        mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock
+      ).mockClear();
+      (
+        mockTestPersonCodingService.getAutocodingReadiness as jest.Mock
+      ).mockClear();
+
+      testResultsChangedSubject.next({
+        workspaceId: 1,
+        statisticsVersion: 'v2'
+      });
+
+      expect(component.selectedStatisticsVersion).toBe('v2');
+      expect(component.filterParams.version).toBe('v2');
+      expect(
+        mockCodingManagementService.fetchCodingStatistics
+      ).not.toHaveBeenCalled();
+      expect(
+        mockTestPersonCodingService.getCodingFreshness
+      ).not.toHaveBeenCalled();
+      expect(
+        mockTestPersonCodingService.getAppliedResultsOverview
+      ).not.toHaveBeenCalled();
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should keep manual status refresh button loading data when automatic refresh is disabled', () => {
+      component.autoRefreshManualCodingJobs = false;
+      (
+        mockCodingManagementService.fetchCodingStatistics as jest.Mock
+      ).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (
+        mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock
+      ).mockClear();
+      (
+        mockTestPersonCodingService.getAutocodingReadiness as jest.Mock
+      ).mockClear();
+
+      component.refreshCodingStatusOverview();
+
+      expect(
+        mockCodingManagementService.fetchCodingStatistics
+      ).toHaveBeenCalledWith('v1');
+      expect(
+        mockTestPersonCodingService.getCodingFreshness
+      ).toHaveBeenCalledWith(1);
+      expect(
+        mockTestPersonCodingService.getAppliedResultsOverview
+      ).toHaveBeenCalledWith(1);
+      expect(
+        mockTestPersonCodingService.getAutocodingReadiness
+      ).toHaveBeenCalledWith(1, 1, true, 'full');
     });
 
     it('should ignore changed test results from a different workspace', () => {
-      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (
+        mockCodingManagementService.fetchCodingStatistics as jest.Mock
+      ).mockClear();
 
-      testResultsChangedSubject.next({ workspaceId: 2, statisticsVersion: 'v2' });
+      testResultsChangedSubject.next({
+        workspaceId: 2,
+        statisticsVersion: 'v2'
+      });
 
       expect(component.selectedStatisticsVersion).toBe('v1');
       expect(component.filterParams.version).toBe('v1');
-      expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+      expect(
+        mockCodingManagementService.fetchCodingStatistics
+      ).not.toHaveBeenCalled();
     });
 
     it('should consume a pending statistics version when opened after results changed', () => {
       fixture.destroy();
-      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
-      (mockTestPersonCodingService.consumePendingStatisticsVersion as jest.Mock).mockClear();
-      (mockTestPersonCodingService.consumePendingStatisticsVersion as jest.Mock)
-        .mockReturnValueOnce('v2');
+      (
+        mockCodingManagementService.fetchCodingStatistics as jest.Mock
+      ).mockClear();
+      (
+        mockTestPersonCodingService.consumePendingStatisticsVersion as jest.Mock
+      ).mockClear();
+      (
+        mockTestPersonCodingService.consumePendingStatisticsVersion as jest.Mock
+      ).mockReturnValueOnce('v2');
 
       fixture = TestBed.createComponent(CodingManagementComponent);
       component = fixture.componentInstance;
@@ -788,8 +1208,12 @@ describe('CodingManagementComponent', () => {
 
       expect(component.selectedStatisticsVersion).toBe('v2');
       expect(component.filterParams.version).toBe('v2');
-      expect(mockTestPersonCodingService.consumePendingStatisticsVersion).toHaveBeenCalledWith(1);
-      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v2');
+      expect(
+        mockTestPersonCodingService.consumePendingStatisticsVersion
+      ).toHaveBeenCalledWith(1);
+      expect(
+        mockCodingManagementService.fetchCodingStatistics
+      ).toHaveBeenCalledWith('v2');
     });
 
     it('should handle status click from statistics card through the normal table filter', () => {
@@ -798,14 +1222,19 @@ describe('CodingManagementComponent', () => {
       component.onStatusClick('200');
 
       expect(component.currentStatusFilter).toBeNull();
-      expect(component.filterParams).toEqual(expect.objectContaining({
-        codedStatus: '200',
-        group: 'ID26010601',
-        responseSource: 'all',
-        version: 'v1'
-      }));
+      expect(component.filterParams).toEqual(
+        expect.objectContaining({
+          codedStatus: '200',
+          group: 'ID26010601',
+          responseSource: 'all',
+          version: 'v1'
+        })
+      );
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
+        expect.objectContaining({
+          ...component.filterParams,
+          regexSearch: false
+        }),
         1,
         100,
         undefined,
@@ -852,7 +1281,10 @@ describe('CodingManagementComponent', () => {
 
       expect(component.filterParams.version).toBe('v2');
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
+        expect.objectContaining({
+          ...component.filterParams,
+          regexSearch: false
+        }),
         1,
         100,
         undefined,
@@ -876,7 +1308,10 @@ describe('CodingManagementComponent', () => {
 
       expect(component.filterParams.responseSource).toBe('base');
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
+        expect.objectContaining({
+          ...component.filterParams,
+          regexSearch: false
+        }),
         1,
         100,
         undefined,
@@ -906,7 +1341,9 @@ describe('CodingManagementComponent', () => {
       expect(component.data).toEqual([]);
       expect(component.totalRecords).toBe(0);
       expect(component.currentStatusFilter).toBeNull();
-      expect(mockCodingManagementService.searchResponses).not.toHaveBeenCalled();
+      expect(
+        mockCodingManagementService.searchResponses
+      ).not.toHaveBeenCalled();
     });
 
     it('should apply derived response source when derived statistics are clicked', () => {
@@ -932,7 +1369,10 @@ describe('CodingManagementComponent', () => {
       expect(component.currentStatusFilter).toBeNull();
       expect(component.pageIndex).toBe(0);
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
+        expect.objectContaining({
+          ...component.filterParams,
+          regexSearch: false
+        }),
         1,
         100,
         undefined,
@@ -968,7 +1408,9 @@ describe('CodingManagementComponent', () => {
 
       expect(component.pageSize).toBe(200);
       expect(component.pageIndex).toBe(1);
-      expect(mockCodingManagementService.fetchResponsesByStatus).toHaveBeenCalledWith(
+      expect(
+        mockCodingManagementService.fetchResponsesByStatus
+      ).toHaveBeenCalledWith(
         '200',
         'v1',
         2, // pageIndex + 1
@@ -991,7 +1433,10 @@ describe('CodingManagementComponent', () => {
       expect(component.sortDirection).toBe('desc');
       expect(component.pageIndex).toBe(0);
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
+        expect.objectContaining({
+          ...component.filterParams,
+          regexSearch: false
+        }),
         1,
         100,
         'score',
@@ -1004,7 +1449,9 @@ describe('CodingManagementComponent', () => {
 
       component.onReplayClick(response);
 
-      expect(mockUiService.openReplayForResponse).toHaveBeenCalledWith(response);
+      expect(mockUiService.openReplayForResponse).toHaveBeenCalledWith(
+        response
+      );
     });
 
     it('should handle show coding scheme from table component', () => {
@@ -1027,46 +1474,51 @@ describe('CodingManagementComponent', () => {
       };
       component.data = [{ id: 1 } as Success];
       component.totalRecords = 2;
-      mockCodingManagementService.searchResponses = jest.fn().mockReturnValue(of({
-        total: 2,
-        data: [
-          {
-            responseId: 1,
-            unitId: 10,
-            variableId: 'v1',
-            value: 'UEsD',
-            status: 'VALUE_CHANGED',
-            unitName: 'Unit1',
-            unitAlias: null,
-            bookletId: 20,
-            bookletName: 'Booklet1',
-            personId: 30,
-            personLogin: 'login1',
-            personCode: 'code1',
-            personGroup: 'group1'
-          },
-          {
-            responseId: 2,
-            unitId: 11,
-            variableId: 'v2',
-            value: 'UEsD',
-            status: 'VALUE_CHANGED',
-            unitName: 'Unit2',
-            unitAlias: null,
-            bookletId: 21,
-            bookletName: 'Booklet2',
-            personId: 31,
-            personLogin: 'login2',
-            personCode: 'code2',
-            personGroup: 'group2'
-          }
-        ]
-      }));
+      mockCodingManagementService.searchResponses = jest.fn().mockReturnValue(
+        of({
+          total: 2,
+          data: [
+            {
+              responseId: 1,
+              unitId: 10,
+              variableId: 'v1',
+              value: 'UEsD',
+              status: 'VALUE_CHANGED',
+              unitName: 'Unit1',
+              unitAlias: null,
+              bookletId: 20,
+              bookletName: 'Booklet1',
+              personId: 30,
+              personLogin: 'login1',
+              personCode: 'code1',
+              personGroup: 'group1'
+            },
+            {
+              responseId: 2,
+              unitId: 11,
+              variableId: 'v2',
+              value: 'UEsD',
+              status: 'VALUE_CHANGED',
+              unitName: 'Unit2',
+              unitAlias: null,
+              bookletId: 21,
+              bookletName: 'Booklet2',
+              personId: 31,
+              personLogin: 'login2',
+              personCode: 'code2',
+              personGroup: 'group2'
+            }
+          ]
+        })
+      );
 
       component.onReviewClick();
 
       expect(mockCodingManagementService.searchResponses).toHaveBeenCalledWith(
-        expect.objectContaining({ ...component.filterParams, regexSearch: false }),
+        expect.objectContaining({
+          ...component.filterParams,
+          regexSearch: false
+        }),
         1,
         2,
         undefined,
@@ -1093,31 +1545,38 @@ describe('CodingManagementComponent', () => {
       };
       component.data = [{ id: 1 } as Success];
       component.totalRecords = 1200;
-      mockCodingManagementService.searchResponses = jest.fn().mockImplementation(
-        (_params, page: number) => of({
+      mockCodingManagementService.searchResponses = jest
+        .fn()
+        .mockImplementation((_params, page: number) => of({
           total: 1200,
-          data: [{
-            responseId: page,
-            unitId: page,
-            variableId: `v${page}`,
-            value: 'UEsD',
-            status: 'VALUE_CHANGED',
-            unitName: `Unit${page}`,
-            unitAlias: null,
-            bookletId: page,
-            bookletName: `Booklet${page}`,
-            personId: page,
-            personLogin: `login${page}`,
-            personCode: `code${page}`,
-            personGroup: `group${page}`
-          }]
+          data: [
+            {
+              responseId: page,
+              unitId: page,
+              variableId: `v${page}`,
+              value: 'UEsD',
+              status: 'VALUE_CHANGED',
+              unitName: `Unit${page}`,
+              unitAlias: null,
+              bookletId: page,
+              bookletName: `Booklet${page}`,
+              personId: page,
+              personLogin: `login${page}`,
+              personCode: `code${page}`,
+              personGroup: `group${page}`
+            }
+          ]
         })
-      );
+        );
 
       component.onReviewClick();
 
-      expect(mockCodingManagementService.searchResponses).toHaveBeenCalledTimes(3);
-      expect(mockCodingManagementService.searchResponses).toHaveBeenNthCalledWith(
+      expect(mockCodingManagementService.searchResponses).toHaveBeenCalledTimes(
+        3
+      );
+      expect(
+        mockCodingManagementService.searchResponses
+      ).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({ geogebra: true }),
         1,
@@ -1125,7 +1584,9 @@ describe('CodingManagementComponent', () => {
         undefined,
         undefined
       );
-      expect(mockCodingManagementService.searchResponses).toHaveBeenNthCalledWith(
+      expect(
+        mockCodingManagementService.searchResponses
+      ).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ geogebra: true }),
         2,
@@ -1133,7 +1594,9 @@ describe('CodingManagementComponent', () => {
         undefined,
         undefined
       );
-      expect(mockCodingManagementService.searchResponses).toHaveBeenNthCalledWith(
+      expect(
+        mockCodingManagementService.searchResponses
+      ).toHaveBeenNthCalledWith(
         3,
         expect.objectContaining({ geogebra: true }),
         3,
@@ -1168,7 +1631,9 @@ describe('CodingManagementComponent', () => {
 
       component.onReviewClick();
 
-      expect(mockCodingManagementService.searchResponses).not.toHaveBeenCalled();
+      expect(
+        mockCodingManagementService.searchResponses
+      ).not.toHaveBeenCalled();
       expect(mockDialog.open).not.toHaveBeenCalled();
       expect(mockSnackBar.open).toHaveBeenCalledWith(
         'coding-management.messages.review-too-many-results',
@@ -1239,7 +1704,9 @@ describe('CodingManagementComponent', () => {
 
   describe('Component Cleanup', () => {
     it('should unsubscribe on destroy', () => {
-      const componentWithPrivate = component as unknown as { destroy$: Subject<void> };
+      const componentWithPrivate = component as unknown as {
+        destroy$: Subject<void>;
+      };
       const destroySpy = jest.spyOn(componentWithPrivate.destroy$, 'next');
       const completeSpy = jest.spyOn(componentWithPrivate.destroy$, 'complete');
 

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -1,25 +1,14 @@
 import {
-  Component,
-  OnInit,
-  OnDestroy,
-  Input,
-  inject
+  Component, OnInit, OnDestroy, Input, inject
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
-  concatMap,
-  finalize,
-  reduce,
-  takeUntil
+  concatMap, finalize, reduce, takeUntil
 } from 'rxjs/operators';
 import { range, Subject } from 'rxjs';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatIcon } from '@angular/material/icon';
-import {
-  MatAnchor,
-  MatButton,
-  MatIconButton
-} from '@angular/material/button';
+import { MatAnchor, MatButton, MatIconButton } from '@angular/material/button';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { PageEvent } from '@angular/material/paginator';
 import { Sort } from '@angular/material/sort';
@@ -74,7 +63,10 @@ import {
   CodingFreshnessSummaryDto,
   CodingFreshnessSummaryItemDto
 } from '../../../../../../../api-dto/coding/coding-freshness.dto';
-import { AutocodingReadinessDto } from '../../../../../../../api-dto/coding/autocoding-readiness.dto';
+import {
+  AutocodingReadinessDetailLevel,
+  AutocodingReadinessDto
+} from '../../../../../../../api-dto/coding/autocoding-readiness.dto';
 import {
   CODING_FRESHNESS_TASK_RESULT_HELP,
   getCodingFreshnessAffectedResponseCount,
@@ -181,6 +173,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   manualAppliedResultsOverview: AppliedResultsOverview | null = null;
   isLoadingManualAppliedResultsOverview = false;
   manualAppliedResultsOverviewLoadFailed = false;
+  autoRefreshManualCodingJobs = true;
+  hasRequestedCodingStatusOverview = false;
   enableRegexSearch = false;
   isStartingFreshnessCoding = false;
   activeFreshnessJobId: string | null = null;
@@ -205,13 +199,24 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
   private freshnessJobPollingInterval: number | null = null;
   private lastResetProgress: number | null | undefined;
+  private codingFreshnessRequestGeneration = 0;
+  private codingFreshnessScopeRequestGeneration = 0;
+  private manualAppliedResultsOverviewRequestGeneration = 0;
+  private autocodingReadinessRequestGeneration = 0;
+  private autocodingReadinessIdleTimeout: ReturnType<typeof setTimeout> | null =
+    null;
+
+  private readonly autocodingReadinessIdleDelayMs = 250;
 
   ngOnInit(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     let pendingStatisticsVersion: StatisticsVersion | null = null;
 
     if (workspaceId) {
-      pendingStatisticsVersion = this.testPersonCodingService.consumePendingStatisticsVersion(workspaceId);
+      pendingStatisticsVersion =
+        this.testPersonCodingService.consumePendingStatisticsVersion(
+          workspaceId
+        );
       if (pendingStatisticsVersion) {
         this.selectStatisticsVersion(pendingStatisticsVersion);
       }
@@ -229,8 +234,18 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         .subscribe(enabled => {
           this.enableRegexSearch = enabled;
         });
+      this.workspaceSettingsService
+        .getAutoRefreshManualCodingJobs(workspaceId)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(enabled => {
+          this.autoRefreshManualCodingJobs = enabled;
+          if (enabled) {
+            this.loadCodingStatusOverview();
+          }
+        });
 
-      this.codingManagementService.hasGeogebraResponses()
+      this.codingManagementService
+        .hasGeogebraResponses()
         .pipe(takeUntil(this.destroy$))
         .subscribe(available => {
           this.isGeogebraAvailable = available;
@@ -271,14 +286,12 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         const previousProgress = this.lastResetProgress;
         this.lastResetProgress = progress;
         this.resetProgress = progress;
-        if (previousProgress !== undefined &&
+        if (
+          previousProgress !== undefined &&
           previousProgress !== null &&
-          progress === null) {
-          this.fetchCodingStatistics();
-          this.loadCodingFreshness();
-          this.loadManualAppliedResultsOverview();
-          this.loadAutocodingReadiness();
-          this.refreshTableData();
+          progress === null
+        ) {
+          this.refreshCodingStatusOverviewAfterChange();
         }
       });
 
@@ -301,11 +314,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         if (event?.jobId && event.jobId === this.activeFreshnessJobId) {
           this.stopFreshnessJobPolling();
         }
-        this.fetchCodingStatistics();
-        this.loadCodingFreshness();
-        this.loadManualAppliedResultsOverview();
-        this.loadAutocodingReadiness();
-        this.refreshTableData();
+        this.refreshCodingStatusOverviewAfterChange();
       });
 
     this.testPersonCodingService.testResultsChanged$
@@ -316,9 +325,6 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
     // Check for active reset job (persists across navigation)
     this.codingManagementService.checkActiveResetJob();
-    this.loadCodingFreshness();
-    this.loadManualAppliedResultsOverview();
-    this.loadAutocodingReadiness();
     this.route.queryParamMap
       .pipe(takeUntil(this.destroy$))
       .subscribe(params => {
@@ -330,6 +336,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.cancelScheduledAutocodingReadinessLoad();
     this.stopFreshnessJobPolling();
     this.destroy$.next();
     this.destroy$.complete();
@@ -357,7 +364,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.referenceVersion = null;
   }
 
-  private refreshAfterTestResultsChanged(event: TestResultsChangedEvent = {}): void {
+  private refreshAfterTestResultsChanged(
+    event: TestResultsChangedEvent = {}
+  ): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (event.workspaceId && event.workspaceId !== workspaceId) {
       return;
@@ -366,39 +375,61 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     if (event.statisticsVersion) {
       this.selectStatisticsVersion(event.statisticsVersion);
       if (workspaceId) {
-        this.testPersonCodingService.consumePendingStatisticsVersion(workspaceId);
+        this.testPersonCodingService.consumePendingStatisticsVersion(
+          workspaceId
+        );
       }
     }
-    this.fetchCodingStatistics();
-    this.loadCodingFreshness();
-    this.loadManualAppliedResultsOverview();
-    this.loadAutocodingReadiness();
-    this.refreshTableData();
+    this.refreshCodingStatusOverviewAfterChange();
   }
 
   fetchCodingStatistics(): void {
-    this.codingManagementService.fetchCodingStatistics(this.selectedStatisticsVersion);
+    this.codingManagementService.fetchCodingStatistics(
+      this.selectedStatisticsVersion
+    );
   }
 
   loadCodingFreshness(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.codingFreshnessRequestGeneration += 1;
+      this.codingFreshnessScopeRequestGeneration += 1;
+      this.codingFreshnessSummary = null;
+      this.codingFreshnessScope = null;
+      this.isLoadingCodingFreshness = false;
       return;
     }
 
+    const requestGeneration = this.codingFreshnessRequestGeneration + 1;
+    this.codingFreshnessRequestGeneration = requestGeneration;
+    this.hasRequestedCodingStatusOverview = true;
     this.isLoadingCodingFreshness = true;
-    this.testPersonCodingService.getCodingFreshness(workspaceId)
+    this.testPersonCodingService
+      .getCodingFreshness(workspaceId)
       .pipe(
         finalize(() => {
-          this.isLoadingCodingFreshness = false;
+          if (
+            this.codingFreshnessRequestGeneration === requestGeneration &&
+            this.appService.selectedWorkspaceId === workspaceId
+          ) {
+            this.isLoadingCodingFreshness = false;
+          }
         }),
         takeUntil(this.destroy$)
       )
       .subscribe(summary => {
+        if (
+          this.codingFreshnessRequestGeneration !== requestGeneration ||
+          this.appService.selectedWorkspaceId !== workspaceId
+        ) {
+          return;
+        }
+
         this.codingFreshnessSummary = summary;
         if (this.hasCodingFreshnessWarnings) {
           this.loadCodingFreshnessScope();
         } else {
+          this.codingFreshnessScopeRequestGeneration += 1;
           this.codingFreshnessScope = null;
         }
       });
@@ -407,12 +438,24 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   loadCodingFreshnessScope(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.codingFreshnessScopeRequestGeneration += 1;
+      this.codingFreshnessScope = null;
       return;
     }
 
-    this.testPersonCodingService.getCodingFreshnessScope(workspaceId)
+    const requestGeneration = this.codingFreshnessScopeRequestGeneration + 1;
+    this.codingFreshnessScopeRequestGeneration = requestGeneration;
+    this.testPersonCodingService
+      .getCodingFreshnessScope(workspaceId)
       .pipe(takeUntil(this.destroy$))
       .subscribe(scope => {
+        if (
+          this.codingFreshnessScopeRequestGeneration !== requestGeneration ||
+          this.appService.selectedWorkspaceId !== workspaceId
+        ) {
+          return;
+        }
+
         this.codingFreshnessScope = scope;
       });
   }
@@ -420,46 +463,155 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   loadManualAppliedResultsOverview(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.manualAppliedResultsOverviewRequestGeneration += 1;
       this.manualAppliedResultsOverview = null;
       this.manualAppliedResultsOverviewLoadFailed = false;
+      this.isLoadingManualAppliedResultsOverview = false;
       return;
     }
 
+    const requestGeneration =
+      this.manualAppliedResultsOverviewRequestGeneration + 1;
+    this.manualAppliedResultsOverviewRequestGeneration = requestGeneration;
+    this.hasRequestedCodingStatusOverview = true;
     this.isLoadingManualAppliedResultsOverview = true;
     this.manualAppliedResultsOverviewLoadFailed = false;
-    this.testPersonCodingService.getAppliedResultsOverview(workspaceId)
+    this.testPersonCodingService
+      .getAppliedResultsOverview(workspaceId)
       .pipe(
         finalize(() => {
-          this.isLoadingManualAppliedResultsOverview = false;
+          if (
+            this.manualAppliedResultsOverviewRequestGeneration ===
+              requestGeneration &&
+            this.appService.selectedWorkspaceId === workspaceId
+          ) {
+            this.isLoadingManualAppliedResultsOverview = false;
+          }
         }),
         takeUntil(this.destroy$)
       )
       .subscribe(overview => {
+        if (
+          this.manualAppliedResultsOverviewRequestGeneration !==
+            requestGeneration ||
+          this.appService.selectedWorkspaceId !== workspaceId
+        ) {
+          return;
+        }
+
         this.manualAppliedResultsOverview = overview;
         this.manualAppliedResultsOverviewLoadFailed = overview === null;
       });
   }
 
-  loadAutocodingReadiness(forceRefresh = false): void {
+  loadAutocodingReadiness(
+    forceRefresh = false,
+    detailLevel: AutocodingReadinessDetailLevel = 'full'
+  ): void {
+    this.cancelScheduledAutocodingReadinessLoad();
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.autocodingReadinessRequestGeneration += 1;
+      this.autocodingReadiness = null;
+      this.autocodingReadinessLoadFailed = false;
+      this.isLoadingAutocodingReadiness = false;
       return;
     }
 
+    const requestGeneration = this.autocodingReadinessRequestGeneration + 1;
+    this.autocodingReadinessRequestGeneration = requestGeneration;
+    this.startAutocodingReadinessLoad(
+      workspaceId,
+      forceRefresh,
+      detailLevel,
+      requestGeneration
+    );
+  }
+
+  private scheduleAutocodingReadinessLoad(
+    forceRefresh = false,
+    detailLevel: AutocodingReadinessDetailLevel = 'summary'
+  ): void {
+    this.cancelScheduledAutocodingReadinessLoad();
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      this.loadAutocodingReadiness(forceRefresh, detailLevel);
+      return;
+    }
+
+    const requestGeneration = this.autocodingReadinessRequestGeneration + 1;
+    this.autocodingReadinessRequestGeneration = requestGeneration;
+    this.hasRequestedCodingStatusOverview = true;
+    this.autocodingReadinessLoadFailed = false;
+
+    this.autocodingReadinessIdleTimeout = setTimeout(() => {
+      this.autocodingReadinessIdleTimeout = null;
+      if (
+        this.autocodingReadinessRequestGeneration !== requestGeneration ||
+        this.appService.selectedWorkspaceId !== workspaceId
+      ) {
+        return;
+      }
+
+      this.startAutocodingReadinessLoad(
+        workspaceId,
+        forceRefresh,
+        detailLevel,
+        requestGeneration
+      );
+    }, this.autocodingReadinessIdleDelayMs);
+  }
+
+  private cancelScheduledAutocodingReadinessLoad(): void {
+    if (this.autocodingReadinessIdleTimeout === null) {
+      return;
+    }
+
+    clearTimeout(this.autocodingReadinessIdleTimeout);
+    this.autocodingReadinessIdleTimeout = null;
+  }
+
+  private startAutocodingReadinessLoad(
+    workspaceId: number,
+    forceRefresh: boolean,
+    detailLevel: AutocodingReadinessDetailLevel,
+    requestGeneration: number
+  ): void {
+    this.hasRequestedCodingStatusOverview = true;
     this.isLoadingAutocodingReadiness = true;
     this.autocodingReadinessLoadFailed = false;
-    this.testPersonCodingService.getAutocodingReadiness(workspaceId, 1, forceRefresh)
+    this.testPersonCodingService
+      .getAutocodingReadiness(workspaceId, 1, forceRefresh, detailLevel)
       .pipe(
         finalize(() => {
-          this.isLoadingAutocodingReadiness = false;
+          if (
+            this.autocodingReadinessRequestGeneration === requestGeneration &&
+            this.appService.selectedWorkspaceId === workspaceId
+          ) {
+            this.isLoadingAutocodingReadiness = false;
+          }
         }),
         takeUntil(this.destroy$)
       )
       .subscribe({
         next: readiness => {
+          if (
+            this.autocodingReadinessRequestGeneration !== requestGeneration ||
+            this.appService.selectedWorkspaceId !== workspaceId
+          ) {
+            return;
+          }
+
           this.autocodingReadiness = readiness;
         },
         error: () => {
+          if (
+            this.autocodingReadinessRequestGeneration !== requestGeneration ||
+            this.appService.selectedWorkspaceId !== workspaceId
+          ) {
+            return;
+          }
+
           this.autocodingReadiness = null;
           this.autocodingReadinessLoadFailed = true;
         }
@@ -470,12 +622,51 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.loadAutocodingReadiness(true);
   }
 
-  private refreshCodingStatusOverview(): void {
+  retryAutocodingReadiness(): void {
+    this.loadAutocodingReadiness(true, 'summary');
+  }
+
+  loadAutocodingReadinessDetails(): void {
+    this.loadAutocodingReadiness(false, 'full');
+  }
+
+  refreshCodingStatusOverview(): void {
     this.fetchCodingStatistics();
+    this.loadCodingStatusOverview(true);
+    this.refreshTableData();
+  }
+
+  private refreshCodingStatusOverviewAfterChange(): void {
+    if (!this.autoRefreshManualCodingJobs) {
+      return;
+    }
+
+    this.fetchCodingStatistics();
+    this.loadCodingStatusOverview();
+    this.refreshTableData();
+  }
+
+  loadCodingStatusOverview(forceAutocodingReadiness = false): void {
+    this.hasRequestedCodingStatusOverview = true;
     this.loadCodingFreshness();
     this.loadManualAppliedResultsOverview();
-    this.loadAutocodingReadiness(true);
-    this.refreshTableData();
+    if (forceAutocodingReadiness) {
+      this.loadAutocodingReadiness(true);
+    } else {
+      this.scheduleAutocodingReadinessLoad();
+    }
+  }
+
+  shouldShowManualCodingStatusRefresh(): boolean {
+    return !this.autoRefreshManualCodingJobs;
+  }
+
+  isCodingStatusOverviewLoading(): boolean {
+    return (
+      this.isLoadingCodingFreshness ||
+      this.isLoadingAutocodingReadiness ||
+      this.isLoadingManualAppliedResultsOverview
+    );
   }
 
   startFreshnessCoding(version: 'v1' | 'v3'): void {
@@ -486,7 +677,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
     if (version === 'v3' && this.isSecondAutocodingWaitingForManualCoding) {
       this.snackBar.open(
-        this.translateService.instant('coding-management.readiness.second-autocoding-waits-snackbar'),
+        this.translateService.instant(
+          'coding-management.readiness.second-autocoding-waits-snackbar'
+        ),
         this.translateService.instant('coding-management.actions.close'),
         { duration: 6000 }
       );
@@ -494,10 +687,11 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     }
 
     this.isStartingFreshnessCoding = true;
-    this.testPersonCodingService.startFreshnessCoding(workspaceId, {
-      version,
-      states: ['PENDING', 'STALE']
-    })
+    this.testPersonCodingService
+      .startFreshnessCoding(workspaceId, {
+        version,
+        states: ['PENDING', 'STALE']
+      })
       .pipe(
         finalize(() => {
           this.isStartingFreshnessCoding = false;
@@ -507,7 +701,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       .subscribe(result => {
         if (!result.jobId) {
           this.snackBar.open(
-            result.message || 'Keine betroffenen Ergebnisse für Auto-Coding gefunden.',
+            result.message ||
+              'Keine betroffenen Ergebnisse für Auto-Coding gefunden.',
             'Schließen',
             { duration: 5000 }
           );
@@ -521,16 +716,18 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
           initialJobId: result.jobId,
           initialAutoCoderRun: version === 'v3' ? 2 : 1
         });
-        dialogRef.afterClosed()
+        dialogRef
+          .afterClosed()
           .pipe(takeUntil(this.destroy$))
           .subscribe(dialogResult => {
             if (this.activeFreshnessJobId !== result.jobId) {
               return;
             }
 
-            const dialogStatus = dialogResult?.jobId === result.jobId ?
-              dialogResult.jobStatus :
-              null;
+            const dialogStatus =
+              dialogResult?.jobId === result.jobId ?
+                dialogResult.jobStatus :
+                null;
             if (this.isTerminalJobStatus(dialogStatus)) {
               this.stopFreshnessJobPolling();
               this.loadCodingFreshness();
@@ -608,7 +805,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   onClearFilters(): void {
-    this.filterParams = this.createDefaultFilterParams(this.selectedStatisticsVersion);
+    this.filterParams = this.createDefaultFilterParams(
+      this.selectedStatisticsVersion
+    );
     this.data = [];
     this.totalRecords = 0;
     this.currentStatusFilter = null;
@@ -632,12 +831,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   onSortChange(sort: Sort): void {
-    this.sortBy = this.isSupportedResponseSort(sort.active) && sort.direction ?
-      sort.active :
-      '';
-    this.sortDirection = sort.direction === 'asc' || sort.direction === 'desc' ?
-      sort.direction :
-      '';
+    this.sortBy =
+      this.isSupportedResponseSort(sort.active) && sort.direction ?
+        sort.active :
+        '';
+    this.sortDirection =
+      sort.direction === 'asc' || sort.direction === 'desc' ?
+        sort.direction :
+        '';
     this.pageIndex = 0;
 
     if (this.currentStatusFilter) {
@@ -656,11 +857,13 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   onShowCodingScheme(unitId: number): void {
-    this.uiService.getCodingSchemeFromUnit(unitId).subscribe(codingSchemeRef => {
-      if (codingSchemeRef) {
-        this.uiService.showCodingSchemeDialog(codingSchemeRef);
-      }
-    });
+    this.uiService
+      .getCodingSchemeFromUnit(unitId)
+      .subscribe(codingSchemeRef => {
+        if (codingSchemeRef) {
+          this.uiService.showCodingSchemeDialog(codingSchemeRef);
+        }
+      });
   }
 
   onShowUnitXml(unitId: number): void {
@@ -670,7 +873,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   onReviewClick(): void {
     if (!this.data || this.data.length === 0) {
       this.snackBar.open(
-        this.translateService.instant('coding-management.messages.no-data-to-review'),
+        this.translateService.instant(
+          'coding-management.messages.no-data-to-review'
+        ),
         this.translateService.instant('coding-management.actions.close'),
         { duration: 3000 }
       );
@@ -703,7 +908,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     const totalReviewRecords = this.totalRecords;
     if (totalReviewRecords <= 0) {
       this.snackBar.open(
-        this.translateService.instant('coding-management.messages.no-data-to-review'),
+        this.translateService.instant(
+          'coding-management.messages.no-data-to-review'
+        ),
         this.translateService.instant('coding-management.actions.close'),
         { duration: 3000 }
       );
@@ -718,45 +925,54 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     const reviewBatchSize = Math.min(this.reviewBatchSize, totalReviewRecords);
     const reviewPageCount = Math.ceil(totalReviewRecords / reviewBatchSize);
 
-    range(0, reviewPageCount).pipe(
-      concatMap(batchIndex => this.codingManagementService.searchResponses(
-        reviewFilterParams,
-        batchIndex + 1,
-        reviewBatchSize,
-        this.sortBy || undefined,
-        this.sortDirection || undefined
-      )),
-      reduce(
-        (
-          responses: Success[],
-          response: { data: SearchResponseItem[]; total: number }
-        ) => responses.concat(this.mapSearchResponseItemsToSuccess(response.data)),
-        [] as Success[]
-      ),
-      finalize(() => {
-        this.isLoadingReview = false;
-      }),
-      takeUntil(this.destroy$)
-    ).subscribe({
-      next: responses => {
-        if (!responses.length) {
+    range(0, reviewPageCount)
+      .pipe(
+        concatMap(batchIndex => this.codingManagementService.searchResponses(
+          reviewFilterParams,
+          batchIndex + 1,
+          reviewBatchSize,
+          this.sortBy || undefined,
+          this.sortDirection || undefined
+        )
+        ),
+        reduce(
+          (
+            responses: Success[],
+            response: { data: SearchResponseItem[]; total: number }
+          ) => responses.concat(
+            this.mapSearchResponseItemsToSuccess(response.data)
+          ),
+          [] as Success[]
+        ),
+        finalize(() => {
+          this.isLoadingReview = false;
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe({
+        next: responses => {
+          if (!responses.length) {
+            this.snackBar.open(
+              this.translateService.instant(
+                'coding-management.messages.no-data-to-review'
+              ),
+              this.translateService.instant('coding-management.actions.close'),
+              { duration: 3000 }
+            );
+            return;
+          }
+          this.openReviewDialog(responses);
+        },
+        error: () => {
           this.snackBar.open(
-            this.translateService.instant('coding-management.messages.no-data-to-review'),
+            this.translateService.instant(
+              'coding-management.messages.review-load-failed'
+            ),
             this.translateService.instant('coding-management.actions.close'),
-            { duration: 3000 }
+            { duration: 5000 }
           );
-          return;
         }
-        this.openReviewDialog(responses);
-      },
-      error: () => {
-        this.snackBar.open(
-          this.translateService.instant('coding-management.messages.review-load-failed'),
-          this.translateService.instant('coding-management.actions.close'),
-          { duration: 5000 }
-        );
-      }
-    });
+      });
   }
 
   private openReviewDialog(responses: Success[]): void {
@@ -767,19 +983,26 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       panelClass: 'full-screen-dialog',
       data: {
         responses,
-        title: this.translateService.instant('coding-management.actions.review-session')
+        title: this.translateService.instant(
+          'coding-management.actions.review-session'
+        )
       }
     });
   }
 
   get codingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
-    return this.allCodingFreshnessWarnings
-      .filter(item => !(item.version === 'v3' && this.isSecondAutocodingWaitingForManualCoding));
+    return this.allCodingFreshnessWarnings.filter(
+      item => !(
+        item.version === 'v3' && this.isSecondAutocodingWaitingForManualCoding
+      )
+    );
   }
 
   get hasCodingFreshnessWarnings(): boolean {
-    return this.codingFreshnessWarnings.length > 0 ||
-      this.shouldShowSecondAutocodingWaitingState;
+    return (
+      this.codingFreshnessWarnings.length > 0 ||
+      this.shouldShowSecondAutocodingWaitingState
+    );
   }
 
   get codingFreshnessChipWarnings(): CodingFreshnessSummaryItemDto[] {
@@ -795,14 +1018,20 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get hasImportedResultsWithoutCoding(): boolean {
-    return !this.hasCodingFreshnessWarnings &&
+    return (
+      !this.hasCodingFreshnessWarnings &&
       (this.codingFreshnessSummary?.currentRevision || 0) > 0 &&
       (this.codingFreshnessSummary?.items || []).length === 0 &&
-      (this.codingStatistics.totalResponses || 0) === 0;
+      (this.codingStatistics.totalResponses || 0) === 0
+    );
   }
 
   get isAutocodingReadinessBlocked(): boolean {
     return this.autocodingReadiness?.readiness === 'BLOCKED';
+  }
+
+  get isAutocodingReadinessDiagnosticsPending(): boolean {
+    return this.autocodingReadiness?.readiness === 'DIAGNOSTICS_PENDING';
   }
 
   get hasAutocodingReadinessLoadFailed(): boolean {
@@ -810,10 +1039,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get hasCodingFreshnessAttention(): boolean {
-    return this.hasAutocodingReadinessLoadFailed ||
+    return (
+      !this.hasRequestedCodingStatusOverview ||
+      this.hasAutocodingReadinessLoadFailed ||
+      this.isAutocodingReadinessDiagnosticsPending ||
       this.isAutocodingReadinessBlocked ||
       this.hasCodingFreshnessWarnings ||
-      this.hasImportedResultsWithoutCoding;
+      this.hasImportedResultsWithoutCoding
+    );
   }
 
   get autoCodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
@@ -825,8 +1058,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get hasManualCodingFreshnessAction(): boolean {
-    return this.manualCodingFreshnessWarnings.length > 0 ||
-      this.shouldShowSecondAutocodingWaitingState;
+    return (
+      this.manualCodingFreshnessWarnings.length > 0 ||
+      this.shouldShowSecondAutocodingWaitingState
+    );
   }
 
   get hasOnlyManualCodingFreshnessWarnings(): boolean {
@@ -834,11 +1069,15 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get codingFreshnessAffectedUnits(): number {
-    return getCodingFreshnessAffectedTaskResultCount(this.codingFreshnessWarnings);
+    return getCodingFreshnessAffectedTaskResultCount(
+      this.codingFreshnessWarnings
+    );
   }
 
   get codingFreshnessAffectedResponses(): number {
-    return getCodingFreshnessAffectedResponseCount(this.codingFreshnessWarnings);
+    return getCodingFreshnessAffectedResponseCount(
+      this.codingFreshnessWarnings
+    );
   }
 
   get codingFreshnessSummaryText(): string {
@@ -849,13 +1088,15 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         );
       }
 
-      const remaining = this.manualAppliedResultsOverview?.remainingResponses || 0;
-      const remainingText = remaining > 0 ?
-        this.translateService.instant(
-          'coding-management.readiness.second-autocoding-waits-remaining',
-          { count: remaining }
-        ) :
-        '';
+      const remaining =
+        this.manualAppliedResultsOverview?.remainingResponses || 0;
+      const remainingText =
+        remaining > 0 ?
+          this.translateService.instant(
+            'coding-management.readiness.second-autocoding-waits-remaining',
+            { count: remaining }
+          ) :
+          '';
 
       return this.translateService.instant(
         'coding-management.readiness.second-autocoding-waits-summary',
@@ -878,20 +1119,46 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get codingFreshnessPanelTitle(): string {
+    if (this.isCodingStatusOverviewLoading()) {
+      return this.translateService.instant(
+        'coding-management.readiness.title-not-checked'
+      );
+    }
+
+    if (!this.hasRequestedCodingStatusOverview) {
+      return this.translateService.instant(
+        'coding-management.readiness.title-not-checked'
+      );
+    }
+
     if (this.hasAutocodingReadinessLoadFailed) {
-      return this.translateService.instant('coding-management.readiness.title-load-failed');
+      return this.translateService.instant(
+        'coding-management.readiness.title-load-failed'
+      );
+    }
+
+    if (this.isAutocodingReadinessDiagnosticsPending) {
+      return this.translateService.instant(
+        'coding-management.readiness.title-diagnostics-pending'
+      );
     }
 
     if (this.isAutocodingReadinessBlocked) {
-      return this.translateService.instant('coding-management.readiness.title-blocked');
+      return this.translateService.instant(
+        'coding-management.readiness.title-blocked'
+      );
     }
 
     if (this.hasImportedResultsWithoutCoding) {
-      return this.translateService.instant('coding-management.readiness.title-not-started');
+      return this.translateService.instant(
+        'coding-management.readiness.title-not-started'
+      );
     }
 
     if (this.shouldShowSecondAutocodingWaitingState) {
-      return this.translateService.instant('coding-management.readiness.title-manual-coding-open');
+      return this.translateService.instant(
+        'coding-management.readiness.title-manual-coding-open'
+      );
     }
 
     return getCodingFreshnessAttentionTitle(this.codingFreshnessWarnings);
@@ -906,8 +1173,27 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       'coding-management.readiness.summary',
       {
         rawResponsesTotal: this.autocodingReadiness.rawResponsesTotal,
-        rawResponsesWithRelevantStatus: this.autocodingReadiness.rawResponsesWithRelevantStatus,
+        rawResponsesWithRelevantStatus:
+          this.autocodingReadiness.rawResponsesWithRelevantStatus,
         codeableResponses: this.autocodingReadiness.codeableResponses
+      }
+    );
+  }
+
+  get autocodingReadinessSummaryPendingText(): string {
+    if (!this.autocodingReadiness) {
+      return '';
+    }
+
+    return this.translateService.instant(
+      'coding-management.readiness.summary-pending-diagnostics',
+      {
+        rawResponsesTotal: this.autocodingReadiness.rawResponsesTotal,
+        rawResponsesWithRelevantStatus:
+          this.autocodingReadiness.rawResponsesWithRelevantStatus,
+        potentialCodeableResponses:
+          this.autocodingReadiness.potentialCodeableResponses ??
+          this.autocodingReadiness.validResponses
       }
     );
   }
@@ -938,15 +1224,24 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get autocodingReadinessMissingUnitPreview(): string {
-    return this.formatPreview(this.autocodingReadiness?.missingUnitFiles || [], 5);
+    return this.formatPreview(
+      this.autocodingReadiness?.missingUnitFiles || [],
+      5
+    );
   }
 
   get autocodingReadinessMissingCodingSchemePreview(): string {
-    return this.formatPreview(this.autocodingReadiness?.missingCodingSchemes || [], 5);
+    return this.formatPreview(
+      this.autocodingReadiness?.missingCodingSchemes || [],
+      5
+    );
   }
 
   get autocodingReadinessInvalidCodingSchemePreview(): string {
-    return this.formatPreview(this.autocodingReadiness?.invalidCodingSchemes || [], 5);
+    return this.formatPreview(
+      this.autocodingReadiness?.invalidCodingSchemes || [],
+      5
+    );
   }
 
   get autocodingReadinessInvalidVariablePreview(): string {
@@ -955,7 +1250,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return '';
     }
 
-    const visible = samples.slice(0, 3)
+    const visible = samples
+      .slice(0, 3)
       .map(sample => {
         const variablePreview = this.formatPreview(sample.sampleVariableIds, 4);
         return `${sample.unitName}: ${variablePreview}`;
@@ -972,7 +1268,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get manualCodingFreshnessGuidanceText(): string {
-    return getCodingFreshnessManualReviewGuidanceText(this.codingFreshnessWarnings);
+    return getCodingFreshnessManualReviewGuidanceText(
+      this.codingFreshnessWarnings
+    );
   }
 
   get codingFreshnessGroupPreview(): string {
@@ -986,7 +1284,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   hasFreshnessAutoCodingWork(version: 'v1' | 'v3'): boolean {
-    return this.autoCodingFreshnessWarnings.some(item => item.version === version);
+    return this.autoCodingFreshnessWarnings.some(
+      item => item.version === version
+    );
   }
 
   getFreshnessVersionLabel(version: 'v1' | 'v2' | 'v3'): string {
@@ -998,7 +1298,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   getFreshnessChipLabel(item: CodingFreshnessSummaryItemDto): string {
-    if (item.version === 'v3' && this.isSecondAutocodingWaitingForManualCoding) {
+    if (
+      item.version === 'v3' &&
+      this.isSecondAutocodingWaitingForManualCoding
+    ) {
       const count = getCodingFreshnessAffectedTaskResultCount([item]);
       const countLabel = `${count} ${count === 1 ? 'Aufgabenbearbeitung' : 'Aufgabenbearbeitungen'}`;
       return this.translateService.instant(
@@ -1014,7 +1317,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   getFreshnessAutoCodingButtonLabel(version: 'v1' | 'v3'): string {
-    return getCodingFreshnessAutoCodingButtonLabel(this.autoCodingFreshnessWarnings, version);
+    return getCodingFreshnessAutoCodingButtonLabel(
+      this.autoCodingFreshnessWarnings,
+      version
+    );
   }
 
   private startFreshnessJobPolling(jobId: string): void {
@@ -1026,7 +1332,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         return;
       }
 
-      this.testPersonCodingService.getJobStatus(workspaceId, jobId)
+      this.testPersonCodingService
+        .getJobStatus(workspaceId, jobId)
         .pipe(takeUntil(this.destroy$))
         .subscribe(status => {
           if (!('status' in status)) {
@@ -1036,7 +1343,11 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
           }
 
           this.activeFreshnessJobProgress = status.progress;
-          if (['completed', 'failed', 'cancelled', 'paused'].includes(status.status)) {
+          if (
+            ['completed', 'failed', 'cancelled', 'paused'].includes(
+              status.status
+            )
+          ) {
             this.stopFreshnessJobPolling();
             if (status.status === 'completed') {
               this.testPersonCodingService.notifyAutoCodingCompleted(jobId);
@@ -1047,7 +1358,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
               );
             } else if (status.status === 'failed') {
               this.snackBar.open(
-                status.error || 'Auto-Coding für betroffene Ergebnisse fehlgeschlagen.',
+                status.error ||
+                  'Auto-Coding für betroffene Ergebnisse fehlgeschlagen.',
                 'Schließen',
                 { duration: 6000 }
               );
@@ -1061,12 +1373,15 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   private get allCodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
-    return (this.codingFreshnessSummary?.items || [])
-      .filter(isCodingFreshnessOpenWarning);
+    return (this.codingFreshnessSummary?.items || []).filter(
+      isCodingFreshnessOpenWarning
+    );
   }
 
   private get secondAutocodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
-    return getSecondAutocodingFreshnessWarnings(this.allCodingFreshnessWarnings);
+    return getSecondAutocodingFreshnessWarnings(
+      this.allCodingFreshnessWarnings
+    );
   }
 
   private get isSecondAutocodingWaitingForManualCoding(): boolean {
@@ -1078,8 +1393,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   private get shouldShowSecondAutocodingWaitingState(): boolean {
-    return this.isSecondAutocodingWaitingForManualCoding &&
-      this.codingFreshnessWarnings.length === 0;
+    return (
+      this.isSecondAutocodingWaitingForManualCoding &&
+      this.codingFreshnessWarnings.length === 0
+    );
   }
 
   private stopFreshnessJobPolling(): void {
@@ -1100,54 +1417,71 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.isLoading = true;
     this.currentStatusFilter = status;
 
-    this.codingManagementService.fetchResponsesByStatus(
-      status,
-      this.selectedStatisticsVersion,
-      page,
-      limit,
-      this.sortBy || undefined,
-      this.sortDirection || undefined
-    ).subscribe({
-      next: response => {
-        this.data = response.data.map((item: ResponseEntity) => {
-          const codeKey = `code_${this.selectedStatisticsVersion}` as keyof ResponseEntity;
-          const scoreKey = `score_${this.selectedStatisticsVersion}` as keyof ResponseEntity;
-          const statusKey = `status_${this.selectedStatisticsVersion}` as keyof ResponseEntity;
+    this.codingManagementService
+      .fetchResponsesByStatus(
+        status,
+        this.selectedStatisticsVersion,
+        page,
+        limit,
+        this.sortBy || undefined,
+        this.sortDirection || undefined
+      )
+      .subscribe({
+        next: response => {
+          this.data = response.data.map((item: ResponseEntity) => {
+            const codeKey =
+              `code_${this.selectedStatisticsVersion}` as keyof ResponseEntity;
+            const scoreKey =
+              `score_${this.selectedStatisticsVersion}` as keyof ResponseEntity;
+            const statusKey =
+              `status_${this.selectedStatisticsVersion}` as keyof ResponseEntity;
 
-          return {
-            id: item.id,
-            unitid: item.unitId,
-            variableid: item.variableid || '',
-            status: item.status || '',
-            value: item.value || '',
-            subform: item.subform || '',
-            code: (item[codeKey] as number)?.toString() || null,
-            score: (item[scoreKey] as number)?.toString() || null,
-            unit: item.unit,
-            codedstatus: (item[statusKey] as string) || '',
-            unitname: item.unit?.name || '',
-            login_name: item.unit?.booklet?.person?.login || '',
-            login_group: (item.unit?.booklet?.person as { group?: string } | undefined)?.group || '',
-            login_code: item.unit?.booklet?.person?.code || '',
-            booklet_id: item.unit?.booklet?.bookletinfo?.name || ''
-          } as Success;
-        });
-        this.totalRecords = response.total;
-        this.isLoading = false;
+            return {
+              id: item.id,
+              unitid: item.unitId,
+              variableid: item.variableid || '',
+              status: item.status || '',
+              value: item.value || '',
+              subform: item.subform || '',
+              code: (item[codeKey] as number)?.toString() || null,
+              score: (item[scoreKey] as number)?.toString() || null,
+              unit: item.unit,
+              codedstatus: (item[statusKey] as string) || '',
+              unitname: item.unit?.name || '',
+              login_name: item.unit?.booklet?.person?.login || '',
+              login_group:
+                (item.unit?.booklet?.person as { group?: string } | undefined)
+                  ?.group || '',
+              login_code: item.unit?.booklet?.person?.code || '',
+              booklet_id: item.unit?.booklet?.bookletinfo?.name || ''
+            } as Success;
+          });
+          this.totalRecords = response.total;
+          this.isLoading = false;
 
-        if (this.data.length === 0) {
-          const statusName = getResponseStatusLabel(status);
-          this.snackBar.open(
-            this.translateService.instant('coding-management.descriptions.no-results', { status: statusName === 'null' ? this.translateService.instant('coding-management.statistics.uncoded-responses-title') : statusName }),
-            this.translateService.instant('close'),
-            { duration: 5000 }
-          );
+          if (this.data.length === 0) {
+            const statusName = getResponseStatusLabel(status);
+            this.snackBar.open(
+              this.translateService.instant(
+                'coding-management.descriptions.no-results',
+                {
+                  status:
+                    statusName === 'null' ?
+                      this.translateService.instant(
+                        'coding-management.statistics.uncoded-responses-title'
+                      ) :
+                      statusName
+                }
+              ),
+              this.translateService.instant('close'),
+              { duration: 5000 }
+            );
+          }
+        },
+        error: () => {
+          this.isLoading = false;
         }
-      },
-      error: () => {
-        this.isLoading = false;
-      }
-    });
+      });
   }
 
   private fetchResponsesWithFilters(): void {
@@ -1160,36 +1494,40 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.codingManagementService.searchResponses(
-      {
-        ...this.filterParams,
-        regexSearch: this.enableRegexSearch
-      },
-      this.pageIndex + 1,
-      this.pageSize,
-      this.sortBy || undefined,
-      this.sortDirection || undefined
-    ).subscribe({
-      next: (response: { data: SearchResponseItem[]; total: number }) => {
-        this.data = this.mapSearchResponseItemsToSuccess(response.data);
-        this.totalRecords = response.total;
-        this.isLoading = false;
+    this.codingManagementService
+      .searchResponses(
+        {
+          ...this.filterParams,
+          regexSearch: this.enableRegexSearch
+        },
+        this.pageIndex + 1,
+        this.pageSize,
+        this.sortBy || undefined,
+        this.sortDirection || undefined
+      )
+      .subscribe({
+        next: (response: { data: SearchResponseItem[]; total: number }) => {
+          this.data = this.mapSearchResponseItemsToSuccess(response.data);
+          this.totalRecords = response.total;
+          this.isLoading = false;
 
-        if (this.data.length === 0) {
-          this.snackBar.open(
-            'Keine Daten mit den angegebenen Filtern gefunden.',
-            'Schließen',
-            { duration: 5000 }
-          );
+          if (this.data.length === 0) {
+            this.snackBar.open(
+              'Keine Daten mit den angegebenen Filtern gefunden.',
+              'Schließen',
+              { duration: 5000 }
+            );
+          }
+        },
+        error: () => {
+          this.isLoading = false;
         }
-      },
-      error: () => {
-        this.isLoading = false;
-      }
-    });
+      });
   }
 
-  private mapSearchResponseItemsToSuccess(items: SearchResponseItem[]): Success[] {
+  private mapSearchResponseItemsToSuccess(
+    items: SearchResponseItem[]
+  ): Success[] {
     return items.map(item => this.mapSearchResponseItemToSuccess(item));
   }
 
@@ -1225,7 +1563,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     };
   }
 
-  private isSupportedResponseSort(sortBy: string): sortBy is CodingResponseSortBy {
+  private isSupportedResponseSort(
+    sortBy: string
+  ): sortBy is CodingResponseSortBy {
     return [
       'unitname',
       'variableid',
@@ -1247,7 +1587,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   private openTestPersonCodingDialog(
     data?: TestPersonCodingDialogData
-  ): MatDialogRef<TestPersonCodingDialogComponent, TestPersonCodingDialogResult | undefined> {
+  ): MatDialogRef<
+    TestPersonCodingDialogComponent,
+    TestPersonCodingDialogResult | undefined
+    > {
     const dialogRef = this.dialog.open(TestPersonCodingDialogComponent, {
       height: '90vh',
       maxWidth: '100vw',
@@ -1256,7 +1599,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       data
     });
 
-    dialogRef.afterClosed()
+    dialogRef
+      .afterClosed()
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.fetchCodingStatistics();
@@ -1266,7 +1610,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   private isTerminalJobStatus(status?: string | null): boolean {
-    return ['completed', 'failed', 'cancelled', 'paused'].includes(status || '');
+    return ['completed', 'failed', 'cancelled', 'paused'].includes(
+      status || ''
+    );
   }
 
   fetchCodingList(): void {
@@ -1274,11 +1620,21 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       width: '500px'
     });
 
-    dialogRef.afterClosed().subscribe((result: { format: ExportFormat; trainingRequired?: boolean } | undefined) => {
-      if (result && result.format) {
-        this.codingManagementService.downloadCodingList(result.format, result.trainingRequired);
-      }
-    });
+    dialogRef
+      .afterClosed()
+      .subscribe(
+        (
+          result:
+          { format: ExportFormat; trainingRequired?: boolean } | undefined
+        ) => {
+          if (result && result.format) {
+            this.codingManagementService.downloadCodingList(
+              result.format,
+              result.trainingRequired
+            );
+          }
+        }
+      );
   }
 
   openExportCodingBook(): void {
@@ -1298,7 +1654,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       { queryParams: { focus: 'manual-freshness' } } :
       undefined;
 
-    this.router.navigate([`/workspace-admin/${workspaceId}/coding/manual`], navigationExtras);
+    this.router.navigate(
+      [`/workspace-admin/${workspaceId}/coding/manual`],
+      navigationExtras
+    );
   }
 
   openTestFiles(): void {
@@ -1337,14 +1696,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private openResetVersionDialog(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
-      this.snackBar.open(
-        'Fehler: Kein Workspace ausgewählt',
-        'Schließen',
-        {
-          duration: 5000,
-          panelClass: ['error-snackbar']
-        }
-      );
+      this.snackBar.open('Fehler: Kein Workspace ausgewählt', 'Schließen', {
+        duration: 5000,
+        panelClass: ['error-snackbar']
+      });
       return;
     }
 
@@ -1355,7 +1710,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     ].find(opt => opt.value === this.selectedStatisticsVersion);
 
     const versionLabel = versionOption?.label || '';
-    const cascadeVersions = this.selectedStatisticsVersion === 'v2' ? ['v3'] : [];
+    const cascadeVersions =
+      this.selectedStatisticsVersion === 'v2' ? ['v3'] : [];
 
     const dialogRef = this.dialog.open(ResetVersionDialogComponent, {
       width: '500px',
@@ -1380,14 +1736,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private openDownloadCodingResultsDialog(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
-      this.snackBar.open(
-        'Fehler: Kein Workspace ausgewählt',
-        'Schließen',
-        {
-          duration: 5000,
-          panelClass: ['error-snackbar']
-        }
-      );
+      this.snackBar.open('Fehler: Kein Workspace ausgewählt', 'Schließen', {
+        duration: 5000,
+        panelClass: ['error-snackbar']
+      });
       return;
     }
 
@@ -1399,44 +1751,61 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       }
     });
 
-    dialogRef.afterClosed().subscribe((result: {
-      version: StatisticsVersion;
-      format: CodingResultsExportFormat;
-      includeReplayUrls: boolean;
-      includeResponseValues: boolean;
-      includeGeoGebraFiles: boolean;
-      includeGeoGebraResponseValues: boolean;
-    } | undefined) => {
-      if (result) {
-        const {
-          version,
-          format,
-          includeReplayUrls,
-          includeResponseValues,
-          includeGeoGebraFiles,
-          includeGeoGebraResponseValues
-        } = result;
-        this.codingManagementService.downloadCodingResults(
-          version,
-          format,
-          includeReplayUrls,
-          includeResponseValues,
-          includeGeoGebraFiles,
-          includeGeoGebraResponseValues
-        )
-          .finally(() => {
-            this.isDownloadInProgress = false;
-          });
+    dialogRef.afterClosed().subscribe(
+      (
+        result:
+        | {
+          version: StatisticsVersion;
+          format: CodingResultsExportFormat;
+          includeReplayUrls: boolean;
+          includeResponseValues: boolean;
+          includeGeoGebraFiles: boolean;
+          includeGeoGebraResponseValues: boolean;
+        }
+        | undefined
+      ) => {
+        if (result) {
+          const {
+            version,
+            format,
+            includeReplayUrls,
+            includeResponseValues,
+            includeGeoGebraFiles,
+            includeGeoGebraResponseValues
+          } = result;
+          this.codingManagementService
+            .downloadCodingResults(
+              version,
+              format,
+              includeReplayUrls,
+              includeResponseValues,
+              includeGeoGebraFiles,
+              includeGeoGebraResponseValues
+            )
+            .finally(() => {
+              this.isDownloadInProgress = false;
+            });
+        }
       }
-    });
+    );
   }
 
   getAvailableStatuses(): string[] {
     const ignoredStatuses = [
-      '0', '1', '2', '3', '10',
-      'UNSET', 'NOT_REACHED', 'DISPLAYED', 'VALUE_CHANGED', 'PARTLY_DISPLAYED'
+      '0',
+      '1',
+      '2',
+      '3',
+      '10',
+      'UNSET',
+      'NOT_REACHED',
+      'DISPLAYED',
+      'VALUE_CHANGED',
+      'PARTLY_DISPLAYED'
     ];
-    return Object.keys(this.codingStatistics.statusCounts).filter(s => !ignoredStatuses.includes(s));
+    return Object.keys(this.codingStatistics.statusCounts).filter(
+      s => !ignoredStatuses.includes(s)
+    );
   }
 
   private refreshTableData(): void {
@@ -1449,7 +1818,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     }
   }
 
-  private createDefaultFilterParams(version: StatisticsVersion = this.selectedStatisticsVersion): FilterParams {
+  private createDefaultFilterParams(
+    version: StatisticsVersion = this.selectedStatisticsVersion
+  ): FilterParams {
     return {
       value: '',
       unitName: '',
@@ -1478,15 +1849,15 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     return filterParams;
   }
 
-  private hasActiveFilters(filterParams: FilterParams = this.filterParams): boolean {
-    return Object.entries(filterParams).some(
-      ([key, value]) => {
-        if (key === 'version') return false;
-        if (key === 'regexSearch') return false;
-        if (key === 'responseSource') return value !== 'all';
-        return typeof value === 'string' ? value.trim() !== '' : value === true;
-      }
-    );
+  private hasActiveFilters(
+    filterParams: FilterParams = this.filterParams
+  ): boolean {
+    return Object.entries(filterParams).some(([key, value]) => {
+      if (key === 'version') return false;
+      if (key === 'regexSearch') return false;
+      if (key === 'responseSource') return value !== 'all';
+      return typeof value === 'string' ? value.trim() !== '' : value === true;
+    });
   }
 
   private formatPreview(values: string[], maxItems: number): string {

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
@@ -39,6 +39,79 @@ describe('CodingTrainingBackendService', () => {
     expect(service).toBeTruthy();
   });
 
+  describe('getCoderTrainings', () => {
+    const coderTrainings = [{
+      id: 10,
+      workspace_id: 1,
+      label: 'Training A',
+      created_at: new Date('2026-01-01T00:00:00.000Z'),
+      updated_at: new Date('2026-01-01T00:00:00.000Z'),
+      jobsCount: 2
+    }];
+
+    it('should share an in-flight coder training request', () => {
+      const received: unknown[] = [];
+
+      service.getCoderTrainings(1).subscribe(trainings => received.push(trainings));
+      service.getCoderTrainings(1).subscribe(trainings => received.push(trainings));
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+      expect(req.request.method).toBe('GET');
+      req.flush(coderTrainings);
+
+      expect(received).toEqual([coderTrainings, coderTrainings]);
+      httpMock.expectNone(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+    });
+
+    it('should reuse cached coder trainings after the first request', () => {
+      const received: unknown[] = [];
+
+      service.getCoderTrainings(1).subscribe(trainings => received.push(trainings));
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+      req.flush(coderTrainings);
+
+      service.getCoderTrainings(1).subscribe(trainings => received.push(trainings));
+
+      expect(received).toEqual([coderTrainings, coderTrainings]);
+      httpMock.expectNone(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+    });
+
+    it('should invalidate cached coder trainings after a training mutation', () => {
+      service.getCoderTrainings(1).subscribe();
+      httpMock
+        .expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`)
+        .flush(coderTrainings);
+
+      service.updateCoderTrainingLabel(1, 10, 'Training B').subscribe();
+      const updateReq = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/10/label`);
+      expect(updateReq.request.method).toBe('PUT');
+      updateReq.flush({});
+
+      service.getCoderTrainings(1).subscribe();
+      httpMock
+        .expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`)
+        .flush([{ ...coderTrainings[0], label: 'Training B' }]);
+    });
+
+    it('should not cache a stale in-flight response after invalidation', () => {
+      service.getCoderTrainings(1).subscribe();
+      const staleListReq = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+
+      service.updateCoderTrainingLabel(1, 10, 'Training B').subscribe();
+      httpMock
+        .expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/10/label`)
+        .flush({});
+
+      staleListReq.flush(coderTrainings);
+
+      service.getCoderTrainings(1).subscribe();
+      httpMock
+        .expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`)
+        .flush([{ ...coderTrainings[0], label: 'Training B' }]);
+    });
+  });
+
   describe('createCoderTrainingJobs', () => {
     it('should create jobs', () => {
       service.createCoderTrainingJobs(1, [], [], 'Label').subscribe();

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -1,7 +1,13 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import {
-  Observable, catchError, of, switchMap, tap
+  Observable,
+  catchError,
+  finalize,
+  of,
+  shareReplay,
+  switchMap,
+  tap
 } from 'rxjs';
 import { SERVER_URL } from '../../injection-tokens';
 import { CoderTraining } from '../models/coder-training.model';
@@ -102,6 +108,8 @@ export class CodingTrainingBackendService {
   private readonly serverUrl = inject(SERVER_URL);
   private http = inject(HttpClient);
   private readonly withinTrainingComparisonCache = new Map<string, WithinTrainingComparisonCacheEntry>();
+  private coderTrainingsCache = new Map<number, CoderTraining[]>();
+  private coderTrainingsInFlight = new Map<number, Observable<CoderTraining[]>>();
 
   private get authHeader() {
     return {};
@@ -168,6 +176,7 @@ export class CodingTrainingBackendService {
       suppressGeneralInstructions
     }, { headers: this.authHeader }).pipe(
       tap(response => {
+        this.invalidateCoderTrainings(workspaceId);
         if (response.trainingId) {
           this.invalidateWithinTrainingComparisonCache(workspaceId, response.trainingId);
         } else {
@@ -178,8 +187,45 @@ export class CodingTrainingBackendService {
   }
 
   getCoderTrainings(workspaceId: number): Observable<CoderTraining[]> {
+    const cachedTrainings = this.coderTrainingsCache.get(workspaceId);
+    if (cachedTrainings) {
+      return of([...cachedTrainings]);
+    }
+
+    const inFlightRequest = this.coderTrainingsInFlight.get(workspaceId);
+    if (inFlightRequest) {
+      return inFlightRequest;
+    }
+
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings`;
-    return this.http.get<CoderTraining[]>(url, { headers: this.authHeader });
+    const request$ = this.http.get<CoderTraining[]>(url, { headers: this.authHeader })
+      .pipe(
+        tap(trainings => {
+          if (this.coderTrainingsInFlight.get(workspaceId) === request$) {
+            this.coderTrainingsCache.set(workspaceId, [...trainings]);
+          }
+        }),
+        finalize(() => {
+          if (this.coderTrainingsInFlight.get(workspaceId) === request$) {
+            this.coderTrainingsInFlight.delete(workspaceId);
+          }
+        }),
+        shareReplay({ bufferSize: 1, refCount: false })
+      );
+
+    this.coderTrainingsInFlight.set(workspaceId, request$);
+    return request$;
+  }
+
+  invalidateCoderTrainings(workspaceId?: number): void {
+    if (workspaceId === undefined) {
+      this.coderTrainingsCache.clear();
+      this.coderTrainingsInFlight.clear();
+      return;
+    }
+
+    this.coderTrainingsCache.delete(workspaceId);
+    this.coderTrainingsInFlight.delete(workspaceId);
   }
 
   updateCoderTraining(
@@ -221,7 +267,10 @@ export class CodingTrainingBackendService {
       allowComments,
       suppressGeneralInstructions
     }, { headers: this.authHeader }).pipe(
-      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
+      tap(() => {
+        this.invalidateCoderTrainings(workspaceId);
+        this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId);
+      })
     );
   }
 
@@ -231,7 +280,10 @@ export class CodingTrainingBackendService {
   ): Observable<{ success: boolean; message: string }> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings/${trainingId}`;
     return this.http.delete<{ success: boolean; message: string }>(url, { headers: this.authHeader }).pipe(
-      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
+      tap(() => {
+        this.invalidateCoderTrainings(workspaceId);
+        this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId);
+      })
     );
   }
 
@@ -244,7 +296,10 @@ export class CodingTrainingBackendService {
     return this.http.put<{ success: boolean; message: string }>(url, {
       label: newLabel
     }, { headers: this.authHeader }).pipe(
-      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
+      tap(() => {
+        this.invalidateCoderTrainings(workspaceId);
+        this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId);
+      })
     );
   }
 

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -316,6 +316,105 @@ describe('TestPersonCodingService', () => {
     });
   });
 
+  describe('getAutocodingReadiness', () => {
+    const readinessResponse = {
+      workspaceId: mockWorkspaceId,
+      autoCoderRun: 1 as const,
+      detailLevel: 'summary' as const,
+      detailsComplete: false,
+      readiness: 'DIAGNOSTICS_PENDING' as const,
+      blockers: [],
+      rawResponsesTotal: 10,
+      rawResponsesWithRelevantStatus: 8,
+      resultUnitsTotal: 0,
+      resultUnitKeysTotal: 0,
+      matchedUnitFiles: 0,
+      missingUnitFiles: [],
+      matchedCodingSchemes: 0,
+      missingCodingSchemes: [],
+      invalidCodingSchemes: [],
+      validVariablePairs: 0,
+      validResponses: 0,
+      codeableResponses: 0,
+      invalidVariableSamples: []
+    };
+
+    it('should reuse cached readiness for repeated non-forced requests', () => {
+      service.getAutocodingReadiness(mockWorkspaceId, 1, false, 'summary')
+        .subscribe(response => {
+          expect(response).toEqual(readinessResponse);
+        });
+
+      const req = httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        request.params.get('detailLevel') === 'summary'
+      ));
+      expect(req.request.method).toBe('GET');
+      req.flush(readinessResponse);
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1, false, 'summary')
+        .subscribe(response => {
+          expect(response).toEqual({
+            ...readinessResponse,
+            fromCache: true
+          });
+        });
+
+      httpMock.expectNone(`${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness`);
+    });
+
+    it('should share in-flight readiness requests', () => {
+      const firstResponse = jest.fn();
+      const secondResponse = jest.fn();
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1, false, 'summary')
+        .subscribe(firstResponse);
+      service.getAutocodingReadiness(mockWorkspaceId, 1, false, 'summary')
+        .subscribe(secondResponse);
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness?autoCoderRun=1&detailLevel=summary`);
+      req.flush(readinessResponse);
+
+      expect(firstResponse).toHaveBeenCalledWith(readinessResponse);
+      expect(secondResponse).toHaveBeenCalledWith(readinessResponse);
+    });
+
+    it('should bypass cached readiness on force refresh', () => {
+      service.getAutocodingReadiness(mockWorkspaceId, 1, false, 'summary')
+        .subscribe();
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness?autoCoderRun=1&detailLevel=summary`)
+        .flush(readinessResponse);
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1, true, 'summary')
+        .subscribe(response => {
+          expect(response).toEqual(readinessResponse);
+        });
+
+      const forcedReq = httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('forceRefresh') === 'true'
+      ));
+      forcedReq.flush(readinessResponse);
+    });
+
+    it('should invalidate cached readiness when test results change', () => {
+      service.getAutocodingReadiness(mockWorkspaceId, 1, false, 'summary')
+        .subscribe();
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness?autoCoderRun=1&detailLevel=summary`)
+        .flush(readinessResponse);
+
+      service.notifyTestResultsChanged({ workspaceId: mockWorkspaceId });
+      service.getAutocodingReadiness(mockWorkspaceId, 1, false, 'summary')
+        .subscribe(response => {
+          expect(response).toEqual(readinessResponse);
+        });
+
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness?autoCoderRun=1&detailLevel=summary`)
+        .flush(readinessResponse);
+    });
+  });
+
   describe('getResponseAnalysis', () => {
     it('should request response analysis with threshold and pagination params', () => {
       const mockResponse = {
@@ -858,7 +957,7 @@ describe('TestPersonCodingService', () => {
   });
 
   describe('coding freshness', () => {
-    it('should request autocoding readiness with run and force-refresh params', () => {
+    it('should request autocoding readiness with run, force-refresh and detail-level params', () => {
       const mockResponse = {
         workspaceId: mockWorkspaceId,
         autoCoderRun: 1,
@@ -879,7 +978,7 @@ describe('TestPersonCodingService', () => {
         invalidVariableSamples: []
       };
 
-      service.getAutocodingReadiness(mockWorkspaceId, 1, true)
+      service.getAutocodingReadiness(mockWorkspaceId, 1, true, 'summary')
         .subscribe(response => {
           expect(response).toEqual(mockResponse);
         });
@@ -887,7 +986,8 @@ describe('TestPersonCodingService', () => {
       const req = httpMock.expectOne(request => (
         request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
         request.params.get('autoCoderRun') === '1' &&
-        request.params.get('forceRefresh') === 'true'
+        request.params.get('forceRefresh') === 'true' &&
+        request.params.get('detailLevel') === 'summary'
       ));
       expect(req.request.method).toBe('GET');
       req.flush(mockResponse);

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -568,7 +568,10 @@ export class TestPersonCodingService {
     )
       .pipe(
         tap(readiness => {
-          if (!forceRefresh) {
+          if (
+            !forceRefresh &&
+            this.autocodingReadinessInFlight.get(cacheKey) === request$
+          ) {
             this.autocodingReadinessCache.set(cacheKey, {
               expiresAt: Date.now() + this.autocodingReadinessCacheTtlMs,
               readiness
@@ -576,7 +579,12 @@ export class TestPersonCodingService {
           }
         }),
         finalize(() => {
-          this.autocodingReadinessInFlight.delete(cacheKey);
+          if (
+            !forceRefresh &&
+            this.autocodingReadinessInFlight.get(cacheKey) === request$
+          ) {
+            this.autocodingReadinessInFlight.delete(cacheKey);
+          }
         }),
         shareReplay({ bufferSize: 1, refCount: false }),
         catchError(error => throwError(() => error))

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -4,7 +4,10 @@ import {
   Observable,
   Subject,
   catchError,
+  finalize,
   of,
+  shareReplay,
+  tap,
   throwError
 } from 'rxjs';
 import Keycloak from 'keycloak-js';
@@ -27,7 +30,10 @@ import {
   CodingFreshnessVersion,
   StartCodingFreshnessJobDto
 } from '../../../../../../api-dto/coding/coding-freshness.dto';
-import { AutocodingReadinessDto } from '../../../../../../api-dto/coding/autocoding-readiness.dto';
+import {
+  AutocodingReadinessDetailLevel,
+  AutocodingReadinessDto
+} from '../../../../../../api-dto/coding/autocoding-readiness.dto';
 import { ResponseMatchingFlag } from '../../ws-admin/services/workspace-settings.service';
 
 interface ExternalCodingImportWithPreviewDto {
@@ -39,6 +45,11 @@ interface ExternalCodingImportWithPreviewDto {
   scoreMode?: 'import' | 'derive';
   existingCodingMode?: 'skip-conflicts' | 'fill-empty' | 'overwrite';
 }
+
+type AutocodingReadinessCacheEntry = {
+  expiresAt: number;
+  readiness: AutocodingReadinessDto;
+};
 
 export interface CodingStatistics {
   totalResponses: number;
@@ -240,7 +251,21 @@ export class TestPersonCodingService {
   private autoCodingCompletedSubject = new Subject<AutoCodingCompletedEvent>();
   private testResultsChangedSubject = new Subject<TestResultsChangedEvent>();
   private pendingStatisticsVersions = new Map<number, CodingStatisticsVersion>();
+
+  private readonly autocodingReadinessCacheTtlMs = 60_000;
+
+  private readonly autocodingReadinessCache = new Map<
+  string,
+  AutocodingReadinessCacheEntry
+  >();
+
+  private readonly autocodingReadinessInFlight = new Map<
+  string,
+  Observable<AutocodingReadinessDto>
+  >();
+
   autoCodingCompleted$ = this.autoCodingCompletedSubject.asObservable();
+
   testResultsChanged$ = this.testResultsChangedSubject.asObservable();
 
   get authHeader() {
@@ -261,10 +286,12 @@ export class TestPersonCodingService {
   }
 
   notifyAutoCodingCompleted(jobId?: string): void {
+    this.invalidateAutocodingReadinessCache();
     this.autoCodingCompletedSubject.next({ jobId });
   }
 
   notifyTestResultsChanged(event: TestResultsChangedEvent = {}): void {
+    this.invalidateAutocodingReadinessCache(event.workspaceId);
     if (event.workspaceId && event.statisticsVersion) {
       this.pendingStatisticsVersions.set(event.workspaceId, event.statisticsVersion);
     }
@@ -494,14 +521,43 @@ export class TestPersonCodingService {
   getAutocodingReadiness(
     workspaceId: number,
     autoCoderRun: 1 | 2 = 1,
-    forceRefresh = false
+    forceRefresh = false,
+    detailLevel: AutocodingReadinessDetailLevel = 'full'
   ): Observable<AutocodingReadinessDto> {
-    let params = new HttpParams().set('autoCoderRun', autoCoderRun.toString());
+    const cacheKey = this.getAutocodingReadinessCacheKey(
+      workspaceId,
+      autoCoderRun,
+      detailLevel
+    );
+    if (forceRefresh) {
+      this.autocodingReadinessCache.delete(cacheKey);
+      this.autocodingReadinessInFlight.delete(cacheKey);
+    } else {
+      const cached = this.autocodingReadinessCache.get(cacheKey);
+      if (cached && cached.expiresAt > Date.now()) {
+        return of({
+          ...cached.readiness,
+          fromCache: true
+        });
+      }
+      if (cached) {
+        this.autocodingReadinessCache.delete(cacheKey);
+      }
+
+      const inFlight = this.autocodingReadinessInFlight.get(cacheKey);
+      if (inFlight) {
+        return inFlight;
+      }
+    }
+
+    let params = new HttpParams()
+      .set('autoCoderRun', autoCoderRun.toString())
+      .set('detailLevel', detailLevel);
     if (forceRefresh) {
       params = params.set('forceRefresh', 'true');
     }
 
-    return this.http
+    const request$ = this.http
       .get<AutocodingReadinessDto>(
       `${this.serverUrl}admin/workspace/${workspaceId}/coding/readiness`,
       {
@@ -511,8 +567,50 @@ export class TestPersonCodingService {
       }
     )
       .pipe(
+        tap(readiness => {
+          if (!forceRefresh) {
+            this.autocodingReadinessCache.set(cacheKey, {
+              expiresAt: Date.now() + this.autocodingReadinessCacheTtlMs,
+              readiness
+            });
+          }
+        }),
+        finalize(() => {
+          this.autocodingReadinessInFlight.delete(cacheKey);
+        }),
+        shareReplay({ bufferSize: 1, refCount: false }),
         catchError(error => throwError(() => error))
       );
+
+    if (!forceRefresh) {
+      this.autocodingReadinessInFlight.set(cacheKey, request$);
+    }
+
+    return request$;
+  }
+
+  private getAutocodingReadinessCacheKey(
+    workspaceId: number,
+    autoCoderRun: 1 | 2,
+    detailLevel: AutocodingReadinessDetailLevel
+  ): string {
+    return `${workspaceId}:${autoCoderRun}:${detailLevel}`;
+  }
+
+  private invalidateAutocodingReadinessCache(workspaceId?: number): void {
+    if (!workspaceId) {
+      this.autocodingReadinessCache.clear();
+      this.autocodingReadinessInFlight.clear();
+      return;
+    }
+
+    const prefix = `${workspaceId}:`;
+    Array.from(this.autocodingReadinessCache.keys())
+      .filter(cacheKey => cacheKey.startsWith(prefix))
+      .forEach(cacheKey => this.autocodingReadinessCache.delete(cacheKey));
+    Array.from(this.autocodingReadinessInFlight.keys())
+      .filter(cacheKey => cacheKey.startsWith(prefix))
+      .forEach(cacheKey => this.autocodingReadinessInFlight.delete(cacheKey));
   }
 
   getCodingFreshnessScope(

--- a/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.html
+++ b/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.html
@@ -1,4 +1,4 @@
-<div class="error-messages-container">
+<div class="error-messages-container priority-errors">
   @if (appService.backendUnavailable) {
   <div class="error-message backend-unavailable">
     <div class="error-content">
@@ -51,7 +51,9 @@
     </div>
   </div>
   }
+</div>
 
+<div class="error-messages-container transient-errors">
   <!-- Other Error Messages -->
   @for (error of appService.errorMessages; track error.id) {
   <div class="error-message other-error">

--- a/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.scss
+++ b/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.scss
@@ -1,17 +1,34 @@
 .error-messages-container {
   position: fixed;
-  top: 80px;
   right: 20px;
   max-width: 500px;
   z-index: 1000;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  pointer-events: none;
 
   @media (max-width: 768px) {
     left: 20px;
     right: 20px;
     max-width: none;
+  }
+}
+
+.priority-errors {
+  top: 80px;
+}
+
+.transient-errors {
+  bottom: 20px;
+  left: 20px;
+  right: auto;
+  max-height: min(45vh, 360px);
+  overflow-y: auto;
+  width: min(500px, calc(100vw - 40px));
+
+  @media (max-width: 768px) {
+    right: 20px;
   }
 }
 
@@ -23,6 +40,7 @@
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   animation: slideIn 0.3s ease-in-out;
+  pointer-events: auto;
 
   &.backend-unavailable {
     background-color: #fff3cd;
@@ -127,7 +145,7 @@
 
 @keyframes slideIn {
   from {
-    transform: translateX(400px);
+    transform: translateX(40px);
     opacity: 0;
   }
   to {

--- a/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.spec.ts
+++ b/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.spec.ts
@@ -139,6 +139,23 @@ describe('ErrorMessageDisplayComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('request-b');
   });
 
+  it('should render ordinary HTTP errors in the transient error layer', () => {
+    appService.errorMessages = [{
+      id: 3,
+      status: 504,
+      message: 'Der Server antwortet gerade nicht.',
+      method: 'GET',
+      urlWithParams: '/api/admin/workspace/5/coding/incomplete-variables',
+      requestCount: 1,
+      isBackendConnectivityError: true
+    } as AppHttpError];
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.transient-errors .other-error')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.priority-errors .other-error')).toBeNull();
+  });
+
   it('should keep technical server messages hidden until details are expanded', () => {
     appService.errorMessages = [{
       id: 2,

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.ts
@@ -321,6 +321,7 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
 
   private flatSearchSubject = new Subject<void>();
   private flatSearchSubscription: Subscription;
+  private flatResponsesSubscription?: Subscription;
   private workspaceCacheInvalidatedSubscription: Subscription;
   private readonly FLAT_FILTER_DEBOUNCE_TIME = 400;
 
@@ -1062,6 +1063,7 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
 
   ngOnDestroy(): void {
     this.flatSearchSubscription.unsubscribe();
+    this.flatResponsesSubscription?.unsubscribe();
     this.workspaceCacheInvalidatedSubscription.unsubscribe();
     this.refreshFilterOptionsTimeoutIds.forEach(id => window.clearTimeout(id)
     );
@@ -1425,7 +1427,8 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
     this.isLoadingFlat = true;
 
     const sessionFilterActive = this.flatFilters.sessionFilter;
-    this.testResultService
+    this.flatResponsesSubscription?.unsubscribe();
+    this.flatResponsesSubscription = this.testResultService
       .getFlatResponses(this.appService.selectedWorkspaceId, {
         page: validPage + 1,
         limit,

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.html
@@ -90,7 +90,32 @@
     </div>
   </div>
 
-  @if (hasCodingFreshnessWarning) {
+  @if (shouldShowCodingFreshnessManualNotice) {
+  <div class="coding-freshness-banner manual-status">
+    <div class="coding-freshness-icon">
+      <mat-icon>sync_disabled</mat-icon>
+    </div>
+    <div class="coding-freshness-copy">
+      <div class="coding-freshness-title">
+        {{ 'test-results-page.coding-status.manual-title' | translate }}
+      </div>
+      <div class="coding-freshness-text">
+        {{ 'test-results-page.coding-status.manual-text' | translate }}
+      </div>
+    </div>
+    <button
+      mat-stroked-button
+      type="button"
+      [disabled]="isLoadingCodingFreshnessStatus"
+      (click)="refreshCodingFreshnessStatusManually()"
+    >
+      <mat-icon [class.inline-rotating-icon]="isLoadingCodingFreshnessStatus">
+        refresh
+      </mat-icon>
+      {{ 'test-results-page.coding-status.refresh' | translate }}
+    </button>
+  </div>
+  } @if (hasCodingFreshnessWarning) {
   <div class="coding-freshness-banner">
     <div class="coding-freshness-icon">
       <mat-icon>warning</mat-icon>

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.scss
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.scss
@@ -88,6 +88,28 @@
       margin-right: 6px;
     }
   }
+
+  &.manual-status {
+    background: rgba(25, 118, 210, 0.07);
+    border-color: rgba(25, 118, 210, 0.22);
+
+    .coding-freshness-icon {
+      color: #1976d2;
+    }
+  }
+}
+
+.inline-rotating-icon {
+  animation: inline-rotate 1.4s linear infinite;
+}
+
+@keyframes inline-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .coding-freshness-icon {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
@@ -8,7 +8,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideHttpClient } from '@angular/common/http';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { provideRouter } from '@angular/router';
 import { environment } from '../../../../environments/environment';
@@ -151,7 +151,8 @@ describe('TestResultsComponent', () => {
         {
           provide: WorkspaceSettingsService,
           useValue: {
-            getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false))
+            getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false)),
+            getAutoRefreshManualCodingJobs: jest.fn().mockReturnValue(of(true))
           }
         },
         {
@@ -217,6 +218,13 @@ describe('TestResultsComponent', () => {
       'response-status': {
         tooltips: {
           DERIVE_ERROR: 'DERIVE_ERROR bedeutet: Ableitung/Solver fehlgeschlagen, z. B. Typkonflikt im Kodierschema. Keine inhaltlich falsche Antwort.'
+        }
+      },
+      'test-results-page': {
+        'coding-status': {
+          'manual-title': 'Kodierstatus wird manuell aktualisiert',
+          'manual-text': 'Automatische Statusprüfungen sind für diesen Arbeitsbereich deaktiviert. Aktualisieren Sie den Kodierstatus nur bei Bedarf.',
+          refresh: 'Kodierstatus aktualisieren'
         }
       }
     });
@@ -387,6 +395,78 @@ describe('TestResultsComponent', () => {
     expect(testResultService.invalidateCache).toHaveBeenCalledWith(1);
     expect(testResultService.getWorkspaceOverview).toHaveBeenCalledWith(1);
     expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalled();
+  });
+
+  it('should not refresh coding state after flat-table deletion when auto refresh is disabled', () => {
+    const testResultService = TestBed.inject(TestResultService) as unknown as {
+      getWorkspaceOverview: jest.Mock;
+      invalidateCache: jest.Mock;
+    };
+    const codingStatisticsService = TestBed.inject(CodingStatisticsService) as unknown as {
+      getCodingFreshness: jest.Mock;
+    };
+    const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
+      getAppliedResultsOverview: jest.Mock;
+      notifyTestResultsChanged: jest.Mock;
+    };
+
+    codingStatisticsService.getCodingFreshness.mockClear();
+    testPersonCodingService.getAppliedResultsOverview.mockClear();
+    (component as unknown as {
+      setAutoRefreshCodingStatus: (enabled: boolean) => void;
+    }).setAutoRefreshCodingStatus(false);
+
+    component.onFlatTableResponseDeleted();
+
+    expect(testResultService.invalidateCache).toHaveBeenCalledWith(1);
+    expect(testResultService.getWorkspaceOverview).toHaveBeenCalledWith(1);
+    expect(codingStatisticsService.getCodingFreshness).not.toHaveBeenCalled();
+    expect(testPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
+    expect(component.shouldShowCodingFreshnessManualNotice).toBe(true);
+    expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalled();
+  });
+
+  it('should keep manual coding status refresh visible after a manual check', () => {
+    (component as unknown as {
+      setAutoRefreshCodingStatus: (enabled: boolean) => void;
+    }).setAutoRefreshCodingStatus(false);
+
+    component.refreshCodingFreshnessStatusManually();
+
+    expect(component.shouldShowCodingFreshnessManualNotice).toBe(true);
+  });
+
+  it('should ignore stale manual coding status responses after status was cleared', () => {
+    const codingStatisticsService = TestBed.inject(CodingStatisticsService) as unknown as {
+      getCodingFreshness: jest.Mock;
+    };
+    const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
+      getAppliedResultsOverview: jest.Mock;
+    };
+    const codingFreshness$ = new Subject<unknown>();
+    const appliedResults$ = new Subject<unknown>();
+
+    codingStatisticsService.getCodingFreshness.mockReturnValue(
+      codingFreshness$.asObservable()
+    );
+    testPersonCodingService.getAppliedResultsOverview.mockReturnValue(
+      appliedResults$.asObservable()
+    );
+    (component as unknown as {
+      setAutoRefreshCodingStatus: (enabled: boolean) => void;
+    }).setAutoRefreshCodingStatus(false);
+
+    component.refreshCodingFreshnessStatusManually();
+    component.onFlatTableResponseDeleted();
+    codingFreshness$.next({ items: [] });
+    codingFreshness$.complete();
+    appliedResults$.next({ appliedResponses: 5 });
+    appliedResults$.complete();
+
+    expect(component.codingFreshnessSummary).toBeNull();
+    expect(component.manualAppliedResultsOverview).toBeNull();
+    expect(component.isLoadingCodingFreshnessStatus).toBe(false);
+    expect(component.isLoadingManualAppliedResultsOverview).toBe(false);
   });
 
   it('should keep the last workspace overview while a reload has no result yet', () => {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
@@ -33,10 +33,13 @@ import {
   BehaviorSubject,
   Subject,
   Subscription,
+  catchError,
   debounceTime,
   distinctUntilChanged,
   finalize,
   firstValueFrom,
+  forkJoin,
+  of,
   switchMap,
   takeWhile,
   timer as rxjsTimer
@@ -461,6 +464,10 @@ export class TestResultsComponent implements OnInit, OnDestroy {
   manualAppliedResultsOverview: AppliedResultsOverview | null = null;
   manualAppliedResultsOverviewLoadFailed: boolean = false;
   isLoadingManualAppliedResultsOverview: boolean = false;
+  autoRefreshCodingStatus: boolean = true;
+  codingFreshnessStatusChecked: boolean = false;
+  isLoadingCodingFreshnessStatus: boolean = false;
+  private codingFreshnessStatusRequestGeneration = 0;
 
   exportJobId: string | null = null;
   isExporting: boolean = false;
@@ -504,7 +511,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       if (wsId === this.appService.selectedWorkspaceId) {
         this.loadWorkspaceOverview();
         this.reloadLogAnomalySummaryIfRequested();
-        this.loadCodingFreshnessStatus();
+        this.refreshCodingFreshnessStatusAfterChange();
         this.createTestResultsList(
           this.pageIndex,
           this.pageSize,
@@ -529,9 +536,9 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       });
 
     this.loadTestResultsLogAnomalySetting();
+    this.loadCodingStatusAutoRefreshSetting();
     this.createTestResultsList(0, this.pageSize);
     this.loadWorkspaceOverview();
-    this.loadCodingFreshnessStatus();
     this.startValidationStatusCheck();
     this.checkExistingExportJobs();
     this.isInitialized = true;
@@ -1264,6 +1271,41 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       });
   }
 
+  private loadCodingStatusAutoRefreshSetting(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      this.setAutoRefreshCodingStatus(true);
+      return;
+    }
+
+    this.workspaceSettingsService
+      .getAutoRefreshManualCodingJobs(workspaceId)
+      .subscribe(enabled => {
+        this.setAutoRefreshCodingStatus(enabled);
+      });
+  }
+
+  private setAutoRefreshCodingStatus(enabled: boolean): void {
+    this.autoRefreshCodingStatus = enabled;
+
+    if (enabled) {
+      this.loadCodingFreshnessStatus({ force: true });
+      return;
+    }
+
+    this.clearCodingFreshnessStatus();
+  }
+
+  private clearCodingFreshnessStatus(): void {
+    this.codingFreshnessStatusRequestGeneration += 1;
+    this.codingFreshnessSummary = null;
+    this.manualAppliedResultsOverview = null;
+    this.manualAppliedResultsOverviewLoadFailed = false;
+    this.isLoadingManualAppliedResultsOverview = false;
+    this.isLoadingCodingFreshnessStatus = false;
+    this.codingFreshnessStatusChecked = false;
+  }
+
   private setShowTestResultsLogAnomalies(enabled: boolean): void {
     this.showTestResultsLogAnomalies = enabled;
 
@@ -1442,60 +1484,69 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       });
   }
 
-  private loadCodingFreshnessStatus(): void {
-    this.loadCodingFreshnessSummary();
-    this.loadManualAppliedResultsOverview();
-  }
-
-  private loadCodingFreshnessSummary(): void {
+  private loadCodingFreshnessStatus(
+    options: { force?: boolean } = {}
+  ): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
-      this.codingFreshnessSummary = null;
+      this.clearCodingFreshnessStatus();
+      return;
+    }
+
+    if (this.isLoadingCodingFreshnessStatus && !options.force) {
       return;
     }
 
     const getCodingFreshness =
       (this.statisticsService as Partial<CodingStatisticsService>).getCodingFreshness;
-    if (!getCodingFreshness) {
-      return;
-    }
+    const codingFreshness$ = getCodingFreshness ?
+      getCodingFreshness.call(this.statisticsService, workspaceId)
+        .pipe(catchError(() => of(null))) :
+      of(null);
 
-    getCodingFreshness.call(this.statisticsService, workspaceId)
+    const requestGeneration =
+      this.codingFreshnessStatusRequestGeneration + 1;
+    this.codingFreshnessStatusRequestGeneration = requestGeneration;
+    this.codingFreshnessStatusChecked = true;
+    this.isLoadingCodingFreshnessStatus = true;
+    this.isLoadingManualAppliedResultsOverview = true;
+    this.manualAppliedResultsOverviewLoadFailed = false;
+
+    forkJoin([
+      codingFreshness$,
+      this.testPersonCodingService.getAppliedResultsOverview(workspaceId)
+        .pipe(catchError(() => of(null)))
+    ])
+      .pipe(finalize(() => {
+        if (this.codingFreshnessStatusRequestGeneration === requestGeneration) {
+          this.isLoadingCodingFreshnessStatus = false;
+          this.isLoadingManualAppliedResultsOverview = false;
+        }
+      }))
       .subscribe({
-        next: summary => {
+        next: ([summary, overview]) => {
+          if (this.codingFreshnessStatusRequestGeneration !== requestGeneration) {
+            return;
+          }
+
           this.codingFreshnessSummary = summary;
-        },
-        error: () => {
-          this.codingFreshnessSummary = null;
+          this.manualAppliedResultsOverview = overview;
+          this.manualAppliedResultsOverviewLoadFailed = overview === null;
         }
       });
   }
 
-  private loadManualAppliedResultsOverview(): void {
-    const workspaceId = this.appService.selectedWorkspaceId;
-    if (!workspaceId) {
-      this.manualAppliedResultsOverview = null;
-      this.manualAppliedResultsOverviewLoadFailed = false;
-      this.isLoadingManualAppliedResultsOverview = false;
+  refreshCodingFreshnessStatusManually(): void {
+    this.loadCodingFreshnessStatus({ force: true });
+  }
+
+  private refreshCodingFreshnessStatusAfterChange(): void {
+    if (this.autoRefreshCodingStatus) {
+      this.loadCodingFreshnessStatus({ force: true });
       return;
     }
 
-    this.isLoadingManualAppliedResultsOverview = true;
-    this.manualAppliedResultsOverviewLoadFailed = false;
-    this.testPersonCodingService.getAppliedResultsOverview(workspaceId)
-      .pipe(finalize(() => {
-        this.isLoadingManualAppliedResultsOverview = false;
-      }))
-      .subscribe({
-        next: overview => {
-          this.manualAppliedResultsOverview = overview;
-          this.manualAppliedResultsOverviewLoadFailed = overview === null;
-        },
-        error: () => {
-          this.manualAppliedResultsOverview = null;
-          this.manualAppliedResultsOverviewLoadFailed = true;
-        }
-      });
+    this.clearCodingFreshnessStatus();
   }
 
   private async fetchCodingFreshnessSummary(
@@ -1575,6 +1626,10 @@ export class TestResultsComponent implements OnInit, OnDestroy {
   get hasCodingFreshnessWarning(): boolean {
     return this.codingFreshnessWarnings.length > 0 ||
       this.shouldShowSecondAutocodingWaitingState;
+  }
+
+  get shouldShowCodingFreshnessManualNotice(): boolean {
+    return !this.autoRefreshCodingStatus;
   }
 
   get codingFreshnessDisplayWarnings(): CodingFreshnessSummaryItemDto[] {
@@ -1743,7 +1798,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
     this.testResultService.invalidateCache(this.appService.selectedWorkspaceId);
     this.loadWorkspaceOverview();
     this.reloadLogAnomalySummaryIfRequested();
-    this.loadCodingFreshnessStatus();
+    this.refreshCodingFreshnessStatusAfterChange();
     this.testPersonCodingService.notifyTestResultsChanged();
   }
 
@@ -2167,7 +2222,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
           this.testResultService.invalidateCache(workspaceId);
         }
         this.loadWorkspaceOverview();
-        this.loadCodingFreshnessStatus();
+        this.refreshCodingFreshnessStatusAfterChange();
         this.createTestResultsList(
           this.pageIndex,
           this.pageSize,
@@ -2667,7 +2722,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
             this.appService.selectedWorkspaceId
           );
           this.loadWorkspaceOverview();
-          this.loadCodingFreshnessStatus();
+          this.refreshCodingFreshnessStatusAfterChange();
           this.testPersonCodingService.notifyTestResultsChanged();
           this.createTestResultsList(
             this.pageIndex,
@@ -2689,7 +2744,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
             { duration: 5000 }
           );
           this.loadWorkspaceOverview();
-          this.loadCodingFreshnessStatus();
+          this.refreshCodingFreshnessStatusAfterChange();
           this.testPersonCodingService.notifyTestResultsChanged();
           this.createTestResultsList(
             this.pageIndex,
@@ -2881,7 +2936,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
                   { duration: 3000 }
                 );
                 this.loadWorkspaceOverview();
-                this.loadCodingFreshnessStatus();
+                this.refreshCodingFreshnessStatusAfterChange();
                 this.testPersonCodingService.notifyTestResultsChanged();
               } else {
                 this.snackBar.open(
@@ -2948,7 +3003,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
                   { duration: 3000 }
                 );
                 this.loadWorkspaceOverview();
-                this.loadCodingFreshnessStatus();
+                this.refreshCodingFreshnessStatusAfterChange();
                 this.testPersonCodingService.notifyTestResultsChanged();
               } else {
                 this.snackBar.open(

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.polling.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.polling.spec.ts
@@ -75,7 +75,8 @@ describe('TestResultsComponent Polling', () => {
         {
           provide: WorkspaceSettingsService,
           useValue: {
-            getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false))
+            getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false)),
+            getAutoRefreshManualCodingJobs: jest.fn().mockReturnValue(of(true))
           }
         },
         {

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
@@ -39,6 +39,39 @@ describe('WorkspaceSettingsService', () => {
       expect(req.request.method).toBe('GET');
       req.flush({});
     });
+
+    it('should share an in-flight setting request', () => {
+      const received: string[] = [];
+
+      service.getWorkspaceSetting(1, 'k').subscribe(setting => {
+        received.push(setting.value);
+      });
+      service.getWorkspaceSetting(1, 'k').subscribe(setting => {
+        received.push(setting.value);
+      });
+
+      const req = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/k`);
+      req.flush({ id: 1, key: 'k', value: 'v' });
+
+      expect(received).toEqual(['v', 'v']);
+    });
+
+    it('should reuse a recently fetched setting without a second request', () => {
+      const received: string[] = [];
+
+      service.getWorkspaceSetting(1, 'k').subscribe(setting => {
+        received.push(setting.value);
+      });
+      const req = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/k`);
+      req.flush({ id: 1, key: 'k', value: 'v' });
+
+      service.getWorkspaceSetting(1, 'k').subscribe(setting => {
+        received.push(setting.value);
+      });
+      httpMock.expectNone(`${mockServerUrl}/workspace/1/settings/k`);
+
+      expect(received).toEqual(['v', 'v']);
+    });
   });
 
   describe('setWorkspaceSetting', () => {
@@ -48,6 +81,20 @@ describe('WorkspaceSettingsService', () => {
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual({ key: 'k', value: 'v', description: undefined });
       req.flush({});
+    });
+
+    it('should invalidate cached settings after persisting a setting', () => {
+      service.getWorkspaceSetting(1, 'k').subscribe();
+      const getReq = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/k`);
+      getReq.flush({ id: 1, key: 'k', value: 'old' });
+
+      service.setWorkspaceSetting(1, 'k', 'new').subscribe();
+      const postReq = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings`);
+      postReq.flush({ id: 1, key: 'k', value: 'new' });
+
+      service.getWorkspaceSetting(1, 'k').subscribe();
+      const secondGetReq = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/k`);
+      secondGetReq.flush({ id: 1, key: 'k', value: 'new' });
     });
   });
 
@@ -96,7 +143,8 @@ describe('WorkspaceSettingsService', () => {
       expect(req.request.body).toEqual({
         key: 'auto-refresh-manual-coding-jobs',
         value: '{"enabled":false}',
-        description: 'Controls whether manual coding job tables refresh automatically when the browser window regains focus'
+        description:
+          'Controls whether coding status and manual coding views refresh automatically'
       });
       req.flush({});
     });

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { finalize, shareReplay, tap } from 'rxjs/operators';
 import { SERVER_URL } from '../../injection-tokens';
 import { WorkspaceSettings } from '../models/workspace-settings.model';
 import { suppressGlobalHttpErrorContext } from '../../core/interceptors/http-error-context';
@@ -25,57 +26,129 @@ export const DEFAULT_RESPONSE_MATCHING_MODE: ResponseMatchingModeDto = {
 export class WorkspaceSettingsService {
   private http = inject(HttpClient);
   private rawServerUrl = inject(SERVER_URL);
+  private readonly settingsCacheTtlMs = 10_000;
+  private readonly settingsCache = new Map<
+  string,
+  { expiresAt: number; value: WorkspaceSettings }
+  >();
+
+  private readonly settingsInFlight = new Map<
+  string,
+  Observable<WorkspaceSettings>
+  >();
+
   private get serverUrl(): string {
-    return this.rawServerUrl.endsWith('/') ? this.rawServerUrl.slice(0, -1) : this.rawServerUrl;
+    return this.rawServerUrl.endsWith('/') ?
+      this.rawServerUrl.slice(0, -1) :
+      this.rawServerUrl;
   }
 
-  getWorkspaceSetting(workspaceId: number, key: string, suppressGlobalError = false): Observable<WorkspaceSettings> {
-    return this.http.get<WorkspaceSettings>(
+  getWorkspaceSetting(
+    workspaceId: number,
+    key: string,
+    suppressGlobalError = false
+  ): Observable<WorkspaceSettings> {
+    const cacheKey = this.getSettingCacheKey(workspaceId, key);
+    const cached = this.settingsCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return new Observable(observer => {
+        observer.next(cached.value);
+        observer.complete();
+      });
+    }
+
+    const inFlight = this.settingsInFlight.get(cacheKey);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const request$ = this.http.get<WorkspaceSettings>(
       `${this.serverUrl}/workspace/${workspaceId}/settings/${key}`,
       suppressGlobalError ? { context: suppressGlobalHttpErrorContext() } : {}
+    ).pipe(
+      tap(setting => this.settingsCache.set(cacheKey, {
+        expiresAt: Date.now() + this.settingsCacheTtlMs,
+        value: setting
+      })),
+      finalize(() => this.settingsInFlight.delete(cacheKey)),
+      shareReplay({ bufferSize: 1, refCount: false })
+    );
+    this.settingsInFlight.set(cacheKey, request$);
+    return request$;
+  }
+
+  setWorkspaceSetting(
+    workspaceId: number,
+    key: string,
+    value: string,
+    description?: string
+  ): Observable<WorkspaceSettings> {
+    return this.http.post<WorkspaceSettings>(
+      `${this.serverUrl}/workspace/${workspaceId}/settings`,
+      {
+        key,
+        value,
+        description
+      }
+    ).pipe(
+      tap(() => this.invalidateWorkspaceSetting(workspaceId, key))
     );
   }
 
-  setWorkspaceSetting(workspaceId: number, key: string, value: string, description?: string): Observable<WorkspaceSettings> {
-    return this.http.post<WorkspaceSettings>(`${this.serverUrl}/workspace/${workspaceId}/settings`, {
-      key,
-      value,
-      description
-    });
+  updateWorkspaceSetting(
+    workspaceId: number,
+    settingId: number,
+    value: string
+  ): Observable<WorkspaceSettings> {
+    return this.http.put<WorkspaceSettings>(
+      `${this.serverUrl}/workspace/${workspaceId}/settings/${settingId}`,
+      {
+        value
+      }
+    ).pipe(
+      tap(() => this.invalidateWorkspaceSettings(workspaceId))
+    );
   }
 
-  updateWorkspaceSetting(workspaceId: number, settingId: number, value: string): Observable<WorkspaceSettings> {
-    return this.http.put<WorkspaceSettings>(`${this.serverUrl}/workspace/${workspaceId}/settings/${settingId}`, {
-      value
-    });
-  }
-
-  deleteWorkspaceSetting(workspaceId: number, settingId: number): Observable<void> {
-    return this.http.delete<void>(`${this.serverUrl}/workspace/${workspaceId}/settings/${settingId}`);
+  deleteWorkspaceSetting(
+    workspaceId: number,
+    settingId: number
+  ): Observable<void> {
+    return this.http.delete<void>(
+      `${this.serverUrl}/workspace/${workspaceId}/settings/${settingId}`
+    ).pipe(
+      tap(() => this.invalidateWorkspaceSettings(workspaceId))
+    );
   }
 
   getAutoFetchCodingStatistics(workspaceId: number): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'auto-fetch-coding-statistics', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? true);
-            } catch {
-              observer.next(true);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'auto-fetch-coding-statistics',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? true);
+          } catch {
             observer.next(true);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(true);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setAutoFetchCodingStatistics(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setAutoFetchCodingStatistics(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -87,57 +160,69 @@ export class WorkspaceSettingsService {
 
   getAutoRefreshManualCodingJobs(workspaceId: number): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'auto-refresh-manual-coding-jobs', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? true);
-            } catch {
-              observer.next(true);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'auto-refresh-manual-coding-jobs',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? true);
+          } catch {
             observer.next(true);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(true);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setAutoRefreshManualCodingJobs(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setAutoRefreshManualCodingJobs(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
       'auto-refresh-manual-coding-jobs',
       value,
-      'Controls whether manual coding job tables refresh automatically when the browser window regains focus'
+      'Controls whether coding status and manual coding views refresh automatically'
     );
   }
 
   getShowTestResultsLogAnomalies(workspaceId: number): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'show-test-results-log-anomalies', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? false);
-            } catch {
-              observer.next(false);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'show-test-results-log-anomalies',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? false);
+          } catch {
             observer.next(false);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(false);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setShowTestResultsLogAnomalies(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setShowTestResultsLogAnomalies(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -147,28 +232,36 @@ export class WorkspaceSettingsService {
     );
   }
 
-  getIncludeDeriveErrorInManualCoding(workspaceId: number): Observable<boolean> {
+  getIncludeDeriveErrorInManualCoding(
+    workspaceId: number
+  ): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'include-derive-error-in-manual-coding', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? false);
-            } catch {
-              observer.next(false);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'include-derive-error-in-manual-coding',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? false);
+          } catch {
             observer.next(false);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(false);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setIncludeDeriveErrorInManualCoding(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setIncludeDeriveErrorInManualCoding(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -180,26 +273,32 @@ export class WorkspaceSettingsService {
 
   getEnableRegexSearch(workspaceId: number): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'enable-regex-search', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? false);
-            } catch {
-              observer.next(false);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'enable-regex-search',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? false);
+          } catch {
             observer.next(false);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(false);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setEnableRegexSearch(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setEnableRegexSearch(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -209,14 +308,18 @@ export class WorkspaceSettingsService {
     );
   }
 
-  getResponseMatchingMode(workspaceId: number): Observable<ResponseMatchingFlag[]> {
+  getResponseMatchingMode(
+    workspaceId: number
+  ): Observable<ResponseMatchingFlag[]> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'response-matching-mode')
-        .subscribe({
+      this.getWorkspaceSetting(workspaceId, 'response-matching-mode').subscribe(
+        {
           next: setting => {
             try {
               const parsed = JSON.parse(setting.value);
-              observer.next(parsed.flags ?? DEFAULT_RESPONSE_MATCHING_MODE.flags);
+              observer.next(
+                parsed.flags ?? DEFAULT_RESPONSE_MATCHING_MODE.flags
+              );
             } catch {
               observer.next(DEFAULT_RESPONSE_MATCHING_MODE.flags);
             }
@@ -226,11 +329,15 @@ export class WorkspaceSettingsService {
             observer.next(DEFAULT_RESPONSE_MATCHING_MODE.flags);
             observer.complete();
           }
-        });
+        }
+      );
     });
   }
 
-  setResponseMatchingMode(workspaceId: number, flags: ResponseMatchingFlag[]): Observable<WorkspaceSettings> {
+  setResponseMatchingMode(
+    workspaceId: number,
+    flags: ResponseMatchingFlag[]
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ flags });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -242,36 +349,50 @@ export class WorkspaceSettingsService {
 
   getAggregationThreshold(workspaceId: number): Observable<number | null> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'duplicate-aggregation-threshold')
-        .subscribe({
-          next: setting => {
-            try {
-              observer.next(this.normalizeAggregationThreshold(setting.value));
-            } catch {
-              observer.next(2);
-            }
-            observer.complete();
-          },
-          error: () => {
-            observer.next(2); // Default
-            observer.complete();
+      this.getWorkspaceSetting(
+        workspaceId,
+        'duplicate-aggregation-threshold'
+      ).subscribe({
+        next: setting => {
+          try {
+            observer.next(this.normalizeAggregationThreshold(setting.value));
+          } catch {
+            observer.next(2);
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(2); // Default
+          observer.complete();
+        }
+      });
     });
   }
 
-  setAggregationThreshold(workspaceId: number, threshold: number | null): Observable<WorkspaceSettings> {
+  setAggregationThreshold(
+    workspaceId: number,
+    threshold: number | null
+  ): Observable<WorkspaceSettings> {
     const normalizedThreshold = this.normalizeAggregationThreshold(threshold);
     return this.setWorkspaceSetting(
       workspaceId,
       'duplicate-aggregation-threshold',
-      normalizedThreshold === null ? 'disabled' : normalizedThreshold.toString(),
+      normalizedThreshold === null ?
+        'disabled' :
+        normalizedThreshold.toString(),
       'Minimum number of identical responses required for aggregation'
     );
   }
 
-  private normalizeAggregationThreshold(value: number | string | null | undefined): number | null {
-    if (value === 'disabled' || value === '0' || value === 0 || value === null) {
+  private normalizeAggregationThreshold(
+    value: number | string | null | undefined
+  ): number | null {
+    if (
+      value === 'disabled' ||
+      value === '0' ||
+      value === 0 ||
+      value === null
+    ) {
       return null;
     }
     const numericValue = Number(value);
@@ -279,5 +400,25 @@ export class WorkspaceSettingsService {
       return 2;
     }
     return Math.min(100, Math.max(2, Math.round(numericValue)));
+  }
+
+  private getSettingCacheKey(workspaceId: number, key: string): string {
+    return `${workspaceId}:${key}`;
+  }
+
+  private invalidateWorkspaceSetting(workspaceId: number, key: string): void {
+    const cacheKey = this.getSettingCacheKey(workspaceId, key);
+    this.settingsCache.delete(cacheKey);
+    this.settingsInFlight.delete(cacheKey);
+  }
+
+  private invalidateWorkspaceSettings(workspaceId: number): void {
+    const prefix = `${workspaceId}:`;
+    Array.from(this.settingsCache.keys())
+      .filter(cacheKey => cacheKey.startsWith(prefix))
+      .forEach(cacheKey => this.settingsCache.delete(cacheKey));
+    Array.from(this.settingsInFlight.keys())
+      .filter(cacheKey => cacheKey.startsWith(prefix))
+      .forEach(cacheKey => this.settingsInFlight.delete(cacheKey));
   }
 }

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
@@ -66,11 +66,19 @@ export class WorkspaceSettingsService {
       `${this.serverUrl}/workspace/${workspaceId}/settings/${key}`,
       suppressGlobalError ? { context: suppressGlobalHttpErrorContext() } : {}
     ).pipe(
-      tap(setting => this.settingsCache.set(cacheKey, {
-        expiresAt: Date.now() + this.settingsCacheTtlMs,
-        value: setting
-      })),
-      finalize(() => this.settingsInFlight.delete(cacheKey)),
+      tap(setting => {
+        if (this.settingsInFlight.get(cacheKey) === request$) {
+          this.settingsCache.set(cacheKey, {
+            expiresAt: Date.now() + this.settingsCacheTtlMs,
+            value: setting
+          });
+        }
+      }),
+      finalize(() => {
+        if (this.settingsInFlight.get(cacheKey) === request$) {
+          this.settingsInFlight.delete(cacheKey);
+        }
+      }),
       shareReplay({ bufferSize: 1, refCount: false })
     );
     this.settingsInFlight.set(cacheKey, request$);

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1158,8 +1158,8 @@
     "coding": "Kodierung",
     "auto-fetch-coding-statistics": "Automatisches Laden der Kodierstatistiken",
     "auto-fetch-coding-statistics-description": "Wenn aktiviert, werden die Kodierstatistiken automatisch beim Öffnen der Kodierungsverwaltung geladen. Wenn deaktiviert, müssen die Statistiken manuell über einen Button geladen werden.",
-    "auto-refresh-manual-coding-jobs": "Automatisches Aktualisieren der Kodierjob-Tabellen",
-    "auto-refresh-manual-coding-jobs-description": "Wenn aktiviert, werden die Kodierjob-Tabellen in Schulung und Durchführung automatisch aktualisiert, wenn das Browserfenster wieder aktiv wird. Wenn deaktiviert, aktualisieren Sie die Tabellen per Button.",
+    "auto-refresh-manual-coding-jobs": "Automatisches Aktualisieren von Kodierstatus und Kodierjobs",
+    "auto-refresh-manual-coding-jobs-description": "Wenn aktiviert, werden Kodierstatus und manuelle Kodieransichten automatisch beim Öffnen oder nach relevanten Fokuswechseln aktualisiert. Wenn deaktiviert, aktualisieren Sie diese Ansichten per Button.",
     "include-derive-error-in-manual-coding": "DERIVE_ERROR in manueller Kodierung zulassen",
     "include-derive-error-in-manual-coding-description": "Wenn aktiviert, können DERIVE_ERROR-Fälle bei Kodierjobdefinitionen gezielt in die manuelle Kodierung aufgenommen werden. Standardmäßig ist diese Funktion deaktiviert.",
     "include-derive-error-in-manual-coding-enabled": "DERIVE_ERROR-Fälle können in die manuelle Kodierung aufgenommen werden",
@@ -1191,8 +1191,8 @@
     "token-copied-to-clipboard": "Token in die Zwischenablage kopiert",
     "auto-fetch-coding-statistics-enabled": "Automatisches Laden der Kodierstatistiken aktiviert",
     "auto-fetch-coding-statistics-disabled": "Automatisches Laden der Kodierstatistiken deaktiviert",
-    "auto-refresh-manual-coding-jobs-enabled": "Automatisches Aktualisieren der Kodierjob-Tabellen aktiviert",
-    "auto-refresh-manual-coding-jobs-disabled": "Automatisches Aktualisieren der Kodierjob-Tabellen deaktiviert",
+    "auto-refresh-manual-coding-jobs-enabled": "Automatisches Aktualisieren von Kodierstatus und Kodierjobs aktiviert",
+    "auto-refresh-manual-coding-jobs-disabled": "Automatisches Aktualisieren von Kodierstatus und Kodierjobs deaktiviert",
     "show-test-results-log-anomalies-enabled": "Log-Auffälligkeiten in Testergebnissen aktiviert",
     "show-test-results-log-anomalies-disabled": "Log-Auffälligkeiten in Testergebnissen deaktiviert",
     "error-saving-setting": "Fehler beim Speichern der Einstellung",
@@ -1381,10 +1381,15 @@
     "readiness": {
       "title-load-failed": "Auto-Coding-Prüfung nicht verfügbar",
       "title-blocked": "Auto-Coding 1 nicht möglich",
+      "title-diagnostics-pending": "Auto-Coding-Basisprüfung abgeschlossen",
+      "title-not-checked": "Kodierstatus nicht geprüft",
       "title-not-started": "Kodierung noch nicht gestartet",
       "title-manual-coding-open": "Manuelle Kodierung abschließen",
       "checking": "Zustand wird geprüft...",
+      "not-checked": "Aktualisieren Sie den Kodierstatus, um den aktuellen Stand zu prüfen.",
       "summary": "{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus, aber {{codeableResponses}} kodierbare Antworten.",
+      "summary-pending-diagnostics": "{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus und {{potentialCodeableResponses}} potenziell kodierbare Antworten.",
+      "pending-diagnostics-help": "Für Unit-Dateien und Kodierschemata liegt noch keine Detailprüfung vor.",
       "details-result-units": "{{count}} Ergebnis-Units",
       "details-unit-files": "{{count}} passende Unit-Dateien",
       "details-coding-schemes": "{{count}} passende Kodierschemata",
@@ -1407,6 +1412,8 @@
       "starting-freshness-coding": "Auto-Coding wird gestartet...",
       "update-running": "Aktualisierung läuft: {{progress}}%",
       "retry": "Erneut prüfen",
+      "check-details": "Details prüfen",
+      "refresh-status": "Aktualisieren",
       "check-test-files": "Testdateien prüfen",
       "open-manual-review": "Manuelle Kodierung öffnen"
     },
@@ -1563,6 +1570,13 @@
     },
     "aria": {
       "select-page": "Seiten auswählen"
+    }
+  },
+  "test-results-page": {
+    "coding-status": {
+      "manual-title": "Kodierstatus wird manuell aktualisiert",
+      "manual-text": "Automatische Statusprüfungen sind für diesen Arbeitsbereich deaktiviert. Aktualisieren Sie den Kodierstatus nur bei Bedarf.",
+      "refresh": "Kodierstatus aktualisieren"
     }
   },
   "test-results-search": {

--- a/cypress/e2e/manual-coding-performance.cy.ts
+++ b/cypress/e2e/manual-coding-performance.cy.ts
@@ -1,0 +1,234 @@
+const workspaceId = Number(Cypress.env('workspaceId') || 47);
+const maxRouteMs = Number(Cypress.env('maxRouteMs') || 5000);
+const maxTabMs = Number(Cypress.env('maxTabMs') || 3000);
+const maxRapidSwitchMs = Number(Cypress.env('maxRapidSwitchMs') || 12000);
+const rapidSwitchRepeats = Number(Cypress.env('rapidSwitchRepeats') || 8);
+const maxCriticalRequests = Number(Cypress.env('maxCriticalRequests') || 80);
+const networkProfile = String(Cypress.env('networkProfile') || 'none');
+const manualLogin = String(Cypress.env('manualLogin') || 'false') === 'true';
+const manualLoginTimeoutMs = Number(
+  Cypress.env('manualLoginTimeoutMs') || 240000
+);
+
+const routes = [
+  {
+    label: 'Testergebnisse',
+    hash: `/#/workspace-admin/${workspaceId}/test-results`,
+    selector: 'coding-box-test-results'
+  },
+  {
+    label: 'Kodieruebersicht',
+    hash: `/#/workspace-admin/${workspaceId}/coding/management`,
+    selector: 'app-coding-management'
+  },
+  {
+    label: 'Manuelle Kodierung',
+    hash: `/#/workspace-admin/${workspaceId}/coding/manual`,
+    selector: 'coding-box-coding-management-manual'
+  }
+];
+
+const criticalApiPattern =
+  /\/api\/admin\/workspace\/\d+\/(coding\/(freshness|incomplete-variables|response-analysis)|test-results)/;
+
+const networkProfiles: Record<
+string,
+{ offline: boolean; latency: number; downloadThroughput: number; uploadThroughput: number }
+> = {
+  'slow-4g': {
+    offline: false,
+    latency: 150,
+    downloadThroughput: (1.6 * 1024 * 1024) / 8,
+    uploadThroughput: (750 * 1024) / 8
+  },
+  'slow-3g': {
+    offline: false,
+    latency: 300,
+    downloadThroughput: (750 * 1024) / 8,
+    uploadThroughput: (250 * 1024) / 8
+  }
+};
+
+function assertNoLoadingStatusContradiction() {
+  cy.get('body')
+    .invoke('text')
+    .then((text) => {
+      const hasCurrent = text.includes('Kodierstand aktuell');
+      const hasLoading =
+        text.includes('Zustand wird geprueft') ||
+        text.includes('Zustand wird geprüft');
+      expect(hasCurrent && hasLoading).to.eq(false);
+    });
+}
+
+function trackCriticalRequests(alias = 'criticalApi') {
+  const calls: string[] = [];
+  cy.intercept('**/api/admin/workspace/**', request => {
+    if (criticalApiPattern.test(request.url)) {
+      calls.push(request.url);
+    }
+  }).as(alias);
+  return calls;
+}
+
+function assertCriticalRequestBudget(calls: string[], label: string) {
+  cy.then(() => {
+    cy.log(`${label}: ${calls.length} critical API requests`);
+    expect(calls.length, `${label} critical API request count`)
+      .to.be.lessThan(maxCriticalRequests);
+  });
+}
+
+function emulateNetworkProfile() {
+  const profile = networkProfiles[networkProfile];
+  if (!profile) return;
+
+  cy.then(() => Cypress.automation('remote:debugger:protocol', {
+    command: 'Network.enable'
+  }));
+  cy.then(() => Cypress.automation('remote:debugger:protocol', {
+    command: 'Network.emulateNetworkConditions',
+    params: profile
+  }));
+}
+
+function resetNetworkProfile() {
+  if (!networkProfiles[networkProfile]) return;
+
+  cy.then(() => Cypress.automation('remote:debugger:protocol', {
+    command: 'Network.emulateNetworkConditions',
+    params: {
+      offline: false,
+      latency: 0,
+      downloadThroughput: -1,
+      uploadThroughput: -1
+    }
+  }));
+}
+
+function waitForManualLoginIfRequested(hash: string, selector: string) {
+  if (!manualLogin) {
+    return;
+  }
+
+  cy.log(
+    'Manual login mode: complete Keycloak login in this browser window if prompted.'
+  );
+  cy.location('href', { timeout: manualLoginTimeoutMs }).should('include', hash);
+  cy.get(selector, { timeout: 60000 }).should('exist');
+}
+
+function measureRoute(label: string, hash: string, selector: string) {
+  let startedAt = 0;
+  if (manualLogin) {
+    cy.visit(hash);
+    waitForManualLoginIfRequested(hash, selector);
+  }
+
+  cy.then(() => {
+    startedAt = Date.now();
+  });
+  cy.visit(hash);
+  cy.location('hash', { timeout: 20000 }).should('include', hash.slice(1));
+  cy.get(selector, { timeout: 20000 }).should('exist');
+  cy.then(() => {
+    const durationMs = Date.now() - startedAt;
+    cy.log(`${label}: ${durationMs} ms`);
+    expect(durationMs, `${label} route duration`).to.be.lessThan(maxRouteMs);
+  });
+  assertNoLoadingStatusContradiction();
+}
+
+describe('Manual coding performance smoke', { testIsolation: false }, () => {
+  afterEach(() => {
+    resetNetworkProfile();
+  });
+
+  it('opens the critical workspace UI routes within the smoke threshold', () => {
+    emulateNetworkProfile();
+    routes.forEach((route) => {
+      measureRoute(route.label, route.hash, route.selector);
+    });
+  });
+
+  it('switches visible manual coding tabs without stale loading status', () => {
+    emulateNetworkProfile();
+    cy.visit(`/#/workspace-admin/${workspaceId}/coding/manual`);
+    waitForManualLoginIfRequested(
+      `/#/workspace-admin/${workspaceId}/coding/manual`,
+      'coding-box-coding-management-manual'
+    );
+    cy.get('coding-box-coding-management-manual', { timeout: 20000 }).should(
+      'exist'
+    );
+
+    cy.get('.manual-coding-tabs .mat-mdc-tab').each((tab) => {
+      const label = tab.text().trim().replace(/\s+/g, ' ') || 'tab';
+      const startedAt = Date.now();
+      cy.wrap(tab).click();
+      cy.get('coding-box-coding-management-manual').should('exist');
+      cy.wait(250);
+      cy.then(() => {
+        const durationMs = Date.now() - startedAt;
+        cy.log(`${label}: ${durationMs} ms`);
+        expect(durationMs, `${label} tab duration`).to.be.lessThan(maxTabMs);
+      });
+      assertNoLoadingStatusContradiction();
+    });
+  });
+
+  it('keeps rapid route changes bounded and avoids excessive critical requests', () => {
+    emulateNetworkProfile();
+    const criticalCalls = trackCriticalRequests('rapidRouteCriticalApi');
+    const startedAt = Date.now();
+
+    Cypress._.times(rapidSwitchRepeats, () => {
+      routes.forEach((route) => {
+        cy.visit(route.hash);
+        cy.get(route.selector, { timeout: 20000 }).should('exist');
+        assertNoLoadingStatusContradiction();
+      });
+    });
+
+    cy.then(() => {
+      const durationMs = Date.now() - startedAt;
+      cy.log(`rapid route switches: ${durationMs} ms`);
+      expect(durationMs, 'rapid route switch duration')
+        .to.be.lessThan(maxRapidSwitchMs);
+    });
+    assertCriticalRequestBudget(criticalCalls, 'rapid route switches');
+  });
+
+  it('keeps rapid manual tab switches bounded and avoids excessive critical requests', () => {
+    emulateNetworkProfile();
+    const criticalCalls = trackCriticalRequests('rapidManualTabCriticalApi');
+    const startedAt = Date.now();
+
+    cy.visit(`/#/workspace-admin/${workspaceId}/coding/manual`);
+    waitForManualLoginIfRequested(
+      `/#/workspace-admin/${workspaceId}/coding/manual`,
+      'coding-box-coding-management-manual'
+    );
+    cy.get('coding-box-coding-management-manual', { timeout: 20000 }).should(
+      'exist'
+    );
+    cy.get('.manual-coding-tabs .mat-mdc-tab')
+      .then(tabs => {
+        const tabCount = tabs.length;
+        Cypress._.times(rapidSwitchRepeats, repeat => {
+          const index = repeat % tabCount;
+          cy.get('.manual-coding-tabs .mat-mdc-tab').eq(index).click();
+          cy.get('coding-box-coding-management-manual').should('exist');
+          assertNoLoadingStatusContradiction();
+        });
+      });
+
+    cy.then(() => {
+      const durationMs = Date.now() - startedAt;
+      cy.log(`rapid manual tab switches: ${durationMs} ms`);
+      expect(durationMs, 'rapid manual tab switch duration')
+        .to.be.lessThan(maxRapidSwitchMs);
+    });
+    assertCriticalRequestBudget(criticalCalls, 'rapid manual tab switches');
+  });
+});

--- a/database/changelog/coding-box.changelog-1.16.3.sql
+++ b/database/changelog/coding-box.changelog-1.16.3.sql
@@ -189,3 +189,12 @@ CREATE INDEX IF NOT EXISTS "replay_statistics_workspace_source_timestamp_idx"
 
 -- rollback DROP INDEX IF EXISTS "public"."replay_statistics_workspace_source_timestamp_idx";
 -- rollback ALTER TABLE "public"."replay_statistics" DROP COLUMN IF EXISTS "replay_source";
+
+-- changeset julian:4
+-- comment: Speed up GeoGebra response existence checks without indexing full response values
+
+CREATE INDEX IF NOT EXISTS "idx_response_geogebra_value_unit"
+  ON "public"."response" ("unitid")
+  WHERE "value" LIKE 'UEsD%' OR "value" ILIKE 'data:%;base64,UEsD%';
+
+-- rollback DROP INDEX IF EXISTS "public"."idx_response_geogebra_value_unit";

--- a/scripts/repro/clone-manual-coding-workspace-metadata.sql
+++ b/scripts/repro/clone-manual-coding-workspace-metadata.sql
@@ -1,0 +1,196 @@
+\set ON_ERROR_STOP on
+
+\if :{?source_workspace_id}
+\else
+  \set source_workspace_id 47
+\endif
+
+\if :{?target_workspace_id}
+\else
+  \set target_workspace_id 54
+\endif
+
+BEGIN;
+
+INSERT INTO file_upload (
+  data,
+  workspace_id,
+  filename,
+  file_size,
+  file_type,
+  file_id,
+  created_at,
+  structured_data,
+  file_id_normalized,
+  coding_scheme_ref_normalized
+)
+SELECT
+  data,
+  :target_workspace_id,
+  filename,
+  file_size,
+  file_type,
+  file_id,
+  now(),
+  structured_data,
+  file_id_normalized,
+  coding_scheme_ref_normalized
+FROM file_upload
+WHERE workspace_id = :source_workspace_id
+ON CONFLICT (workspace_id, file_id) DO UPDATE
+SET
+  data = EXCLUDED.data,
+  filename = EXCLUDED.filename,
+  file_size = EXCLUDED.file_size,
+  file_type = EXCLUDED.file_type,
+  structured_data = EXCLUDED.structured_data,
+  file_id_normalized = EXCLUDED.file_id_normalized,
+  coding_scheme_ref_normalized = EXCLUDED.coding_scheme_ref_normalized;
+
+INSERT INTO resource_package (
+  elements,
+  name,
+  created_at,
+  "workspaceId",
+  package_size,
+  package_type,
+  scope,
+  detected_version,
+  content_hash,
+  original_filename
+)
+SELECT
+  elements,
+  name,
+  now(),
+  :target_workspace_id,
+  package_size,
+  package_type,
+  scope,
+  detected_version,
+  content_hash,
+  original_filename
+FROM resource_package
+WHERE "workspaceId" = :source_workspace_id
+  AND NOT EXISTS (
+    SELECT 1
+    FROM resource_package existing
+    WHERE existing."workspaceId" = :target_workspace_id
+      AND existing.name = resource_package.name
+      AND existing.package_type = resource_package.package_type
+      AND existing.scope = resource_package.scope
+  );
+
+CREATE TEMP TABLE scale_missings_profile_map AS
+WITH inserted AS (
+  INSERT INTO missings_profile (label, missings, workspace_id)
+  SELECT label, missings, :target_workspace_id
+  FROM missings_profile
+  WHERE workspace_id = :source_workspace_id
+  ON CONFLICT (workspace_id, label) DO UPDATE
+  SET missings = EXCLUDED.missings
+  RETURNING id, label
+)
+SELECT source.id AS source_id, inserted.id AS target_id
+FROM missings_profile source
+JOIN inserted
+  ON inserted.label = source.label
+WHERE source.workspace_id = :source_workspace_id;
+
+INSERT INTO variable_bundle (
+  workspace_id,
+  name,
+  description,
+  variables,
+  created_at,
+  updated_at
+)
+SELECT
+  :target_workspace_id,
+  name,
+  description,
+  variables,
+  now(),
+  now()
+FROM variable_bundle
+WHERE workspace_id = :source_workspace_id
+  AND NOT EXISTS (
+    SELECT 1
+    FROM variable_bundle existing
+    WHERE existing.workspace_id = :target_workspace_id
+      AND existing.name = variable_bundle.name
+  );
+
+INSERT INTO job_definitions (
+  duration_seconds,
+  created_at,
+  updated_at,
+  max_coding_cases,
+  double_coding_absolute,
+  double_coding_percentage,
+  status,
+  assigned_variables,
+  assigned_variable_bundles,
+  assigned_coders,
+  workspace_id,
+  case_ordering_mode,
+  suppress_general_instructions,
+  show_score,
+  allow_comments,
+  assigned_coder_configs,
+  distribution_seed,
+  missings_profile_id,
+  distribution_snapshots
+)
+SELECT
+  duration_seconds,
+  now(),
+  now(),
+  max_coding_cases,
+  double_coding_absolute,
+  double_coding_percentage,
+  status,
+  assigned_variables,
+  assigned_variable_bundles,
+  assigned_coders,
+  :target_workspace_id,
+  case_ordering_mode,
+  suppress_general_instructions,
+  show_score,
+  allow_comments,
+  assigned_coder_configs,
+  distribution_seed || '-scale-' || :target_workspace_id,
+  profile_map.target_id,
+  distribution_snapshots
+FROM job_definitions source
+LEFT JOIN scale_missings_profile_map profile_map
+  ON profile_map.source_id = source.missings_profile_id
+WHERE source.workspace_id = :source_workspace_id
+  AND NOT EXISTS (
+    SELECT 1
+    FROM job_definitions existing
+    WHERE existing.workspace_id = :target_workspace_id
+      AND existing.distribution_seed = source.distribution_seed || '-scale-' || :target_workspace_id
+  );
+
+COMMIT;
+
+SELECT 'file_upload' AS table_name, count(*) AS rows
+FROM file_upload
+WHERE workspace_id = :target_workspace_id
+UNION ALL
+SELECT 'resource_package', count(*)
+FROM resource_package
+WHERE "workspaceId" = :target_workspace_id
+UNION ALL
+SELECT 'missings_profile', count(*)
+FROM missings_profile
+WHERE workspace_id = :target_workspace_id
+UNION ALL
+SELECT 'variable_bundle', count(*)
+FROM variable_bundle
+WHERE workspace_id = :target_workspace_id
+UNION ALL
+SELECT 'job_definitions', count(*)
+FROM job_definitions
+WHERE workspace_id = :target_workspace_id;

--- a/scripts/repro/create-manual-coding-scale-workspace.sql
+++ b/scripts/repro/create-manual-coding-scale-workspace.sql
@@ -1,0 +1,194 @@
+\set ON_ERROR_STOP on
+
+\if :{?source_workspace_id}
+\else
+  \set source_workspace_id 47
+\endif
+
+\if :{?target_person_count}
+\else
+  \set target_person_count 5000
+\endif
+
+\if :{?target_workspace_name}
+\else
+  \set target_workspace_name 'Manual Coding Scale Workspace'
+\endif
+
+BEGIN;
+
+CREATE TEMP TABLE scale_source_persons AS
+SELECT
+  p.*,
+  row_number() OVER (ORDER BY p.id) AS source_index,
+  count(*) OVER () AS source_count
+FROM persons p
+WHERE p.workspace_id = :source_workspace_id
+  AND p.consider = true
+ORDER BY p.id;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM scale_source_persons) THEN
+    RAISE EXCEPTION 'No source persons found for source workspace.';
+  END IF;
+END $$;
+
+INSERT INTO workspace (name, settings)
+SELECT :'target_workspace_name', settings
+FROM workspace
+WHERE id = :source_workspace_id
+RETURNING id AS target_workspace_id \gset
+
+INSERT INTO workspace_user (workspace_id, user_id, access_level, can_code)
+SELECT :target_workspace_id, user_id, access_level, can_code
+FROM workspace_user
+WHERE workspace_id = :source_workspace_id
+ON CONFLICT DO NOTHING;
+
+CREATE TEMP TABLE scale_person_plan AS
+SELECT
+  target_index,
+  source.id AS source_person_id,
+  left(source.login, 56) || '_s' || target_index::text AS target_login,
+  left(source.code, 56) || '_s' || target_index::text AS target_code,
+  left(source."group", 56) || '_scale' AS target_group,
+  source.booklets,
+  source.source AS original_source
+FROM generate_series(1, :target_person_count) AS target_index
+JOIN scale_source_persons source
+  ON source.source_index =
+    (((target_index - 1) % source.source_count) + 1);
+
+INSERT INTO persons (
+  "group",
+  login,
+  code,
+  booklets,
+  workspace_id,
+  uploaded_at,
+  source,
+  consider
+)
+SELECT
+  target_group,
+  target_login,
+  target_code,
+  booklets,
+  :target_workspace_id,
+  now(),
+  'scale:' || :target_workspace_id || ':' || target_index || ':' || source_person_id,
+  true
+FROM scale_person_plan;
+
+CREATE TEMP TABLE scale_person_map AS
+SELECT
+  plan.target_index,
+  plan.source_person_id,
+  person.id AS target_person_id
+FROM scale_person_plan plan
+JOIN persons person
+  ON person.workspace_id = :target_workspace_id
+  AND person.login = plan.target_login
+  AND person.code = plan.target_code
+  AND person."group" = plan.target_group;
+
+INSERT INTO booklet (infoid, personid, lastts, firstts)
+SELECT
+  source_booklet.infoid,
+  person_map.target_person_id,
+  source_booklet.lastts,
+  source_booklet.firstts
+FROM booklet source_booklet
+JOIN scale_person_map person_map
+  ON person_map.source_person_id = source_booklet.personid;
+
+CREATE TEMP TABLE scale_booklet_map AS
+SELECT
+  source_booklet.id AS source_booklet_id,
+  target_booklet.id AS target_booklet_id
+FROM booklet source_booklet
+JOIN scale_person_map person_map
+  ON person_map.source_person_id = source_booklet.personid
+JOIN booklet target_booklet
+  ON target_booklet.personid = person_map.target_person_id
+  AND target_booklet.infoid = source_booklet.infoid;
+
+INSERT INTO unit (bookletid, name, alias)
+SELECT
+  booklet_map.target_booklet_id,
+  source_unit.name,
+  source_unit.alias
+FROM unit source_unit
+JOIN scale_booklet_map booklet_map
+  ON booklet_map.source_booklet_id = source_unit.bookletid;
+
+CREATE TEMP TABLE scale_unit_map AS
+SELECT
+  source_unit.id AS source_unit_id,
+  target_unit.id AS target_unit_id
+FROM unit source_unit
+JOIN scale_booklet_map booklet_map
+  ON booklet_map.source_booklet_id = source_unit.bookletid
+JOIN unit target_unit
+  ON target_unit.bookletid = booklet_map.target_booklet_id
+  AND target_unit.name = source_unit.name
+  AND COALESCE(target_unit.alias, '') = COALESCE(source_unit.alias, '');
+
+INSERT INTO response (
+  unitid,
+  variableid,
+  status,
+  value,
+  subform,
+  code_v1,
+  score_v1,
+  status_v1,
+  status_v2,
+  code_v2,
+  score_v2,
+  status_v3,
+  code_v3,
+  score_v3,
+  is_autocoder_generated
+)
+SELECT
+  unit_map.target_unit_id,
+  source_response.variableid,
+  source_response.status,
+  source_response.value,
+  source_response.subform,
+  source_response.code_v1,
+  source_response.score_v1,
+  source_response.status_v1,
+  source_response.status_v2,
+  source_response.code_v2,
+  source_response.score_v2,
+  source_response.status_v3,
+  source_response.code_v3,
+  source_response.score_v3,
+  source_response.is_autocoder_generated
+FROM response source_response
+JOIN scale_unit_map unit_map
+  ON unit_map.source_unit_id = source_response.unitid;
+
+COMMIT;
+
+SELECT
+  :target_workspace_id AS workspace_id,
+  :'target_workspace_name' AS workspace_name,
+  count(DISTINCT person.id) AS persons,
+  count(DISTINCT booklet.id) AS booklets,
+  count(DISTINCT unit.id) AS units,
+  count(response.id) AS responses
+FROM workspace workspace
+LEFT JOIN persons person
+  ON person.workspace_id = workspace.id
+LEFT JOIN booklet booklet
+  ON booklet.personid = person.id
+LEFT JOIN unit unit
+  ON unit.bookletid = booklet.id
+LEFT JOIN response response
+  ON response.unitid = unit.id
+WHERE workspace.id = :target_workspace_id
+GROUP BY workspace.id;

--- a/scripts/repro/manual-coding-api-load-test.mjs
+++ b/scripts/repro/manual-coding-api-load-test.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * Repro/load helper for manual coding and response-analysis endpoints.
+ *
+ * Example:
+ * AUTH_TOKEN=... WORKSPACE_ID=47 CONCURRENCY=4 ROUNDS=5 \
+ *   node scripts/repro/manual-coding-api-load-test.mjs
+ *
+ * Optional:
+ * - BASE_URL=http://localhost:3333/api
+ * - TRIGGER_RESPONSE_ANALYSIS=true includes one POST trigger before the load.
+ * - CONCURRENCY_LEVELS=1,4,8 runs multiple concurrency stages.
+ * - ENDPOINT_SET=manual|test-results|all limits endpoint coverage.
+ * - OUTPUT_JSON=/tmp/manual-coding-api-load.json writes machine-readable results.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { performance } from 'node:perf_hooks';
+
+const baseUrl = process.env.BASE_URL || 'http://localhost:3333/api';
+const workspaceId = process.env.WORKSPACE_ID || '47';
+const authToken = process.env.AUTH_TOKEN;
+const concurrency = Number.parseInt(process.env.CONCURRENCY || '4', 10);
+const concurrencyLevels = (process.env.CONCURRENCY_LEVELS || '')
+  .split(',')
+  .map(level => Number.parseInt(level.trim(), 10))
+  .filter(level => Number.isInteger(level) && level > 0);
+const rounds = Number.parseInt(process.env.ROUNDS || '5', 10);
+const triggerResponseAnalysis =
+  process.env.TRIGGER_RESPONSE_ANALYSIS === 'true';
+const endpointSet = process.env.ENDPOINT_SET || 'manual';
+const outputJson = process.env.OUTPUT_JSON;
+
+if (!authToken) {
+  throw new Error(
+    'AUTH_TOKEN is required. Example: AUTH_TOKEN=... node scripts/repro/manual-coding-api-load-test.mjs'
+  );
+}
+
+if (!Number.isInteger(concurrency) || concurrency <= 0) {
+  throw new Error('CONCURRENCY must be a positive integer.');
+}
+
+if (!['manual', 'test-results', 'all'].includes(endpointSet)) {
+  throw new Error('ENDPOINT_SET must be manual, test-results, or all.');
+}
+
+if (!Number.isInteger(rounds) || rounds <= 0) {
+  throw new Error('ROUNDS must be a positive integer.');
+}
+
+const manualEndpoints = [
+  {
+    name: 'incomplete-variables',
+    path: `/admin/workspace/${workspaceId}/coding/incomplete-variables`
+  },
+  {
+    name: 'scope-summary',
+    path: `/admin/workspace/${workspaceId}/coding/incomplete-variables/scope-summary`
+  },
+  {
+    name: 'coding-freshness',
+    path: `/admin/workspace/${workspaceId}/coding/freshness`
+  },
+  {
+    name: 'response-analysis',
+    path: `/admin/workspace/${workspaceId}/coding/response-analysis?threshold=2&emptyLimit=10&duplicateLimit=10`
+  }
+];
+
+const testResultsEndpoints = [
+  {
+    name: 'flat-responses-page',
+    path: `/admin/workspace/${workspaceId}/test-results/flat-responses?page=1&limit=100`
+  },
+  {
+    name: 'flat-response-filter-options',
+    path: `/admin/workspace/${workspaceId}/test-results/flat-responses/filter-options`
+  },
+  {
+    name: 'test-results-overview',
+    path: `/admin/workspace/${workspaceId}/test-results/overview`
+  }
+];
+
+const endpoints = [
+  ...(endpointSet === 'test-results' ? [] : manualEndpoints),
+  ...(endpointSet === 'manual' ? [] : testResultsEndpoints)
+];
+
+async function request(endpoint, options = {}) {
+  const startedAt = performance.now();
+  const response = await fetch(`${baseUrl}${endpoint.path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(options.headers || {})
+    }
+  });
+  const text = await response.text();
+  const durationMs = performance.now() - startedAt;
+
+  return {
+    endpoint: endpoint.name,
+    status: response.status,
+    ok: response.ok,
+    durationMs,
+    bytes: Buffer.byteLength(text)
+  };
+}
+
+function average(values) {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function percentile(values, percent) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil((percent / 100) * sorted.length) - 1
+  );
+  return sorted[index];
+}
+
+function summarize(results) {
+  return endpoints.map((endpoint) => {
+    const endpointResults = results.filter(
+      (result) => result.endpoint === endpoint.name
+    );
+    const durations = endpointResults.map((result) => result.durationMs);
+    return {
+      endpoint: endpoint.name,
+      requests: endpointResults.length,
+      errors: endpointResults.filter((result) => !result.ok).length,
+      p50Ms: Math.round(percentile(durations, 50)),
+      p95Ms: Math.round(percentile(durations, 95)),
+      maxMs: Math.round(Math.max(...durations, 0)),
+      avgMs: Math.round(average(durations))
+    };
+  });
+}
+
+async function runWorker(workerId, currentRounds) {
+  const results = [];
+  for (let round = 1; round <= currentRounds; round += 1) {
+    for (const endpoint of endpoints) {
+      const result = await request(endpoint);
+      results.push({ ...result, workerId, round });
+    }
+  }
+  return results;
+}
+
+async function runStage(currentConcurrency) {
+  if (triggerResponseAnalysis) {
+    const triggerEndpoint = {
+      name: 'response-analysis-trigger',
+      path: `/admin/workspace/${workspaceId}/coding/response-analysis`
+    };
+    const result = await request(triggerEndpoint, { method: 'POST' });
+    console.log(JSON.stringify({ trigger: result }, null, 2));
+  }
+
+  const startedAt = performance.now();
+  const workerResults = await Promise.all(
+    Array.from({ length: currentConcurrency }, (_, index) => runWorker(index + 1, rounds))
+  );
+  const results = workerResults.flat();
+  const durationMs = performance.now() - startedAt;
+
+  return {
+    baseUrl,
+    workspaceId,
+    endpointSet,
+    concurrency: currentConcurrency,
+    rounds,
+    totalRequests: results.length,
+    durationMs: Math.round(durationMs),
+    summary: summarize(results)
+  };
+}
+
+const stages = concurrencyLevels.length ? concurrencyLevels : [concurrency];
+const stageResults = [];
+
+for (const stageConcurrency of stages) {
+  const result = await runStage(stageConcurrency);
+  stageResults.push(result);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  stages: stageResults
+};
+
+if (outputJson) {
+  await writeFile(outputJson, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+}

--- a/scripts/repro/redis-cache-hygiene.md
+++ b/scripts/repro/redis-cache-hygiene.md
@@ -1,0 +1,75 @@
+# Redis cache hygiene notes
+
+Use `scripts/repro/redis-cache-inventory.mjs` before deleting Redis data. The
+script is read-only and reports key counts, `MEMORY USAGE`, TTL distribution,
+and the largest keys grouped by Kodierbox/Bull prefix.
+
+## Current local finding
+
+Measured on the local scale-test Redis after the 5000-person workspace run:
+
+- `cache:responses`: about 72k keys, 1.8 GiB, all expiring. These are replay
+  response cache entries from `ResponseCacheSchedulerService`.
+- `queue:response-analysis`: 179 keys, 402 MiB, mostly without expiry. These
+  are Bull job hashes. Completed response-analysis jobs used to retain large
+  job return values.
+- `cache:response-analysis`: 39 keys, 108 MiB. These are application result
+  caches and derived page caches. Some have TTL, some are revision/run marker
+  style keys without expiry.
+- `cache:coding_applied_results_overview` and
+  `cache:workspace-overview-stats`: under 1 KiB each. They are not the Redis
+  pressure source.
+
+## Cleanup classes
+
+Safe to delete in local/performance test environments:
+
+- `coding-box:cache:responses:<workspaceId>:*`
+  Rebuilt from PostgreSQL on demand. Deleting this may make replay/unit-response
+  views cold again, but does not lose source data.
+- `coding-box:cache:response-analysis:<workspaceId>*`
+  Recomputed by response-analysis. Deleting this may trigger a new analysis.
+- Completed/stale Bull jobs in `coding-box:response-analysis:*`
+  These should not be used as the durable result store. Results live in
+  `cache:response-analysis:*`. New jobs now use `removeOnComplete` and
+  `removeOnFail` to prevent future accumulation.
+
+Do not delete blindly:
+
+- Active, waiting, or delayed Bull queue keys for imports, exports, validation,
+  coding jobs, and response-analysis. Use the process overview or Bull APIs to
+  confirm job state first.
+- `coding-box:cache:workspace_unit_variables:*` or similar workspace-file
+  derived caches while users are actively coding. They are rebuildable, but
+  deleting them can create avoidable cold UI work.
+- Revisioned overview caches for active workspaces unless invalidating after
+  data changes. They are tiny and intentionally no-expiry.
+
+## Recommended local cleanup sequence
+
+1. Run:
+
+   ```bash
+   node scripts/repro/redis-cache-inventory.mjs > /tmp/kodierbox-redis-inventory.json
+   ```
+
+2. If Redis memory pressure is local-test-only, delete expiring response cache
+   keys for the scale workspace first:
+
+   ```bash
+   docker exec kodierbox-redis-1 redis-cli --scan --pattern 'coding-box:cache:responses:54:*' \
+     | xargs -r -n 500 docker exec kodierbox-redis-1 redis-cli UNLINK
+   ```
+
+3. Clean completed response-analysis jobs through Bull/application APIs where
+   possible. Avoid raw deletion while a response-analysis job is active.
+
+4. Re-run the inventory and compare group totals.
+
+## Product follow-up
+
+- Keep `response-analysis` queue jobs small/short-lived. Completed jobs can be
+  removed because the API reads durable results from Redis cache keys.
+- Consider making the nightly response-cache warmup skip very large workspaces
+  or use a lower explicit TTL. The default 24h TTL can consume multiple GiB on
+  synthetic 5000-person data.

--- a/scripts/repro/redis-cache-inventory.mjs
+++ b/scripts/repro/redis-cache-inventory.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import Redis from 'ioredis';
+
+const host = process.env.REDIS_HOST || 'localhost';
+const port = Number.parseInt(process.env.REDIS_PORT || '6379', 10);
+const scanCount = Number.parseInt(process.env.SCAN_COUNT || '500', 10);
+const topLimit = Number.parseInt(process.env.TOP_LIMIT || '25', 10);
+const sampleLimit = Number.parseInt(process.env.SAMPLE_LIMIT || '0', 10);
+const namespacePrefix = process.env.REDIS_NAMESPACE_PREFIX || 'coding-box:';
+const cachePrefix = `${namespacePrefix}cache:`;
+
+const redis = new Redis({ host, port, lazyConnect: true, maxRetriesPerRequest: 1 });
+
+function logicalKey(key) {
+  if (key.startsWith(cachePrefix)) {
+    return key.slice(cachePrefix.length);
+  }
+  if (key.startsWith(namespacePrefix)) {
+    return key.slice(namespacePrefix.length);
+  }
+  return key;
+}
+
+function classify(key) {
+  const logical = logicalKey(key);
+  if (key.startsWith(cachePrefix)) {
+    const knownCachePrefixes = [
+      'response-analysis:',
+      'response_analysis:',
+      'response_analysis_page:',
+      'validation:v2:',
+      'responses:',
+      'manual_coding_variables:',
+      'manual_coding_scope_summary:',
+      'coding_statistics:',
+      'coding_statistics_version:',
+      'coding_applied_results_overview:',
+      'workspace-overview-stats-',
+      'flat_response_filter_options:',
+      'flat_responses_count:',
+      'flat-frequencies-',
+      'unit_variables:',
+      'workspace_unit_variables:'
+    ];
+    const match = knownCachePrefixes.find(prefix => logical.startsWith(prefix));
+    if (match) {
+      return `cache:${match.replace(/[:/-]$/, '')}`;
+    }
+    return `cache:${logical.split(/[:_-]/, 1)[0] || 'unknown'}`;
+  }
+
+  const queueMatch = logical.match(/^([^:]+):/);
+  if (queueMatch) {
+    return `queue:${queueMatch[1]}`;
+  }
+  return 'other';
+}
+
+function createStats() {
+  return {
+    keys: 0,
+    bytes: 0,
+    noExpire: 0,
+    expiring: 0,
+    missingMemory: 0,
+    minTtl: Number.POSITIVE_INFINITY,
+    maxTtl: 0
+  };
+}
+
+function addStats(stats, memoryBytes, ttl) {
+  stats.keys += 1;
+  if (Number.isFinite(memoryBytes)) {
+    stats.bytes += memoryBytes;
+  } else {
+    stats.missingMemory += 1;
+  }
+  if (ttl === -1) {
+    stats.noExpire += 1;
+  } else if (ttl > 0) {
+    stats.expiring += 1;
+    stats.minTtl = Math.min(stats.minTtl, ttl);
+    stats.maxTtl = Math.max(stats.maxTtl, ttl);
+  }
+}
+
+function humanBytes(bytes) {
+  const units = ['B', 'KiB', 'MiB', 'GiB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function serializeStats([group, stats]) {
+  return {
+    group,
+    keys: stats.keys,
+    bytes: stats.bytes,
+    humanBytes: humanBytes(stats.bytes),
+    noExpire: stats.noExpire,
+    expiring: stats.expiring,
+    minTtlSeconds: Number.isFinite(stats.minTtl) ? stats.minTtl : null,
+    maxTtlSeconds: stats.maxTtl || null,
+    missingMemory: stats.missingMemory
+  };
+}
+
+async function scanKeys() {
+  const groups = new Map();
+  const allStats = createStats();
+  const largest = [];
+  let cursor = '0';
+  let scanned = 0;
+
+  do {
+    const [nextCursor, keys] = await redis.scan(cursor, 'COUNT', scanCount);
+    cursor = nextCursor;
+    const batch = sampleLimit > 0 ?
+      keys.slice(0, Math.max(0, sampleLimit - scanned)) :
+      keys;
+    if (batch.length === 0) {
+      continue;
+    }
+    const pipeline = redis.pipeline();
+    batch.forEach(key => {
+      pipeline.memory('USAGE', key);
+      pipeline.ttl(key);
+      pipeline.type(key);
+    });
+    const replies = await pipeline.exec();
+    for (let index = 0; index < batch.length; index += 1) {
+      const key = batch[index];
+      const memoryReply = replies[index * 3];
+      const ttlReply = replies[index * 3 + 1];
+      const typeReply = replies[index * 3 + 2];
+      const memoryBytes = memoryReply?.[0] ? NaN : Number(memoryReply[1]);
+      const ttl = ttlReply?.[0] ? -2 : Number(ttlReply[1]);
+      const type = typeReply?.[0] ? 'unknown' : String(typeReply[1]);
+      const groupName = classify(key);
+      const group = groups.get(groupName) || createStats();
+
+      addStats(group, memoryBytes, ttl);
+      addStats(allStats, memoryBytes, ttl);
+      groups.set(groupName, group);
+
+      largest.push({
+        key,
+        group: groupName,
+        type,
+        ttlSeconds: ttl,
+        bytes: Number.isFinite(memoryBytes) ? memoryBytes : 0,
+        humanBytes: humanBytes(Number.isFinite(memoryBytes) ? memoryBytes : 0)
+      });
+    }
+    scanned += batch.length;
+  } while (cursor !== '0' && (sampleLimit === 0 || scanned < sampleLimit));
+
+  largest.sort((a, b) => b.bytes - a.bytes);
+  const sortedGroups = Array.from(groups.entries())
+    .map(serializeStats)
+    .sort((a, b) => b.bytes - a.bytes);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    redis: { host, port, namespacePrefix, scannedKeys: scanned },
+    totals: serializeStats(['all', allStats]),
+    groups: sortedGroups,
+    largestKeys: largest.slice(0, topLimit)
+  };
+}
+
+try {
+  await redis.connect();
+  const report = await scanKeys();
+  console.log(JSON.stringify(report, null, 2));
+} finally {
+  redis.disconnect();
+}

--- a/scripts/repro/workspace-consider-scale-load-test.mjs
+++ b/scripts/repro/workspace-consider-scale-load-test.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+
+/**
+ * Repro helper for scale tests without creating additional large workspaces.
+ *
+ * It temporarily changes persons.consider in an existing scale workspace to
+ * emulate 1k/2.5k/5k active test persons, clears relevant caches, measures
+ * selected API endpoints, and restores the original consider flags.
+ *
+ * Example:
+ * AUTH_TOKEN=... WORKSPACE_ID=54 TIERS=1000,2500,5000 CONCURRENCY_LEVELS=1,4 \
+ *   node scripts/repro/workspace-consider-scale-load-test.mjs
+ *
+ * Optional ENDPOINTS:
+ * - overview
+ * - geogebra
+ * - applied
+ * - readiness (uses forceRefresh=true and can be expensive on large workspaces)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import { performance } from 'node:perf_hooks';
+
+const authToken = process.env.AUTH_TOKEN;
+const baseUrl = process.env.BASE_URL || 'http://localhost:3333/api';
+const workspaceId = Number.parseInt(process.env.WORKSPACE_ID || '54', 10);
+const tiers = (process.env.TIERS || '1000,2500,5000')
+  .split(',')
+  .map(value => Number.parseInt(value.trim(), 10))
+  .filter(value => Number.isInteger(value) && value > 0);
+const concurrencyLevels = (process.env.CONCURRENCY_LEVELS || '1,4')
+  .split(',')
+  .map(value => Number.parseInt(value.trim(), 10))
+  .filter(value => Number.isInteger(value) && value > 0);
+const rounds = Number.parseInt(process.env.ROUNDS || '1', 10);
+const dbContainer = process.env.DB_CONTAINER || 'kodierbox-db-1';
+const redisContainer = process.env.REDIS_CONTAINER || 'kodierbox-redis-1';
+const outputJson = process.env.OUTPUT_JSON;
+const requestedEndpointNames = (process.env.ENDPOINTS || 'overview,geogebra,applied')
+  .split(',')
+  .map(value => value.trim())
+  .filter(Boolean);
+
+if (!authToken) {
+  throw new Error('AUTH_TOKEN is required.');
+}
+if (!Number.isInteger(workspaceId) || workspaceId <= 0) {
+  throw new Error('WORKSPACE_ID must be a positive integer.');
+}
+if (tiers.length === 0) {
+  throw new Error('TIERS must contain at least one positive integer.');
+}
+if (concurrencyLevels.length === 0) {
+  throw new Error('CONCURRENCY_LEVELS must contain at least one positive integer.');
+}
+if (!Number.isInteger(rounds) || rounds <= 0) {
+  throw new Error('ROUNDS must be a positive integer.');
+}
+
+const endpointCatalog = {
+  overview: {
+    name: 'test-results-overview',
+    path: `/admin/workspace/${workspaceId}/test-results/overview`
+  },
+  geogebra: {
+    name: 'geogebra-existence',
+    path: `/admin/workspace/${workspaceId}/responses/geogebra-existence`
+  },
+  readiness: {
+    name: 'coding-readiness',
+    path: `/admin/workspace/${workspaceId}/coding/readiness?autoCoderRun=1&forceRefresh=true`
+  },
+  applied: {
+    name: 'applied-results-overview',
+    path: `/admin/workspace/${workspaceId}/coding/applied-results-overview`
+  }
+};
+
+const endpoints = requestedEndpointNames.map(name => {
+  const endpoint = endpointCatalog[name];
+  if (!endpoint) {
+    throw new Error(
+      `Unknown endpoint "${name}". Supported: ${Object.keys(endpointCatalog).join(', ')}.`
+    );
+  }
+  return endpoint;
+});
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+    ...options
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} failed:\n${result.stderr || result.stdout}`
+    );
+  }
+  return result.stdout;
+}
+
+function sql(query) {
+  return run('docker', [
+    'exec',
+    dbContainer,
+    'psql',
+    '-U',
+    'root',
+    '-d',
+    'coding-box',
+    '-At',
+    '-v',
+    'ON_ERROR_STOP=1',
+    '-c',
+    query
+  ]).trim();
+}
+
+function captureOriginalConsiderState() {
+  const rows = sql(`
+    SELECT id || ':' || CASE WHEN consider THEN '1' ELSE '0' END
+    FROM persons
+    WHERE workspace_id = ${workspaceId}
+    ORDER BY id
+  `);
+  return rows ? rows.split('\n') : [];
+}
+
+function restoreOriginalConsiderState(rows) {
+  if (rows.length === 0) {
+    return;
+  }
+  const falseIds = rows
+    .filter(row => row.endsWith(':0'))
+    .map(row => Number.parseInt(row.split(':')[0], 10))
+    .filter(Number.isInteger);
+
+  sql(`UPDATE persons SET consider = true WHERE workspace_id = ${workspaceId}`);
+  if (falseIds.length > 0) {
+    sql(`
+      UPDATE persons
+      SET consider = false
+      WHERE workspace_id = ${workspaceId}
+        AND id IN (${falseIds.join(',')})
+    `);
+  }
+}
+
+function setActivePersons(activePersons) {
+  sql(`
+    WITH ranked AS (
+      SELECT id, row_number() OVER (ORDER BY id) AS rn
+      FROM persons
+      WHERE workspace_id = ${workspaceId}
+    )
+    UPDATE persons p
+    SET consider = ranked.rn <= ${activePersons}
+    FROM ranked
+    WHERE p.id = ranked.id
+  `);
+  return Number.parseInt(sql(`
+    SELECT count(*)
+    FROM persons
+    WHERE workspace_id = ${workspaceId}
+      AND consider = true
+  `), 10);
+}
+
+function redisScan(pattern) {
+  const output = run('docker', [
+    'exec',
+    redisContainer,
+    'redis-cli',
+    '--scan',
+    '--pattern',
+    pattern
+  ]);
+  return output.split('\n').map(line => line.trim()).filter(Boolean);
+}
+
+function clearRedisPattern(pattern) {
+  const keys = redisScan(pattern);
+  for (let index = 0; index < keys.length; index += 200) {
+    const chunk = keys.slice(index, index + 200);
+    if (chunk.length > 0) {
+      run('docker', ['exec', redisContainer, 'redis-cli', 'UNLINK', ...chunk]);
+    }
+  }
+  return keys.length;
+}
+
+function clearWorkspaceCaches() {
+  const patterns = [
+    `*workspace-overview-stats-${workspaceId}*`,
+    `*geogebra-existence:${workspaceId}*`,
+    `*coding_readiness:${workspaceId}*`,
+    `*coding_applied_results_overview*${workspaceId}*`,
+    `*flat_responses_count:${workspaceId}*`,
+    `*response-analysis:${workspaceId}*`
+  ];
+  return Object.fromEntries(
+    patterns.map(pattern => [pattern, clearRedisPattern(pattern)])
+  );
+}
+
+async function request(endpoint) {
+  const startedAt = performance.now();
+  const response = await fetch(`${baseUrl}${endpoint.path}`, {
+    headers: { Authorization: `Bearer ${authToken}` }
+  });
+  const text = await response.text();
+  return {
+    endpoint: endpoint.name,
+    status: response.status,
+    ok: response.ok,
+    durationMs: performance.now() - startedAt,
+    bytes: Buffer.byteLength(text)
+  };
+}
+
+function percentile(values, percent) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil((percent / 100) * sorted.length) - 1
+  );
+  return sorted[index];
+}
+
+function summarize(results) {
+  return endpoints.map(endpoint => {
+    const endpointResults = results.filter(
+      result => result.endpoint === endpoint.name
+    );
+    const durations = endpointResults.map(result => result.durationMs);
+    return {
+      endpoint: endpoint.name,
+      requests: endpointResults.length,
+      errors: endpointResults.filter(result => !result.ok).length,
+      p50Ms: Math.round(percentile(durations, 50)),
+      p95Ms: Math.round(percentile(durations, 95)),
+      maxMs: Math.round(Math.max(...durations, 0))
+    };
+  });
+}
+
+async function runStage(concurrency) {
+  const startedAt = performance.now();
+  const workers = await Promise.all(
+    Array.from({ length: concurrency }, async (_, index) => {
+      const results = [];
+      for (let round = 1; round <= rounds; round += 1) {
+        for (const endpoint of endpoints) {
+          results.push({
+            ...(await request(endpoint)),
+            workerId: index + 1,
+            round
+          });
+        }
+      }
+      return results;
+    })
+  );
+  const results = workers.flat();
+  return {
+    concurrency,
+    rounds,
+    totalRequests: results.length,
+    durationMs: Math.round(performance.now() - startedAt),
+    summary: summarize(results)
+  };
+}
+
+const originalConsiderState = captureOriginalConsiderState();
+const report = {
+  generatedAt: new Date().toISOString(),
+  baseUrl,
+  workspaceId,
+  endpoints: requestedEndpointNames,
+  tiers: []
+};
+
+try {
+  for (const tier of tiers) {
+    const activePersons = setActivePersons(tier);
+    const clearedCaches = clearWorkspaceCaches();
+    const tierResult = {
+      requestedPersons: tier,
+      activePersons,
+      clearedCaches,
+      stages: []
+    };
+    for (const concurrency of concurrencyLevels) {
+      tierResult.stages.push(await runStage(concurrency));
+    }
+    report.tiers.push(tierResult);
+    console.log(JSON.stringify(tierResult, null, 2));
+  }
+} finally {
+  restoreOriginalConsiderState(originalConsiderState);
+  clearWorkspaceCaches();
+}
+
+if (outputJson) {
+  await writeFile(outputJson, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+}


### PR DESCRIPTION
## Summary

Refs #813

This PR improves the perceived and measured performance of the manual coding administration flows, especially for testergebnisse, Kodierübersicht, and manuelle Kodierung with auto-refresh enabled.

Changes include:
- response-analysis summary/page/chunk caching to avoid repeatedly serving large cached payloads
- stale-run and source-revision guards for background analysis jobs
- in-flight dedupe and stale-cache protection for manual coding availability data
- faster backend query filters for unit/variable pairs and applied-results counts
- UI race guards so stale auto-refresh responses no longer overwrite the active tab/workspace state
- split transient and priority error overlays so ordinary HTTP errors do not cover navigation, dialogs, or export progress
- Cypress and repro scripts for slow-network, rapid-tab, and large-workspace performance checks

## Root Cause

The slow feeling was not mainly caused by Angular rendering. The main sources were backend-side duplicate work and large cached response-analysis payloads being serialized and returned during cache hits. Rapid tab changes and auto-refresh could also start overlapping requests; old responses then risked updating current UI state. For stale paginator states, response-analysis could miss chunk caches and fall back toward heavier paths even though the summary was already available.

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-job.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx test frontend --testFile=apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.spec.ts --runInBand --skip-nx-cache`
- `npx nx lint backend --skip-nx-cache`
- `npx nx lint frontend --skip-nx-cache`
- Cypress UI smoke against `http://localhost:4201`, workspace 54, slow-4g profile, manual login: 4/4 passing

## Notes

The issue is intentionally only referenced and not closed by this PR description. Local disk space was tight during the largest-scale repro work, so further tests beyond 5000 active test persons should be run on a machine with more free space.
