### PR TITLE
Split coding overview backend cache optimizations from #830

### DIFF
--- a/api-dto/coding/autocoding-readiness.dto.ts
+++ b/api-dto/coding/autocoding-readiness.dto.ts
@@ -1,4 +1,10 @@
-export type AutocodingReadinessStatus = 'READY' | 'BLOCKED' | 'NO_RESULTS';
+export type AutocodingReadinessStatus =
+  | 'READY'
+  | 'BLOCKED'
+  | 'NO_RESULTS'
+  | 'DIAGNOSTICS_PENDING';
+
+export type AutocodingReadinessDetailLevel = 'summary' | 'full';
 
 export type AutocodingReadinessBlocker =
   | 'NO_RELEVANT_RESPONSES'
@@ -18,6 +24,8 @@ export interface AutocodingInvalidVariableSampleDto {
 export interface AutocodingReadinessDto {
   workspaceId: number;
   autoCoderRun: 1 | 2;
+  detailLevel?: AutocodingReadinessDetailLevel;
+  detailsComplete?: boolean;
   readiness: AutocodingReadinessStatus;
   blockers: AutocodingReadinessBlocker[];
   rawResponsesTotal: number;
@@ -31,6 +39,7 @@ export interface AutocodingReadinessDto {
   invalidCodingSchemes: string[];
   validVariablePairs: number;
   validResponses: number;
+  potentialCodeableResponses?: number;
   codeableResponses: number;
   invalidVariableSamples: AutocodingInvalidVariableSampleDto[];
   computedAt?: string;

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
@@ -148,11 +148,12 @@ describe('WorkspaceCodingStatisticsController', () => {
   });
 
   it('delegates autocoding readiness requests with parsed options', async () => {
-    await controller.getAutocodingReadiness(5, '2', 'true');
+    await controller.getAutocodingReadiness(5, '2', 'true', 'summary');
 
     expect(codingReadinessService.getReadiness).toHaveBeenCalledWith(5, {
       autoCoderRun: 2,
-      forceRefresh: true
+      forceRefresh: true,
+      detailLevel: 'summary'
     });
   });
 

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -45,7 +45,10 @@ import {
   CodingFreshnessVersion,
   StartCodingFreshnessJobDto
 } from '../../../../../../api-dto/coding/coding-freshness.dto';
-import { AutocodingReadinessDto } from '../../../../../../api-dto/coding/autocoding-readiness.dto';
+import {
+  AutocodingReadinessDetailLevel,
+  AutocodingReadinessDto
+} from '../../../../../../api-dto/coding/autocoding-readiness.dto';
 import { JobQueueService } from '../../job-queue/job-queue.service';
 import { sanitizeCsvText } from '../../utils/csv.util';
 
@@ -1067,17 +1070,25 @@ export class WorkspaceCodingStatisticsController {
     required: false,
     description: 'Ignore the short-lived readiness cache and recalculate.'
   })
+  @ApiQuery({
+    name: 'detailLevel',
+    required: false,
+    description: 'Return a lightweight summary or full diagnostics.',
+    enum: ['summary', 'full']
+  })
   @ApiOkResponse({
     description: 'Auto-coding readiness diagnostics retrieved successfully.'
   })
   async getAutocodingReadiness(
     @WorkspaceId() workspace_id: number,
       @Query('autoCoderRun') autoCoderRun?: string | string[],
-      @Query('forceRefresh') forceRefresh?: string | string[]
+      @Query('forceRefresh') forceRefresh?: string | string[],
+      @Query('detailLevel') detailLevel?: string | string[]
   ): Promise<AutocodingReadinessDto> {
     return this.codingReadinessService.getReadiness(workspace_id, {
       autoCoderRun: this.parseAutoCoderRun(autoCoderRun),
-      forceRefresh: this.parseBooleanQuery(forceRefresh)
+      forceRefresh: this.parseBooleanQuery(forceRefresh),
+      detailLevel: this.parseReadinessDetailLevel(detailLevel)
     });
   }
 
@@ -1244,6 +1255,22 @@ export class WorkspaceCodingStatisticsController {
       return numericValue;
     }
     throw new BadRequestException('autoCoderRun must be 1 or 2');
+  }
+
+  private parseReadinessDetailLevel(
+    value?: string | string[]
+  ): AutocodingReadinessDetailLevel {
+    const values = this.parseArrayQuery(value);
+    if (values.length === 0) {
+      return 'full';
+    }
+    if (values.length > 1) {
+      throw new BadRequestException('detailLevel must be provided only once');
+    }
+    if (values[0] === 'summary' || values[0] === 'full') {
+      return values[0];
+    }
+    throw new BadRequestException('detailLevel must be summary or full');
   }
 
   private parseBooleanQuery(value?: string | string[]): boolean {

--- a/apps/backend/src/app/admin/workspace/workspace-files.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-files.controller.ts
@@ -37,7 +37,10 @@ import { FileDownloadDto } from '../../../../../../api-dto/files/file-download.d
 import { WorkspaceFilesService, WorkspaceCoreService } from '../../database/services/workspace';
 import { TestFilesUploadResultDto } from '../../../../../../api-dto/files/test-files-upload-result.dto';
 import { WorkspaceSettingsDto } from '../../../../../../api-dto/workspaces/workspace-settings-dto';
-import { PersonService } from '../../database/services/test-results';
+import {
+  PersonService,
+  WorkspaceTestResultsService
+} from '../../database/services/test-results';
 import { CodingStatisticsService, CodingValidationService } from '../../database/services/coding';
 import { Setting } from '../../database/entities/setting.entity';
 import {
@@ -56,6 +59,7 @@ export class WorkspaceFilesController {
     private readonly personService: PersonService,
     private readonly codingStatisticsService: CodingStatisticsService,
     private readonly codingValidationService: CodingValidationService,
+    private readonly workspaceTestResultsService: WorkspaceTestResultsService,
     @InjectRepository(Setting)
     private readonly settingRepository: Repository<Setting>
   ) { }
@@ -206,10 +210,15 @@ export class WorkspaceFilesController {
     );
 
     if (success) {
-      await this.codingStatisticsService.invalidateCache(workspaceId);
-      await this.codingValidationService.invalidateIncompleteVariablesCache(
-        workspaceId
-      );
+      await Promise.all([
+        this.codingStatisticsService.invalidateCache(workspaceId),
+        this.codingValidationService.invalidateIncompleteVariablesCache(
+          workspaceId
+        ),
+        this.workspaceTestResultsService.invalidateWorkspaceStatsCache(
+          workspaceId
+        )
+      ]);
     }
 
     return success;
@@ -254,10 +263,15 @@ export class WorkspaceFilesController {
     );
 
     if (success) {
-      await this.codingStatisticsService.invalidateCache(workspaceId);
-      await this.codingValidationService.invalidateIncompleteVariablesCache(
-        workspaceId
-      );
+      await Promise.all([
+        this.codingStatisticsService.invalidateCache(workspaceId),
+        this.codingValidationService.invalidateIncompleteVariablesCache(
+          workspaceId
+        ),
+        this.workspaceTestResultsService.invalidateWorkspaceStatsCache(
+          workspaceId
+        )
+      ]);
     }
 
     return success;

--- a/apps/backend/src/app/cache/coding-incomplete-cache-scheduler.service.ts
+++ b/apps/backend/src/app/cache/coding-incomplete-cache-scheduler.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -7,7 +7,7 @@ import { CodingValidationService } from '../database/services/coding';
 import Persons from '../database/entities/persons.entity';
 
 @Injectable()
-export class CodingIncompleteCacheSchedulerService implements OnModuleInit {
+export class CodingIncompleteCacheSchedulerService {
   private readonly logger = new Logger(CodingIncompleteCacheSchedulerService.name);
 
   constructor(
@@ -21,6 +21,13 @@ export class CodingIncompleteCacheSchedulerService implements OnModuleInit {
    * Run on module initialization to pre-cache all manual coding variables.
    */
   async onModuleInit(): Promise<void> {
+    if (!this.isStartupWarmupEnabled()) {
+      this.logger.log(
+        'Skipping manual coding variables cache warmup on startup'
+      );
+      return;
+    }
+
     this.logger.log('Starting manual coding variables cache warmup on application startup');
 
     try {
@@ -171,5 +178,10 @@ export class CodingIncompleteCacheSchedulerService implements OnModuleInit {
     const rssMB = (memUsage.rss / 1024 / 1024).toFixed(1);
 
     return `Heap: ${heapUsedMB}MB/${heapTotalMB}MB (${heapPercent}%), RSS: ${rssMB}MB`;
+  }
+
+  private isStartupWarmupEnabled(): boolean {
+    return process.env.ENABLE_STARTUP_CACHE_WARMUP === 'true' ||
+      process.env.ENABLE_CODING_INCOMPLETE_STARTUP_WARMUP === 'true';
   }
 }

--- a/apps/backend/src/app/cache/coding-statistics-cache-scheduler.service.ts
+++ b/apps/backend/src/app/cache/coding-statistics-cache-scheduler.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -7,7 +7,7 @@ import { CodingStatisticsService } from '../database/services/coding';
 import Persons from '../database/entities/persons.entity';
 
 @Injectable()
-export class CodingStatisticsCacheSchedulerService implements OnModuleInit {
+export class CodingStatisticsCacheSchedulerService {
   private readonly logger = new Logger(CodingStatisticsCacheSchedulerService.name);
 
   constructor(
@@ -21,6 +21,13 @@ export class CodingStatisticsCacheSchedulerService implements OnModuleInit {
    * Run on module initialization to pre-cache all coding statistics
    */
   async onModuleInit(): Promise<void> {
+    if (!this.isStartupWarmupEnabled()) {
+      this.logger.log(
+        'Skipping coding statistics cache warmup on startup'
+      );
+      return;
+    }
+
     this.logger.log('Starting coding statistics cache warmup on application startup');
 
     try {
@@ -171,5 +178,10 @@ export class CodingStatisticsCacheSchedulerService implements OnModuleInit {
     const rssMB = (memUsage.rss / 1024 / 1024).toFixed(1);
 
     return `Heap: ${heapUsedMB}MB/${heapTotalMB}MB (${heapPercent}%), RSS: ${rssMB}MB`;
+  }
+
+  private isStartupWarmupEnabled(): boolean {
+    return process.env.ENABLE_STARTUP_CACHE_WARMUP === 'true' ||
+      process.env.ENABLE_CODING_STATISTICS_STARTUP_WARMUP === 'true';
   }
 }

--- a/apps/backend/src/app/database/services/coding/coding-applied-results-overview-cache-key.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-applied-results-overview-cache-key.util.ts
@@ -1,0 +1,13 @@
+export const getCodingAppliedResultsOverviewCacheKey = (
+  workspaceId: number,
+  testResultsRevision: number,
+  codingRevision: number
+): string => `coding_applied_results_overview:${workspaceId}:r${testResultsRevision}:c${codingRevision}`;
+
+export const getCodingAppliedResultsOverviewCachePattern = (
+  workspaceId: number
+): string => `coding_applied_results_overview:${workspaceId}:*`;
+
+export const getCodingAppliedResultsOverviewVersionKey = (
+  workspaceId: number
+): string => `coding_applied_results_overview:version:${workspaceId}`;

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -99,7 +99,11 @@ describe('CodingJobService', () => {
   let fileUploadRepository: ReturnType<typeof createRepo>;
   let settingRepository: ReturnType<typeof createRepo>;
   let connection: { transaction: jest.Mock };
-  let cacheService: { delete: jest.Mock };
+  let cacheService: {
+    delete: jest.Mock;
+    incr: jest.Mock;
+    deleteByPattern: jest.Mock;
+  };
   let codingFreshnessService: { reconcileAppliedManualCodingJobs: jest.Mock };
   let codingFileCacheService: { getVariablePageMap: jest.Mock };
   let missingsProfilesService: {
@@ -198,7 +202,11 @@ describe('CodingJobService', () => {
       })
       )
     };
-    cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
     jobDefinitionRepository.createQueryBuilder.mockReturnValue({
       setLock: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
@@ -1756,6 +1764,12 @@ describe('CodingJobService', () => {
     );
     expect(cacheService.delete).toHaveBeenCalledWith(
       'coding_incomplete_variables_v8:7'
+    );
+    expect(cacheService.incr).toHaveBeenCalledWith(
+      'coding_applied_results_overview:version:7'
+    );
+    expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+      'coding_applied_results_overview:7:*'
     );
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -69,6 +69,10 @@ import {
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
 import { CodingFreshnessService } from './coding-freshness.service';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 import { CodingFileCacheService } from './coding-file-cache.service';
 import { CodingReplayAnchorService } from './coding-replay-anchor.service';
 import {
@@ -2940,9 +2944,17 @@ export class CodingJobService {
     workspaceId: number
   ): Promise<void> {
     const cacheKey = getCodingIncompleteVariablesCacheKey(workspaceId);
-    await this.cacheService.delete(cacheKey);
+    await Promise.all([
+      this.cacheService.delete(cacheKey),
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspaceId)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspaceId)
+      )
+    ]);
     this.logger.log(
-      `Invalidated manual coding variables cache for workspace ${workspaceId}`
+      `Invalidated manual coding variables and applied results overview cache for workspace ${workspaceId}`
     );
   }
 
@@ -3267,22 +3279,16 @@ export class CodingJobService {
       })
       .andWhere('person.consider = :consider', { consider: true });
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    allVariables.forEach((variable, index) => {
-      const unitParam = `unitName${index}`;
-      const variableParam = `variableId${index}`;
-      conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unit_name;
-      parameters[variableParam] = variable.variable_id;
-    });
-
-    if (conditions.length > 0) {
-      queryBuilder.andWhere(`(${conditions.join(' OR ')})`, parameters);
-    }
+    this.applyVariablePairFilter(
+      queryBuilder,
+      allVariables.map(variable => ({
+        unitName: variable.unit_name,
+        variableId: variable.variable_id
+      })),
+      'unit.name',
+      'response.variableid',
+      'codingJobResponses'
+    );
 
     // Exclude aggregated duplicates (marked with code_v2 = -111)
     queryBuilder.andWhere(
@@ -4906,20 +4912,16 @@ export class CodingJobService {
       .andWhere('person.consider = :consider', { consider: true });
     this.applyManualCodingCandidateStatusFilter(queryBuilder);
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    allVariables.forEach((variable, index) => {
-      const unitParam = `cjUnitName${index}`;
-      const variableParam = `cjVariableId${index}`;
-      conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unit_name;
-      parameters[variableParam] = variable.variable_id;
-    });
-
-    queryBuilder.andWhere(`(${conditions.join(' OR ')})`, parameters);
+    this.applyVariablePairFilter(
+      queryBuilder,
+      allVariables.map(variable => ({
+        unitName: variable.unit_name,
+        variableId: variable.variable_id
+      })),
+      'unit.name',
+      'response.variableid',
+      'codingJobSlimResponses'
+    );
     queryBuilder.andWhere(
       '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
       {
@@ -5693,22 +5695,13 @@ export class CodingJobService {
       );
     applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `unitName${index}`;
-      const variableParam = `variableId${index}`;
-      conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    if (conditions.length > 0) {
-      queryBuilder.andWhere(`(${conditions.join(' OR ')})`, parameters);
-    }
+    this.applyVariablePairFilter(
+      queryBuilder,
+      variables,
+      'unit.name',
+      'response.variableid',
+      'responsesForVariables'
+    );
 
     return queryBuilder.orderBy('response.id', 'ASC').getMany();
   }
@@ -5760,22 +5753,13 @@ export class CodingJobService {
       );
     applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `slimUnitName${index}`;
-      const variableParam = `slimVariableId${index}`;
-      conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    if (conditions.length > 0) {
-      queryBuilder.andWhere(`(${conditions.join(' OR ')})`, parameters);
-    }
+    this.applyVariablePairFilter(
+      queryBuilder,
+      variables,
+      'unit.name',
+      'response.variableid',
+      'slimResponsesForVariables'
+    );
 
     const raw = await queryBuilder.orderBy('response.id', 'ASC').getRawMany();
 
@@ -5831,20 +5815,11 @@ export class CodingJobService {
       );
     }
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `assignedUnitName${index}`;
-      const variableParam = `assignedVariableId${index}`;
-      conditions.push(
-        `(cju.unit_name = :${unitParam} AND cju.variable_id = :${variableParam})`
-      );
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    query.andWhere(`(${conditions.join(' OR ')})`, parameters);
+    this.applyCodingJobUnitVariablePairFilter(
+      query,
+      variables,
+      'assignedResponseIdsForVariables'
+    );
     await this.applyCodingJobUnitExclusions(
       query,
       workspaceId,
@@ -5856,6 +5831,56 @@ export class CodingJobService {
       rawResults
         .map(row => Number(row.responseId))
         .filter(responseId => Number.isFinite(responseId))
+    );
+  }
+
+  private applyVariablePairFilter(
+    queryBuilder: SelectQueryBuilder<ResponseEntity>,
+    variables: VariableReference[],
+    unitColumn: string,
+    variableColumn: string,
+    parameterPrefix: string
+  ): void {
+    if (variables.length === 0) {
+      return;
+    }
+
+    const parameters: Record<string, string> = {};
+    const pairs = variables.map((variable, index) => {
+      const unitParam = `${parameterPrefix}UnitName${index}`;
+      const variableParam = `${parameterPrefix}VariableId${index}`;
+      parameters[unitParam] = variable.unitName;
+      parameters[variableParam] = variable.variableId;
+      return `(:${unitParam}, :${variableParam})`;
+    });
+
+    queryBuilder.andWhere(
+      `(${unitColumn}, ${variableColumn}) IN (${pairs.join(', ')})`,
+      parameters
+    );
+  }
+
+  private applyCodingJobUnitVariablePairFilter(
+    queryBuilder: SelectQueryBuilder<CodingJobUnit>,
+    variables: VariableReference[],
+    parameterPrefix: string
+  ): void {
+    if (variables.length === 0) {
+      return;
+    }
+
+    const parameters: Record<string, string> = {};
+    const pairs = variables.map((variable, index) => {
+      const unitParam = `${parameterPrefix}UnitName${index}`;
+      const variableParam = `${parameterPrefix}VariableId${index}`;
+      parameters[unitParam] = variable.unitName;
+      parameters[variableParam] = variable.variableId;
+      return `(:${unitParam}, :${variableParam})`;
+    });
+
+    queryBuilder.andWhere(
+      `(cju.unit_name, cju.variable_id) IN (${pairs.join(', ')})`,
+      parameters
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -10,8 +10,19 @@ jest.mock('../workspace/workspace-files.service', () => ({
 const createRepository = () => ({
   createQueryBuilder: jest.fn(),
   find: jest.fn(),
-  findOne: jest.fn()
+  findOne: jest.fn(),
+  query: jest.fn().mockResolvedValue([])
 });
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
 
 type MockQueryBuilder = Record<string, jest.Mock> & {
   subQueryProbes: Record<string, jest.Mock>[];
@@ -67,26 +78,47 @@ const createQueryBuilder = (rawResults: unknown[] = []) => {
     'orderBy'
   ].forEach(method => {
     queryBuilder[method] = jest.fn((condition?: unknown) => {
+      if (method === 'leftJoin' && typeof condition === 'function') {
+        condition(createSubQueryProbe(queryBuilder));
+      }
       executeBrackets(condition, queryBuilder);
       return queryBuilder;
     });
   });
   queryBuilder.getRawMany = jest.fn().mockResolvedValue(rawResults);
+  queryBuilder.getRawOne = jest.fn().mockResolvedValue({
+    count: rawResults.length.toString()
+  });
   queryBuilder.getCount = jest.fn().mockResolvedValue(0);
   return queryBuilder;
 };
 
 const expectProductiveManualPoolExists = (queryBuilder: MockQueryBuilder) => {
-  expect(queryBuilder.subQueryProbes).toHaveLength(1);
-  const [existsBuilder] = queryBuilder.subQueryProbes;
-  expect(existsBuilder.from).toHaveBeenCalledWith('coding_job_unit', 'manual_cju');
-  expect(existsBuilder.innerJoin).toHaveBeenCalledWith(
+  const assignedResponsesBuilder = queryBuilder.subQueryProbes.find(
+    probe => probe.select.mock.calls.some(
+      call => call[0] === 'DISTINCT manual_cju.response_id'
+    )
+  );
+  expect(assignedResponsesBuilder).toBeDefined();
+  expect(assignedResponsesBuilder.select).toHaveBeenCalledWith(
+    'DISTINCT manual_cju.response_id',
+    'response_id'
+  );
+  expect(assignedResponsesBuilder.from).toHaveBeenCalledWith(
+    'coding_job_unit',
+    'manual_cju'
+  );
+  expect(assignedResponsesBuilder.innerJoin).toHaveBeenCalledWith(
     'coding_job',
     'manual_cj',
     'manual_cj.id = manual_cju.coding_job_id'
   );
-  expect(existsBuilder.where).toHaveBeenCalledWith('manual_cju.response_id = response.id');
-  expect(existsBuilder.andWhere).toHaveBeenCalledWith('manual_cj.training_id IS NULL');
+  expect(assignedResponsesBuilder.where).toHaveBeenCalledWith(
+    'manual_cj.training_id IS NULL'
+  );
+  expect(assignedResponsesBuilder.andWhere).toHaveBeenCalledWith(
+    expect.stringContaining('coding_issue_review')
+  );
 };
 
 describe('CodingProgressService variable coverage conflicts', () => {
@@ -102,6 +134,15 @@ describe('CodingProgressService variable coverage conflicts', () => {
     getManualInstructionVariableMap: jest.Mock;
   };
   let service: CodingProgressService;
+
+  const mockCoverageResponseCounts = (...counts: number[]) => {
+    responseRepository.query.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT COUNT(response.id) AS count')) {
+        return Promise.resolve([{ count: String(counts.shift() ?? 0) }]);
+      }
+      return Promise.resolve([]);
+    });
+  };
 
   beforeEach(() => {
     responseRepository = createRepository();
@@ -139,6 +180,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
   it('keeps covered source responses in status totals but excludes them from progress totals', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    mockCoverageResponseCounts(3);
 
     responseRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([
       {
@@ -201,6 +243,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
   it('does not let unassigned pre-coded derived responses cover source responses in manual totals', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    mockCoverageResponseCounts(3, 3);
     const allResponses = [
       {
         responseId: '100',
@@ -233,9 +276,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
     const manualPoolResponses = allResponses.slice(1);
 
     responseRepository.createQueryBuilder
-      .mockReturnValueOnce(createQueryBuilder(allResponses))
       .mockReturnValueOnce(createQueryBuilder(manualPoolResponses))
-      .mockReturnValueOnce(createQueryBuilder(allResponses))
       .mockReturnValueOnce(createQueryBuilder(manualPoolResponses));
     codingJobUnitRepository.createQueryBuilder
       .mockReturnValueOnce(createQueryBuilder([]))
@@ -281,6 +322,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
     const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
+    mockCoverageResponseCounts(2);
     const responses = [
       {
         responseId: '100',
@@ -303,7 +345,6 @@ describe('CodingProgressService variable coverage conflicts', () => {
     ];
 
     responseRepository.createQueryBuilder
-      .mockReturnValueOnce(createQueryBuilder(responses))
       .mockReturnValueOnce(createQueryBuilder(responses));
     settingRepository.findOne.mockResolvedValue({ content: 'disabled' });
     workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
@@ -326,15 +367,287 @@ describe('CodingProgressService variable coverage conflicts', () => {
     });
   });
 
-  it('limits manual pool existence checks to non-training coding jobs', async () => {
-    const allResponsesQuery = createQueryBuilder([]);
-    const manualPoolQuery = createQueryBuilder([]);
-    const variableCoverageQuery = createQueryBuilder([]);
+  it('returns cached applied result overview by test results revision', async () => {
+    const cachedOverview = {
+      totalIncompleteResponses: 2,
+      appliedResponses: 1,
+      remainingResponses: 1,
+      completionPercentage: 50,
+      rawTotalIncompleteResponses: 2,
+      rawAppliedResponses: 1,
+      rawCompletionPercentage: 50,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0,
+      statusTotalIncompleteResponses: 2,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0,
+      deriveErrorTotalResponses: 0,
+      deriveErrorAppliedResponses: 0,
+      deriveErrorRemainingResponses: 0,
+      deriveErrorRawTotalResponses: 0,
+      deriveErrorRawAppliedResponses: 0
+    };
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(cachedOverview),
+      set: jest.fn(),
+      getNumber: jest.fn().mockResolvedValue(3),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
+    };
+    responseRepository.query.mockResolvedValue([{ revision: 9 }]);
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
 
-    responseRepository.createQueryBuilder
-      .mockReturnValueOnce(allResponsesQuery)
-      .mockReturnValueOnce(manualPoolQuery)
-      .mockReturnValueOnce(variableCoverageQuery);
+    const result = await cachedService.getAppliedResultsOverview(5);
+
+    expect(result).toBe(cachedOverview);
+    expect(cacheService.get).toHaveBeenCalledWith(
+      'coding_applied_results_overview:5:r9:c3'
+    );
+    expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('reuses an in-flight applied result overview query for the same revision', async () => {
+    const overview = {
+      totalIncompleteResponses: 1,
+      appliedResponses: 0,
+      remainingResponses: 1,
+      completionPercentage: 0,
+      rawTotalIncompleteResponses: 1,
+      rawAppliedResponses: 0,
+      rawCompletionPercentage: 0,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0,
+      statusTotalIncompleteResponses: 1,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0,
+      deriveErrorTotalResponses: 0,
+      deriveErrorAppliedResponses: 0,
+      deriveErrorRemainingResponses: 0,
+      deriveErrorRawTotalResponses: 0,
+      deriveErrorRawAppliedResponses: 0
+    };
+    const overviewDeferred = createDeferred<typeof overview>();
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+      getNumber: jest.fn().mockResolvedValue(4),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
+    };
+    responseRepository.query.mockResolvedValue([{ revision: 10 }]);
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
+    const internals = cachedService as unknown as {
+      computeAndCacheAppliedResultsOverview: (
+        workspaceId: number,
+        testResultsRevision: number,
+        codingRevision: number,
+        cacheKey: string
+      ) => Promise<typeof overview>;
+    };
+    const computeSpy = jest
+      .spyOn(internals, 'computeAndCacheAppliedResultsOverview')
+      .mockReturnValue(overviewDeferred.promise);
+
+    const firstRequest = cachedService.getAppliedResultsOverview(5);
+    const secondRequest = cachedService.getAppliedResultsOverview(5);
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+
+    expect(computeSpy).toHaveBeenCalledTimes(1);
+    expect(computeSpy).toHaveBeenCalledWith(
+      5,
+      10,
+      4,
+      'coding_applied_results_overview:5:r10:c4'
+    );
+
+    overviewDeferred.resolve(overview);
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual(
+      [overview, overview]
+    );
+  });
+
+  it('does not cache stale applied result overview when revision changes while computing', async () => {
+    const overview = {
+      totalIncompleteResponses: 1,
+      appliedResponses: 1,
+      remainingResponses: 0,
+      completionPercentage: 100,
+      rawTotalIncompleteResponses: 1,
+      rawAppliedResponses: 1,
+      rawCompletionPercentage: 100,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0,
+      statusTotalIncompleteResponses: 1,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0,
+      deriveErrorTotalResponses: 0,
+      deriveErrorAppliedResponses: 0,
+      deriveErrorRemainingResponses: 0,
+      deriveErrorRawTotalResponses: 0,
+      deriveErrorRawAppliedResponses: 0
+    };
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+      getNumber: jest.fn().mockResolvedValue(0),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
+    };
+    responseRepository.query
+      .mockResolvedValueOnce([{ revision: 11 }])
+      .mockResolvedValueOnce([{ revision: 12 }]);
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
+    const internals = cachedService as unknown as {
+      computeAppliedResultsOverview: (
+        workspaceId: number
+      ) => Promise<typeof overview>;
+    };
+    jest
+      .spyOn(internals, 'computeAppliedResultsOverview')
+      .mockResolvedValue(overview);
+
+    await cachedService.getAppliedResultsOverview(5);
+
+    expect(cacheService.set).not.toHaveBeenCalledWith(
+      'coding_applied_results_overview:5:r11:c0',
+      expect.anything(),
+      0
+    );
+  });
+
+  it('does not cache stale applied result overview when coding revision changes while computing', async () => {
+    const overview = {
+      totalIncompleteResponses: 1,
+      appliedResponses: 1,
+      remainingResponses: 0,
+      completionPercentage: 100,
+      rawTotalIncompleteResponses: 1,
+      rawAppliedResponses: 1,
+      rawCompletionPercentage: 100,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0,
+      statusTotalIncompleteResponses: 1,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0,
+      deriveErrorTotalResponses: 0,
+      deriveErrorAppliedResponses: 0,
+      deriveErrorRemainingResponses: 0,
+      deriveErrorRawTotalResponses: 0,
+      deriveErrorRawAppliedResponses: 0
+    };
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+      getNumber: jest.fn()
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(3),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
+    };
+    responseRepository.query.mockResolvedValue([{ revision: 11 }]);
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
+    const internals = cachedService as unknown as {
+      computeAppliedResultsOverview: (
+        workspaceId: number
+      ) => Promise<typeof overview>;
+    };
+    jest
+      .spyOn(internals, 'computeAppliedResultsOverview')
+      .mockResolvedValue(overview);
+
+    await cachedService.getAppliedResultsOverview(5);
+
+    expect(cacheService.set).not.toHaveBeenCalledWith(
+      'coding_applied_results_overview:5:r11:c2',
+      expect.anything(),
+      0
+    );
+  });
+
+  it('invalidates applied result overview keys and bumps the coding revision', async () => {
+    const cacheService = {
+      get: jest.fn(),
+      set: jest.fn(),
+      getNumber: jest.fn(),
+      incr: jest.fn().mockResolvedValue(8),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
+    const cachedService = new CodingProgressService(
+      responseRepository as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      settingRepository as never,
+      workspaceFilesService as never,
+      { resolveExclusionsForQueries: jest.fn() } as never,
+      undefined,
+      cacheService as never
+    );
+
+    await cachedService.invalidateAppliedResultsOverviewCache(5);
+
+    expect(cacheService.incr).toHaveBeenCalledWith(
+      'coding_applied_results_overview:version:5'
+    );
+    expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+      'coding_applied_results_overview:5:*'
+    );
+  });
+
+  it('limits manual pool existence checks to non-training coding jobs', async () => {
+    mockCoverageResponseCounts(0);
+    const responseQueries: MockQueryBuilder[] = [];
+    responseRepository.createQueryBuilder.mockImplementation(() => {
+      const query = createQueryBuilder([]);
+      responseQueries.push(query);
+      return query;
+    });
     codingJobUnitRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([]));
     settingRepository.findOne.mockResolvedValue({ content: 'disabled' });
     jobDefinitionRepository.find.mockResolvedValue([]);
@@ -342,13 +655,17 @@ describe('CodingProgressService variable coverage conflicts', () => {
     await service.getCodingProgressOverview(5);
     await service.getVariableCoverageOverview(5);
 
-    expectProductiveManualPoolExists(manualPoolQuery);
-    expectProductiveManualPoolExists(variableCoverageQuery);
+    const manualPoolQueries = responseQueries.filter(query => query.subQueryProbes.some(probe => probe.select.mock.calls.some(
+      call => call[0] === 'DISTINCT manual_cju.response_id'
+    )));
+    expect(manualPoolQueries.length).toBeGreaterThanOrEqual(1);
+    manualPoolQueries.forEach(expectProductiveManualPoolExists);
   });
 
   it('excludes covered source responses from case coverage while preserving status totals', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    mockCoverageResponseCounts(3);
 
     responseRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([
       {
@@ -523,6 +840,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
   it('excludes intended-incomplete variables without manual instructions from case coverage', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
+    mockCoverageResponseCounts(2);
     const responses = [
       {
         responseId: '100',
@@ -545,7 +863,6 @@ describe('CodingProgressService variable coverage conflicts', () => {
     ];
 
     responseRepository.createQueryBuilder
-      .mockReturnValueOnce(createQueryBuilder(responses))
       .mockReturnValueOnce(createQueryBuilder(responses));
     codingJobUnitRepository.createQueryBuilder
       .mockReturnValueOnce(createQueryBuilder([]))

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -12,6 +12,9 @@ import { Setting } from '../../entities/setting.entity';
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import {
   applyResolvedExclusionsToQuery,
+  normalizeExclusionBookletId,
+  normalizeExclusionUnitId,
+  ResolvedWorkspaceExclusions,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
 import {
@@ -32,6 +35,12 @@ import {
   applyNonCodingIssueReviewJobFilter,
   getNonCodingIssueReviewJobSqlCondition
 } from './coding-job-type.util';
+import { CacheService } from '../../../cache/cache.service';
+import {
+  getCodingAppliedResultsOverviewCacheKey,
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 
 type ResponseMatchingFlag =
   | 'NO_AGGREGATION'
@@ -53,7 +62,7 @@ interface CoverageResponse {
 }
 
 interface CoverageResponseScope {
-  allResponses: CoverageResponse[];
+  statusTotalResponseCount: number;
   manualResponses: CoverageResponse[];
   excludedSourceSummary: ManualCodingExcludedSourceSummary;
 }
@@ -81,6 +90,27 @@ interface EffectiveVariableCaseCoverage {
 }
 
 interface DeriveErrorManualProgress {
+  deriveErrorTotalResponses: number;
+  deriveErrorAppliedResponses: number;
+  deriveErrorRemainingResponses: number;
+  deriveErrorRawTotalResponses: number;
+  deriveErrorRawAppliedResponses: number;
+}
+
+interface AppliedResultsOverview {
+  totalIncompleteResponses: number;
+  appliedResponses: number;
+  remainingResponses: number;
+  completionPercentage: number;
+  rawTotalIncompleteResponses: number;
+  rawAppliedResponses: number;
+  rawCompletionPercentage: number;
+  aggregationActive: boolean;
+  aggregationThreshold: number | null;
+  aggregatedDuplicateCases: number;
+  statusTotalIncompleteResponses: number;
+  coveredSourceVariableCount: number;
+  coveredSourceResponseCount: number;
   deriveErrorTotalResponses: number;
   deriveErrorAppliedResponses: number;
   deriveErrorRemainingResponses: number;
@@ -123,6 +153,15 @@ interface ManualCodingVariableLookups {
 @Injectable()
 export class CodingProgressService {
   private readonly logger = new Logger(CodingProgressService.name);
+  private readonly appliedResultsOverviewInFlight = new Map<
+  string,
+  Promise<AppliedResultsOverview>
+  >();
+
+  private readonly appliedResultsOverviewPrewarmTimers = new Map<
+  number,
+  NodeJS.Timeout
+  >();
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -138,7 +177,9 @@ export class CodingProgressService {
     private workspaceFilesService: WorkspaceFilesService,
     private workspaceExclusionService: WorkspaceExclusionService,
     @Optional()
-    private missingsProfilesService?: MissingsProfilesService
+    private missingsProfilesService?: MissingsProfilesService,
+    @Optional()
+    private cacheService?: CacheService
   ) { }
 
   private async getDefaultMirCode(workspaceId: number): Promise<number> {
@@ -152,6 +193,112 @@ export class CodingProgressService {
       'mir'
     );
     return missing.code;
+  }
+
+  private async createAppliedResultsOverviewCacheKey(
+    workspaceId: number
+  ): Promise<string> {
+    const [testResultsRevision, codingRevision] = await Promise.all([
+      this.resolveTestResultsRevision(workspaceId),
+      this.resolveAppliedResultsOverviewRevision(workspaceId)
+    ]);
+    return this.getAppliedResultsOverviewCacheKey(
+      workspaceId,
+      testResultsRevision,
+      codingRevision
+    );
+  }
+
+  private getAppliedResultsOverviewCacheKey(
+    workspaceId: number,
+    testResultsRevision: number,
+    codingRevision: number
+  ): string {
+    return getCodingAppliedResultsOverviewCacheKey(
+      workspaceId,
+      testResultsRevision,
+      codingRevision
+    );
+  }
+
+  async invalidateAppliedResultsOverviewCache(
+    workspaceId: number,
+    options: { prewarm?: boolean } = {}
+  ): Promise<void> {
+    if (!this.cacheService) {
+      return;
+    }
+
+    this.dropAppliedResultsOverviewInFlight(workspaceId);
+    await Promise.all([
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspaceId)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspaceId)
+      )
+    ]);
+
+    if (options.prewarm) {
+      this.scheduleAppliedResultsOverviewPrewarm(workspaceId);
+    }
+  }
+
+  private dropAppliedResultsOverviewInFlight(workspaceId: number): void {
+    const prefix = `coding_applied_results_overview:${workspaceId}:`;
+    Array.from(this.appliedResultsOverviewInFlight.keys())
+      .filter(cacheKey => cacheKey.startsWith(prefix))
+      .forEach(cacheKey => this.appliedResultsOverviewInFlight.delete(cacheKey));
+  }
+
+  private scheduleAppliedResultsOverviewPrewarm(workspaceId: number): void {
+    if (!this.cacheService || process.env.NODE_ENV === 'test') {
+      return;
+    }
+
+    const existingTimer = this.appliedResultsOverviewPrewarmTimers.get(workspaceId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
+    const timer = setTimeout(() => {
+      this.appliedResultsOverviewPrewarmTimers.delete(workspaceId);
+      this.getAppliedResultsOverview(workspaceId).catch(error => {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `Could not prewarm applied results overview for workspace ${workspaceId}: ${message}`
+        );
+      });
+    }, 500);
+
+    timer.unref?.();
+    this.appliedResultsOverviewPrewarmTimers.set(workspaceId, timer);
+  }
+
+  private async resolveTestResultsRevision(workspaceId: number): Promise<number> {
+    try {
+      const rows = (await this.responseRepository.query(
+        'SELECT revision FROM workspace_test_results_revision WHERE workspace_id = $1',
+        [workspaceId]
+      )) as Array<{ revision: number | string }>;
+      return Number(rows[0]?.revision || 0);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve test result revision for applied results overview cache: ${message}`
+      );
+      return 0;
+    }
+  }
+
+  private async resolveAppliedResultsOverviewRevision(workspaceId: number): Promise<number> {
+    if (!this.cacheService) {
+      return 0;
+    }
+    return this.cacheService.getNumber(
+      getCodingAppliedResultsOverviewVersionKey(workspaceId),
+      0
+    );
   }
 
   async getCodingProgressOverview(workspaceId: number): Promise<{
@@ -200,7 +347,7 @@ export class CodingProgressService {
       aggregationActive: effectiveProgress.aggregationActive,
       aggregationThreshold: effectiveProgress.aggregationThreshold,
       aggregatedDuplicateCases: effectiveProgress.aggregatedDuplicateCases,
-      statusTotalCasesToCode: responseScope.allResponses.length,
+      statusTotalCasesToCode: responseScope.statusTotalResponseCount,
       coveredSourceVariableCount:
         responseScope.excludedSourceSummary.coveredSourceVariableCount,
       coveredSourceResponseCount:
@@ -208,26 +355,77 @@ export class CodingProgressService {
     };
   }
 
-  async getAppliedResultsOverview(workspaceId: number): Promise<{
-    totalIncompleteResponses: number;
-    appliedResponses: number;
-    remainingResponses: number;
-    completionPercentage: number;
-    rawTotalIncompleteResponses: number;
-    rawAppliedResponses: number;
-    rawCompletionPercentage: number;
-    aggregationActive: boolean;
-    aggregationThreshold: number | null;
-    aggregatedDuplicateCases: number;
-    statusTotalIncompleteResponses: number;
-    coveredSourceVariableCount: number;
-    coveredSourceResponseCount: number;
-    deriveErrorTotalResponses: number;
-    deriveErrorAppliedResponses: number;
-    deriveErrorRemainingResponses: number;
-    deriveErrorRawTotalResponses: number;
-    deriveErrorRawAppliedResponses: number;
-  }> {
+  async getAppliedResultsOverview(workspaceId: number): Promise<AppliedResultsOverview> {
+    if (!this.cacheService) {
+      return this.computeAppliedResultsOverview(workspaceId);
+    }
+
+    const [testResultsRevision, codingRevision] = await Promise.all([
+      this.resolveTestResultsRevision(workspaceId),
+      this.resolveAppliedResultsOverviewRevision(workspaceId)
+    ]);
+    const cacheKey = this.getAppliedResultsOverviewCacheKey(
+      workspaceId,
+      testResultsRevision,
+      codingRevision
+    );
+    const cached = await this.cacheService.get<AppliedResultsOverview>(
+      cacheKey
+    );
+    if (cached) {
+      return cached;
+    }
+
+    const inFlightOverview = this.appliedResultsOverviewInFlight.get(cacheKey);
+    if (inFlightOverview) {
+      return inFlightOverview;
+    }
+
+    const overviewPromise = this.computeAndCacheAppliedResultsOverview(
+      workspaceId,
+      testResultsRevision,
+      codingRevision,
+      cacheKey
+    );
+    this.appliedResultsOverviewInFlight.set(cacheKey, overviewPromise);
+    try {
+      return await overviewPromise;
+    } finally {
+      if (this.appliedResultsOverviewInFlight.get(cacheKey) === overviewPromise) {
+        this.appliedResultsOverviewInFlight.delete(cacheKey);
+      }
+    }
+  }
+
+  private async computeAndCacheAppliedResultsOverview(
+    workspaceId: number,
+    testResultsRevision: number,
+    codingRevision: number,
+    cacheKey: string
+  ): Promise<AppliedResultsOverview> {
+    const overview = await this.computeAppliedResultsOverview(workspaceId);
+    const [currentTestResultsRevision, currentCodingRevision] = await Promise.all([
+      this.resolveTestResultsRevision(workspaceId),
+      this.resolveAppliedResultsOverviewRevision(workspaceId)
+    ]);
+    if (
+      currentTestResultsRevision === testResultsRevision &&
+      currentCodingRevision === codingRevision
+    ) {
+      await this.cacheService?.set(cacheKey, overview, 0);
+    } else {
+      this.logger.log(
+        `Skipped caching stale applied results overview for workspace ${workspaceId} ` +
+        `(planned test revision ${testResultsRevision}, current test revision ${currentTestResultsRevision}; ` +
+        `planned coding revision ${codingRevision}, current coding revision ${currentCodingRevision})`
+      );
+    }
+    return overview;
+  }
+
+  private async computeAppliedResultsOverview(
+    workspaceId: number
+  ): Promise<AppliedResultsOverview> {
     const responseScope = await this.getCoverageResponseScope(workspaceId);
     const responses = responseScope.manualResponses;
     const appliedResponseIds = new Set(
@@ -252,7 +450,7 @@ export class CodingProgressService {
       appliedResponseIds
     );
 
-    return {
+    const overview = {
       totalIncompleteResponses: effectiveProgress.effectiveTotalCasesToCode,
       appliedResponses: effectiveProgress.effectiveCompletedCases,
       remainingResponses: Math.max(
@@ -266,13 +464,14 @@ export class CodingProgressService {
       aggregationActive: effectiveProgress.aggregationActive,
       aggregationThreshold: effectiveProgress.aggregationThreshold,
       aggregatedDuplicateCases: effectiveProgress.aggregatedDuplicateCases,
-      statusTotalIncompleteResponses: responseScope.allResponses.length,
+      statusTotalIncompleteResponses: responseScope.statusTotalResponseCount,
       coveredSourceVariableCount:
         responseScope.excludedSourceSummary.coveredSourceVariableCount,
       coveredSourceResponseCount:
         responseScope.excludedSourceSummary.coveredSourceResponseCount,
       ...deriveErrorProgress
     };
+    return overview;
   }
 
   async getCaseCoverageOverview(workspaceId: number): Promise<{
@@ -334,7 +533,7 @@ export class CodingProgressService {
       aggregationActive: effectiveCoverage.aggregationActive,
       aggregationThreshold: effectiveCoverage.aggregationThreshold,
       aggregatedDuplicateCases: effectiveCoverage.aggregatedDuplicateCases,
-      statusTotalCasesToCode: responseScope.allResponses.length,
+      statusTotalCasesToCode: responseScope.statusTotalResponseCount,
       coveredSourceVariableCount:
         responseScope.excludedSourceSummary.coveredSourceVariableCount,
       coveredSourceResponseCount:
@@ -366,8 +565,8 @@ export class CodingProgressService {
   }
 
   private async getCoverageResponseScope(workspaceId: number): Promise<CoverageResponseScope> {
-    const [allResponses, manualPoolResponses] = await Promise.all([
-      this.getCoverageResponses(workspaceId),
+    const [statusTotalResponseCount, manualPoolResponses] = await Promise.all([
+      this.getCoverageResponseCount(workspaceId),
       this.getCoverageResponses(workspaceId, true)
     ]);
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
@@ -417,7 +616,7 @@ export class CodingProgressService {
     );
 
     return {
-      allResponses,
+      statusTotalResponseCount,
       manualResponses,
       excludedSourceSummary
     };
@@ -568,25 +767,27 @@ export class CodingProgressService {
       .leftJoin('booklet.bookletinfo', 'bookletinfo')
       .leftJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('person.consider = :consider', { consider: true })
-      .orderBy('response.id', 'ASC');
+      .andWhere('person.consider = :consider', { consider: true });
     this.applyManualProgressStatusFilter(query, 'andWhere');
 
     if (manualPoolOnly) {
+      query.leftJoin(
+        subQuery => subQuery
+          .select('DISTINCT manual_cju.response_id', 'response_id')
+          .from('coding_job_unit', 'manual_cju')
+          .innerJoin(
+            'coding_job',
+            'manual_cj',
+            'manual_cj.id = manual_cju.coding_job_id'
+          )
+          .where('manual_cj.training_id IS NULL')
+          .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj')),
+        'assigned_manual_response',
+        'assigned_manual_response.response_id = response.id'
+      );
       query.andWhere(new Brackets(qb => {
         qb.where('response.code_v2 IS NULL')
-          .orWhere(subQuery => {
-            const exists = subQuery
-              .subQuery()
-              .select('1')
-              .from('coding_job_unit', 'manual_cju')
-              .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
-              .where('manual_cju.response_id = response.id')
-              .andWhere('manual_cj.training_id IS NULL')
-              .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
-              .getQuery();
-            return `EXISTS (${exists})`;
-          });
+          .orWhere('assigned_manual_response.response_id IS NOT NULL');
       }));
     } else {
       query.andWhere(
@@ -619,6 +820,108 @@ export class CodingProgressService {
       personCode: row.personCode ?? '',
       personGroup: row.personGroup ?? ''
     }));
+  }
+
+  private async getCoverageResponseCount(workspaceId: number): Promise<number> {
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
+    const params: unknown[] = [
+      workspaceId,
+      true,
+      statusStringToNumber('CODING_INCOMPLETE'),
+      statusStringToNumber('INTENDED_INCOMPLETE'),
+      statusStringToNumber('DERIVE_ERROR'),
+      -111,
+      defaultMirCode
+    ];
+    const exclusionSql = this.buildCoverageResponseCountExclusionSql(
+      exclusions,
+      params
+    );
+    const rows = await this.responseRepository.query(
+      `
+        WITH scoped_units AS MATERIALIZED (
+          SELECT unit.id
+          FROM persons person
+          INNER JOIN booklet booklet
+            ON booklet.personid = person.id
+          INNER JOIN unit unit
+            ON unit.bookletid = booklet.id
+          LEFT JOIN bookletinfo bookletinfo
+            ON bookletinfo.id = booklet.infoid
+          WHERE person.workspace_id = $1
+            AND person.consider = $2
+            ${exclusionSql}
+        ),
+        manual_derive_responses AS MATERIALIZED (
+          SELECT DISTINCT manual_derive_cju.response_id
+          FROM coding_job_unit manual_derive_cju
+          INNER JOIN coding_job manual_derive_cj
+            ON manual_derive_cj.id = manual_derive_cju.coding_job_id
+          WHERE manual_derive_cj.training_id IS NULL
+            AND ${getNonCodingIssueReviewJobSqlCondition('manual_derive_cj')}
+        )
+        SELECT COUNT(response.id) AS count
+        FROM scoped_units
+        INNER JOIN response response
+          ON response.unitid = scoped_units.id
+        LEFT JOIN manual_derive_responses
+          ON manual_derive_responses.response_id = response.id
+        WHERE (
+          response.status_v1 IN ($3, $4)
+          OR (
+            response.status_v1 = $5
+            AND manual_derive_responses.response_id IS NOT NULL
+          )
+        )
+          AND (
+            response.code_v2 IS NULL
+            OR (response.code_v2 != $6 AND response.code_v2 != $7)
+          )
+      `,
+      params
+    ) as Array<{ count?: number | string }>;
+    return Number(rows[0]?.count || 0);
+  }
+
+  private buildCoverageResponseCountExclusionSql(
+    exclusions: ResolvedWorkspaceExclusions,
+    params: unknown[]
+  ): string {
+    const conditions: string[] = [];
+    const unitNameSql = 'REGEXP_REPLACE(UPPER(unit.name), \'\\.XML$\', \'\', \'i\')';
+    const bookletNameSql = 'UPPER(bookletinfo.name)';
+
+    if (exclusions.globalIgnoredUnits.length > 0) {
+      const placeholders = exclusions.globalIgnoredUnits.map(value => {
+        params.push(normalizeExclusionUnitId(value));
+        return `$${params.length}`;
+      });
+      conditions.push(`${unitNameSql} NOT IN (${placeholders.join(', ')})`);
+    }
+
+    if (exclusions.ignoredBooklets.length > 0) {
+      const placeholders = exclusions.ignoredBooklets.map(value => {
+        params.push(normalizeExclusionBookletId(value));
+        return `$${params.length}`;
+      });
+      conditions.push(`${bookletNameSql} NOT IN (${placeholders.join(', ')})`);
+    }
+
+    if (exclusions.testletIgnoredUnits.length > 0) {
+      const pairConditions = exclusions.testletIgnoredUnits.map(exclusion => {
+        params.push(normalizeExclusionBookletId(exclusion.bookletId));
+        const bookletPlaceholder = `$${params.length}`;
+        params.push(normalizeExclusionUnitId(exclusion.unitId));
+        const unitPlaceholder = `$${params.length}`;
+        return `(${bookletNameSql} = ${bookletPlaceholder} AND ${unitNameSql} = ${unitPlaceholder})`;
+      });
+      conditions.push(`NOT (${pairConditions.join(' OR ')})`);
+    }
+
+    return conditions.length > 0 ?
+      `AND ${conditions.join('\n            AND ')}` :
+      '';
   }
 
   private async getAssignedCoverageResponseRows(workspaceId: number): Promise<number[]> {

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
@@ -21,11 +21,13 @@ type QueryBuilderMock = {
 type ReadinessFixture = {
   units: Unit[];
   rawResponsesTotal: number;
+  activePersonHash?: string;
   candidateRows: Array<{
     unitid: number | string;
     variableid: string;
     response_count: number | string;
   }>;
+  candidateResponsesTotal?: number;
   unitFiles: FileUpload[];
   codingSchemeFiles?: FileUpload[];
   unitVariableMap: Map<string, Set<string>>;
@@ -35,6 +37,16 @@ type ReadinessQueryMocks = {
   unitQuery: QueryBuilderMock;
   countQuery: QueryBuilderMock;
   candidateQuery: QueryBuilderMock;
+  fileUploadRepository: {
+    find: jest.Mock;
+  };
+  responseRepository: {
+    createQueryBuilder: jest.Mock;
+    query: jest.Mock;
+  };
+  workspaceFilesService: {
+    getUnitVariableMap: jest.Mock;
+  };
 };
 
 const createQueryBuilderMock = (): QueryBuilderMock => {
@@ -109,9 +121,25 @@ const createService = (
 
   const countQuery = createQueryBuilderMock();
   countQuery.getCount.mockResolvedValue(fixture.rawResponsesTotal);
+  countQuery.getRawOne.mockResolvedValue({
+    raw_responses_total: fixture.rawResponsesTotal,
+    raw_responses_with_relevant_status:
+      fixture.candidateResponsesTotal ??
+      fixture.candidateRows.reduce(
+        (sum, row) => sum + Number(row.response_count || 0),
+        0
+      )
+  });
 
   const candidateQuery = createQueryBuilderMock();
   candidateQuery.getRawMany.mockResolvedValue(fixture.candidateRows);
+  candidateQuery.getCount.mockResolvedValue(
+    fixture.candidateResponsesTotal ??
+      fixture.candidateRows.reduce(
+        (sum, row) => sum + Number(row.response_count || 0),
+        0
+      )
+  );
 
   const fileRevisionQuery = createQueryBuilderMock();
   fileRevisionQuery.getRawOne.mockResolvedValue({
@@ -119,17 +147,19 @@ const createService = (
     max_created_at: '2026-05-20T08:00:00.000Z'
   });
 
-  Object.assign(queryMocks || {}, {
-    unitQuery,
-    countQuery,
-    candidateQuery
-  });
-
   const responseRepository = {
     createQueryBuilder: jest.fn()
       .mockReturnValueOnce(countQuery)
       .mockReturnValueOnce(candidateQuery),
-    query: jest.fn().mockResolvedValue([{ revision: 1 }])
+    query: jest.fn().mockImplementation((query: string) => {
+      if (query.includes('FROM persons')) {
+        return Promise.resolve([{
+          active_count: '1',
+          active_hash: fixture.activePersonHash || 'active-person-hash'
+        }]);
+      }
+      return Promise.resolve([{ revision: 1 }]);
+    })
   };
   const unitRepository = {
     createQueryBuilder: jest.fn().mockReturnValue(unitQuery)
@@ -150,6 +180,15 @@ const createService = (
       testletIgnoredUnits: []
     })
   };
+
+  Object.assign(queryMocks || {}, {
+    unitQuery,
+    countQuery,
+    candidateQuery,
+    fileUploadRepository,
+    responseRepository,
+    workspaceFilesService
+  });
 
   return new CodingReadinessService(
     responseRepository as never,
@@ -235,6 +274,150 @@ describe('CodingReadinessService', () => {
     expect(internals.readinessCache.has('2|1|1|files|0|scope')).toBe(true);
     expect(internals.readinessInFlight.has('1|1|1|files|0|scope')).toBe(false);
     expect(internals.cacheRevisionByWorkspace.get(1)).toBe(5);
+  });
+
+  it('returns summary readiness without loading units, variables or files', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 3,
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 3 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+
+    const readiness = await service.getReadiness(1, {
+      forceRefresh: true,
+      detailLevel: 'summary'
+    });
+
+    expect(readiness).toMatchObject({
+      detailLevel: 'summary',
+      detailsComplete: false,
+      readiness: 'DIAGNOSTICS_PENDING',
+      rawResponsesTotal: 3,
+      rawResponsesWithRelevantStatus: 3,
+      validResponses: 0,
+      potentialCodeableResponses: 3,
+      codeableResponses: 0,
+      matchedUnitFiles: 0,
+      matchedCodingSchemes: 0
+    });
+    expect(queryMocks.unitQuery?.getMany).not.toHaveBeenCalled();
+    expect(queryMocks.countQuery?.getRawOne).toHaveBeenCalledTimes(1);
+    expect(queryMocks.candidateQuery?.getCount).not.toHaveBeenCalled();
+    expect(queryMocks.candidateQuery?.getRawMany).not.toHaveBeenCalled();
+    expect(queryMocks.fileUploadRepository?.find).not.toHaveBeenCalled();
+    expect(
+      queryMocks.workspaceFilesService?.getUnitVariableMap
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse workspace-wide summary readiness when active persons changed', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 3,
+      activePersonHash: 'first-active-set',
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 3 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+    queryMocks.responseRepository?.createQueryBuilder.mockReturnValue(
+      queryMocks.countQuery
+    );
+
+    await service.getReadiness(1, {
+      detailLevel: 'summary'
+    });
+    queryMocks.responseRepository?.createQueryBuilder.mockReset();
+    queryMocks.responseRepository?.createQueryBuilder.mockReturnValue(
+      queryMocks.countQuery
+    );
+    queryMocks.responseRepository?.query.mockImplementation((query: string) => {
+      if (query.includes('FROM persons')) {
+        return Promise.resolve([{
+          active_count: '2',
+          active_hash: 'second-active-set'
+        }]);
+      }
+      return Promise.resolve([{ revision: 1 }]);
+    });
+    queryMocks.countQuery?.getRawOne.mockReset();
+    queryMocks.countQuery?.getRawOne.mockResolvedValue({
+      raw_responses_total: 7,
+      raw_responses_with_relevant_status: 5
+    });
+
+    const readiness = await service.getReadiness(1, {
+      detailLevel: 'summary'
+    });
+
+    expect(readiness.rawResponsesTotal).toBe(7);
+    expect(readiness.rawResponsesWithRelevantStatus).toBe(5);
+    expect(readiness.fromCache).toBe(false);
+    expect(queryMocks.countQuery?.getRawOne).toHaveBeenCalledTimes(1);
+  });
+
+  it('can block from summary readiness when no relevant candidate responses exist', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 2,
+      candidateResponsesTotal: 0,
+      candidateRows: [],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+
+    const readiness = await service.getReadiness(1, {
+      forceRefresh: true,
+      detailLevel: 'summary'
+    });
+
+    expect(readiness).toMatchObject({
+      detailLevel: 'summary',
+      detailsComplete: true,
+      readiness: 'BLOCKED',
+      validResponses: 0,
+      codeableResponses: 0
+    });
+    expect(readiness.blockers).toEqual(['NO_RELEVANT_RESPONSES']);
+    expect(queryMocks.fileUploadRepository?.find).not.toHaveBeenCalled();
+    expect(
+      queryMocks.workspaceFilesService?.getUnitVariableMap
+    ).not.toHaveBeenCalled();
   });
 
   it('keeps missing files as diagnostics without blocking partially codeable data', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
@@ -1,4 +1,6 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException, Injectable, Logger, Optional
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   Brackets, In, Repository, SelectQueryBuilder
@@ -17,6 +19,7 @@ import {
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import {
   AutocodingInvalidVariableSampleDto,
+  AutocodingReadinessDetailLevel,
   AutocodingReadinessBlocker,
   AutocodingReadinessDto,
   AutocodingReadinessStatus
@@ -25,18 +28,21 @@ import {
   getCodingVariableIdCandidateSql,
   isCodingVariableIdCandidate
 } from './coding-response-candidate.util';
+import { CacheService } from '../../../cache/cache.service';
 
 export type AutocodingReadinessOptions = {
   personIds?: string[];
   unitIds?: number[];
   autoCoderRun?: 1 | 2;
   forceRefresh?: boolean;
+  detailLevel?: AutocodingReadinessDetailLevel;
 };
 
 type ReadinessCacheSignature = {
   sourceRevision: number;
   fileRevision: string;
   cacheRevision: number;
+  activePersonHash: string;
   scopedUnitHash: string;
 };
 
@@ -49,6 +55,11 @@ type CandidateVariableCountRow = {
   unitid: string | number;
   variableid: string;
   response_count: string | number;
+};
+
+type SummaryReadinessCountRow = {
+  raw_responses_total: string | number;
+  raw_responses_with_relevant_status: string | number;
 };
 
 type CandidateVariableCount = {
@@ -88,7 +99,8 @@ export class CodingReadinessService {
   private readonly logger = new Logger(CodingReadinessService.name);
   private readonly maxSamplesPerUnit = 8;
   private readonly maxSampleUnits = 10;
-  private readonly cacheTtlMs = 60_000;
+  private readonly cacheTtlMs = 10 * 60_000;
+  private readonly distributedCacheTtlSeconds = 60 * 60;
   private readonly readinessCache = new Map<string, ReadinessCacheEntry>();
   private readonly readinessInFlight = new Map<string, Promise<AutocodingReadinessDto>>();
   private readonly cacheRevisionByWorkspace = new Map<number, number>();
@@ -101,7 +113,9 @@ export class CodingReadinessService {
     @InjectRepository(FileUpload)
     private readonly fileUploadRepository: Repository<FileUpload>,
     private readonly workspaceFilesService: WorkspaceFilesService,
-    private readonly workspaceExclusionService: WorkspaceExclusionService
+    private readonly workspaceExclusionService: WorkspaceExclusionService,
+    @Optional()
+    private readonly cacheService?: CacheService
   ) {}
 
   async getReadiness(
@@ -110,29 +124,41 @@ export class CodingReadinessService {
   ): Promise<AutocodingReadinessDto> {
     const startedAt = Date.now();
     const autoCoderRun = options.autoCoderRun || 1;
-    const units = await this.getScopedUnits(workspaceId, options);
-    const unitIds = units.map(unit => unit.id);
+    const detailLevel = options.detailLevel || 'full';
+    const workspaceWide = this.isWorkspaceWideReadiness(options);
+    const scopedUnits = workspaceWide ?
+      null :
+      await this.getScopedUnits(workspaceId, options);
+    const unitIds = scopedUnits?.map(unit => unit.id) || [];
 
-    if (unitIds.length === 0) {
-      return this.withComputationMetadata(
-        this.emptyReadiness(workspaceId, autoCoderRun, 'NO_RESULTS'),
-        startedAt,
-        false,
-        {
-          sourceRevision: 0,
-          fileRevision: '0:',
-          cacheRevision: this.getWorkspaceCacheRevision(workspaceId),
-          scopedUnitHash: ''
-        }
-      );
-    }
-
-    const cacheSignature = await this.getCacheSignature(workspaceId, unitIds, options);
-    const cacheKey = this.buildCacheKey(workspaceId, autoCoderRun, cacheSignature);
+    const cacheSignature = await this.getCacheSignature(
+      workspaceId,
+      unitIds,
+      options,
+      workspaceWide
+    );
+    const cacheKey = this.buildCacheKey(
+      workspaceId,
+      autoCoderRun,
+      detailLevel,
+      cacheSignature
+    );
     if (!options.forceRefresh) {
       const cached = this.getCachedReadiness(cacheKey);
       if (cached) {
         return cached;
+      }
+      const distributedCached = await this.getDistributedCachedReadiness(
+        workspaceId,
+        autoCoderRun,
+        cacheKey
+      );
+      if (distributedCached) {
+        this.setCachedReadiness(cacheKey, distributedCached);
+        return {
+          ...distributedCached,
+          fromCache: true
+        };
       }
     }
 
@@ -144,8 +170,9 @@ export class CodingReadinessService {
     const readinessPromise = this.computeReadiness(
       workspaceId,
       autoCoderRun,
+      detailLevel,
       options,
-      units,
+      scopedUnits,
       startedAt,
       cacheSignature,
       cacheKey
@@ -235,12 +262,42 @@ export class CodingReadinessService {
   private async computeReadiness(
     workspaceId: number,
     autoCoderRun: 1 | 2,
+    detailLevel: AutocodingReadinessDetailLevel,
     options: AutocodingReadinessOptions,
-    units: Unit[],
+    scopedUnits: Unit[] | null,
     startedAt: number,
     cacheSignature: ReadinessCacheSignature,
     cacheKey: string
   ): Promise<AutocodingReadinessDto> {
+    if (detailLevel === 'summary') {
+      return this.computeSummaryReadiness(
+        workspaceId,
+        autoCoderRun,
+        options,
+        scopedUnits,
+        startedAt,
+        cacheSignature,
+        cacheKey
+      );
+    }
+
+    const units = scopedUnits ?? await this.getScopedUnits(workspaceId, options);
+    if (units.length === 0) {
+      const emptyReadiness = this.withComputationMetadata(
+        this.emptyReadiness(
+          workspaceId,
+          autoCoderRun,
+          'NO_RESULTS',
+          detailLevel
+        ),
+        startedAt,
+        false,
+        cacheSignature
+      );
+      this.setCachedReadiness(cacheKey, emptyReadiness);
+      return emptyReadiness;
+    }
+
     const [rawResponsesTotal, candidateVariableCounts] = await Promise.all([
       this.countRawResponses(workspaceId, options, autoCoderRun),
       this.getCandidateVariableCounts(workspaceId, options, autoCoderRun)
@@ -279,6 +336,8 @@ export class CodingReadinessService {
     const readiness = this.withComputationMetadata({
       workspaceId,
       autoCoderRun,
+      detailLevel: 'full',
+      detailsComplete: true,
       readiness: this.getReadinessStatus(
         rawResponsesTotal,
         codeableResponses,
@@ -304,6 +363,61 @@ export class CodingReadinessService {
     this.logger.debug(
       `Computed autocoding readiness for workspace ${workspaceId}, run ${autoCoderRun} ` +
       `in ${readiness.computationMs}ms: ${readiness.readiness}.`
+    );
+    return readiness;
+  }
+
+  private async computeSummaryReadiness(
+    workspaceId: number,
+    autoCoderRun: 1 | 2,
+    options: AutocodingReadinessOptions,
+    scopedUnits: Unit[] | null,
+    startedAt: number,
+    cacheSignature: ReadinessCacheSignature,
+    cacheKey: string
+  ): Promise<AutocodingReadinessDto> {
+    const {
+      rawResponsesTotal,
+      rawResponsesWithRelevantStatus
+    } = await this.countSummaryResponses(workspaceId, options, autoCoderRun);
+    const potentialCodeableResponses = rawResponsesWithRelevantStatus;
+    const blockers = this.getSummaryBlockers({
+      rawResponsesTotal,
+      rawResponsesWithRelevantStatus
+    });
+    const needsFullDiagnostics =
+      rawResponsesTotal > 0 &&
+      rawResponsesWithRelevantStatus > 0;
+
+    const readiness = this.withComputationMetadata({
+      workspaceId,
+      autoCoderRun,
+      detailLevel: 'summary',
+      detailsComplete: !needsFullDiagnostics,
+      readiness: needsFullDiagnostics ?
+        'DIAGNOSTICS_PENDING' :
+        this.getReadinessStatus(rawResponsesTotal, 0, blockers),
+      blockers,
+      rawResponsesTotal,
+      rawResponsesWithRelevantStatus,
+      resultUnitsTotal: scopedUnits?.length || 0,
+      resultUnitKeysTotal: 0,
+      matchedUnitFiles: 0,
+      missingUnitFiles: [],
+      matchedCodingSchemes: 0,
+      missingCodingSchemes: [],
+      invalidCodingSchemes: [],
+      validVariablePairs: 0,
+      validResponses: 0,
+      potentialCodeableResponses,
+      codeableResponses: 0,
+      invalidVariableSamples: []
+    }, startedAt, false, cacheSignature);
+
+    this.setCachedReadiness(cacheKey, readiness);
+    this.logger.debug(
+      `Computed summary autocoding readiness for workspace ${workspaceId}, ` +
+      `run ${autoCoderRun} in ${readiness.computationMs}ms: ${readiness.readiness}.`
     );
     return readiness;
   }
@@ -344,6 +458,36 @@ export class CodingReadinessService {
     const query = await this.createScopedResponseQuery(workspaceId, options);
     this.applyAutocoderGeneratedFilter(query, autoCoderRun);
     return query.getCount();
+  }
+
+  private async countSummaryResponses(
+    workspaceId: number,
+    options: AutocodingReadinessOptions,
+    autoCoderRun: 1 | 2
+  ): Promise<{
+      rawResponsesTotal: number;
+      rawResponsesWithRelevantStatus: number;
+    }> {
+    const query = await this.createScopedResponseQuery(workspaceId, options);
+    this.applyAutocoderGeneratedFilter(query, autoCoderRun);
+    const derivePending = statusStringToNumber('DERIVE_PENDING') as number;
+    const candidateCondition =
+      `((response.status IN (3, 2, 1) OR response.status_v1 = ${derivePending}) ` +
+      `AND ${getCodingVariableIdCandidateSql('response')})`;
+    const row = await query
+      .select('COUNT(response.id)', 'raw_responses_total')
+      .addSelect(
+        `COUNT(response.id) FILTER (WHERE ${candidateCondition})`,
+        'raw_responses_with_relevant_status'
+      )
+      .getRawOne<SummaryReadinessCountRow>();
+
+    return {
+      rawResponsesTotal: Number(row?.raw_responses_total || 0),
+      rawResponsesWithRelevantStatus: Number(
+        row?.raw_responses_with_relevant_status || 0
+      )
+    };
   }
 
   private async getCandidateVariableCounts(
@@ -753,6 +897,21 @@ export class CodingReadinessService {
     return blockers;
   }
 
+  private getSummaryBlockers(input: {
+    rawResponsesTotal: number;
+    rawResponsesWithRelevantStatus: number;
+  }): AutocodingReadinessBlocker[] {
+    if (input.rawResponsesTotal === 0) {
+      return [];
+    }
+
+    const blockers: AutocodingReadinessBlocker[] = [];
+    if (input.rawResponsesWithRelevantStatus === 0) {
+      blockers.push('NO_RELEVANT_RESPONSES');
+    }
+    return blockers;
+  }
+
   private getReadinessStatus(
     rawResponsesTotal: number,
     codeableResponses: number,
@@ -800,11 +959,14 @@ export class CodingReadinessService {
   private emptyReadiness(
     workspaceId: number,
     autoCoderRun: 1 | 2,
-    readiness: AutocodingReadinessStatus
+    readiness: AutocodingReadinessStatus,
+    detailLevel: AutocodingReadinessDetailLevel = 'full'
   ): AutocodingReadinessDto {
     return {
       workspaceId,
       autoCoderRun,
+      detailLevel,
+      detailsComplete: true,
       readiness,
       blockers: [],
       rawResponsesTotal: 0,
@@ -847,19 +1009,35 @@ export class CodingReadinessService {
   private async getCacheSignature(
     workspaceId: number,
     unitIds: number[],
-    options: AutocodingReadinessOptions
+    options: AutocodingReadinessOptions,
+    workspaceWide: boolean
   ): Promise<ReadinessCacheSignature> {
-    const [sourceRevision, fileRevision] = await Promise.all([
+    const [sourceRevision, fileRevision, activePersonHash] = await Promise.all([
       this.getWorkspaceResultsRevision(workspaceId),
-      this.getWorkspaceFileRevision(workspaceId)
+      this.getWorkspaceFileRevision(workspaceId),
+      workspaceWide ?
+        this.getWorkspaceActivePersonHash(workspaceId) :
+        Promise.resolve('scoped')
     ]);
 
     return {
       sourceRevision,
       fileRevision,
       cacheRevision: this.getWorkspaceCacheRevision(workspaceId),
-      scopedUnitHash: this.hashScope(unitIds, options)
+      activePersonHash,
+      scopedUnitHash: workspaceWide ?
+        this.hashValues(['workspace-wide']) :
+        this.hashScope(unitIds, options)
     };
+  }
+
+  private isWorkspaceWideReadiness(
+    options: AutocodingReadinessOptions
+  ): boolean {
+    return (
+      this.uniquePositiveIds((options.personIds || []).map(id => Number(id))).length === 0 &&
+      this.uniquePositiveIds(options.unitIds || []).length === 0
+    );
   }
 
   private getWorkspaceCacheRevision(workspaceId: number): number {
@@ -917,17 +1095,44 @@ export class CodingReadinessService {
     }
   }
 
+  private async getWorkspaceActivePersonHash(workspaceId: number): Promise<string> {
+    try {
+      const rows = await this.responseRepository.query(
+        `
+          SELECT
+            COUNT(id)::text AS active_count,
+            COALESCE(md5(string_agg(id::text, ',' ORDER BY id)), '') AS active_hash
+          FROM persons
+          WHERE workspace_id = $1
+            AND consider = true
+        `,
+        [workspaceId]
+      ) as Array<{ active_count: string; active_hash: string }>;
+      const row = rows[0];
+      return `${row?.active_count || '0'}:${row?.active_hash || ''}`;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve active person signature for readiness cache: ${message}`
+      );
+      return '0:';
+    }
+  }
+
   private buildCacheKey(
     workspaceId: number,
     autoCoderRun: 1 | 2,
+    detailLevel: AutocodingReadinessDetailLevel,
     signature: ReadinessCacheSignature
   ): string {
     return [
       workspaceId,
       autoCoderRun,
+      detailLevel,
       signature.sourceRevision,
       signature.fileRevision,
       signature.cacheRevision,
+      signature.activePersonHash,
       signature.scopedUnitHash
     ].join('|');
   }
@@ -956,6 +1161,52 @@ export class CodingReadinessService {
     this.readinessCache.set(cacheKey, {
       expiresAt: Date.now() + this.cacheTtlMs,
       readiness
+    });
+    this.setDistributedCachedReadiness(cacheKey, readiness);
+  }
+
+  private getDistributedReadinessCacheKey(
+    workspaceId: number,
+    autoCoderRun: 1 | 2,
+    cacheKey: string
+  ): string {
+    return `coding_readiness:${workspaceId}:run${autoCoderRun}:${this.hashValues([cacheKey])}`;
+  }
+
+  private async getDistributedCachedReadiness(
+    workspaceId: number,
+    autoCoderRun: 1 | 2,
+    cacheKey: string
+  ): Promise<AutocodingReadinessDto | null> {
+    if (!this.cacheService) {
+      return null;
+    }
+    return this.cacheService.get<AutocodingReadinessDto>(
+      this.getDistributedReadinessCacheKey(workspaceId, autoCoderRun, cacheKey)
+    );
+  }
+
+  private setDistributedCachedReadiness(
+    cacheKey: string,
+    readiness: AutocodingReadinessDto
+  ): void {
+    if (!this.cacheService) {
+      return;
+    }
+    const distributedCacheKey = this.getDistributedReadinessCacheKey(
+      readiness.workspaceId,
+      readiness.autoCoderRun,
+      cacheKey
+    );
+    this.cacheService.set(
+      distributedCacheKey,
+      readiness,
+      this.distributedCacheTtlSeconds
+    ).catch(error => {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not store autocoding readiness cache ${distributedCacheKey}: ${message}`
+      );
     });
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
@@ -36,7 +36,9 @@ describe('CodingStatisticsService', () => {
     mockCacheService = {
       get: jest.fn(),
       set: jest.fn(),
-      delete: jest.fn()
+      delete: jest.fn(),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
     } as unknown as jest.Mocked<CacheService>;
 
     mockJobQueueService = {
@@ -334,11 +336,19 @@ describe('CodingStatisticsService', () => {
 
     it('should invalidate incomplete variables cache', async () => {
       mockCacheService.delete.mockResolvedValue(true);
+      mockCacheService.incr.mockResolvedValue(1);
+      mockCacheService.deleteByPattern.mockResolvedValue(undefined);
 
       await service.invalidateIncompleteVariablesCache(1);
 
       expect(mockCacheService.delete).toHaveBeenCalledWith(
         'coding_incomplete_variables_v8:1'
+      );
+      expect(mockCacheService.incr).toHaveBeenCalledWith(
+        'coding_applied_results_overview:version:1'
+      );
+      expect(mockCacheService.deleteByPattern).toHaveBeenCalledWith(
+        'coding_applied_results_overview:1:*'
       );
     });
 
@@ -786,21 +796,10 @@ describe('CodingStatisticsService', () => {
   });
 
   describe('Application bootstrap', () => {
-    it('should preload statistics for all workspaces on bootstrap', async () => {
-      mockResponseRepository.query.mockResolvedValue([
-        { workspace_id: '1' },
-        { workspace_id: '2' }
-      ]);
-      mockWorkspaceCoreService.getIgnoredUnits.mockResolvedValue([]);
-      mockFileUploadRepository.find.mockResolvedValue([]);
-      mockResponseRepository.query.mockResolvedValue([]);
-
+    it('should leave workspace preload to the sequential cache scheduler', async () => {
       await service.onApplicationBootstrap();
 
-      expect(mockResponseRepository.query).toHaveBeenCalledWith(
-        expect.stringContaining('SELECT DISTINCT person.workspace_id'),
-        expect.any(Array)
-      );
+      expect(mockResponseRepository.query).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
@@ -1,5 +1,5 @@
 import {
-  Inject, Injectable, Logger, OnApplicationBootstrap, forwardRef
+  Inject, Injectable, Logger, forwardRef
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -28,6 +28,10 @@ import {
   type CodingStatisticsVersion
 } from './coding-statistics-cache-key.util';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 import { getEffectiveCodingStatusExpression } from '../../utils/effective-coding-status-expression.util';
 
 export interface KappaCalculationResult {
@@ -52,7 +56,7 @@ export interface KappaVariableSummary {
 }
 
 @Injectable()
-export class CodingStatisticsService implements OnApplicationBootstrap {
+export class CodingStatisticsService {
   private readonly logger = new Logger(CodingStatisticsService.name);
   private readonly CACHE_TTL_SECONDS = 0; // No expiration (TTL=0 means no EX flag in Redis) - persist until explicitly invalidated
 
@@ -74,21 +78,9 @@ export class CodingStatisticsService implements OnApplicationBootstrap {
       return;
     }
 
-    this.logger.log('Application bootstrap: Loading coding statistics for all workspaces...');
-    try {
-      const workspaceIds = await this.getWorkspaceIdsWithResponses();
-      this.logger.log(`Found ${workspaceIds.length} workspaces with responses, preloading statistics...`);
-
-      const preloadPromises = workspaceIds.map(workspaceId => this.getCodingStatistics(workspaceId).catch(error => {
-        this.logger.error(`Failed to preload statistics for workspace ${workspaceId}: ${error.message}`);
-      })
-      );
-
-      await Promise.allSettled(preloadPromises);
-      this.logger.log('Finished preloading coding statistics for all workspaces');
-    } catch (error) {
-      this.logger.error(`Error during application bootstrap: ${error.message}`);
-    }
+    this.logger.log(
+      'Skipping coding statistics service preload; cache scheduler handles warmup sequentially.'
+    );
   }
 
   private async getWorkspaceIdsWithResponses(): Promise<number[]> {
@@ -305,8 +297,16 @@ export class CodingStatisticsService implements OnApplicationBootstrap {
 
   async invalidateIncompleteVariablesCache(workspace_id: number): Promise<void> {
     const cacheKey = getCodingIncompleteVariablesCacheKey(workspace_id);
-    await this.cacheService.delete(cacheKey);
-    this.logger.log(`Invalidated incomplete variables cache for workspace ${workspace_id}`);
+    await Promise.all([
+      this.cacheService.delete(cacheKey),
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspace_id)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspace_id)
+      )
+    ]);
+    this.logger.log(`Invalidated incomplete variables and applied results overview cache for workspace ${workspace_id}`);
   }
 
   async refreshStatistics(workspace_id: number, version: CodingStatisticsVersion = 'v1'): Promise<CodingStatistics> {

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -72,9 +72,11 @@ describe('CodingValidationService', () => {
       }
     },
     ...overrides
-  } as unknown as ResponseEntity);
+  }) as unknown as ResponseEntity;
 
-  const createQueryBuilderMock = <T extends Record<string, unknown>>(rawResults: T[] = []) => ({
+  const createQueryBuilderMock = <T extends Record<string, unknown>>(
+    rawResults: T[] = []
+  ) => ({
     innerJoin: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
     leftJoinAndSelect: jest.fn().mockReturnThis(),
@@ -101,11 +103,23 @@ describe('CodingValidationService', () => {
     unitName,
     variableid,
     value: overrides.value ?? `value-${index + 1}`,
-    ...(overrides.statusV1 !== undefined ? { statusV1: overrides.statusV1 } : {}),
+    ...(overrides.statusV1 !== undefined ?
+      { statusV1: overrides.statusV1 } :
+      {}),
     personLogin: `${variableid}-person-${index + 1}`,
     personCode: `${index + 1}`,
     personGroup: 'group'
   }));
+
+  const createDeferred = <T>() => {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  };
 
   beforeEach(async () => {
     mockResponseRepository = {
@@ -123,7 +137,9 @@ describe('CodingValidationService', () => {
       storeValidationResults: jest.fn(),
       get: jest.fn(),
       set: jest.fn(),
-      delete: jest.fn()
+      delete: jest.fn(),
+      incr: jest.fn(),
+      deleteByPattern: jest.fn()
     } as unknown as jest.Mocked<CacheService>;
 
     mockWorkspaceFilesService = {
@@ -138,10 +154,12 @@ describe('CodingValidationService', () => {
 
     mockWorkspacePlayerService = {
       findUnitDef: jest.fn().mockResolvedValue([{ file_id: 'UNIT1.VOUD' }]),
-      findUnit: jest.fn().mockResolvedValue([{
-        file_id: 'UNIT1',
-        data: '<Unit><DefinitionRef player="VERONA-1.0.0"/></Unit>'
-      }]),
+      findUnit: jest.fn().mockResolvedValue([
+        {
+          file_id: 'UNIT1',
+          data: '<Unit><DefinitionRef player="VERONA-1.0.0"/></Unit>'
+        }
+      ]),
       findPlayer: jest.fn().mockResolvedValue([{ file_id: 'VERONA-1.0.0' }])
     } as unknown as jest.Mocked<WorkspacePlayerService>;
 
@@ -153,7 +171,9 @@ describe('CodingValidationService', () => {
     } as unknown as jest.Mocked<CodingJobService>;
     mockQueryBuilder.getRawMany.mockResolvedValue([]);
     mockQueryBuilder.getCount.mockResolvedValue(0);
-    mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(new Map());
+    mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
+      new Map()
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -501,7 +521,8 @@ describe('CodingValidationService', () => {
         mockCacheService.storeValidationResults.mock.calls[0][1][0].combination
       ).not.toHaveProperty('url');
       expect(
-        mockCacheService.storeValidationResults.mock.calls[0][1][0].responseFound
+        mockCacheService.storeValidationResults.mock.calls[0][1][0]
+          .responseFound
       ).toBe(true);
     });
 
@@ -545,6 +566,116 @@ describe('CodingValidationService', () => {
       );
     });
 
+    it('should reuse an in-flight uncached variables query for the same workspace', async () => {
+      const dbVariables = [
+        {
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 5,
+          deriveErrorResponseCount: 0,
+          isDerived: false,
+          coderTrainingRequired: false
+        }
+      ];
+      const enrichedVariables = [
+        {
+          ...dbVariables[0],
+          casesInJobs: 0,
+          availableCases: 5,
+          uniqueCasesAfterAggregation: 5
+        }
+      ];
+      const dbVariablesDeferred = createDeferred<typeof dbVariables>();
+      const serviceInternals = service as unknown as {
+        fetchCodingIncompleteVariablesFromDb: (
+          workspaceId: number,
+          unitName?: string,
+          trainingRequired?: boolean,
+          includeDeriveErrorOnly?: boolean
+        ) => Promise<typeof dbVariables>;
+        enrichVariablesWithCaseInfo: (
+          workspaceId: number,
+          variables: typeof dbVariables
+        ) => Promise<typeof enrichedVariables>;
+      };
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      const fetchSpy = jest
+        .spyOn(serviceInternals, 'fetchCodingIncompleteVariablesFromDb')
+        .mockReturnValue(dbVariablesDeferred.promise);
+      const enrichSpy = jest
+        .spyOn(serviceInternals, 'enrichVariablesWithCaseInfo')
+        .mockResolvedValue(enrichedVariables);
+
+      const firstRequest = service.getCodingIncompleteVariables(1);
+      const secondRequest = service.getCodingIncompleteVariables(1);
+      await Promise.resolve();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      dbVariablesDeferred.resolve(dbVariables);
+
+      await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual(
+        [enrichedVariables, enrichedVariables]
+      );
+      expect(enrichSpy).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not cache stale variables when the cache is invalidated while a query is running', async () => {
+      const dbVariables = [
+        {
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 5,
+          deriveErrorResponseCount: 0,
+          isDerived: false,
+          coderTrainingRequired: false
+        }
+      ];
+      const enrichedVariables = [
+        {
+          ...dbVariables[0],
+          casesInJobs: 0,
+          availableCases: 5,
+          uniqueCasesAfterAggregation: 5
+        }
+      ];
+      const dbVariablesDeferred = createDeferred<typeof dbVariables>();
+      const serviceInternals = service as unknown as {
+        fetchCodingIncompleteVariablesFromDb: (
+          workspaceId: number,
+          unitName?: string,
+          trainingRequired?: boolean,
+          includeDeriveErrorOnly?: boolean
+        ) => Promise<typeof dbVariables>;
+        enrichVariablesWithCaseInfo: (
+          workspaceId: number,
+          variables: typeof dbVariables
+        ) => Promise<typeof enrichedVariables>;
+      };
+
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockCacheService.delete.mockResolvedValue(true);
+      jest
+        .spyOn(serviceInternals, 'fetchCodingIncompleteVariablesFromDb')
+        .mockReturnValue(dbVariablesDeferred.promise);
+      jest
+        .spyOn(serviceInternals, 'enrichVariablesWithCaseInfo')
+        .mockResolvedValue(enrichedVariables);
+
+      const request = service.getCodingIncompleteVariables(1);
+      await Promise.resolve();
+
+      await service.invalidateIncompleteVariablesCache(1);
+      dbVariablesDeferred.resolve(dbVariables);
+
+      await expect(request).resolves.toEqual(enrichedVariables);
+      expect(mockCacheService.set).not.toHaveBeenCalled();
+    });
+
     it('should include INTENDED_INCOMPLETE variables even when they are defined in the scheme', async () => {
       const codingIncompleteQb = createQueryBuilderMock([
         { unitName: 'unit1', variableId: 'var1', responseCount: '5' }
@@ -556,11 +687,14 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
@@ -570,9 +704,15 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getIntendedIncompleteSchemeVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1', 'intended-only'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1', 'intended-only'])]])
       );
@@ -616,20 +756,29 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['manual-var', 'auto-only-var'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['manual-var'])]])
       );
@@ -640,7 +789,9 @@ describe('CodingValidationService', () => {
 
       const result = await service.getCodingIncompleteVariables(1);
 
-      expect(result.map(variable => variable.variableId)).toEqual(['manual-var']);
+      expect(result.map(variable => variable.variableId)).toEqual([
+        'manual-var'
+      ]);
     });
 
     it('should expose DERIVE_ERROR response counts per manual coding variable', async () => {
@@ -654,20 +805,29 @@ describe('CodingValidationService', () => {
       ]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1', 'var2'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         ...createSlimResponses('unit1', 'var1', 5),
@@ -696,32 +856,58 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const assignedResponsesQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'other', personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'other',
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         }
       ] as never);
 
@@ -749,32 +935,50 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb)
-        .mockReturnValueOnce(createQueryBuilderMock([
-          { unitName: 'unit1', variableId: 'derived-var', responseCount: '3' }
-        ]))
-        .mockReturnValueOnce(createQueryBuilderMock([
-          { unitName: 'unit1', variableId: 'base-var', responseCount: '3' },
-          { unitName: 'unit1', variableId: 'standalone-var', responseCount: '2' }
-        ]))
+        .mockReturnValueOnce(
+          createQueryBuilderMock([
+            { unitName: 'unit1', variableId: 'derived-var', responseCount: '3' }
+          ])
+        )
+        .mockReturnValueOnce(
+          createQueryBuilderMock([
+            { unitName: 'unit1', variableId: 'base-var', responseCount: '3' },
+            {
+              unitName: 'unit1',
+              variableId: 'standalone-var',
+              responseCount: '2'
+            }
+          ])
+        )
         .mockReturnValueOnce(createQueryBuilderMock([]));
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
-        new Map([['UNIT1', new Set(['base-var', 'derived-var', 'standalone-var'])]])
+        new Map([
+          ['UNIT1', new Set(['base-var', 'derived-var', 'standalone-var'])]
+        ])
       );
       mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['derived-var'])]])
       );
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
         new Map([
-          [getManualCodingScopeKey('unit1', 'base-var'), new Set(['derived-var'])]
+          [
+            getManualCodingScopeKey('unit1', 'base-var'),
+            new Set(['derived-var'])
+          ]
         ])
       );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
@@ -817,20 +1021,29 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
@@ -885,11 +1098,14 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
@@ -899,8 +1115,12 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['derived-var'])]])
       );
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
@@ -919,10 +1139,11 @@ describe('CodingValidationService', () => {
           isDerived: true
         })
       ]);
-      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
-        1,
-        [{ unitName: 'unit1', variableId: 'derived-var' }]
-      );
+      expect(
+        mockCodingJobService.getSlimResponsesForVariables
+      ).toHaveBeenCalledWith(1, [
+        { unitName: 'unit1', variableId: 'derived-var' }
+      ]);
     });
 
     it('should calculate availability on aggregation groups instead of raw job response counts', async () => {
@@ -938,41 +1159,73 @@ describe('CodingValidationService', () => {
         { unitName: 'unit1', variableId: 'var1', responseId: '5' }
       ]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(4);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-1'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person-1'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-2'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person-2'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-3'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person-3'
         },
         {
-          id: 4, unitName: 'unit1', variableid: 'var1', value: 'same', personLogin: 'person-4'
+          id: 4,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          personLogin: 'person-4'
         },
         {
-          id: 5, unitName: 'unit1', variableid: 'var1', value: 'single', personLogin: 'person-5'
+          id: 5,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'single',
+          personLogin: 'person-5'
         },
         {
-          id: 6, unitName: 'unit1', variableid: 'var1', value: 'single', personLogin: 'person-6'
+          id: 6,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'single',
+          personLogin: 'person-6'
         }
       ] as never);
 
@@ -1000,35 +1253,67 @@ describe('CodingValidationService', () => {
         { unitName: 'unit1', variableId: 'var1', responseId: '2' }
       ]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-2', personCode: 'code-2', personGroup: 'group'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-2',
+          personCode: 'code-2',
+          personGroup: 'group'
         },
         {
-          id: 4, unitName: 'unit1', variableid: 'var1', value: 'other-value', personLogin: 'person-3', personCode: 'code-3', personGroup: 'group'
+          id: 4,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'other-value',
+          personLogin: 'person-3',
+          personCode: 'code-3',
+          personGroup: 'group'
         }
       ] as never);
 
@@ -1054,32 +1339,61 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const assignedResponsesQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group', bookletName: 'Booklet A'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group',
+          bookletName: 'Booklet A'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group', bookletName: 'Booklet A'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group',
+          bookletName: 'Booklet A'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same-value', personLogin: 'person-1', personCode: 'code-1', personGroup: 'group', bookletName: 'Booklet B'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same-value',
+          personLogin: 'person-1',
+          personCode: 'code-1',
+          personGroup: 'group',
+          bookletName: 'Booklet B'
         }
       ] as never);
 
@@ -1109,32 +1423,52 @@ describe('CodingValidationService', () => {
       const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
       const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: codingIncompleteStatus
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: codingIncompleteStatus
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: deriveErrorStatus
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: deriveErrorStatus
         }
       ] as never);
 
@@ -1145,10 +1479,11 @@ describe('CodingValidationService', () => {
         true
       );
 
-      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
-        1,
-        [{ unitName: 'unit1', variableId: 'var1', includeDeriveError: true }]
-      );
+      expect(
+        mockCodingJobService.getSlimResponsesForVariables
+      ).toHaveBeenCalledWith(1, [
+        { unitName: 'unit1', variableId: 'var1', includeDeriveError: true }
+      ]);
       expect(result).toEqual([
         expect.objectContaining({
           unitName: 'unit1',
@@ -1171,12 +1506,14 @@ describe('CodingValidationService', () => {
       const assignedResponsesQb = createQueryBuilderMock([]);
       const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
@@ -1186,10 +1523,15 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['derived-var'])]])
       );
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
         new Map([
-          [getManualCodingScopeKey('unit1', 'source-var'), new Set(['derived-var'])]
+          [
+            getManualCodingScopeKey('unit1', 'source-var'),
+            new Set(['derived-var'])
+          ]
         ])
       );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
@@ -1198,12 +1540,9 @@ describe('CodingValidationService', () => {
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
-        createSlimResponses(
-          'unit1',
-          'derived-var',
-          2,
-          { statusV1: deriveErrorStatus }
-        ) as never
+        createSlimResponses('unit1', 'derived-var', 2, {
+          statusV1: deriveErrorStatus
+        }) as never
       );
 
       const result = await service.getCodingIncompleteVariables(
@@ -1213,11 +1552,18 @@ describe('CodingValidationService', () => {
         true
       );
 
-      expect(result.map(variable => variable.variableId)).toEqual(['derived-var']);
-      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
-        1,
-        [{ unitName: 'unit1', variableId: 'derived-var', includeDeriveError: true }]
-      );
+      expect(result.map(variable => variable.variableId)).toEqual([
+        'derived-var'
+      ]);
+      expect(
+        mockCodingJobService.getSlimResponsesForVariables
+      ).toHaveBeenCalledWith(1, [
+        {
+          unitName: 'unit1',
+          variableId: 'derived-var',
+          includeDeriveError: true
+        }
+      ]);
     });
 
     it('should suppress DERIVE_ERROR counts for covered source variables that remain regular candidates', async () => {
@@ -1234,12 +1580,14 @@ describe('CodingValidationService', () => {
       const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
       const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(assignedResponsesQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValueOnce(assignedResponsesQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
@@ -1249,10 +1597,15 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['derived-var'])]])
       );
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
       mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
         new Map([
-          [getManualCodingScopeKey('unit1', 'source-var'), new Set(['derived-var'])]
+          [
+            getManualCodingScopeKey('unit1', 'source-var'),
+            new Set(['derived-var'])
+          ]
         ])
       );
       mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
@@ -1261,24 +1614,15 @@ describe('CodingValidationService', () => {
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
-        ...createSlimResponses(
-          'unit1',
-          'source-var',
-          1,
-          { statusV1: codingIncompleteStatus }
-        ),
-        ...createSlimResponses(
-          'unit1',
-          'derived-var',
-          1,
-          { statusV1: codingIncompleteStatus }
-        ),
-        ...createSlimResponses(
-          'unit1',
-          'derived-var',
-          2,
-          { statusV1: deriveErrorStatus }
-        ).map((response, index) => ({ ...response, id: index + 10 }))
+        ...createSlimResponses('unit1', 'source-var', 1, {
+          statusV1: codingIncompleteStatus
+        }),
+        ...createSlimResponses('unit1', 'derived-var', 1, {
+          statusV1: codingIncompleteStatus
+        }),
+        ...createSlimResponses('unit1', 'derived-var', 2, {
+          statusV1: deriveErrorStatus
+        }).map((response, index) => ({ ...response, id: index + 10 }))
       ] as never);
 
       const result = await service.getCodingIncompleteVariables(
@@ -1298,13 +1642,16 @@ describe('CodingValidationService', () => {
           deriveErrorResponseCount: 2
         })
       ]);
-      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
-        1,
-        [
-          { unitName: 'unit1', variableId: 'source-var' },
-          { unitName: 'unit1', variableId: 'derived-var', includeDeriveError: true }
-        ]
-      );
+      expect(
+        mockCodingJobService.getSlimResponsesForVariables
+      ).toHaveBeenCalledWith(1, [
+        { unitName: 'unit1', variableId: 'source-var' },
+        {
+          unitName: 'unit1',
+          variableId: 'derived-var',
+          includeDeriveError: true
+        }
+      ]);
     });
 
     it('should apply training deduplication when DERIVE_ERROR case counts are requested without aggregation', async () => {
@@ -1320,7 +1667,8 @@ describe('CodingValidationService', () => {
       const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
       const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
@@ -1333,23 +1681,57 @@ describe('CodingValidationService', () => {
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set(['var1'])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getResponseMatchingMode.mockResolvedValue([]);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
         {
-          id: 1, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 1,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: codingIncompleteStatus,
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 2, unitName: 'unit1', variableid: 'var1', value: 'same', statusV1: codingIncompleteStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'same',
+          statusV1: codingIncompleteStatus,
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 3, unitName: 'unit1', variableid: 'var1', value: 'other', statusV1: codingIncompleteStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 3,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'other',
+          statusV1: codingIncompleteStatus,
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         },
         {
-          id: 4, unitName: 'unit1', variableid: 'var1', value: 'other', statusV1: deriveErrorStatus, personLogin: 'person', personCode: 'code', personGroup: 'group'
+          id: 4,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'other',
+          statusV1: deriveErrorStatus,
+          personLogin: 'person',
+          personCode: 'code',
+          personGroup: 'group'
         }
       ] as never);
 
@@ -1443,9 +1825,7 @@ describe('CodingValidationService', () => {
   });
 
   describe('validateManualCodeAvailability', () => {
-    const mockManualScopeQueries = (
-      variableId = 'var1'
-    ): void => {
+    const mockManualScopeQueries = (variableId = 'var1'): void => {
       const codingIncompleteQb = createQueryBuilderMock([
         { unitName: 'unit1', variableId, responseCount: '5' }
       ]);
@@ -1453,21 +1833,29 @@ describe('CodingValidationService', () => {
       const deriveErrorQb = createQueryBuilderMock([]);
       const casesInJobsQb = createQueryBuilderMock([]);
 
-      mockResponseRepository.createQueryBuilder = jest.fn()
+      mockResponseRepository.createQueryBuilder = jest
+        .fn()
         .mockReturnValueOnce(codingIncompleteQb)
         .mockReturnValueOnce(intendedIncompleteQb)
         .mockReturnValueOnce(deriveErrorQb);
-      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValue(casesInJobsQb);
+      (
+        mockCodingJobUnitRepository.createQueryBuilder as jest.Mock
+      ).mockReturnValue(casesInJobsQb);
 
       mockCacheService.get.mockResolvedValue(null);
       mockCacheService.set.mockResolvedValue(true);
       mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
         new Map([['UNIT1', new Set([variableId])]])
       );
-      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
-      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(
+        new Map()
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map()
+      );
       mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
       mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
         createSlimResponses('unit1', variableId, 5) as never
@@ -1500,7 +1888,8 @@ describe('CodingValidationService', () => {
                 {
                   id: 3,
                   label: 'Visually empty HTML',
-                  manualInstruction: '<p style="margin-top: 0; min-height: 1em"></p>'
+                  manualInstruction:
+                    '<p style="margin-top: 0; min-height: 1em"></p>'
                 }
               ]
             }
@@ -1647,13 +2036,24 @@ describe('CodingValidationService', () => {
   });
 
   describe('invalidateIncompleteVariablesCache', () => {
-    it('should delete cache key for workspace', async () => {
+    it('should delete manual coding cache keys for workspace', async () => {
       mockCacheService.delete.mockResolvedValue(true);
+      mockCacheService.incr.mockResolvedValue(1);
+      mockCacheService.deleteByPattern.mockResolvedValue(undefined);
 
       await service.invalidateIncompleteVariablesCache(1);
 
       expect(mockCacheService.delete).toHaveBeenCalledWith(
         'coding_incomplete_variables_v8:1'
+      );
+      expect(mockCacheService.delete).toHaveBeenCalledWith(
+        'coding_incomplete_variables_v8:1:scope-summary'
+      );
+      expect(mockCacheService.incr).toHaveBeenCalledWith(
+        'coding_applied_results_overview:version:1'
+      );
+      expect(mockCacheService.deleteByPattern).toHaveBeenCalledWith(
+        'coding_applied_results_overview:1:*'
       );
     });
   });
@@ -1706,7 +2106,10 @@ describe('CodingValidationService', () => {
       ]);
       mockQueryBuilder.getCount.mockResolvedValueOnce(1);
 
-      const result = await service.getAppliedResultsCount(1, undefined as never);
+      const result = await service.getAppliedResultsCount(
+        1,
+        undefined as never
+      );
 
       expect(result).toBe(1);
       expect(mockQueryBuilder.getCount).toHaveBeenCalledTimes(1);
@@ -1722,7 +2125,9 @@ describe('CodingValidationService', () => {
 
       await service.getAppliedResultsCount(1, incompleteVariables);
 
-      expect(mockResponseRepository.createQueryBuilder).toHaveBeenCalledTimes(2);
+      expect(mockResponseRepository.createQueryBuilder).toHaveBeenCalledTimes(
+        2
+      );
       expect(mockQueryBuilder.getCount).toHaveBeenCalledTimes(2);
     });
 

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -45,6 +45,10 @@ import {
   applyNonCodingIssueReviewJobFilter,
   getNonCodingIssueReviewJobSqlCondition
 } from './coding-job-type.util';
+import {
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 
 interface NormalizedExpectedCombination {
   unitKey: string;
@@ -115,6 +119,25 @@ type ManualCodingVariableWithCaseInfo = {
 export class CodingValidationService {
   private readonly logger = new Logger(CodingValidationService.name);
 
+  private readonly manualCodingCacheTtlSeconds = 300;
+
+  private readonly slowManualCodingQueryThresholdMs = 3000;
+
+  private readonly manualCodingVariablesInFlight = new Map<
+  string,
+  Promise<ManualCodingVariableWithCaseInfo[]>
+  >();
+
+  private readonly manualCodingScopeSummaryInFlight = new Map<
+  string,
+  Promise<ManualCodingScopeSummary>
+  >();
+
+  private readonly manualCodingCacheGenerationByWorkspace = new Map<
+  number,
+  number
+  >();
+
   constructor(
     @InjectRepository(ResponseEntity)
     private responseRepository: Repository<ResponseEntity>,
@@ -126,7 +149,7 @@ export class CodingValidationService {
     @Inject(forwardRef(() => CodingJobService))
     private codingJobService: CodingJobService,
     private workspacePlayerService: WorkspacePlayerService
-  ) { }
+  ) {}
 
   async validateCodingCompleteness(
     workspaceId: number,
@@ -140,7 +163,8 @@ export class CodingValidationService {
       );
       const startTime = Date.now();
 
-      const combinationsHash = generateExpectedCombinationsHash(expectedCombinations);
+      const combinationsHash =
+        generateExpectedCombinationsHash(expectedCombinations);
       const cacheKey = this.cacheService.generateValidationCacheKey(
         workspaceId,
         combinationsHash
@@ -173,7 +197,10 @@ export class CodingValidationService {
       const allResults: ValidationResultDto[] = [];
       let totalMissingCount = 0;
       const replayAssetIssueCache = new Map<string, Promise<string[]>>();
-      const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+      const exclusions =
+        await this.workspaceExclusionService.resolveExclusionsForQueries(
+          workspaceId
+        );
 
       const batchSize = 100;
       for (let i = 0; i < expectedCombinations.length; i += batchSize) {
@@ -185,13 +212,12 @@ export class CodingValidationService {
         );
 
         for (const expected of batch) {
-          const normalizedExpected = this.normalizeExpectedCombination(expected);
-          const safeCombination = this.buildSafeExpectedCombination(
-            normalizedExpected
-          );
-          const inputIssues = this.getExpectedCombinationInputIssues(
-            normalizedExpected
-          );
+          const normalizedExpected =
+            this.normalizeExpectedCombination(expected);
+          const safeCombination =
+            this.buildSafeExpectedCombination(normalizedExpected);
+          const inputIssues =
+            this.getExpectedCombinationInputIssues(normalizedExpected);
 
           if (inputIssues.length > 0) {
             totalMissingCount += 1;
@@ -215,7 +241,10 @@ export class CodingValidationService {
             .andWhere('response.value IS NOT NULL')
             .andWhere('response.value != :empty', { empty: '' });
 
-          this.applyExpectedCombinationFilters(queryBuilder, normalizedExpected);
+          this.applyExpectedCombinationFilters(
+            queryBuilder,
+            normalizedExpected
+          );
           applyResolvedExclusionsToQuery(queryBuilder, exclusions);
 
           const response = await queryBuilder.getOne();
@@ -224,15 +253,16 @@ export class CodingValidationService {
           if (!response) {
             issues.push('Keine passende Antwort gefunden.');
           } else {
-            const unitName = response.unit?.name ||
+            const unitName =
+              response.unit?.name ||
               normalizedExpected.unitKey ||
               normalizedExpected.unitAlias;
             issues.push(
-              ...await this.getReplayAssetIssues(
+              ...(await this.getReplayAssetIssues(
                 workspaceId,
                 unitName,
                 replayAssetIssueCache
-              )
+              ))
             );
           }
 
@@ -280,7 +310,8 @@ export class CodingValidationService {
 
       const endTime = Date.now();
       this.logger.log(
-        `Validation completed in ${endTime - startTime}ms. Processed all ${expectedCombinations.length
+        `Validation completed in ${endTime - startTime}ms. Processed all ${
+          expectedCombinations.length
         } combinations with ${totalMissingCount} missing responses.`
       );
 
@@ -374,8 +405,12 @@ export class CodingValidationService {
       ...(expected.personGroup ? { person_group: expected.personGroup } : {}),
       booklet_id: expected.bookletId,
       variable_id: expected.variableId,
-      ...(expected.variablePage ? { variable_page: expected.variablePage } : {}),
-      ...(expected.variableAnchor ? { variable_anchor: expected.variableAnchor } : {})
+      ...(expected.variablePage ?
+        { variable_page: expected.variablePage } :
+        {}),
+      ...(expected.variableAnchor ?
+        { variable_anchor: expected.variableAnchor } :
+        {})
     };
   }
 
@@ -388,17 +423,19 @@ export class CodingValidationService {
     ) as string[];
 
     queryBuilder
-      .andWhere(new Brackets(qb => {
-        unitCandidates.forEach((unitCandidate, index) => {
-          const parameterName = `unitCandidate${index}`;
-          const condition = `(unit.name = :${parameterName} OR unit.alias = :${parameterName})`;
-          if (index === 0) {
-            qb.where(condition, { [parameterName]: unitCandidate });
-          } else {
-            qb.orWhere(condition, { [parameterName]: unitCandidate });
-          }
-        });
-      }))
+      .andWhere(
+        new Brackets(qb => {
+          unitCandidates.forEach((unitCandidate, index) => {
+            const parameterName = `unitCandidate${index}`;
+            const condition = `(unit.name = :${parameterName} OR unit.alias = :${parameterName})`;
+            if (index === 0) {
+              qb.where(condition, { [parameterName]: unitCandidate });
+            } else {
+              qb.orWhere(condition, { [parameterName]: unitCandidate });
+            }
+          });
+        })
+      )
       .andWhere('person.login = :loginName', {
         loginName: expected.loginName
       })
@@ -447,7 +484,10 @@ export class CodingValidationService {
 
     try {
       const [unitDef, unitFile] = await Promise.all([
-        this.workspacePlayerService.findUnitDef(workspaceId, normalizedUnitName),
+        this.workspacePlayerService.findUnitDef(
+          workspaceId,
+          normalizedUnitName
+        ),
         this.workspacePlayerService.findUnit(workspaceId, normalizedUnitName)
       ]);
 
@@ -500,8 +540,14 @@ export class CodingValidationService {
 
     const module = matches[1] || '';
     const major = parseInt(matches[3], 10) || 0;
-    const minor = typeof matches[4] === 'string' ? parseInt(matches[4].substring(1), 10) : 0;
-    const patch = typeof matches[5] === 'string' ? parseInt(matches[5].substring(1), 10) : 0;
+    const minor =
+      typeof matches[4] === 'string' ?
+        parseInt(matches[4].substring(1), 10) :
+        0;
+    const patch =
+      typeof matches[5] === 'string' ?
+        parseInt(matches[5].substring(1), 10) :
+        0;
     return `${module}-${major}.${minor}.${patch}`.toUpperCase();
   }
 
@@ -526,6 +572,7 @@ export class CodingValidationService {
       coderTrainingRequired: boolean;
     }[]
     > {
+    const startedAt = Date.now();
     try {
       if (
         unitName ||
@@ -535,8 +582,12 @@ export class CodingValidationService {
       ) {
         const queryDetails = [
           unitName ? ` and unit ${unitName}` : '',
-          trainingRequired !== undefined ? ` (trainingRequired: ${trainingRequired})` : '',
-          excludeJobDefinitionId !== undefined ? ` excluding job definition ${excludeJobDefinitionId}` : ''
+          trainingRequired !== undefined ?
+            ` (trainingRequired: ${trainingRequired})` :
+            '',
+          excludeJobDefinitionId !== undefined ?
+            ` excluding job definition ${excludeJobDefinitionId}` :
+            ''
         ].join('');
         this.logger.log(
           `Querying manual coding variables for workspace ${workspaceId}${queryDetails} (not cached)`
@@ -576,31 +627,32 @@ export class CodingValidationService {
         );
         return cachedResult;
       }
+      const inFlightResult = this.manualCodingVariablesInFlight.get(cacheKey);
+      if (inFlightResult) {
+        this.logger.log(
+          `Reusing in-flight manual coding variables query for workspace ${workspaceId}`
+        );
+        return await inFlightResult;
+      }
+
       this.logger.log(
         `Cache miss: Querying manual coding variables for workspace ${workspaceId}`
       );
-      const variables = await this.fetchCodingIncompleteVariablesFromDb(
+      const cacheGeneration =
+        this.getManualCodingCacheGeneration(workspaceId);
+      const queryPromise = this.fetchAndCacheCodingIncompleteVariables(
         workspaceId,
-        undefined,
-        undefined,
-        includeDeriveErrorOnly
+        cacheKey,
+        cacheGeneration
       );
-      const result = await this.enrichVariablesWithCaseInfo(
-        workspaceId,
-        variables
-      );
-
-      const cacheSet = await this.cacheService.set(cacheKey, result, 300); // Cache for 5 minutes
-      if (cacheSet) {
-        this.logger.log(
-          `Cached ${result.length} manual coding variables for workspace ${workspaceId}`
-        );
-      } else {
-        this.logger.warn(
-          `Failed to cache manual coding variables for workspace ${workspaceId}`
-        );
+      this.manualCodingVariablesInFlight.set(cacheKey, queryPromise);
+      try {
+        return await queryPromise;
+      } finally {
+        if (this.manualCodingVariablesInFlight.get(cacheKey) === queryPromise) {
+          this.manualCodingVariablesInFlight.delete(cacheKey);
+        }
       }
-      return result;
     } catch (error) {
       this.logger.error(
         `Error getting manual coding variables: ${error.message}`,
@@ -608,6 +660,12 @@ export class CodingValidationService {
       );
       throw new Error(
         'Could not get manual coding variables. Please check the database connection.'
+      );
+    } finally {
+      this.logSlowManualCodingQuery(
+        'getCodingIncompleteVariables',
+        workspaceId,
+        startedAt
       );
     }
   }
@@ -617,21 +675,60 @@ export class CodingValidationService {
     unitName?: string,
     trainingRequired?: boolean
   ): Promise<ManualCodingScopeSummary> {
+    const startedAt = Date.now();
     try {
+      const canUseCache = !unitName && trainingRequired === undefined;
+      const cacheKey =
+        this.generateManualCodingScopeSummaryCacheKey(workspaceId);
+
+      if (canUseCache) {
+        const cachedSummary =
+          await this.cacheService.get<ManualCodingScopeSummary>(cacheKey);
+        if (cachedSummary) {
+          this.logger.log(
+            `Retrieved manual coding scope summary from cache for workspace ${workspaceId}`
+          );
+          return cachedSummary;
+        }
+      }
+
+      if (canUseCache) {
+        const inFlightSummary =
+          this.manualCodingScopeSummaryInFlight.get(cacheKey);
+        if (inFlightSummary) {
+          this.logger.log(
+            `Reusing in-flight manual coding scope summary query for workspace ${workspaceId}`
+          );
+          return await inFlightSummary;
+        }
+
+        const cacheGeneration =
+          this.getManualCodingCacheGeneration(workspaceId);
+        const summaryPromise = this.fetchAndCacheManualCodingScopeSummary(
+          workspaceId,
+          cacheKey,
+          cacheGeneration
+        );
+        this.manualCodingScopeSummaryInFlight.set(cacheKey, summaryPromise);
+        try {
+          return await summaryPromise;
+        } finally {
+          if (
+            this.manualCodingScopeSummaryInFlight.get(cacheKey) ===
+            summaryPromise
+          ) {
+            this.manualCodingScopeSummaryInFlight.delete(cacheKey);
+          }
+        }
+      }
+
       const scope = await this.fetchManualCodingScopeFromDb(
         workspaceId,
         unitName,
         trainingRequired
       );
 
-      return {
-        manualVariableCount: scope.variables.length,
-        manualResponseCount: scope.variables.reduce(
-          (sum, variable) => sum + variable.responseCount,
-          0
-        ),
-        ...scope.excludedSourceSummary
-      };
+      return this.createManualCodingScopeSummary(scope);
     } catch (error) {
       this.logger.error(
         `Error getting manual coding scope summary: ${error.message}`,
@@ -639,6 +736,12 @@ export class CodingValidationService {
       );
       throw new Error(
         'Could not get manual coding scope summary. Please check the database connection.'
+      );
+    } finally {
+      this.logSlowManualCodingQuery(
+        'getManualCodingScopeSummary',
+        workspaceId,
+        startedAt
       );
     }
   }
@@ -648,6 +751,7 @@ export class CodingValidationService {
     unitName?: string,
     trainingRequired?: boolean
   ): Promise<ManualCodeAvailabilityValidationDto> {
+    const startedAt = Date.now();
     try {
       const [variables, variableDetailsByKey] = await Promise.all([
         this.getCodingIncompleteVariables(
@@ -678,8 +782,7 @@ export class CodingValidationService {
             responseCount: variable.responseCount,
             casesInJobs: variable.casesInJobs,
             availableCases: variable.availableCases,
-            uniqueCasesAfterAggregation:
-              variable.uniqueCasesAfterAggregation,
+            uniqueCasesAfterAggregation: variable.uniqueCasesAfterAggregation,
             regularCodeCount: counts.regularCodeCount,
             selectableRegularCodeCount: counts.selectableRegularCodeCount,
             onlySpecialOptionsAvailable: true,
@@ -704,12 +807,18 @@ export class CodingValidationService {
       throw new Error(
         'Could not validate manual code availability. Please check the coding schemes.'
       );
+    } finally {
+      this.logSlowManualCodingQuery(
+        'validateManualCodeAvailability',
+        workspaceId,
+        startedAt
+      );
     }
   }
 
   /**
-     * Enrich variables with case information (cases in jobs, available cases, and unique cases after aggregation)
-     */
+   * Enrich variables with case information (cases in jobs, available cases, and unique cases after aggregation)
+   */
   private async enrichVariablesWithCaseInfo(
     workspaceId: number,
     variables: ManualCodingVariableCaseCounts[],
@@ -755,9 +864,11 @@ export class CodingValidationService {
       return result;
     }
 
-    const aggregationThreshold = await this.codingJobService.getAggregationThreshold(workspaceId);
+    const aggregationThreshold =
+      await this.codingJobService.getAggregationThreshold(workspaceId);
 
-    const matchingFlags = await this.codingJobService.getResponseMatchingMode(workspaceId);
+    const matchingFlags =
+      await this.codingJobService.getResponseMatchingMode(workspaceId);
     const variableReferences = variables.map(v => ({
       unitName: v.unitName,
       variableId: v.variableId,
@@ -782,17 +893,24 @@ export class CodingValidationService {
       .filter(variable => variable.isDerived)
       .forEach(variable => {
         const unitKey = variable.unitName.toUpperCase();
-        const derivedVariables = derivedVariableMap.get(unitKey) || new Set<string>();
+        const derivedVariables =
+          derivedVariableMap.get(unitKey) || new Set<string>();
         derivedVariables.add(variable.variableId);
         derivedVariableMap.set(unitKey, derivedVariables);
       });
+    const responsesByVariable = new Map<string, SlimCodingResponse[]>();
+    slimResponses.forEach(response => {
+      const key = `${response.unitName}::${response.variableid}`;
+      const responses = responsesByVariable.get(key) || [];
+      responses.push(response);
+      responsesByVariable.set(key, responses);
+    });
 
     for (const variable of variables) {
       const key = `${variable.unitName}::${variable.variableId}`;
 
-      const varResponsesWithRequestedStatuses = slimResponses.filter(
-        r => r.unitName === variable.unitName && r.variableid === variable.variableId
-      );
+      const varResponsesWithRequestedStatuses =
+        responsesByVariable.get(key) || [];
 
       const countAggregatedCases = (responses: SlimCodingResponse[]) => {
         const responsesWithCaseFields: ManualCodingDeduplicationResponse[] =
@@ -801,7 +919,8 @@ export class CodingValidationService {
             responseId: response.id,
             variableId: response.variableid
           }));
-        const assignedResponseIds = assignedResponseIdsByVariable.get(key) || new Set<number>();
+        const assignedResponseIds =
+          assignedResponseIdsByVariable.get(key) || new Set<number>();
 
         return countEffectiveManualCodingCases(
           responsesWithCaseFields,
@@ -812,10 +931,12 @@ export class CodingValidationService {
         );
       };
 
-      const includeDeriveErrorForVariable = includeDeriveErrorInCaseInfo &&
-        variable.deriveErrorResponseCount > 0;
+      const includeDeriveErrorForVariable =
+        includeDeriveErrorInCaseInfo && variable.deriveErrorResponseCount > 0;
       const regularVarResponses = includeDeriveErrorForVariable ?
-        varResponsesWithRequestedStatuses.filter(response => response.statusV1 !== DERIVE_ERROR_STATUS) :
+        varResponsesWithRequestedStatuses.filter(
+          response => response.statusV1 !== DERIVE_ERROR_STATUS
+        ) :
         varResponsesWithRequestedStatuses;
       const regularCaseInfo = countAggregatedCases(regularVarResponses);
       const deriveErrorCaseInfo = includeDeriveErrorForVariable ?
@@ -824,15 +945,22 @@ export class CodingValidationService {
 
       result.set(key, {
         casesInJobs: regularCaseInfo.casesInJobs,
-        availableCases: Math.max(0, regularCaseInfo.uniqueCases - regularCaseInfo.casesInJobs),
+        availableCases: Math.max(
+          0,
+          regularCaseInfo.uniqueCases - regularCaseInfo.casesInJobs
+        ),
         uniqueCasesAfterAggregation: regularCaseInfo.uniqueCases,
-        ...(deriveErrorCaseInfo ? {
-          availableCasesWithDeriveError: Math.max(
-            0,
-            deriveErrorCaseInfo.uniqueCases - deriveErrorCaseInfo.casesInJobs
-          ),
-          uniqueCasesAfterAggregationWithDeriveError: deriveErrorCaseInfo.uniqueCases
-        } : {})
+        ...(deriveErrorCaseInfo ?
+          {
+            availableCasesWithDeriveError: Math.max(
+              0,
+              deriveErrorCaseInfo.uniqueCases -
+                  deriveErrorCaseInfo.casesInJobs
+            ),
+            uniqueCasesAfterAggregationWithDeriveError:
+                deriveErrorCaseInfo.uniqueCases
+          } :
+          {})
       });
     }
 
@@ -851,22 +979,16 @@ export class CodingValidationService {
     const variableDetailsByKey = new Map<string, VariableDetailDto>();
 
     unitVariableDetails.forEach(unitDetails => {
-      const unitKeys = [
-        unitDetails.unitName,
-        unitDetails.unitId
-      ].filter(Boolean);
+      const unitKeys = [unitDetails.unitName, unitDetails.unitId].filter(
+        Boolean
+      );
 
       unitDetails.variables.forEach(variable => {
-        const variableIds = [
-          variable.alias || variable.id
-        ].filter(Boolean);
+        const variableIds = [variable.alias || variable.id].filter(Boolean);
 
         unitKeys.forEach(unitKey => {
           variableIds.forEach(variableId => {
-            const key = this.getManualCodeAvailabilityKey(
-              unitKey,
-              variableId
-            );
+            const key = this.getManualCodeAvailabilityKey(unitKey, variableId);
             if (!variableDetailsByKey.has(key)) {
               variableDetailsByKey.set(key, variable);
             }
@@ -887,15 +1009,14 @@ export class CodingValidationService {
 
     return {
       regularCodeCount: regularCodes.length,
-      selectableRegularCodeCount: regularCodes.filter(
-        code => this.hasManualInstruction(code)
+      selectableRegularCodeCount: regularCodes.filter(code => this.hasManualInstruction(code)
       ).length
     };
   }
 
-  private hasManualInstruction(
-    code: { manualInstruction?: string | null }
-  ): boolean {
+  private hasManualInstruction(code: {
+    manualInstruction?: string | null;
+  }): boolean {
     return hasVisibleManualInstruction(code);
   }
 
@@ -903,7 +1024,9 @@ export class CodingValidationService {
     unitName: string | null | undefined,
     variableId: string | null | undefined
   ): string {
-    return `${String(unitName || '').trim().toUpperCase()}::${String(variableId || '').trim()}`;
+    return `${String(unitName || '')
+      .trim()
+      .toUpperCase()}::${String(variableId || '').trim()}`;
   }
 
   private async getAssignedResponseIdsByVariable(
@@ -917,7 +1040,10 @@ export class CodingValidationService {
       return result;
     }
 
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     const query = this.codingJobUnitRepository
       .createQueryBuilder('cju')
       .select('cju.unit_name', 'unitName')
@@ -937,18 +1063,7 @@ export class CodingValidationService {
       );
     }
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `assignedUnitName${index}`;
-      const variableParam = `assignedVariableId${index}`;
-      conditions.push(`(cju.unit_name = :${unitParam} AND cju.variable_id = :${variableParam})`);
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    query.andWhere(`(${conditions.join(' OR ')})`, parameters);
+    this.applyAssignedVariablePairFilter(query, variables);
     applyNonCodingIssueReviewJobFilter(
       query,
       'coding_job',
@@ -983,7 +1098,14 @@ export class CodingValidationService {
     trainingRequired?: boolean,
     includeDeriveErrorOnly = false
   ): Promise<
-    { unitName: string; variableId: string; responseCount: number; deriveErrorResponseCount: number; isDerived: boolean; coderTrainingRequired: boolean }[]
+    {
+      unitName: string;
+      variableId: string;
+      responseCount: number;
+      deriveErrorResponseCount: number;
+      isDerived: boolean;
+      coderTrainingRequired: boolean;
+    }[]
     > {
     const scope = await this.fetchManualCodingScopeFromDb(
       workspaceId,
@@ -994,13 +1116,54 @@ export class CodingValidationService {
     return scope.variables;
   }
 
+  private applyAssignedVariablePairFilter(
+    query: SelectQueryBuilder<CodingJobUnit>,
+    variables: { unitName: string; variableId: string }[]
+  ): void {
+    const parameters: Record<string, string> = {};
+    const pairs = variables.map((variable, index) => {
+      const unitParam = `assignedUnitName${index}`;
+      const variableParam = `assignedVariableId${index}`;
+      parameters[unitParam] = variable.unitName;
+      parameters[variableParam] = variable.variableId;
+      return `(:${unitParam}, :${variableParam})`;
+    });
+
+    query.andWhere(
+      `(cju.unit_name, cju.variable_id) IN (${pairs.join(', ')})`,
+      parameters
+    );
+  }
+
+  private createResponseVariablePairCondition(
+    variables: { unitName: string; variableId: string }[],
+    parameterPrefix: string
+  ): { condition: string; parameters: Record<string, string> } {
+    const parameters: Record<string, string> = {};
+    const pairs = variables.map((variable, index) => {
+      const unitParam = `${parameterPrefix}UnitName${index}`;
+      const variableParam = `${parameterPrefix}VariableId${index}`;
+      parameters[unitParam] = variable.unitName;
+      parameters[variableParam] = variable.variableId;
+      return `(:${unitParam}, :${variableParam})`;
+    });
+
+    return {
+      condition: `(unit.name, response.variableid) IN (${pairs.join(', ')})`,
+      parameters
+    };
+  }
+
   private async fetchManualCodingScopeFromDb(
     workspaceId: number,
     unitName?: string,
     trainingRequired?: boolean,
     includeDeriveErrorOnly = false
   ): Promise<ManualCodingScopeFromDb> {
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     // Helper to build the base query for a given status
     const buildQuery = (status: number) => {
       const qb = this.responseRepository
@@ -1013,7 +1176,9 @@ export class CodingValidationService {
         .leftJoin('booklet.bookletinfo', 'bookletinfo')
         .leftJoin('booklet.person', 'person')
         .where('response.status_v1 = :status', { status })
-        .andWhere('person.workspace_id = :workspace_id', { workspace_id: workspaceId })
+        .andWhere('person.workspace_id = :workspace_id', {
+          workspace_id: workspaceId
+        })
         .andWhere('person.consider = :consider', { consider: true })
         // Exclude special/auto codes represented as negative code_v2 values.
         .andWhere('(response.code_v2 IS NULL OR response.code_v2 >= 0)')
@@ -1028,19 +1193,34 @@ export class CodingValidationService {
     };
 
     // Run both queries in parallel
-    const [codingIncompleteRaw, intendedIncompleteRaw, deriveErrorCountsByKey] = await Promise.all([
-      buildQuery(statusStringToNumber('CODING_INCOMPLETE')).getRawMany(),
-      buildQuery(statusStringToNumber('INTENDED_INCOMPLETE')).getRawMany(),
-      this.getDeriveErrorResponseCountsByVariable(workspaceId, unitName)
-    ]);
+    const [codingIncompleteRaw, intendedIncompleteRaw, deriveErrorCountsByKey] =
+      await Promise.all([
+        buildQuery(statusStringToNumber('CODING_INCOMPLETE')).getRawMany(),
+        buildQuery(statusStringToNumber('INTENDED_INCOMPLETE')).getRawMany(),
+        this.getDeriveErrorResponseCountsByVariable(workspaceId, unitName)
+      ]);
 
     this.logger.debug(
-      `[DEBUG] CODING_INCOMPLETE raw results (${codingIncompleteRaw.length}): ${
-        codingIncompleteRaw.map((r: { unitName: string; variableId: string; responseCount: string }) => `${r.unitName}::${r.variableId}(${r.responseCount})`).join(', ')}`
+      `[DEBUG] CODING_INCOMPLETE raw results (${codingIncompleteRaw.length}): ${codingIncompleteRaw
+        .map(
+          (r: {
+            unitName: string;
+            variableId: string;
+            responseCount: string;
+          }) => `${r.unitName}::${r.variableId}(${r.responseCount})`
+        )
+        .join(', ')}`
     );
     this.logger.debug(
-      `[DEBUG] INTENDED_INCOMPLETE raw results (${intendedIncompleteRaw.length}): ${
-        intendedIncompleteRaw.map((r: { unitName: string; variableId: string; responseCount: string }) => `${r.unitName}::${r.variableId}(${r.responseCount})`).join(', ')}`
+      `[DEBUG] INTENDED_INCOMPLETE raw results (${intendedIncompleteRaw.length}): ${intendedIncompleteRaw
+        .map(
+          (r: {
+            unitName: string;
+            variableId: string;
+            responseCount: string;
+          }) => `${r.unitName}::${r.variableId}(${r.responseCount})`
+        )
+        .join(', ')}`
     );
 
     // Load both lookup maps from the file service
@@ -1053,7 +1233,9 @@ export class CodingValidationService {
     ] = await Promise.all([
       this.workspaceFilesService.getUnitVariableMap(workspaceId),
       this.workspaceFilesService.getDerivedVariableMap(workspaceId),
-      this.workspaceFilesService.getCoderTrainingRequiredVariableMap(workspaceId),
+      this.workspaceFilesService.getCoderTrainingRequiredVariableMap(
+        workspaceId
+      ),
       this.workspaceFilesService.getDerivedVariablesBySourceMap(workspaceId),
       this.workspaceFilesService.getManualInstructionVariableMap(workspaceId)
     ]);
@@ -1065,25 +1247,35 @@ export class CodingValidationService {
     });
 
     const derivedVariableSets = new Map<string, Set<string>>();
-    derivedVariableMap.forEach((variables: Set<string>, unitNameKey: string) => {
-      derivedVariableSets.set(unitNameKey.toUpperCase(), variables);
-    });
+    derivedVariableMap.forEach(
+      (variables: Set<string>, unitNameKey: string) => {
+        derivedVariableSets.set(unitNameKey.toUpperCase(), variables);
+      }
+    );
 
     const trainingRequiredSets = new Map<string, Set<string>>();
-    trainingRequiredMap.forEach((variables: Set<string>, unitNameKey: string) => {
-      trainingRequiredSets.set(unitNameKey.toUpperCase(), variables);
-    });
+    trainingRequiredMap.forEach(
+      (variables: Set<string>, unitNameKey: string) => {
+        trainingRequiredSets.set(unitNameKey.toUpperCase(), variables);
+      }
+    );
 
     const manualInstructionSets = new Map<string, Set<string>>();
-    manualInstructionMap.forEach((variables: Set<string>, unitNameKey: string) => {
-      manualInstructionSets.set(unitNameKey.toUpperCase(), variables);
-    });
+    manualInstructionMap.forEach(
+      (variables: Set<string>, unitNameKey: string) => {
+        manualInstructionSets.set(unitNameKey.toUpperCase(), variables);
+      }
+    );
 
     this.logger.debug(
       `[DEBUG] unitVariableMap units: [${Array.from(validVariableSets.keys()).join(', ')}]`
     );
     // Filter results, applying trainingRequired filter if provided
-    const filterFn = (row: { unitName: string; variableId: string; responseCount: string }) => {
+    const filterFn = (row: {
+      unitName: string;
+      variableId: string;
+      responseCount: string;
+    }) => {
       const unitKey = row.unitName?.toUpperCase();
       const variableId = row.variableId;
 
@@ -1092,7 +1284,8 @@ export class CodingValidationService {
       if (!validVars?.has(variableId)) return false;
 
       // Filter by trainingRequired
-      const isRequired = trainingRequiredSets.get(unitKey)?.has(variableId) || false;
+      const isRequired =
+        trainingRequiredSets.get(unitKey)?.has(variableId) || false;
       if (trainingRequired !== undefined) {
         if (isRequired !== trainingRequired) {
           return false;
@@ -1126,49 +1319,62 @@ export class CodingValidationService {
     );
     const deriveErrorCoveredSourceKeys = includeDeriveErrorOnly ?
       getCoveredSourceKeysForManualDerivedVariables(
-        Array.from(manualInstructionSets.entries()).flatMap(([manualUnitName, variables]) => (
-          Array.from(variables)
+        Array.from(manualInstructionSets.entries()).flatMap(
+          ([manualUnitName, variables]) => Array.from(variables)
             .map(variableId => ({ unitName: manualUnitName, variableId }))
             .filter(row => filterFn({
               unitName: row.unitName,
               variableId: row.variableId,
               responseCount: '0'
-            }))
-        )),
+            })
+            )
+        ),
         derivedVariablesBySourceMap
       ) :
       new Set<string>();
     const getScopedDeriveErrorResponseCount = (
       responseUnitName: string,
       variableId: string
-    ): number => (
-      includeDeriveErrorOnly &&
+    ): number => (includeDeriveErrorOnly &&
       isCoveredSourceVariable(
         { unitName: responseUnitName, variableId },
         deriveErrorCoveredSourceKeys
       ) ?
-        0 :
-        deriveErrorCountsByKey.get(`${responseUnitName}::${variableId}`) || 0
-    );
+      0 :
+      deriveErrorCountsByKey.get(`${responseUnitName}::${variableId}`) || 0);
 
     // Merge results, summing response counts for variables that appear in both
-    const mergedMap = new Map<string, {
+    const mergedMap = new Map<
+    string,
+    {
       unitName: string;
       variableId: string;
       responseCount: number;
       deriveErrorResponseCount: number;
       isDerived: boolean;
       coderTrainingRequired: boolean;
-    }>();
+    }
+    >();
 
-    for (const row of [...filteredCodingIncomplete, ...filteredIntendedIncomplete]) {
+    for (const row of [
+      ...filteredCodingIncomplete,
+      ...filteredIntendedIncomplete
+    ]) {
       const key = `${row.unitName}::${row.variableId}`;
       const existing = mergedMap.get(key);
       const count = parseInt(row.responseCount, 10);
-      const deriveErrorResponseCount =
-        getScopedDeriveErrorResponseCount(row.unitName, row.variableId);
-      const isDerived = derivedVariableSets.get(row.unitName?.toUpperCase())?.has(row.variableId) ?? false;
-      const coderTrainingRequired = trainingRequiredSets.get(row.unitName?.toUpperCase())?.has(row.variableId) ?? false;
+      const deriveErrorResponseCount = getScopedDeriveErrorResponseCount(
+        row.unitName,
+        row.variableId
+      );
+      const isDerived =
+        derivedVariableSets
+          .get(row.unitName?.toUpperCase())
+          ?.has(row.variableId) ?? false;
+      const coderTrainingRequired =
+        trainingRequiredSets
+          .get(row.unitName?.toUpperCase())
+          ?.has(row.variableId) ?? false;
 
       if (existing) {
         existing.responseCount += count;
@@ -1199,11 +1405,13 @@ export class CodingValidationService {
         ) {
           return;
         }
-        if (!filterFn({
-          unitName: deriveUnitName,
-          variableId,
-          responseCount: String(deriveErrorResponseCount)
-        })) {
+        if (
+          !filterFn({
+            unitName: deriveUnitName,
+            variableId,
+            responseCount: String(deriveErrorResponseCount)
+          })
+        ) {
           return;
         }
 
@@ -1212,8 +1420,14 @@ export class CodingValidationService {
           variableId,
           responseCount: 0,
           deriveErrorResponseCount,
-          isDerived: derivedVariableSets.get(deriveUnitName?.toUpperCase())?.has(variableId) ?? false,
-          coderTrainingRequired: trainingRequiredSets.get(deriveUnitName?.toUpperCase())?.has(variableId) ?? false
+          isDerived:
+            derivedVariableSets
+              .get(deriveUnitName?.toUpperCase())
+              ?.has(variableId) ?? false,
+          coderTrainingRequired:
+            trainingRequiredSets
+              .get(deriveUnitName?.toUpperCase())
+              ?.has(variableId) ?? false
         });
       });
     }
@@ -1222,7 +1436,7 @@ export class CodingValidationService {
 
     this.logger.log(
       `Found ${codingIncompleteRaw.length} CODING_INCOMPLETE + ${intendedIncompleteRaw.length} INTENDED_INCOMPLETE variable groups, ` +
-      `filtered to ${result.length} valid variables${unitName ? ` for unit ${unitName}` : ''}`
+        `filtered to ${result.length} valid variables${unitName ? ` for unit ${unitName}` : ''}`
     );
 
     return {
@@ -1235,7 +1449,10 @@ export class CodingValidationService {
     workspaceId: number,
     unitName?: string
   ): Promise<Map<string, number>> {
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     const query = this.responseRepository
       .createQueryBuilder('response')
       .select('unit.name', 'unitName')
@@ -1248,7 +1465,9 @@ export class CodingValidationService {
       .where('response.status_v1 = :status', {
         status: statusStringToNumber('DERIVE_ERROR')
       })
-      .andWhere('person.workspace_id = :workspace_id', { workspace_id: workspaceId })
+      .andWhere('person.workspace_id = :workspace_id', {
+        workspace_id: workspaceId
+      })
       .andWhere('person.consider = :consider', { consider: true })
       .andWhere('(response.code_v2 IS NULL OR response.code_v2 >= 0)')
       .groupBy('unit.name')
@@ -1270,7 +1489,10 @@ export class CodingValidationService {
 
     return rawResults.reduce((counts, row) => {
       if (row.unitName && row.variableId) {
-        counts.set(`${row.unitName}::${row.variableId}`, parseInt(row.responseCount, 10) || 0);
+        counts.set(
+          `${row.unitName}::${row.variableId}`,
+          parseInt(row.responseCount, 10) || 0
+        );
       }
       return counts;
     }, new Map<string, number>());
@@ -1281,21 +1503,146 @@ export class CodingValidationService {
   }
 
   async invalidateIncompleteVariablesCache(workspaceId: number): Promise<void> {
+    this.bumpManualCodingCacheGeneration(workspaceId);
     const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
-    await this.cacheService.delete(cacheKey);
+    const scopeSummaryCacheKey =
+      this.generateManualCodingScopeSummaryCacheKey(workspaceId);
+    this.manualCodingVariablesInFlight.delete(cacheKey);
+    this.manualCodingScopeSummaryInFlight.delete(scopeSummaryCacheKey);
+    await Promise.all([
+      this.cacheService.delete(cacheKey),
+      this.cacheService.delete(scopeSummaryCacheKey),
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspaceId)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspaceId)
+      )
+    ]);
     this.logger.log(
-      `Invalidated manual coding variables cache for workspace ${workspaceId}`
+      `Invalidated manual coding variables and applied results overview cache for workspace ${workspaceId}`
+    );
+  }
+
+  private async fetchAndCacheCodingIncompleteVariables(
+    workspaceId: number,
+    cacheKey: string,
+    cacheGeneration: number
+  ): Promise<ManualCodingVariableWithCaseInfo[]> {
+    const variables = await this.fetchCodingIncompleteVariablesFromDb(
+      workspaceId,
+      undefined,
+      undefined,
+      false
+    );
+    const result = await this.enrichVariablesWithCaseInfo(
+      workspaceId,
+      variables
+    );
+
+    if (this.getManualCodingCacheGeneration(workspaceId) !== cacheGeneration) {
+      this.logger.log(
+        `Skipped caching stale manual coding variables for workspace ${workspaceId}`
+      );
+      return result;
+    }
+
+    const cacheSet = await this.cacheService.set(
+      cacheKey,
+      result,
+      this.manualCodingCacheTtlSeconds
+    );
+    if (cacheSet) {
+      this.logger.log(
+        `Cached ${result.length} manual coding variables for workspace ${workspaceId}`
+      );
+    } else {
+      this.logger.warn(
+        `Failed to cache manual coding variables for workspace ${workspaceId}`
+      );
+    }
+    return result;
+  }
+
+  private async fetchAndCacheManualCodingScopeSummary(
+    workspaceId: number,
+    cacheKey: string,
+    cacheGeneration: number
+  ): Promise<ManualCodingScopeSummary> {
+    const scope = await this.fetchManualCodingScopeFromDb(workspaceId);
+    const summary = this.createManualCodingScopeSummary(scope);
+
+    if (this.getManualCodingCacheGeneration(workspaceId) !== cacheGeneration) {
+      this.logger.log(
+        `Skipped caching stale manual coding scope summary for workspace ${workspaceId}`
+      );
+      return summary;
+    }
+
+    await this.cacheService.set(
+      cacheKey,
+      summary,
+      this.manualCodingCacheTtlSeconds
+    );
+    return summary;
+  }
+
+  private createManualCodingScopeSummary(
+    scope: ManualCodingScopeFromDb
+  ): ManualCodingScopeSummary {
+    return {
+      manualVariableCount: scope.variables.length,
+      manualResponseCount: scope.variables.reduce(
+        (sum, variable) => sum + variable.responseCount,
+        0
+      ),
+      ...scope.excludedSourceSummary
+    };
+  }
+
+  private getManualCodingCacheGeneration(workspaceId: number): number {
+    return this.manualCodingCacheGenerationByWorkspace.get(workspaceId) || 0;
+  }
+
+  private bumpManualCodingCacheGeneration(workspaceId: number): void {
+    this.manualCodingCacheGenerationByWorkspace.set(
+      workspaceId,
+      this.getManualCodingCacheGeneration(workspaceId) + 1
+    );
+  }
+
+  private generateManualCodingScopeSummaryCacheKey(
+    workspaceId: number
+  ): string {
+    return `${this.generateIncompleteVariablesCacheKey(workspaceId)}:scope-summary`;
+  }
+
+  private logSlowManualCodingQuery(
+    operation: string,
+    workspaceId: number,
+    startedAt: number
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    if (durationMs < this.slowManualCodingQueryThresholdMs) {
+      return;
+    }
+
+    this.logger.warn(
+      `${operation} for workspace ${workspaceId} took ${durationMs} ms`
     );
   }
 
   /**
-     * Get the number of unique cases (response_ids) already assigned to coding jobs for each variable
-     * This counts distinct response_ids to properly handle double-coding scenarios
-     */
+   * Get the number of unique cases (response_ids) already assigned to coding jobs for each variable
+   * This counts distinct response_ids to properly handle double-coding scenarios
+   */
   async getVariableCasesInJobs(
     workspaceId: number
   ): Promise<Map<string, number>> {
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     const query = this.codingJobUnitRepository
       .createQueryBuilder('cju')
       .select('cju.unit_name', 'unitName')
@@ -1335,7 +1682,10 @@ export class CodingValidationService {
   private async getDeriveErrorManualJobVariables(
     workspaceId: number
   ): Promise<Array<{ unitName: string; variableId: string }>> {
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
     const query = this.codingJobUnitRepository
       .createQueryBuilder('cju')
       .select('cju.unit_name', 'unitName')
@@ -1360,7 +1710,10 @@ export class CodingValidationService {
       parameterPrefix: 'appliedResultsDeriveErrorVariables'
     });
 
-    const rawResults = await query.getRawMany<{ unitName: string; variableId: string }>();
+    const rawResults = await query.getRawMany<{
+      unitName: string;
+      variableId: string;
+    }>();
     return rawResults.filter(row => row.unitName && row.variableId);
   }
 
@@ -1371,7 +1724,8 @@ export class CodingValidationService {
     const providedVariables = Array.isArray(incompleteVariables) ?
       incompleteVariables :
       [];
-    const deriveErrorManualVariables = await this.getDeriveErrorManualJobVariables(workspaceId);
+    const deriveErrorManualVariables =
+      await this.getDeriveErrorManualJobVariables(workspaceId);
     return createManualCodingVariableReferences([
       ...providedVariables,
       ...deriveErrorManualVariables
@@ -1400,11 +1754,18 @@ export class CodingValidationService {
       }
 
       let totalAppliedCount = 0;
-      const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+      const exclusions =
+        await this.workspaceExclusionService.resolveExclusionsForQueries(
+          workspaceId
+        );
       const batchSize = 50;
       for (let i = 0; i < appliedResultsVariables.length; i += batchSize) {
         const batch = appliedResultsVariables.slice(i, i + batchSize);
 
+        const variablePairCondition = this.createResponseVariablePairCondition(
+          batch,
+          `appliedResults${i}`
+        );
         const query = this.responseRepository
           .createQueryBuilder('response')
           .innerJoin('response.unit', 'unit')
@@ -1413,14 +1774,15 @@ export class CodingValidationService {
           .innerJoin('booklet.person', 'person')
           .where('person.workspace_id = :workspaceId', { workspaceId })
           .andWhere('person.consider = :consider', { consider: true })
-          .andWhere(new Brackets(qb => {
-            qb.where('response.status_v1 IN (:...sourceStatuses)', {
-              sourceStatuses: [
-                statusStringToNumber('CODING_INCOMPLETE'),
-                statusStringToNumber('INTENDED_INCOMPLETE')
-              ]
-            }).orWhere(
-              `response.status_v1 = :deriveErrorStatus
+          .andWhere(
+            new Brackets(qb => {
+              qb.where('response.status_v1 IN (:...sourceStatuses)', {
+                sourceStatuses: [
+                  statusStringToNumber('CODING_INCOMPLETE'),
+                  statusStringToNumber('INTENDED_INCOMPLETE')
+                ]
+              }).orWhere(
+                `response.status_v1 = :deriveErrorStatus
                 AND EXISTS (
                   SELECT 1
                   FROM coding_job_unit manual_derive_cju
@@ -1430,9 +1792,10 @@ export class CodingValidationService {
                     AND manual_derive_cj.training_id IS NULL
                     AND ${getNonCodingIssueReviewJobSqlCondition('manual_derive_cj')}
                 )`,
-              { deriveErrorStatus: statusStringToNumber('DERIVE_ERROR') }
-            );
-          }))
+                { deriveErrorStatus: statusStringToNumber('DERIVE_ERROR') }
+              );
+            })
+          )
           .andWhere('response.status_v2 IN (:...targetStatuses)', {
             targetStatuses: [
               statusStringToNumber('CODING_COMPLETE'),
@@ -1441,28 +1804,21 @@ export class CodingValidationService {
             ]
           })
           .andWhere('(response.code_v2 IS NULL OR response.code_v2 >= 0)')
-          .andWhere(new Brackets(qb => {
-            batch.forEach((variable, index) => {
-              const parameters = {
-                [`appliedUnitName${index}`]: variable.unitName,
-                [`appliedVariableId${index}`]: variable.variableId
-              };
-              const condition = `(unit.name = :appliedUnitName${index} AND response.variableid = :appliedVariableId${index})`;
-              if (index === 0) {
-                qb.where(condition, parameters);
-              } else {
-                qb.orWhere(condition, parameters);
-              }
-            });
-          }));
+          .andWhere(
+            variablePairCondition.condition,
+            variablePairCondition.parameters
+          );
 
-        applyResolvedExclusionsToQuery(query, exclusions, { parameterPrefix: `appliedResults${i}` });
+        applyResolvedExclusionsToQuery(query, exclusions, {
+          parameterPrefix: `appliedResults${i}`
+        });
 
         const batchCount = await query.getCount();
         totalAppliedCount += batchCount;
 
         this.logger.debug(
-          `Batch ${Math.floor(i / batchSize) + 1
+          `Batch ${
+            Math.floor(i / batchSize) + 1
           }: ${batchCount} applied results`
         );
       }

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -51,7 +51,11 @@ describe('ExternalCodingImportService', () => {
         }
       }
     };
-    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
     const codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };
@@ -140,7 +144,11 @@ describe('ExternalCodingImportService', () => {
         }
       }
     };
-    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
     const codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };
@@ -221,7 +229,11 @@ describe('ExternalCodingImportService', () => {
         }
       }
     };
-    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1),
+      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+    };
     const codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
@@ -15,6 +15,10 @@ import FileUpload from '../../entities/file_upload.entity';
 import { CodingFreshnessService } from './coding-freshness.service';
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
 import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingAppliedResultsOverviewCachePattern,
+  getCodingAppliedResultsOverviewVersionKey
+} from './coding-applied-results-overview-cache-key.util';
 
 interface ExternalCodingRow {
   unit_key?: string;
@@ -1251,7 +1255,15 @@ export class ExternalCodingImportService {
    */
   async invalidateIncompleteVariablesCache(workspaceId: number): Promise<void> {
     const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
-    await this.cacheService.delete(cacheKey);
-    this.logger.log(`Invalidated manual coding variables cache for workspace ${workspaceId}`);
+    await Promise.all([
+      this.cacheService.delete(cacheKey),
+      this.cacheService.incr(
+        getCodingAppliedResultsOverviewVersionKey(workspaceId)
+      ),
+      this.cacheService.deleteByPattern(
+        getCodingAppliedResultsOverviewCachePattern(workspaceId)
+      )
+    ]);
+    this.logger.log(`Invalidated manual coding variables and applied results overview cache for workspace ${workspaceId}`);
   }
 }

--- a/apps/backend/src/app/database/services/test-results/testcenter.service.ts
+++ b/apps/backend/src/app/database/services/test-results/testcenter.service.ts
@@ -29,6 +29,7 @@ import { CacheService } from '../../../cache/cache.service';
 import { WorkspaceTestResultsService } from './workspace-test-results.service';
 import { CodingFreshnessService } from '../coding/coding-freshness.service';
 import { CodingAnalysisService } from '../coding/coding-analysis.service';
+import { CodingProgressService } from '../coding/coding-progress.service';
 import { TestResultsMutationSummary } from './person-persistence.service';
 import { withWorkspaceTestResultsMutationLock } from '../shared/workspace-test-results-lock.util';
 
@@ -73,7 +74,9 @@ export class TestcenterService {
     @Optional()
     private readonly codingFreshnessService?: CodingFreshnessService,
     @Optional()
-    private readonly codingAnalysisService?: CodingAnalysisService
+    private readonly codingAnalysisService?: CodingAnalysisService,
+    @Optional()
+    private readonly codingProgressService?: CodingProgressService
   ) {}
 
   persons: Person[] = [];
@@ -1169,7 +1172,11 @@ export class TestcenterService {
       await Promise.all([
         this.codingAnalysisService?.invalidateCache(workspaceId),
         this.workspaceTestResultsService.invalidateCodingStatisticsCache(workspaceId),
-        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId)
+        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId),
+        this.codingProgressService?.invalidateAppliedResultsOverviewCache(
+          workspaceId,
+          { prewarm: true }
+        )
       ]);
     } catch (error) {
       const detail = error instanceof Error ? error.message : 'Unknown error';

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.ts
@@ -25,6 +25,7 @@ import { JobQueueService, TestResultsUploadJobData } from '../../../job-queue/jo
 import { WorkspaceTestResultsService } from './workspace-test-results.service';
 import { CodingFreshnessService } from '../coding/coding-freshness.service';
 import { CodingAnalysisService } from '../coding/coding-analysis.service';
+import { CodingProgressService } from '../coding/coding-progress.service';
 import { withWorkspaceTestResultsMutationLock } from '../shared/workspace-test-results-lock.util';
 
 type PersonWithoutBooklets = Omit<Person, 'booklets'>;
@@ -63,7 +64,9 @@ export class UploadResultsService {
     @Optional()
     private readonly codingFreshnessService?: CodingFreshnessService,
     @Optional()
-    private readonly codingAnalysisService?: CodingAnalysisService
+    private readonly codingAnalysisService?: CodingAnalysisService,
+    @Optional()
+    private readonly codingProgressService?: CodingProgressService
   ) {
   }
 
@@ -132,7 +135,11 @@ export class UploadResultsService {
       await Promise.all([
         this.codingAnalysisService?.invalidateCache(workspaceId),
         this.workspaceTestResultsService.invalidateCodingStatisticsCache(workspaceId),
-        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId)
+        this.workspaceTestResultsService.invalidateCodingAvailabilityCache(workspaceId),
+        this.codingProgressService?.invalidateAppliedResultsOverviewCache(
+          workspaceId,
+          { prewarm: true }
+        )
       ]);
     } catch (error) {
       const detail = error instanceof Error ? error.message : 'Unknown error';

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -62,6 +62,16 @@ const mockQueryBuilder = () => ({
   execute: jest.fn().mockResolvedValue({ affected: 0 })
 });
 
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
 type WorkspaceTestResultsServiceWithLogAnomalyLookup = {
   findLogAnomaliesForBooklets: (
     bookletIds: number[],
@@ -1254,6 +1264,97 @@ describe('WorkspaceTestResultsService', () => {
   });
 
   describe('getWorkspaceTestResultsOverview', () => {
+    it('should return cached overview by test results revision without querying aggregates', async () => {
+      const workspaceId = 1;
+      const cachedOverview = {
+        testPersons: 10,
+        testGroups: 2,
+        uniqueBooklets: 3,
+        uniqueUnits: 4,
+        uniqueResponses: 5,
+        responseStatusCounts: { DISPLAYED: 5 },
+        sessionBrowserCounts: { Chrome: 1 },
+        sessionOsCounts: { Windows: 1 },
+        sessionScreenCounts: { '1920x1080': 1 }
+      };
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 7 }]);
+      cacheService.get.mockResolvedValue(cachedOverview);
+
+      const result = await service.getWorkspaceTestResultsOverview(workspaceId);
+
+      expect(result).toBe(cachedOverview);
+      expect(cacheService.get).toHaveBeenCalledWith(
+        'workspace-overview-stats-1:v7'
+      );
+      expect(personsRepository.count).not.toHaveBeenCalled();
+      expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should reuse an in-flight overview query for the same workspace revision', async () => {
+      const workspaceId = 1;
+      const overview = {
+        testPersons: 1,
+        testGroups: 1,
+        uniqueBooklets: 1,
+        uniqueUnits: 1,
+        uniqueResponses: 1,
+        responseStatusCounts: {},
+        sessionBrowserCounts: {},
+        sessionOsCounts: {},
+        sessionScreenCounts: {}
+      };
+      const overviewDeferred = createDeferred<typeof overview>();
+      const serviceInternals = service as unknown as {
+        computeAndCacheWorkspaceTestResultsOverview: (
+          workspaceId: number,
+          revision: number,
+          cacheKey: string,
+          cacheGeneration: number
+        ) => Promise<typeof overview>;
+      };
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 8 }]);
+      cacheService.get.mockResolvedValue(null);
+      const computeSpy = jest
+        .spyOn(serviceInternals, 'computeAndCacheWorkspaceTestResultsOverview')
+        .mockReturnValue(overviewDeferred.promise);
+
+      const firstRequest = service.getWorkspaceTestResultsOverview(workspaceId);
+      const secondRequest = service.getWorkspaceTestResultsOverview(workspaceId);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(computeSpy).toHaveBeenCalledTimes(1);
+      expect(computeSpy).toHaveBeenCalledWith(
+        workspaceId,
+        8,
+        'workspace-overview-stats-1:v8',
+        0
+      );
+
+      overviewDeferred.resolve(overview);
+      await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual(
+        [overview, overview]
+      );
+    });
+
+    it('should not cache an overview if the test results revision changes while computing', async () => {
+      const workspaceId = 1;
+      (dataSource.query as jest.Mock)
+        .mockResolvedValueOnce([{ revision: 1 }])
+        .mockResolvedValueOnce([{ revision: 2 }]);
+      cacheService.get.mockResolvedValue(null);
+      (personsRepository.count as jest.Mock).mockResolvedValue(10);
+
+      await service.getWorkspaceTestResultsOverview(workspaceId);
+
+      expect(cacheService.set).not.toHaveBeenCalledWith(
+        'workspace-overview-stats-1:v1',
+        expect.anything(),
+        0
+      );
+    });
+
     it('should return correct statistics', async () => {
       const workspaceId = 1;
 
@@ -1274,15 +1375,12 @@ describe('WorkspaceTestResultsService', () => {
       unitQb.getRawMany.mockResolvedValue(['unit1', 'unit2']);
       unitQb.getRawOne.mockResolvedValue({ count: 2 });
 
-      const responseCountQb = mockQueryBuilder();
       const responseStatusQb = mockQueryBuilder();
       (responseRepository.createQueryBuilder as jest.Mock)
-        .mockReturnValueOnce(responseCountQb)
         .mockReturnValueOnce(responseStatusQb);
-      responseCountQb.getCount.mockResolvedValue(100);
       responseStatusQb.getRawMany.mockResolvedValue([
-        { status: '0', count: '5' },
-        { status: '1', count: '10' }
+        { status: '0', count: '55' },
+        { status: '1', count: '45' }
       ]);
 
       const sessionBrowserQb = mockQueryBuilder();
@@ -1304,13 +1402,22 @@ describe('WorkspaceTestResultsService', () => {
       expect(result.uniqueBooklets).toBe(1); // 1 booklet row mock
       expect(result.uniqueUnits).toBe(2);
       expect(result.uniqueResponses).toBe(100);
-      expect(result.responseStatusCounts).toEqual({ UNSET: 5, NOT_REACHED: 10 });
+      expect(result.responseStatusCounts).toEqual({ UNSET: 55, NOT_REACHED: 45 });
       expect(result.sessionBrowserCounts).toEqual({ Chrome: 20 });
-      expect(responseCountQb.andWhere).toHaveBeenCalledWith(
-        'response.is_autocoder_generated IS NOT TRUE'
-      );
+      expect(responseRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
       expect(responseStatusQb.andWhere).toHaveBeenCalledWith(
         'response.is_autocoder_generated IS NOT TRUE'
+      );
+      expect(cacheService.set).toHaveBeenCalledWith(
+        'workspace-overview-stats-1:v0',
+        expect.objectContaining({
+          testPersons: 10,
+          testGroups: 2,
+          uniqueBooklets: 1,
+          uniqueUnits: 2,
+          uniqueResponses: 100
+        }),
+        0
       );
     });
 
@@ -1349,6 +1456,112 @@ describe('WorkspaceTestResultsService', () => {
       expect(unitQb.andWhere).toHaveBeenCalledWith(
         expect.stringContaining("REGEXP_REPLACE(UPPER(unit.name), '\\.XML$', '', 'i') NOT IN"),
         expect.objectContaining({ workspaceExclusionIgnoredUnits: ['UNIT1'] }) // .XML stripped and uppercase
+      );
+    });
+
+    it('should invalidate legacy and revisioned overview cache entries', async () => {
+      const workspaceId = 1;
+
+      await service.invalidateWorkspaceStatsCache(workspaceId);
+
+      expect(cacheService.delete).toHaveBeenCalledWith(
+        'workspace-overview-stats-1'
+      );
+      expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+        'workspace-overview-stats-1:*'
+      );
+    });
+  });
+
+  describe('hasGeogebraResponses', () => {
+    it('uses a revisioned cache and stops the database query after the first match', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getRawOne.mockResolvedValue({ exists: 1 });
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 4 }]);
+
+      await expect(service.hasGeogebraResponses(1)).resolves.toBe(true);
+
+      expect(cacheService.get).toHaveBeenCalledWith(
+        'geogebra-existence:1:v4'
+      );
+      expect(qb.select).toHaveBeenCalledWith('1', 'exists');
+      expect(qb.limit).toHaveBeenCalledWith(1);
+      expect(qb.getCount).not.toHaveBeenCalled();
+      expect(qb.innerJoin).not.toHaveBeenCalledWith(
+        'booklet.bookletinfo',
+        'bookletinfo'
+      );
+      expect(cacheService.set).toHaveBeenCalledWith(
+        'geogebra-existence:1:v4',
+        true,
+        0
+      );
+    });
+
+    it('joins bookletinfo for geogebra existence only when booklet exclusions need it', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getRawOne.mockResolvedValue(null);
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 4 }]);
+      (workspaceExclusionService.resolveExclusionsForQueries as jest.Mock)
+        .mockResolvedValue({
+          globalIgnoredUnits: [],
+          ignoredBooklets: ['BOOKLET1'],
+          testletIgnoredUnits: []
+        });
+
+      await expect(service.hasGeogebraResponses(1)).resolves.toBe(false);
+
+      expect(qb.innerJoin).toHaveBeenCalledWith(
+        'booklet.bookletinfo',
+        'bookletinfo'
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'UPPER(bookletinfo.name) NOT IN (:...workspaceExclusionIgnoredBooklets)',
+        { workspaceExclusionIgnoredBooklets: ['BOOKLET1'] }
+      );
+    });
+
+    it('returns cached geogebra existence without querying responses', async () => {
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 4 }]);
+      cacheService.get.mockResolvedValueOnce(false);
+
+      await expect(service.hasGeogebraResponses(1)).resolves.toBe(false);
+
+      expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('reuses an in-flight geogebra existence query for the same workspace revision', async () => {
+      const geogebraDeferred = createDeferred<boolean>();
+      const serviceInternals = service as unknown as {
+        computeAndCacheGeoGebraExistence: (
+          workspaceId: number,
+          revision: number,
+          cacheKey: string
+        ) => Promise<boolean>;
+      };
+      (dataSource.query as jest.Mock).mockResolvedValue([{ revision: 4 }]);
+      const computeSpy = jest
+        .spyOn(serviceInternals, 'computeAndCacheGeoGebraExistence')
+        .mockReturnValue(geogebraDeferred.promise);
+
+      const firstRequest = service.hasGeogebraResponses(1);
+      const secondRequest = service.hasGeogebraResponses(1);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(computeSpy).toHaveBeenCalledTimes(1);
+      expect(computeSpy).toHaveBeenCalledWith(
+        1,
+        4,
+        'geogebra-existence:1:v4'
+      );
+
+      geogebraDeferred.resolve(true);
+      await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual(
+        [true, true]
       );
     });
   });

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -14,6 +14,7 @@ import {
 import { Response } from 'express';
 import * as csv from 'fast-csv';
 import * as fs from 'fs';
+import { createHash } from 'node:crypto';
 import { Writable } from 'stream';
 import { ResponseValueType } from '@iqbspecs/response/response.interface';
 import Persons from '../../entities/persons.entity';
@@ -294,6 +295,26 @@ interface LogDeleteCounts {
 @Injectable()
 export class WorkspaceTestResultsService {
   private readonly logger = new Logger(WorkspaceTestResultsService.name);
+  private readonly workspaceOverviewStatsInFlight = new Map<
+  string,
+  Promise<WorkspaceOverviewStats>
+  >();
+
+  private readonly workspaceOverviewCacheGenerationByWorkspace = new Map<
+  number,
+  number
+  >();
+
+  private readonly workspaceOverviewPrewarmTimers = new Map<
+  number,
+  ReturnType<typeof setTimeout>
+  >();
+
+  private readonly geoGebraExistenceInFlight = new Map<string, Promise<boolean>>();
+
+  private readonly slowWorkspaceOverviewThresholdMs = 1000;
+  private readonly slowGeoGebraExistenceThresholdMs = 1000;
+  private readonly workspaceOverviewPrewarmDelayMs = 500;
   private static readonly codingResponseStatuses = [
     statusStringToNumber('NOT_REACHED') || 1,
     statusStringToNumber('DISPLAYED') || 2,
@@ -1628,12 +1649,17 @@ export class WorkspaceTestResultsService {
   }
 
   async invalidateWorkspaceStatsCache(workspaceId: number): Promise<void> {
+    this.bumpWorkspaceOverviewCacheGeneration(workspaceId);
+    this.dropWorkspaceOverviewInFlight(workspaceId);
     await Promise.all([
       this.cacheService.delete(`${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}`),
+      this.cacheService.deleteByPattern(`${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}:*`),
+      this.cacheService.deleteByPattern(`geogebra-existence:${workspaceId}:*`),
       this.cacheService.deleteByPattern(`${FLAT_FREQUENCIES_CACHE_PREFIX}${workspaceId}-*`),
       this.cacheService.delete(`flat_response_filter_options:version:${workspaceId}`),
       this.cacheService.deleteByPattern(`flat_response_filter_options:${workspaceId}:*`)
     ]);
+    this.scheduleWorkspaceOverviewPrewarm(workspaceId);
   }
 
   async invalidateCodingStatisticsCache(workspaceId: number): Promise<void> {
@@ -1657,12 +1683,49 @@ export class WorkspaceTestResultsService {
       throw new Error('Invalid workspaceId provided');
     }
 
-    const cacheKey = `${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}`;
+    const revision = await this.resolveTestResultsRevision(workspaceId);
+    const cacheKey = this.getWorkspaceOverviewStatsCacheKey(
+      workspaceId,
+      revision
+    );
     const cachedOverview = await this.cacheService.get<WorkspaceOverviewStats>(cacheKey);
     if (cachedOverview) {
       return cachedOverview;
     }
 
+    const inFlightOverview = this.workspaceOverviewStatsInFlight.get(cacheKey);
+    if (inFlightOverview) {
+      this.logger.log(
+        `Reusing in-flight workspace overview query for workspace ${workspaceId} (revision ${revision})`
+      );
+      return inFlightOverview;
+    }
+
+    const cacheGeneration =
+      this.getWorkspaceOverviewCacheGeneration(workspaceId);
+    const overviewPromise = this.computeAndCacheWorkspaceTestResultsOverview(
+      workspaceId,
+      revision,
+      cacheKey,
+      cacheGeneration
+    );
+    this.workspaceOverviewStatsInFlight.set(cacheKey, overviewPromise);
+    try {
+      return await overviewPromise;
+    } finally {
+      if (this.workspaceOverviewStatsInFlight.get(cacheKey) === overviewPromise) {
+        this.workspaceOverviewStatsInFlight.delete(cacheKey);
+      }
+    }
+  }
+
+  private async computeAndCacheWorkspaceTestResultsOverview(
+    workspaceId: number,
+    revision: number,
+    cacheKey: string,
+    cacheGeneration: number
+  ): Promise<WorkspaceOverviewStats> {
+    const startedAt = Date.now();
     const testPersonsPromise = this.personsRepository.count({
       where: { workspace_id: workspaceId, consider: true }
     });
@@ -1704,19 +1767,6 @@ export class WorkspaceTestResultsService {
       .getRawOne()
       .then(res => Number(res?.count || 0));
 
-    const uniqueResponsesQuery = this.responseRepository
-      .createQueryBuilder('response')
-      .innerJoin('response.unit', 'unit')
-      .innerJoin('unit.booklet', 'booklet')
-      .innerJoin('booklet.bookletinfo', 'bookletinfo')
-      .innerJoin('booklet.person', 'person')
-      .where('person.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('person.consider = :consider', { consider: true });
-
-    this.applyExclusionsToQuery(uniqueResponsesQuery, exclusions);
-    this.excludeAutocoderGeneratedResponses(uniqueResponsesQuery);
-    const uniqueResponsesPromise = uniqueResponsesQuery.getCount();
-
     const statusRowsQuery = this.responseRepository
       .createQueryBuilder('response')
       .innerJoin('response.unit', 'unit')
@@ -1738,7 +1788,6 @@ export class WorkspaceTestResultsService {
       testGroups,
       uniqueBooklets,
       uniqueUnits,
-      uniqueResponses,
       statusRows,
       browserRows,
       osRows,
@@ -1748,7 +1797,6 @@ export class WorkspaceTestResultsService {
       testGroupsPromise,
       uniqueBookletsPromise,
       uniqueUnitsPromise,
-      uniqueResponsesPromise,
       statusRowsPromise,
       this.sessionRepository
         .createQueryBuilder('session')
@@ -1795,10 +1843,13 @@ export class WorkspaceTestResultsService {
     ]);
 
     const responseStatusCounts: Record<string, number> = {};
+    let uniqueResponses = 0;
     (statusRows || []).forEach(r => {
       const num = Number(r.status);
       const label = statusNumberToString(num) || String(num);
-      responseStatusCounts[label] = Number(r.count) || 0;
+      const count = Number(r.count) || 0;
+      responseStatusCounts[label] = count;
+      uniqueResponses += count;
     });
 
     const mapSessionCounts = (
@@ -1828,7 +1879,18 @@ export class WorkspaceTestResultsService {
       sessionScreenCounts
     };
 
-    await this.cacheService.set(cacheKey, result, 60); // Cache for 1 minute
+    const currentRevision = await this.resolveTestResultsRevision(workspaceId);
+    if (
+      currentRevision === revision &&
+      this.getWorkspaceOverviewCacheGeneration(workspaceId) === cacheGeneration
+    ) {
+      await this.cacheService.set(cacheKey, result, 0);
+    } else {
+      this.logger.log(
+        `Skipped caching stale workspace overview for workspace ${workspaceId} (planned revision ${revision}, current revision ${currentRevision})`
+      );
+    }
+    this.logWorkspaceOverviewTiming(workspaceId, revision, startedAt);
     return result;
   }
 
@@ -2431,6 +2493,131 @@ export class WorkspaceTestResultsService {
     );
   }
 
+  private async findTagsByUnitId(unitIds: number[]): Promise<Map<number, string[]>> {
+    const uniqueUnitIds = Array.from(
+      new Set(unitIds.filter(unitId => Number.isFinite(unitId) && unitId > 0))
+    );
+    if (uniqueUnitIds.length === 0) {
+      return new Map();
+    }
+
+    const tags = await this.unitTagService.findAllByUnitIds(uniqueUnitIds);
+    const tagsByUnitId = new Map<number, string[]>();
+
+    tags.forEach(tag => {
+      if (!tagsByUnitId.has(tag.unitId)) {
+        tagsByUnitId.set(tag.unitId, []);
+      }
+      tagsByUnitId.get(tag.unitId)!.push(tag.tag);
+    });
+
+    return tagsByUnitId;
+  }
+
+  private async createFlatResponseCountCacheKey(
+    workspaceId: number,
+    signature: Record<string, unknown>
+  ): Promise<string> {
+    const revision = await this.resolveTestResultsRevision(workspaceId);
+    const hash = createHash('sha1')
+      .update(JSON.stringify(signature))
+      .digest('hex')
+      .slice(0, 16);
+
+    return `flat_responses_count:${workspaceId}:v${revision}:${hash}`;
+  }
+
+  private getWorkspaceOverviewStatsCacheKey(
+    workspaceId: number,
+    revision: number
+  ): string {
+    return `${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}:v${revision}`;
+  }
+
+  private getGeoGebraExistenceCacheKey(
+    workspaceId: number,
+    revision: number
+  ): string {
+    return `geogebra-existence:${workspaceId}:v${revision}`;
+  }
+
+  private getWorkspaceOverviewCacheGeneration(workspaceId: number): number {
+    return this.workspaceOverviewCacheGenerationByWorkspace.get(workspaceId) ?? 0;
+  }
+
+  private bumpWorkspaceOverviewCacheGeneration(workspaceId: number): void {
+    this.workspaceOverviewCacheGenerationByWorkspace.set(
+      workspaceId,
+      this.getWorkspaceOverviewCacheGeneration(workspaceId) + 1
+    );
+  }
+
+  private dropWorkspaceOverviewInFlight(workspaceId: number): void {
+    const baseKey = `${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}`;
+    Array.from(this.workspaceOverviewStatsInFlight.keys())
+      .filter(key => key === baseKey || key.startsWith(`${baseKey}:`))
+      .forEach(key => this.workspaceOverviewStatsInFlight.delete(key));
+  }
+
+  private scheduleWorkspaceOverviewPrewarm(workspaceId: number): void {
+    if (process.env.NODE_ENV === 'test') {
+      return;
+    }
+    const existingTimer = this.workspaceOverviewPrewarmTimers.get(workspaceId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+    const timer = setTimeout(() => {
+      this.workspaceOverviewPrewarmTimers.delete(workspaceId);
+      this.getWorkspaceTestResultsOverview(workspaceId)
+        .then(() => {
+          this.logger.debug(
+            `Prewarmed workspace overview cache for workspace ${workspaceId}`
+          );
+        })
+        .catch(error => {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.warn(
+            `Workspace overview cache prewarm failed for workspace ${workspaceId}: ${message}`
+          );
+        });
+    }, this.workspaceOverviewPrewarmDelayMs);
+    timer.unref?.();
+    this.workspaceOverviewPrewarmTimers.set(workspaceId, timer);
+  }
+
+  private logWorkspaceOverviewTiming(
+    workspaceId: number,
+    revision: number,
+    startedAt: number
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    const message =
+      `Workspace test results overview for workspace ${workspaceId} ` +
+      `(revision ${revision}) computed in ${durationMs}ms.`;
+    if (durationMs >= this.slowWorkspaceOverviewThresholdMs) {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.debug(message);
+  }
+
+  private async resolveTestResultsRevision(workspaceId: number): Promise<number> {
+    try {
+      const rows = (await this.connection.query(
+        'SELECT revision FROM workspace_test_results_revision WHERE workspace_id = $1',
+        [workspaceId]
+      )) as Array<{ revision: number | string }>;
+      return Number(rows[0]?.revision || 0);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Could not resolve test result revision for flat response count cache: ${message}`
+      );
+      return 0;
+    }
+  }
+
   async findFlatResponses(
     workspaceId: number,
     options: {
@@ -2665,7 +2852,6 @@ export class WorkspaceTestResultsService {
       .innerJoin('unit.booklet', 'bookletEntity')
       .innerJoin('bookletEntity.person', 'person')
       .innerJoin('bookletEntity.bookletinfo', 'bookletinfo')
-      .leftJoin('unit.tags', 'unitTag')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true });
 
@@ -2712,7 +2898,14 @@ export class WorkspaceTestResultsService {
       });
     }
     if (tags) {
-      qb.andWhere('unitTag.tag ILIKE :tags', { tags: `%${tags}%` });
+      qb.andWhere(
+        `EXISTS (
+          SELECT 1 FROM unit_tag unit_tag_filter
+          WHERE unit_tag_filter."unitId" = unit.id
+            AND unit_tag_filter.tag ILIKE :tags
+        )`,
+        { tags: `%${tags}%` }
+      );
     }
 
     if (geogebraOnly) {
@@ -2963,8 +3156,14 @@ export class WorkspaceTestResultsService {
       });
     }
     if (tags) {
-      countQb.leftJoin('unit.tags', 'unitTag');
-      countQb.andWhere('unitTag.tag ILIKE :tags', { tags: `%${tags}%` });
+      countQb.andWhere(
+        `EXISTS (
+          SELECT 1 FROM unit_tag unit_tag_filter
+          WHERE unit_tag_filter."unitId" = unit.id
+            AND unit_tag_filter.tag ILIKE :tags
+        )`,
+        { tags: `%${tags}%` }
+      );
     }
 
     if (geogebraOnly) {
@@ -3128,10 +3327,49 @@ export class WorkspaceTestResultsService {
 
     // Note: Session filters above are applied as separate EXISTS per dimension.
 
-    const total = await countQb
-      .select('COUNT(DISTINCT response.id)', 'cnt')
-      .getRawOne()
-      .then(r => Number(r?.cnt || 0));
+    const countCacheKey = await this.createFlatResponseCountCacheKey(
+      workspaceId,
+      {
+        code,
+        group,
+        login,
+        booklet,
+        unit,
+        response,
+        responseStatus,
+        responseValue,
+        tags,
+        geogebraOnly,
+        audioLowOnly,
+        hasValueOnly,
+        audioLowThreshold,
+        shortProcessingOnly,
+        shortProcessingThresholdMs,
+        longLoadingOnly,
+        longLoadingThresholdMs,
+        processingDurations,
+        processingDurationThresholdMs,
+        processingDurationMinMs,
+        processingDurationMaxMs,
+        unitProgress,
+        sessionBrowsers,
+        sessionOs,
+        sessionScreens,
+        sessionIds,
+        logAnomalyCodes,
+        logAnomalyThresholds,
+        exclusions
+      }
+    );
+    const cachedTotal = await this.cacheService.get<number>(countCacheKey);
+    let total = cachedTotal;
+    if (total === null) {
+      total = await countQb
+        .select('COUNT(response.id)', 'cnt')
+        .getRawOne()
+        .then(r => Number(r?.cnt || 0));
+      await this.cacheService.set(countCacheKey, total, 3600);
+    }
 
     const raw = await qb
       .select([
@@ -3146,22 +3384,9 @@ export class WorkspaceTestResultsService {
         'COALESCE(unit.alias, unit.name) AS "unit"',
         'response.variableid AS "response"',
         'response.status AS "responseStatus"',
-        'SUBSTRING(response.value, 1, :maxResponseValueLen) AS "responseValue"',
-        "COALESCE(string_agg(DISTINCT unitTag.tag, ','), '') AS \"tags\""
+        'SUBSTRING(response.value, 1, :maxResponseValueLen) AS "responseValue"'
       ])
       .setParameter('maxResponseValueLen', MAX_RESPONSE_VALUE_LEN)
-      .groupBy('response.id')
-      .addGroupBy('unit.id')
-      .addGroupBy('bookletEntity.id')
-      .addGroupBy('person.id')
-      .addGroupBy('bookletinfo.name')
-      .addGroupBy('unit.alias')
-      .addGroupBy('unit.name')
-      .addGroupBy('person.code')
-      .addGroupBy('person.group')
-      .addGroupBy('person.login')
-      .addGroupBy('response.variableid')
-      .addGroupBy('response.status')
       .orderBy('person.code', 'ASC')
       .addOrderBy('bookletinfo.name', 'ASC')
       .addOrderBy('unit.alias', 'ASC')
@@ -3170,21 +3395,18 @@ export class WorkspaceTestResultsService {
       .limit(validLimit)
       .getRawMany();
 
-    const mapped = (raw || []).map(r => {
-      const tagsStr = String(r.tags || '');
-      const tagList = tagsStr ?
-        tagsStr
-          .split(',')
-          .map(t => t.trim())
-          .filter(Boolean) :
-        [];
+    const tagsByUnitId = await this.findTagsByUnitId(
+      raw.map(r => Number(r.unitId))
+    );
 
+    const mapped = (raw || []).map(r => {
       const statusNum = Number(r.responseStatus);
       const statusLabel = statusNumberToString(statusNum);
+      const unitId = Number(r.unitId);
       return {
         bookletId: Number(r.bookletId),
         responseId: Number(r.responseId),
-        unitId: Number(r.unitId),
+        unitId,
         personId: Number(r.personId),
         code: String(r.code || ''),
         group: String(r.group || ''),
@@ -3194,7 +3416,7 @@ export class WorkspaceTestResultsService {
         response: String(r.response || ''),
         responseStatus: statusLabel || String(r.responseStatus ?? ''),
         responseValue: String(r.responseValue ?? ''),
-        tags: tagList,
+        tags: tagsByUnitId.get(unitId) || [],
         logAnomalies: []
       };
     });
@@ -7967,12 +8189,54 @@ export class WorkspaceTestResultsService {
   }
 
   async hasGeogebraResponses(workspaceId: number): Promise<boolean> {
+    const revision = await this.resolveTestResultsRevision(workspaceId);
+    const cacheKey = this.getGeoGebraExistenceCacheKey(workspaceId, revision);
+    const cached = await this.cacheService.get<boolean>(cacheKey);
+    if (cached !== null && cached !== undefined) {
+      return cached;
+    }
+
+    const inFlight = this.geoGebraExistenceInFlight.get(cacheKey);
+    if (inFlight) {
+      this.logger.log(
+        `Reusing in-flight GeoGebra existence query for workspace ${workspaceId} (revision ${revision})`
+      );
+      return inFlight;
+    }
+
+    const promise = this.computeAndCacheGeoGebraExistence(
+      workspaceId,
+      revision,
+      cacheKey
+    );
+    this.geoGebraExistenceInFlight.set(cacheKey, promise);
+    try {
+      return await promise;
+    } finally {
+      if (this.geoGebraExistenceInFlight.get(cacheKey) === promise) {
+        this.geoGebraExistenceInFlight.delete(cacheKey);
+      }
+    }
+  }
+
+  private async computeAndCacheGeoGebraExistence(
+    workspaceId: number,
+    revision: number,
+    cacheKey: string
+  ): Promise<boolean> {
+    const startedAt = Date.now();
+    const exclusionsStartedAt = Date.now();
+
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const exclusionsDurationMs = Date.now() - exclusionsStartedAt;
+    const queryStartedAt = Date.now();
+    const needsBookletInfoForExclusions =
+      exclusions.ignoredBooklets.length > 0 ||
+      exclusions.testletIgnoredUnits.length > 0;
     const query = this.responseRepository
       .createQueryBuilder('response')
       .innerJoin('response.unit', 'unit')
       .innerJoin('unit.booklet', 'booklet')
-      .innerJoin('booklet.bookletinfo', 'bookletinfo')
       .innerJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
@@ -7980,10 +8244,51 @@ export class WorkspaceTestResultsService {
         WorkspaceTestResultsService.createGeoGebraValueCondition('response'),
         WorkspaceTestResultsService.geoGebraValueParams
       );
-    this.applyExclusionsToQuery(query, exclusions);
-    const count = await query
-      .getCount();
+    if (needsBookletInfoForExclusions) {
+      query.innerJoin('booklet.bookletinfo', 'bookletinfo');
+    }
+    this.applyExclusionsToQuery(query, exclusions, {
+      bookletInfoAlias: needsBookletInfoForExclusions ? 'bookletinfo' : null
+    });
+    const row = await query
+      .select('1', 'exists')
+      .limit(1)
+      .getRawOne();
+    const queryDurationMs = Date.now() - queryStartedAt;
+    const result = Boolean(row);
+    const currentRevision = await this.resolveTestResultsRevision(workspaceId);
+    if (currentRevision === revision) {
+      await this.cacheService.set(cacheKey, result, 0);
+    }
+    this.logGeoGebraExistenceTiming(
+      workspaceId,
+      revision,
+      result,
+      startedAt,
+      exclusionsDurationMs,
+      queryDurationMs
+    );
 
-    return count > 0;
+    return result;
+  }
+
+  private logGeoGebraExistenceTiming(
+    workspaceId: number,
+    revision: number,
+    result: boolean,
+    startedAt: number,
+    exclusionsDurationMs: number,
+    queryDurationMs: number
+  ): void {
+    const durationMs = Date.now() - startedAt;
+    const message =
+      `GeoGebra existence for workspace ${workspaceId} ` +
+      `(revision ${revision}, result ${result}) computed in ${durationMs}ms ` +
+      `(exclusions ${exclusionsDurationMs}ms, query ${queryDurationMs}ms).`;
+    if (durationMs >= this.slowGeoGebraExistenceThresholdMs) {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.debug(message);
   }
 }

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -2519,10 +2519,10 @@ export class WorkspaceTestResultsService {
     signature: Record<string, unknown>
   ): Promise<string> {
     const revision = await this.resolveTestResultsRevision(workspaceId);
-    const hash = createHash('sha1')
+    const hash = createHash('sha256')
       .update(JSON.stringify(signature))
       .digest('hex')
-      .slice(0, 16);
+      .slice(0, 32);
 
     return `flat_responses_count:${workspaceId}:v${revision}:${hash}`;
   }

--- a/apps/backend/src/app/prototype-methods.spec.ts
+++ b/apps/backend/src/app/prototype-methods.spec.ts
@@ -205,5 +205,5 @@ describe('backend controller prototype method smoke coverage', () => {
     }
 
     expect(invoked).toBeGreaterThan(300);
-  }, 60000);
+  }, 120000);
 });

--- a/database/changelog/coding-box.changelog-1.16.3.sql
+++ b/database/changelog/coding-box.changelog-1.16.3.sql
@@ -189,3 +189,12 @@ CREATE INDEX IF NOT EXISTS "replay_statistics_workspace_source_timestamp_idx"
 
 -- rollback DROP INDEX IF EXISTS "public"."replay_statistics_workspace_source_timestamp_idx";
 -- rollback ALTER TABLE "public"."replay_statistics" DROP COLUMN IF EXISTS "replay_source";
+
+-- changeset julian:4
+-- comment: Speed up GeoGebra response existence checks without indexing full response values
+
+CREATE INDEX IF NOT EXISTS "idx_response_geogebra_value_unit"
+  ON "public"."response" ("unitid")
+  WHERE "value" LIKE 'UEsD%' OR "value" ILIKE 'data:%;base64,UEsD%';
+
+-- rollback DROP INDEX IF EXISTS "public"."idx_response_geogebra_value_unit";


### PR DESCRIPTION
## What changed

Split the backend query/cache optimizations out of #830.

- adds revisioned cache keys and in-flight reuse for coding overview/backend status queries
- optimizes workspace overview, GeoGebra existence and flat response count paths
- includes the SHA-256 flat response count cache-key fix
- fixes the review blocker where person include/exclude changed `person.consider` without invalidating revisioned workspace overview caches

## Why

These backend optimizations are materially larger than the minimal refresh-trigger fix and carry separate cache-correctness risk, so they should be reviewed in isolation.

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx lint backend --skip-nx-cache`
