### PR TITLE
Reduce automatic kappa loading

### DIFF
--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -2112,6 +2112,282 @@ describe('CoderTrainingService', () => {
     });
   });
 
+  describe('getWithinTrainingCodingComparison', () => {
+    it('groups raw coding rows by response and keeps manual discussion results authoritative', async () => {
+      (coderTrainingRepository.findOne as jest.Mock).mockResolvedValueOnce({
+        id: 5,
+        workspace_id: 1
+      });
+      mockRepository.find
+        .mockResolvedValueOnce([
+          {
+            id: 11,
+            name: 'job-a',
+            missings_profile_id: null,
+            codingJobCoders: [{ user: { username: 'Alice' } }]
+          },
+          {
+            id: 12,
+            name: 'job-b',
+            missings_profile_id: null,
+            codingJobCoders: [{ user: { username: 'Bob' } }]
+          }
+        ])
+        .mockResolvedValueOnce([
+          {
+            response_id: 102,
+            code: 99,
+            score: 4,
+            notes: 'manual note',
+            manager_user_id: 23,
+            manager_name: 'Old Manager'
+          }
+        ])
+        .mockResolvedValueOnce([
+          { id: 23, username: 'Manager' }
+        ]);
+
+      const qb = {
+        innerJoin: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            jobId: 11,
+            unitRowId: 1,
+            responseId: 101,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            personCode: 'P1',
+            personLogin: 'login-1',
+            personGroup: 'group',
+            bookletName: 'booklet',
+            givenAnswer: 'answer 1',
+            replayCodeV1: null,
+            replayCodeV2: null,
+            replayCodeV3: 7,
+            replayScoreV1: null,
+            replayScoreV2: null,
+            replayScoreV3: 2,
+            code: 7,
+            score: 2,
+            notes: 'a',
+            codingIssueOption: null
+          },
+          {
+            jobId: 12,
+            unitRowId: 2,
+            responseId: 101,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            personCode: 'P1',
+            personLogin: 'login-1',
+            personGroup: 'group',
+            bookletName: 'booklet',
+            givenAnswer: 'answer 1',
+            replayCodeV1: null,
+            replayCodeV2: null,
+            replayCodeV3: 7,
+            replayScoreV1: null,
+            replayScoreV2: null,
+            replayScoreV3: 2,
+            code: 7,
+            score: 2,
+            notes: 'b',
+            codingIssueOption: null
+          },
+          {
+            jobId: 11,
+            unitRowId: 3,
+            responseId: 102,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            personCode: 'P2',
+            personLogin: 'login-2',
+            personGroup: 'group',
+            bookletName: 'booklet',
+            givenAnswer: 'answer 2',
+            replayCodeV1: null,
+            replayCodeV2: null,
+            replayCodeV3: null,
+            replayScoreV1: null,
+            replayScoreV2: null,
+            replayScoreV3: null,
+            code: 8,
+            score: 2,
+            notes: null,
+            codingIssueOption: null
+          },
+          {
+            jobId: 12,
+            unitRowId: 4,
+            responseId: 102,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            personCode: 'P2',
+            personLogin: 'login-2',
+            personGroup: 'group',
+            bookletName: 'booklet',
+            givenAnswer: 'answer 2',
+            replayCodeV1: null,
+            replayCodeV2: null,
+            replayCodeV3: null,
+            replayScoreV1: null,
+            replayScoreV2: null,
+            replayScoreV3: null,
+            code: 9,
+            score: 3,
+            notes: null,
+            codingIssueOption: null
+          }
+        ])
+      };
+      (mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      const result = await service.getWithinTrainingCodingComparison(1, 5);
+
+      expect(coderTrainingRepository.findOne).toHaveBeenCalledWith({
+        where: { workspace_id: 1, id: 5 }
+      });
+      expect(codingJobRepository.find).toHaveBeenCalledWith({
+        where: { workspace_id: 1, training_id: 5 },
+        relations: ['codingJobCoders.user'],
+        order: { id: 'ASC' }
+      });
+      expect(qb.getRawMany).toHaveBeenCalled();
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        responseId: 101,
+        givenAnswer: 'answer 1',
+        replayCode: 7,
+        replayScore: 2,
+        discussionCode: 7,
+        discussionScore: 2,
+        discussionSource: 'auto_agreement',
+        coders: [
+          {
+            jobId: 11, coderName: 'Alice', code: '7', score: 2, notes: 'a'
+          },
+          {
+            jobId: 12, coderName: 'Bob', code: '7', score: 2, notes: 'b'
+          }
+        ]
+      });
+      expect(result[1]).toMatchObject({
+        responseId: 102,
+        discussionCode: 99,
+        discussionScore: 4,
+        discussionNotes: 'manual note',
+        discussionManagerUserId: 23,
+        discussionManagerName: 'Manager',
+        discussionSource: 'manual'
+      });
+    });
+
+    it('rejects automatic missing agreement when raw comparison jobs use different missing profiles', async () => {
+      (coderTrainingRepository.findOne as jest.Mock).mockResolvedValueOnce({
+        id: 5,
+        workspace_id: 1
+      });
+      missingsProfilesService.getMissingsProfileDetails.mockResolvedValue({
+        parseMissings: () => [
+          {
+            id: 'mir', label: 'missing invalid response', code: -98, score: 0
+          },
+          {
+            id: 'mci', label: 'missing coding impossible', code: -97, score: 0
+          },
+          {
+            id: 'mbi_mbo', label: 'missing by omission', code: -99, score: 0
+          }
+        ]
+      });
+      mockRepository.find
+        .mockResolvedValueOnce([
+          {
+            id: 11,
+            name: 'job-a',
+            missings_profile_id: 77,
+            codingJobCoders: [{ user: { username: 'Alice' } }]
+          },
+          {
+            id: 12,
+            name: 'job-b',
+            missings_profile_id: 78,
+            codingJobCoders: [{ user: { username: 'Bob' } }]
+          }
+        ])
+        .mockResolvedValueOnce([]);
+
+      const qb = {
+        innerJoin: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            jobId: 11,
+            unitRowId: 1,
+            responseId: 101,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            personCode: 'P1',
+            personLogin: 'login-1',
+            personGroup: 'group',
+            bookletName: 'booklet',
+            givenAnswer: 'answer 1',
+            replayCodeV1: null,
+            replayCodeV2: null,
+            replayCodeV3: null,
+            replayScoreV1: null,
+            replayScoreV2: null,
+            replayScoreV3: null,
+            code: -99,
+            score: null,
+            notes: null,
+            codingIssueOption: null
+          },
+          {
+            jobId: 12,
+            unitRowId: 2,
+            responseId: 101,
+            unitName: 'UNIT',
+            variableId: 'VAR',
+            personCode: 'P1',
+            personLogin: 'login-1',
+            personGroup: 'group',
+            bookletName: 'booklet',
+            givenAnswer: 'answer 1',
+            replayCodeV1: null,
+            replayCodeV2: null,
+            replayCodeV3: null,
+            replayScoreV1: null,
+            replayScoreV2: null,
+            replayScoreV3: null,
+            code: -99,
+            score: null,
+            notes: null,
+            codingIssueOption: null
+          }
+        ])
+      };
+      (mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await expect(service.getWithinTrainingCodingComparison(1, 5))
+        .rejects
+        .toThrow('Conflicting missing profiles for response 101 in training 5');
+    });
+  });
+
   describe('saveDiscussionResult', () => {
     const createTrainingWithUnit = (unitOverrides: Partial<CodingJobUnit> = {}) => {
       const unit = {

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -136,6 +136,29 @@ type TrainingResponseJobUnit = {
   unit: CodingJobUnit;
 };
 
+type WithinTrainingCodingRow = {
+  jobId: number | string;
+  unitRowId: number | string;
+  responseId: number | string;
+  unitName: string;
+  variableId: string;
+  personCode: string;
+  personLogin: string;
+  personGroup: string | null;
+  bookletName: string;
+  givenAnswer: string | null;
+  replayCodeV1: number | string | null;
+  replayCodeV2: number | string | null;
+  replayCodeV3: number | string | null;
+  replayScoreV1: number | string | null;
+  replayScoreV2: number | string | null;
+  replayScoreV3: number | string | null;
+  code: number | string | null;
+  score: number | string | null;
+  notes: string | null;
+  codingIssueOption: number | string | null;
+};
+
 type MissingCodePair = { mirCode: number; mciCode: number };
 type MissingCodeDisplayContext = MissingCodePair & {
   negativeCodes: Set<number>;
@@ -827,6 +850,38 @@ export class CoderTrainingService {
     };
   }
 
+  private async deriveAutomaticDiscussionResultForRawResponse(
+    workspaceId: number,
+    trainingId: number,
+    responseId: number,
+    jobs: Array<Pick<CodingJob, 'id' | 'missings_profile_id'>>,
+    unitsByJobId: Map<number, WithinTrainingCodingRow>,
+    coders: WithinTrainingCoderResult[]
+  ): Promise<{ code: number; score: number | null } | null> {
+    const result = this.deriveAutomaticDiscussionResult(coders);
+    if (!result || result.code >= 0) {
+      return result;
+    }
+
+    const responseJobs = jobs.filter(job => unitsByJobId.has(job.id));
+    const resolvedProfileIds = await Promise.all(responseJobs.map(job => (
+      this.missingsProfilesService.resolveMissingsProfileId(workspaceId, job.missings_profile_id)
+    )));
+    const profileKeys = new Set(resolvedProfileIds);
+    if (profileKeys.size > 1) {
+      throw new BadRequestException(`Conflicting missing profiles for response ${responseId} in training ${trainingId}`);
+    }
+
+    return {
+      code: result.code,
+      score: await this.getMissingScoreForProfile(
+        workspaceId,
+        resolvedProfileIds[0] ?? null,
+        result.code
+      )
+    };
+  }
+
   private findTrainingUnitForResponse(
     training: CoderTraining,
     responseId: number,
@@ -976,6 +1031,14 @@ export class CoderTrainingService {
       exclusions
     );
 
+    return this.getMissingScoreForProfile(workspaceId, profileId, code);
+  }
+
+  private async getMissingScoreForProfile(
+    workspaceId: number,
+    profileId: number | null,
+    code: number
+  ): Promise<number> {
     try {
       return (await this.missingsProfilesService.getMissingByCodeForProfileOrDefault(
         workspaceId,
@@ -2168,9 +2231,7 @@ export class CoderTrainingService {
     workspaceId: number,
     trainingId: number
   ): Promise<Array<{
-
       responseId: number;
-
       unitName: string;
       variableId: string;
       personCode: string;
@@ -2195,17 +2256,36 @@ export class CoderTrainingService {
       where: {
         workspace_id: workspaceId,
         id: trainingId
-      },
-      relations: ['codingJobs.codingJobCoders.user', 'codingJobs.codingJobUnits.response.unit.booklet.person']
+      }
     });
 
-    if (!training || !training.codingJobs) {
+    if (!training) {
+      return [];
+    }
+
+    const jobs = await this.codingJobRepository.find({
+      where: {
+        workspace_id: workspaceId,
+        training_id: trainingId
+      },
+      relations: ['codingJobCoders.user'],
+      order: { id: 'ASC' }
+    });
+
+    if (jobs.length === 0) {
       return [];
     }
 
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-    const missingCodesByJobId = await this.buildMissingCodesByJobId(workspaceId, training.codingJobs);
+    const missingCodesByJobId = await this.buildMissingCodesByJobId(workspaceId, jobs);
     const defaultMissingCodeContext = await this.getDefaultMissingCodeDisplayContext(workspaceId);
+    const coderNameByJobId = new Map<number, string>();
+    jobs.forEach(job => {
+      const coderName = job.codingJobCoders?.[0]?.user?.username ?
+        `${job.codingJobCoders[0].user.username}` :
+        `Coder ${job.name}`;
+      coderNameByJobId.set(job.id, coderName);
+    });
 
     const unitVariableMap = new Map<string, {
       responseId: number;
@@ -2221,32 +2301,79 @@ export class CoderTrainingService {
       replayScore: number | null;
     }>();
 
-    training.codingJobs.forEach(job => {
-      job.codingJobUnits?.forEach(unit => {
-        if (isExcludedByResolvedExclusions(exclusions, unit.booklet_name, unit.unit_name)) {
-          return;
-        }
-        const unitVariableKey = unit.response_id.toString();
-        if (!unitVariableMap.has(unitVariableKey)) {
-          const givenAnswer = unit.response?.value || '';
-          const personGroup = unit.response?.unit?.booklet?.person?.group || '';
-          const testPerson = `${unit.person_login} (${personGroup}) - ${unit.booklet_name}`;
+    const query = this.codingJobUnitRepository
+      .createQueryBuilder('cju')
+      .innerJoin('cju.coding_job', 'cj')
+      .leftJoin('cju.response', 'resp')
+      .select('cj.id', 'jobId')
+      .addSelect('cju.id', 'unitRowId')
+      .addSelect('cju.response_id', 'responseId')
+      .addSelect('cju.unit_name', 'unitName')
+      .addSelect('cju.variable_id', 'variableId')
+      .addSelect('cju.person_code', 'personCode')
+      .addSelect('cju.person_login', 'personLogin')
+      .addSelect('cju.person_group', 'personGroup')
+      .addSelect('cju.booklet_name', 'bookletName')
+      .addSelect('resp.value', 'givenAnswer')
+      .addSelect('resp.code_v1', 'replayCodeV1')
+      .addSelect('resp.code_v2', 'replayCodeV2')
+      .addSelect('resp.code_v3', 'replayCodeV3')
+      .addSelect('resp.score_v1', 'replayScoreV1')
+      .addSelect('resp.score_v2', 'replayScoreV2')
+      .addSelect('resp.score_v3', 'replayScoreV3')
+      .addSelect('cju.code', 'code')
+      .addSelect('cju.score', 'score')
+      .addSelect('cju.notes', 'notes')
+      .addSelect('cju.coding_issue_option', 'codingIssueOption')
+      .where('cj.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('cj.training_id = :trainingId', { trainingId })
+      .orderBy('cju.id', 'ASC')
+      .addOrderBy('cj.id', 'ASC');
 
-          unitVariableMap.set(unitVariableKey, {
-            responseId: unit.response_id,
-            unitName: unit.unit_name,
-            variableId: unit.variable_id,
-            personCode: unit.person_code,
-            personLogin: unit.person_login,
-            personGroup: personGroup,
-            bookletName: unit.booklet_name,
-            testPerson,
-            givenAnswer,
-            replayCode: unit.response?.code_v3 ?? unit.response?.code_v2 ?? unit.response?.code_v1 ?? null,
-            replayScore: unit.response?.score_v3 ?? unit.response?.score_v2 ?? unit.response?.score_v1 ?? null
-          });
-        }
-      });
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      unitNameExpression: 'cju.unit_name',
+      bookletNameExpression: 'cju.booklet_name',
+      parameterPrefix: 'withinTrainingComparison'
+    });
+
+    const rows = await query.getRawMany<WithinTrainingCodingRow>();
+    const unitsByResponseId = new Map<number, Map<number, WithinTrainingCodingRow>>();
+
+    rows.forEach(row => {
+      const responseId = this.toNullableScore(row.responseId);
+      const jobId = this.toNullableScore(row.jobId);
+      if (responseId === null || jobId === null) {
+        return;
+      }
+
+      const unitVariableKey = responseId.toString();
+      if (!unitVariableMap.has(unitVariableKey)) {
+        const personGroup = row.personGroup || '';
+        const testPerson = `${row.personLogin} (${personGroup}) - ${row.bookletName}`;
+
+        unitVariableMap.set(unitVariableKey, {
+          responseId,
+          unitName: row.unitName,
+          variableId: row.variableId,
+          personCode: row.personCode,
+          personLogin: row.personLogin,
+          personGroup,
+          bookletName: row.bookletName,
+          testPerson,
+          givenAnswer: row.givenAnswer || '',
+          replayCode: this.toNullableScore(row.replayCodeV3) ??
+            this.toNullableScore(row.replayCodeV2) ??
+            this.toNullableScore(row.replayCodeV1),
+          replayScore: this.toNullableScore(row.replayScoreV3) ??
+            this.toNullableScore(row.replayScoreV2) ??
+            this.toNullableScore(row.replayScoreV1)
+        });
+      }
+
+      if (!unitsByResponseId.has(responseId)) {
+        unitsByResponseId.set(responseId, new Map<number, WithinTrainingCodingRow>());
+      }
+      unitsByResponseId.get(responseId)!.set(jobId, row);
     });
 
     const comparisonData = [];
@@ -2279,31 +2406,12 @@ export class CoderTrainingService {
     }
 
     for (const [, unitVar] of unitVariableMap.entries()) {
-      const codersData: WithinTrainingCoderResult[] = [];
-
-      for (const job of training.codingJobs) {
-        let code: number | null = null;
-        let score: number | null = null;
-        let notes: string | null = null;
-        let codingIssueOption: number | null = null;
-
-        const coderName = job.codingJobCoders && job.codingJobCoders.length > 0 && job.codingJobCoders[0].user ?
-          `${job.codingJobCoders[0].user.username || 'Unknown'}` :
-          `Coder ${job.name}`;
-
-        job.codingJobUnits?.forEach(unit => {
-          if (
-            unit.response_id === unitVar.responseId &&
-            !isExcludedByResolvedExclusions(exclusions, unit.booklet_name, unit.unit_name)
-          ) {
-            code = unit.code;
-            if (unit.score !== null) {
-              score = unit.score;
-            }
-            notes = unit.notes;
-            codingIssueOption = unit.coding_issue_option;
-          }
-        });
+      const unitsByJobId = unitsByResponseId.get(unitVar.responseId) ?? new Map<number, WithinTrainingCodingRow>();
+      const codersData: WithinTrainingCoderResult[] = jobs.map(job => {
+        const unit = unitsByJobId.get(job.id);
+        const code = this.toNullableScore(unit?.code);
+        const score = this.toNullableScore(unit?.score);
+        const codingIssueOption = this.toNullableScore(unit?.codingIssueOption);
 
         const mappedDisplay = this.mapDisplayCodeAndScore(
           code,
@@ -2312,26 +2420,27 @@ export class CoderTrainingService {
           missingCodesByJobId.get(job.id) ?? defaultMissingCodeContext
         );
 
-        codersData.push({
+        return {
           jobId: job.id,
-          coderName,
+          coderName: coderNameByJobId.get(job.id) ?? `Coder ${job.name}`,
           code: mappedDisplay.code,
           score: mappedDisplay.score,
-          notes,
+          notes: unit?.notes ?? null,
           codingIssueOption
-        });
-      }
+        };
+      });
 
       const discussionResult = discussionByResponseId.get(unitVar.responseId);
       const hasManualDiscussionResult = discussionResult?.code !== null && discussionResult?.code !== undefined;
       const automaticDiscussionResult = hasManualDiscussionResult ?
         null :
-        await this.deriveAutomaticDiscussionResultForResponse(
+        await this.deriveAutomaticDiscussionResultForRawResponse(
           workspaceId,
-          training,
+          trainingId,
           unitVar.responseId,
-          codersData,
-          exclusions
+          jobs,
+          unitsByJobId,
+          codersData
         );
       let discussionCode = automaticDiscussionResult?.code ?? null;
       let discussionScore = automaticDiscussionResult?.score ?? null;
@@ -2373,7 +2482,7 @@ export class CoderTrainingService {
       });
     }
 
-    this.logger.log(`Generated within-training comparison data for ${comparisonData.length} unit/variable combinations across ${training.codingJobs.length} coders`);
+    this.logger.log(`Generated within-training comparison data for ${comparisonData.length} unit/variable combinations across ${jobs.length} coders`);
 
     return comparisonData;
   }

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -164,6 +164,135 @@ describe('CodingResultsComparisonComponent', () => {
     expect(component.comparisonMode).toBe('within-training');
   });
 
+  it('should load within-training comparison without requesting kappa while kappa section is collapsed', () => {
+    codingTrainingBackendService.compareWithinTrainingCodingResults.mockReturnValue(of([
+      {
+        responseId: 1,
+        unitName: 'Unit1',
+        variableId: 'Var1',
+        testPerson: 'Test1',
+        personLogin: 'login',
+        personCode: 'code',
+        personGroup: 'group',
+        bookletName: 'booklet',
+        givenAnswer: 'answer',
+        replayCode: null,
+        replayScore: null,
+        discussionCode: null,
+        discussionScore: null,
+        discussionNotes: null,
+        discussionManagerUserId: null,
+        discussionManagerName: null,
+        discussionSource: null,
+        coders: [
+          {
+            jobId: 1,
+            coderName: 'Coder1',
+            code: '7',
+            score: 2,
+            notes: null,
+            codingIssueOption: null
+          }
+        ]
+      }
+    ]));
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.showKappaStatistics = false;
+
+    component.loadComparison();
+
+    expect(codingTrainingBackendService.compareWithinTrainingCodingResults).toHaveBeenCalledWith(1, 5);
+    expect(codingTrainingBackendService.getTrainingCohensKappa).not.toHaveBeenCalled();
+    expect(component.withinTrainingData).toHaveLength(1);
+    expect(component.isLoading).toBe(false);
+  });
+
+  it('should ignore stale within-training comparison responses after a training switch', () => {
+    const firstTrainingResponse$ = new Subject<unknown[]>();
+    const secondTrainingResponse$ = new Subject<unknown[]>();
+    codingTrainingBackendService.compareWithinTrainingCodingResults.mockImplementation(
+      (_workspaceId: number, trainingId: number) => (
+        trainingId === 5 ? firstTrainingResponse$.asObservable() : secondTrainingResponse$.asObservable()
+      )
+    );
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.loadComparison();
+
+    component.selectedTrainingForWithin = 6;
+    component.loadComparison();
+    secondTrainingResponse$.next([
+      {
+        responseId: 2,
+        unitName: 'Unit2',
+        variableId: 'Var2',
+        testPerson: 'Training 6',
+        personLogin: 'login-2',
+        personCode: 'code-2',
+        personGroup: 'group',
+        bookletName: 'booklet',
+        givenAnswer: 'answer 2',
+        replayCode: null,
+        replayScore: null,
+        discussionCode: null,
+        discussionScore: null,
+        discussionNotes: null,
+        discussionManagerUserId: null,
+        discussionManagerName: null,
+        discussionSource: null,
+        coders: [
+          {
+            jobId: 1,
+            coderName: 'Coder 1',
+            code: '7',
+            score: 2,
+            notes: null,
+            codingIssueOption: null
+          }
+        ]
+      }
+    ]);
+
+    firstTrainingResponse$.next([
+      {
+        responseId: 1,
+        unitName: 'Unit1',
+        variableId: 'Var1',
+        testPerson: 'Training 5',
+        personLogin: 'login-1',
+        personCode: 'code-1',
+        personGroup: 'group',
+        bookletName: 'booklet',
+        givenAnswer: 'answer 1',
+        replayCode: null,
+        replayScore: null,
+        discussionCode: null,
+        discussionScore: null,
+        discussionNotes: null,
+        discussionManagerUserId: null,
+        discussionManagerName: null,
+        discussionSource: null,
+        coders: [
+          {
+            jobId: 1,
+            coderName: 'Coder 1',
+            code: '8',
+            score: 3,
+            notes: null,
+            codingIssueOption: null
+          }
+        ]
+      }
+    ]);
+
+    expect(component.selectedTrainingForWithin).toBe(6);
+    expect(component.withinTrainingData).toHaveLength(1);
+    expect(component.withinTrainingData[0].responseId).toBe(2);
+    expect(component.dataSource.data[0].responseId).toBe(2);
+    expect(component.isLoading).toBe(false);
+  });
+
   it('should expose replay as its own table column', () => {
     expect(component.displayedColumns).toEqual([
       'index',

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -269,6 +269,8 @@ export class CodingResultsComparisonComponent implements OnInit {
   private dialog = inject(MatDialog);
   private testPersonCodingService = inject(TestPersonCodingService);
   private ngUnsubscribe = new Subject<void>();
+  private comparisonRequestId = 0;
+  private kappaRequestId = 0;
 
   isLoading = false;
   isLoadingKappa = false;
@@ -1460,6 +1462,8 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   onModeChange(): void {
+    this.comparisonRequestId += 1;
+    this.isLoading = false;
     this.resetKappaState();
     this.selectedTrainings.clear();
     this.filteredTrainings = [...this.availableTrainings];
@@ -1482,6 +1486,8 @@ export class CodingResultsComparisonComponent implements OnInit {
     if (this.comparisonMode === 'between-trainings' && this.selectedTrainings.selected.length >= 2) {
       this.loadComparison();
     } else {
+      this.comparisonRequestId += 1;
+      this.isLoading = false;
       this.comparisonData = [];
       this.availableCodersFromTrainings = [];
       this.codersFromTrainingsFormControl.setValue([]);
@@ -1497,6 +1503,8 @@ export class CodingResultsComparisonComponent implements OnInit {
     if (this.comparisonMode === 'within-training' && this.selectedTrainingForWithin) {
       this.loadComparison();
     } else {
+      this.comparisonRequestId += 1;
+      this.isLoading = false;
       this.withinTrainingData = [];
       this.availableCoders = [];
       this.codersFormControl.setValue([]);
@@ -1626,119 +1634,154 @@ export class CodingResultsComparisonComponent implements OnInit {
         return;
       }
 
+      this.comparisonRequestId += 1;
+      const requestId = this.comparisonRequestId;
       this.isLoading = true;
       this.resetKappaState();
       const trainingIds = this.selectedTrainings.selected.join(',');
-      this.codingTrainingBackendService.compareTrainingCodingResults(this.data.workspaceId, trainingIds).subscribe({
-        next: data => {
-          this.comparisonData = data;
+      this.codingTrainingBackendService.compareTrainingCodingResults(this.data.workspaceId, trainingIds)
+        .pipe(takeUntil(this.ngUnsubscribe))
+        .subscribe({
+          next: data => {
+            if (requestId !== this.comparisonRequestId ||
+              this.comparisonMode !== 'between-trainings' ||
+              this.selectedTrainings.selected.join(',') !== trainingIds) {
+              return;
+            }
+            this.comparisonData = data;
 
-          // Extract all unique coders available in the data
-          const codersMap = new Map<string, { trainingId: number; trainingLabel: string; coderId: number; coderName: string }>();
-          this.comparisonData.forEach(item => {
-            item.coders.forEach(c => {
-              const key = `${c.trainingId}_${c.coderId}`;
-              if (!codersMap.has(key)) {
-                codersMap.set(key, {
-                  trainingId: c.trainingId,
-                  trainingLabel: c.trainingLabel,
-                  coderId: c.coderId,
-                  coderName: c.coderName
-                });
-              }
+            // Extract all unique coders available in the data
+            const codersMap = new Map<string, { trainingId: number; trainingLabel: string; coderId: number; coderName: string }>();
+            this.comparisonData.forEach(item => {
+              item.coders.forEach(c => {
+                const key = `${c.trainingId}_${c.coderId}`;
+                if (!codersMap.has(key)) {
+                  codersMap.set(key, {
+                    trainingId: c.trainingId,
+                    trainingLabel: c.trainingLabel,
+                    coderId: c.coderId,
+                    coderName: c.coderName
+                  });
+                }
+              });
             });
-          });
 
-          this.availableCodersFromTrainings = Array.from(codersMap.values()).sort((a, b) => {
-            if (a.trainingId !== b.trainingId) return a.trainingId - b.trainingId;
-            return a.coderName.localeCompare(b.coderName);
-          });
-
-          const previousSelection = this.codersFromTrainingsFormControl.value || [];
-          const allKeys = this.availableCodersFromTrainings.map(c => `${c.trainingId}_${c.coderId}`);
-
-          let newSelection: string[];
-          if (previousSelection.length === 0) {
-            newSelection = allKeys;
-          } else {
-            const currentlySelectedTrainings = new Set(previousSelection.map(key => key.split('_')[0]));
-            newSelection = allKeys.filter(key => {
-              const [trainingId] = key.split('_');
-              return previousSelection.includes(key) || !currentlySelectedTrainings.has(trainingId);
+            this.availableCodersFromTrainings = Array.from(codersMap.values()).sort((a, b) => {
+              if (a.trainingId !== b.trainingId) return a.trainingId - b.trainingId;
+              return a.coderName.localeCompare(b.coderName);
             });
+
+            const previousSelection = this.codersFromTrainingsFormControl.value || [];
+            const allKeys = this.availableCodersFromTrainings.map(c => `${c.trainingId}_${c.coderId}`);
+
+            let newSelection: string[];
+            if (previousSelection.length === 0) {
+              newSelection = allKeys;
+            } else {
+              const currentlySelectedTrainings = new Set(previousSelection.map(key => key.split('_')[0]));
+              newSelection = allKeys.filter(key => {
+                const [trainingId] = key.split('_');
+                return previousSelection.includes(key) || !currentlySelectedTrainings.has(trainingId);
+              });
+            }
+
+            this.codersFromTrainingsFormControl.setValue(newSelection);
+            this.selectedCodersFromTrainings = new Set(newSelection);
+            this.updateDisplayedColumns();
+            this.refreshDisplayedRows();
+            this.isLoading = false;
+          },
+          error: () => {
+            if (requestId !== this.comparisonRequestId ||
+              this.comparisonMode !== 'between-trainings' ||
+              this.selectedTrainings.selected.join(',') !== trainingIds) {
+              return;
+            }
+            this.snackBar.open(this.translate.instant('variable-analysis.error-loading-results'), this.translate.instant('common.close'), { duration: 3000 });
+            this.isLoading = false;
           }
-
-          this.codersFromTrainingsFormControl.setValue(newSelection);
-          this.selectedCodersFromTrainings = new Set(newSelection);
-          this.updateDisplayedColumns();
-          this.refreshDisplayedRows();
-          this.isLoading = false;
-        },
-        error: () => {
-          this.snackBar.open(this.translate.instant('variable-analysis.error-loading-results'), this.translate.instant('common.close'), { duration: 3000 });
-          this.isLoading = false;
-        }
-      });
+        });
     } else if (this.comparisonMode === 'within-training') {
       if (!this.selectedTrainingForWithin) {
         this.snackBar.open(this.translate.instant('coding.trainings.select-training'), this.translate.instant('common.close'), { duration: 3000 });
         return;
       }
 
+      this.comparisonRequestId += 1;
+      const requestId = this.comparisonRequestId;
+      const trainingId = this.selectedTrainingForWithin;
       this.isLoading = true;
       this.resetKappaState();
-      this.codingTrainingBackendService.compareWithinTrainingCodingResults(this.data.workspaceId, this.selectedTrainingForWithin).subscribe({
-        next: data => {
-          const mappedData: WithinTrainingComparison[] = data.map(item => ({
-            responseId: item.responseId,
-            unitName: item.unitName,
-            variableId: item.variableId,
-            testperson: item.testPerson,
-            personLogin: item.personLogin,
-            personCode: item.personCode,
-            personGroup: item.personGroup,
-            bookletName: item.bookletName,
-            givenAnswer: item.givenAnswer,
-            replayCode: item.replayCode,
-            replayScore: item.replayScore,
-            discussionCode: item.discussionCode,
-            discussionScore: item.discussionScore,
-            discussionNotes: item.discussionNotes,
-            discussionManagerUserId: item.discussionManagerUserId,
-            discussionManagerName: item.discussionManagerName,
-            discussionSource: item.discussionSource,
-            coders: item.coders
-          }));
-
-          // Determine available coders from all data items
-          if (mappedData.length > 0) {
-            this.availableCoders = mappedData[0].coders.map(c => ({
-              jobId: c.jobId,
-              coderName: c.coderName
+      this.withinTrainingData = [];
+      this.availableCoders = [];
+      this.codersFormControl.setValue([]);
+      this.selectedCoderIds.clear();
+      this.dataSource.data = [];
+      this.codingTrainingBackendService.compareWithinTrainingCodingResults(this.data.workspaceId, trainingId)
+        .pipe(takeUntil(this.ngUnsubscribe))
+        .subscribe({
+          next: data => {
+            if (requestId !== this.comparisonRequestId ||
+              this.comparisonMode !== 'within-training' ||
+              this.selectedTrainingForWithin !== trainingId) {
+              return;
+            }
+            const mappedData: WithinTrainingComparison[] = data.map(item => ({
+              responseId: item.responseId,
+              unitName: item.unitName,
+              variableId: item.variableId,
+              testperson: item.testPerson,
+              personLogin: item.personLogin,
+              personCode: item.personCode,
+              personGroup: item.personGroup,
+              bookletName: item.bookletName,
+              givenAnswer: item.givenAnswer,
+              replayCode: item.replayCode,
+              replayScore: item.replayScore,
+              discussionCode: item.discussionCode,
+              discussionScore: item.discussionScore,
+              discussionNotes: item.discussionNotes,
+              discussionManagerUserId: item.discussionManagerUserId,
+              discussionManagerName: item.discussionManagerName,
+              discussionSource: item.discussionSource,
+              coders: item.coders
             }));
-            // Select all coders by default
-            const allCoderIds = this.availableCoders.map(c => c.jobId);
-            this.codersFormControl.setValue(allCoderIds);
-            this.selectedCoderIds.setSelection(...allCoderIds);
-          } else {
-            this.availableCoders = [];
-            this.codersFormControl.setValue([]);
-            this.selectedCoderIds.clear();
-          }
 
-          this.withinTrainingData = mappedData;
-          this.initDiscussionValues(mappedData);
-          this.updateDisplayedColumns();
-          this.refreshDisplayedRows();
-          // Automatically load Kappa statistics to show Mean Agreement in summary
-          this.loadKappaStatistics();
-          this.isLoading = false;
-        },
-        error: () => {
-          this.snackBar.open(this.translate.instant('variable-analysis.error-loading-results'), this.translate.instant('common.close'), { duration: 3000 });
-          this.isLoading = false;
-        }
-      });
+            // Determine available coders from all data items
+            if (mappedData.length > 0) {
+              this.availableCoders = mappedData[0].coders.map(c => ({
+                jobId: c.jobId,
+                coderName: c.coderName
+              }));
+              // Select all coders by default
+              const allCoderIds = this.availableCoders.map(c => c.jobId);
+              this.codersFormControl.setValue(allCoderIds);
+              this.selectedCoderIds.setSelection(...allCoderIds);
+            } else {
+              this.availableCoders = [];
+              this.codersFormControl.setValue([]);
+              this.selectedCoderIds.clear();
+            }
+
+            this.withinTrainingData = mappedData;
+            this.initDiscussionValues(mappedData);
+            this.updateDisplayedColumns();
+            this.refreshDisplayedRows();
+            if (this.showKappaStatistics) {
+              this.loadKappaStatistics();
+            }
+            this.isLoading = false;
+          },
+          error: () => {
+            if (requestId !== this.comparisonRequestId ||
+              this.comparisonMode !== 'within-training' ||
+              this.selectedTrainingForWithin !== trainingId) {
+              return;
+            }
+            this.snackBar.open(this.translate.instant('variable-analysis.error-loading-results'), this.translate.instant('common.close'), { duration: 3000 });
+            this.isLoading = false;
+          }
+        });
     }
   }
 
@@ -1794,22 +1837,36 @@ export class CodingResultsComparisonComponent implements OnInit {
     }
 
     this.resetKappaState();
+    this.kappaRequestId += 1;
+    const requestId = this.kappaRequestId;
+    const trainingId = this.selectedTrainingForWithin;
     this.isLoadingKappa = true;
     const level = this.useCodeLevel ? 'code' : 'score';
     this.codingTrainingBackendService
       .getTrainingCohensKappa(
         this.data.workspaceId,
-        this.selectedTrainingForWithin,
+        trainingId,
         this.useWeightedMean,
         level
       )
+      .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe({
         next: stats => {
+          if (requestId !== this.kappaRequestId ||
+            this.comparisonMode !== 'within-training' ||
+            this.selectedTrainingForWithin !== trainingId) {
+            return;
+          }
           this.originalKappaStatistics = stats;
           this.filterKappaStatistics();
           this.isLoadingKappa = false;
         },
         error: () => {
+          if (requestId !== this.kappaRequestId ||
+            this.comparisonMode !== 'within-training' ||
+            this.selectedTrainingForWithin !== trainingId) {
+            return;
+          }
           this.isLoadingKappa = false;
           this.snackBar.open(
             this.translate.instant('coding.trainings.kappa.error'),
@@ -2020,6 +2077,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   private resetKappaState(): void {
+    this.kappaRequestId += 1;
     this.kappaStatistics = null;
     this.originalKappaStatistics = null;
     this.variableKappaSummaries = [];


### PR DESCRIPTION
## Summary

Issue: #831

This change reduces duplicate Kappa work in training result comparisons by loading Kappa statistics only when the Kappa section is actually opened or already visible. It also keeps comparison and Kappa requests isolated so stale responses from earlier selections cannot overwrite the current view.

On the backend, the within-training comparison now uses a lighter raw-query path for the comparison data and preserves the existing discussion-result behavior, including validation for automatic negative missing-code agreements across missing profiles.

## Validation

- `npx nx lint frontend`
- `npx nx test frontend`
- `npx nx lint backend`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coder-training.service.spec.ts --runInBand`
- `npx nx test backend --runInBand`
- `git diff --check`
- Live Docker UI check for within-training comparison, explicit Kappa expansion, coder filtering, and between-training comparison

## Notes

The issue is referenced for context only and is not closed by this PR.