### PR TITLE
[813] Limit manual coding refresh triggers

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -5,7 +5,9 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
-import { Observable, of, throwError } from 'rxjs';
+import {
+  Observable, of, Subject, throwError
+} from 'rxjs';
 import { CodingManagementManualComponent } from './coding-management-manual.component';
 import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
@@ -1338,6 +1340,94 @@ describe('CodingManagementManualComponent', () => {
     expect(incompleteVariablesSpy).toHaveBeenCalled();
     expect(loadCodingFreshnessSpy).toHaveBeenCalled();
     expect(loadResponseAnalysisSpy).toHaveBeenCalled();
+  });
+
+  it('should wait for the auto-refresh setting before loading initial coding freshness', () => {
+    const manualRefreshSetting$ = new Subject<boolean>();
+    const isolatedFixture = TestBed.createComponent(CodingManagementManualComponent);
+    const isolatedComponent = isolatedFixture.componentInstance;
+    const componentInternals = isolatedComponent as unknown as {
+      appService: { selectedWorkspaceId: number };
+      workspaceSettingsService: {
+        getAutoRefreshManualCodingJobs: (workspaceId: number) => Observable<boolean>;
+      };
+      loadCodersForExport(): void;
+      loadJobDefinitionsForExport(): void;
+      loadInitialManualCodingState(): void;
+      loadManualCodingApplyPermission(): void;
+      loadCodingFreshness(): void;
+    };
+    const previousWorkspaceId = componentInternals.appService.selectedWorkspaceId;
+    const getSettingSpy = jest
+      .spyOn(componentInternals.workspaceSettingsService, 'getAutoRefreshManualCodingJobs')
+      .mockReturnValue(manualRefreshSetting$.asObservable());
+    jest.spyOn(componentInternals, 'loadCodersForExport').mockImplementation();
+    jest.spyOn(componentInternals, 'loadJobDefinitionsForExport').mockImplementation();
+    jest.spyOn(componentInternals, 'loadInitialManualCodingState').mockImplementation();
+    jest.spyOn(componentInternals, 'loadManualCodingApplyPermission').mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+
+    try {
+      componentInternals.appService.selectedWorkspaceId = 5;
+
+      isolatedComponent.ngOnInit();
+
+      expect(getSettingSpy).toHaveBeenCalledWith(5);
+      expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
+
+      manualRefreshSetting$.next(true);
+
+      expect(loadCodingFreshnessSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      isolatedFixture.destroy();
+      componentInternals.appService.selectedWorkspaceId = previousWorkspaceId;
+      getSettingSpy.mockRestore();
+    }
+  });
+
+  it('should skip initial coding freshness when auto-refresh is disabled', () => {
+    const manualRefreshSetting$ = new Subject<boolean>();
+    const isolatedFixture = TestBed.createComponent(CodingManagementManualComponent);
+    const isolatedComponent = isolatedFixture.componentInstance;
+    const componentInternals = isolatedComponent as unknown as {
+      appService: { selectedWorkspaceId: number };
+      workspaceSettingsService: {
+        getAutoRefreshManualCodingJobs: (workspaceId: number) => Observable<boolean>;
+      };
+      loadCodersForExport(): void;
+      loadJobDefinitionsForExport(): void;
+      loadInitialManualCodingState(): void;
+      loadManualCodingApplyPermission(): void;
+      loadCodingFreshness(): void;
+    };
+    const previousWorkspaceId = componentInternals.appService.selectedWorkspaceId;
+    const getSettingSpy = jest
+      .spyOn(componentInternals.workspaceSettingsService, 'getAutoRefreshManualCodingJobs')
+      .mockReturnValue(manualRefreshSetting$.asObservable());
+    jest.spyOn(componentInternals, 'loadCodersForExport').mockImplementation();
+    jest.spyOn(componentInternals, 'loadJobDefinitionsForExport').mockImplementation();
+    jest.spyOn(componentInternals, 'loadInitialManualCodingState').mockImplementation();
+    jest.spyOn(componentInternals, 'loadManualCodingApplyPermission').mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+
+    try {
+      componentInternals.appService.selectedWorkspaceId = 5;
+
+      isolatedComponent.ngOnInit();
+      manualRefreshSetting$.next(false);
+
+      expect(getSettingSpy).toHaveBeenCalledWith(5);
+      expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
+      expect(isolatedComponent.autoRefreshManualCodingJobs).toBe(false);
+    } finally {
+      isolatedFixture.destroy();
+      componentInternals.appService.selectedWorkspaceId = previousWorkspaceId;
+      getSettingSpy.mockRestore();
+    }
   });
 
   it('should ignore duplicate tab change events for the active manual tab', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1354,10 +1354,10 @@ describe('CodingManagementManualComponent', () => {
     expect(loadManualTabDataSpy).not.toHaveBeenCalled();
   });
 
-  it('should refresh the active manual workflow tab when the window regains focus', () => {
+  it('should refresh the active manual workflow tab without reloading jobs when the window regains focus', () => {
     component.selectedManualTabIndex = 1;
     const componentInternals = component as unknown as {
-      loadManualTabData(tab: 'planning'): void;
+      loadManualTabData(tab: 'planning', options?: { reloadCodingJobs?: boolean }): void;
       loadCodingFreshness(): void;
       reloadCodingJobsList(): void;
     };
@@ -1378,7 +1378,27 @@ describe('CodingManagementManualComponent', () => {
       { reloadCodingJobs: false }
     );
     expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
-    expect(reloadCodingJobsListSpy).toHaveBeenCalled();
+    expect(reloadCodingJobsListSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not refresh manual workflow tabs on focus when auto-refresh is disabled', () => {
+    component.selectedManualTabIndex = 1;
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      loadManualTabData(tab: 'planning', options?: { reloadCodingJobs?: boolean }): void;
+      loadCodingFreshness(): void;
+    };
+    const loadManualTabDataSpy = jest
+      .spyOn(componentInternals, 'loadManualTabData')
+      .mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+
+    window.dispatchEvent(new Event('focus'));
+
+    expect(loadManualTabDataSpy).not.toHaveBeenCalled();
+    expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
   });
 
   it('should not reload coding jobs twice when execution regains focus', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -275,8 +275,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   duplicateAggregationThreshold = 2;
   isApplyingDuplicateAggregation = false;
   private analysisPollingTimer?: ReturnType<typeof setTimeout>;
-  private readonly windowFocusRefreshThrottleMs = 1000;
+  private readonly windowFocusRefreshThrottleMs = 30000;
+  private readonly codingFreshnessRefreshThrottleMs = 30000;
   private lastWindowFocusRefreshAt = 0;
+  private lastCodingFreshnessRefreshAt = 0;
+  private codingFreshnessRequestGeneration = 0;
   private readonly handleWindowFocus = () => {
     if (!this.shouldRefreshManualStateOnFocus()) {
       return;
@@ -1515,10 +1518,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   refreshManualCodingPlanning(): void {
     const activeTab = this.activeManualTab;
-    this.loadManualTabData(activeTab);
+    this.loadManualTabData(activeTab, { forceRefresh: true });
     this.loadJobDefinitionsForExport();
     if (activeTab !== 'planning') {
-      this.loadCodingFreshness();
+      this.loadCodingFreshness({ force: true });
     }
     if (this.shouldReloadCodingJobsAfterManualTabData(activeTab)) {
       this.reloadCodingJobsList();
@@ -1530,29 +1533,25 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private shouldRefreshManualStateOnFocus(): boolean {
-    return this.activeManualTab === 'planning' ||
-      this.activeManualTab === 'execution' ||
-      this.activeManualTab === 'completion';
+    return this.autoRefreshManualCodingJobs &&
+      (this.activeManualTab === 'planning' ||
+        this.activeManualTab === 'execution' ||
+        this.activeManualTab === 'completion');
   }
 
   private refreshManualStateAfterExternalChange(): void {
     const activeTab = this.activeManualTab;
     this.loadManualTabData(activeTab, { reloadCodingJobs: false });
-    this.loadJobDefinitionsForExport();
     if (activeTab !== 'planning') {
       this.loadCodingFreshness();
     }
     if (this.shouldReloadCodingJobsAfterManualTabData(activeTab)) {
       this.reloadCodingJobsList();
     }
-
-    if (this.codingJobDefinitionsComponent) {
-      this.codingJobDefinitionsComponent.refresh();
-    }
   }
 
   private shouldReloadCodingJobsAfterManualTabData(tab: ManualCodingTab): boolean {
-    return tab !== 'training' && tab !== 'execution' && tab !== 'completion';
+    return tab === 'preparation';
   }
 
   isAnyPlanningDataLoading(): boolean {
@@ -2629,13 +2628,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private loadManualTabData(
     tab: ManualCodingTab,
-    options: { reloadCodingJobs?: boolean } = {}
+    options: { reloadCodingJobs?: boolean; forceRefresh?: boolean } = {}
   ): void {
     if (!this.isManualTabAvailable(tab)) {
       return;
     }
 
     const reloadCodingJobs = options.reloadCodingJobs ?? true;
+    const forceRefresh = options.forceRefresh ?? false;
     switch (tab) {
       case 'preparation':
         this.loadResponseAnalysis();
@@ -2646,7 +2646,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.loadCodingProgressOverview();
         this.loadCodingIncompleteVariables();
         this.loadManualFreshnessDecisionData();
-        this.loadCodingFreshness();
+        this.loadCodingFreshness({ force: forceRefresh });
         this.loadResponseAnalysisForPlanningIfNeeded();
         return;
       case 'training':
@@ -2969,24 +2969,59 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return score === null ? 'NA' : score;
   }
 
-  private loadCodingFreshness(): void {
+  private loadCodingFreshness(options: { force?: boolean } = {}): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.codingFreshnessRequestGeneration += 1;
       this.codingFreshnessSummary = null;
+      this.isLoadingCodingFreshness = false;
       return;
     }
 
+    if (!options.force && !this.autoRefreshManualCodingJobs) {
+      this.codingFreshnessRequestGeneration += 1;
+      this.isLoadingCodingFreshness = false;
+      return;
+    }
+
+    const now = Date.now();
+    if (
+      !options.force &&
+      (this.isLoadingCodingFreshness ||
+        (this.codingFreshnessSummary &&
+          now - this.lastCodingFreshnessRefreshAt <
+            this.codingFreshnessRefreshThrottleMs))
+    ) {
+      return;
+    }
+
+    const requestGeneration = this.codingFreshnessRequestGeneration + 1;
+    this.codingFreshnessRequestGeneration = requestGeneration;
     this.isLoadingCodingFreshness = true;
     this.testPersonCodingService
       .getCodingFreshness(workspaceId)
       .pipe(
         takeUntil(this.destroy$),
         finalize(() => {
-          this.isLoadingCodingFreshness = false;
+          if (
+            this.codingFreshnessRequestGeneration === requestGeneration &&
+            this.appService.selectedWorkspaceId === workspaceId
+          ) {
+            this.isLoadingCodingFreshness = false;
+          }
         })
       )
       .subscribe(summary => {
+        if (
+          this.codingFreshnessRequestGeneration !== requestGeneration ||
+          this.appService.selectedWorkspaceId !== workspaceId ||
+          (!options.force && !this.autoRefreshManualCodingJobs)
+        ) {
+          return;
+        }
+
         this.codingFreshnessSummary = summary;
+        this.lastCodingFreshnessRefreshAt = Date.now();
       });
   }
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -215,6 +215,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   validationProgress: ValidationProgress | null = null;
   isLoading = false;
   autoRefreshManualCodingJobs = true;
+  private hasLoadedManualCodingJobRefreshSetting = false;
   canApplyManualCodingResults = false;
   canManageManualCodingJobs = false;
   selectedManualTabIndex = 0;
@@ -526,7 +527,6 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.loadInitialManualCodingState();
     this.loadManualCodingJobRefreshSetting();
     this.loadManualCodingApplyPermission();
-    this.loadCodingFreshness();
     this.document.defaultView?.addEventListener('focus', this.handleWindowFocus);
   }
 
@@ -2674,6 +2674,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private loadManualCodingJobRefreshSetting(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.hasLoadedManualCodingJobRefreshSetting = true;
       this.autoRefreshManualCodingJobs = true;
       return;
     }
@@ -2681,8 +2682,19 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.workspaceSettingsService
       .getAutoRefreshManualCodingJobs(workspaceId)
       .pipe(takeUntil(this.destroy$))
-      .subscribe(enabled => {
-        this.autoRefreshManualCodingJobs = enabled;
+      .subscribe({
+        next: enabled => {
+          this.hasLoadedManualCodingJobRefreshSetting = true;
+          this.autoRefreshManualCodingJobs = enabled;
+          if (enabled) {
+            this.loadCodingFreshness();
+          }
+        },
+        error: () => {
+          this.hasLoadedManualCodingJobRefreshSetting = true;
+          this.autoRefreshManualCodingJobs = true;
+          this.loadCodingFreshness();
+        }
       });
   }
 
@@ -2974,6 +2986,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     if (!workspaceId) {
       this.codingFreshnessRequestGeneration += 1;
       this.codingFreshnessSummary = null;
+      this.isLoadingCodingFreshness = false;
+      return;
+    }
+
+    if (!options.force && !this.hasLoadedManualCodingJobRefreshSetting) {
+      this.codingFreshnessRequestGeneration += 1;
       this.isLoadingCodingFreshness = false;
       return;
     }

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
@@ -60,6 +60,8 @@
         <div class="coding-freshness-text">
           @if (isLoadingCodingFreshness || isLoadingAutocodingReadiness || isLoadingManualAppliedResultsOverview) {
           {{ 'coding-management.readiness.checking' | translate }}
+          } @else if (isCodingStatusOverviewPendingManualRefresh) {
+          {{ 'coding-management.readiness.manual-refresh-required' | translate }}
           } @else if (hasAutocodingReadinessLoadFailed) {
           {{ 'coding-management.readiness.load-failed' | translate }}
           } @else if (isAutocodingReadinessBlocked) {
@@ -113,6 +115,17 @@
         }
       </div>
     </div>
+
+    @if (shouldShowManualCodingStatusRefresh()) {
+    <div class="coding-freshness-actions">
+      <button mat-stroked-button color="primary"
+        [disabled]="isLoadingCodingFreshness || isLoadingManualAppliedResultsOverview || isLoadingAutocodingReadiness"
+        (click)="refreshCodingStatusOverview()">
+        <mat-icon>refresh</mat-icon>
+        {{ 'coding-management.readiness.refresh-status' | translate }}
+      </button>
+    </div>
+    }
 
     @if (isStartingFreshnessCoding) {
     <div class="coding-freshness-job">

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -93,7 +93,8 @@ describe('CodingManagementComponent', () => {
 
     mockWorkspaceSettingsService = {
       getAutoFetchCodingStatistics: jest.fn().mockReturnValue(of(false)),
-      getEnableRegexSearch: jest.fn().mockReturnValue(of(false))
+      getEnableRegexSearch: jest.fn().mockReturnValue(of(false)),
+      getAutoRefreshManualCodingJobs: jest.fn().mockReturnValue(of(true))
     };
     autoCodingCompletedSubject = new Subject<{ jobId?: string }>();
     testResultsChangedSubject = new Subject<TestResultsChangedEvent>();
@@ -248,6 +249,8 @@ describe('CodingManagementComponent', () => {
           'title-blocked': 'Auto-Coding 1 nicht möglich',
           'title-not-started': 'Kodierung noch nicht gestartet',
           'title-manual-coding-open': 'Manuelle Kodierung abschließen',
+          'title-not-checked': 'Kodierstand nicht automatisch geprüft',
+          'manual-refresh-required': 'Die automatische Aktualisierung ist deaktiviert. Aktualisieren Sie den Status bei Bedarf manuell.',
           summary: '{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus, aber {{codeableResponses}} kodierbare Antworten.',
           'details-result-units': '{{count}} Ergebnis-Units',
           'details-unit-files': '{{count}} passende Unit-Dateien',
@@ -261,6 +264,7 @@ describe('CodingManagementComponent', () => {
           'second-autocoding-waits-chip': '{{version}}: {{count}} wartet',
           'second-autocoding-waits-snackbar': 'Schließen Sie zuerst die manuelle Kodierung ab und übernehmen Sie die Ergebnisse.',
           'starting-freshness-coding': 'Auto-Coding wird gestartet...',
+          'refresh-status': 'Status aktualisieren',
           'open-manual-review': 'Manuelle Kodierung öffnen'
         }
       }
@@ -291,6 +295,10 @@ describe('CodingManagementComponent', () => {
 
     it('should check regex search setting on init', () => {
       expect(mockWorkspaceSettingsService.getEnableRegexSearch).toHaveBeenCalledWith(1);
+    });
+
+    it('should check manual coding auto-refresh setting on init', () => {
+      expect(mockWorkspaceSettingsService.getAutoRefreshManualCodingJobs).toHaveBeenCalledWith(1);
     });
 
     it('should load autocoding readiness for the first autocoder run', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -378,6 +378,23 @@ describe('CodingManagementComponent', () => {
   });
 
   describe('Coding Freshness', () => {
+    it('should show pending manual status refresh as an attention state', () => {
+      component.autoRefreshManualCodingJobs = false;
+      component.hasRequestedCodingStatusOverview = false;
+
+      expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(true);
+      expect(component.hasCodingFreshnessAttention).toBe(true);
+      expect(component.codingFreshnessPanelTitle).toBe('Kodierstand nicht automatisch geprüft');
+
+      fixture.detectChanges();
+      const freshnessPanel = fixture.nativeElement.querySelector(
+        '.coding-freshness-panel'
+      ) as HTMLElement;
+      const stateIcon = freshnessPanel.querySelector('mat-icon') as HTMLElement;
+      expect(freshnessPanel.classList.contains('is-current')).toBe(false);
+      expect(stateIcon.textContent?.trim()).toBe('warning');
+    });
+
     it('should keep second auto-coding waiting while manual coding results are still open', () => {
       component.codingFreshnessSummary = {
         workspaceId: 1,

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -182,6 +182,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   isLoadingManualAppliedResultsOverview = false;
   manualAppliedResultsOverviewLoadFailed = false;
   enableRegexSearch = false;
+  autoRefreshManualCodingJobs = true;
+  hasRequestedCodingStatusOverview = false;
   isStartingFreshnessCoding = false;
   activeFreshnessJobId: string | null = null;
   activeFreshnessJobProgress: number | null = null;
@@ -228,6 +230,15 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         .pipe(takeUntil(this.destroy$))
         .subscribe(enabled => {
           this.enableRegexSearch = enabled;
+        });
+      this.workspaceSettingsService
+        .getAutoRefreshManualCodingJobs(workspaceId)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(enabled => {
+          this.autoRefreshManualCodingJobs = enabled;
+          if (enabled) {
+            this.loadCodingStatusOverview();
+          }
         });
 
       this.codingManagementService.hasGeogebraResponses()
@@ -301,11 +312,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         if (event?.jobId && event.jobId === this.activeFreshnessJobId) {
           this.stopFreshnessJobPolling();
         }
-        this.fetchCodingStatistics();
-        this.loadCodingFreshness();
-        this.loadManualAppliedResultsOverview();
-        this.loadAutocodingReadiness();
-        this.refreshTableData();
+        this.refreshCodingStatusOverviewAfterChange();
       });
 
     this.testPersonCodingService.testResultsChanged$
@@ -316,9 +323,6 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
     // Check for active reset job (persists across navigation)
     this.codingManagementService.checkActiveResetJob();
-    this.loadCodingFreshness();
-    this.loadManualAppliedResultsOverview();
-    this.loadAutocodingReadiness();
     this.route.queryParamMap
       .pipe(takeUntil(this.destroy$))
       .subscribe(params => {
@@ -369,11 +373,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         this.testPersonCodingService.consumePendingStatisticsVersion(workspaceId);
       }
     }
-    this.fetchCodingStatistics();
-    this.loadCodingFreshness();
-    this.loadManualAppliedResultsOverview();
-    this.loadAutocodingReadiness();
-    this.refreshTableData();
+    this.refreshCodingStatusOverviewAfterChange();
   }
 
   fetchCodingStatistics(): void {
@@ -470,12 +470,31 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.loadAutocodingReadiness(true);
   }
 
-  private refreshCodingStatusOverview(): void {
+  refreshCodingStatusOverview(): void {
     this.fetchCodingStatistics();
+    this.loadCodingStatusOverview(true);
+    this.refreshTableData();
+  }
+
+  private refreshCodingStatusOverviewAfterChange(): void {
+    if (!this.autoRefreshManualCodingJobs) {
+      return;
+    }
+
+    this.fetchCodingStatistics();
+    this.loadCodingStatusOverview();
+    this.refreshTableData();
+  }
+
+  loadCodingStatusOverview(forceAutocodingReadiness = false): void {
+    this.hasRequestedCodingStatusOverview = true;
     this.loadCodingFreshness();
     this.loadManualAppliedResultsOverview();
-    this.loadAutocodingReadiness(true);
-    this.refreshTableData();
+    this.loadAutocodingReadiness(forceAutocodingReadiness);
+  }
+
+  shouldShowManualCodingStatusRefresh(): boolean {
+    return !this.autoRefreshManualCodingJobs;
   }
 
   startFreshnessCoding(version: 'v1' | 'v3'): void {
@@ -816,6 +835,11 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       this.hasImportedResultsWithoutCoding;
   }
 
+  get isCodingStatusOverviewPendingManualRefresh(): boolean {
+    return !this.hasRequestedCodingStatusOverview &&
+      this.shouldShowManualCodingStatusRefresh();
+  }
+
   get autoCodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
     return getCodingFreshnessAutoCodingWarnings(this.codingFreshnessWarnings);
   }
@@ -878,6 +902,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get codingFreshnessPanelTitle(): string {
+    if (this.isCodingStatusOverviewPendingManualRefresh) {
+      return this.translateService.instant('coding-management.readiness.title-not-checked');
+    }
+
     if (this.hasAutocodingReadinessLoadFailed) {
       return this.translateService.instant('coding-management.readiness.title-load-failed');
     }

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -829,7 +829,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get hasCodingFreshnessAttention(): boolean {
-    return this.hasAutocodingReadinessLoadFailed ||
+    return this.isCodingStatusOverviewPendingManualRefresh ||
+      this.hasAutocodingReadinessLoadFailed ||
       this.isAutocodingReadinessBlocked ||
       this.hasCodingFreshnessWarnings ||
       this.hasImportedResultsWithoutCoding;

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1383,7 +1383,9 @@
       "title-blocked": "Auto-Coding 1 nicht möglich",
       "title-not-started": "Kodierung noch nicht gestartet",
       "title-manual-coding-open": "Manuelle Kodierung abschließen",
+      "title-not-checked": "Kodierstand nicht automatisch geprüft",
       "checking": "Zustand wird geprüft...",
+      "manual-refresh-required": "Die automatische Aktualisierung ist deaktiviert. Aktualisieren Sie den Status bei Bedarf manuell.",
       "summary": "{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus, aber {{codeableResponses}} kodierbare Antworten.",
       "details-result-units": "{{count}} Ergebnis-Units",
       "details-unit-files": "{{count}} passende Unit-Dateien",
@@ -1407,6 +1409,7 @@
       "starting-freshness-coding": "Auto-Coding wird gestartet...",
       "update-running": "Aktualisierung läuft: {{progress}}%",
       "retry": "Erneut prüfen",
+      "refresh-status": "Status aktualisieren",
       "check-test-files": "Testdateien prüfen",
       "open-manual-review": "Manuelle Kodierung öffnen"
     },


### PR DESCRIPTION
## What changed

Split out the minimal ticket fix from #830.

- gates coding status refreshes in the coding overview behind the existing manual-coding auto-refresh setting
- keeps a manual status refresh action visible when automatic refresh is disabled
- avoids claiming the coding status is current before a manual check has run
- prevents focus refreshes in manual coding when auto-refresh is disabled
- stops planning/focus refreshes from reloading coding jobs and job definitions without an explicit action

## Why

Issue #813 describes repeated status/readiness/job reloads while switching tabs or returning focus to the browser. This PR keeps the behavior change small and leaves backend cache/query optimizations and other UI guards to separate PRs.

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts --runInBand --skip-nx-cache`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts --runInBand --skip-nx-cache`
- `npx nx lint frontend --skip-nx-cache`
