### PR TITLE
Fix variable coverage aggregation counts

### DIFF
--- a/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
+++ b/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
@@ -26,6 +26,11 @@ export interface ManualCodingDeduplicationResponse extends AggregationSourceResp
   bookletName?: string | null;
 }
 
+export interface EffectiveManualCodingCaseCounts {
+  uniqueCases: number;
+  casesInJobs: number;
+}
+
 export function normalizeAggregationValue(
   value: string | null,
   flags: readonly AggregationMatchingFlag[]
@@ -89,6 +94,54 @@ export function deduplicateManualCodingResponses<T extends ManualCodingDeduplica
   }
 
   return Array.from(dedupedByPersonValue.values());
+}
+
+export function countEffectiveManualCodingCases<T extends ManualCodingDeduplicationResponse>(
+  responses: T[],
+  assignedResponseIds: ReadonlySet<number>,
+  matchingFlags: readonly AggregationMatchingFlag[],
+  threshold: number | null,
+  derivedVariableMap: Map<string, Set<string>>
+): EffectiveManualCodingCaseCounts {
+  const assignedDeduplicationKeys = new Set(
+    responses
+      .filter(response => assignedResponseIds.has(response.responseId))
+      .map(response => getManualCodingDeduplicationKey(response))
+  );
+  const dedupedResponses = deduplicateManualCodingResponses(responses);
+  const assignedDedupedResponseIds = new Set(
+    dedupedResponses
+      .filter(response => (
+        assignedResponseIds.has(response.responseId) ||
+        assignedDeduplicationKeys.has(getManualCodingDeduplicationKey(response))
+      ))
+      .map(response => response.responseId)
+  );
+  const aggregatedGroups = buildAggregationGroups(
+    dedupedResponses,
+    matchingFlags,
+    threshold,
+    derivedVariableMap
+  );
+  let uniqueCases = 0;
+  let casesInJobs = 0;
+
+  for (const group of aggregatedGroups) {
+    if (threshold !== null && group.responses.length >= threshold) {
+      uniqueCases += 1;
+      if (group.responses.some(response => assignedDedupedResponseIds.has(response.responseId))) {
+        casesInJobs += 1;
+      }
+      continue;
+    }
+
+    uniqueCases += group.responses.length;
+    casesInJobs += group.responses
+      .filter(response => assignedDedupedResponseIds.has(response.responseId))
+      .length;
+  }
+
+  return { uniqueCases, casesInJobs };
 }
 
 export function buildAggregationGroups<T extends AggregationSourceResponse>(

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -109,6 +109,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
     jobDefinitionRepository = createRepository();
     variableBundleRepository = createRepository();
     settingRepository = createRepository();
+    settingRepository.findOne.mockResolvedValue({ content: 'disabled' });
 
     workspaceFilesService = {
       getUnitVariableMap: jest.fn().mockResolvedValue(new Map()),
@@ -702,6 +703,163 @@ describe('CodingProgressService variable coverage conflicts', () => {
     expect(result.coverageByStatus.approved).toEqual(['FULL_UNIT:01']);
     expect(result.coverageByStatus.pending_review).toEqual(['PARTIAL_UNIT:01']);
     expect(result.coverageByStatus.conflicted).toEqual([]);
+  });
+
+  it('classifies duplicate-aggregated variable coverage on effective cases', async () => {
+    const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+    const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
+
+    settingRepository.findOne.mockImplementation(async ({ where }: { where: { key: string } }) => {
+      if (where.key === 'workspace-5-duplicate-aggregation-threshold') {
+        return { content: '2' };
+      }
+
+      if (where.key === 'workspace-5-response-matching-mode') {
+        return { content: JSON.stringify({ flags: ['IGNORE_CASE', 'IGNORE_WHITESPACE'] }) };
+      }
+
+      return null;
+    });
+    responseRepository.createQueryBuilder
+      .mockReturnValueOnce(createQueryBuilder([
+        {
+          unitName: 'AGG_UNIT',
+          variableId: '01',
+          statusV1: String(codingIncompleteStatus),
+          caseCount: '3'
+        }
+      ]))
+      .mockReturnValueOnce(createQueryBuilder([
+        {
+          responseId: '100',
+          unitName: 'AGG_UNIT',
+          variableId: '01',
+          value: 'Same answer',
+          codeV2: null,
+          statusV2: null,
+          statusV1: String(codingIncompleteStatus),
+          bookletName: 'BookletA',
+          personLogin: 'login-1',
+          personCode: 'code-1',
+          personGroup: 'group-1'
+        },
+        {
+          responseId: '101',
+          unitName: 'AGG_UNIT',
+          variableId: '01',
+          value: 'sameanswer',
+          codeV2: null,
+          statusV2: null,
+          statusV1: String(codingIncompleteStatus),
+          bookletName: 'BookletA',
+          personLogin: 'login-2',
+          personCode: 'code-2',
+          personGroup: 'group-1'
+        },
+        {
+          responseId: '102',
+          unitName: 'AGG_UNIT',
+          variableId: '01',
+          value: ' SAME ANSWER ',
+          codeV2: null,
+          statusV2: null,
+          statusV1: String(codingIncompleteStatus),
+          bookletName: 'BookletA',
+          personLogin: 'login-3',
+          personCode: 'code-3',
+          personGroup: 'group-1'
+        },
+        {
+          responseId: '103',
+          unitName: 'AGG_UNIT',
+          variableId: '01',
+          value: 'already applied answer',
+          codeV2: null,
+          statusV2: String(codingCompleteStatus),
+          statusV1: String(codingIncompleteStatus),
+          bookletName: 'BookletA',
+          personLogin: 'login-4',
+          personCode: 'code-4',
+          personGroup: 'group-1'
+        }
+      ]))
+      .mockReturnValueOnce(createQueryBuilder([
+        {
+          responseId: '100',
+          unitName: 'AGG_UNIT',
+          variableId: '01',
+          value: 'Same answer',
+          codeV2: null,
+          statusV2: null,
+          statusV1: String(codingIncompleteStatus),
+          bookletName: 'BookletA',
+          personLogin: 'login-1',
+          personCode: 'code-1',
+          personGroup: 'group-1'
+        },
+        {
+          responseId: '101',
+          unitName: 'AGG_UNIT',
+          variableId: '01',
+          value: 'sameanswer',
+          codeV2: null,
+          statusV2: null,
+          statusV1: String(codingIncompleteStatus),
+          bookletName: 'BookletA',
+          personLogin: 'login-2',
+          personCode: 'code-2',
+          personGroup: 'group-1'
+        },
+        {
+          responseId: '102',
+          unitName: 'AGG_UNIT',
+          variableId: '01',
+          value: ' SAME ANSWER ',
+          codeV2: null,
+          statusV2: null,
+          statusV1: String(codingIncompleteStatus),
+          bookletName: 'BookletA',
+          personLogin: 'login-3',
+          personCode: 'code-3',
+          personGroup: 'group-1'
+        },
+        {
+          responseId: '103',
+          unitName: 'AGG_UNIT',
+          variableId: '01',
+          value: 'already applied answer',
+          codeV2: null,
+          statusV2: String(codingCompleteStatus),
+          statusV1: String(codingIncompleteStatus),
+          bookletName: 'BookletA',
+          personLogin: 'login-4',
+          personCode: 'code-4',
+          personGroup: 'group-1'
+        }
+      ]));
+    workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
+      ['AGG_UNIT', new Set(['01'])]
+    ]));
+    jobDefinitionRepository.find.mockResolvedValue([
+      {
+        id: 40,
+        status: 'approved',
+        assigned_variables: [{ unitName: 'AGG_UNIT', variableId: '01' }]
+      }
+    ]);
+    codingJobUnitRepository.createQueryBuilder
+      .mockReturnValueOnce(createQueryBuilder([{ responseId: '100' }]))
+      .mockReturnValueOnce(createQueryBuilder([]));
+
+    const result = await service.getVariableCoverageOverview(5);
+
+    expect(result.totalVariables).toBe(1);
+    expect(result.coveredVariables).toBe(1);
+    expect(result.fullyAbgedeckteVariablen).toBe(1);
+    expect(result.partiallyAbgedeckteVariablen).toBe(0);
+    expect(result.variableCaseCounts).toEqual([
+      { unitName: 'AGG_UNIT', variableId: '01', caseCount: 3 }
+    ]);
   });
 
   it('flags variables when the same response is assigned through multiple job definitions', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -720,123 +720,71 @@ describe('CodingProgressService variable coverage conflicts', () => {
 
       return null;
     });
+    const incompleteVariablesQuery = createQueryBuilder([
+      {
+        unitName: 'AGG_UNIT',
+        variableId: '01',
+        statusV1: String(codingIncompleteStatus),
+        caseCount: '3'
+      }
+    ]);
+    const variableResponsesQuery = createQueryBuilder([
+      {
+        responseId: '100',
+        unitName: 'AGG_UNIT',
+        variableId: '01',
+        value: 'Same answer',
+        codeV2: null,
+        statusV2: null,
+        statusV1: String(codingIncompleteStatus),
+        bookletName: 'BookletA',
+        personLogin: 'login-1',
+        personCode: 'code-1',
+        personGroup: 'group-1'
+      },
+      {
+        responseId: '101',
+        unitName: 'AGG_UNIT',
+        variableId: '01',
+        value: 'sameanswer',
+        codeV2: null,
+        statusV2: null,
+        statusV1: String(codingIncompleteStatus),
+        bookletName: 'BookletA',
+        personLogin: 'login-2',
+        personCode: 'code-2',
+        personGroup: 'group-1'
+      },
+      {
+        responseId: '102',
+        unitName: 'AGG_UNIT',
+        variableId: '01',
+        value: ' SAME ANSWER ',
+        codeV2: null,
+        statusV2: null,
+        statusV1: String(codingIncompleteStatus),
+        bookletName: 'BookletA',
+        personLogin: 'login-3',
+        personCode: 'code-3',
+        personGroup: 'group-1'
+      },
+      {
+        responseId: '103',
+        unitName: 'AGG_UNIT',
+        variableId: '01',
+        value: 'already applied answer',
+        codeV2: null,
+        statusV2: String(codingCompleteStatus),
+        statusV1: String(codingIncompleteStatus),
+        bookletName: 'BookletA',
+        personLogin: 'login-4',
+        personCode: 'code-4',
+        personGroup: 'group-1'
+      }
+    ]);
     responseRepository.createQueryBuilder
-      .mockReturnValueOnce(createQueryBuilder([
-        {
-          unitName: 'AGG_UNIT',
-          variableId: '01',
-          statusV1: String(codingIncompleteStatus),
-          caseCount: '3'
-        }
-      ]))
-      .mockReturnValueOnce(createQueryBuilder([
-        {
-          responseId: '100',
-          unitName: 'AGG_UNIT',
-          variableId: '01',
-          value: 'Same answer',
-          codeV2: null,
-          statusV2: null,
-          statusV1: String(codingIncompleteStatus),
-          bookletName: 'BookletA',
-          personLogin: 'login-1',
-          personCode: 'code-1',
-          personGroup: 'group-1'
-        },
-        {
-          responseId: '101',
-          unitName: 'AGG_UNIT',
-          variableId: '01',
-          value: 'sameanswer',
-          codeV2: null,
-          statusV2: null,
-          statusV1: String(codingIncompleteStatus),
-          bookletName: 'BookletA',
-          personLogin: 'login-2',
-          personCode: 'code-2',
-          personGroup: 'group-1'
-        },
-        {
-          responseId: '102',
-          unitName: 'AGG_UNIT',
-          variableId: '01',
-          value: ' SAME ANSWER ',
-          codeV2: null,
-          statusV2: null,
-          statusV1: String(codingIncompleteStatus),
-          bookletName: 'BookletA',
-          personLogin: 'login-3',
-          personCode: 'code-3',
-          personGroup: 'group-1'
-        },
-        {
-          responseId: '103',
-          unitName: 'AGG_UNIT',
-          variableId: '01',
-          value: 'already applied answer',
-          codeV2: null,
-          statusV2: String(codingCompleteStatus),
-          statusV1: String(codingIncompleteStatus),
-          bookletName: 'BookletA',
-          personLogin: 'login-4',
-          personCode: 'code-4',
-          personGroup: 'group-1'
-        }
-      ]))
-      .mockReturnValueOnce(createQueryBuilder([
-        {
-          responseId: '100',
-          unitName: 'AGG_UNIT',
-          variableId: '01',
-          value: 'Same answer',
-          codeV2: null,
-          statusV2: null,
-          statusV1: String(codingIncompleteStatus),
-          bookletName: 'BookletA',
-          personLogin: 'login-1',
-          personCode: 'code-1',
-          personGroup: 'group-1'
-        },
-        {
-          responseId: '101',
-          unitName: 'AGG_UNIT',
-          variableId: '01',
-          value: 'sameanswer',
-          codeV2: null,
-          statusV2: null,
-          statusV1: String(codingIncompleteStatus),
-          bookletName: 'BookletA',
-          personLogin: 'login-2',
-          personCode: 'code-2',
-          personGroup: 'group-1'
-        },
-        {
-          responseId: '102',
-          unitName: 'AGG_UNIT',
-          variableId: '01',
-          value: ' SAME ANSWER ',
-          codeV2: null,
-          statusV2: null,
-          statusV1: String(codingIncompleteStatus),
-          bookletName: 'BookletA',
-          personLogin: 'login-3',
-          personCode: 'code-3',
-          personGroup: 'group-1'
-        },
-        {
-          responseId: '103',
-          unitName: 'AGG_UNIT',
-          variableId: '01',
-          value: 'already applied answer',
-          codeV2: null,
-          statusV2: String(codingCompleteStatus),
-          statusV1: String(codingIncompleteStatus),
-          bookletName: 'BookletA',
-          personLogin: 'login-4',
-          personCode: 'code-4',
-          personGroup: 'group-1'
-        }
-      ]));
+      .mockReturnValueOnce(incompleteVariablesQuery)
+      .mockReturnValueOnce(variableResponsesQuery);
     workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
       ['AGG_UNIT', new Set(['01'])]
     ]));
