### PR TITLE
Fix frontend translation cache busting

### DIFF
--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -11,7 +11,6 @@ import {
 } from '@angular/common/http';
 import { registerLocaleData, HashLocationStrategy, LocationStrategy } from '@angular/common';
 import localeDeAt from '@angular/common/locales/de-AT';
-import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   AutoRefreshTokenService, createInterceptorCondition,
@@ -20,6 +19,7 @@ import {
   UserActivityService,
   withAutoRefreshToken
 } from 'keycloak-angular';
+import { Observable } from 'rxjs';
 import { routes } from './app.routes';
 import { environment } from '../environments/environment';
 import { authInterceptor } from './core/interceptors/auth.interceptor';
@@ -27,8 +27,20 @@ import { journalInterceptor } from './core/interceptors/journal-interceptor';
 import { SERVER_URL } from './injection-tokens';
 import { AUTH_SESSION_IDLE_TIMEOUT_MS } from './core/services/auth-session.config';
 
-export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
-  return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+const translationCacheBust = Date.now().toString();
+
+export class CacheBustingTranslateLoader implements TranslateLoader {
+  constructor(private http: HttpClient) {}
+
+  getTranslation(lang: string): Observable<Record<string, unknown>> {
+    return this.http.get<Record<string, unknown>>(
+      `./assets/i18n/${lang}.json?v=${translationCacheBust}`
+    );
+  }
+}
+
+export function createTranslateLoader(http: HttpClient): CacheBustingTranslateLoader {
+  return new CacheBustingTranslateLoader(http);
 }
 
 const allUrlsCondition = createInterceptorCondition<IncludeBearerTokenCondition>({

--- a/config/frontend/default.conf.http-template
+++ b/config/frontend/default.conf.http-template
@@ -23,7 +23,13 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
     }
 
-    location ^~ /assets/ {
+    location ~* "^/assets/i18n/[^/]+\.json$" {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+        try_files $uri =404;
+    }
+
+    location /assets/ {
         root   /usr/share/nginx/html;
         add_header Cache-Control "no-cache, must-revalidate, max-age=0" always;
         try_files $uri =404;

--- a/config/frontend/default.conf.https-template
+++ b/config/frontend/default.conf.https-template
@@ -37,7 +37,13 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
     }
 
-    location ^~ /assets/ {
+    location ~* "^/assets/i18n/[^/]+\.json$" {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+        try_files $uri =404;
+    }
+
+    location /assets/ {
         root   /usr/share/nginx/html;
         add_header Cache-Control "no-cache, must-revalidate, max-age=0" always;
         try_files $uri =404;

--- a/config/frontend/default.conf.template
+++ b/config/frontend/default.conf.template
@@ -23,7 +23,13 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
     }
 
-    location ^~ /assets/ {
+    location ~* "^/assets/i18n/[^/]+\.json$" {
+        root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+        try_files $uri =404;
+    }
+
+    location /assets/ {
         root   /usr/share/nginx/html;
         add_header Cache-Control "no-cache, must-revalidate, max-age=0" always;
         try_files $uri =404;


### PR DESCRIPTION
## Summary

Fixes stale frontend translation assets after a new release/deployment. Translation JSON files are requested with a cache-busting query parameter and Nginx now serves `/assets/i18n/*.json` with no-store cache headers.

## Changes

- Load frontend translations through a small cache-busting TranslateLoader.
- Send no-store headers for `/assets/i18n/*.json` in all frontend Nginx templates.
- Keep the existing cache behaviour for other assets and hashed JS/CSS files.

## Validation

- `git diff --check`
- `npx nx lint frontend`
- `npx nx test frontend` (185 suites, 1631 tests)
- `npx nx build frontend`
- `nginx -t` in `nginxinc/nginx-unprivileged:stable` for `default.conf.template`, `default.conf.http-template`, and rendered `default.conf.https-template`
