### PR TITLE
Split UI race guards and error overlay changes from #830

### DIFF
--- a/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.spec.ts
@@ -110,6 +110,26 @@ describe('CoderTrainingsListComponent', () => {
     expect(component.coderTrainings.map(training => training.id)).toEqual([10, 11]);
   });
 
+  it('reuses an in-flight training list request', async () => {
+    const service = TestBed.inject(CodingTrainingBackendService) as unknown as {
+      getCoderTrainings: jest.Mock;
+    };
+    const trainings$ = new Subject<CoderTraining[]>();
+    service.getCoderTrainings.mockReturnValue(trainings$.asObservable());
+
+    const firstLoad = component.loadCoderTrainings();
+    const secondLoad = component.loadCoderTrainings();
+
+    expect(secondLoad).toBe(firstLoad);
+    expect(service.getCoderTrainings).toHaveBeenCalledTimes(1);
+
+    trainings$.next(trainings);
+    trainings$.complete();
+
+    await firstLoad;
+    await secondLoad;
+  });
+
   it('builds descriptive action labels for training rows', () => {
     const actionTarget = component.getTrainingActionTarget(trainings[0]);
 

--- a/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.ts
+++ b/apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.ts
@@ -95,6 +95,8 @@ export class CoderTrainingsListComponent implements OnInit, OnChanges, OnDestroy
   duplicateTrainingLabels = new Set<string>();
   selectedTrainingName: string | null = null;
   isLoading = false;
+  private loadCoderTrainingsPromise?: Promise<void>;
+  private loadCoderTrainingsWorkspaceId?: number;
   displayedColumns: string[] = ['actions', 'label', 'jobsCount', 'selectionStrategy', 'created_at'];
 
   ngOnInit(): void {
@@ -141,47 +143,72 @@ export class CoderTrainingsListComponent implements OnInit, OnChanges, OnDestroy
   }
 
   loadCoderTrainings(options: { resetFilters?: boolean } = {}): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const workspaceId = this.getCurrentWorkspaceId();
-      if (!workspaceId) {
-        this.clearTrainingState({ resetFilters: true });
-        reject();
-        return;
-      }
-
+    const workspaceId = this.getCurrentWorkspaceId();
+    if (!workspaceId) {
       this.loadRequestId += 1;
-      const requestId = this.loadRequestId;
-      this.isLoading = true;
-      this.clearTrainingState({ resetFilters: options.resetFilters });
+      this.clearTrainingState({ resetFilters: true });
+      this.isLoading = false;
+      this.loadCoderTrainingsPromise = undefined;
+      this.loadCoderTrainingsWorkspaceId = undefined;
+      return Promise.reject();
+    }
 
-      this.codingTrainingBackendService.getCoderTrainings(workspaceId)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: (trainings: CoderTraining[]) => {
-            if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
-              resolve();
-              return;
-            }
+    if (
+      !options.resetFilters &&
+      this.isLoading &&
+      this.loadCoderTrainingsPromise &&
+      this.loadCoderTrainingsWorkspaceId === workspaceId
+    ) {
+      return this.loadCoderTrainingsPromise;
+    }
 
-            this.originalData = trainings;
-            this.rebuildTrainingNameFilterOptions();
-            this.clearUnavailableTrainingNameFilter();
-            this.applyAllFilters();
-            this.isLoading = false;
-            resolve();
-          },
-          error: () => {
-            if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
-              resolve();
-              return;
-            }
+    this.loadRequestId += 1;
+    const requestId = this.loadRequestId;
+    this.isLoading = true;
+    this.loadCoderTrainingsWorkspaceId = workspaceId;
+    this.clearTrainingState({ resetFilters: options.resetFilters });
 
-            this.clearTrainingState({ resetFilters: options.resetFilters });
-            this.isLoading = false;
-            reject();
-          }
-        });
+    let resolveLoad: () => void = () => {};
+    let rejectLoad: () => void = () => {};
+    const loadPromise = new Promise<void>((resolve, reject) => {
+      resolveLoad = resolve;
+      rejectLoad = reject;
     });