@@ -847,8 +795,9 @@ describe('CodingProgressService variable coverage conflicts', () => {
         assigned_variables: [{ unitName: 'AGG_UNIT', variableId: '01' }]
       }
     ]);
+    const assignedResponseIdsQuery = createQueryBuilder([{ responseId: '100' }]);
     codingJobUnitRepository.createQueryBuilder
-      .mockReturnValueOnce(createQueryBuilder([{ responseId: '100' }]))
+      .mockReturnValueOnce(assignedResponseIdsQuery)
       .mockReturnValueOnce(createQueryBuilder([]));
 
     const result = await service.getVariableCoverageOverview(5);
@@ -860,6 +809,20 @@ describe('CodingProgressService variable coverage conflicts', () => {
     expect(result.variableCaseCounts).toEqual([
       { unitName: 'AGG_UNIT', variableId: '01', caseCount: 3 }
     ]);
+    expect(variableResponsesQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('unit.name = :variableCoverageResponsesUnitName0'),
+      expect.objectContaining({
+        variableCoverageResponsesUnitName0: 'AGG_UNIT',
+        variableCoverageResponsesVariableId0: '01'
+      })
+    );
+    expect(assignedResponseIdsQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('cju.unit_name = :assignedVariableCoverageUnitName0'),
+      expect.objectContaining({
+        assignedVariableCoverageUnitName0: 'AGG_UNIT',
+        assignedVariableCoverageVariableId0: '01'
+      })
+    );
   });
 
   it('flags variables when the same response is assigned through multiple job definitions', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -93,9 +93,17 @@ interface ManualProgressStatusQuery {
   andWhere: (condition: string | Brackets, parameters?: Record<string, unknown>) => unknown;
 }
 
+interface VariableReferenceFilterQuery {
+  andWhere: (condition: string | Brackets, parameters?: Record<string, unknown>) => unknown;
+}
+
 interface VariableDefinitionReference {
   id: number;
   status: string;
+}
+
+interface VariableCaseCount extends UnitVariableReference {
+  caseCount: number;
 }
 
 interface CrossDefinitionCaseRow {
@@ -948,16 +956,8 @@ export class CodingProgressService {
       );
 
       const variablesNeedingCoding = new Set<string>();
-      const variableCaseCounts: {
-        unitName: string;
-        variableId: string;
-        caseCount: number;
-      }[] = [];
-      const variableCaseCountMap = new Map<string, {
-        unitName: string;
-        variableId: string;
-        caseCount: number;
-      }>();
+      const variableCaseCounts: VariableCaseCount[] = [];
+      const variableCaseCountMap = new Map<string, VariableCaseCount>();
 
       filteredIncompleteVariablesResult.forEach(row => {
         const variableKey = `${row.unitName}:${row.variableId}`;
@@ -1041,8 +1041,11 @@ export class CodingProgressService {
         });
       }
 
+      const coveredVariableCaseCounts = variableCaseCounts.filter(
+        variable => coveredVariables.has(`${variable.unitName}:${variable.variableId}`)
+      );
       const effectiveVariableCaseCoverageMap =
-        await this.getEffectiveVariableCasesInJobs(workspaceId, variableCaseCounts);
+        await this.getEffectiveVariableCasesInJobs(workspaceId, coveredVariableCaseCounts);
 
       const crossDefinitionCaseConflicts = await this.getCrossDefinitionCaseConflicts(workspaceId);
       const conflictedVariables = new Map<string, VariableDefinitionReference[]>();
@@ -1152,8 +1155,13 @@ export class CodingProgressService {
   }
 
   private async getVariableCasesInJobs(
-    workspaceId: number
+    workspaceId: number,
+    variables: UnitVariableReference[]
   ): Promise<Map<string, number>> {
+    if (variables.length === 0) {
+      return new Map<string, number>();
+    }
+
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     const query = this.codingJobUnitRepository
       .createQueryBuilder('cju')
@@ -1169,6 +1177,11 @@ export class CodingProgressService {
       })
       .groupBy('cju.unit_name')
       .addGroupBy('cju.variable_id');
+    this.applyVariableReferenceFilter(query, variables, {
+      unitNameExpression: 'cju.unit_name',
+      variableIdExpression: 'cju.variable_id',
+      parameterPrefix: 'variableCasesInJobs'
+    });
     applyNonCodingIssueReviewJobFilter(
       query,
       'coding_job',
@@ -1193,11 +1206,7 @@ export class CodingProgressService {
 
   private async getEffectiveVariableCasesInJobs(
     workspaceId: number,
-    variables: Array<{
-      unitName: string;
-      variableId: string;
-      caseCount: number;
-    }>
+    variables: VariableCaseCount[]
   ): Promise<Map<string, EffectiveVariableCaseCoverage>> {
     const result = new Map<string, EffectiveVariableCaseCoverage>();
 
@@ -1211,7 +1220,7 @@ export class CodingProgressService {
       aggregationThreshold !== null && !matchingFlags.includes('NO_AGGREGATION');
 
     if (!aggregationActive) {
-      const casesInJobsMap = await this.getVariableCasesInJobs(workspaceId);
+      const casesInJobsMap = await this.getVariableCasesInJobs(workspaceId, variables);
       variables.forEach(variable => {
         const key = `${variable.unitName}::${variable.variableId}`;
         result.set(key, {
@@ -1228,14 +1237,14 @@ export class CodingProgressService {
     const variableKeys = new Set(
       variables.map(variable => `${variable.unitName}:${variable.variableId}`)
     );
-    const [responseScope, assignedResponseIds, derivedVariableMap] = await Promise.all([
-      this.getCoverageResponseScope(workspaceId),
-      this.getAssignedCoverageResponseIds(workspaceId),
+    const [responses, assignedResponseIds, derivedVariableMap] = await Promise.all([
+      this.getCoverageResponsesForVariables(workspaceId, variables),
+      this.getAssignedCoverageResponseIdsForVariables(workspaceId, variables),
       this.getDerivedVariableMap(workspaceId)
     ]);
     const responsesByVariable = new Map<string, CoverageResponse[]>();
 
-    responseScope.manualResponses
+    responses
       .filter(response => (
         response.statusV1 === codingIncompleteStatus ||
         response.statusV1 === intendedIncompleteStatus
@@ -1244,16 +1253,16 @@ export class CodingProgressService {
       .filter(response => variableKeys.has(`${response.unitName}:${response.variableId}`))
       .forEach(response => {
         const key = `${response.unitName}::${response.variableId}`;
-        const responses = responsesByVariable.get(key) || [];
-        responses.push(response);
-        responsesByVariable.set(key, responses);
+        const variableResponses = responsesByVariable.get(key) || [];
+        variableResponses.push(response);
+        responsesByVariable.set(key, variableResponses);
       });
 
     variables.forEach(variable => {
       const key = `${variable.unitName}::${variable.variableId}`;
-      const responses = responsesByVariable.get(key) || [];
+      const variableResponses = responsesByVariable.get(key) || [];
       const responsesWithCaseFields: ManualCodingDeduplicationResponse[] =
-        responses.map(response => ({
+        variableResponses.map(response => ({
           responseId: response.responseId,
           unitName: response.unitName,
           variableId: response.variableId,
@@ -1278,6 +1287,166 @@ export class CodingProgressService {
     });
 
     return result;
+  }
+
+  private async getCoverageResponsesForVariables(
+    workspaceId: number,
+    variables: UnitVariableReference[]
+  ): Promise<CoverageResponse[]> {
+    if (variables.length === 0) {
+      return [];
+    }
+
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const query = this.responseRepository
+      .createQueryBuilder('response')
+      .select('response.id', 'responseId')
+      .addSelect('response.value', 'value')
+      .addSelect('response.code_v2', 'codeV2')
+      .addSelect('response.status_v2', 'statusV2')
+      .addSelect('response.status_v1', 'statusV1')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('unit.name', 'unitName')
+      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
+      .addSelect("COALESCE(person.login, '')", 'personLogin')
+      .addSelect("COALESCE(person.code, '')", 'personCode')
+      .addSelect("COALESCE(person.group, '')", 'personGroup')
+      .leftJoin('response.unit', 'unit')
+      .leftJoin('unit.booklet', 'booklet')
+      .leftJoin('booklet.bookletinfo', 'bookletinfo')
+      .leftJoin('booklet.person', 'person')
+      .where('response.status_v1 IN (:...statuses)', {
+        statuses: [
+          statusStringToNumber('CODING_INCOMPLETE'),
+          statusStringToNumber('INTENDED_INCOMPLETE')
+        ]
+      })
+      .andWhere('person.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('person.consider = :consider', { consider: true })
+      .andWhere('(response.status_v2 IS NULL OR response.status_v2 != :completedV2Status)', {
+        completedV2Status: statusStringToNumber('CODING_COMPLETE')
+      })
+      .andWhere(new Brackets(qb => {
+        qb.where('response.code_v2 IS NULL')
+          .orWhere(subQuery => {
+            const exists = subQuery
+              .subQuery()
+              .select('1')
+              .from('coding_job_unit', 'manual_cju')
+              .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
+              .where('manual_cju.response_id = response.id')
+              .andWhere('manual_cj.training_id IS NULL')
+              .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
+              .getQuery();
+            return `EXISTS (${exists})`;
+          });
+      }))
+      .orderBy('response.id', 'ASC');
+    this.applyVariableReferenceFilter(query, variables, {
+      unitNameExpression: 'unit.name',
+      variableIdExpression: 'response.variableid',
+      parameterPrefix: 'variableCoverageResponses'
+    });
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      parameterPrefix: 'variableCoverageResponses'
+    });
+    const raw = await query.getRawMany();
+
+    return raw.map(row => ({
+      responseId: Number(row.responseId),
+      value: row.value ?? null,
+      codeV2: row.codeV2 === null || row.codeV2 === undefined ? null : Number(row.codeV2),
+      statusV2: row.statusV2 === null || row.statusV2 === undefined ? null : Number(row.statusV2),
+      statusV1: row.statusV1 === null || row.statusV1 === undefined ? null : Number(row.statusV1),
+      variableId: row.variableId,
+      unitName: row.unitName,
+      bookletName: row.bookletName ?? '',
+      personLogin: row.personLogin ?? '',
+      personCode: row.personCode ?? '',
+      personGroup: row.personGroup ?? ''
+    }));
+  }
+
+  private async getAssignedCoverageResponseIdsForVariables(
+    workspaceId: number,
+    variables: UnitVariableReference[]
+  ): Promise<Set<number>> {
+    if (variables.length === 0) {
+      return new Set<number>();
+    }
+
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const query = this.codingJobUnitRepository
+      .createQueryBuilder('cju')
+      .select('DISTINCT cju.response_id', 'responseId')
+      .innerJoin('cju.response', 'response')
+      .leftJoin('cju.coding_job', 'coding_job')
+      .leftJoin('response.unit', 'unit')
+      .leftJoin('unit.booklet', 'booklet')
+      .leftJoin('booklet.bookletinfo', 'bookletinfo')
+      .leftJoin('booklet.person', 'person')
+      .where('person.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('person.consider = :consider', { consider: true })
+      .andWhere('coding_job.training_id IS NULL')
+      .andWhere('(response.status_v2 IS NULL OR response.status_v2 != :completedV2Status)', {
+        completedV2Status: statusStringToNumber('CODING_COMPLETE')
+      })
+      .andWhere(new Brackets(qb => {
+        qb.where('response.code_v2 IS NULL')
+          .orWhere(subQuery => {
+            const exists = subQuery
+              .subQuery()
+              .select('1')
+              .from('coding_job_unit', 'assigned_cju')
+              .where('assigned_cju.response_id = response.id')
+              .getQuery();
+            return `EXISTS (${exists})`;
+          });
+      }));
+    applyNonCodingIssueReviewJobFilter(
+      query,
+      'coding_job',
+      'assignedVariableCoverageReviewJobType'
+    );
+    this.applyManualProgressStatusFilter(query, 'andWhere');
+    this.applyVariableReferenceFilter(query, variables, {
+      unitNameExpression: 'cju.unit_name',
+      variableIdExpression: 'cju.variable_id',
+      parameterPrefix: 'assignedVariableCoverage'
+    });
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      unitNameExpression: 'cju.unit_name',
+      bookletNameExpression: 'cju.booklet_name',
+      parameterPrefix: 'assignedVariableCoverage'
+    });
+    const raw = await query.getRawMany();
+
+    return new Set(raw.map(row => Number(row.responseId)));
+  }
+
+  private applyVariableReferenceFilter(
+    query: VariableReferenceFilterQuery,
+    variables: UnitVariableReference[],
+    options: {
+      unitNameExpression: string;
+      variableIdExpression: string;
+      parameterPrefix: string;
+    }
+  ): void {
+    const conditions: string[] = [];
+    const parameters: Record<string, string> = {};
+
+    variables.forEach((variable, index) => {
+      const unitParam = `${options.parameterPrefix}UnitName${index}`;
+      const variableParam = `${options.parameterPrefix}VariableId${index}`;
+      conditions.push(
+        `(${options.unitNameExpression} = :${unitParam} AND ${options.variableIdExpression} = :${variableParam})`
+      );
+      parameters[unitParam] = variable.unitName;
+      parameters[variableParam] = variable.variableId;
+    });
+
+    query.andWhere(`(${conditions.join(' OR ')})`, parameters);
   }
 
   private async getCrossDefinitionCaseConflicts(

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -16,6 +16,8 @@ import {
 } from '../workspace/workspace-exclusion.service';
 import {
   buildAggregationGroups,
+  countEffectiveManualCodingCases,
+  ManualCodingDeduplicationResponse,
   summarizeAggregationGroups
 } from './aggregation-metrics.util';
 import { IQB_STANDARD_MISSING_CODES, MissingsProfilesService } from './missings-profiles.service';
@@ -44,6 +46,10 @@ interface CoverageResponse {
   codeV2: number | null;
   statusV2: number | null;
   statusV1: number | null;
+  personLogin: string;
+  personCode: string;
+  personGroup: string;
+  bookletName: string;
 }
 
 interface CoverageResponseScope {
@@ -67,6 +73,11 @@ interface EffectiveCaseProgress {
   aggregationActive: boolean;
   aggregationThreshold: number | null;
   aggregatedDuplicateCases: number;
+}
+
+interface EffectiveVariableCaseCoverage {
+  effectiveTotalCasesToCode: number;
+  effectiveCasesInJobs: number;
 }
 
 interface DeriveErrorManualProgress {
@@ -540,6 +551,10 @@ export class CodingProgressService {
       .addSelect('response.status_v1', 'statusV1')
       .addSelect('response.variableid', 'variableId')
       .addSelect('unit.name', 'unitName')
+      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
+      .addSelect("COALESCE(person.login, '')", 'personLogin')
+      .addSelect("COALESCE(person.code, '')", 'personCode')
+      .addSelect("COALESCE(person.group, '')", 'personGroup')
       .leftJoin('response.unit', 'unit')
       .leftJoin('unit.booklet', 'booklet')
       .leftJoin('booklet.bookletinfo', 'bookletinfo')
@@ -590,7 +605,11 @@ export class CodingProgressService {
       statusV2: row.statusV2 === null || row.statusV2 === undefined ? null : Number(row.statusV2),
       statusV1: row.statusV1 === null || row.statusV1 === undefined ? null : Number(row.statusV1),
       variableId: row.variableId,
-      unitName: row.unitName
+      unitName: row.unitName,
+      bookletName: row.bookletName ?? '',
+      personLogin: row.personLogin ?? '',
+      personCode: row.personCode ?? '',
+      personGroup: row.personGroup ?? ''
     }));
   }
 
@@ -858,6 +877,9 @@ export class CodingProgressService {
         })
         .andWhere('person.workspace_id = :workspaceId', { workspaceId })
         .andWhere('person.consider = :consider', { consider: true })
+        .andWhere('(response.status_v2 IS NULL OR response.status_v2 != :completedV2Status)', {
+          completedV2Status: statusStringToNumber('CODING_COMPLETE')
+        })
         // Exclude pre-processed responses (not in manual coding pool)
         .andWhere(new Brackets(qb => {
           qb.where('response.code_v2 IS NULL')
@@ -1019,8 +1041,8 @@ export class CodingProgressService {
         });
       }
 
-      // Get cases in jobs map for conflict detection
-      const casesInJobsMap = await this.getVariableCasesInJobs(workspaceId);
+      const effectiveVariableCaseCoverageMap =
+        await this.getEffectiveVariableCasesInJobs(workspaceId, variableCaseCounts);
 
       const crossDefinitionCaseConflicts = await this.getCrossDefinitionCaseConflicts(workspaceId);
       const conflictedVariables = new Map<string, VariableDefinitionReference[]>();
@@ -1045,20 +1067,25 @@ export class CodingProgressService {
           return;
         }
 
-        // Check if variable is fully or partially covered based on cases in jobs
+        // Check if variable is fully or partially covered on the effective case level.
         const variableCaseInfo = variableCaseCounts.find(
           v => `${v.unitName}:${v.variableId}` === variableKey
         );
 
         if (variableCaseInfo) {
-          const casesInJobs =
-            casesInJobsMap.get(
-              `${variableCaseInfo.unitName}::${variableCaseInfo.variableId}`
-            ) || 0;
+          const effectiveCoverage = effectiveVariableCaseCoverageMap.get(
+            `${variableCaseInfo.unitName}::${variableCaseInfo.variableId}`
+          ) || {
+            effectiveTotalCasesToCode: variableCaseInfo.caseCount,
+            effectiveCasesInJobs: 0
+          };
 
-          if (casesInJobs >= variableCaseInfo.caseCount) {
+          if (
+            effectiveCoverage.effectiveTotalCasesToCode > 0 &&
+            effectiveCoverage.effectiveCasesInJobs >= effectiveCoverage.effectiveTotalCasesToCode
+          ) {
             fullyAbgedeckteVariablen.add(variableKey);
-          } else if (casesInJobs > 0) {
+          } else if (effectiveCoverage.effectiveCasesInJobs > 0) {
             partiallyAbgedeckteVariablen.add(variableKey);
           }
         }
@@ -1134,8 +1161,12 @@ export class CodingProgressService {
       .addSelect('cju.variable_id', 'variableId')
       .addSelect('COUNT(DISTINCT cju.response_id)', 'casesInJobs')
       .leftJoin('cju.coding_job', 'coding_job')
+      .innerJoin('cju.response', 'response')
       .where('coding_job.workspace_id = :workspaceId', { workspaceId })
       .andWhere('coding_job.training_id IS NULL')
+      .andWhere('(response.status_v2 IS NULL OR response.status_v2 != :completedV2Status)', {
+        completedV2Status: statusStringToNumber('CODING_COMPLETE')
+      })
       .groupBy('cju.unit_name')
       .addGroupBy('cju.variable_id');
     applyNonCodingIssueReviewJobFilter(
@@ -1158,6 +1189,95 @@ export class CodingProgressService {
     });
 
     return casesInJobsMap;
+  }
+
+  private async getEffectiveVariableCasesInJobs(
+    workspaceId: number,
+    variables: Array<{
+      unitName: string;
+      variableId: string;
+      caseCount: number;
+    }>
+  ): Promise<Map<string, EffectiveVariableCaseCoverage>> {
+    const result = new Map<string, EffectiveVariableCaseCoverage>();
+
+    if (variables.length === 0) {
+      return result;
+    }
+
+    const aggregationThreshold = await this.getAggregationThreshold(workspaceId);
+    const matchingFlags = await this.getResponseMatchingMode(workspaceId);
+    const aggregationActive =
+      aggregationThreshold !== null && !matchingFlags.includes('NO_AGGREGATION');
+
+    if (!aggregationActive) {
+      const casesInJobsMap = await this.getVariableCasesInJobs(workspaceId);
+      variables.forEach(variable => {
+        const key = `${variable.unitName}::${variable.variableId}`;
+        result.set(key, {
+          effectiveTotalCasesToCode: variable.caseCount,
+          effectiveCasesInJobs: casesInJobsMap.get(key) || 0
+        });
+      });
+      return result;
+    }
+
+    const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+    const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
+    const variableKeys = new Set(
+      variables.map(variable => `${variable.unitName}:${variable.variableId}`)
+    );
+    const [responseScope, assignedResponseIds, derivedVariableMap] = await Promise.all([
+      this.getCoverageResponseScope(workspaceId),
+      this.getAssignedCoverageResponseIds(workspaceId),
+      this.getDerivedVariableMap(workspaceId)
+    ]);
+    const responsesByVariable = new Map<string, CoverageResponse[]>();
+
+    responseScope.manualResponses
+      .filter(response => (
+        response.statusV1 === codingIncompleteStatus ||
+        response.statusV1 === intendedIncompleteStatus
+      ))
+      .filter(response => response.statusV2 !== codingCompleteStatus)
+      .filter(response => variableKeys.has(`${response.unitName}:${response.variableId}`))
+      .forEach(response => {
+        const key = `${response.unitName}::${response.variableId}`;
+        const responses = responsesByVariable.get(key) || [];
+        responses.push(response);
+        responsesByVariable.set(key, responses);
+      });
+
+    variables.forEach(variable => {
+      const key = `${variable.unitName}::${variable.variableId}`;
+      const responses = responsesByVariable.get(key) || [];
+      const responsesWithCaseFields: ManualCodingDeduplicationResponse[] =
+        responses.map(response => ({
+          responseId: response.responseId,
+          unitName: response.unitName,
+          variableId: response.variableId,
+          value: response.value,
+          personLogin: response.personLogin,
+          personCode: response.personCode,
+          personGroup: response.personGroup,
+          bookletName: response.bookletName
+        }));
+      const effectiveCaseCounts = countEffectiveManualCodingCases(
+        responsesWithCaseFields,
+        assignedResponseIds,
+        matchingFlags,
+        aggregationThreshold,
+        derivedVariableMap
+      );
+
+      result.set(key, {
+        effectiveTotalCasesToCode: effectiveCaseCounts.uniqueCases,
+        effectiveCasesInJobs: effectiveCaseCounts.casesInJobs
+      });
+    });
+
+    return result;
   }
 
   private async getCrossDefinitionCaseConflicts(

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -26,9 +26,7 @@ import {
 } from '../workspace/workspace-exclusion.service';
 import { CodingJobService } from './coding-job.service';
 import {
-  buildAggregationGroups,
-  deduplicateManualCodingResponses,
-  getManualCodingDeduplicationKey,
+  countEffectiveManualCodingCases,
   ManualCodingDeduplicationResponse
 } from './aggregation-metrics.util';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
@@ -804,45 +802,14 @@ export class CodingValidationService {
             variableId: response.variableid
           }));
         const assignedResponseIds = assignedResponseIdsByVariable.get(key) || new Set<number>();
-        const assignedDeduplicationKeys = new Set(
-          responsesWithCaseFields
-            .filter(response => assignedResponseIds.has(response.responseId))
-            .map(response => getManualCodingDeduplicationKey(response))
-        );
-        const dedupedResponses = deduplicateManualCodingResponses(responsesWithCaseFields);
-        const assignedDedupedResponseIds = new Set(
-          dedupedResponses
-            .filter(response => (
-              assignedResponseIds.has(response.responseId) ||
-              assignedDeduplicationKeys.has(getManualCodingDeduplicationKey(response))
-            ))
-            .map(response => response.responseId)
-        );
-        const aggregatedGroups = buildAggregationGroups(
-          dedupedResponses,
+
+        return countEffectiveManualCodingCases(
+          responsesWithCaseFields,
+          assignedResponseIds,
           matchingFlags,
           aggregationThreshold,
           derivedVariableMap
         );
-
-        let uniqueCases = 0;
-        let casesInJobs = 0;
-
-        for (const group of aggregatedGroups) {
-          if (aggregationThreshold !== null && group.responses.length >= aggregationThreshold) {
-            uniqueCases += 1;
-            if (group.responses.some(response => assignedDedupedResponseIds.has(response.responseId))) {
-              casesInJobs += 1;
-            }
-          } else {
-            uniqueCases += group.responses.length;
-            casesInJobs += group.responses
-              .filter(response => assignedDedupedResponseIds.has(response.responseId))
-              .length;
-          }
-        }
-
-        return { uniqueCases, casesInJobs };
       };
 
       const includeDeriveErrorForVariable = includeDeriveErrorInCaseInfo &&


### PR DESCRIPTION
## Summary

- Align variable coverage full/partial classification with duplicate-aggregated effective coding cases.
- Share the effective manual coding case counting logic between progress and validation paths.
- Exclude already completed status_v2 responses from variable coverage availability, matching job-definition availability.

## Validation

- npx nx test backend --runTestsByPath apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts apps/backend/src/app/database/services/coding/aggregation-metrics.util.spec.ts --runInBand
- npx nx test backend --runTestsByPath apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts --runInBand
- npx nx lint backend
- git diff --check

## Notes

Context: issue 795 discussion. This PR intentionally does not use GitHub auto-closing keywords.
