### PR TITLE
Split response analysis chunk caching from #830

### DIFF
--- a/api-dto/coding/response-analysis.dto.ts
+++ b/api-dto/coding/response-analysis.dto.ts
@@ -23,6 +23,7 @@ export interface DuplicateValueGroupDto {
   variableId: string;
   normalizedValue: string;
   originalValue: string;
+  occurrenceCount?: number;
   occurrences: {
     personLogin: string;
     personCode: string;
@@ -65,6 +66,8 @@ export interface ResponseAnalysisDto {
   aggregationSummary: AggregationSummaryDto;
   matchingFlags: string[];
   analysisTimestamp: string;
+  sourceRevision?: number;
+  currentSourceRevision?: number;
   isCalculating?: boolean;
   progress?: number;
 }

--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
@@ -21,7 +21,11 @@ import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
 import { WorkspaceId } from './workspace.decorator';
 import { AccessLevelGuard, RequireAccessLevel } from './access-level.guard';
-import { CodingValidationService, CodingAnalysisService, MissingsProfilesService } from '../../database/services/coding';
+import {
+  CodingValidationService,
+  CodingAnalysisService,
+  MissingsProfilesService
+} from '../../database/services/coding';
 import { VariableAnalysisReplayService } from '../../database/services/test-results';
 import { ExportValidationResultsService } from '../../database/services/validation';
 import { VariableAnalysisItemDto } from '../../../../../../api-dto/coding/variable-analysis-item.dto';
@@ -44,7 +48,7 @@ export class WorkspaceCodingAnalysisController {
     private missingsProfilesService: MissingsProfilesService,
     @InjectRepository(Setting)
     private readonly settingRepository: Repository<Setting>
-  ) { }
+  ) {}
 
   @Get(':workspace_id/coding/variable-analysis')
   @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
@@ -96,7 +100,8 @@ export class WorkspaceCodingAnalysisController {
   @ApiQuery({
     name: 'regexSearch',
     required: false,
-    description: 'Interpret variable ID filter as a case-sensitive regular expression',
+    description:
+      'Interpret variable ID filter as a case-sensitive regular expression',
     type: Boolean
   })
   async getVariableAnalysis(
@@ -117,8 +122,12 @@ export class WorkspaceCodingAnalysisController {
       }> {
     const validPage = Math.max(1, page);
     const validLimit = Math.min(Math.max(1, limit), 500); // Set maximum limit to 500
-    const effectiveRegexSearch = regexSearch === 'true' &&
-      await getWorkspaceRegexSearchEnabled(this.settingRepository, workspace_id);
+    const effectiveRegexSearch =
+      regexSearch === 'true' &&
+      (await getWorkspaceRegexSearchEnabled(
+        this.settingRepository,
+        workspace_id
+      ));
 
     return this.variableAnalysisReplayService.getVariableAnalysis(
       workspace_id,
@@ -224,13 +233,15 @@ export class WorkspaceCodingAnalysisController {
   @ApiQuery({
     name: 'includeDeriveErrorOnly',
     required: false,
-    description: 'Also include variables that only have DERIVE_ERROR responses and expose DERIVE_ERROR-aware case counts',
+    description:
+      'Also include variables that only have DERIVE_ERROR responses and expose DERIVE_ERROR-aware case counts',
     type: Boolean
   })
   @ApiQuery({
     name: 'excludeJobDefinitionId',
     required: false,
-    description: 'Ignore coding jobs from this job definition when calculating remaining cases',
+    description:
+      'Ignore coding jobs from this job definition when calculating remaining cases',
     type: Number
   })
   @ApiOkResponse({
@@ -261,19 +272,23 @@ export class WorkspaceCodingAnalysisController {
           },
           uniqueCasesAfterAggregation: {
             type: 'number',
-            description: 'Number of unique coding cases after applying aggregation grouping (1 per duplicate group)'
+            description:
+              'Number of unique coding cases after applying aggregation grouping (1 per duplicate group)'
           },
           availableCasesWithDeriveError: {
             type: 'number',
-            description: 'Number of available cases when DERIVE_ERROR is included'
+            description:
+              'Number of available cases when DERIVE_ERROR is included'
           },
           uniqueCasesAfterAggregationWithDeriveError: {
             type: 'number',
-            description: 'Number of unique coding cases after aggregation when DERIVE_ERROR is included'
+            description:
+              'Number of unique coding cases after aggregation when DERIVE_ERROR is included'
           },
           isDerived: {
             type: 'boolean',
-            description: 'Whether this is a derived variable (computed from other variables)'
+            description:
+              'Whether this is a derived variable (computed from other variables)'
           }
         }
       }
@@ -368,7 +383,9 @@ export class WorkspaceCodingAnalysisController {
     @WorkspaceId() workspace_id: number,
       @Query('unitName') unitName?: string,
       @Query('trainingRequired') trainingRequired?: string
-  ): Promise<Awaited<ReturnType<CodingValidationService['getManualCodingScopeSummary']>>> {
+  ): Promise<
+      Awaited<ReturnType<CodingValidationService['getManualCodingScopeSummary']>>
+      > {
     let trainingRequiredParam: boolean | undefined;
     if (trainingRequired === 'true') {
       trainingRequiredParam = true;
@@ -453,8 +470,7 @@ export class WorkspaceCodingAnalysisController {
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiBody({
-    description:
-      'List of manual coding variables to check for applied results',
+    description: 'List of manual coding variables to check for applied results',
     schema: {
       type: 'object',
       properties: {
@@ -601,7 +617,8 @@ export class WorkspaceCodingAnalysisController {
             },
             duplicateResponses: {
               type: 'number',
-              description: 'Number of responses in aggregatable duplicate groups'
+              description:
+                'Number of responses in aggregatable duplicate groups'
             },
             collapsedCases: {
               type: 'number',
@@ -635,9 +652,21 @@ export class WorkspaceCodingAnalysisController {
           type: 'string',
           description: 'ISO timestamp of when the analysis was performed'
         },
+        sourceRevision: {
+          type: 'number',
+          nullable: true,
+          description:
+            'Test result revision the cached analysis was calculated from'
+        },
+        currentSourceRevision: {
+          type: 'number',
+          nullable: true,
+          description: 'Current test result revision for the workspace'
+        },
         isCalculating: {
           type: 'boolean',
-          description: 'Whether the analysis is currently being calculated in the background'
+          description:
+            'Whether the analysis is currently being calculated in the background'
         }
       }
     }
@@ -652,9 +681,14 @@ export class WorkspaceCodingAnalysisController {
   ) {
     const validThreshold = this.normalizeIntegerParam(threshold, 2, 2, 100);
     const vEmptyPage = this.normalizeIntegerParam(emptyPage, 1, 1);
-    const vEmptyLimit = this.normalizeIntegerParam(emptyLimit, 50, 1);
+    const vEmptyLimit = this.normalizeIntegerParam(emptyLimit, 50, 1, 500);
     const vDuplicatePage = this.normalizeIntegerParam(duplicatePage, 1, 1);
-    const vDuplicateLimit = this.normalizeIntegerParam(duplicateLimit, 50, 1);
+    const vDuplicateLimit = this.normalizeIntegerParam(
+      duplicateLimit,
+      50,
+      1,
+      500
+    );
 
     return this.codingAnalysisService.getResponseAnalysis(
       workspace_id,
@@ -674,9 +708,7 @@ export class WorkspaceCodingAnalysisController {
   @ApiOkResponse({
     description: 'Current response aggregation settings.'
   })
-  async getAggregationSettings(
-  @WorkspaceId() workspace_id: number
-  ) {
+  async getAggregationSettings(@WorkspaceId() workspace_id: number) {
     return this.codingAnalysisService.getAggregationSettings(workspace_id);
   }
 
@@ -692,7 +724,8 @@ export class WorkspaceCodingAnalysisController {
       properties: {
         threshold: {
           type: 'number',
-          description: 'Minimum number of duplicate occurrences to trigger aggregation',
+          description:
+            'Minimum number of duplicate occurrences to trigger aggregation',
           example: 2,
           minimum: 2,
           maximum: 100
@@ -735,7 +768,8 @@ export class WorkspaceCodingAnalysisController {
       properties: {
         threshold: {
           type: 'number',
-          description: 'Minimum number of duplicate occurrences to trigger aggregation',
+          description:
+            'Minimum number of duplicate occurrences to trigger aggregation',
           example: 2,
           minimum: 2
         },
@@ -764,7 +798,8 @@ export class WorkspaceCodingAnalysisController {
         },
         uniqueCodingCases: {
           type: 'number',
-          description: 'New total count of unique coding cases after aggregation'
+          description:
+            'New total count of unique coding cases after aggregation'
         },
         message: { type: 'string' }
       }
@@ -799,9 +834,10 @@ export class WorkspaceCodingAnalysisController {
     @WorkspaceId() workspace_id: number,
                    @Body() body: { threshold?: number } = {}
   ): Promise<void> {
-    const threshold = body.threshold === undefined ?
-      undefined :
-      this.normalizeIntegerParam(body.threshold, 2, 2, 100);
+    const threshold =
+      body.threshold === undefined ?
+        undefined :
+        this.normalizeIntegerParam(body.threshold, 2, 2, 100);
 
     await this.codingAnalysisService.startAnalysis(
       workspace_id,

--- a/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-analysis.controller.ts
@@ -590,8 +590,16 @@ export class WorkspaceCodingAnalysisController {
                   variableId: { type: 'string' },
                   normalizedValue: { type: 'string' },
                   originalValue: { type: 'string' },
+                  occurrenceCount: {
+                    type: 'number',
+                    nullable: true,
+                    description:
+                      'Total number of matching responses. occurrences may contain only a preview.'
+                  },
                   occurrences: {
                     type: 'array',
+                    description:
+                      'Preview of matching responses for this duplicate group.',
                     items: {
                       type: 'object',
                       properties: {

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
@@ -218,17 +218,54 @@ describe('CodingAnalysisService aggregation settings', () => {
         matchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
         threshold: 4,
         cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
-        runId: 'existing-run'
+        runId: 'existing-run',
+        sourceRevision: 11
       }
     });
 
     await service.startAnalysis(7, [ResponseMatchingFlag.IGNORE_CASE], 4);
 
+    expect(jobQueueService.getCodingAnalysisJobForCacheKey).toHaveBeenCalledWith(
+      7,
+      'response-analysis:7_IGNORE_CASE_t4',
+      11
+    );
     expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
     expect(cacheService.set).not.toHaveBeenCalledWith(
       'response-analysis:7_IGNORE_CASE_t4:run',
       expect.any(String),
       0
+    );
+  });
+
+  it('queues a superseding analysis when an older revision job uses the same cache key', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    jobQueueService.getActiveCodingAnalysisJob.mockResolvedValue({
+      id: 'old-job',
+      data: {
+        workspaceId: 7,
+        matchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
+        threshold: 4,
+        cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
+        runId: 'old-run',
+        sourceRevision: 10
+      }
+    });
+
+    await service.startAnalysis(7, [ResponseMatchingFlag.IGNORE_CASE], 4);
+
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'response-analysis:7_IGNORE_CASE_t4:run',
+      expect.any(String),
+      0
+    );
+    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 7,
+        cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
+        sourceRevision: 11,
+        runId: expect.any(String)
+      })
     );
   });
 
@@ -489,7 +526,7 @@ describe('CodingAnalysisService aggregation settings', () => {
     );
   });
 
-  it('keeps legacy cached response analysis without revision usable', async () => {
+  it('marks legacy cached response analysis without revision stale', async () => {
     const { service, cacheService, jobQueueService } = createService();
     const cachedAnalysis = {
       emptyResponses: { total: 0, totalUncoded: 0, items: [] },
@@ -517,8 +554,14 @@ describe('CodingAnalysisService aggregation settings', () => {
     const result = await service.getResponseAnalysis(7);
 
     expect(result.currentSourceRevision).toBe(11);
-    expect(result.isCalculating).toBe(false);
-    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+    expect(result.isCalculating).toBe(true);
+    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 7,
+        cacheKey: 'response-analysis:7__t2',
+        sourceRevision: 11
+      })
+    );
   });
 
   it('keeps only a duplicate occurrence preview in page caches', () => {

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
@@ -5,6 +5,12 @@ import { ResponseEntity } from '../../entities/response.entity';
 import Persons from '../../entities/persons.entity';
 import { Unit } from '../../entities/unit.entity';
 import { Booklet } from '../../entities/booklet.entity';
+import {
+  createDuplicateValuePageCache,
+  createEmptyResponseChunkCaches,
+  createDuplicateValueChunkCaches,
+  RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+} from './response-analysis-page-cache.util';
 
 jest.mock('./coding-job.service', () => ({
   ResponseMatchingFlag: {
@@ -34,18 +40,22 @@ describe('CodingAnalysisService aggregation settings', () => {
     };
     const responseRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
-      update: jest.fn().mockResolvedValue(undefined)
+      update: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue([{ revision: 11 }])
     } as unknown as Repository<ResponseEntity>;
     const codingJobService = {
       getAggregationThreshold: jest.fn().mockResolvedValue(2),
       getResponseMatchingMode: jest.fn().mockResolvedValue([]),
       setAggregationThreshold: jest.fn().mockResolvedValue(undefined),
-      setResponseMatchingMode: jest.fn().mockImplementation((_workspaceId, flags) => Promise.resolve(flags)),
-      normalizeResponseMatchingFlags: jest.fn().mockImplementation(flags => (
-        flags?.includes(ResponseMatchingFlag.NO_AGGREGATION) ?
+      setResponseMatchingMode: jest
+        .fn()
+        .mockImplementation((_workspaceId, flags) => Promise.resolve(flags)),
+      normalizeResponseMatchingFlags: jest
+        .fn()
+        .mockImplementation(flags => (flags?.includes(ResponseMatchingFlag.NO_AGGREGATION) ?
           [ResponseMatchingFlag.NO_AGGREGATION] :
-          Array.from(new Set(flags ?? []))
-      ))
+          Array.from(new Set(flags ?? [])))
+        )
     };
     const codingValidationService = {
       invalidateIncompleteVariablesCache: jest.fn().mockResolvedValue(undefined)
@@ -54,12 +64,14 @@ describe('CodingAnalysisService aggregation settings', () => {
       invalidateCache: jest.fn().mockResolvedValue(undefined)
     };
     const cacheService = {
+      get: jest.fn().mockResolvedValue(null),
       delete: jest.fn().mockResolvedValue(undefined),
       set: jest.fn().mockResolvedValue(true),
       deleteByPattern: jest.fn().mockResolvedValue(undefined)
     };
     const jobQueueService = {
       getActiveCodingAnalysisJob: jest.fn().mockResolvedValue(null),
+      getCodingAnalysisJobForCacheKey: jest.fn().mockResolvedValue(null),
       addCodingAnalysisJob: jest.fn().mockResolvedValue(undefined)
     };
 
@@ -108,14 +120,23 @@ describe('CodingAnalysisService aggregation settings', () => {
       aggregationActive: true,
       revertedResponses: 2
     });
-    expect(codingJobService.setAggregationThreshold).toHaveBeenCalledWith(7, 100);
-    expect(codingJobService.setResponseMatchingMode).toHaveBeenCalledWith(7, [ResponseMatchingFlag.IGNORE_CASE]);
+    expect(codingJobService.setAggregationThreshold).toHaveBeenCalledWith(
+      7,
+      100
+    );
+    expect(codingJobService.setResponseMatchingMode).toHaveBeenCalledWith(7, [
+      ResponseMatchingFlag.IGNORE_CASE
+    ]);
     expect(responseRepository.update).toHaveBeenCalledWith(
       { id: expect.anything() },
       { code_v2: null, score_v2: null, status_v2: null }
     );
-    expect(cacheService.deleteByPattern).toHaveBeenCalledWith('response-analysis:7_*');
-    expect(codingValidationService.invalidateIncompleteVariablesCache).toHaveBeenCalledWith(7);
+    expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+      'response-analysis:7_*'
+    );
+    expect(
+      codingValidationService.invalidateIncompleteVariablesCache
+    ).toHaveBeenCalledWith(7);
     expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(7);
   });
 
@@ -135,17 +156,18 @@ describe('CodingAnalysisService aggregation settings', () => {
   });
 
   it('clears the selected analysis cache before a forced restart', async () => {
-    const {
-      service,
-      cacheService,
-      jobQueueService
-    } = createService();
+    const { service, cacheService, jobQueueService } = createService();
 
     await service.startAnalysis(7, [ResponseMatchingFlag.IGNORE_CASE], 4, {
       forceRefresh: true
     });
 
-    expect(cacheService.delete).toHaveBeenCalledWith('response-analysis:7_IGNORE_CASE_t4');
+    expect(cacheService.delete).toHaveBeenCalledWith(
+      'response-analysis:7_IGNORE_CASE_t4'
+    );
+    expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+      'response-analysis:7_IGNORE_CASE_t4:*'
+    );
     expect(cacheService.set).toHaveBeenCalledWith(
       'response-analysis:7_IGNORE_CASE_t4:run',
       expect.any(String),
@@ -156,15 +178,13 @@ describe('CodingAnalysisService aggregation settings', () => {
       matchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
       threshold: 4,
       cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
-      runId: expect.any(String)
+      runId: expect.any(String),
+      sourceRevision: 11
     });
   });
 
   it('queues a superseding forced restart even when an older workspace analysis is active', async () => {
-    const {
-      service,
-      jobQueueService
-    } = createService();
+    const { service, jobQueueService } = createService();
     jobQueueService.getActiveCodingAnalysisJob.mockResolvedValue({
       id: 'old-job',
       data: {
@@ -180,10 +200,371 @@ describe('CodingAnalysisService aggregation settings', () => {
       forceRefresh: true
     });
 
-    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith(expect.objectContaining({
-      workspaceId: 7,
-      cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
-      runId: expect.any(String)
-    }));
+    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 7,
+        cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
+        runId: expect.any(String)
+      })
+    );
+  });
+
+  it('reuses an existing matching response analysis job without resetting its run marker', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    jobQueueService.getCodingAnalysisJobForCacheKey.mockResolvedValue({
+      id: 'queued-job',
+      data: {
+        workspaceId: 7,
+        matchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
+        threshold: 4,
+        cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
+        runId: 'existing-run'
+      }
+    });
+
+    await service.startAnalysis(7, [ResponseMatchingFlag.IGNORE_CASE], 4);
+
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+    expect(cacheService.set).not.toHaveBeenCalledWith(
+      'response-analysis:7_IGNORE_CASE_t4:run',
+      expect.any(String),
+      0
+    );
+  });
+
+  it('serves response analysis from lightweight page caches without reading the full payload', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    cacheService.get.mockImplementation((key: string) => {
+      if (key === 'response-analysis:7__t2:summary') {
+        return Promise.resolve({
+          emptyResponses: { total: 12, totalUncoded: 9 },
+          duplicateValues: {
+            total: 3,
+            totalResponses: 8,
+            isAggregationApplied: false
+          },
+          aggregationSummary: {
+            duplicateGroups: 3,
+            duplicateResponses: 8,
+            collapsedCases: 5,
+            rawCases: 8,
+            effectiveCases: 3,
+            threshold: 2,
+            aggregationActive: true
+          },
+          matchingFlags: [],
+          analysisTimestamp: '2026-05-22T00:00:00.000Z',
+          sourceRevision: 11
+        });
+      }
+      if (key === 'response-analysis:7__t2:empty:p2:l5') {
+        return Promise.resolve({
+          items: [
+            {
+              responseId: 101,
+              unitName: 'u',
+              unitAlias: null,
+              variableId: 'v',
+              personLogin: 'p',
+              personCode: 'c',
+              personGroup: 'g',
+              bookletName: 'b',
+              value: null
+            }
+          ],
+          page: 2,
+          pageSize: 5
+        });
+      }
+      if (key === 'response-analysis:7__t2:duplicate:p3:l10') {
+        return Promise.resolve({
+          groups: [],
+          page: 3,
+          pageSize: 10
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await service.getResponseAnalysis(7, 2, 2, 5, 3, 10);
+
+    expect(result.emptyResponses.total).toBe(12);
+    expect(result.emptyResponses.page).toBe(2);
+    expect(result.emptyResponses.items).toHaveLength(1);
+    expect(result.duplicateValues.totalResponses).toBe(8);
+    expect(result.currentSourceRevision).toBe(11);
+    expect(result.isCalculating).toBe(false);
+    expect(cacheService.get).not.toHaveBeenCalledWith(
+      'response-analysis:7__t2'
+    );
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+  });
+
+  it('serves response analysis pages from chunk caches without reading the full payload', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    const analysis = {
+      emptyResponses: {
+        total: 2,
+        totalUncoded: 2,
+        items: [
+          {
+            responseId: 101,
+            unitName: 'u1',
+            unitAlias: null,
+            variableId: 'v',
+            personLogin: 'p1',
+            personCode: 'c1',
+            personGroup: 'g',
+            bookletName: 'b',
+            value: null
+          },
+          {
+            responseId: 102,
+            unitName: 'u2',
+            unitAlias: null,
+            variableId: 'v',
+            personLogin: 'p2',
+            personCode: 'c2',
+            personGroup: 'g',
+            bookletName: 'b',
+            value: null
+          }
+        ]
+      },
+      duplicateValues: {
+        total: 1,
+        totalResponses: 6,
+        groups: [
+          {
+            unitName: 'u',
+            unitAlias: null,
+            variableId: 'v',
+            normalizedValue: 'same',
+            originalValue: 'same',
+            occurrences: Array.from({ length: 6 }, (_, index) => ({
+              personLogin: `p${index}`,
+              personCode: `${index}`,
+              bookletName: 'b',
+              responseId: index,
+              value: 'same'
+            }))
+          }
+        ],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 1,
+        duplicateResponses: 6,
+        collapsedCases: 5,
+        rawCases: 8,
+        effectiveCases: 3,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: '2026-05-22T00:00:00.000Z',
+      sourceRevision: 11
+    };
+    const emptyChunks = createEmptyResponseChunkCaches(analysis);
+    const duplicateChunks = createDuplicateValueChunkCaches(analysis);
+    cacheService.get.mockImplementation((key: string) => {
+      if (key === 'response-analysis:7__t2:summary') {
+        return Promise.resolve({
+          emptyResponses: { total: 2, totalUncoded: 2 },
+          duplicateValues: {
+            total: 1,
+            totalResponses: 6,
+            isAggregationApplied: false
+          },
+          aggregationSummary: analysis.aggregationSummary,
+          matchingFlags: [],
+          analysisTimestamp: analysis.analysisTimestamp,
+          sourceRevision: 11
+        });
+      }
+      if (key === 'response-analysis:7__t2:empty-chunk:0') {
+        return Promise.resolve(emptyChunks[0]);
+      }
+      if (key === 'response-analysis:7__t2:duplicate-chunk:0') {
+        return Promise.resolve(duplicateChunks[0]);
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await service.getResponseAnalysis(7, 2, 1, 1, 1, 1);
+
+    expect(result.emptyResponses.items).toHaveLength(1);
+    expect(result.emptyResponses.items[0].responseId).toBe(101);
+    expect(result.duplicateValues.groups).toHaveLength(1);
+    expect(result.duplicateValues.groups[0].occurrences).toHaveLength(
+      RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+    );
+    expect(result.currentSourceRevision).toBe(11);
+    expect(result.isCalculating).toBe(false);
+    expect(cacheService.get).not.toHaveBeenCalledWith(
+      'response-analysis:7__t2'
+    );
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+  });
+
+  it('serves out-of-range response analysis pages from summary cache without recalculating', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    cacheService.get.mockImplementation((key: string) => {
+      if (key === 'response-analysis:7__t2:summary') {
+        return Promise.resolve({
+          emptyResponses: { total: 2, totalUncoded: 2 },
+          duplicateValues: {
+            total: 1,
+            totalResponses: 6,
+            isAggregationApplied: false
+          },
+          aggregationSummary: {
+            duplicateGroups: 1,
+            duplicateResponses: 6,
+            collapsedCases: 5,
+            rawCases: 8,
+            effectiveCases: 3,
+            threshold: 2,
+            aggregationActive: true
+          },
+          matchingFlags: [],
+          analysisTimestamp: '2026-05-22T00:00:00.000Z',
+          sourceRevision: 11
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await service.getResponseAnalysis(7, 2, 99, 50, 42, 50);
+
+    expect(result.emptyResponses.total).toBe(2);
+    expect(result.emptyResponses.page).toBe(99);
+    expect(result.emptyResponses.items).toEqual([]);
+    expect(result.duplicateValues.total).toBe(1);
+    expect(result.duplicateValues.page).toBe(42);
+    expect(result.duplicateValues.groups).toEqual([]);
+    expect(cacheService.get).not.toHaveBeenCalledWith(
+      'response-analysis:7__t2'
+    );
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+  });
+
+  it('marks cached response analysis stale when the test result revision changed', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    const cachedAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 0,
+        totalResponses: 0,
+        groups: [],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 0,
+        duplicateResponses: 0,
+        collapsedCases: 0,
+        rawCases: 5,
+        effectiveCases: 5,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: '2026-05-22T00:00:00.000Z',
+      sourceRevision: 10
+    };
+    cacheService.get.mockImplementation((key: string) => Promise.resolve(key === 'response-analysis:7__t2' ? cachedAnalysis : null)
+    );
+
+    const result = await service.getResponseAnalysis(7);
+
+    expect(result.sourceRevision).toBe(10);
+    expect(result.currentSourceRevision).toBe(11);
+    expect(result.isCalculating).toBe(true);
+    expect(jobQueueService.addCodingAnalysisJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 7,
+        cacheKey: 'response-analysis:7__t2',
+        sourceRevision: 11
+      })
+    );
+  });
+
+  it('keeps legacy cached response analysis without revision usable', async () => {
+    const { service, cacheService, jobQueueService } = createService();
+    const cachedAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 0,
+        totalResponses: 0,
+        groups: [],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 0,
+        duplicateResponses: 0,
+        collapsedCases: 0,
+        rawCases: 5,
+        effectiveCases: 5,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: '2026-05-22T00:00:00.000Z'
+    };
+    cacheService.get.mockImplementation((key: string) => Promise.resolve(key === 'response-analysis:7__t2' ? cachedAnalysis : null)
+    );
+
+    const result = await service.getResponseAnalysis(7);
+
+    expect(result.currentSourceRevision).toBe(11);
+    expect(result.isCalculating).toBe(false);
+    expect(jobQueueService.addCodingAnalysisJob).not.toHaveBeenCalled();
+  });
+
+  it('keeps only a duplicate occurrence preview in page caches', () => {
+    const pageCache = createDuplicateValuePageCache(
+      {
+        emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+        duplicateValues: {
+          total: 1,
+          totalResponses: 12,
+          isAggregationApplied: false,
+          groups: [
+            {
+              unitName: 'u',
+              unitAlias: null,
+              variableId: 'v',
+              normalizedValue: 'same',
+              originalValue: 'same',
+              occurrences: Array.from({ length: 12 }, (_, index) => ({
+                personLogin: `person-${index}`,
+                personCode: `${index}`,
+                bookletName: 'booklet',
+                responseId: index,
+                value: 'same'
+              }))
+            }
+          ]
+        },
+        aggregationSummary: {
+          duplicateGroups: 1,
+          duplicateResponses: 12,
+          collapsedCases: 11,
+          rawCases: 12,
+          effectiveCases: 1,
+          threshold: 2,
+          aggregationActive: true
+        },
+        matchingFlags: [],
+        analysisTimestamp: '2026-05-22T00:00:00.000Z'
+      },
+      1,
+      10
+    );
+
+    expect(pageCache.groups[0].occurrenceCount).toBe(12);
+    expect(pageCache.groups[0].occurrences).toHaveLength(
+      RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+    );
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
@@ -378,7 +378,8 @@ export class CodingAnalysisService {
     const reusableJob =
       await this.jobQueueService.getCodingAnalysisJobForCacheKey(
         workspaceId,
-        cacheKey
+        cacheKey,
+        sourceRevision
       );
     if (reusableJob && !options.forceRefresh) {
       this.logger.log(
@@ -391,10 +392,20 @@ export class CodingAnalysisService {
     const activeJob =
       await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
     if (activeJob && !options.forceRefresh) {
+      const activeJobData = activeJob.data;
+      if (
+        activeJobData.cacheKey !== cacheKey ||
+        activeJobData.sourceRevision === sourceRevision
+      ) {
+        this.logger.log(
+          `Analysis job already running for workspace ${workspaceId} (Job ID: ${activeJob.id})`
+        );
+        return;
+      }
+
       this.logger.log(
-        `Analysis job already running for workspace ${workspaceId} (Job ID: ${activeJob.id})`
+        `Superseding stale response analysis job for workspace ${workspaceId} (Job ID: ${activeJob.id})`
       );
-      return;
     }
 
     if (activeJob && options.forceRefresh) {
@@ -677,10 +688,7 @@ export class CodingAnalysisService {
     analysis: Pick<ResponseAnalysisDto, 'sourceRevision'>,
     currentSourceRevision: number
   ): boolean {
-    return (
-      analysis.sourceRevision !== undefined &&
-      analysis.sourceRevision !== currentSourceRevision
-    );
+    return analysis.sourceRevision !== currentSourceRevision;
   }
 
   private async getWorkspaceResultsRevision(

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
@@ -9,14 +9,9 @@ import { ResponseEntity } from '../../entities/response.entity';
 import {
   ResponseAnalysisDto,
   EmptyResponseDto,
-  DuplicateValueGroupDto,
-  EmptyResponseAnalysisDto,
-  DuplicateValueAnalysisDto
+  DuplicateValueGroupDto
 } from '../../../../../../../api-dto/coding/response-analysis.dto';
-import {
-  CodingJobService,
-  ResponseMatchingFlag
-} from './coding-job.service';
+import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { CodingValidationService } from './coding-validation.service';
 import { CodingStatisticsService } from './coding-statistics.service';
 import { CacheService } from '../../../cache/cache.service';
@@ -27,6 +22,28 @@ import {
   getCodingAnalysisCacheKey,
   getCodingAnalysisRunMarkerKey
 } from './coding-analysis-cache-key.util';
+import {
+  createDuplicateValuePageCache,
+  createEmptyResponsePageCache,
+  createDuplicateValuePageCacheFromChunks,
+  createDuplicateValueChunkCaches,
+  createEmptyResponseChunkCaches,
+  createEmptyResponsePageCacheFromChunks,
+  createResponseAnalysisFromCachedParts,
+  createResponseAnalysisSummaryCache,
+  DuplicateValueChunkCache,
+  DuplicateValuePageCache,
+  EmptyResponseChunkCache,
+  EmptyResponsePageCache,
+  getRequiredResponseAnalysisChunkIndexes,
+  getResponseAnalysisDuplicateChunkCacheKey,
+  getResponseAnalysisDerivedCachePattern,
+  getResponseAnalysisDuplicatePageCacheKey,
+  getResponseAnalysisEmptyChunkCacheKey,
+  getResponseAnalysisEmptyPageCacheKey,
+  getResponseAnalysisSummaryCacheKey,
+  ResponseAnalysisSummaryCache
+} from './response-analysis-page-cache.util';
 
 export interface AggregationSettingsResult {
   success: boolean;
@@ -40,6 +57,7 @@ export interface AggregationSettingsResult {
 @Injectable()
 export class CodingAnalysisService {
   private readonly logger = new Logger(CodingAnalysisService.name);
+  private readonly slowResponseAnalysisThresholdMs = 3000;
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -55,7 +73,7 @@ export class CodingAnalysisService {
     private codingStatisticsService: CodingStatisticsService,
     private cacheService: CacheService,
     private jobQueueService: JobQueueService
-  ) { }
+  ) {}
 
   /**
    * Analyzes responses for a workspace to identify:
@@ -71,41 +89,157 @@ export class CodingAnalysisService {
     emptyLimit = 50,
     duplicatePage = 1,
     duplicateLimit = 50
-  ): Promise<ResponseAnalysisDto & { isCalculating?: boolean; progress?: number }> {
+  ): Promise<
+    ResponseAnalysisDto & { isCalculating?: boolean; progress?: number }
+    > {
+    const startedAt = Date.now();
+    let timingStatus = 'failed';
     try {
       const requestedThreshold = this.normalizeThreshold(threshold);
       this.logger.log(
         `Getting response analysis for workspace ${workspaceId} with threshold ${requestedThreshold}`
       );
 
-      const matchingFlags = await this.codingJobService.getResponseMatchingMode(
-        workspaceId
-      );
+      const [matchingFlags, currentSourceRevision] = await Promise.all([
+        this.codingJobService.getResponseMatchingMode(workspaceId),
+        this.getWorkspaceResultsRevision(workspaceId)
+      ]);
 
       // If NO_AGGREGATION is set, we want to see all duplicates regardless of the requested threshold
-      const effectiveThreshold = matchingFlags.includes(ResponseMatchingFlag.NO_AGGREGATION) ?
+      const effectiveThreshold = matchingFlags.includes(
+        ResponseMatchingFlag.NO_AGGREGATION
+      ) ?
         2 :
         requestedThreshold;
 
       // Check cache for the FULL analysis for this threshold
-      const cacheKey = this.getCacheKey(workspaceId, matchingFlags, effectiveThreshold);
-      const fullAnalysis = await this.cacheService.get<ResponseAnalysisDto>(cacheKey);
+      const cacheKey = this.getCacheKey(
+        workspaceId,
+        matchingFlags,
+        effectiveThreshold
+      );
+      const summaryCache =
+        await this.cacheService.get<ResponseAnalysisSummaryCache>(
+          getResponseAnalysisSummaryCacheKey(cacheKey)
+        );
 
       // Check if a job is currently running
-      const activeJob = await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
+      const activeJob =
+        await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
       const isCalculating = !!activeJob;
       let progress = 0;
       if (activeJob) {
         progress = await activeJob.progress();
       }
 
+      const chunkedPageCaches = summaryCache ?
+        await this.getResponseAnalysisPageCachesFromChunks(
+          cacheKey,
+          emptyPage,
+          emptyLimit,
+          duplicatePage,
+          duplicateLimit,
+          summaryCache
+        ) :
+        null;
+
+      if (
+        summaryCache &&
+        chunkedPageCaches?.emptyPageCache &&
+        chunkedPageCaches?.duplicatePageCache
+      ) {
+        const analysisIsStale = this.isAnalysisSourceRevisionStale(
+          summaryCache,
+          currentSourceRevision
+        );
+        if (analysisIsStale && !isCalculating) {
+          await this.startAnalysis(
+            workspaceId,
+            matchingFlags,
+            effectiveThreshold,
+            {
+              sourceRevision: currentSourceRevision
+            }
+          );
+        }
+        timingStatus = analysisIsStale ? 'stale-chunk-cache' : 'chunk-cache-hit';
+        return createResponseAnalysisFromCachedParts(
+          summaryCache,
+          chunkedPageCaches.emptyPageCache,
+          chunkedPageCaches.duplicatePageCache,
+          currentSourceRevision,
+          isCalculating || analysisIsStale,
+          progress
+        );
+      }
+
+      const [emptyPageCache, duplicatePageCache] = summaryCache ?
+        await Promise.all([
+          this.cacheService.get<EmptyResponsePageCache>(
+            getResponseAnalysisEmptyPageCacheKey(
+              cacheKey,
+              emptyPage,
+              emptyLimit
+            )
+          ),
+          this.cacheService.get<DuplicateValuePageCache>(
+            getResponseAnalysisDuplicatePageCacheKey(
+              cacheKey,
+              duplicatePage,
+              duplicateLimit
+            )
+          )
+        ]) :
+        [null, null];
+
+      if (summaryCache && emptyPageCache && duplicatePageCache) {
+        const analysisIsStale = this.isAnalysisSourceRevisionStale(
+          summaryCache,
+          currentSourceRevision
+        );
+        if (analysisIsStale && !isCalculating) {
+          await this.startAnalysis(
+            workspaceId,
+            matchingFlags,
+            effectiveThreshold,
+            {
+              sourceRevision: currentSourceRevision
+            }
+          );
+        }
+        timingStatus = analysisIsStale ? 'stale-page-cache' : 'page-cache-hit';
+        return createResponseAnalysisFromCachedParts(
+          summaryCache,
+          emptyPageCache,
+          duplicatePageCache,
+          currentSourceRevision,
+          isCalculating || analysisIsStale,
+          progress
+        );
+      }
+
+      const fullAnalysis =
+        await this.cacheService.get<ResponseAnalysisDto>(cacheKey);
+
       if (fullAnalysis && !fullAnalysis.aggregationSummary) {
         await this.invalidateCache(workspaceId);
         if (!isCalculating) {
-          await this.startAnalysis(workspaceId, matchingFlags, effectiveThreshold);
+          await this.startAnalysis(
+            workspaceId,
+            matchingFlags,
+            effectiveThreshold,
+            {
+              sourceRevision: currentSourceRevision
+            }
+          );
         }
+        timingStatus = 'legacy-cache-missing-summary';
         return {
-          ...this.createEmptyAnalysisResult(matchingFlags, effectiveThreshold),
+          ...this.createEmptyAnalysisResult(
+            matchingFlags,
+            effectiveThreshold,
+            currentSourceRevision
+          ),
           isCalculating: true,
           progress
         };
@@ -115,56 +249,86 @@ export class CodingAnalysisService {
         if (!isCalculating) {
           // If no analysis and no job running, trigger one (or return empty with isCalculating=false and let frontend trigger)
           // For better UX, let's trigger it automatically if missing
-          await this.startAnalysis(workspaceId, matchingFlags, effectiveThreshold);
+          await this.startAnalysis(
+            workspaceId,
+            matchingFlags,
+            effectiveThreshold,
+            {
+              sourceRevision: currentSourceRevision
+            }
+          );
+          timingStatus = 'cache-miss-started';
           return {
-            ...this.createEmptyAnalysisResult(matchingFlags, effectiveThreshold),
+            ...this.createEmptyAnalysisResult(
+              matchingFlags,
+              effectiveThreshold,
+              currentSourceRevision
+            ),
             isCalculating: true,
             progress
           };
         }
+        timingStatus = 'cache-miss-existing-job';
         return {
-          ...this.createEmptyAnalysisResult(matchingFlags, effectiveThreshold),
+          ...this.createEmptyAnalysisResult(
+            matchingFlags,
+            effectiveThreshold,
+            currentSourceRevision
+          ),
           isCalculating: true,
           progress
         };
       }
 
-      // Slice the results for pagination
-      const emptyStart = (emptyPage - 1) * emptyLimit;
-      const emptyItems = fullAnalysis.emptyResponses.items.slice(
-        emptyStart,
-        emptyStart + emptyLimit
+      const analysisIsStale = this.isAnalysisSourceRevisionStale(
+        fullAnalysis,
+        currentSourceRevision
+      );
+      if (analysisIsStale && !isCalculating) {
+        await this.startAnalysis(
+          workspaceId,
+          matchingFlags,
+          effectiveThreshold,
+          {
+            sourceRevision: currentSourceRevision
+          }
+        );
+      }
+      timingStatus = analysisIsStale ? 'stale-cache' : 'cache-hit';
+      await this.writeResponseAnalysisDerivedCaches(
+        cacheKey,
+        fullAnalysis,
+        emptyPage,
+        emptyLimit,
+        duplicatePage,
+        duplicateLimit
       );
 
-      const duplicateStart = (duplicatePage - 1) * duplicateLimit;
-      const duplicateGroups = fullAnalysis.duplicateValues.groups.slice(
-        duplicateStart,
-        duplicateStart + duplicateLimit
-      );
-
-      return {
-        ...fullAnalysis,
-        emptyResponses: {
-          ...fullAnalysis.emptyResponses,
-          items: emptyItems,
-          page: emptyPage,
-          pageSize: emptyLimit
-        } as EmptyResponseAnalysisDto,
-        duplicateValues: {
-          ...fullAnalysis.duplicateValues,
-          groups: duplicateGroups,
-          page: duplicatePage,
-          pageSize: duplicateLimit
-        } as DuplicateValueAnalysisDto,
-        isCalculating,
+      return createResponseAnalysisFromCachedParts(
+        createResponseAnalysisSummaryCache(fullAnalysis),
+        createEmptyResponsePageCache(fullAnalysis, emptyPage, emptyLimit),
+        createDuplicateValuePageCache(
+          fullAnalysis,
+          duplicatePage,
+          duplicateLimit
+        ),
+        currentSourceRevision,
+        isCalculating || analysisIsStale,
         progress
-      };
+      );
     } catch (error) {
       this.logger.error(
         `Error analyzing responses for workspace ${workspaceId}: ${error.message}`,
         error.stack
       );
       throw new Error(`Failed to analyze responses: ${error.message}`);
+    } finally {
+      this.logResponseAnalysisTiming(
+        'getResponseAnalysis',
+        workspaceId,
+        startedAt,
+        timingStatus
+      );
     }
   }
 
@@ -172,31 +336,64 @@ export class CodingAnalysisService {
     workspaceId: number,
     matchingFlags?: ResponseMatchingFlag[],
     threshold?: number,
-    options: { forceRefresh?: boolean } = {}
+    options: { forceRefresh?: boolean; sourceRevision?: number } = {}
   ): Promise<void> {
-    const activeMatchingFlags = matchingFlags ||
-      await this.codingJobService.getResponseMatchingMode(workspaceId);
-    const savedThreshold = threshold === undefined ?
-      await this.codingJobService.getAggregationThreshold(workspaceId) :
-      threshold;
+    const activeMatchingFlags =
+      matchingFlags ||
+      (await this.codingJobService.getResponseMatchingMode(workspaceId));
+    const savedThreshold =
+      threshold === undefined ?
+        await this.codingJobService.getAggregationThreshold(workspaceId) :
+        threshold;
     const activeThreshold = this.normalizeThreshold(savedThreshold ?? 2);
 
     // If NO_AGGREGATION is set, we want to see all duplicates regardless of the requested threshold
-    const effectiveThreshold = activeMatchingFlags.includes(ResponseMatchingFlag.NO_AGGREGATION) ?
+    const effectiveThreshold = activeMatchingFlags.includes(
+      ResponseMatchingFlag.NO_AGGREGATION
+    ) ?
       2 :
       activeThreshold;
 
-    const cacheKey = this.getCacheKey(workspaceId, activeMatchingFlags, effectiveThreshold);
+    const cacheKey = this.getCacheKey(
+      workspaceId,
+      activeMatchingFlags,
+      effectiveThreshold
+    );
+    const sourceRevision =
+      options.sourceRevision ??
+      (await this.getWorkspaceResultsRevision(workspaceId));
 
     if (options.forceRefresh) {
-      await this.cacheService.delete(cacheKey);
-      this.logger.log(`Invalidated response analysis cache before restart for workspace ${workspaceId}`);
+      await Promise.all([
+        this.cacheService.delete(cacheKey),
+        this.cacheService.deleteByPattern(
+          getResponseAnalysisDerivedCachePattern(cacheKey)
+        )
+      ]);
+      this.logger.log(
+        `Invalidated response analysis cache before restart for workspace ${workspaceId}`
+      );
     }
 
-    // Check if job already running
-    const activeJob = await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
+    const reusableJob =
+      await this.jobQueueService.getCodingAnalysisJobForCacheKey(
+        workspaceId,
+        cacheKey
+      );
+    if (reusableJob && !options.forceRefresh) {
+      this.logger.log(
+        `Reusing queued response analysis for workspace ${workspaceId} (Job ID: ${reusableJob.id})`
+      );
+      return;
+    }
+
+    // Check if another analysis for this workspace is already running.
+    const activeJob =
+      await this.jobQueueService.getActiveCodingAnalysisJob(workspaceId);
     if (activeJob && !options.forceRefresh) {
-      this.logger.log(`Analysis job already running for workspace ${workspaceId} (Job ID: ${activeJob.id})`);
+      this.logger.log(
+        `Analysis job already running for workspace ${workspaceId} (Job ID: ${activeJob.id})`
+      );
       return;
     }
 
@@ -207,16 +404,38 @@ export class CodingAnalysisService {
     }
 
     const runId = randomUUID();
-    await this.cacheService.set(getCodingAnalysisRunMarkerKey(cacheKey), runId, 0);
+    await this.cacheService.set(
+      getCodingAnalysisRunMarkerKey(cacheKey),
+      runId,
+      0
+    );
 
     await this.jobQueueService.addCodingAnalysisJob({
       workspaceId,
       matchingFlags: activeMatchingFlags as unknown as string[],
       threshold: effectiveThreshold,
       cacheKey,
-      runId
+      runId,
+      sourceRevision
     });
-    this.logger.log(`Triggered background response analysis for workspace ${workspaceId}`);
+    this.logger.log(
+      `Triggered background response analysis for workspace ${workspaceId}`
+    );
+  }
+
+  private logResponseAnalysisTiming(
+    operation: string,
+    workspaceId: number,
+    startedAt: number,
+    status: string
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    const message = `${operation} for workspace ${workspaceId} finished in ${durationMs}ms (${status})`;
+    if (durationMs >= this.slowResponseAnalysisThresholdMs) {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.debug(message);
   }
 
   private analyzeBatch(
@@ -304,19 +523,24 @@ export class CodingAnalysisService {
     }
   }
 
-  async getAggregationSettings(workspaceId: number): Promise<AggregationSettingsResult> {
+  async getAggregationSettings(
+    workspaceId: number
+  ): Promise<AggregationSettingsResult> {
     const [threshold, flags] = await Promise.all([
       this.codingJobService.getAggregationThreshold(workspaceId),
       this.codingJobService.getResponseMatchingMode(workspaceId)
     ]);
     const normalizedThreshold = this.normalizeThreshold(threshold ?? 2);
-    const normalizedFlags = this.codingJobService.normalizeResponseMatchingFlags(flags);
+    const normalizedFlags =
+      this.codingJobService.normalizeResponseMatchingFlags(flags);
 
     return {
       success: true,
       threshold: normalizedThreshold,
       flags: normalizedFlags,
-      aggregationActive: !normalizedFlags.includes(ResponseMatchingFlag.NO_AGGREGATION),
+      aggregationActive: !normalizedFlags.includes(
+        ResponseMatchingFlag.NO_AGGREGATION
+      ),
       revertedResponses: 0,
       message: 'Aggregation settings loaded.'
     };
@@ -328,24 +552,37 @@ export class CodingAnalysisService {
     flags?: ResponseMatchingFlag[]
   ): Promise<AggregationSettingsResult> {
     const validThreshold = this.normalizeThreshold(threshold);
-    const currentFlags = flags ?? await this.codingJobService.getResponseMatchingMode(workspaceId);
-    const normalizedFlags = this.codingJobService.normalizeResponseMatchingFlags(currentFlags);
+    const currentFlags =
+      flags ??
+      (await this.codingJobService.getResponseMatchingMode(workspaceId));
+    const normalizedFlags =
+      this.codingJobService.normalizeResponseMatchingFlags(currentFlags);
 
     try {
-      await this.codingJobService.setAggregationThreshold(workspaceId, validThreshold);
-      const savedFlags = await this.codingJobService.setResponseMatchingMode(workspaceId, normalizedFlags);
-      const revertedCount = await this.revertMaterializedDuplicateAggregation(workspaceId);
+      await this.codingJobService.setAggregationThreshold(
+        workspaceId,
+        validThreshold
+      );
+      const savedFlags = await this.codingJobService.setResponseMatchingMode(
+        workspaceId,
+        normalizedFlags
+      );
+      const revertedCount =
+        await this.revertMaterializedDuplicateAggregation(workspaceId);
       await this.invalidateAggregationDependentCaches(workspaceId);
 
       return {
         success: true,
         threshold: validThreshold,
         flags: savedFlags,
-        aggregationActive: !savedFlags.includes(ResponseMatchingFlag.NO_AGGREGATION),
+        aggregationActive: !savedFlags.includes(
+          ResponseMatchingFlag.NO_AGGREGATION
+        ),
         revertedResponses: revertedCount,
-        message: revertedCount > 0 ?
-          `Aggregation settings saved. Reverted ${revertedCount} materialized duplicate responses.` :
-          'Aggregation settings saved.'
+        message:
+          revertedCount > 0 ?
+            `Aggregation settings saved. Reverted ${revertedCount} materialized duplicate responses.` :
+            'Aggregation settings saved.'
       };
     } catch (error) {
       this.logger.error(
@@ -357,7 +594,9 @@ export class CodingAnalysisService {
         success: false,
         threshold: validThreshold,
         flags: normalizedFlags,
-        aggregationActive: !normalizedFlags.includes(ResponseMatchingFlag.NO_AGGREGATION),
+        aggregationActive: !normalizedFlags.includes(
+          ResponseMatchingFlag.NO_AGGREGATION
+        ),
         revertedResponses: 0,
         message: `Error saving aggregation settings: ${error.message}`
       };
@@ -379,11 +618,18 @@ export class CodingAnalysisService {
       uniqueCodingCases: number;
       message: string;
     }> {
-    const currentFlags = await this.codingJobService.getResponseMatchingMode(workspaceId);
+    const currentFlags =
+      await this.codingJobService.getResponseMatchingMode(workspaceId);
     const nextFlags = aggregateMode ?
-      currentFlags.filter(flag => flag !== ResponseMatchingFlag.NO_AGGREGATION) :
+      currentFlags.filter(
+        flag => flag !== ResponseMatchingFlag.NO_AGGREGATION
+      ) :
       [ResponseMatchingFlag.NO_AGGREGATION];
-    const result = await this.saveAggregationSettings(workspaceId, threshold, nextFlags);
+    const result = await this.saveAggregationSettings(
+      workspaceId,
+      threshold,
+      nextFlags
+    );
 
     return {
       success: result.success,
@@ -396,7 +642,8 @@ export class CodingAnalysisService {
 
   private createEmptyAnalysisResult(
     matchingFlags: ResponseMatchingFlag[],
-    threshold: number | null = null
+    threshold: number | null = null,
+    sourceRevision?: number
   ): ResponseAnalysisDto {
     const result: ResponseAnalysisDto = {
       emptyResponses: {
@@ -418,26 +665,210 @@ export class CodingAnalysisService {
         matchingFlags
       ),
       matchingFlags: matchingFlags as unknown as string[],
-      analysisTimestamp: new Date().toISOString()
+      analysisTimestamp: new Date().toISOString(),
+      sourceRevision,
+      currentSourceRevision: sourceRevision
     };
 
     return result;
+  }
+
+  private isAnalysisSourceRevisionStale(
+    analysis: Pick<ResponseAnalysisDto, 'sourceRevision'>,
+    currentSourceRevision: number
+  ): boolean {
+    return (
+      analysis.sourceRevision !== undefined &&
+      analysis.sourceRevision !== currentSourceRevision
+    );
+  }
+
+  private async getWorkspaceResultsRevision(
+    workspaceId: number
+  ): Promise<number> {
+    try {
+      const rows = (await this.responseRepository.query(
+        'SELECT revision FROM workspace_test_results_revision WHERE workspace_id = $1',
+        [workspaceId]
+      )) as Array<{ revision: number | string }>;
+      return Number(rows[0]?.revision || 0);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve test result revision for response analysis: ${message}`
+      );
+      return 0;
+    }
   }
 
   /**
    * Invalidates all cached analysis results for a given workspace
    */
   async invalidateCache(workspaceId: number): Promise<void> {
-    this.logger.log(`Invalidating response analysis cache for workspace ${workspaceId}`);
+    this.logger.log(
+      `Invalidating response analysis cache for workspace ${workspaceId}`
+    );
     // "response-analysis:1_*" matches all variations (flags, thresholds) for workspace 1
     const pattern = `${CODING_ANALYSIS_CACHE_KEY_PREFIX}:${workspaceId}_*`;
     await this.cacheService.deleteByPattern(pattern);
   }
 
-  private async invalidateAggregationDependentCaches(workspaceId: number): Promise<void> {
+  private async invalidateAggregationDependentCaches(
+    workspaceId: number
+  ): Promise<void> {
     await this.invalidateCache(workspaceId);
-    await this.codingValidationService.invalidateIncompleteVariablesCache(workspaceId);
+    await this.codingValidationService.invalidateIncompleteVariablesCache(
+      workspaceId
+    );
     await this.codingStatisticsService.invalidateCache(workspaceId);
+  }
+
+  private async writeResponseAnalysisDerivedCaches(
+    cacheKey: string,
+    analysis: ResponseAnalysisDto,
+    emptyPage: number,
+    emptyLimit: number,
+    duplicatePage: number,
+    duplicateLimit: number
+  ): Promise<void> {
+    const writes: Promise<boolean>[] = [
+      this.cacheService.set(
+        getResponseAnalysisSummaryCacheKey(cacheKey),
+        createResponseAnalysisSummaryCache(analysis)
+      ),
+      this.cacheService.set(
+        getResponseAnalysisEmptyPageCacheKey(cacheKey, emptyPage, emptyLimit),
+        createEmptyResponsePageCache(analysis, emptyPage, emptyLimit)
+      ),
+      this.cacheService.set(
+        getResponseAnalysisDuplicatePageCacheKey(
+          cacheKey,
+          duplicatePage,
+          duplicateLimit
+        ),
+        createDuplicateValuePageCache(analysis, duplicatePage, duplicateLimit)
+      )
+    ];
+
+    for (const chunk of createEmptyResponseChunkCaches(analysis)) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisEmptyChunkCacheKey(cacheKey, chunk.chunkIndex),
+          chunk
+        )
+      );
+    }
+
+    for (const chunk of createDuplicateValueChunkCaches(analysis)) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisDuplicateChunkCacheKey(cacheKey, chunk.chunkIndex),
+          chunk
+        )
+      );
+    }
+
+    await Promise.all(writes);
+  }
+
+  private async getResponseAnalysisPageCachesFromChunks(
+    cacheKey: string,
+    emptyPage: number,
+    emptyLimit: number,
+    duplicatePage: number,
+    duplicateLimit: number,
+    summaryCache: ResponseAnalysisSummaryCache
+  ): Promise<{
+      emptyPageCache: EmptyResponsePageCache | null;
+      duplicatePageCache: DuplicateValuePageCache | null;
+    }> {
+    const emptyOutOfRangePageCache =
+      this.createOutOfRangeEmptyResponsePageCache(
+        summaryCache.emptyResponses.total,
+        emptyPage,
+        emptyLimit
+      );
+    const duplicateOutOfRangePageCache =
+      this.createOutOfRangeDuplicateValuePageCache(
+        summaryCache.duplicateValues.total,
+        duplicatePage,
+        duplicateLimit
+      );
+    const emptyChunkIndexes = emptyOutOfRangePageCache ?
+      [] :
+      getRequiredResponseAnalysisChunkIndexes(emptyPage, emptyLimit);
+    const duplicateChunkIndexes = duplicateOutOfRangePageCache ?
+      [] :
+      getRequiredResponseAnalysisChunkIndexes(duplicatePage, duplicateLimit);
+    const emptyChunkReads: Promise<EmptyResponseChunkCache | null>[] = [];
+    for (const chunkIndex of emptyChunkIndexes) {
+      emptyChunkReads.push(
+        this.cacheService.get<EmptyResponseChunkCache>(
+          getResponseAnalysisEmptyChunkCacheKey(cacheKey, chunkIndex)
+        )
+      );
+    }
+
+    const duplicateChunkReads: Promise<DuplicateValueChunkCache | null>[] = [];
+    for (const chunkIndex of duplicateChunkIndexes) {
+      duplicateChunkReads.push(
+        this.cacheService.get<DuplicateValueChunkCache>(
+          getResponseAnalysisDuplicateChunkCacheKey(cacheKey, chunkIndex)
+        )
+      );
+    }
+
+    const [emptyChunks, duplicateChunks] = await Promise.all([
+      Promise.all(emptyChunkReads),
+      Promise.all(duplicateChunkReads)
+    ]);
+
+    if (
+      emptyChunks.some(chunk => chunk === null) ||
+      duplicateChunks.some(chunk => chunk === null)
+    ) {
+      return {
+        emptyPageCache: null,
+        duplicatePageCache: null
+      };
+    }
+
+    return {
+      emptyPageCache:
+        emptyOutOfRangePageCache ??
+        createEmptyResponsePageCacheFromChunks(
+          emptyChunks as EmptyResponseChunkCache[],
+          emptyPage,
+          emptyLimit
+        ),
+      duplicatePageCache:
+        duplicateOutOfRangePageCache ??
+        createDuplicateValuePageCacheFromChunks(
+          duplicateChunks as DuplicateValueChunkCache[],
+          duplicatePage,
+          duplicateLimit
+        )
+    };
+  }
+
+  private createOutOfRangeEmptyResponsePageCache(
+    total: number,
+    page: number,
+    pageSize: number
+  ): EmptyResponsePageCache | null {
+    return (page - 1) * pageSize >= total ?
+      { items: [], page, pageSize } :
+      null;
+  }
+
+  private createOutOfRangeDuplicateValuePageCache(
+    total: number,
+    page: number,
+    pageSize: number
+  ): DuplicateValuePageCache | null {
+    return (page - 1) * pageSize >= total ?
+      { groups: [], page, pageSize } :
+      null;
   }
 
   private getCacheKey(
@@ -456,7 +887,9 @@ export class CodingAnalysisService {
     return Math.min(100, Math.max(2, Math.round(parsed)));
   }
 
-  private async revertMaterializedDuplicateAggregation(workspaceId: number): Promise<number> {
+  private async revertMaterializedDuplicateAggregation(
+    workspaceId: number
+  ): Promise<number> {
     const aggregatedResponses = await this.responseRepository
       .createQueryBuilder('response')
       .select('response.id', 'id')

--- a/apps/backend/src/app/database/services/coding/response-analysis-page-cache.util.ts
+++ b/apps/backend/src/app/database/services/coding/response-analysis-page-cache.util.ts
@@ -1,0 +1,297 @@
+import {
+  AggregationSummaryDto,
+  DuplicateValueAnalysisDto,
+  DuplicateValueGroupDto,
+  EmptyResponseAnalysisDto,
+  EmptyResponseDto,
+  ResponseAnalysisDto
+} from '../../../../../../../api-dto/coding/response-analysis.dto';
+
+export interface ResponseAnalysisSummaryCache {
+  emptyResponses: Omit<EmptyResponseAnalysisDto, 'items' | 'page' | 'pageSize'>;
+  duplicateValues: Omit<
+  DuplicateValueAnalysisDto,
+  'groups' | 'page' | 'pageSize'
+  >;
+  aggregationSummary: AggregationSummaryDto;
+  matchingFlags: string[];
+  analysisTimestamp: string;
+  sourceRevision?: number;
+}
+
+export interface EmptyResponsePageCache {
+  items: EmptyResponseDto[];
+  page: number;
+  pageSize: number;
+}
+
+export interface DuplicateValuePageCache {
+  groups: DuplicateValueGroupDto[];
+  page: number;
+  pageSize: number;
+}
+
+export interface EmptyResponseChunkCache {
+  items: EmptyResponseDto[];
+  chunkIndex: number;
+  chunkSize: number;
+}
+
+export interface DuplicateValueChunkCache {
+  groups: DuplicateValueGroupDto[];
+  chunkIndex: number;
+  chunkSize: number;
+}
+
+export const RESPONSE_ANALYSIS_EMPTY_PAGE_LIMITS = [5, 10, 25, 50, 100];
+export const RESPONSE_ANALYSIS_DUPLICATE_PAGE_LIMITS = [5, 10, 20, 50, 100];
+export const RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT = 5;
+export const RESPONSE_ANALYSIS_CHUNK_SIZE = 500;
+
+export function getResponseAnalysisSummaryCacheKey(cacheKey: string): string {
+  return `${cacheKey}:summary`;
+}
+
+export function getResponseAnalysisEmptyPageCacheKey(
+  cacheKey: string,
+  page: number,
+  pageSize: number
+): string {
+  return `${cacheKey}:empty:p${page}:l${pageSize}`;
+}
+
+export function getResponseAnalysisDuplicatePageCacheKey(
+  cacheKey: string,
+  page: number,
+  pageSize: number
+): string {
+  return `${cacheKey}:duplicate:p${page}:l${pageSize}`;
+}
+
+export function getResponseAnalysisEmptyChunkCacheKey(
+  cacheKey: string,
+  chunkIndex: number
+): string {
+  return `${cacheKey}:empty-chunk:${chunkIndex}`;
+}
+
+export function getResponseAnalysisDuplicateChunkCacheKey(
+  cacheKey: string,
+  chunkIndex: number
+): string {
+  return `${cacheKey}:duplicate-chunk:${chunkIndex}`;
+}
+
+export function getResponseAnalysisDerivedCachePattern(
+  cacheKey: string
+): string {
+  return `${cacheKey}:*`;
+}
+
+export function createResponseAnalysisSummaryCache(
+  analysis: ResponseAnalysisDto
+): ResponseAnalysisSummaryCache {
+  return {
+    emptyResponses: {
+      total: analysis.emptyResponses.total,
+      totalUncoded: analysis.emptyResponses.totalUncoded
+    },
+    duplicateValues: {
+      total: analysis.duplicateValues.total,
+      totalResponses: analysis.duplicateValues.totalResponses,
+      isAggregationApplied: analysis.duplicateValues.isAggregationApplied
+    },
+    aggregationSummary: analysis.aggregationSummary,
+    matchingFlags: analysis.matchingFlags,
+    analysisTimestamp: analysis.analysisTimestamp,
+    sourceRevision: analysis.sourceRevision
+  };
+}
+
+export function createEmptyResponsePageCache(
+  analysis: ResponseAnalysisDto,
+  page: number,
+  pageSize: number
+): EmptyResponsePageCache {
+  const start = (page - 1) * pageSize;
+  return {
+    items: analysis.emptyResponses.items.slice(start, start + pageSize),
+    page,
+    pageSize
+  };
+}
+
+export function createDuplicateValuePageCache(
+  analysis: ResponseAnalysisDto,
+  page: number,
+  pageSize: number
+): DuplicateValuePageCache {
+  const start = (page - 1) * pageSize;
+  return {
+    groups: analysis.duplicateValues.groups
+      .slice(start, start + pageSize)
+      .map(group => ({
+        ...group,
+        occurrenceCount: group.occurrenceCount ?? group.occurrences.length,
+        occurrences: group.occurrences.slice(
+          0,
+          RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+        )
+      })),
+    page,
+    pageSize
+  };
+}
+
+export function createEmptyResponseChunkCaches(
+  analysis: ResponseAnalysisDto,
+  chunkSize = RESPONSE_ANALYSIS_CHUNK_SIZE
+): EmptyResponseChunkCache[] {
+  return chunkArray(analysis.emptyResponses.items, chunkSize).map(
+    (items, chunkIndex) => ({
+      items,
+      chunkIndex,
+      chunkSize
+    })
+  );
+}
+
+export function createDuplicateValueChunkCaches(
+  analysis: ResponseAnalysisDto,
+  chunkSize = RESPONSE_ANALYSIS_CHUNK_SIZE
+): DuplicateValueChunkCache[] {
+  return chunkArray(
+    analysis.duplicateValues.groups.map(group => ({
+      ...group,
+      occurrenceCount: group.occurrenceCount ?? group.occurrences.length,
+      occurrences: group.occurrences.slice(
+        0,
+        RESPONSE_ANALYSIS_OCCURRENCE_PREVIEW_LIMIT
+      )
+    })),
+    chunkSize
+  ).map((groups, chunkIndex) => ({
+    groups,
+    chunkIndex,
+    chunkSize
+  }));
+}
+
+export function getRequiredResponseAnalysisChunkIndexes(
+  page: number,
+  pageSize: number,
+  chunkSize = RESPONSE_ANALYSIS_CHUNK_SIZE
+): number[] {
+  const start = Math.max(0, (page - 1) * pageSize);
+  const end = Math.max(start, start + pageSize - 1);
+  const firstChunk = Math.floor(start / chunkSize);
+  const lastChunk = Math.floor(end / chunkSize);
+  return Array.from(
+    { length: lastChunk - firstChunk + 1 },
+    (_, index) => firstChunk + index
+  );
+}
+
+export function createEmptyResponsePageCacheFromChunks(
+  chunks: EmptyResponseChunkCache[],
+  page: number,
+  pageSize: number
+): EmptyResponsePageCache | null {
+  const items = slicePageFromChunks(chunks, page, pageSize, chunk => chunk.items);
+  return items ? { items, page, pageSize } : null;
+}
+
+export function createDuplicateValuePageCacheFromChunks(
+  chunks: DuplicateValueChunkCache[],
+  page: number,
+  pageSize: number
+): DuplicateValuePageCache | null {
+  const groups = slicePageFromChunks(chunks, page, pageSize, chunk => chunk.groups);
+  return groups ? { groups, page, pageSize } : null;
+}
+
+export function createResponseAnalysisFromCachedParts(
+  summary: ResponseAnalysisSummaryCache,
+  emptyPage: EmptyResponsePageCache,
+  duplicatePage: DuplicateValuePageCache,
+  currentSourceRevision: number,
+  isCalculating: boolean,
+  progress: number
+): ResponseAnalysisDto {
+  return {
+    emptyResponses: {
+      ...summary.emptyResponses,
+      items: emptyPage.items,
+      page: emptyPage.page,
+      pageSize: emptyPage.pageSize
+    },
+    duplicateValues: {
+      ...summary.duplicateValues,
+      groups: duplicatePage.groups,
+      page: duplicatePage.page,
+      pageSize: duplicatePage.pageSize
+    },
+    aggregationSummary: summary.aggregationSummary,
+    matchingFlags: summary.matchingFlags,
+    analysisTimestamp: summary.analysisTimestamp,
+    sourceRevision: summary.sourceRevision,
+    currentSourceRevision,
+    isCalculating,
+    progress
+  };
+}
+
+function chunkArray<T>(items: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let start = 0; start < items.length; start += chunkSize) {
+    chunks.push(items.slice(start, start + chunkSize));
+  }
+  if (chunks.length === 0) {
+    chunks.push([]);
+  }
+  return chunks;
+}
+
+function slicePageFromChunks<T, TChunk>(
+  chunks: TChunk[],
+  page: number,
+  pageSize: number,
+  getItems: (chunk: TChunk) => T[]
+): T[] | null {
+  if (chunks.length === 0 || chunks.some(chunk => !chunk)) {
+    return null;
+  }
+  const chunkSize = getChunkSize(chunks[0]);
+  if (!chunkSize) {
+    return null;
+  }
+  const orderedChunks = [...chunks].sort(
+    (a, b) => getChunkIndex(a) - getChunkIndex(b)
+  );
+  const firstChunkStart = getChunkIndex(orderedChunks[0]) * chunkSize;
+  const pageStart = Math.max(0, (page - 1) * pageSize);
+  const relativeStart = pageStart - firstChunkStart;
+  if (relativeStart < 0) {
+    return null;
+  }
+
+  return orderedChunks
+    .flatMap(chunk => getItems(chunk))
+    .slice(relativeStart, relativeStart + pageSize);
+}
+
+function getChunkIndex(chunk: unknown): number {
+  return typeof chunk === 'object' && chunk !== null &&
+    'chunkIndex' in chunk &&
+    typeof chunk.chunkIndex === 'number' ?
+    chunk.chunkIndex :
+    0;
+}
+
+function getChunkSize(chunk: unknown): number | null {
+  return typeof chunk === 'object' && chunk !== null &&
+    'chunkSize' in chunk &&
+    typeof chunk.chunkSize === 'number' ?
+    chunk.chunkSize :
+    null;
+}

--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -416,17 +416,30 @@ describe('JobQueueService', () => {
   it('finds queued response analysis jobs by workspace and cache key', async () => {
     const matchingJob = createJob({
       workspaceId: 1,
-      cacheKey: 'response-analysis:1__t2'
+      cacheKey: 'response-analysis:1__t2',
+      sourceRevision: 11
+    });
+    const staleRevisionJob = createJob({
+      workspaceId: 1,
+      cacheKey: 'response-analysis:1__t2',
+      sourceRevision: 10
     });
     const otherJob = createJob({
       workspaceId: 1,
       cacheKey: 'response-analysis:1_IGNORE_CASE_t2'
     });
-    queues[8].getJobs.mockResolvedValue([otherJob, matchingJob]);
+    queues[8].getJobs.mockResolvedValue([
+      otherJob,
+      staleRevisionJob,
+      matchingJob
+    ]);
 
     await expect(
-      service.getCodingAnalysisJobForCacheKey(1, 'response-analysis:1__t2')
+      service.getCodingAnalysisJobForCacheKey(1, 'response-analysis:1__t2', 11)
     ).resolves.toBe(matchingJob);
+    await expect(
+      service.getCodingAnalysisJobForCacheKey(1, 'response-analysis:1__t2', 12)
+    ).resolves.toBeNull();
   });
 
   it('expires large completed response analysis queue jobs', async () => {

--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -1,7 +1,10 @@
 import { ConflictException } from '@nestjs/common';
 import { JobQueueService } from './job-queue.service';
 
-const createJob = (data: Record<string, unknown> = { workspaceId: 1, taskId: 7 }, state = 'waiting') => ({
+const createJob = (
+  data: Record<string, unknown> = { workspaceId: 1, taskId: 7 },
+  state = 'waiting'
+) => ({
   id: 'job-1',
   data,
   failedReason: undefined,
@@ -20,7 +23,11 @@ const createQueue = (job = createJob()) => ({
   getJob: jest.fn().mockResolvedValue(job),
   getJobs: jest.fn().mockResolvedValue([job]),
   getJobCounts: jest.fn().mockResolvedValue({
-    waiting: 1, active: 0, completed: 0, failed: 0, delayed: 0
+    waiting: 1,
+    active: 0,
+    completed: 0,
+    failed: 0,
+    delayed: 0
   }),
   isReady: jest.fn().mockResolvedValue(undefined),
   client: { ping: jest.fn().mockResolvedValue('PONG') }
@@ -57,98 +64,182 @@ describe('JobQueueService', () => {
     queues[0].getJobs.mockResolvedValue([]);
     queues[6].getJobs.mockResolvedValue([]);
 
-    await expect(service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })).resolves.toMatchObject({ data: { workspaceId: 1 } });
-    await expect(service.getTestPersonCodingJob('job-1')).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.addUploadJob({
-      workspaceId: 1,
-      file: { originalname: 'results.xml' } as never,
-      resultType: 'responses',
-      overwriteExisting: false
-    })).resolves.toHaveProperty('data.resultType', 'responses');
-    await expect(service.getUploadJob('job-1')).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).resolves.toHaveProperty('data.version', 'v1');
-    await expect(service.getResetCodingVersionJob('job-1')).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.addCodingAnalysisJob({
-      workspaceId: 1, matchingFlags: [], threshold: 0, cacheKey: 'k'
-    })).resolves.toHaveProperty('data.cacheKey', 'k');
-    await expect(service.getCodingAnalysisJob('job-1')).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.addVariableAnalysisJob({ workspaceId: 1, unitId: 2 })).resolves.toHaveProperty('data.unitId', 2);
-    await expect(service.getVariableAnalysisJob('job-1')).resolves.toHaveProperty('id', 'job-1');
+    await expect(
+      service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })
+    ).resolves.toMatchObject({ data: { workspaceId: 1 } });
+    await expect(
+      service.getTestPersonCodingJob('job-1')
+    ).resolves.toHaveProperty('id', 'job-1');
+    await expect(
+      service.addUploadJob({
+        workspaceId: 1,
+        file: { originalname: 'results.xml' } as never,
+        resultType: 'responses',
+        overwriteExisting: false
+      })
+    ).resolves.toHaveProperty('data.resultType', 'responses');
+    await expect(service.getUploadJob('job-1')).resolves.toHaveProperty(
+      'id',
+      'job-1'
+    );
+    await expect(
+      service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })
+    ).resolves.toHaveProperty('data.version', 'v1');
+    await expect(
+      service.getResetCodingVersionJob('job-1')
+    ).resolves.toHaveProperty('id', 'job-1');
+    await expect(
+      service.addCodingAnalysisJob({
+        workspaceId: 1,
+        matchingFlags: [],
+        threshold: 0,
+        cacheKey: 'k'
+      })
+    ).resolves.toHaveProperty('data.cacheKey', 'k');
+    await expect(service.getCodingAnalysisJob('job-1')).resolves.toHaveProperty(
+      'id',
+      'job-1'
+    );
+    await expect(
+      service.addVariableAnalysisJob({ workspaceId: 1, unitId: 2 })
+    ).resolves.toHaveProperty('data.unitId', 2);
+    await expect(
+      service.getVariableAnalysisJob('job-1')
+    ).resolves.toHaveProperty('id', 'job-1');
     queues[10].getJobs.mockResolvedValue([]);
-    await expect(service.addExternalCodingImportJob({ workspaceId: 1, tempFilePath: '/tmp/a', fileName: 'a.csv' })).resolves.toHaveProperty('data.fileName', 'a.csv');
-    await expect(service.getExternalCodingImportJob('job-1')).resolves.toHaveProperty('id', 'job-1');
+    await expect(
+      service.addExternalCodingImportJob({
+        workspaceId: 1,
+        tempFilePath: '/tmp/a',
+        fileName: 'a.csv'
+      })
+    ).resolves.toHaveProperty('data.fileName', 'a.csv');
+    await expect(
+      service.getExternalCodingImportJob('job-1')
+    ).resolves.toHaveProperty('id', 'job-1');
   });
 
   it('prevents duplicate active jobs where required', async () => {
-    await expect(service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addCodingStatisticsJob(1, 'v2')).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addFlatResponseFilterOptionsJob(1, 250)).resolves.toBeNull();
-    await expect(service.addCodebookGenerationJob({
-      workspaceId: 1,
-      missingsProfile: 1,
-      contentOptions: {
-        exportFormat: 'docx',
-        missingsProfile: 'default',
-        hasOnlyManualCoding: false,
-        hasGeneralInstructions: false,
-        hasDerivedVars: false,
-        hasOnlyVarsWithCodes: false,
-        hasClosedVars: false,
-        codeLabelToUpper: false,
-        showScore: false,
-        hideItemVarRelation: false
-      },
-      unitIds: [1]
-    })).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addValidationTaskJob({ taskId: 7 })).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.addExternalCodingImportJob({ workspaceId: 1, tempFilePath: '/tmp/a', fileName: 'a.csv' })).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addCodingStatisticsJob(1, 'v2')
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addFlatResponseFilterOptionsJob(1, 250)
+    ).resolves.toBeNull();
+    await expect(
+      service.addCodebookGenerationJob({
+        workspaceId: 1,
+        missingsProfile: 1,
+        contentOptions: {
+          exportFormat: 'docx',
+          missingsProfile: 'default',
+          hasOnlyManualCoding: false,
+          hasGeneralInstructions: false,
+          hasDerivedVars: false,
+          hasOnlyVarsWithCodes: false,
+          hasClosedVars: false,
+          codeLabelToUpper: false,
+          showScore: false,
+          hideItemVarRelation: false
+        },
+        unitIds: [1]
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addValidationTaskJob({ taskId: 7 })
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.addExternalCodingImportJob({
+        workspaceId: 1,
+        tempFilePath: '/tmp/a',
+        fileName: 'a.csv'
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 
   it('allows jobs when no duplicate active job exists', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
 
-    await expect(service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })).resolves.toHaveProperty('data.workspaceId', 1);
-    await expect(service.addCodingStatisticsJob(1, 'v1')).resolves.toHaveProperty('data.version', 'v1');
-    await expect(service.addFlatResponseFilterOptionsJob(1, 100)).resolves.toHaveProperty('data.processingDurationThresholdMs', 100);
-    await expect(service.addCodebookGenerationJob({
-      workspaceId: 1,
-      missingsProfile: 1,
-      contentOptions: {
-        exportFormat: 'docx',
-        missingsProfile: 'default',
-        hasOnlyManualCoding: false,
-        hasGeneralInstructions: false,
-        hasDerivedVars: false,
-        hasOnlyVarsWithCodes: false,
-        hasClosedVars: false,
-        codeLabelToUpper: false,
-        showScore: false,
-        hideItemVarRelation: false
-      },
-      unitIds: [1]
-    })).resolves.toHaveProperty('data.workspaceId', 1);
-    await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).resolves.toHaveProperty('data.version', 'v1');
-    await expect(service.addValidationTaskJob({ taskId: 8 })).resolves.toHaveProperty('data.taskId', 8);
-    await expect(service.addExportJob({ workspaceId: 1, userId: 2, exportType: 'coding-list' })).resolves.toHaveProperty('data.exportType', 'coding-list');
+    await expect(
+      service.addTestPersonCodingJob({ workspaceId: 1, personIds: ['p1'] })
+    ).resolves.toHaveProperty('data.workspaceId', 1);
+    await expect(
+      service.addCodingStatisticsJob(1, 'v1')
+    ).resolves.toHaveProperty('data.version', 'v1');
+    await expect(
+      service.addFlatResponseFilterOptionsJob(1, 100)
+    ).resolves.toHaveProperty('data.processingDurationThresholdMs', 100);
+    await expect(
+      service.addCodebookGenerationJob({
+        workspaceId: 1,
+        missingsProfile: 1,
+        contentOptions: {
+          exportFormat: 'docx',
+          missingsProfile: 'default',
+          hasOnlyManualCoding: false,
+          hasGeneralInstructions: false,
+          hasDerivedVars: false,
+          hasOnlyVarsWithCodes: false,
+          hasClosedVars: false,
+          codeLabelToUpper: false,
+          showScore: false,
+          hideItemVarRelation: false
+        },
+        unitIds: [1]
+      })
+    ).resolves.toHaveProperty('data.workspaceId', 1);
+    await expect(
+      service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })
+    ).resolves.toHaveProperty('data.version', 'v1');
+    await expect(
+      service.addValidationTaskJob({ taskId: 8 })
+    ).resolves.toHaveProperty('data.taskId', 8);
+    await expect(
+      service.addExportJob({
+        workspaceId: 1,
+        userId: 2,
+        exportType: 'coding-list'
+      })
+    ).resolves.toHaveProperty('data.exportType', 'coding-list');
   });
 
   it('cancels and deletes jobs across queues', async () => {
-    await expect(service.cancelJob('test-person-coding', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelJob('test-person-coding', 'job-1')
+    ).resolves.toBe(true);
     await expect(service.cancelJob('unknown', 'job-1')).resolves.toBe(false);
-    await expect(service.deleteJob('test-person-coding', 'job-1')).resolves.toBe(true);
-    await expect(service.cancelTestPersonCodingJob('job-1')).resolves.toBe(true);
-    await expect(service.deleteTestPersonCodingJob('job-1')).resolves.toBe(true);
+    await expect(
+      service.deleteJob('test-person-coding', 'job-1')
+    ).resolves.toBe(true);
+    await expect(service.cancelTestPersonCodingJob('job-1')).resolves.toBe(
+      true
+    );
+    await expect(service.deleteTestPersonCodingJob('job-1')).resolves.toBe(
+      true
+    );
     await expect(service.cancelExportJob('job-1')).resolves.toBe(true);
     await expect(service.markExportJobCancelled('job-1')).resolves.toBe(true);
     await expect(service.isExportJobCancelled('job-1')).resolves.toBe(false);
     await expect(service.deleteExportJob('job-1')).resolves.toBe(true);
-    await expect(service.deleteVariableAnalysisJob('job-1')).resolves.toBe(true);
-    await expect(service.cancelVariableAnalysisJob('job-1')).resolves.toBe(true);
+    await expect(service.deleteVariableAnalysisJob('job-1')).resolves.toBe(
+      true
+    );
+    await expect(service.cancelVariableAnalysisJob('job-1')).resolves.toBe(
+      true
+    );
   });
 
   it('aborts registered export cancellation signals when an export job is marked cancelled', async () => {
-    const exportJob = createJob({ workspaceId: 1, exportType: 'coding-list' }, 'active');
+    const exportJob = createJob(
+      { workspaceId: 1, exportType: 'coding-list' },
+      'active'
+    );
     queues[2].getJob.mockResolvedValue(exportJob);
     const signal = service.createExportJobCancellationSignal('job-1');
 
@@ -158,7 +249,10 @@ describe('JobQueueService', () => {
   });
 
   it('aborts registered export cancellation signals when cancelling an active export job directly', async () => {
-    const exportJob = createJob({ workspaceId: 1, exportType: 'coding-list' }, 'active');
+    const exportJob = createJob(
+      { workspaceId: 1, exportType: 'coding-list' },
+      'active'
+    );
     queues[2].getJob.mockResolvedValue(exportJob);
     const signal = service.createExportJobCancellationSignal('job-1');
 
@@ -172,11 +266,15 @@ describe('JobQueueService', () => {
     const otherWorkspaceJob = createJob({ workspaceId: 2 }, 'waiting');
 
     queues[0].getJob.mockResolvedValueOnce(otherWorkspaceJob);
-    await expect(service.cancelWorkspaceJob(1, 'test-person-coding', 'job-1')).resolves.toBe(false);
+    await expect(
+      service.cancelWorkspaceJob(1, 'test-person-coding', 'job-1')
+    ).resolves.toBe(false);
     expect(otherWorkspaceJob.remove).not.toHaveBeenCalled();
 
     queues[0].getJob.mockResolvedValueOnce(ownJob);
-    await expect(service.cancelWorkspaceJob(1, 'test-person-coding', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'test-person-coding', 'job-1')
+    ).resolves.toBe(true);
     expect(ownJob.remove).toHaveBeenCalled();
   });
 
@@ -184,20 +282,33 @@ describe('JobQueueService', () => {
     const validationJob = createJob({ taskId: 7 }, 'waiting');
     queues[7].getJob.mockResolvedValue(validationJob);
 
-    validationTaskRepository.find.mockResolvedValueOnce([{ id: 7, workspace_id: 2 }]);
-    await expect(service.cancelWorkspaceJob(1, 'validation-task', 'job-1')).resolves.toBe(false);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      { id: 7, workspace_id: 2 }
+    ]);
+    await expect(
+      service.cancelWorkspaceJob(1, 'validation-task', 'job-1')
+    ).resolves.toBe(false);
     expect(validationJob.remove).not.toHaveBeenCalled();
 
-    validationTaskRepository.find.mockResolvedValueOnce([{ id: 7, workspace_id: 1 }]);
-    await expect(service.cancelWorkspaceJob(1, 'validation-task', 'job-1')).resolves.toBe(true);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      { id: 7, workspace_id: 1 }
+    ]);
+    await expect(
+      service.cancelWorkspaceJob(1, 'validation-task', 'job-1')
+    ).resolves.toBe(true);
     expect(validationJob.remove).toHaveBeenCalled();
   });
 
   it('marks supported active jobs for cancellation without removing locked jobs', async () => {
-    const exportJob = createJob({ workspaceId: 1, exportType: 'test-results' }, 'active');
+    const exportJob = createJob(
+      { workspaceId: 1, exportType: 'test-results' },
+      'active'
+    );
     queues[2].getJob.mockResolvedValue(exportJob);
 
-    await expect(service.cancelWorkspaceJob(1, 'data-export', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'data-export', 'job-1')
+    ).resolves.toBe(true);
     expect(exportJob.update).toHaveBeenCalledWith({
       workspaceId: 1,
       exportType: 'test-results',
@@ -206,13 +317,18 @@ describe('JobQueueService', () => {
     expect(exportJob.discard).toHaveBeenCalled();
     expect(exportJob.remove).not.toHaveBeenCalled();
 
-    const databaseExportJob = createJob({
-      requestedByUserId: 3,
-      scope: 'workspace',
-      workspaceId: 1
-    }, 'active');
+    const databaseExportJob = createJob(
+      {
+        requestedByUserId: 3,
+        scope: 'workspace',
+        workspaceId: 1
+      },
+      'active'
+    );
     queues[11].getJob.mockResolvedValue(databaseExportJob);
-    await expect(service.cancelWorkspaceJob(1, 'database-export', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'database-export', 'job-1')
+    ).resolves.toBe(true);
     expect(databaseExportJob.update).toHaveBeenCalledWith({
       requestedByUserId: 3,
       scope: 'workspace',
@@ -224,7 +340,9 @@ describe('JobQueueService', () => {
 
     const unsupportedActiveJob = createJob({ workspaceId: 1 }, 'active');
     queues[1].getJob.mockResolvedValue(unsupportedActiveJob);
-    await expect(service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')).resolves.toBe(false);
+    await expect(
+      service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')
+    ).resolves.toBe(false);
     expect(unsupportedActiveJob.remove).not.toHaveBeenCalled();
   });
 
@@ -232,41 +350,107 @@ describe('JobQueueService', () => {
     const pausedJob = createJob({ workspaceId: 1 }, 'paused');
     queues[1].getJob.mockResolvedValue(pausedJob);
 
-    await expect(service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')
+    ).resolves.toBe(true);
     expect(pausedJob.remove).toHaveBeenCalled();
 
     const cancelledJob = createJob({ workspaceId: 1 }, 'cancelled');
     queues[1].getJob.mockResolvedValue(cancelledJob);
 
-    await expect(service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')).resolves.toBe(true);
+    await expect(
+      service.cancelWorkspaceJob(1, 'coding-statistics', 'job-1')
+    ).resolves.toBe(true);
     expect(cancelledJob.remove).toHaveBeenCalled();
   });
 
   it('handles missing jobs and failing queue operations', async () => {
     queues.forEach(queue => queue.getJob.mockResolvedValue(null));
 
-    await expect(service.cancelJob('test-person-coding', 'missing')).resolves.toBe(false);
-    await expect(service.deleteJob('test-person-coding', 'missing')).resolves.toBe(false);
-    await expect(service.cancelTestPersonCodingJob('missing')).resolves.toBe(false);
-    await expect(service.deleteTestPersonCodingJob('missing')).resolves.toBe(false);
+    await expect(
+      service.cancelJob('test-person-coding', 'missing')
+    ).resolves.toBe(false);
+    await expect(
+      service.deleteJob('test-person-coding', 'missing')
+    ).resolves.toBe(false);
+    await expect(service.cancelTestPersonCodingJob('missing')).resolves.toBe(
+      false
+    );
+    await expect(service.deleteTestPersonCodingJob('missing')).resolves.toBe(
+      false
+    );
     await expect(service.cancelExportJob('missing')).resolves.toBe(false);
-    await expect(service.markExportJobCancelled('missing')).resolves.toBe(false);
+    await expect(service.markExportJobCancelled('missing')).resolves.toBe(
+      false
+    );
     await expect(service.isExportJobCancelled('missing')).resolves.toBe(false);
     await expect(service.deleteExportJob('missing')).resolves.toBe(false);
-    await expect(service.deleteVariableAnalysisJob('missing')).resolves.toBe(false);
-    await expect(service.cancelVariableAnalysisJob('missing')).resolves.toBe(false);
+    await expect(service.deleteVariableAnalysisJob('missing')).resolves.toBe(
+      false
+    );
+    await expect(service.cancelVariableAnalysisJob('missing')).resolves.toBe(
+      false
+    );
   });
 
   it('lists workspace jobs and queue-specific jobs', async () => {
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
     expect(workspaceJobs.length).toBeGreaterThan(0);
-    expect(workspaceJobs[0]).toMatchObject({ queueName: expect.any(String), status: 'waiting' });
+    expect(workspaceJobs[0]).toMatchObject({
+      queueName: expect.any(String),
+      status: 'waiting'
+    });
 
     await expect(service.getTestPersonCodingJobs(1)).resolves.toHaveLength(1);
     await expect(service.getExportJobs(1)).resolves.toHaveLength(1);
     await expect(service.getVariableAnalysisJobs(1)).resolves.toHaveLength(1);
-    await expect(service.getActiveCodingAnalysisJob(1)).resolves.toHaveProperty('id', 'job-1');
-    await expect(service.getActiveResetCodingVersionJob(1)).resolves.toHaveProperty('id', 'job-1');
+    await expect(service.getActiveCodingAnalysisJob(1)).resolves.toHaveProperty(
+      'id',
+      'job-1'
+    );
+    await expect(
+      service.getActiveResetCodingVersionJob(1)
+    ).resolves.toHaveProperty('id', 'job-1');
+  });
+
+  it('finds queued response analysis jobs by workspace and cache key', async () => {
+    const matchingJob = createJob({
+      workspaceId: 1,
+      cacheKey: 'response-analysis:1__t2'
+    });
+    const otherJob = createJob({
+      workspaceId: 1,
+      cacheKey: 'response-analysis:1_IGNORE_CASE_t2'
+    });
+    queues[8].getJobs.mockResolvedValue([otherJob, matchingJob]);
+
+    await expect(
+      service.getCodingAnalysisJobForCacheKey(1, 'response-analysis:1__t2')
+    ).resolves.toBe(matchingJob);
+  });
+
+  it('expires large completed response analysis queue jobs', async () => {
+    queues[8].add.mockResolvedValue(createJob());
+
+    await service.addCodingAnalysisJob({
+      workspaceId: 1,
+      matchingFlags: [],
+      threshold: 2,
+      cacheKey: 'response-analysis:1__t2'
+    });
+
+    expect(queues[8].add).toHaveBeenCalledWith(
+      {
+        workspaceId: 1,
+        matchingFlags: [],
+        threshold: 2,
+        cacheKey: 'response-analysis:1__t2'
+      },
+      {
+        removeOnComplete: { age: 3600, count: 10 },
+        removeOnFail: { age: 86400, count: 50 }
+      }
+    );
   });
 
   it('covers all registered process overview queues', async () => {
@@ -290,18 +474,18 @@ describe('JobQueueService', () => {
 
   it('uses validation task progress and metadata from the task entity in the process overview', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
-    queues[7].getJobs.mockResolvedValue([
-      createJob({ taskId: 7 }, 'active')
+    queues[7].getJobs.mockResolvedValue([createJob({ taskId: 7 }, 'active')]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'processing',
+        progress: 65,
+        progress_message: 'Testdateien werden geprüft...',
+        error: 'Schema validation failed'
+      }
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'processing',
-      progress: 65,
-      progress_message: 'Testdateien werden geprüft...',
-      error: 'Schema validation failed'
-    }]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -325,15 +509,17 @@ describe('JobQueueService', () => {
     queues[7].getJobs.mockResolvedValue([
       createJob({ taskId: 7 }, 'completed')
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'cancelled',
-      progress: 30,
-      progress_message: 'Validierung abgebrochen.',
-      error: 'Cancelled by user'
-    }]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'cancelled',
+        progress: 30,
+        progress_message: 'Validierung abgebrochen.',
+        error: 'Cancelled by user'
+      }
+    ]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -354,18 +540,18 @@ describe('JobQueueService', () => {
 
   it('keeps active Bull validation tasks active even when the task entity is cancelled', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
-    queues[7].getJobs.mockResolvedValue([
-      createJob({ taskId: 7 }, 'active')
+    queues[7].getJobs.mockResolvedValue([createJob({ taskId: 7 }, 'active')]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'cancelled',
+        progress: 30,
+        progress_message: 'Validierung abgebrochen.',
+        error: 'Cancelled by user'
+      }
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'cancelled',
-      progress: 30,
-      progress_message: 'Validierung abgebrochen.',
-      error: 'Cancelled by user'
-    }]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -389,15 +575,17 @@ describe('JobQueueService', () => {
     queues[7].getJobs.mockResolvedValue([
       createJob({ taskId: 7 }, 'completed')
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'failed',
-      progress: 100,
-      progress_message: 'Validierung fehlgeschlagen.',
-      error: 'Schema validation failed'
-    }]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'failed',
+        progress: 100,
+        progress_message: 'Validierung fehlgeschlagen.',
+        error: 'Schema validation failed'
+      }
+    ]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -486,7 +674,9 @@ describe('JobQueueService', () => {
         isCancelled: false
       }
     });
-    expect(JSON.stringify(workspaceJobs[0].data)).not.toContain('requestedByUserId');
+    expect(JSON.stringify(workspaceJobs[0].data)).not.toContain(
+      'requestedByUserId'
+    );
   });
 
   it('ignores stale null jobs returned by Bull when listing workspace jobs', async () => {
@@ -509,20 +699,34 @@ describe('JobQueueService', () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
     queues[1].getJobs.mockResolvedValue([null] as never);
 
-    await expect(service.assertNoDependencyConflicts('data-export', 1)).resolves.toBeUndefined();
+    await expect(
+      service.assertNoDependencyConflicts('data-export', 1)
+    ).resolves.toBeUndefined();
   });
 
   it('checks dependency conflicts and redis status', async () => {
-    await expect(service.assertNoActiveUploadForWorkspace(1)).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.assertNoDependencyConflicts('data-export', 1)).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.assertNoActiveUploadForWorkspace(1)
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.assertNoDependencyConflicts('data-export', 1)
+    ).rejects.toBeInstanceOf(ConflictException);
 
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
-    await expect(service.assertNoActiveUploadForWorkspace(1)).resolves.toBeUndefined();
-    await expect(service.assertNoDependencyConflicts('data-export', 1)).resolves.toBeUndefined();
+    await expect(
+      service.assertNoActiveUploadForWorkspace(1)
+    ).resolves.toBeUndefined();
+    await expect(
+      service.assertNoDependencyConflicts('data-export', 1)
+    ).resolves.toBeUndefined();
 
-    await expect(service.checkRedisConnection()).resolves.toMatchObject({ connected: true });
+    await expect(service.checkRedisConnection()).resolves.toMatchObject({
+      connected: true
+    });
     queues[0].client = null;
-    await expect(service.checkRedisConnection()).resolves.toMatchObject({ connected: false });
+    await expect(service.checkRedisConnection()).resolves.toMatchObject({
+      connected: false
+    });
   });
 
   it('deletes all variable analysis jobs including active ones', async () => {

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  Logger,
-  ConflictException
-} from '@nestjs/common';
+import { Injectable, Logger, ConflictException } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
@@ -17,7 +13,13 @@ import {
 
 type ProcessOverviewValidationTask = Pick<
 ValidationTask,
-'id' | 'workspace_id' | 'validation_type' | 'status' | 'progress' | 'progress_message' | 'error'
+| 'id'
+| 'workspace_id'
+| 'validation_type'
+| 'status'
+| 'progress'
+| 'progress_message'
+| 'error'
 >;
 
 export interface TestResultsUploadJobData {
@@ -28,7 +30,13 @@ export interface TestResultsUploadJobData {
   personMatchMode?: 'strict' | 'loose';
   overwriteMode?: 'skip' | 'merge' | 'replace';
   scope?: 'person' | 'workspace' | 'group' | 'booklet' | 'unit' | 'response';
-  scopeFilters?: { groupName?: string; bookletName?: string; unitNameOrAlias?: string; variableId?: string; subform?: string };
+  scopeFilters?: {
+    groupName?: string;
+    bookletName?: string;
+    unitNameOrAlias?: string;
+    variableId?: string;
+    subform?: string;
+  };
 }
 
 export interface TestPersonCodingJobData {
@@ -97,6 +105,7 @@ export interface CodingAnalysisJobData {
   threshold: number;
   cacheKey: string;
   runId?: string;
+  sourceRevision?: number;
 }
 
 export interface VariableAnalysisJobData {
@@ -168,9 +177,7 @@ export interface ExportJobData {
   anonymizeCoders?: boolean;
   usePseudoCoders?: boolean;
   doubleCodingMethod?:
-  | 'new-row-per-variable'
-  | 'new-column-per-coder'
-  | 'most-frequent';
+  'new-row-per-variable' | 'new-column-per-coder' | 'most-frequent';
   includeComments?: boolean;
   includeModalValue?: boolean;
   includeDoubleCoded?: boolean;
@@ -192,11 +199,7 @@ export interface ExportJobData {
 }
 
 export type ExportJobProgressPhase =
-  | 'preparing'
-  | 'counting'
-  | 'writing'
-  | 'finalizing'
-  | 'completed';
+  'preparing' | 'counting' | 'writing' | 'finalizing' | 'completed';
 
 export interface ExportJobProgress {
   percentage: number;
@@ -241,31 +244,106 @@ export interface RedisConnectionStatus {
 export class JobQueueService {
   private readonly logger = new Logger(JobQueueService.name);
 
-  private readonly exportCancellationControllers = new Map<string, AbortController>();
+  private readonly exportCancellationControllers = new Map<
+  string,
+  AbortController
+  >();
 
   private readonly DEPENDENCY_RULES: ReadonlyArray<{
     target: string;
     blockedBy: string;
     label: string;
   }> = [
-      { target: 'test-results-upload', blockedBy: 'validation-task', label: 'validation' },
-      { target: 'test-results-upload', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'test-results-upload', blockedBy: 'reset-coding-version', label: 'reset coding version' },
-      { target: 'test-results-upload', blockedBy: 'external-coding-import', label: 'external coding import' },
-      { target: 'test-person-coding', blockedBy: 'test-results-upload', label: 'test results upload' },
-      { target: 'test-person-coding', blockedBy: 'reset-coding-version', label: 'reset coding version' },
-      { target: 'test-person-coding', blockedBy: 'external-coding-import', label: 'external coding import' },
-      { target: 'validation-task', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'validation-task', blockedBy: 'test-results-upload', label: 'test results upload' },
-      { target: 'validation-task', blockedBy: 'reset-coding-version', label: 'reset coding version' },
-      { target: 'coding-statistics', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'coding-statistics', blockedBy: 'external-coding-import', label: 'external coding import' },
-      { target: 'data-export', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'reset-coding-version', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'reset-coding-version', blockedBy: 'external-coding-import', label: 'external coding import' },
-      { target: 'external-coding-import', blockedBy: 'test-person-coding', label: 'auto-coding' },
-      { target: 'external-coding-import', blockedBy: 'test-results-upload', label: 'test results upload' },
-      { target: 'external-coding-import', blockedBy: 'reset-coding-version', label: 'reset coding version' }
+      {
+        target: 'test-results-upload',
+        blockedBy: 'validation-task',
+        label: 'validation'
+      },
+      {
+        target: 'test-results-upload',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'test-results-upload',
+        blockedBy: 'reset-coding-version',
+        label: 'reset coding version'
+      },
+      {
+        target: 'test-results-upload',
+        blockedBy: 'external-coding-import',
+        label: 'external coding import'
+      },
+      {
+        target: 'test-person-coding',
+        blockedBy: 'test-results-upload',
+        label: 'test results upload'
+      },
+      {
+        target: 'test-person-coding',
+        blockedBy: 'reset-coding-version',
+        label: 'reset coding version'
+      },
+      {
+        target: 'test-person-coding',
+        blockedBy: 'external-coding-import',
+        label: 'external coding import'
+      },
+      {
+        target: 'validation-task',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'validation-task',
+        blockedBy: 'test-results-upload',
+        label: 'test results upload'
+      },
+      {
+        target: 'validation-task',
+        blockedBy: 'reset-coding-version',
+        label: 'reset coding version'
+      },
+      {
+        target: 'coding-statistics',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'coding-statistics',
+        blockedBy: 'external-coding-import',
+        label: 'external coding import'
+      },
+      {
+        target: 'data-export',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'reset-coding-version',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'reset-coding-version',
+        blockedBy: 'external-coding-import',
+        label: 'external coding import'
+      },
+      {
+        target: 'external-coding-import',
+        blockedBy: 'test-person-coding',
+        label: 'auto-coding'
+      },
+      {
+        target: 'external-coding-import',
+        blockedBy: 'test-results-upload',
+        label: 'test results upload'
+      },
+      {
+        target: 'external-coding-import',
+        blockedBy: 'reset-coding-version',
+        label: 'reset coding version'
+      }
     ];
 
   constructor(
@@ -280,11 +358,13 @@ export class JobQueueService {
     @InjectQueue('validation-task') private validationTaskQueue: Queue,
     @InjectQueue('response-analysis') private responseAnalysisQueue: Queue,
     @InjectQueue('variable-analysis') private variableAnalysisQueue: Queue,
-    @InjectQueue('external-coding-import') private externalCodingImportQueue: Queue,
-    @InjectQueue('database-export') private databaseExportQueue: Queue<DatabaseExportJobData>,
+    @InjectQueue('external-coding-import')
+    private externalCodingImportQueue: Queue,
+    @InjectQueue('database-export')
+    private databaseExportQueue: Queue<DatabaseExportJobData>,
     @InjectRepository(ValidationTask)
     private readonly validationTaskRepository: Repository<ValidationTask>
-  ) { }
+  ) {}
 
   private getQueue(name: string): Queue {
     return this.getAllQueues().get(name);
@@ -376,24 +456,37 @@ export class JobQueueService {
     workspaceId: number
   ): Promise<boolean> {
     if (queueName === 'validation-task') {
-      const taskId = Number((job.data as ValidationTaskJobData | undefined)?.taskId);
+      const taskId = Number(
+        (job.data as ValidationTaskJobData | undefined)?.taskId
+      );
       if (!taskId) return false;
 
       const tasks = await this.validationTaskRepository.find({
         where: { id: In([taskId]) },
         select: ['id', 'workspace_id']
       });
-      return tasks.some(task => Number(task.workspace_id) === Number(workspaceId));
+      return tasks.some(
+        task => Number(task.workspace_id) === Number(workspaceId)
+      );
     }
 
-    const jobWorkspaceId = Number((job.data as { workspaceId?: number } | undefined)?.workspaceId);
+    const jobWorkspaceId = Number(
+      (job.data as { workspaceId?: number } | undefined)?.workspaceId
+    );
     return Boolean(jobWorkspaceId) && jobWorkspaceId === Number(workspaceId);
   }
 
   private async cancelKnownJob(queueName: string, job: Job): Promise<boolean> {
     try {
       const state = await job.getState();
-      const removableStates = ['waiting', 'delayed', 'paused', 'completed', 'failed', 'cancelled'];
+      const removableStates = [
+        'waiting',
+        'delayed',
+        'paused',
+        'completed',
+        'failed',
+        'cancelled'
+      ];
       if (removableStates.includes(state)) {
         await job.remove();
         return true;
@@ -433,13 +526,21 @@ export class JobQueueService {
     return this.cancelKnownJob(queueName, job);
   }
 
-  async cancelWorkspaceJob(workspaceId: number, queueName: string, jobId: string): Promise<boolean> {
+  async cancelWorkspaceJob(
+    workspaceId: number,
+    queueName: string,
+    jobId: string
+  ): Promise<boolean> {
     const queue = this.getQueue(queueName);
     if (!queue) return false;
     const job = await queue.getJob(jobId);
     if (!job) return false;
 
-    const belongsToWorkspace = await this.jobBelongsToWorkspace(queueName, job, workspaceId);
+    const belongsToWorkspace = await this.jobBelongsToWorkspace(
+      queueName,
+      job,
+      workspaceId
+    );
     if (!belongsToWorkspace) return false;
 
     return this.cancelKnownJob(queueName, job);
@@ -465,75 +566,99 @@ export class JobQueueService {
 
     for (const [queueName, queue] of queues.entries()) {
       processPromises.push(
-        queue.getJobs(['active', 'waiting', 'delayed', 'completed', 'failed', 'paused']).then(async jobs => {
-          const existingJobs = jobs.filter(Boolean);
-          let matchedJobs = existingJobs;
-          let validationTaskMap = new Map<number, ProcessOverviewValidationTask>();
-          if (queueName === 'validation-task') {
-            const taskIds = existingJobs.map(j => j.data?.taskId as number).filter(Boolean);
-            if (taskIds.length === 0) return [];
-            const tasks = await this.validationTaskRepository.find({
-              where: { id: In(taskIds) },
-              select: [
-                'id',
-                'workspace_id',
-                'validation_type',
-                'status',
-                'progress',
-                'progress_message',
-                'error'
-              ]
-            }) as ProcessOverviewValidationTask[];
-            validationTaskMap = new Map(tasks.map(t => [Number(t.id), t]));
-            matchedJobs = existingJobs.filter(j => (
-              Number(validationTaskMap.get(Number(j.data?.taskId))?.workspace_id) === Number(workspaceId)
-            ));
-          } else {
-            matchedJobs = existingJobs.filter(j => j.data && j.data.workspaceId === workspaceId);
-          }
-
-          const mappedPromises = matchedJobs.map(async job => {
-            const bullState = await job.getState();
-            const validationTask = queueName === 'validation-task' ?
-              validationTaskMap.get(Number(job.data?.taskId)) :
-              undefined;
-            const status = this.getProcessOverviewStatus(
-              queueName,
-              bullState,
-              job.data,
-              validationTask
-            );
-            let progress: unknown = typeof validationTask?.progress === 'number' ?
-              validationTask.progress :
-              job.progress();
-
-            // For completed jobs, ensure progress shows as 100% if it's numeric/empty
-            if (status === 'completed') {
-              if (typeof progress !== 'object' || progress === null) {
-                progress = 100;
-              }
-            } else if (progress === undefined || progress === null) {
-              progress = 0;
+        queue
+          .getJobs([
+            'active',
+            'waiting',
+            'delayed',
+            'completed',
+            'failed',
+            'paused'
+          ])
+          .then(async jobs => {
+            const existingJobs = jobs.filter(Boolean);
+            let matchedJobs = existingJobs;
+            let validationTaskMap = new Map<
+            number,
+            ProcessOverviewValidationTask
+            >();
+            if (queueName === 'validation-task') {
+              const taskIds = existingJobs
+                .map(j => j.data?.taskId as number)
+                .filter(Boolean);
+              if (taskIds.length === 0) return [];
+              const tasks = (await this.validationTaskRepository.find({
+                where: { id: In(taskIds) },
+                select: [
+                  'id',
+                  'workspace_id',
+                  'validation_type',
+                  'status',
+                  'progress',
+                  'progress_message',
+                  'error'
+                ]
+              })) as ProcessOverviewValidationTask[];
+              validationTaskMap = new Map(tasks.map(t => [Number(t.id), t]));
+              matchedJobs = existingJobs.filter(
+                j => Number(
+                  validationTaskMap.get(Number(j.data?.taskId))?.workspace_id
+                ) === Number(workspaceId)
+              );
+            } else {
+              matchedJobs = existingJobs.filter(
+                j => j.data && j.data.workspaceId === workspaceId
+              );
             }
 
-            return {
-              id: job.id,
-              queueName: queueName,
-              status: status,
-              progress: progress,
-              data: this.sanitizeJobData({
-                ...job.data,
-                validationType: validationTask?.validation_type,
-                progressMessage: validationTask?.progress_message
-              }),
-              failedReason: this.getProcessFailedReason(status, job, validationTask),
-              timestamp: job.timestamp,
-              processedOn: job.processedOn,
-              finishedOn: job.finishedOn
-            } as ProcessDto;
-          });
-          return Promise.all(mappedPromises);
-        })
+            const mappedPromises = matchedJobs.map(async job => {
+              const bullState = await job.getState();
+              const validationTask =
+                queueName === 'validation-task' ?
+                  validationTaskMap.get(Number(job.data?.taskId)) :
+                  undefined;
+              const status = this.getProcessOverviewStatus(
+                queueName,
+                bullState,
+                job.data,
+                validationTask
+              );
+              let progress: unknown =
+                typeof validationTask?.progress === 'number' ?
+                  validationTask.progress :
+                  job.progress();
+
+              // For completed jobs, ensure progress shows as 100% if it's numeric/empty
+              if (status === 'completed') {
+                if (typeof progress !== 'object' || progress === null) {
+                  progress = 100;
+                }
+              } else if (progress === undefined || progress === null) {
+                progress = 0;
+              }
+
+              return {
+                id: job.id,
+                queueName: queueName,
+                status: status,
+                progress: progress,
+                data: this.sanitizeJobData({
+                  ...job.data,
+                  validationType: validationTask?.validation_type,
+                  progressMessage: validationTask?.progress_message
+                }),
+                failedReason: this.getProcessFailedReason(
+                  status,
+                  job,
+                  validationTask
+                ),
+                timestamp: job.timestamp,
+                processedOn: job.processedOn,
+                finishedOn: job.finishedOn
+              } as ProcessDto;
+            });
+            return Promise.all(mappedPromises);
+          })
       );
     }
 
@@ -614,7 +739,9 @@ export class JobQueueService {
     workspaceId: number
   ): Promise<Job | undefined> {
     const queue = this.getQueue(queueName);
-    const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(Boolean);
+    const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(
+      Boolean
+    );
 
     if (queueName === 'validation-task') {
       const taskIds = jobs.map(j => j.data?.taskId as number).filter(Boolean);
@@ -623,8 +750,12 @@ export class JobQueueService {
         where: { id: In(taskIds) },
         select: ['id', 'workspace_id']
       });
-      const taskWorkspaceMap = new Map(tasks.map(t => [t.id, t.workspace_id]));
-      return jobs.find(j => taskWorkspaceMap.get(j.data?.taskId) === workspaceId);
+      const taskWorkspaceMap = new Map(
+        tasks.map(t => [t.id, t.workspace_id])
+      );
+      return jobs.find(
+        j => taskWorkspaceMap.get(j.data?.taskId) === workspaceId
+      );
     }
 
     return jobs.find(j => j.data?.workspaceId === workspaceId);
@@ -636,7 +767,10 @@ export class JobQueueService {
   ): Promise<void> {
     const rules = this.DEPENDENCY_RULES.filter(r => r.target === targetQueue);
     for (const rule of rules) {
-      const blockingJob = await this.hasActiveJobForWorkspace(rule.blockedBy, workspaceId);
+      const blockingJob = await this.hasActiveJobForWorkspace(
+        rule.blockedBy,
+        workspaceId
+      );
       if (blockingJob) {
         throw new ConflictException(
           `Cannot start: a ${rule.label} job is still active for this workspace (job ${blockingJob.id}). Please wait until it completes.`
@@ -649,7 +783,9 @@ export class JobQueueService {
     queue: Queue,
     matchFn: (data: T) => boolean
   ): Promise<Job<T> | undefined> {
-    const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(Boolean);
+    const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(
+      Boolean
+    );
     return jobs.find(job => matchFn(job.data));
   }
 
@@ -866,7 +1002,7 @@ export class JobQueueService {
       'delayed'
     ]);
     this.logger.log(`Found ${jobs.length} export jobs in total`);
-    return jobs.filter(job => job.data.workspaceId === workspaceId);
+    return jobs.filter(job => job?.data?.workspaceId === workspaceId);
   }
 
   createExportJobCancellationSignal(jobId: string): AbortSignal {
@@ -1017,7 +1153,9 @@ export class JobQueueService {
     return this.codebookGenerationQueue.add(data, options);
   }
 
-  async getCodebookGenerationJob(jobId: string): Promise<Job<CodebookGenerationJobData>> {
+  async getCodebookGenerationJob(
+    jobId: string
+  ): Promise<Job<CodebookGenerationJobData>> {
     return this.codebookGenerationQueue.getJob(jobId);
   }
 
@@ -1075,8 +1213,14 @@ export class JobQueueService {
     data: CodingAnalysisJobData,
     options?: JobOptions
   ): Promise<Job<CodingAnalysisJobData>> {
-    this.logger.log(`Adding coding analysis job for workspace ${data.workspaceId}`);
-    return this.responseAnalysisQueue.add(data, options);
+    this.logger.log(
+      `Adding coding analysis job for workspace ${data.workspaceId}`
+    );
+    return this.responseAnalysisQueue.add(data, {
+      removeOnComplete: { age: 3600, count: 10 },
+      removeOnFail: { age: 86400, count: 50 },
+      ...options
+    });
   }
 
   async getCodingAnalysisJob(
@@ -1088,19 +1232,38 @@ export class JobQueueService {
   async getActiveCodingAnalysisJob(
     workspaceId: number
   ): Promise<Job<CodingAnalysisJobData> | null> {
+    return this.findCodingAnalysisJob(
+      job => job.data.workspaceId === workspaceId
+    );
+  }
+
+  async getCodingAnalysisJobForCacheKey(
+    workspaceId: number,
+    cacheKey: string
+  ): Promise<Job<CodingAnalysisJobData> | null> {
+    return this.findCodingAnalysisJob(
+      job => job.data.workspaceId === workspaceId && job.data.cacheKey === cacheKey
+    );
+  }
+
+  private async findCodingAnalysisJob(
+    predicate: (job: Job<CodingAnalysisJobData>) => boolean
+  ): Promise<Job<CodingAnalysisJobData> | null> {
     const jobs = await this.responseAnalysisQueue.getJobs([
       'active',
       'waiting',
       'delayed'
     ]);
-    return jobs.find(job => job.data.workspaceId === workspaceId) || null;
+    return jobs.find(predicate) || null;
   }
 
   async addVariableAnalysisJob(
     data: VariableAnalysisJobData,
     options?: JobOptions
   ): Promise<Job<VariableAnalysisJobData>> {
-    this.logger.log(`Adding variable analysis job for workspace ${data.workspaceId}`);
+    this.logger.log(
+      `Adding variable analysis job for workspace ${data.workspaceId}`
+    );
     return this.variableAnalysisQueue.add(data, {
       removeOnComplete: { age: 86400 },
       removeOnFail: { age: 604800 },
@@ -1117,7 +1280,9 @@ export class JobQueueService {
   async getVariableAnalysisJobs(
     workspaceId: number
   ): Promise<Job<VariableAnalysisJobData>[]> {
-    this.logger.log(`Fetching all variable analysis jobs for workspace ${workspaceId}`);
+    this.logger.log(
+      `Fetching all variable analysis jobs for workspace ${workspaceId}`
+    );
     const jobs = await this.variableAnalysisQueue.getJobs([
       'completed',
       'failed',
@@ -1139,14 +1304,19 @@ export class JobQueueService {
       this.logger.log(`Variable analysis job ${jobId} has been deleted`);
       return true;
     } catch (error) {
-      this.logger.error(`Error deleting variable analysis job: ${error.message}`, error.stack);
+      this.logger.error(
+        `Error deleting variable analysis job: ${error.message}`,
+        error.stack
+      );
       return false;
     }
   }
 
   async deleteVariableAnalysisJobs(workspaceId: number): Promise<void> {
     const jobs = await this.getVariableAnalysisJobs(workspaceId);
-    this.logger.log(`Deleting all ${jobs.length} variable analysis jobs for workspace ${workspaceId}`);
+    this.logger.log(
+      `Deleting all ${jobs.length} variable analysis jobs for workspace ${workspaceId}`
+    );
 
     for (const job of jobs) {
       try {
@@ -1154,12 +1324,14 @@ export class JobQueueService {
         if (state === 'active') {
           await job.discard();
           // If removal fails for an active job, we at least discarded it to prevent retries
-          await job.remove().catch(() => { });
+          await job.remove().catch(() => {});
         } else {
           await job.remove();
         }
       } catch (error) {
-        this.logger.warn(`Failed to remove variable analysis job ${job.id}: ${error.message}`);
+        this.logger.warn(
+          `Failed to remove variable analysis job ${job.id}: ${error.message}`
+        );
       }
     }
   }
@@ -1176,19 +1348,26 @@ export class JobQueueService {
 
       if (state === 'waiting' || state === 'delayed') {
         await job.remove();
-        this.logger.log(`Variable analysis job ${jobId} has been cancelled and removed from queue`);
+        this.logger.log(
+          `Variable analysis job ${jobId} has been cancelled and removed from queue`
+        );
         return true;
       }
 
       if (state === 'active') {
         await job.discard();
-        this.logger.log(`Variable analysis job ${jobId} is active, marked for discard`);
+        this.logger.log(
+          `Variable analysis job ${jobId} is active, marked for discard`
+        );
         return true;
       }
 
       return true; // Already finished or failed
     } catch (error) {
-      this.logger.error(`Error cancelling variable analysis job: ${error.message}`, error.stack);
+      this.logger.error(
+        `Error cancelling variable analysis job: ${error.message}`,
+        error.stack
+      );
       return false;
     }
   }

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -1239,21 +1239,27 @@ export class JobQueueService {
 
   async getCodingAnalysisJobForCacheKey(
     workspaceId: number,
-    cacheKey: string
+    cacheKey: string,
+    sourceRevision?: number
   ): Promise<Job<CodingAnalysisJobData> | null> {
     return this.findCodingAnalysisJob(
-      job => job.data.workspaceId === workspaceId && job.data.cacheKey === cacheKey
+      job => job.data.workspaceId === workspaceId &&
+        job.data.cacheKey === cacheKey &&
+        (
+          sourceRevision === undefined ||
+          job.data.sourceRevision === sourceRevision
+        )
     );
   }
 
   private async findCodingAnalysisJob(
     predicate: (job: Job<CodingAnalysisJobData>) => boolean
   ): Promise<Job<CodingAnalysisJobData> | null> {
-    const jobs = await this.responseAnalysisQueue.getJobs([
+    const jobs = (await this.responseAnalysisQueue.getJobs([
       'active',
       'waiting',
       'delayed'
-    ]);
+    ])).filter(Boolean);
     return jobs.find(predicate) || null;
   }
 

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.spec.ts
@@ -11,7 +11,8 @@ describe('CodingAnalysisProcessor', () => {
       {} as never,
       cacheService as CacheService,
       {} as WorkspaceExclusionService,
-      {} as WorkspaceFilesService
+      {} as WorkspaceFilesService,
+      { getCodingIncompleteVariables: jest.fn() } as never
     );
     const analysis: ResponseAnalysisDto = {
       emptyResponses: {
@@ -71,23 +72,77 @@ describe('CodingAnalysisProcessor', () => {
       get: jest.fn().mockResolvedValue('newer-run'),
       set: jest.fn().mockResolvedValue(true)
     };
-    const { processor, analysis } = createProcessor(cacheService);
+    const { processor } = createProcessor(cacheService);
 
-    await expect(processor.handleResponseAnalysis(createJob('old-run'))).resolves.toBe(analysis);
+    await expect(processor.handleResponseAnalysis(createJob('old-run'))).resolves.toMatchObject({
+      cacheKey: 'response-analysis:7__t2',
+      status: 'stale-skip',
+      workspaceId: 7
+    });
 
     expect(cacheService.get).toHaveBeenCalledWith('response-analysis:7__t2:run');
     expect(cacheService.set).not.toHaveBeenCalled();
   });
 
-  it('caches analysis results for the latest marked run', async () => {
+  it('caches lightweight analysis pages for the latest marked run', async () => {
     const cacheService = {
       get: jest.fn().mockResolvedValue('current-run'),
       set: jest.fn().mockResolvedValue(true)
     };
     const { processor, analysis } = createProcessor(cacheService);
 
-    await expect(processor.handleResponseAnalysis(createJob('current-run'))).resolves.toBe(analysis);
+    await expect(processor.handleResponseAnalysis(createJob('current-run'))).resolves.toMatchObject({
+      cacheKey: 'response-analysis:7__t2',
+      status: 'cached',
+      workspaceId: 7
+    });
 
-    expect(cacheService.set).toHaveBeenCalledWith('response-analysis:7__t2', analysis);
+    expect(cacheService.set).not.toHaveBeenCalledWith(
+      'response-analysis:7__t2',
+      analysis
+    );
+    expect(cacheService.set.mock.calls[0][0]).toBe(
+      'response-analysis:7__t2:summary'
+    );
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'response-analysis:7__t2:empty-chunk:0',
+      expect.objectContaining({ chunkIndex: 0 })
+    );
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'response-analysis:7__t2:duplicate-chunk:0',
+      expect.objectContaining({ chunkIndex: 0 })
+    );
+  });
+
+  it('normalizes manual analysis variable keys for query filters', async () => {
+    const codingValidationService = {
+      getCodingIncompleteVariables: jest.fn().mockResolvedValue([
+        { unitName: ' unit-a.XML ', variableId: 'var1' },
+        { unitName: 'UNIT-A', variableId: 'var1' },
+        { unitName: 'unit-b', variableId: ' var2 ' },
+        { unitName: '', variableId: 'ignored' },
+        { unitName: 'unit-c', variableId: '' }
+      ])
+    };
+    const processor = new CodingAnalysisProcessor(
+      {} as never,
+      {} as CacheService,
+      {} as WorkspaceExclusionService,
+      {} as WorkspaceFilesService,
+      codingValidationService as never
+    );
+
+    const variables = await (processor as unknown as {
+      getManualAnalysisVariables: (workspaceId: number) => Promise<
+      { unitName: string; variableId: string }[]
+      >;
+    }).getManualAnalysisVariables(7);
+
+    expect(codingValidationService.getCodingIncompleteVariables)
+      .toHaveBeenCalledWith(7);
+    expect(variables).toEqual([
+      { unitName: 'UNIT-A', variableId: 'var1' },
+      { unitName: 'UNIT-B', variableId: 'var2' }
+    ]);
   });
 });

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
@@ -2,9 +2,10 @@ import { Processor, Process } from '@nestjs/bull';
 import { Logger, Optional } from '@nestjs/common';
 import { Job } from 'bull';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Brackets } from 'typeorm';
+import { Repository, Brackets, SelectQueryBuilder } from 'typeorm';
 import { ResponseEntity } from '../../database/entities/response.entity';
 import { ResponseMatchingFlag } from '../../database/services/coding/coding-job.service';
+import { CodingValidationService } from '../../database/services/coding';
 import {
   ResponseAnalysisDto,
   EmptyResponseDto,
@@ -26,13 +27,57 @@ import {
 } from '../../database/services/coding/aggregation-metrics.util';
 import { getCodingAnalysisRunMarkerKey } from '../../database/services/coding/coding-analysis-cache-key.util';
 import {
+  createDuplicateValueChunkCaches,
+  createDuplicateValuePageCache,
+  createEmptyResponseChunkCaches,
+  createEmptyResponsePageCache,
+  createResponseAnalysisSummaryCache,
+  getResponseAnalysisDuplicateChunkCacheKey,
+  getResponseAnalysisDuplicatePageCacheKey,
+  getResponseAnalysisEmptyChunkCacheKey,
+  getResponseAnalysisEmptyPageCacheKey,
+  getResponseAnalysisSummaryCacheKey,
+  RESPONSE_ANALYSIS_DUPLICATE_PAGE_LIMITS,
+  RESPONSE_ANALYSIS_EMPTY_PAGE_LIMITS
+} from '../../database/services/coding/response-analysis-page-cache.util';
+import {
   IQB_STANDARD_MISSING_CODES,
   MissingsProfilesService
 } from '../../database/services/coding/missings-profiles.service';
 
+interface ManualAnalysisVariable {
+  unitName: string;
+  variableId: string;
+}
+
+interface AnalysisResponseRow {
+  responseId: number | string;
+  value: string | null;
+  variableId: string;
+  statusV2: number | string | null;
+  codeV2: number | string | null;
+  unitName: string | null;
+  unitAlias: string | null;
+  personLogin: string | null;
+  personCode: string | null;
+  personGroup: string | null;
+  bookletName: string | null;
+}
+
+interface CodingAnalysisJobResult {
+  workspaceId: number;
+  cacheKey: string;
+  status: 'cached' | 'stale-skip';
+  sourceRevision?: number;
+  completedAt: string;
+}
+
 @Processor('response-analysis')
 export class CodingAnalysisProcessor {
   private readonly logger = new Logger(CodingAnalysisProcessor.name);
+  private readonly slowResponseAnalysisThresholdMs = 3000;
+  private readonly normalizedUnitNameExpression =
+    "regexp_replace(UPPER(unit.name), '\\.XML$', '', 'i')";
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -40,32 +85,44 @@ export class CodingAnalysisProcessor {
     private cacheService: CacheService,
     private workspaceExclusionService: WorkspaceExclusionService,
     private workspaceFilesService: WorkspaceFilesService,
+    private codingValidationService: CodingValidationService,
     @Optional()
     private missingsProfilesService?: MissingsProfilesService
-  ) { }
+  ) {}
 
   private async getDefaultMirCode(workspaceId: number): Promise<number> {
     if (!this.missingsProfilesService) {
       return IQB_STANDARD_MISSING_CODES.mir;
     }
 
-    const missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
-      workspaceId,
-      null,
-      'mir'
-    );
+    const missing =
+      await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+        workspaceId,
+        null,
+        'mir'
+      );
     return missing.code;
   }
 
   @Process()
-  async handleResponseAnalysis(job: Job<CodingAnalysisJobData>) {
+  async handleResponseAnalysis(
+    job: Job<CodingAnalysisJobData>
+  ): Promise<CodingAnalysisJobResult> {
     const {
       workspaceId, matchingFlags, threshold, cacheKey
     } = job.data;
-    this.logger.log(`Processing response analysis for workspace ${workspaceId}...`);
+    const startedAt = Date.now();
+    this.logger.log(
+      `Processing response analysis for workspace ${workspaceId}...`
+    );
 
     try {
-      const analysis = await this.computeResponseAnalysis(workspaceId, matchingFlags as ResponseMatchingFlag[], threshold, job);
+      const analysis = await this.computeResponseAnalysis(
+        workspaceId,
+        matchingFlags as ResponseMatchingFlag[],
+        threshold,
+        job
+      );
       if (job.data.runId) {
         const currentRunId = await this.cacheService.get<string>(
           getCodingAnalysisRunMarkerKey(cacheKey)
@@ -74,18 +131,108 @@ export class CodingAnalysisProcessor {
           this.logger.log(
             `Skipping stale response analysis cache write for workspace ${workspaceId} (job ${job.id})`
           );
-          return analysis;
+          this.logResponseAnalysisTiming(
+            workspaceId,
+            startedAt,
+            'completed-stale-skip'
+          );
+          return this.createJobResult(job.data, 'stale-skip');
         }
       }
 
-      await this.cacheService.set(cacheKey, analysis);
+      await this.writeResponseAnalysisPageCaches(cacheKey, analysis);
 
-      this.logger.log(`Response analysis for workspace ${workspaceId} completed and cached.`);
-      return analysis;
+      this.logResponseAnalysisTiming(
+        workspaceId,
+        startedAt,
+        'completed-and-cached'
+      );
+      return this.createJobResult(job.data, 'cached');
     } catch (error) {
-      this.logger.error(`Response analysis failed: ${error.message}`, error.stack);
+      this.logResponseAnalysisTiming(workspaceId, startedAt, 'failed');
+      this.logger.error(
+        `Response analysis failed: ${error.message}`,
+        error.stack
+      );
       throw error;
     }
+  }
+
+  private async writeResponseAnalysisPageCaches(
+    cacheKey: string,
+    analysis: ResponseAnalysisDto
+  ): Promise<void> {
+    const writes: Promise<boolean>[] = [
+      this.cacheService.set(
+        getResponseAnalysisSummaryCacheKey(cacheKey),
+        createResponseAnalysisSummaryCache(analysis)
+      )
+    ];
+
+    for (const limit of RESPONSE_ANALYSIS_EMPTY_PAGE_LIMITS) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisEmptyPageCacheKey(cacheKey, 1, limit),
+          createEmptyResponsePageCache(analysis, 1, limit)
+        )
+      );
+    }
+
+    for (const limit of RESPONSE_ANALYSIS_DUPLICATE_PAGE_LIMITS) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisDuplicatePageCacheKey(cacheKey, 1, limit),
+          createDuplicateValuePageCache(analysis, 1, limit)
+        )
+      );
+    }
+
+    for (const chunk of createEmptyResponseChunkCaches(analysis)) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisEmptyChunkCacheKey(cacheKey, chunk.chunkIndex),
+          chunk
+        )
+      );
+    }
+
+    for (const chunk of createDuplicateValueChunkCaches(analysis)) {
+      writes.push(
+        this.cacheService.set(
+          getResponseAnalysisDuplicateChunkCacheKey(cacheKey, chunk.chunkIndex),
+          chunk
+        )
+      );
+    }
+
+    await Promise.all(writes);
+  }
+
+  private createJobResult(
+    data: CodingAnalysisJobData,
+    status: CodingAnalysisJobResult['status']
+  ): CodingAnalysisJobResult {
+    return {
+      workspaceId: data.workspaceId,
+      cacheKey: data.cacheKey,
+      status,
+      sourceRevision: data.sourceRevision,
+      completedAt: new Date().toISOString()
+    };
+  }
+
+  private logResponseAnalysisTiming(
+    workspaceId: number,
+    startedAt: number,
+    status: string
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    const message = `Response analysis for workspace ${workspaceId} ${status} in ${durationMs}ms.`;
+    if (durationMs >= this.slowResponseAnalysisThresholdMs) {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.log(message);
   }
 
   private async computeResponseAnalysis(
@@ -95,16 +242,45 @@ export class CodingAnalysisProcessor {
     job?: Job<CodingAnalysisJobData>
   ): Promise<ResponseAnalysisDto> {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
-    const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
-    const derivedVariableMap = await this.getDerivedVariableMap(workspaceId);
+    const intendedIncompleteStatus = statusStringToNumber(
+      'INTENDED_INCOMPLETE'
+    );
+    const [
+      exclusions,
+      defaultMirCode,
+      derivedVariableMap,
+      sourceRevision,
+      manualVariables
+    ] = await Promise.all([
+      this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId),
+      this.getDefaultMirCode(workspaceId),
+      this.getDerivedVariableMap(workspaceId),
+      this.resolveSourceRevision(workspaceId, job?.data.sourceRevision),
+      this.getManualAnalysisVariables(workspaceId)
+    ]);
 
-    // 1. Identify relevant Unit+Variable combinations
-    this.logger.log(`Identifying relevant variables for analysis in workspace ${workspaceId}...`);
+    if (manualVariables.length === 0) {
+      this.logger.warn(
+        `No manual coding variables found for analysis in workspace ${workspaceId}`
+      );
+      return this.createEmptyAnalysisResult(
+        matchingFlags,
+        threshold,
+        sourceRevision
+      );
+    }
+
+    this.logger.log(
+      `Restricting response analysis for workspace ${workspaceId} to ${manualVariables.length} manual coding variables.`
+    );
+
+    // 1. Identify relevant UnitName+Variable combinations
+    this.logger.log(
+      `Identifying relevant variables for analysis in workspace ${workspaceId}...`
+    );
     const relevantVariablesQuery = this.responseRepository
       .createQueryBuilder('response')
-      .select('response.unitid', 'unitId')
+      .select(this.normalizedUnitNameExpression, 'unitName')
       .addSelect('response.variableid', 'variableId')
       .distinct(true)
       .innerJoin('response.unit', 'unit')
@@ -113,17 +289,32 @@ export class CodingAnalysisProcessor {
       .innerJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('response.status_v1 IN (:...statuses)', { statuses: [codingIncompleteStatus, intendedIncompleteStatus] });
+      .andWhere('response.status_v1 IN (:...statuses)', {
+        statuses: [codingIncompleteStatus, intendedIncompleteStatus]
+      });
+    this.applyManualVariableFilter(
+      relevantVariablesQuery,
+      manualVariables,
+      'relevantManualVariable'
+    );
     applyResolvedExclusionsToQuery(relevantVariablesQuery, exclusions);
-    const relevantVariables = await relevantVariablesQuery
-      .getRawMany();
+    const relevantVariables =
+      await relevantVariablesQuery.getRawMany<ManualAnalysisVariable>();
 
     if (relevantVariables.length === 0) {
-      this.logger.warn(`No relevant variables found for analysis in workspace ${workspaceId}`);
-      return this.createEmptyAnalysisResult(matchingFlags, threshold);
+      this.logger.warn(
+        `No relevant variables found for analysis in workspace ${workspaceId}`
+      );
+      return this.createEmptyAnalysisResult(
+        matchingFlags,
+        threshold,
+        sourceRevision
+      );
     }
 
-    this.logger.log(`Found ${relevantVariables.length} variable groups to analyze. Processing in chunks...`);
+    this.logger.log(
+      `Found ${relevantVariables.length} variable groups to analyze. Processing in chunks...`
+    );
 
     const emptyResponses: EmptyResponseDto[] = [];
     const duplicateValueGroups: DuplicateValueGroupDto[] = [];
@@ -139,23 +330,41 @@ export class CodingAnalysisProcessor {
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
       .andWhere('response.code_v2 = :aggregatedCode', { aggregatedCode: -111 });
+    this.applyManualVariableFilter(
+      aggregationAppliedQuery,
+      manualVariables,
+      'aggregationManualVariable'
+    );
     applyResolvedExclusionsToQuery(aggregationAppliedQuery, exclusions);
-    const isAggregationApplied = await aggregationAppliedQuery
-      .getCount() > 0;
+    const isAggregationApplied = (await aggregationAppliedQuery.getCount()) > 0;
 
     // 2. Process in chunks
-    const chunkSize = 50; // Number of variable groups per query
+    const chunkSize = 25; // Number of unit-name variable groups per query
     for (let i = 0; i < relevantVariables.length; i += chunkSize) {
       const chunk = relevantVariables.slice(i, i + chunkSize);
 
-      const qb = this.responseRepository.createQueryBuilder('response')
-        .leftJoinAndSelect('response.unit', 'unit')
-        .leftJoinAndSelect('unit.booklet', 'booklet')
-        .leftJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
-        .leftJoinAndSelect('booklet.person', 'person')
+      const qb = this.responseRepository
+        .createQueryBuilder('response')
+        .select('response.id', 'responseId')
+        .addSelect('response.value', 'value')
+        .addSelect('response.variableid', 'variableId')
+        .addSelect('response.status_v2', 'statusV2')
+        .addSelect('response.code_v2', 'codeV2')
+        .addSelect('unit.name', 'unitName')
+        .addSelect('unit.alias', 'unitAlias')
+        .addSelect('person.login', 'personLogin')
+        .addSelect('person.code', 'personCode')
+        .addSelect('person.group', 'personGroup')
+        .addSelect('bookletinfo.name', 'bookletName')
+        .leftJoin('response.unit', 'unit')
+        .leftJoin('unit.booklet', 'booklet')
+        .leftJoin('booklet.bookletinfo', 'bookletinfo')
+        .leftJoin('booklet.person', 'person')
         .where('person.workspace_id = :workspaceId', { workspaceId })
         .andWhere('person.consider = :consider', { consider: true })
-        .andWhere('response.status_v1 IN (:...statuses)', { statuses: [codingIncompleteStatus, intendedIncompleteStatus] })
+        .andWhere('response.status_v1 IN (:...statuses)', {
+          statuses: [codingIncompleteStatus, intendedIncompleteStatus]
+        })
         // Exclude already-aggregated responses (non-master duplicates) so they don't reappear after aggregation
         .andWhere(
           '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :emptyCode))',
@@ -163,18 +372,29 @@ export class CodingAnalysisProcessor {
         );
       applyResolvedExclusionsToQuery(qb, exclusions);
 
-      qb.andWhere(new Brackets(qbInside => {
-        chunk.forEach((item, index) => {
-          const params = { [`uid${index}`]: item.unitId, [`vid${index}`]: item.variableId };
-          if (index === 0) {
-            qbInside.where(`response.unitid = :uid${index} AND response.variableid = :vid${index}`, params);
-          } else {
-            qbInside.orWhere(`response.unitid = :uid${index} AND response.variableid = :vid${index}`, params);
-          }
-        });
-      }));
+      qb.andWhere(
+        new Brackets(qbInside => {
+          chunk.forEach((item, index) => {
+            const params = {
+              [`unitName${index}`]: item.unitName,
+              [`vid${index}`]: item.variableId
+            };
+            if (index === 0) {
+              qbInside.where(
+                `${this.normalizedUnitNameExpression} = :unitName${index} AND response.variableid = :vid${index}`,
+                params
+              );
+            } else {
+              qbInside.orWhere(
+                `${this.normalizedUnitNameExpression} = :unitName${index} AND response.variableid = :vid${index}`,
+                params
+              );
+            }
+          });
+        })
+      );
 
-      const responsesBatch = await qb.getMany();
+      const responsesBatch = await qb.getRawMany<AnalysisResponseRow>();
       totalProcessed += responsesBatch.length;
 
       this.analyzeBatch(
@@ -186,14 +406,23 @@ export class CodingAnalysisProcessor {
       );
 
       // Explicitly free memory if possible (though GC handles function scope)
-      if ((i + chunkSize) % 500 === 0 || (i + chunkSize) >= relevantVariables.length) {
+      if (
+        (i + chunkSize) % 500 === 0 ||
+        i + chunkSize >= relevantVariables.length
+      ) {
         const processed = Math.min(i + chunkSize, relevantVariables.length);
-        const progress = Math.round((processed / relevantVariables.length) * 100);
+        const progress = Math.round(
+          (processed / relevantVariables.length) * 100
+        );
         if (job) {
           await job.progress(progress);
         }
-        this.logger.log(`Processed ${processed}/${relevantVariables.length} variable groups...`);
-        if (global.gc) { global.gc(); }
+        this.logger.log(
+          `Processed ${processed}/${relevantVariables.length} variable groups...`
+        );
+        if (global.gc) {
+          global.gc();
+        }
       }
     }
 
@@ -204,13 +433,17 @@ export class CodingAnalysisProcessor {
         // Merge occurrences into the existing group
         mergedGroupsMap.get(key)!.occurrences.push(...group.occurrences);
       } else {
-        mergedGroupsMap.set(key, { ...group, occurrences: [...group.occurrences] });
+        mergedGroupsMap.set(key, {
+          ...group,
+          occurrences: [...group.occurrences]
+        });
       }
     }
 
     // Apply threshold filter on merged groups and build the final list
-    const mergedGroups = Array.from(mergedGroupsMap.values())
-      .filter(group => group.occurrences.length >= threshold);
+    const mergedGroups = Array.from(mergedGroupsMap.values()).filter(
+      group => group.occurrences.length >= threshold
+    );
 
     // Sort results
     emptyResponses.sort((a, b) => {
@@ -236,7 +469,9 @@ export class CodingAnalysisProcessor {
       matchingFlags
     );
 
-    this.logger.log(`Analysis complete. Processed ${totalProcessed} responses. Found ${mergedGroups.length} duplicate groups.`);
+    this.logger.log(
+      `Analysis complete. Processed ${totalProcessed} responses. Found ${mergedGroups.length} duplicate groups.`
+    );
 
     return {
       emptyResponses: {
@@ -252,12 +487,13 @@ export class CodingAnalysisProcessor {
       },
       aggregationSummary,
       matchingFlags: matchingFlags as unknown as string[],
-      analysisTimestamp: new Date().toISOString()
+      analysisTimestamp: new Date().toISOString(),
+      sourceRevision
     };
   }
 
   private analyzeBatch(
-    responses: ResponseEntity[],
+    responses: AnalysisResponseRow[],
     matchingFlags: ResponseMatchingFlag[],
     emptyResponses: EmptyResponseDto[],
     duplicateValueGroups: DuplicateValueGroupDto[],
@@ -267,7 +503,7 @@ export class CodingAnalysisProcessor {
     // Since our query chunked by Unit+Variable, we can treat this batch as a collection of complete groups
 
     // Group responses by unit+variable
-    const responsesByUnitVariable = new Map<string, ResponseEntity[]>();
+    const responsesByUnitVariable = new Map<string, AnalysisResponseRow[]>();
 
     for (const response of responses) {
       // Empty Check - IMPROVED LOGIC
@@ -275,30 +511,36 @@ export class CodingAnalysisProcessor {
 
       if (!isAggregatableValue(value)) {
         emptyResponses.push({
-          unitName: response.unit?.name || '',
-          unitAlias: response.unit?.alias || null,
-          variableId: response.variableid,
-          personLogin: response.unit?.booklet?.person?.login || '',
-          personCode: response.unit?.booklet?.person?.code || '',
-          personGroup: response.unit?.booklet?.person?.group || '',
-          bookletName: response.unit?.booklet?.bookletinfo?.name || 'Unknown',
-          responseId: response.id,
+          unitName: response.unitName || '',
+          unitAlias: response.unitAlias || null,
+          variableId: response.variableId,
+          personLogin: response.personLogin || '',
+          personCode: response.personCode || '',
+          personGroup: response.personGroup || '',
+          bookletName: response.bookletName || 'Unknown',
+          responseId: Number(response.responseId),
           value: response.value,
-          isCoded: response.status_v2 !== null,
-          assignedCode: response.code_v2
+          isCoded:
+            response.statusV2 !== null && response.statusV2 !== undefined,
+          assignedCode:
+            response.codeV2 === null || response.codeV2 === undefined ?
+              null :
+              Number(response.codeV2)
         });
         continue; // Skip empty for duplicates
       }
 
-      if (isDerivedAggregationVariable(
-        derivedVariableMap,
-        response.unit?.name || '',
-        response.variableid
-      )) {
+      if (
+        isDerivedAggregationVariable(
+          derivedVariableMap,
+          response.unitName || '',
+          response.variableId
+        )
+      ) {
         continue;
       }
 
-      const key = `${response.unit?.name || response.unitid}_${response.variableid}`;
+      const key = `${response.unitName || ''}_${response.variableId}`;
       if (!responsesByUnitVariable.has(key)) {
         responsesByUnitVariable.set(key, []);
       }
@@ -306,7 +548,7 @@ export class CodingAnalysisProcessor {
     }
 
     for (const [, groupResponses] of responsesByUnitVariable.entries()) {
-      const valueGroups = new Map<string, ResponseEntity[]>();
+      const valueGroups = new Map<string, AnalysisResponseRow[]>();
       for (const response of groupResponses) {
         const normalizedValue = normalizeAggregationValue(
           response.value,
@@ -321,16 +563,16 @@ export class CodingAnalysisProcessor {
       for (const [normalizedValue, valGroup] of valueGroups.entries()) {
         const first = valGroup[0];
         duplicateValueGroups.push({
-          unitName: first.unit?.name || '',
-          unitAlias: first.unit?.alias || null,
-          variableId: first.variableid,
+          unitName: first.unitName || '',
+          unitAlias: first.unitAlias || null,
+          variableId: first.variableId,
           normalizedValue,
           originalValue: first.value || '',
           occurrences: valGroup.map(r => ({
-            personLogin: r.unit?.booklet?.person?.login || 'Unknown',
-            personCode: r.unit?.booklet?.person?.code || '',
-            bookletName: r.unit?.booklet?.bookletinfo?.name || 'Unknown',
-            responseId: r.id,
+            personLogin: r.personLogin || 'Unknown',
+            personCode: r.personCode || '',
+            bookletName: r.bookletName || 'Unknown',
+            responseId: Number(r.responseId),
             value: r.value || ''
           }))
         });
@@ -340,7 +582,8 @@ export class CodingAnalysisProcessor {
 
   private createEmptyAnalysisResult(
     matchingFlags: ResponseMatchingFlag[],
-    threshold: number | null = null
+    threshold: number | null = null,
+    sourceRevision?: number
   ): ResponseAnalysisDto {
     const result: ResponseAnalysisDto = {
       emptyResponses: {
@@ -362,20 +605,107 @@ export class CodingAnalysisProcessor {
         matchingFlags
       ),
       matchingFlags: matchingFlags as unknown as string[],
-      analysisTimestamp: new Date().toISOString()
+      analysisTimestamp: new Date().toISOString(),
+      sourceRevision
     };
 
     return result;
+  }
+
+  private async getManualAnalysisVariables(
+    workspaceId: number
+  ): Promise<ManualAnalysisVariable[]> {
+    const variables =
+      await this.codingValidationService.getCodingIncompleteVariables(
+        workspaceId
+      );
+    const uniqueVariables = new Map<string, ManualAnalysisVariable>();
+
+    variables.forEach(variable => {
+      const unitName = this.normalizeUnitName(variable.unitName);
+      const variableId = String(variable.variableId || '').trim();
+      if (!unitName || !variableId) {
+        return;
+      }
+      uniqueVariables.set(`${unitName}::${variableId}`, {
+        unitName,
+        variableId
+      });
+    });
+
+    return Array.from(uniqueVariables.values());
+  }
+
+  private normalizeUnitName(unitName: string | null | undefined): string {
+    return String(unitName || '')
+      .trim()
+      .replace(/\.XML$/i, '')
+      .toUpperCase();
+  }
+
+  private applyManualVariableFilter(
+    query: SelectQueryBuilder<ResponseEntity>,
+    variables: ManualAnalysisVariable[],
+    parameterPrefix: string
+  ): void {
+    query.andWhere(
+      new Brackets(qbInside => {
+        variables.forEach((variable, index) => {
+          const unitParam = `${parameterPrefix}Unit${index}`;
+          const variableParam = `${parameterPrefix}Variable${index}`;
+          const params = {
+            [unitParam]: variable.unitName,
+            [variableParam]: variable.variableId
+          };
+          const condition =
+            `${this.normalizedUnitNameExpression} = :${unitParam} ` +
+            `AND response.variableid = :${variableParam}`;
+
+          if (index === 0) {
+            qbInside.where(condition, params);
+            return;
+          }
+          qbInside.orWhere(condition, params);
+        });
+      })
+    );
+  }
+
+  private async resolveSourceRevision(
+    workspaceId: number,
+    plannedRevision?: number
+  ): Promise<number> {
+    if (plannedRevision !== undefined) {
+      return plannedRevision;
+    }
+
+    try {
+      const rows = (await this.responseRepository.query(
+        'SELECT revision FROM workspace_test_results_revision WHERE workspace_id = $1',
+        [workspaceId]
+      )) as Array<{ revision: number | string }>;
+      return Number(rows[0]?.revision || 0);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve test result revision for response analysis: ${message}`
+      );
+      return 0;
+    }
   }
 
   private async getDerivedVariableMap(
     workspaceId: number
   ): Promise<Map<string, Set<string>>> {
     try {
-      return await this.workspaceFilesService.getDerivedVariableMap(workspaceId);
+      return await this.workspaceFilesService.getDerivedVariableMap(
+        workspaceId
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      this.logger.warn(`Could not load derived variable map for workspace ${workspaceId}: ${message}`);
+      this.logger.warn(
+        `Could not load derived variable map for workspace ${workspaceId}: ${message}`
+      );
       return new Map<string, Set<string>>();
     }
   }

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -854,11 +854,16 @@
                       }}"</span
                     >
                     <span class="occurrence-count"
-                      >({{ group.occurrences.length }}x)</span
+                      >({{ getDuplicateOccurrenceCount(group) }}x)</span
                     >
                   </div>
                   <ul class="occurrence-list">
-                    <li *ngFor="let occ of group.occurrences | slice: 0 : 5">
+                    <li
+                      *ngFor="
+                        let occ of group.occurrences
+                          | slice: 0 : duplicateOccurrencePreviewLimit
+                      "
+                    >
                       {{ occ.personLogin
                       }}{{
                         occ.personCode ? ' (' + occ.personCode + ')' : ''
@@ -866,10 +871,10 @@
                       - {{ occ.bookletName }}
                     </li>
                     <li
-                      *ngIf="group.occurrences.length > 5"
+                      *ngIf="getRemainingDuplicateOccurrenceCount(group) > 0"
                       class="more-occurrences"
                     >
-                      +{{ group.occurrences.length - 5 }}
+                      +{{ getRemainingDuplicateOccurrenceCount(group) }}
                       {{
                         'coding-management-manual.response-analysis.more'
                           | translate

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -22,6 +22,9 @@ import { ManualCodingExportDialogComponent } from '../manual-coding-export-dialo
 import type {
   ManualCodeAvailabilityWarningDto
 } from '../../../../../../../api-dto/coding/manual-code-availability.dto';
+import type {
+  DuplicateValueGroupDto
+} from '../../../../../../../api-dto/coding/response-analysis.dto';
 import { DoubleCodedReviewComponent } from '../double-coded-review/double-coded-review.component';
 
 type VariableCoverageOverview = NonNullable<
@@ -52,6 +55,27 @@ const createManualCodeAvailabilityWarning = (
   onlySpecialOptionsAvailable: true,
   message: 'Variable hat keine regulären Codes mit manueller Instruktion.'
 });
+
+const createDuplicateValueGroup = (
+  occurrenceCount: number | undefined,
+  previewCount: number
+): DuplicateValueGroupDto => {
+  const group: DuplicateValueGroupDto = {
+    unitName: 'Unit A',
+    unitAlias: null,
+    variableId: 'VAR_A',
+    normalizedValue: 'same-answer',
+    originalValue: 'same-answer',
+    occurrences: Array.from({ length: previewCount }, (_, index) => ({
+      personLogin: `person-${index + 1}`,
+      personCode: `code-${index + 1}`,
+      bookletName: 'Booklet A',
+      responseId: index + 1,
+      value: 'same-answer'
+    }))
+  };
+  return occurrenceCount === undefined ? group : { ...group, occurrenceCount };
+};
 
 describe('CodingManagementManualComponent', () => {
   let component: CodingManagementManualComponent;
@@ -499,6 +523,67 @@ describe('CodingManagementManualComponent', () => {
       ResponseMatchingFlag.IGNORE_CASE
     ]);
     expect(triggerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses occurrenceCount for duplicate occurrence totals when only a preview is loaded', () => {
+    const previewOnlyGroup = createDuplicateValueGroup(12, 5);
+    const legacyFullGroup = createDuplicateValueGroup(undefined, 8);
+
+    expect(component.getDuplicateOccurrenceCount(previewOnlyGroup)).toBe(12);
+    expect(
+      component.getRemainingDuplicateOccurrenceCount(previewOnlyGroup)
+    ).toBe(7);
+    expect(component.getDuplicateOccurrenceCount(legacyFullGroup)).toBe(8);
+    expect(
+      component.getRemainingDuplicateOccurrenceCount(legacyFullGroup)
+    ).toBe(3);
+  });
+
+  it('uses occurrenceCount for duplicate aggregation threshold checks', () => {
+    const dialog = {
+      open: jest.fn().mockReturnValue({ afterClosed: () => of(false) })
+    };
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      dialog: typeof dialog;
+    };
+
+    componentInternals.dialog = dialog;
+    componentInternals.appService.selectedWorkspaceId = 5;
+    component.duplicateAggregationThreshold = 10;
+    component.responseAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 1,
+        totalResponses: 12,
+        groups: [createDuplicateValueGroup(12, 5)],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 1,
+        duplicateResponses: 12,
+        collapsedCases: 11,
+        rawCases: 12,
+        effectiveCases: 1,
+        threshold: 10,
+        aggregationActive: false
+      },
+      matchingFlags: [],
+      analysisTimestamp: new Date().toISOString()
+    };
+
+    component.onApplyDuplicateAggregation();
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        data: {
+          duplicateGroups: 1,
+          totalResponses: 12,
+          threshold: 10
+        }
+      })
+    );
   });
 
   it('should not block preparation for duplicates when aggregation is active', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -84,7 +84,10 @@ import {
   WorkspaceSettingsService
 } from '../../../ws-admin/services/workspace-settings.service';
 import { CodingStatistics } from '../../../../../../../api-dto/coding/coding-statistics';
-import { ResponseAnalysisDto } from '../../../../../../../api-dto/coding/response-analysis.dto';
+import {
+  DuplicateValueGroupDto,
+  ResponseAnalysisDto
+} from '../../../../../../../api-dto/coding/response-analysis.dto';
 import {
   CodingFreshnessSummaryDto,
   CodingFreshnessSummaryItemDto
@@ -258,6 +261,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   // Response analysis data
   responseAnalysis: ResponseAnalysisDto | null = null;
   responseAnalysisError: string | null = null;
+  readonly duplicateOccurrencePreviewLimit = 5;
 
   isLoadingResponseAnalysis = false;
   showEmptyResponsesDetails = false;
@@ -4214,6 +4218,27 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.showDuplicateValuesDetails = !this.showDuplicateValuesDetails;
   }
 
+  getDuplicateOccurrenceCount(group: DuplicateValueGroupDto): number {
+    if (
+      typeof group.occurrenceCount === 'number' &&
+      Number.isFinite(group.occurrenceCount)
+    ) {
+      return Math.max(group.occurrenceCount, group.occurrences.length);
+    }
+    return group.occurrences.length;
+  }
+
+  getRemainingDuplicateOccurrenceCount(group: DuplicateValueGroupDto): number {
+    const visibleOccurrences = Math.min(
+      group.occurrences.length,
+      this.duplicateOccurrencePreviewLimit
+    );
+    return Math.max(
+      0,
+      this.getDuplicateOccurrenceCount(group) - visibleOccurrences
+    );
+  }
+
   onApplyEmptyResponseCoding(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId || !this.responseAnalysis || !this.emptyResponseMissing) {
@@ -4292,7 +4317,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
     // Filter groups that meet the threshold
     const groupsMeetingThreshold = this.responseAnalysis.duplicateValues.groups.filter(
-      group => group.occurrences.length >= this.duplicateAggregationThreshold
+      group => this.getDuplicateOccurrenceCount(group) >=
+        this.duplicateAggregationThreshold
     );
 
     if (groupsMeetingThreshold.length === 0) {
@@ -4306,7 +4332,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     const totalResponsesInGroups = groupsMeetingThreshold.reduce(
-      (sum, group) => sum + group.occurrences.length,
+      (sum, group) => sum + this.getDuplicateOccurrenceCount(group),
       0
     );
 


### PR DESCRIPTION
## What changed

Split the response-analysis caching part out of #830.

- adds lightweight page/chunk caches for response analysis results
- avoids reading full cached payloads for paged analysis views
- marks stale cached analysis when the test-result revision changes
- keeps queue progress/run markers aligned with the cached analysis run

## Why

This is a backend performance/cache optimization and should be reviewed independently from the ticket-level refresh-trigger behavior.

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx test backend --testFile=apps/backend/src/app/job-queue/job-queue.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx test backend --testFile=apps/backend/src/app/job-queue/processors/coding-analysis.processor.spec.ts --runInBand --skip-nx-cache`
- `npx nx lint backend --skip-nx-cache`