+    this.loadCoderTrainingsPromise = loadPromise;
+
+    this.codingTrainingBackendService.getCoderTrainings(workspaceId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (trainings: CoderTraining[]) => {
+          if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
+            resolveLoad();
+            return;
+          }
+
+          this.originalData = trainings;
+          this.rebuildTrainingNameFilterOptions();
+          this.clearUnavailableTrainingNameFilter();
+          this.applyAllFilters();
+          this.isLoading = false;
+          this.loadCoderTrainingsPromise = undefined;
+          this.loadCoderTrainingsWorkspaceId = undefined;
+          resolveLoad();
+        },
+        error: () => {
+          if (requestId !== this.loadRequestId || this.getCurrentWorkspaceId() !== workspaceId) {
+            resolveLoad();
+            return;
+          }
+
+          this.clearTrainingState({ resetFilters: options.resetFilters });
+          this.isLoading = false;
+          this.loadCoderTrainingsPromise = undefined;
+          this.loadCoderTrainingsWorkspaceId = undefined;
+          rejectLoad();
+        }
+      });
+
+    return loadPromise;
   }
 
   requestFullEdit(training: CoderTraining): void {

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
@@ -39,6 +39,79 @@ describe('CodingTrainingBackendService', () => {
     expect(service).toBeTruthy();
   });
 
+  describe('getCoderTrainings', () => {
+    const coderTrainings = [{
+      id: 10,
+      workspace_id: 1,
+      label: 'Training A',
+      created_at: new Date('2026-01-01T00:00:00.000Z'),
+      updated_at: new Date('2026-01-01T00:00:00.000Z'),
+      jobsCount: 2
+    }];
+
+    it('should share an in-flight coder training request', () => {
+      const received: unknown[] = [];
+
+      service.getCoderTrainings(1).subscribe(trainings => received.push(trainings));
+      service.getCoderTrainings(1).subscribe(trainings => received.push(trainings));
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+      expect(req.request.method).toBe('GET');
+      req.flush(coderTrainings);
+
+      expect(received).toEqual([coderTrainings, coderTrainings]);
+      httpMock.expectNone(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+    });
+
+    it('should reuse cached coder trainings after the first request', () => {
+      const received: unknown[] = [];
+
+      service.getCoderTrainings(1).subscribe(trainings => received.push(trainings));
+
+      const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+      req.flush(coderTrainings);
+
+      service.getCoderTrainings(1).subscribe(trainings => received.push(trainings));
+
+      expect(received).toEqual([coderTrainings, coderTrainings]);
+      httpMock.expectNone(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+    });
+
+    it('should invalidate cached coder trainings after a training mutation', () => {
+      service.getCoderTrainings(1).subscribe();
+      httpMock
+        .expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`)
+        .flush(coderTrainings);
+
+      service.updateCoderTrainingLabel(1, 10, 'Training B').subscribe();
+      const updateReq = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/10/label`);
+      expect(updateReq.request.method).toBe('PUT');
+      updateReq.flush({});
+
+      service.getCoderTrainings(1).subscribe();
+      httpMock
+        .expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`)
+        .flush([{ ...coderTrainings[0], label: 'Training B' }]);
+    });
+
+    it('should not cache a stale in-flight response after invalidation', () => {
+      service.getCoderTrainings(1).subscribe();
+      const staleListReq = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`);
+
+      service.updateCoderTrainingLabel(1, 10, 'Training B').subscribe();
+      httpMock
+        .expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/10/label`)
+        .flush({});
+
+      staleListReq.flush(coderTrainings);
+
+      service.getCoderTrainings(1).subscribe();
+      httpMock
+        .expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings`)
+        .flush([{ ...coderTrainings[0], label: 'Training B' }]);
+    });
+  });
+
   describe('createCoderTrainingJobs', () => {
     it('should create jobs', () => {
       service.createCoderTrainingJobs(1, [], [], 'Label').subscribe();

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -1,7 +1,13 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import {
-  Observable, catchError, of, switchMap, tap
+  Observable,
+  catchError,
+  finalize,
+  of,
+  shareReplay,
+  switchMap,
+  tap
 } from 'rxjs';
 import { SERVER_URL } from '../../injection-tokens';
 import { CoderTraining } from '../models/coder-training.model';
@@ -102,6 +108,8 @@ export class CodingTrainingBackendService {
   private readonly serverUrl = inject(SERVER_URL);
   private http = inject(HttpClient);
   private readonly withinTrainingComparisonCache = new Map<string, WithinTrainingComparisonCacheEntry>();
+  private coderTrainingsCache = new Map<number, CoderTraining[]>();
+  private coderTrainingsInFlight = new Map<number, Observable<CoderTraining[]>>();
 
   private get authHeader() {
     return {};
@@ -168,6 +176,7 @@ export class CodingTrainingBackendService {
       suppressGeneralInstructions
     }, { headers: this.authHeader }).pipe(
       tap(response => {
+        this.invalidateCoderTrainings(workspaceId);
         if (response.trainingId) {
           this.invalidateWithinTrainingComparisonCache(workspaceId, response.trainingId);
         } else {
@@ -178,8 +187,45 @@ export class CodingTrainingBackendService {
   }
 
   getCoderTrainings(workspaceId: number): Observable<CoderTraining[]> {
+    const cachedTrainings = this.coderTrainingsCache.get(workspaceId);
+    if (cachedTrainings) {
+      return of([...cachedTrainings]);
+    }
+
+    const inFlightRequest = this.coderTrainingsInFlight.get(workspaceId);
+    if (inFlightRequest) {
+      return inFlightRequest;
+    }
+
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings`;
-    return this.http.get<CoderTraining[]>(url, { headers: this.authHeader });
+    const request$ = this.http.get<CoderTraining[]>(url, { headers: this.authHeader })
+      .pipe(
+        tap(trainings => {
+          if (this.coderTrainingsInFlight.get(workspaceId) === request$) {
+            this.coderTrainingsCache.set(workspaceId, [...trainings]);
+          }
+        }),
+        finalize(() => {
+          if (this.coderTrainingsInFlight.get(workspaceId) === request$) {
+            this.coderTrainingsInFlight.delete(workspaceId);
+          }
+        }),
+        shareReplay({ bufferSize: 1, refCount: false })
+      );
+
+    this.coderTrainingsInFlight.set(workspaceId, request$);
+    return request$;
+  }
+
+  invalidateCoderTrainings(workspaceId?: number): void {
+    if (workspaceId === undefined) {
+      this.coderTrainingsCache.clear();
+      this.coderTrainingsInFlight.clear();
+      return;
+    }
+
+    this.coderTrainingsCache.delete(workspaceId);
+    this.coderTrainingsInFlight.delete(workspaceId);
   }
 
   updateCoderTraining(
@@ -221,7 +267,10 @@ export class CodingTrainingBackendService {
       allowComments,
       suppressGeneralInstructions
     }, { headers: this.authHeader }).pipe(
-      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
+      tap(() => {
+        this.invalidateCoderTrainings(workspaceId);
+        this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId);
+      })
     );
   }
 
@@ -231,7 +280,10 @@ export class CodingTrainingBackendService {
   ): Observable<{ success: boolean; message: string }> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings/${trainingId}`;
     return this.http.delete<{ success: boolean; message: string }>(url, { headers: this.authHeader }).pipe(
-      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
+      tap(() => {
+        this.invalidateCoderTrainings(workspaceId);
+        this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId);
+      })
     );
   }
 
@@ -244,7 +296,10 @@ export class CodingTrainingBackendService {
     return this.http.put<{ success: boolean; message: string }>(url, {
       label: newLabel
     }, { headers: this.authHeader }).pipe(
-      tap(() => this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId))
+      tap(() => {
+        this.invalidateCoderTrainings(workspaceId);
+        this.invalidateWithinTrainingComparisonCache(workspaceId, trainingId);
+      })
     );
   }
 

--- a/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.html
+++ b/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.html
@@ -1,4 +1,4 @@
-<div class="error-messages-container">
+<div class="error-messages-container priority-errors">
   @if (appService.backendUnavailable) {
   <div class="error-message backend-unavailable">
     <div class="error-content">
@@ -51,7 +51,9 @@
     </div>
   </div>
   }
+</div>
 
+<div class="error-messages-container transient-errors">
   <!-- Other Error Messages -->
   @for (error of appService.errorMessages; track error.id) {
   <div class="error-message other-error">

--- a/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.scss
+++ b/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.scss
@@ -1,17 +1,34 @@
 .error-messages-container {
   position: fixed;
-  top: 80px;
   right: 20px;
   max-width: 500px;
   z-index: 1000;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  pointer-events: none;
 
   @media (max-width: 768px) {
     left: 20px;
     right: 20px;
     max-width: none;
+  }
+}
+
+.priority-errors {
+  top: 80px;
+}
+
+.transient-errors {
+  bottom: 20px;
+  left: 20px;
+  right: auto;
+  max-height: min(45vh, 360px);
+  overflow-y: auto;
+  width: min(500px, calc(100vw - 40px));
+
+  @media (max-width: 768px) {
+    right: 20px;
   }
 }
 
@@ -23,6 +40,7 @@
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   animation: slideIn 0.3s ease-in-out;
+  pointer-events: auto;
 
   &.backend-unavailable {
     background-color: #fff3cd;
@@ -127,7 +145,7 @@
 
 @keyframes slideIn {
   from {
-    transform: translateX(400px);
+    transform: translateX(40px);
     opacity: 0;
   }
   to {

--- a/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.spec.ts
+++ b/apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.spec.ts
@@ -139,6 +139,23 @@ describe('ErrorMessageDisplayComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('request-b');
   });
 
+  it('should render ordinary HTTP errors in the transient error layer', () => {
+    appService.errorMessages = [{
+      id: 3,
+      status: 504,
+      message: 'Der Server antwortet gerade nicht.',
+      method: 'GET',
+      urlWithParams: '/api/admin/workspace/5/coding/incomplete-variables',
+      requestCount: 1,
+      isBackendConnectivityError: true
+    } as AppHttpError];
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.transient-errors .other-error')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.priority-errors .other-error')).toBeNull();
+  });
+
   it('should keep technical server messages hidden until details are expanded', () => {
     appService.errorMessages = [{
       id: 2,

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.ts
@@ -321,6 +321,7 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
 
   private flatSearchSubject = new Subject<void>();
   private flatSearchSubscription: Subscription;
+  private flatResponsesSubscription?: Subscription;
   private workspaceCacheInvalidatedSubscription: Subscription;
   private readonly FLAT_FILTER_DEBOUNCE_TIME = 400;
 
@@ -1062,6 +1063,7 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
 
   ngOnDestroy(): void {
     this.flatSearchSubscription.unsubscribe();
+    this.flatResponsesSubscription?.unsubscribe();
     this.workspaceCacheInvalidatedSubscription.unsubscribe();
     this.refreshFilterOptionsTimeoutIds.forEach(id => window.clearTimeout(id)
     );
@@ -1425,7 +1427,8 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
     this.isLoadingFlat = true;
 
     const sessionFilterActive = this.flatFilters.sessionFilter;
-    this.testResultService
+    this.flatResponsesSubscription?.unsubscribe();
+    this.flatResponsesSubscription = this.testResultService
       .getFlatResponses(this.appService.selectedWorkspaceId, {
         page: validPage + 1,
         limit,

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.html
@@ -90,7 +90,32 @@
     </div>
   </div>
 
-  @if (hasCodingFreshnessWarning) {
+  @if (shouldShowCodingFreshnessManualNotice) {
+  <div class="coding-freshness-banner manual-status">
+    <div class="coding-freshness-icon">
+      <mat-icon>sync_disabled</mat-icon>
+    </div>
+    <div class="coding-freshness-copy">
+      <div class="coding-freshness-title">
+        {{ 'test-results-page.coding-status.manual-title' | translate }}
+      </div>
+      <div class="coding-freshness-text">
+        {{ 'test-results-page.coding-status.manual-text' | translate }}
+      </div>
+    </div>
+    <button
+      mat-stroked-button
+      type="button"
+      [disabled]="isLoadingCodingFreshnessStatus"
+      (click)="refreshCodingFreshnessStatusManually()"
+    >
+      <mat-icon [class.inline-rotating-icon]="isLoadingCodingFreshnessStatus">
+        refresh
+      </mat-icon>
+      {{ 'test-results-page.coding-status.refresh' | translate }}
+    </button>
+  </div>
+  } @if (hasCodingFreshnessWarning) {
   <div class="coding-freshness-banner">
     <div class="coding-freshness-icon">
       <mat-icon>warning</mat-icon>

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.scss
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.scss
@@ -88,6 +88,28 @@
       margin-right: 6px;
     }
   }
+
+  &.manual-status {
+    background: rgba(25, 118, 210, 0.07);
+    border-color: rgba(25, 118, 210, 0.22);
+
+    .coding-freshness-icon {
+      color: #1976d2;
+    }
+  }
+}
+
+.inline-rotating-icon {
+  animation: inline-rotate 1.4s linear infinite;
+}
+
+@keyframes inline-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .coding-freshness-icon {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
@@ -8,7 +8,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideHttpClient } from '@angular/common/http';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { provideRouter } from '@angular/router';
 import { environment } from '../../../../environments/environment';
@@ -151,7 +151,8 @@ describe('TestResultsComponent', () => {
         {
           provide: WorkspaceSettingsService,
           useValue: {
-            getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false))
+            getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false)),
+            getAutoRefreshManualCodingJobs: jest.fn().mockReturnValue(of(true))
           }
         },
         {
@@ -217,6 +218,13 @@ describe('TestResultsComponent', () => {
       'response-status': {
         tooltips: {
           DERIVE_ERROR: 'DERIVE_ERROR bedeutet: Ableitung/Solver fehlgeschlagen, z. B. Typkonflikt im Kodierschema. Keine inhaltlich falsche Antwort.'
+        }
+      },
+      'test-results-page': {
+        'coding-status': {
+          'manual-title': 'Kodierstatus wird manuell aktualisiert',
+          'manual-text': 'Automatische Statusprüfungen sind für diesen Arbeitsbereich deaktiviert. Aktualisieren Sie den Kodierstatus nur bei Bedarf.',
+          refresh: 'Kodierstatus aktualisieren'
         }
       }
     });
@@ -387,6 +395,78 @@ describe('TestResultsComponent', () => {
     expect(testResultService.invalidateCache).toHaveBeenCalledWith(1);
     expect(testResultService.getWorkspaceOverview).toHaveBeenCalledWith(1);
     expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalled();
+  });
+
+  it('should not refresh coding state after flat-table deletion when auto refresh is disabled', () => {
+    const testResultService = TestBed.inject(TestResultService) as unknown as {
+      getWorkspaceOverview: jest.Mock;
+      invalidateCache: jest.Mock;
+    };
+    const codingStatisticsService = TestBed.inject(CodingStatisticsService) as unknown as {
+      getCodingFreshness: jest.Mock;
+    };
+    const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
+      getAppliedResultsOverview: jest.Mock;
+      notifyTestResultsChanged: jest.Mock;
+    };
+
+    codingStatisticsService.getCodingFreshness.mockClear();
+    testPersonCodingService.getAppliedResultsOverview.mockClear();
+    (component as unknown as {
+      setAutoRefreshCodingStatus: (enabled: boolean) => void;
+    }).setAutoRefreshCodingStatus(false);
+
+    component.onFlatTableResponseDeleted();
+
+    expect(testResultService.invalidateCache).toHaveBeenCalledWith(1);
+    expect(testResultService.getWorkspaceOverview).toHaveBeenCalledWith(1);
+    expect(codingStatisticsService.getCodingFreshness).not.toHaveBeenCalled();
+    expect(testPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
+    expect(component.shouldShowCodingFreshnessManualNotice).toBe(true);
+    expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalled();
+  });
+
+  it('should keep manual coding status refresh visible after a manual check', () => {
+    (component as unknown as {
+      setAutoRefreshCodingStatus: (enabled: boolean) => void;
+    }).setAutoRefreshCodingStatus(false);
+
+    component.refreshCodingFreshnessStatusManually();
+
+    expect(component.shouldShowCodingFreshnessManualNotice).toBe(true);
+  });
+
+  it('should ignore stale manual coding status responses after status was cleared', () => {
+    const codingStatisticsService = TestBed.inject(CodingStatisticsService) as unknown as {
+      getCodingFreshness: jest.Mock;
+    };
+    const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
+      getAppliedResultsOverview: jest.Mock;
+    };
+    const codingFreshness$ = new Subject<unknown>();
+    const appliedResults$ = new Subject<unknown>();
+
+    codingStatisticsService.getCodingFreshness.mockReturnValue(
+      codingFreshness$.asObservable()
+    );
+    testPersonCodingService.getAppliedResultsOverview.mockReturnValue(
+      appliedResults$.asObservable()
+    );
+    (component as unknown as {
+      setAutoRefreshCodingStatus: (enabled: boolean) => void;
+    }).setAutoRefreshCodingStatus(false);
+
+    component.refreshCodingFreshnessStatusManually();
+    component.onFlatTableResponseDeleted();
+    codingFreshness$.next({ items: [] });
+    codingFreshness$.complete();
+    appliedResults$.next({ appliedResponses: 5 });
+    appliedResults$.complete();
+
+    expect(component.codingFreshnessSummary).toBeNull();
+    expect(component.manualAppliedResultsOverview).toBeNull();
+    expect(component.isLoadingCodingFreshnessStatus).toBe(false);
+    expect(component.isLoadingManualAppliedResultsOverview).toBe(false);
   });
 
   it('should keep the last workspace overview while a reload has no result yet', () => {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
@@ -33,10 +33,13 @@ import {
   BehaviorSubject,
   Subject,
   Subscription,
+  catchError,
   debounceTime,
   distinctUntilChanged,
   finalize,
   firstValueFrom,
+  forkJoin,
+  of,
   switchMap,
   takeWhile,
   timer as rxjsTimer
@@ -461,6 +464,10 @@ export class TestResultsComponent implements OnInit, OnDestroy {
   manualAppliedResultsOverview: AppliedResultsOverview | null = null;
   manualAppliedResultsOverviewLoadFailed: boolean = false;
   isLoadingManualAppliedResultsOverview: boolean = false;
+  autoRefreshCodingStatus: boolean = true;
+  codingFreshnessStatusChecked: boolean = false;
+  isLoadingCodingFreshnessStatus: boolean = false;
+  private codingFreshnessStatusRequestGeneration = 0;
 
   exportJobId: string | null = null;
   isExporting: boolean = false;
@@ -504,7 +511,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       if (wsId === this.appService.selectedWorkspaceId) {
         this.loadWorkspaceOverview();
         this.reloadLogAnomalySummaryIfRequested();
-        this.loadCodingFreshnessStatus();
+        this.refreshCodingFreshnessStatusAfterChange();
         this.createTestResultsList(
           this.pageIndex,
           this.pageSize,
@@ -529,9 +536,9 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       });
 
     this.loadTestResultsLogAnomalySetting();
+    this.loadCodingStatusAutoRefreshSetting();
     this.createTestResultsList(0, this.pageSize);
     this.loadWorkspaceOverview();
-    this.loadCodingFreshnessStatus();
     this.startValidationStatusCheck();
     this.checkExistingExportJobs();
     this.isInitialized = true;
@@ -1264,6 +1271,41 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       });
   }
 
+  private loadCodingStatusAutoRefreshSetting(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      this.setAutoRefreshCodingStatus(true);
+      return;
+    }
+
+    this.workspaceSettingsService
+      .getAutoRefreshManualCodingJobs(workspaceId)
+      .subscribe(enabled => {
+        this.setAutoRefreshCodingStatus(enabled);
+      });
+  }
+
+  private setAutoRefreshCodingStatus(enabled: boolean): void {
+    this.autoRefreshCodingStatus = enabled;
+
+    if (enabled) {
+      this.loadCodingFreshnessStatus({ force: true });
+      return;
+    }
+
+    this.clearCodingFreshnessStatus();
+  }
+
+  private clearCodingFreshnessStatus(): void {
+    this.codingFreshnessStatusRequestGeneration += 1;
+    this.codingFreshnessSummary = null;
+    this.manualAppliedResultsOverview = null;
+    this.manualAppliedResultsOverviewLoadFailed = false;
+    this.isLoadingManualAppliedResultsOverview = false;
+    this.isLoadingCodingFreshnessStatus = false;
+    this.codingFreshnessStatusChecked = false;
+  }
+
   private setShowTestResultsLogAnomalies(enabled: boolean): void {
     this.showTestResultsLogAnomalies = enabled;
 
@@ -1442,60 +1484,69 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       });
   }
 
-  private loadCodingFreshnessStatus(): void {
-    this.loadCodingFreshnessSummary();
-    this.loadManualAppliedResultsOverview();
-  }
-
-  private loadCodingFreshnessSummary(): void {
+  private loadCodingFreshnessStatus(
+    options: { force?: boolean } = {}
+  ): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
-      this.codingFreshnessSummary = null;
+      this.clearCodingFreshnessStatus();
+      return;
+    }
+
+    if (this.isLoadingCodingFreshnessStatus && !options.force) {
       return;
     }
 
     const getCodingFreshness =
       (this.statisticsService as Partial<CodingStatisticsService>).getCodingFreshness;
-    if (!getCodingFreshness) {
-      return;
-    }
+    const codingFreshness$ = getCodingFreshness ?
+      getCodingFreshness.call(this.statisticsService, workspaceId)
+        .pipe(catchError(() => of(null))) :
+      of(null);
 
-    getCodingFreshness.call(this.statisticsService, workspaceId)
+    const requestGeneration =
+      this.codingFreshnessStatusRequestGeneration + 1;
+    this.codingFreshnessStatusRequestGeneration = requestGeneration;
+    this.codingFreshnessStatusChecked = true;
+    this.isLoadingCodingFreshnessStatus = true;
+    this.isLoadingManualAppliedResultsOverview = true;
+    this.manualAppliedResultsOverviewLoadFailed = false;
+
+    forkJoin([
+      codingFreshness$,
+      this.testPersonCodingService.getAppliedResultsOverview(workspaceId)
+        .pipe(catchError(() => of(null)))
+    ])
+      .pipe(finalize(() => {
+        if (this.codingFreshnessStatusRequestGeneration === requestGeneration) {
+          this.isLoadingCodingFreshnessStatus = false;
+          this.isLoadingManualAppliedResultsOverview = false;
+        }
+      }))
       .subscribe({
-        next: summary => {
+        next: ([summary, overview]) => {
+          if (this.codingFreshnessStatusRequestGeneration !== requestGeneration) {
+            return;
+          }
+
           this.codingFreshnessSummary = summary;
-        },
-        error: () => {
-          this.codingFreshnessSummary = null;
+          this.manualAppliedResultsOverview = overview;
+          this.manualAppliedResultsOverviewLoadFailed = overview === null;
         }
       });
   }
 
-  private loadManualAppliedResultsOverview(): void {
-    const workspaceId = this.appService.selectedWorkspaceId;
-    if (!workspaceId) {
-      this.manualAppliedResultsOverview = null;
-      this.manualAppliedResultsOverviewLoadFailed = false;
-      this.isLoadingManualAppliedResultsOverview = false;
+  refreshCodingFreshnessStatusManually(): void {
+    this.loadCodingFreshnessStatus({ force: true });
+  }
+
+  private refreshCodingFreshnessStatusAfterChange(): void {
+    if (this.autoRefreshCodingStatus) {
+      this.loadCodingFreshnessStatus({ force: true });
       return;
     }
 
-    this.isLoadingManualAppliedResultsOverview = true;
-    this.manualAppliedResultsOverviewLoadFailed = false;
-    this.testPersonCodingService.getAppliedResultsOverview(workspaceId)
-      .pipe(finalize(() => {
-        this.isLoadingManualAppliedResultsOverview = false;
-      }))
-      .subscribe({
-        next: overview => {
-          this.manualAppliedResultsOverview = overview;
-          this.manualAppliedResultsOverviewLoadFailed = overview === null;
-        },
-        error: () => {
-          this.manualAppliedResultsOverview = null;
-          this.manualAppliedResultsOverviewLoadFailed = true;
-        }
-      });
+    this.clearCodingFreshnessStatus();
   }
 
   private async fetchCodingFreshnessSummary(
@@ -1575,6 +1626,10 @@ export class TestResultsComponent implements OnInit, OnDestroy {
   get hasCodingFreshnessWarning(): boolean {
     return this.codingFreshnessWarnings.length > 0 ||
       this.shouldShowSecondAutocodingWaitingState;
+  }
+
+  get shouldShowCodingFreshnessManualNotice(): boolean {
+    return !this.autoRefreshCodingStatus;
   }
 
   get codingFreshnessDisplayWarnings(): CodingFreshnessSummaryItemDto[] {
@@ -1743,7 +1798,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
     this.testResultService.invalidateCache(this.appService.selectedWorkspaceId);
     this.loadWorkspaceOverview();
     this.reloadLogAnomalySummaryIfRequested();
-    this.loadCodingFreshnessStatus();
+    this.refreshCodingFreshnessStatusAfterChange();
     this.testPersonCodingService.notifyTestResultsChanged();
   }
 
@@ -2167,7 +2222,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
           this.testResultService.invalidateCache(workspaceId);
         }
         this.loadWorkspaceOverview();
-        this.loadCodingFreshnessStatus();
+        this.refreshCodingFreshnessStatusAfterChange();
         this.createTestResultsList(
           this.pageIndex,
           this.pageSize,
@@ -2667,7 +2722,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
             this.appService.selectedWorkspaceId
           );
           this.loadWorkspaceOverview();
-          this.loadCodingFreshnessStatus();
+          this.refreshCodingFreshnessStatusAfterChange();
           this.testPersonCodingService.notifyTestResultsChanged();
           this.createTestResultsList(
             this.pageIndex,
@@ -2689,7 +2744,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
             { duration: 5000 }
           );
           this.loadWorkspaceOverview();
-          this.loadCodingFreshnessStatus();
+          this.refreshCodingFreshnessStatusAfterChange();
           this.testPersonCodingService.notifyTestResultsChanged();
           this.createTestResultsList(
             this.pageIndex,
@@ -2881,7 +2936,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
                   { duration: 3000 }
                 );
                 this.loadWorkspaceOverview();
-                this.loadCodingFreshnessStatus();
+                this.refreshCodingFreshnessStatusAfterChange();
                 this.testPersonCodingService.notifyTestResultsChanged();
               } else {
                 this.snackBar.open(
@@ -2948,7 +3003,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
                   { duration: 3000 }
                 );
                 this.loadWorkspaceOverview();
-                this.loadCodingFreshnessStatus();
+                this.refreshCodingFreshnessStatusAfterChange();
                 this.testPersonCodingService.notifyTestResultsChanged();
               } else {
                 this.snackBar.open(

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.polling.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.polling.spec.ts
@@ -75,7 +75,8 @@ describe('TestResultsComponent Polling', () => {
         {
           provide: WorkspaceSettingsService,
           useValue: {
-            getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false))
+            getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false)),
+            getAutoRefreshManualCodingJobs: jest.fn().mockReturnValue(of(true))
           }
         },
         {

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
@@ -39,6 +39,49 @@ describe('WorkspaceSettingsService', () => {
       expect(req.request.method).toBe('GET');
       req.flush({});
     });
+
+    it('should share an in-flight setting request', () => {
+      const received: string[] = [];
+
+      service.getWorkspaceSetting(1, 'k').subscribe(setting => {
+        received.push(setting.value);
+      });
+      service.getWorkspaceSetting(1, 'k').subscribe(setting => {
+        received.push(setting.value);
+      });
+
+      const req = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/k`);
+      req.flush({ id: 1, key: 'k', value: 'v' });
+
+      expect(received).toEqual(['v', 'v']);
+    });
+
+    it('should keep suppressed and default in-flight setting requests separate', () => {
+      service.getWorkspaceSetting(1, 'k', true).subscribe();
+      service.getWorkspaceSetting(1, 'k', false).subscribe();
+
+      const requests = httpMock.match(`${mockServerUrl}/workspace/1/settings/k`);
+      expect(requests).toHaveLength(2);
+      requests[0].flush({ id: 1, key: 'k', value: 'quiet' });
+      requests[1].flush({ id: 1, key: 'k', value: 'default' });
+    });
+
+    it('should reuse a recently fetched setting without a second request', () => {
+      const received: string[] = [];
+
+      service.getWorkspaceSetting(1, 'k').subscribe(setting => {
+        received.push(setting.value);
+      });
+      const req = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/k`);
+      req.flush({ id: 1, key: 'k', value: 'v' });
+
+      service.getWorkspaceSetting(1, 'k').subscribe(setting => {
+        received.push(setting.value);
+      });
+      httpMock.expectNone(`${mockServerUrl}/workspace/1/settings/k`);
+
+      expect(received).toEqual(['v', 'v']);
+    });
   });
 
   describe('setWorkspaceSetting', () => {
@@ -48,6 +91,20 @@ describe('WorkspaceSettingsService', () => {
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual({ key: 'k', value: 'v', description: undefined });
       req.flush({});
+    });
+
+    it('should invalidate cached settings after persisting a setting', () => {
+      service.getWorkspaceSetting(1, 'k').subscribe();
+      const getReq = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/k`);
+      getReq.flush({ id: 1, key: 'k', value: 'old' });
+
+      service.setWorkspaceSetting(1, 'k', 'new').subscribe();
+      const postReq = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings`);
+      postReq.flush({ id: 1, key: 'k', value: 'new' });
+
+      service.getWorkspaceSetting(1, 'k').subscribe();
+      const secondGetReq = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/k`);
+      secondGetReq.flush({ id: 1, key: 'k', value: 'new' });
     });
   });
 
@@ -96,7 +153,8 @@ describe('WorkspaceSettingsService', () => {
       expect(req.request.body).toEqual({
         key: 'auto-refresh-manual-coding-jobs',
         value: '{"enabled":false}',
-        description: 'Controls whether manual coding job tables refresh automatically when the browser window regains focus'
+        description:
+          'Controls whether coding status and manual coding views refresh automatically'
       });
       req.flush({});
     });

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { finalize, shareReplay, tap } from 'rxjs/operators';
 import { SERVER_URL } from '../../injection-tokens';
 import { WorkspaceSettings } from '../models/workspace-settings.model';
 import { suppressGlobalHttpErrorContext } from '../../core/interceptors/http-error-context';
@@ -25,57 +26,142 @@ export const DEFAULT_RESPONSE_MATCHING_MODE: ResponseMatchingModeDto = {
 export class WorkspaceSettingsService {
   private http = inject(HttpClient);
   private rawServerUrl = inject(SERVER_URL);
+  private readonly settingsCacheTtlMs = 10_000;
+  private readonly settingsCache = new Map<
+  string,
+  { expiresAt: number; value: WorkspaceSettings }
+  >();
+
+  private readonly settingsInFlight = new Map<
+  string,
+  Observable<WorkspaceSettings>
+  >();
+
   private get serverUrl(): string {
-    return this.rawServerUrl.endsWith('/') ? this.rawServerUrl.slice(0, -1) : this.rawServerUrl;
+    return this.rawServerUrl.endsWith('/') ?
+      this.rawServerUrl.slice(0, -1) :
+      this.rawServerUrl;
   }
 
-  getWorkspaceSetting(workspaceId: number, key: string, suppressGlobalError = false): Observable<WorkspaceSettings> {
-    return this.http.get<WorkspaceSettings>(
+  getWorkspaceSetting(
+    workspaceId: number,
+    key: string,
+    suppressGlobalError = false
+  ): Observable<WorkspaceSettings> {
+    const cacheKey = this.getSettingCacheKey(workspaceId, key);
+    const requestCacheKey = this.getSettingRequestCacheKey(
+      workspaceId,
+      key,
+      suppressGlobalError
+    );
+    const cached = this.settingsCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return new Observable(observer => {
+        observer.next(cached.value);
+        observer.complete();
+      });
+    }
+
+    const inFlight = this.settingsInFlight.get(requestCacheKey);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const request$ = this.http.get<WorkspaceSettings>(
       `${this.serverUrl}/workspace/${workspaceId}/settings/${key}`,
       suppressGlobalError ? { context: suppressGlobalHttpErrorContext() } : {}
+    ).pipe(
+      tap(setting => {
+        if (this.settingsInFlight.get(requestCacheKey) === request$) {
+          this.settingsCache.set(cacheKey, {
+            expiresAt: Date.now() + this.settingsCacheTtlMs,
+            value: setting
+          });
+        }
+      }),
+      finalize(() => {
+        if (this.settingsInFlight.get(requestCacheKey) === request$) {
+          this.settingsInFlight.delete(requestCacheKey);
+        }
+      }),
+      shareReplay({ bufferSize: 1, refCount: false })
+    );
+    this.settingsInFlight.set(requestCacheKey, request$);
+    return request$;
+  }
+
+  setWorkspaceSetting(
+    workspaceId: number,
+    key: string,
+    value: string,
+    description?: string
+  ): Observable<WorkspaceSettings> {
+    return this.http.post<WorkspaceSettings>(
+      `${this.serverUrl}/workspace/${workspaceId}/settings`,
+      {
+        key,
+        value,
+        description
+      }
+    ).pipe(
+      tap(() => this.invalidateWorkspaceSetting(workspaceId, key))
     );
   }
 
-  setWorkspaceSetting(workspaceId: number, key: string, value: string, description?: string): Observable<WorkspaceSettings> {
-    return this.http.post<WorkspaceSettings>(`${this.serverUrl}/workspace/${workspaceId}/settings`, {
-      key,
-      value,
-      description
-    });
+  updateWorkspaceSetting(
+    workspaceId: number,
+    settingId: number,
+    value: string
+  ): Observable<WorkspaceSettings> {
+    return this.http.put<WorkspaceSettings>(
+      `${this.serverUrl}/workspace/${workspaceId}/settings/${settingId}`,
+      {
+        value
+      }
+    ).pipe(
+      tap(() => this.invalidateWorkspaceSettings(workspaceId))
+    );
   }
 
-  updateWorkspaceSetting(workspaceId: number, settingId: number, value: string): Observable<WorkspaceSettings> {
-    return this.http.put<WorkspaceSettings>(`${this.serverUrl}/workspace/${workspaceId}/settings/${settingId}`, {
-      value
-    });
-  }
-
-  deleteWorkspaceSetting(workspaceId: number, settingId: number): Observable<void> {
-    return this.http.delete<void>(`${this.serverUrl}/workspace/${workspaceId}/settings/${settingId}`);
+  deleteWorkspaceSetting(
+    workspaceId: number,
+    settingId: number
+  ): Observable<void> {
+    return this.http.delete<void>(
+      `${this.serverUrl}/workspace/${workspaceId}/settings/${settingId}`
+    ).pipe(
+      tap(() => this.invalidateWorkspaceSettings(workspaceId))
+    );
   }
 
   getAutoFetchCodingStatistics(workspaceId: number): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'auto-fetch-coding-statistics', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? true);
-            } catch {
-              observer.next(true);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'auto-fetch-coding-statistics',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? true);
+          } catch {
             observer.next(true);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(true);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setAutoFetchCodingStatistics(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setAutoFetchCodingStatistics(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -87,57 +173,69 @@ export class WorkspaceSettingsService {
 
   getAutoRefreshManualCodingJobs(workspaceId: number): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'auto-refresh-manual-coding-jobs', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? true);
-            } catch {
-              observer.next(true);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'auto-refresh-manual-coding-jobs',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? true);
+          } catch {
             observer.next(true);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(true);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setAutoRefreshManualCodingJobs(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setAutoRefreshManualCodingJobs(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
       'auto-refresh-manual-coding-jobs',
       value,
-      'Controls whether manual coding job tables refresh automatically when the browser window regains focus'
+      'Controls whether coding status and manual coding views refresh automatically'
     );
   }
 
   getShowTestResultsLogAnomalies(workspaceId: number): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'show-test-results-log-anomalies', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? false);
-            } catch {
-              observer.next(false);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'show-test-results-log-anomalies',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? false);
+          } catch {
             observer.next(false);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(false);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setShowTestResultsLogAnomalies(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setShowTestResultsLogAnomalies(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -147,28 +245,36 @@ export class WorkspaceSettingsService {
     );
   }
 
-  getIncludeDeriveErrorInManualCoding(workspaceId: number): Observable<boolean> {
+  getIncludeDeriveErrorInManualCoding(
+    workspaceId: number
+  ): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'include-derive-error-in-manual-coding', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? false);
-            } catch {
-              observer.next(false);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'include-derive-error-in-manual-coding',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? false);
+          } catch {
             observer.next(false);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(false);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setIncludeDeriveErrorInManualCoding(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setIncludeDeriveErrorInManualCoding(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -180,26 +286,32 @@ export class WorkspaceSettingsService {
 
   getEnableRegexSearch(workspaceId: number): Observable<boolean> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'enable-regex-search', true)
-        .subscribe({
-          next: setting => {
-            try {
-              const parsed = JSON.parse(setting.value);
-              observer.next(parsed.enabled ?? false);
-            } catch {
-              observer.next(false);
-            }
-            observer.complete();
-          },
-          error: () => {
+      this.getWorkspaceSetting(
+        workspaceId,
+        'enable-regex-search',
+        true
+      ).subscribe({
+        next: setting => {
+          try {
+            const parsed = JSON.parse(setting.value);
+            observer.next(parsed.enabled ?? false);
+          } catch {
             observer.next(false);
-            observer.complete();
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(false);
+          observer.complete();
+        }
+      });
     });
   }
 
-  setEnableRegexSearch(workspaceId: number, enabled: boolean): Observable<WorkspaceSettings> {
+  setEnableRegexSearch(
+    workspaceId: number,
+    enabled: boolean
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ enabled });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -209,14 +321,18 @@ export class WorkspaceSettingsService {
     );
   }
 
-  getResponseMatchingMode(workspaceId: number): Observable<ResponseMatchingFlag[]> {
+  getResponseMatchingMode(
+    workspaceId: number
+  ): Observable<ResponseMatchingFlag[]> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'response-matching-mode')
-        .subscribe({
+      this.getWorkspaceSetting(workspaceId, 'response-matching-mode').subscribe(
+        {
           next: setting => {
             try {
               const parsed = JSON.parse(setting.value);
-              observer.next(parsed.flags ?? DEFAULT_RESPONSE_MATCHING_MODE.flags);
+              observer.next(
+                parsed.flags ?? DEFAULT_RESPONSE_MATCHING_MODE.flags
+              );
             } catch {
               observer.next(DEFAULT_RESPONSE_MATCHING_MODE.flags);
             }
@@ -226,11 +342,15 @@ export class WorkspaceSettingsService {
             observer.next(DEFAULT_RESPONSE_MATCHING_MODE.flags);
             observer.complete();
           }
-        });
+        }
+      );
     });
   }
 
-  setResponseMatchingMode(workspaceId: number, flags: ResponseMatchingFlag[]): Observable<WorkspaceSettings> {
+  setResponseMatchingMode(
+    workspaceId: number,
+    flags: ResponseMatchingFlag[]
+  ): Observable<WorkspaceSettings> {
     const value = JSON.stringify({ flags });
     return this.setWorkspaceSetting(
       workspaceId,
@@ -242,36 +362,50 @@ export class WorkspaceSettingsService {
 
   getAggregationThreshold(workspaceId: number): Observable<number | null> {
     return new Observable(observer => {
-      this.getWorkspaceSetting(workspaceId, 'duplicate-aggregation-threshold')
-        .subscribe({
-          next: setting => {
-            try {
-              observer.next(this.normalizeAggregationThreshold(setting.value));
-            } catch {
-              observer.next(2);
-            }
-            observer.complete();
-          },
-          error: () => {
-            observer.next(2); // Default
-            observer.complete();
+      this.getWorkspaceSetting(
+        workspaceId,
+        'duplicate-aggregation-threshold'
+      ).subscribe({
+        next: setting => {
+          try {
+            observer.next(this.normalizeAggregationThreshold(setting.value));
+          } catch {
+            observer.next(2);
           }
-        });
+          observer.complete();
+        },
+        error: () => {
+          observer.next(2); // Default
+          observer.complete();
+        }
+      });
     });
   }
 
-  setAggregationThreshold(workspaceId: number, threshold: number | null): Observable<WorkspaceSettings> {
+  setAggregationThreshold(
+    workspaceId: number,
+    threshold: number | null
+  ): Observable<WorkspaceSettings> {
     const normalizedThreshold = this.normalizeAggregationThreshold(threshold);
     return this.setWorkspaceSetting(
       workspaceId,
       'duplicate-aggregation-threshold',
-      normalizedThreshold === null ? 'disabled' : normalizedThreshold.toString(),
+      normalizedThreshold === null ?
+        'disabled' :
+        normalizedThreshold.toString(),
       'Minimum number of identical responses required for aggregation'
     );
   }
 
-  private normalizeAggregationThreshold(value: number | string | null | undefined): number | null {
-    if (value === 'disabled' || value === '0' || value === 0 || value === null) {
+  private normalizeAggregationThreshold(
+    value: number | string | null | undefined
+  ): number | null {
+    if (
+      value === 'disabled' ||
+      value === '0' ||
+      value === 0 ||
+      value === null
+    ) {
       return null;
     }
     const numericValue = Number(value);
@@ -279,5 +413,37 @@ export class WorkspaceSettingsService {
       return 2;
     }
     return Math.min(100, Math.max(2, Math.round(numericValue)));
+  }
+
+  private getSettingCacheKey(workspaceId: number, key: string): string {
+    return `${workspaceId}:${key}`;
+  }
+
+  private getSettingRequestCacheKey(
+    workspaceId: number,
+    key: string,
+    suppressGlobalError: boolean
+  ): string {
+    const errorMode = suppressGlobalError ? 'quiet' : 'default';
+    return `${this.getSettingCacheKey(workspaceId, key)}:${errorMode}`;
+  }
+
+  private invalidateWorkspaceSetting(workspaceId: number, key: string): void {
+    const cacheKey = this.getSettingCacheKey(workspaceId, key);
+    const requestPrefix = `${cacheKey}:`;
+    this.settingsCache.delete(cacheKey);
+    Array.from(this.settingsInFlight.keys())
+      .filter(inFlightKey => inFlightKey.startsWith(requestPrefix))
+      .forEach(inFlightKey => this.settingsInFlight.delete(inFlightKey));
+  }
+
+  private invalidateWorkspaceSettings(workspaceId: number): void {
+    const prefix = `${workspaceId}:`;
+    Array.from(this.settingsCache.keys())
+      .filter(cacheKey => cacheKey.startsWith(prefix))
+      .forEach(cacheKey => this.settingsCache.delete(cacheKey));
+    Array.from(this.settingsInFlight.keys())
+      .filter(cacheKey => cacheKey.startsWith(prefix))
+      .forEach(cacheKey => this.settingsInFlight.delete(cacheKey));
   }
 }


### PR DESCRIPTION
## What changed

Split UI guard/error-overlay changes out of #830.

- adds in-flight/cache guards for coder training list requests
- keeps stale training-list responses from replacing data after workspace changes
- isolates workspace-settings cache/in-flight behavior and fixes suppressed vs default error-context request sharing
- adjusts test-results UI refresh/error states
- keeps global error details collapsed and session reauthentication behavior clearer

## Why

These are useful UI robustness changes, but they are not the minimal #813 refresh-trigger fix and should not be reviewed together with backend cache work.

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts --runInBand --skip-nx-cache`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coder-trainings-list/coder-trainings-list.component.spec.ts --runInBand --skip-nx-cache`
- `npx nx test frontend --testFile=apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts --runInBand --skip-nx-cache`
- `npx nx test frontend --testFile=apps/frontend/src/app/ws-admin/components/test-results/test-results.polling.spec.ts --runInBand --skip-nx-cache`
- `npx nx test frontend --testFile=apps/frontend/src/app/shared/components/error-message-display/error-message-display.component.spec.ts --runInBand --skip-nx-cache`
- `npx nx lint frontend --skip-nx-cache`
