### PR TITLE
Improve training comparison freshness caching

### DIFF
--- a/api-dto/coding/training-comparison-freshness.dto.ts
+++ b/api-dto/coding/training-comparison-freshness.dto.ts
@@ -1,0 +1,13 @@
+export interface TrainingComparisonFreshnessDto {
+  workspaceId: number;
+  trainingId: number;
+  version: string;
+  jobCount: number;
+  unitCount: number;
+  responseCount: number;
+  discussionResultCount: number;
+  latestTrainingChange: string | null;
+  latestJobChange: string | null;
+  latestUnitChange: string | null;
+  latestDiscussionChange: string | null;
+}

--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.spec.ts
@@ -9,6 +9,7 @@ describe('WorkspaceCoderTrainingController', () => {
   let controller: WorkspaceCoderTrainingController;
   let coderTrainingService: {
     getWithinTrainingCodingComparison: jest.Mock;
+    getWithinTrainingComparisonFreshness: jest.Mock;
     transformToCoderPairs: jest.Mock;
     saveDiscussionResult: jest.Mock;
   };
@@ -24,6 +25,7 @@ describe('WorkspaceCoderTrainingController', () => {
   beforeEach(() => {
     coderTrainingService = {
       getWithinTrainingCodingComparison: jest.fn(),
+      getWithinTrainingComparisonFreshness: jest.fn(),
       transformToCoderPairs: jest.fn(),
       saveDiscussionResult: jest.fn()
     };
@@ -174,6 +176,28 @@ describe('WorkspaceCoderTrainingController', () => {
     expect(result.workspaceSummary.weightingMethod).toBe('unweighted');
     expect(result.workspaceSummary.calculationLevel).toBe('code');
     expect(result.workspaceSummary.totalDoubleCodedResponses).toBe(2);
+  });
+
+  it('forwards comparison freshness requests to the service', async () => {
+    coderTrainingService.getWithinTrainingComparisonFreshness.mockResolvedValue({
+      workspaceId: 12,
+      trainingId: 5,
+      version: 'fresh-1',
+      jobCount: 2,
+      unitCount: 4,
+      responseCount: 3,
+      discussionResultCount: 1,
+      latestTrainingChange: '2026-07-01T10:00:00.000Z',
+      latestJobChange: '2026-07-01T10:01:00.000Z',
+      latestUnitChange: '2026-07-01T10:02:00.000Z',
+      latestDiscussionChange: '2026-07-01T10:03:00.000Z'
+    });
+
+    const result = await controller.getTrainingComparisonFreshness(12, 5);
+
+    expect(coderTrainingService.getWithinTrainingComparisonFreshness)
+      .toHaveBeenCalledWith(12, 5);
+    expect(result.version).toBe('fresh-1');
   });
 
   it('forwards discussion result notes to the service', async () => {

--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
@@ -34,6 +34,7 @@ import {
   TrainingDiscussionApplyPreviewDto,
   TrainingDiscussionApplySource
 } from '../../../../../../api-dto/coding/training-discussion-apply.dto';
+import { TrainingComparisonFreshnessDto } from '../../../../../../api-dto/coding/training-comparison-freshness.dto';
 
 @ApiTags('Admin Workspace Coder Training')
 @Controller('admin/workspace')
@@ -1054,6 +1055,48 @@ export class WorkspaceCoderTrainingController {
       workspace_id,
       trainingId,
       body.label.trim()
+    );
+  }
+
+  @Get(':workspace_id/coding/coder-trainings/:trainingId/comparison-freshness')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiTags('coding')
+  @ApiParam({ name: 'workspace_id', type: Number })
+  @ApiParam({
+    name: 'trainingId',
+    type: Number,
+    description: 'ID of the coder training'
+  })
+  @ApiOkResponse({
+    description: 'Freshness token for cached within-training comparison data',
+    schema: {
+      type: 'object',
+      properties: {
+        workspaceId: { type: 'number' },
+        trainingId: { type: 'number' },
+        version: { type: 'string' },
+        jobCount: { type: 'number' },
+        unitCount: { type: 'number' },
+        responseCount: { type: 'number' },
+        discussionResultCount: { type: 'number' },
+        latestTrainingChange: { type: 'string', nullable: true },
+        latestJobChange: { type: 'string', nullable: true },
+        latestUnitChange: { type: 'string', nullable: true },
+        latestDiscussionChange: { type: 'string', nullable: true }
+      }
+    }
+  })
+  async getTrainingComparisonFreshness(
+    @WorkspaceId() workspace_id: number,
+      @Param('trainingId') trainingId: number
+  ): Promise<TrainingComparisonFreshnessDto> {
+    if (!trainingId || trainingId <= 0) {
+      throw new Error('Valid training ID must be provided');
+    }
+
+    return this.coderTrainingService.getWithinTrainingComparisonFreshness(
+      workspace_id,
+      trainingId
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -2113,6 +2113,186 @@ describe('CoderTrainingService', () => {
   });
 
   describe('getWithinTrainingCodingComparison', () => {
+    const createFreshnessQueryBuilder = (
+      row: Record<string, unknown> = {},
+      rows: Record<string, unknown>[] = []
+    ) => ({
+      innerJoin: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue(rows),
+      getRawOne: jest.fn().mockResolvedValue(row)
+    });
+
+    it('builds a within-training comparison freshness token from aggregate changes', async () => {
+      (coderTrainingRepository.findOne as jest.Mock).mockResolvedValueOnce({
+        id: 5,
+        workspace_id: 1,
+        updated_at: new Date('2026-06-01T10:00:00Z')
+      });
+      (codingJobRepository.find as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 11,
+          workspace_id: 1,
+          training_id: 5,
+          missings_profile_id: null,
+          updated_at: new Date('2026-06-01T10:05:00Z')
+        },
+        {
+          id: 12,
+          workspace_id: 1,
+          training_id: 5,
+          missings_profile_id: 7,
+          updated_at: new Date('2026-06-01T10:10:00Z')
+        }
+      ]);
+
+      const unitQb = createFreshnessQueryBuilder({
+        unitCount: '4',
+        responseCount: '2',
+        latestUnitChange: '2026-06-01T10:20:00.000Z'
+      });
+      const responseQb = createFreshnessQueryBuilder({}, [
+        { responseId: '101', responseHash: 'response-hash-101' },
+        { responseId: '102', responseHash: 'response-hash-102' }
+      ]);
+      const discussionQb = createFreshnessQueryBuilder({
+        discussionResultCount: '1',
+        latestDiscussionChange: '2026-06-01T10:30:00.000Z'
+      });
+      (mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(unitQb)
+        .mockReturnValueOnce(responseQb)
+        .mockReturnValueOnce(discussionQb);
+
+      const result = await service.getWithinTrainingComparisonFreshness(1, 5);
+
+      expect(result).toMatchObject({
+        workspaceId: 1,
+        trainingId: 5,
+        jobCount: 2,
+        unitCount: 4,
+        responseCount: 2,
+        discussionResultCount: 1,
+        latestTrainingChange: '2026-06-01T10:00:00.000Z',
+        latestJobChange: '2026-06-01T10:10:00.000Z',
+        latestUnitChange: '2026-06-01T10:20:00.000Z',
+        latestDiscussionChange: '2026-06-01T10:30:00.000Z'
+      });
+      expect(result.version).toHaveLength(16);
+      expect(unitQb.innerJoin).toHaveBeenCalledWith('cju.coding_job', 'cj');
+      expect(unitQb.leftJoin).not.toHaveBeenCalledWith('cju.response', 'resp');
+      expect(responseQb.leftJoin).toHaveBeenCalledWith('cju.response', 'resp');
+      expect(responseQb.addSelect).toHaveBeenCalledWith(
+        expect.stringContaining('resp.value'),
+        'responseHash'
+      );
+      expect(responseQb.groupBy).toHaveBeenCalledWith('cju.response_id');
+      expect(discussionQb.where).toHaveBeenCalledWith('ctdr.workspace_id = :workspaceId', { workspaceId: 1 });
+    });
+
+    it('changes the within-training freshness token when discussion results change', async () => {
+      (coderTrainingRepository.findOne as jest.Mock).mockResolvedValue({
+        id: 5,
+        workspace_id: 1,
+        updated_at: new Date('2026-06-01T10:00:00Z')
+      });
+      (codingJobRepository.find as jest.Mock).mockResolvedValue([
+        {
+          id: 11,
+          workspace_id: 1,
+          training_id: 5,
+          missings_profile_id: null,
+          updated_at: new Date('2026-06-01T10:05:00Z')
+        }
+      ]);
+
+      (mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(createFreshnessQueryBuilder({
+          unitCount: '2',
+          responseCount: '1',
+          latestUnitChange: '2026-06-01T10:20:00.000Z'
+        }))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({}, [
+          { responseId: '101', responseHash: 'response-hash' }
+        ]))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({
+          discussionResultCount: '0',
+          latestDiscussionChange: null
+        }))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({
+          unitCount: '2',
+          responseCount: '1',
+          latestUnitChange: '2026-06-01T10:20:00.000Z'
+        }))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({}, [
+          { responseId: '101', responseHash: 'response-hash' }
+        ]))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({
+          discussionResultCount: '1',
+          latestDiscussionChange: '2026-06-01T10:35:00.000Z'
+        }));
+
+      const before = await service.getWithinTrainingComparisonFreshness(1, 5);
+      const after = await service.getWithinTrainingComparisonFreshness(1, 5);
+
+      expect(before.version).not.toBe(after.version);
+    });
+
+    it('changes the within-training freshness token when response data changes', async () => {
+      (coderTrainingRepository.findOne as jest.Mock).mockResolvedValue({
+        id: 5,
+        workspace_id: 1,
+        updated_at: new Date('2026-06-01T10:00:00Z')
+      });
+      (codingJobRepository.find as jest.Mock).mockResolvedValue([
+        {
+          id: 11,
+          workspace_id: 1,
+          training_id: 5,
+          missings_profile_id: null,
+          updated_at: new Date('2026-06-01T10:05:00Z')
+        }
+      ]);
+
+      (mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(createFreshnessQueryBuilder({
+          unitCount: '2',
+          responseCount: '1',
+          latestUnitChange: '2026-06-01T10:20:00.000Z'
+        }))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({}, [
+          { responseId: '101', responseHash: 'response-hash-before' }
+        ]))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({
+          discussionResultCount: '0',
+          latestDiscussionChange: null
+        }))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({
+          unitCount: '2',
+          responseCount: '1',
+          latestUnitChange: '2026-06-01T10:20:00.000Z'
+        }))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({}, [
+          { responseId: '101', responseHash: 'response-hash-after' }
+        ]))
+        .mockReturnValueOnce(createFreshnessQueryBuilder({
+          discussionResultCount: '0',
+          latestDiscussionChange: null
+        }));
+
+      const before = await service.getWithinTrainingComparisonFreshness(1, 5);
+      const after = await service.getWithinTrainingComparisonFreshness(1, 5);
+
+      expect(before.version).not.toBe(after.version);
+    });
+
     it('groups raw coding rows by response and keeps manual discussion results authoritative', async () => {
       (coderTrainingRepository.findOne as jest.Mock).mockResolvedValueOnce({
         id: 5,

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import {
   Repository, In, IsNull, Not, Brackets
 } from 'typeorm';
+import { createHash } from 'crypto';
 import { CodingJob } from '../../entities/coding-job.entity';
 import { CodingJobCoder } from '../../entities/coding-job-coder.entity';
 import { CodingJobVariable } from '../../entities/coding-job-variable.entity';
@@ -40,6 +41,7 @@ import {
   buildAggregationGroups,
   deduplicateManualCodingResponses
 } from './aggregation-metrics.util';
+import { TrainingComparisonFreshnessDto } from '../../../../../../../api-dto/coding/training-comparison-freshness.dto';
 
 interface CoderTrainingResponse {
   responseId: number;
@@ -157,6 +159,22 @@ type WithinTrainingCodingRow = {
   score: number | string | null;
   notes: string | null;
   codingIssueOption: number | string | null;
+};
+
+type TrainingComparisonFreshnessAggregateRow = {
+  unitCount: number | string | null;
+  responseCount: number | string | null;
+  latestUnitChange: Date | string | null;
+};
+
+type TrainingDiscussionFreshnessAggregateRow = {
+  discussionResultCount: number | string | null;
+  latestDiscussionChange: Date | string | null;
+};
+
+type TrainingComparisonResponseFreshnessRow = {
+  responseId: number | string | null;
+  responseHash: string | null;
 };
 
 type MissingCodePair = { mirCode: number; mciCode: number };
@@ -2225,6 +2243,210 @@ export class CoderTrainingService {
     this.logger.log(`Generated comparison data for ${comparisonData.length} unique responses across ${trainings.length} trainings`);
 
     return comparisonData;
+  }
+
+  private toFreshnessNumber(value: number | string | null | undefined): number {
+    const numericValue = Number(value ?? 0);
+    return Number.isFinite(numericValue) ? numericValue : 0;
+  }
+
+  private toFreshnessIsoString(value: Date | string | null | undefined): string | null {
+    if (!value) {
+      return null;
+    }
+
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value.toISOString();
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value) : date.toISOString();
+  }
+
+  private createTrainingComparisonVersion(payload: Record<string, unknown>): string {
+    return createHash('sha256')
+      .update(JSON.stringify(payload))
+      .digest('hex')
+      .slice(0, 16);
+  }
+
+  private createTrainingComparisonResponseSignature(rows: TrainingComparisonResponseFreshnessRow[]): string {
+    const normalizedRows = rows
+      .map(row => ({
+        responseId: this.toFreshnessNumber(row.responseId),
+        responseHash: row.responseHash ?? ''
+      }))
+      .sort((a, b) => a.responseId - b.responseId);
+
+    return createHash('sha256')
+      .update(JSON.stringify(normalizedRows))
+      .digest('hex');
+  }
+
+  private createExclusionFreshnessSignature(exclusions: {
+    globalIgnoredUnits: string[];
+    ignoredBooklets: string[];
+    testletIgnoredUnits: { bookletId: string; unitId: string }[];
+  }): Record<string, unknown> {
+    return {
+      globalIgnoredUnits: [...exclusions.globalIgnoredUnits].sort(),
+      ignoredBooklets: [...exclusions.ignoredBooklets].sort(),
+      testletIgnoredUnits: [...exclusions.testletIgnoredUnits]
+        .map(item => `${item.bookletId}:${item.unitId}`)
+        .sort()
+    };
+  }
+
+  async getWithinTrainingComparisonFreshness(
+    workspaceId: number,
+    trainingId: number
+  ): Promise<TrainingComparisonFreshnessDto> {
+    const training = await this.coderTrainingRepository.findOne({
+      where: {
+        workspace_id: workspaceId,
+        id: trainingId
+      }
+    });
+
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const jobs = training ?
+      await this.codingJobRepository.find({
+        where: {
+          workspace_id: workspaceId,
+          training_id: trainingId
+        },
+        order: { id: 'ASC' }
+      }) :
+      [];
+
+    let unitAggregate: TrainingComparisonFreshnessAggregateRow = {
+      unitCount: 0,
+      responseCount: 0,
+      latestUnitChange: null
+    };
+    let responseSignature = '';
+
+    if (jobs.length > 0) {
+      const unitQuery = this.codingJobUnitRepository
+        .createQueryBuilder('cju')
+        .innerJoin('cju.coding_job', 'cj')
+        .select('COUNT(DISTINCT cju.id)', 'unitCount')
+        .addSelect('COUNT(DISTINCT cju.response_id)', 'responseCount')
+        .addSelect('MAX(cju.updated_at)', 'latestUnitChange')
+        .where('cj.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('cj.training_id = :trainingId', { trainingId });
+
+      applyResolvedExclusionsToQuery(unitQuery, exclusions, {
+        unitNameExpression: 'cju.unit_name',
+        bookletNameExpression: 'cju.booklet_name',
+        parameterPrefix: 'withinTrainingFreshness'
+      });
+
+      unitAggregate = await unitQuery.getRawOne<TrainingComparisonFreshnessAggregateRow>() ?? unitAggregate;
+
+      const responseSignatureQuery = this.codingJobUnitRepository
+        .createQueryBuilder('cju')
+        .innerJoin('cju.coding_job', 'cj')
+        .leftJoin('cju.response', 'resp')
+        .select('cju.response_id', 'responseId')
+        .addSelect(`
+          MD5(
+            CONCAT_WS(
+              CHR(31),
+              CAST(cju.response_id AS text),
+              COALESCE(resp.value, ''),
+              COALESCE(CAST(resp.code_v1 AS text), ''),
+              COALESCE(CAST(resp.score_v1 AS text), ''),
+              COALESCE(CAST(resp.code_v2 AS text), ''),
+              COALESCE(CAST(resp.score_v2 AS text), ''),
+              COALESCE(CAST(resp.code_v3 AS text), ''),
+              COALESCE(CAST(resp.score_v3 AS text), '')
+            )
+          )
+        `, 'responseHash')
+        .where('cj.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('cj.training_id = :trainingId', { trainingId })
+        .groupBy('cju.response_id')
+        .addGroupBy('resp.value')
+        .addGroupBy('resp.code_v1')
+        .addGroupBy('resp.score_v1')
+        .addGroupBy('resp.code_v2')
+        .addGroupBy('resp.score_v2')
+        .addGroupBy('resp.code_v3')
+        .addGroupBy('resp.score_v3')
+        .orderBy('cju.response_id', 'ASC');
+
+      applyResolvedExclusionsToQuery(responseSignatureQuery, exclusions, {
+        unitNameExpression: 'cju.unit_name',
+        bookletNameExpression: 'cju.booklet_name',
+        parameterPrefix: 'withinTrainingResponseFreshness'
+      });
+
+      responseSignature = this.createTrainingComparisonResponseSignature(
+        await responseSignatureQuery.getRawMany<TrainingComparisonResponseFreshnessRow>()
+      );
+    }
+
+    const discussionAggregate = (await this.coderTrainingDiscussionResultRepository
+      .createQueryBuilder('ctdr')
+      .select('COUNT(DISTINCT ctdr.id)', 'discussionResultCount')
+      .addSelect('MAX(ctdr.updated_at)', 'latestDiscussionChange')
+      .where('ctdr.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('ctdr.training_id = :trainingId', { trainingId })
+      .getRawOne<TrainingDiscussionFreshnessAggregateRow>()) ?? {
+      discussionResultCount: 0,
+      latestDiscussionChange: null
+    };
+
+    const latestTrainingChange = this.toFreshnessIsoString(training?.updated_at);
+    const latestJobChange = this.toFreshnessIsoString(
+      jobs
+        .map(job => job.updated_at)
+        .filter((value): value is Date => !!value)
+        .sort((a, b) => b.getTime() - a.getTime())[0]
+    );
+    const latestUnitChange = this.toFreshnessIsoString(unitAggregate.latestUnitChange);
+    const latestDiscussionChange = this.toFreshnessIsoString(discussionAggregate.latestDiscussionChange);
+    const jobCount = jobs.length;
+    const unitCount = this.toFreshnessNumber(unitAggregate.unitCount);
+    const responseCount = this.toFreshnessNumber(unitAggregate.responseCount);
+    const discussionResultCount = this.toFreshnessNumber(discussionAggregate.discussionResultCount);
+    const missingProfileSignature = jobs
+      .map(job => (job.missings_profile_id ?? 'default').toString())
+      .sort()
+      .join(',');
+
+    const versionPayload = {
+      workspaceId,
+      trainingId,
+      trainingExists: !!training,
+      jobIds: jobs.map(job => job.id),
+      jobCount,
+      unitCount,
+      responseCount,
+      discussionResultCount,
+      latestTrainingChange,
+      latestJobChange,
+      latestUnitChange,
+      latestDiscussionChange,
+      responseSignature,
+      missingProfileSignature,
+      exclusions: this.createExclusionFreshnessSignature(exclusions)
+    };
+
+    return {
+      workspaceId,
+      trainingId,
+      version: this.createTrainingComparisonVersion(versionPayload),
+      jobCount,
+      unitCount,
+      responseCount,
+      discussionResultCount,
+      latestTrainingChange,
+      latestJobChange,
+      latestUnitChange,
+      latestDiscussionChange
+    };
   }
 
   async getWithinTrainingCodingComparison(

--- a/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.spec.ts
@@ -3,7 +3,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { CoderTrainingsListComponent } from './coder-trainings-list.component';
 import { CodingTrainingBackendService } from '../../services/coding-training-backend.service';
 import { AppService } from '../../../core/services/app.service';
@@ -14,6 +14,11 @@ describe('CoderTrainingsListComponent', () => {
   let fixture: ComponentFixture<CoderTrainingsListComponent>;
   let component: CoderTrainingsListComponent;
   let matDialogMock: { open: jest.Mock };
+  let codingTrainingBackendServiceMock: {
+    getCoderTrainings: jest.Mock;
+    getCodingJobsForTraining: jest.Mock;
+    deleteCoderTraining: jest.Mock;
+  };
 
   const trainings: CoderTraining[] = [
     {
@@ -44,6 +49,11 @@ describe('CoderTrainingsListComponent', () => {
 
   beforeEach(async () => {
     matDialogMock = { open: jest.fn(() => ({ afterClosed: () => of(null) })) };
+    codingTrainingBackendServiceMock = {
+      getCoderTrainings: jest.fn().mockReturnValue(of(trainings)),
+      getCodingJobsForTraining: jest.fn().mockReturnValue(of([])),
+      deleteCoderTraining: jest.fn().mockReturnValue(of({ success: true }))
+    };
 
     await TestBed.configureTestingModule({
       imports: [
@@ -54,11 +64,7 @@ describe('CoderTrainingsListComponent', () => {
       providers: [
         {
           provide: CodingTrainingBackendService,
-          useValue: {
-            getCoderTrainings: jest.fn().mockReturnValue(of(trainings)),
-            getCodingJobsForTraining: jest.fn().mockReturnValue(of([])),
-            deleteCoderTraining: jest.fn().mockReturnValue(of({ success: true }))
-          }
+          useValue: codingTrainingBackendServiceMock
         },
         { provide: AppService, useValue: { selectedWorkspaceId: 1 } },
         { provide: BackendMessageTranslatorService, useValue: { translateMessage: jest.fn((message: string) => message) } },
@@ -91,6 +97,16 @@ describe('CoderTrainingsListComponent', () => {
     component.selectedTrainingName = 'Duplicate Label';
     component.onTrainingNameFilterChange();
 
+    expect(component.coderTrainings.map(training => training.id)).toEqual([10, 11]);
+  });
+
+  it('keeps the selected training name filter across normal reloads', async () => {
+    component.selectedTrainingName = 'Duplicate Label';
+    codingTrainingBackendServiceMock.getCoderTrainings.mockReturnValue(of(trainings));
+
+    await component.loadCoderTrainings();
+
+    expect(component.selectedTrainingName).toBe('Duplicate Label');
     expect(component.coderTrainings.map(training => training.id)).toEqual([10, 11]);
   });
 
@@ -134,5 +150,38 @@ describe('CoderTrainingsListComponent', () => {
         }
       })
     );
+  });
+
+  it('reloads trainings for a changed workspace and ignores stale responses', () => {
+    const workspace1$ = new Subject<CoderTraining[]>();
+    const workspace2Trainings: CoderTraining[] = [{
+      id: 20,
+      workspace_id: 2,
+      label: 'Workspace 2 Training',
+      created_at: new Date('2026-05-14T10:00:00'),
+      updated_at: new Date('2026-05-14T10:00:00'),
+      jobsCount: 1
+    }];
+    codingTrainingBackendServiceMock.getCoderTrainings.mockImplementation((workspaceId: number) => (
+      workspaceId === 1 ? workspace1$.asObservable() : of(workspace2Trainings)
+    ));
+
+    component.workspaceId = 1;
+    component.ngOnInit();
+    component.workspaceId = 2;
+    component.ngOnChanges({
+      workspaceId: {
+        currentValue: 2,
+        previousValue: 1,
+        firstChange: false,
+        isFirstChange: () => false
+      }
+    });
+
+    workspace1$.next(trainings);
+
+    expect(codingTrainingBackendServiceMock.getCoderTrainings).toHaveBeenCalledWith(1);
+    expect(codingTrainingBackendServiceMock.getCoderTrainings).toHaveBeenCalledWith(2);
+    expect(component.coderTrainings).toEqual(workspace2Trainings);
   });
 });

--- a/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.ts
+++ b/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.ts
@@ -1,11 +1,13 @@
 import {
   Component,
   OnDestroy,
+  OnChanges,
   OnInit,
   inject,
   Input,
   Output,
-  EventEmitter
+  EventEmitter,
+  SimpleChanges
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -72,7 +74,7 @@ interface TrainingNameFilterOption {
   templateUrl: './coder-trainings-list.component.html',
   styleUrls: ['./coder-trainings-list.component.scss']
 })
-export class CoderTrainingsListComponent implements OnInit, OnDestroy {
+export class CoderTrainingsListComponent implements OnInit, OnChanges, OnDestroy {
   private codingTrainingBackendService = inject(CodingTrainingBackendService);
   private appService = inject(AppService);
   private dialog = inject(MatDialog);
@@ -80,8 +82,10 @@ export class CoderTrainingsListComponent implements OnInit, OnDestroy {
   private translate = inject(TranslateService);
   private backendMessageTranslator = inject(BackendMessageTranslatorService);
   private destroy$ = new Subject<void>();
+  private loadRequestId = 0;
 
   @Input() showCreateButton = true;
+  @Input() workspaceId?: number;
   @Output() onCreateTraining = new EventEmitter<void>();
   @Output() onEditTraining = new EventEmitter<CoderTraining>(); // New
 
@@ -97,34 +101,82 @@ export class CoderTrainingsListComponent implements OnInit, OnDestroy {
     this.loadCoderTrainings();
   }
 
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.workspaceId && !changes.workspaceId.firstChange) {
+      this.loadRequestId += 1;
+      this.clearTrainingState({ resetFilters: true });
+      this.loadCoderTrainings({ resetFilters: true });
+    }
+  }
+
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
   }
 
-  loadCoderTrainings(): Promise<void> {
+  private getCurrentWorkspaceId(): number {
+    return this.workspaceId || this.appService.selectedWorkspaceId;
+  }
+
+  private clearTrainingState(options: { resetFilters?: boolean } = {}): void {
+    this.coderTrainings = [];
+    this.originalData = [];
+    this.trainingNameFilterOptions = [];
+    this.duplicateTrainingLabels.clear();
+    if (options.resetFilters) {
+      this.selectedTrainingName = null;
+    }
+  }
+
+  private clearUnavailableTrainingNameFilter(): void {
+    if (!this.selectedTrainingName) {
+      return;
+    }
+
+    const selectedOptionExists = this.trainingNameFilterOptions
+      .some(option => option.label === this.selectedTrainingName);
+    if (!selectedOptionExists) {
+      this.selectedTrainingName = null;
+    }
+  }
+
+  loadCoderTrainings(options: { resetFilters?: boolean } = {}): Promise<void> {
     return new Promise((resolve, reject) => {
-      const workspaceId = this.appService.selectedWorkspaceId;
+      const workspaceId = this.getCurrentWorkspaceId();
       if (!workspaceId) {
+        this.clearTrainingState({ resetFilters: true });
         reject();
         return;
       }
+
+      this.loadRequestId += 1;
+      const requestId = this.loadRequestId;
+      this.isLoading = true;
+      this.clearTrainingState({ resetFilters: options.resetFilters });
 
       this.codingTrainingBackendService.getCoderTrainings(workspaceId)
         .pipe(takeUntil(this.destroy$))
         .subscribe({
           next: (trainings: CoderTraining[]) => {
+            if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
+              resolve();
+              return;
+            }
+
             this.originalData = trainings;
             this.rebuildTrainingNameFilterOptions();
+            this.clearUnavailableTrainingNameFilter();
             this.applyAllFilters();
             this.isLoading = false;
             resolve();
           },
           error: () => {
-            this.coderTrainings = [];
-            this.originalData = [];
-            this.trainingNameFilterOptions = [];
-            this.duplicateTrainingLabels.clear();
+            if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
+              resolve();
+              return;
+            }
+
+            this.clearTrainingState({ resetFilters: options.resetFilters });
             this.isLoading = false;
             reject();
           }

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -1969,6 +1969,7 @@
           </div>
           <coding-box-coder-trainings-list
             [showCreateButton]="false"
+            [workspaceId]="workspaceId"
             (onCreateTraining)="openCoderTraining()"
             (onEditTraining)="openTrainingEdit($event)"
           >

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -543,6 +543,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return this.visibleManualCodingTabs[this.selectedManualTabIndex] || 'preparation';
   }
 
+  get workspaceId(): number {
+    return this.appService.selectedWorkspaceId;
+  }
+
   get visibleManualCodingTabs(): ManualCodingTab[] {
     if (this.canShowManualCompletionTab()) {
       return this.manualCodingTabs;

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -26,6 +26,7 @@ describe('CodingResultsComparisonComponent', () => {
     getCoderTrainings: jest.Mock;
     compareTrainingCodingResults: jest.Mock;
     compareWithinTrainingCodingResults: jest.Mock;
+    getCachedWithinTrainingCodingResults: jest.Mock;
     saveDiscussionResult: jest.Mock;
     previewApplyDiscussionResults: jest.Mock;
     applyDiscussionResults: jest.Mock;
@@ -57,6 +58,7 @@ describe('CodingResultsComparisonComponent', () => {
       getCoderTrainings: jest.fn().mockReturnValue({ subscribe: jest.fn() }),
       compareTrainingCodingResults: jest.fn(),
       compareWithinTrainingCodingResults: jest.fn(),
+      getCachedWithinTrainingCodingResults: jest.fn(),
       saveDiscussionResult: jest.fn().mockReturnValue(of({
         success: true,
         code: 7,
@@ -165,7 +167,7 @@ describe('CodingResultsComparisonComponent', () => {
   });
 
   it('should load within-training comparison without requesting kappa while kappa section is collapsed', () => {
-    codingTrainingBackendService.compareWithinTrainingCodingResults.mockReturnValue(of([
+    codingTrainingBackendService.getCachedWithinTrainingCodingResults.mockReturnValue(of([
       {
         responseId: 1,
         unitName: 'Unit1',
@@ -202,7 +204,7 @@ describe('CodingResultsComparisonComponent', () => {
 
     component.loadComparison();
 
-    expect(codingTrainingBackendService.compareWithinTrainingCodingResults).toHaveBeenCalledWith(1, 5);
+    expect(codingTrainingBackendService.getCachedWithinTrainingCodingResults).toHaveBeenCalledWith(1, 5);
     expect(codingTrainingBackendService.getTrainingCohensKappa).not.toHaveBeenCalled();
     expect(component.withinTrainingData).toHaveLength(1);
     expect(component.isLoading).toBe(false);
@@ -211,7 +213,7 @@ describe('CodingResultsComparisonComponent', () => {
   it('should ignore stale within-training comparison responses after a training switch', () => {
     const firstTrainingResponse$ = new Subject<unknown[]>();
     const secondTrainingResponse$ = new Subject<unknown[]>();
-    codingTrainingBackendService.compareWithinTrainingCodingResults.mockImplementation(
+    codingTrainingBackendService.getCachedWithinTrainingCodingResults.mockImplementation(
       (_workspaceId: number, trainingId: number) => (
         trainingId === 5 ? firstTrainingResponse$.asObservable() : secondTrainingResponse$.asObservable()
       )

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -1717,7 +1717,7 @@ export class CodingResultsComparisonComponent implements OnInit {
       this.codersFormControl.setValue([]);
       this.selectedCoderIds.clear();
       this.dataSource.data = [];
-      this.codingTrainingBackendService.compareWithinTrainingCodingResults(this.data.workspaceId, trainingId)
+      this.codingTrainingBackendService.getCachedWithinTrainingCodingResults(this.data.workspaceId, trainingId)
         .pipe(takeUntil(this.ngUnsubscribe))
         .subscribe({
           next: data => {

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
@@ -198,6 +198,130 @@ describe('CodingTrainingBackendService', () => {
     });
   });
 
+  describe('getTrainingComparisonFreshness', () => {
+    it('should request the training comparison freshness token', () => {
+      service.getTrainingComparisonFreshness(1, 5).subscribe(result => {
+        expect(result.version).toBe('v1');
+      });
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`);
+      expect(req.request.method).toBe('GET');
+      req.flush({
+        workspaceId: 1,
+        trainingId: 5,
+        version: 'v1',
+        jobCount: 2,
+        unitCount: 4,
+        responseCount: 2,
+        discussionResultCount: 0,
+        latestTrainingChange: null,
+        latestJobChange: null,
+        latestUnitChange: null,
+        latestDiscussionChange: null
+      });
+    });
+  });
+
+  describe('getCachedWithinTrainingCodingResults', () => {
+    const freshness = (version: string) => ({
+      workspaceId: 1,
+      trainingId: 5,
+      version,
+      jobCount: 2,
+      unitCount: 4,
+      responseCount: 2,
+      discussionResultCount: 0,
+      latestTrainingChange: null,
+      latestJobChange: null,
+      latestUnitChange: null,
+      latestDiscussionChange: null
+    });
+
+    const comparisonData = [{
+      responseId: 1,
+      unitName: 'Unit',
+      variableId: 'Var',
+      personCode: 'P1',
+      personLogin: 'login',
+      personGroup: 'group',
+      bookletName: 'booklet',
+      testPerson: 'login (group) - booklet',
+      givenAnswer: 'answer',
+      replayCode: null,
+      replayScore: null,
+      discussionCode: null,
+      discussionScore: null,
+      discussionNotes: null,
+      discussionManagerUserId: null,
+      discussionManagerName: null,
+      discussionSource: null,
+      coders: []
+    }];
+
+    it('should reuse cached comparison data while freshness is unchanged', () => {
+      const firstResults: unknown[] = [];
+      service.getCachedWithinTrainingCodingResults(1, 5).subscribe(result => firstResults.push(result));
+
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
+        .flush(freshness('v1'));
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
+        .flush(comparisonData);
+      expect(firstResults).toEqual([comparisonData]);
+
+      const secondResults: unknown[] = [];
+      service.getCachedWithinTrainingCodingResults(1, 5).subscribe(result => secondResults.push(result));
+
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
+        .flush(freshness('v1'));
+      httpMock.expectNone(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`);
+      expect(secondResults).toEqual([comparisonData]);
+    });
+
+    it('should reload comparison data when freshness changes', () => {
+      service.getCachedWithinTrainingCodingResults(1, 5).subscribe();
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
+        .flush(freshness('v1'));
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
+        .flush(comparisonData);
+
+      const updatedData = [{ ...comparisonData[0], responseId: 2 }];
+      const results: unknown[] = [];
+      service.getCachedWithinTrainingCodingResults(1, 5).subscribe(result => results.push(result));
+
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
+        .flush(freshness('v2'));
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
+        .flush(updatedData);
+      expect(results).toEqual([updatedData]);
+    });
+
+    it('should invalidate cached comparison data after saving a discussion result', () => {
+      service.getCachedWithinTrainingCodingResults(1, 5).subscribe();
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
+        .flush(freshness('v1'));
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
+        .flush(comparisonData);
+
+      service.saveDiscussionResult(1, 5, 99, 7, 2, 'Replay note').subscribe();
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/discussion-result`)
+        .flush({
+          success: true,
+          code: 7,
+          score: 2,
+          notes: 'Replay note',
+          source: 'manual',
+          managerUserId: 1,
+          managerName: 'Manager'
+        });
+
+      service.getCachedWithinTrainingCodingResults(1, 5).subscribe();
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
+        .flush(freshness('v1'));
+      httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
+        .flush(comparisonData);
+    });
+  });
+
   describe('discussion result apply', () => {
     it('should request an apply preview', () => {
       service.previewApplyDiscussionResults(1, 5, 'manual').subscribe();

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import {
+  Observable, catchError, of, switchMap, tap
+} from 'rxjs';
 import { SERVER_URL } from '../../injection-tokens';
 import { CoderTraining } from '../models/coder-training.model';
 import {
@@ -9,6 +11,7 @@ import {
   TrainingDiscussionApplyPreviewDto,
   TrainingDiscussionApplySource
 } from '../../../../../../api-dto/coding/training-discussion-apply.dto';
+import { TrainingComparisonFreshnessDto } from '../../../../../../api-dto/coding/training-comparison-freshness.dto';
 
 export interface CoderTrainingJob {
   coderId: number;
@@ -87,15 +90,38 @@ export interface CodingJobForTraining {
   unitsCount: number;
 }
 
+interface WithinTrainingComparisonCacheEntry {
+  freshness: TrainingComparisonFreshnessDto;
+  data: WithinTrainingCodingResult[];
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class CodingTrainingBackendService {
   private readonly serverUrl = inject(SERVER_URL);
   private http = inject(HttpClient);
+  private readonly withinTrainingComparisonCache = new Map<string, WithinTrainingComparisonCacheEntry>();
 
   private get authHeader() {
     return {};
+  }
+
+  private getWithinTrainingComparisonCacheKey(workspaceId: number, trainingId: number): string {
+    return `${workspaceId}:${trainingId}`;
+  }
+
+  invalidateWithinTrainingComparisonCache(workspaceId: number, trainingId?: number): void {
+    if (trainingId !== undefined) {
+      this.withinTrainingComparisonCache.delete(
+        this.getWithinTrainingComparisonCacheKey(workspaceId, trainingId)
+      );
+      return;
+    }
+
+    Array.from(this.withinTrainingComparisonCache.keys())
+      .filter(key => key.startsWith(`${workspaceId}:`))
+      .forEach(key => this.withinTrainingComparisonCache.delete(key));
   }
 
   createCoderTrainingJobs(
@@ -140,7 +166,15 @@ export class CodingTrainingBackendService {
       showScore,
       allowComments,
       suppressGeneralInstructions
-    }, { headers: this.authHeader });
+    }, { headers: this.authHeader }).pipe(
+      tap(response => {
+        if (response.trainingId) {
+          this.invalidateWithinTrainingComparisonCache(workspaceId, response.trainingId);
+        } else {
+          this.invalidateWithinTrainingComparisonCache(workspaceId);
+        }
+      })
+    );
   }
 
   getCoderTrainings(workspaceId: number): Observable<CoderTraining[]> {
@@ -186,7 +220,9 @@ export class CodingTrainingBackendService {
       showScore,
       allowComments,
       suppressGeneralInstructions
-    }, { headers: this.authHeader });
+    }, { headers: this.authHeader }).pipe(
+      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
+    );
   }
 
   deleteCoderTraining(
@@ -194,7 +230,9 @@ export class CodingTrainingBackendService {
     trainingId: number
   ): Observable<{ success: boolean; message: string }> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings/${trainingId}`;
-    return this.http.delete<{ success: boolean; message: string }>(url, { headers: this.authHeader });
+    return this.http.delete<{ success: boolean; message: string }>(url, { headers: this.authHeader }).pipe(
+      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
+    );
   }
 
   updateCoderTrainingLabel(
@@ -205,7 +243,9 @@ export class CodingTrainingBackendService {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings/${trainingId}/label`;
     return this.http.put<{ success: boolean; message: string }>(url, {
       label: newLabel
-    }, { headers: this.authHeader });
+    }, { headers: this.authHeader }).pipe(
+      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
+    );
   }
 
   compareTrainingCodingResults(
@@ -225,6 +265,44 @@ export class CodingTrainingBackendService {
   ): Observable<WithinTrainingCodingResult[]> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/compare-within-training?trainingId=${trainingId}`;
     return this.http.get<WithinTrainingCodingResult[]>(url, { headers: this.authHeader });
+  }
+
+  getTrainingComparisonFreshness(
+    workspaceId: number,
+    trainingId: number
+  ): Observable<TrainingComparisonFreshnessDto> {
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings/${trainingId}/comparison-freshness`;
+    return this.http.get<TrainingComparisonFreshnessDto>(url, { headers: this.authHeader });
+  }
+
+  getCachedWithinTrainingCodingResults(
+    workspaceId: number,
+    trainingId: number
+  ): Observable<WithinTrainingCodingResult[]> {
+    const cacheKey = this.getWithinTrainingComparisonCacheKey(workspaceId, trainingId);
+
+    return this.getTrainingComparisonFreshness(workspaceId, trainingId).pipe(
+      catchError(() => of(null)),
+      switchMap(freshness => {
+        if (!freshness) {
+          return this.compareWithinTrainingCodingResults(workspaceId, trainingId);
+        }
+
+        const cached = this.withinTrainingComparisonCache.get(cacheKey);
+        if (cached && cached.freshness.version === freshness.version) {
+          return of(cached.data);
+        }
+
+        return this.compareWithinTrainingCodingResults(workspaceId, trainingId).pipe(
+          tap(data => {
+            this.withinTrainingComparisonCache.set(cacheKey, {
+              freshness,
+              data
+            });
+          })
+        );
+      })
+    );
   }
 
   saveDiscussionResult(
@@ -258,6 +336,8 @@ export class CodingTrainingBackendService {
         responseId, code, score, notes
       },
       { headers: this.authHeader }
+    ).pipe(
+      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
     );
   }
 
@@ -284,6 +364,8 @@ export class CodingTrainingBackendService {
       url,
       request,
       { headers: this.authHeader }
+    ).pipe(
+      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
     );
   }
 


### PR DESCRIPTION
## Summary
- add a comparison freshness endpoint for within-training coding comparisons
- cache within-training comparison data in the frontend while the freshness version is unchanged
- avoid automatic Kappa loading until the Kappa section is shown
- reload training lists safely when switching workspaces and preserve filters on normal refreshes

## Validation
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.spec.ts --runInBand
- npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coder-training.service.spec.ts --runInBand
- npx nx lint frontend
- npx nx lint backend
- git diff --check
- PostgreSQL syntax check for the response freshness hash expression in the local Docker DB

Refs #831
