### PR TITLE
Split manual coding performance repro tooling from #830

### DIFF
--- a/cypress/e2e/manual-coding-performance.cy.ts
+++ b/cypress/e2e/manual-coding-performance.cy.ts
@@ -1,0 +1,234 @@
+const workspaceId = Number(Cypress.env('workspaceId') || 47);
+const maxRouteMs = Number(Cypress.env('maxRouteMs') || 5000);
+const maxTabMs = Number(Cypress.env('maxTabMs') || 3000);
+const maxRapidSwitchMs = Number(Cypress.env('maxRapidSwitchMs') || 12000);
+const rapidSwitchRepeats = Number(Cypress.env('rapidSwitchRepeats') || 8);
+const maxCriticalRequests = Number(Cypress.env('maxCriticalRequests') || 80);
+const networkProfile = String(Cypress.env('networkProfile') || 'none');
+const manualLogin = String(Cypress.env('manualLogin') || 'false') === 'true';
+const manualLoginTimeoutMs = Number(
+  Cypress.env('manualLoginTimeoutMs') || 240000
+);
+
+const routes = [
+  {
+    label: 'Testergebnisse',
+    hash: `/#/workspace-admin/${workspaceId}/test-results`,
+    selector: 'coding-box-test-results'
+  },
+  {
+    label: 'Kodieruebersicht',
+    hash: `/#/workspace-admin/${workspaceId}/coding/management`,
+    selector: 'app-coding-management'
+  },
+  {
+    label: 'Manuelle Kodierung',
+    hash: `/#/workspace-admin/${workspaceId}/coding/manual`,
+    selector: 'coding-box-coding-management-manual'
+  }
+];
+
+const criticalApiPattern =
+  /\/api\/admin\/workspace\/\d+\/(coding\/(freshness|incomplete-variables|response-analysis)|test-results)/;
+
+const networkProfiles: Record<
+string,
+{ offline: boolean; latency: number; downloadThroughput: number; uploadThroughput: number }
+> = {
+  'slow-4g': {
+    offline: false,
+    latency: 150,
+    downloadThroughput: (1.6 * 1024 * 1024) / 8,
+    uploadThroughput: (750 * 1024) / 8
+  },
+  'slow-3g': {
+    offline: false,
+    latency: 300,
+    downloadThroughput: (750 * 1024) / 8,
+    uploadThroughput: (250 * 1024) / 8
+  }
+};
+
+function assertNoLoadingStatusContradiction() {
+  cy.get('body')
+    .invoke('text')
+    .then((text) => {
+      const hasCurrent = text.includes('Kodierstand aktuell');
+      const hasLoading =
+        text.includes('Zustand wird geprueft') ||
+        text.includes('Zustand wird geprüft');
+      expect(hasCurrent && hasLoading).to.eq(false);
+    });
+}
+
+function trackCriticalRequests(alias = 'criticalApi') {
+  const calls: string[] = [];
+  cy.intercept('**/api/admin/workspace/**', request => {
+    if (criticalApiPattern.test(request.url)) {
+      calls.push(request.url);
+    }
+  }).as(alias);
+  return calls;
+}
+
+function assertCriticalRequestBudget(calls: string[], label: string) {
+  cy.then(() => {
+    cy.log(`${label}: ${calls.length} critical API requests`);
+    expect(calls.length, `${label} critical API request count`)
+      .to.be.lessThan(maxCriticalRequests);
+  });
+}
+
+function emulateNetworkProfile() {
+  const profile = networkProfiles[networkProfile];
+  if (!profile) return;
+
+  cy.then(() => Cypress.automation('remote:debugger:protocol', {
+    command: 'Network.enable'
+  }));
+  cy.then(() => Cypress.automation('remote:debugger:protocol', {
+    command: 'Network.emulateNetworkConditions',
+    params: profile
+  }));
+}
+
+function resetNetworkProfile() {
+  if (!networkProfiles[networkProfile]) return;
+
+  cy.then(() => Cypress.automation('remote:debugger:protocol', {
+    command: 'Network.emulateNetworkConditions',
+    params: {
+      offline: false,
+      latency: 0,
+      downloadThroughput: -1,
+      uploadThroughput: -1
+    }
+  }));
+}
+
+function waitForManualLoginIfRequested(hash: string, selector: string) {
+  if (!manualLogin) {
+    return;
+  }
+
+  cy.log(
+    'Manual login mode: complete Keycloak login in this browser window if prompted.'
+  );
+  cy.location('href', { timeout: manualLoginTimeoutMs }).should('include', hash);
+  cy.get(selector, { timeout: 60000 }).should('exist');
+}
+
+function measureRoute(label: string, hash: string, selector: string) {
+  let startedAt = 0;
+  if (manualLogin) {
+    cy.visit(hash);
+    waitForManualLoginIfRequested(hash, selector);
+  }
+
+  cy.then(() => {
+    startedAt = Date.now();
+  });
+  cy.visit(hash);
+  cy.location('hash', { timeout: 20000 }).should('include', hash.slice(1));
+  cy.get(selector, { timeout: 20000 }).should('exist');
+  cy.then(() => {
+    const durationMs = Date.now() - startedAt;
+    cy.log(`${label}: ${durationMs} ms`);
+    expect(durationMs, `${label} route duration`).to.be.lessThan(maxRouteMs);
+  });
+  assertNoLoadingStatusContradiction();
+}
+
+describe('Manual coding performance smoke', { testIsolation: false }, () => {
+  afterEach(() => {
+    resetNetworkProfile();
+  });
+
+  it('opens the critical workspace UI routes within the smoke threshold', () => {
+    emulateNetworkProfile();
+    routes.forEach((route) => {
+      measureRoute(route.label, route.hash, route.selector);
+    });
+  });
+
+  it('switches visible manual coding tabs without stale loading status', () => {
+    emulateNetworkProfile();
+    cy.visit(`/#/workspace-admin/${workspaceId}/coding/manual`);
+    waitForManualLoginIfRequested(
+      `/#/workspace-admin/${workspaceId}/coding/manual`,
+      'coding-box-coding-management-manual'
+    );
+    cy.get('coding-box-coding-management-manual', { timeout: 20000 }).should(
+      'exist'
+    );
+
+    cy.get('.manual-coding-tabs .mat-mdc-tab').each((tab) => {
+      const label = tab.text().trim().replace(/\s+/g, ' ') || 'tab';
+      const startedAt = Date.now();
+      cy.wrap(tab).click();
+      cy.get('coding-box-coding-management-manual').should('exist');
+      cy.wait(250);
+      cy.then(() => {
+        const durationMs = Date.now() - startedAt;
+        cy.log(`${label}: ${durationMs} ms`);
+        expect(durationMs, `${label} tab duration`).to.be.lessThan(maxTabMs);
+      });
+      assertNoLoadingStatusContradiction();
+    });
+  });
+
+  it('keeps rapid route changes bounded and avoids excessive critical requests', () => {
+    emulateNetworkProfile();
+    const criticalCalls = trackCriticalRequests('rapidRouteCriticalApi');
+    const startedAt = Date.now();
+
+    Cypress._.times(rapidSwitchRepeats, () => {
+      routes.forEach((route) => {
+        cy.visit(route.hash);
+        cy.get(route.selector, { timeout: 20000 }).should('exist');
+        assertNoLoadingStatusContradiction();
+      });
+    });
+
+    cy.then(() => {
+      const durationMs = Date.now() - startedAt;
+      cy.log(`rapid route switches: ${durationMs} ms`);
+      expect(durationMs, 'rapid route switch duration')
+        .to.be.lessThan(maxRapidSwitchMs);
+    });
+    assertCriticalRequestBudget(criticalCalls, 'rapid route switches');
+  });
+
+  it('keeps rapid manual tab switches bounded and avoids excessive critical requests', () => {
+    emulateNetworkProfile();
+    const criticalCalls = trackCriticalRequests('rapidManualTabCriticalApi');
+    const startedAt = Date.now();
+
+    cy.visit(`/#/workspace-admin/${workspaceId}/coding/manual`);
+    waitForManualLoginIfRequested(
+      `/#/workspace-admin/${workspaceId}/coding/manual`,
+      'coding-box-coding-management-manual'
+    );
+    cy.get('coding-box-coding-management-manual', { timeout: 20000 }).should(
+      'exist'
+    );
+    cy.get('.manual-coding-tabs .mat-mdc-tab')
+      .then(tabs => {
+        const tabCount = tabs.length;
+        Cypress._.times(rapidSwitchRepeats, repeat => {
+          const index = repeat % tabCount;
+          cy.get('.manual-coding-tabs .mat-mdc-tab').eq(index).click();
+          cy.get('coding-box-coding-management-manual').should('exist');
+          assertNoLoadingStatusContradiction();
+        });
+      });
+
+    cy.then(() => {
+      const durationMs = Date.now() - startedAt;
+      cy.log(`rapid manual tab switches: ${durationMs} ms`);
+      expect(durationMs, 'rapid manual tab switch duration')
+        .to.be.lessThan(maxRapidSwitchMs);
+    });
+    assertCriticalRequestBudget(criticalCalls, 'rapid manual tab switches');
+  });
+});

--- a/scripts/repro/clone-manual-coding-workspace-metadata.sql
+++ b/scripts/repro/clone-manual-coding-workspace-metadata.sql
@@ -1,0 +1,196 @@
+\set ON_ERROR_STOP on
+
+\if :{?source_workspace_id}
+\else
+  \set source_workspace_id 47
+\endif
+
+\if :{?target_workspace_id}
+\else
+  \set target_workspace_id 54
+\endif
+
+BEGIN;
+
+INSERT INTO file_upload (
+  data,
+  workspace_id,
+  filename,
+  file_size,
+  file_type,
+  file_id,
+  created_at,
+  structured_data,
+  file_id_normalized,
+  coding_scheme_ref_normalized
+)
+SELECT
+  data,
+  :target_workspace_id,
+  filename,
+  file_size,
+  file_type,
+  file_id,
+  now(),
+  structured_data,
+  file_id_normalized,
+  coding_scheme_ref_normalized
+FROM file_upload
+WHERE workspace_id = :source_workspace_id
+ON CONFLICT (workspace_id, file_id) DO UPDATE
+SET
+  data = EXCLUDED.data,
+  filename = EXCLUDED.filename,
+  file_size = EXCLUDED.file_size,
+  file_type = EXCLUDED.file_type,
+  structured_data = EXCLUDED.structured_data,
+  file_id_normalized = EXCLUDED.file_id_normalized,
+  coding_scheme_ref_normalized = EXCLUDED.coding_scheme_ref_normalized;
+
+INSERT INTO resource_package (
+  elements,
+  name,
+  created_at,
+  "workspaceId",
+  package_size,
+  package_type,
+  scope,
+  detected_version,
+  content_hash,
+  original_filename
+)
+SELECT
+  elements,
+  name,
+  now(),
+  :target_workspace_id,
+  package_size,
+  package_type,
+  scope,
+  detected_version,
+  content_hash,
+  original_filename
+FROM resource_package
+WHERE "workspaceId" = :source_workspace_id
+  AND NOT EXISTS (
+    SELECT 1
+    FROM resource_package existing
+    WHERE existing."workspaceId" = :target_workspace_id
+      AND existing.name = resource_package.name
+      AND existing.package_type = resource_package.package_type
+      AND existing.scope = resource_package.scope
+  );
+
+CREATE TEMP TABLE scale_missings_profile_map AS
+WITH inserted AS (
+  INSERT INTO missings_profile (label, missings, workspace_id)
+  SELECT label, missings, :target_workspace_id
+  FROM missings_profile
+  WHERE workspace_id = :source_workspace_id
+  ON CONFLICT (workspace_id, label) DO UPDATE
+  SET missings = EXCLUDED.missings
+  RETURNING id, label
+)
+SELECT source.id AS source_id, inserted.id AS target_id
+FROM missings_profile source
+JOIN inserted
+  ON inserted.label = source.label
+WHERE source.workspace_id = :source_workspace_id;
+
+INSERT INTO variable_bundle (
+  workspace_id,
+  name,
+  description,
+  variables,
+  created_at,
+  updated_at
+)
+SELECT
+  :target_workspace_id,
+  name,
+  description,
+  variables,
+  now(),
+  now()
+FROM variable_bundle
+WHERE workspace_id = :source_workspace_id
+  AND NOT EXISTS (
+    SELECT 1
+    FROM variable_bundle existing
+    WHERE existing.workspace_id = :target_workspace_id
+      AND existing.name = variable_bundle.name
+  );
+
+INSERT INTO job_definitions (
+  duration_seconds,
+  created_at,
+  updated_at,
+  max_coding_cases,
+  double_coding_absolute,
+  double_coding_percentage,
+  status,
+  assigned_variables,
+  assigned_variable_bundles,
+  assigned_coders,
+  workspace_id,
+  case_ordering_mode,
+  suppress_general_instructions,
+  show_score,
+  allow_comments,
+  assigned_coder_configs,
+  distribution_seed,
+  missings_profile_id,
+  distribution_snapshots
+)
+SELECT
+  duration_seconds,
+  now(),
+  now(),
+  max_coding_cases,
+  double_coding_absolute,
+  double_coding_percentage,
+  status,
+  assigned_variables,
+  assigned_variable_bundles,
+  assigned_coders,
+  :target_workspace_id,
+  case_ordering_mode,
+  suppress_general_instructions,
+  show_score,
+  allow_comments,
+  assigned_coder_configs,
+  distribution_seed || '-scale-' || :target_workspace_id,
+  profile_map.target_id,
+  distribution_snapshots
+FROM job_definitions source
+LEFT JOIN scale_missings_profile_map profile_map
+  ON profile_map.source_id = source.missings_profile_id
+WHERE source.workspace_id = :source_workspace_id
+  AND NOT EXISTS (
+    SELECT 1
+    FROM job_definitions existing
+    WHERE existing.workspace_id = :target_workspace_id
+      AND existing.distribution_seed = source.distribution_seed || '-scale-' || :target_workspace_id
+  );
+
+COMMIT;
+
+SELECT 'file_upload' AS table_name, count(*) AS rows
+FROM file_upload
+WHERE workspace_id = :target_workspace_id
+UNION ALL
+SELECT 'resource_package', count(*)
+FROM resource_package
+WHERE "workspaceId" = :target_workspace_id
+UNION ALL
+SELECT 'missings_profile', count(*)
+FROM missings_profile
+WHERE workspace_id = :target_workspace_id
+UNION ALL
+SELECT 'variable_bundle', count(*)
+FROM variable_bundle
+WHERE workspace_id = :target_workspace_id
+UNION ALL
+SELECT 'job_definitions', count(*)
+FROM job_definitions
+WHERE workspace_id = :target_workspace_id;

--- a/scripts/repro/create-manual-coding-scale-workspace.sql
+++ b/scripts/repro/create-manual-coding-scale-workspace.sql
@@ -1,0 +1,194 @@
+\set ON_ERROR_STOP on
+
+\if :{?source_workspace_id}
+\else
+  \set source_workspace_id 47
+\endif
+
+\if :{?target_person_count}
+\else
+  \set target_person_count 5000
+\endif
+
+\if :{?target_workspace_name}
+\else
+  \set target_workspace_name 'Manual Coding Scale Workspace'
+\endif
+
+BEGIN;
+
+CREATE TEMP TABLE scale_source_persons AS
+SELECT
+  p.*,
+  row_number() OVER (ORDER BY p.id) AS source_index,
+  count(*) OVER () AS source_count
+FROM persons p
+WHERE p.workspace_id = :source_workspace_id
+  AND p.consider = true
+ORDER BY p.id;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM scale_source_persons) THEN
+    RAISE EXCEPTION 'No source persons found for source workspace.';
+  END IF;
+END $$;
+
+INSERT INTO workspace (name, settings)
+SELECT :'target_workspace_name', settings
+FROM workspace
+WHERE id = :source_workspace_id
+RETURNING id AS target_workspace_id \gset
+
+INSERT INTO workspace_user (workspace_id, user_id, access_level, can_code)
+SELECT :target_workspace_id, user_id, access_level, can_code
+FROM workspace_user
+WHERE workspace_id = :source_workspace_id
+ON CONFLICT DO NOTHING;
+
+CREATE TEMP TABLE scale_person_plan AS
+SELECT
+  target_index,
+  source.id AS source_person_id,
+  left(source.login, 56) || '_s' || target_index::text AS target_login,
+  left(source.code, 56) || '_s' || target_index::text AS target_code,
+  left(source."group", 56) || '_scale' AS target_group,
+  source.booklets,
+  source.source AS original_source
+FROM generate_series(1, :target_person_count) AS target_index
+JOIN scale_source_persons source
+  ON source.source_index =
+    (((target_index - 1) % source.source_count) + 1);
+
+INSERT INTO persons (
+  "group",
+  login,
+  code,
+  booklets,
+  workspace_id,
+  uploaded_at,
+  source,
+  consider
+)
+SELECT
+  target_group,
+  target_login,
+  target_code,
+  booklets,
+  :target_workspace_id,
+  now(),
+  'scale:' || :target_workspace_id || ':' || target_index || ':' || source_person_id,
+  true
+FROM scale_person_plan;
+
+CREATE TEMP TABLE scale_person_map AS
+SELECT
+  plan.target_index,
+  plan.source_person_id,
+  person.id AS target_person_id
+FROM scale_person_plan plan
+JOIN persons person
+  ON person.workspace_id = :target_workspace_id
+  AND person.login = plan.target_login
+  AND person.code = plan.target_code
+  AND person."group" = plan.target_group;
+
+INSERT INTO booklet (infoid, personid, lastts, firstts)
+SELECT
+  source_booklet.infoid,
+  person_map.target_person_id,
+  source_booklet.lastts,
+  source_booklet.firstts
+FROM booklet source_booklet
+JOIN scale_person_map person_map
+  ON person_map.source_person_id = source_booklet.personid;
+
+CREATE TEMP TABLE scale_booklet_map AS
+SELECT
+  source_booklet.id AS source_booklet_id,
+  target_booklet.id AS target_booklet_id
+FROM booklet source_booklet
+JOIN scale_person_map person_map
+  ON person_map.source_person_id = source_booklet.personid
+JOIN booklet target_booklet
+  ON target_booklet.personid = person_map.target_person_id
+  AND target_booklet.infoid = source_booklet.infoid;
+
+INSERT INTO unit (bookletid, name, alias)
+SELECT
+  booklet_map.target_booklet_id,
+  source_unit.name,
+  source_unit.alias
+FROM unit source_unit
+JOIN scale_booklet_map booklet_map
+  ON booklet_map.source_booklet_id = source_unit.bookletid;
+
+CREATE TEMP TABLE scale_unit_map AS
+SELECT
+  source_unit.id AS source_unit_id,
+  target_unit.id AS target_unit_id
+FROM unit source_unit
+JOIN scale_booklet_map booklet_map
+  ON booklet_map.source_booklet_id = source_unit.bookletid
+JOIN unit target_unit
+  ON target_unit.bookletid = booklet_map.target_booklet_id
+  AND target_unit.name = source_unit.name
+  AND COALESCE(target_unit.alias, '') = COALESCE(source_unit.alias, '');
+
+INSERT INTO response (
+  unitid,
+  variableid,
+  status,
+  value,
+  subform,
+  code_v1,
+  score_v1,
+  status_v1,
+  status_v2,
+  code_v2,
+  score_v2,
+  status_v3,
+  code_v3,
+  score_v3,
+  is_autocoder_generated
+)
+SELECT
+  unit_map.target_unit_id,
+  source_response.variableid,
+  source_response.status,
+  source_response.value,
+  source_response.subform,
+  source_response.code_v1,
+  source_response.score_v1,
+  source_response.status_v1,
+  source_response.status_v2,
+  source_response.code_v2,
+  source_response.score_v2,
+  source_response.status_v3,
+  source_response.code_v3,
+  source_response.score_v3,
+  source_response.is_autocoder_generated
+FROM response source_response
+JOIN scale_unit_map unit_map
+  ON unit_map.source_unit_id = source_response.unitid;
+
+COMMIT;
+
+SELECT
+  :target_workspace_id AS workspace_id,
+  :'target_workspace_name' AS workspace_name,
+  count(DISTINCT person.id) AS persons,
+  count(DISTINCT booklet.id) AS booklets,
+  count(DISTINCT unit.id) AS units,
+  count(response.id) AS responses
+FROM workspace workspace
+LEFT JOIN persons person
+  ON person.workspace_id = workspace.id
+LEFT JOIN booklet booklet
+  ON booklet.personid = person.id
+LEFT JOIN unit unit
+  ON unit.bookletid = booklet.id
+LEFT JOIN response response
+  ON response.unitid = unit.id
+WHERE workspace.id = :target_workspace_id
+GROUP BY workspace.id;

--- a/scripts/repro/manual-coding-api-load-test.mjs
+++ b/scripts/repro/manual-coding-api-load-test.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * Repro/load helper for manual coding and response-analysis endpoints.
+ *
+ * Example:
+ * AUTH_TOKEN=... WORKSPACE_ID=47 CONCURRENCY=4 ROUNDS=5 \
+ *   node scripts/repro/manual-coding-api-load-test.mjs
+ *
+ * Optional:
+ * - BASE_URL=http://localhost:3333/api
+ * - TRIGGER_RESPONSE_ANALYSIS=true includes one POST trigger before the load.
+ * - CONCURRENCY_LEVELS=1,4,8 runs multiple concurrency stages.
+ * - ENDPOINT_SET=manual|test-results|all limits endpoint coverage.
+ * - OUTPUT_JSON=/tmp/manual-coding-api-load.json writes machine-readable results.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { performance } from 'node:perf_hooks';
+
+const baseUrl = process.env.BASE_URL || 'http://localhost:3333/api';
+const workspaceId = process.env.WORKSPACE_ID || '47';
+const authToken = process.env.AUTH_TOKEN;
+const concurrency = Number.parseInt(process.env.CONCURRENCY || '4', 10);
+const concurrencyLevels = (process.env.CONCURRENCY_LEVELS || '')
+  .split(',')
+  .map(level => Number.parseInt(level.trim(), 10))
+  .filter(level => Number.isInteger(level) && level > 0);
+const rounds = Number.parseInt(process.env.ROUNDS || '5', 10);
+const triggerResponseAnalysis =
+  process.env.TRIGGER_RESPONSE_ANALYSIS === 'true';
+const endpointSet = process.env.ENDPOINT_SET || 'manual';
+const outputJson = process.env.OUTPUT_JSON;
+
+if (!authToken) {
+  throw new Error(
+    'AUTH_TOKEN is required. Example: AUTH_TOKEN=... node scripts/repro/manual-coding-api-load-test.mjs'
+  );
+}
+
+if (!Number.isInteger(concurrency) || concurrency <= 0) {
+  throw new Error('CONCURRENCY must be a positive integer.');
+}
+
+if (!['manual', 'test-results', 'all'].includes(endpointSet)) {
+  throw new Error('ENDPOINT_SET must be manual, test-results, or all.');
+}
+
+if (!Number.isInteger(rounds) || rounds <= 0) {
+  throw new Error('ROUNDS must be a positive integer.');
+}
+
+const manualEndpoints = [
+  {
+    name: 'incomplete-variables',
+    path: `/admin/workspace/${workspaceId}/coding/incomplete-variables`
+  },
+  {
+    name: 'scope-summary',
+    path: `/admin/workspace/${workspaceId}/coding/incomplete-variables/scope-summary`
+  },
+  {
+    name: 'coding-freshness',
+    path: `/admin/workspace/${workspaceId}/coding/freshness`
+  },
+  {
+    name: 'response-analysis',
+    path: `/admin/workspace/${workspaceId}/coding/response-analysis?threshold=2&emptyLimit=10&duplicateLimit=10`
+  }
+];
+
+const testResultsEndpoints = [
+  {
+    name: 'flat-responses-page',
+    path: `/admin/workspace/${workspaceId}/test-results/flat-responses?page=1&limit=100`
+  },
+  {
+    name: 'flat-response-filter-options',
+    path: `/admin/workspace/${workspaceId}/test-results/flat-responses/filter-options`
+  },
+  {
+    name: 'test-results-overview',
+    path: `/admin/workspace/${workspaceId}/test-results/overview`
+  }
+];
+
+const endpoints = [
+  ...(endpointSet === 'test-results' ? [] : manualEndpoints),
+  ...(endpointSet === 'manual' ? [] : testResultsEndpoints)
+];
+
+async function request(endpoint, options = {}) {
+  const startedAt = performance.now();
+  const response = await fetch(`${baseUrl}${endpoint.path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(options.headers || {})
+    }
+  });
+  const text = await response.text();
+  const durationMs = performance.now() - startedAt;
+
+  return {
+    endpoint: endpoint.name,
+    status: response.status,
+    ok: response.ok,
+    durationMs,
+    bytes: Buffer.byteLength(text)
+  };
+}
+
+function average(values) {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function percentile(values, percent) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil((percent / 100) * sorted.length) - 1
+  );
+  return sorted[index];
+}
+
+function summarize(results) {
+  return endpoints.map((endpoint) => {
+    const endpointResults = results.filter(
+      (result) => result.endpoint === endpoint.name
+    );
+    const durations = endpointResults.map((result) => result.durationMs);
+    return {
+      endpoint: endpoint.name,
+      requests: endpointResults.length,
+      errors: endpointResults.filter((result) => !result.ok).length,
+      p50Ms: Math.round(percentile(durations, 50)),
+      p95Ms: Math.round(percentile(durations, 95)),
+      maxMs: Math.round(Math.max(...durations, 0)),
+      avgMs: Math.round(average(durations))
+    };
+  });
+}
+
+async function runWorker(workerId, currentRounds) {
+  const results = [];
+  for (let round = 1; round <= currentRounds; round += 1) {
+    for (const endpoint of endpoints) {
+      const result = await request(endpoint);
+      results.push({ ...result, workerId, round });
+    }
+  }
+  return results;
+}
+
+async function runStage(currentConcurrency) {
+  if (triggerResponseAnalysis) {
+    const triggerEndpoint = {
+      name: 'response-analysis-trigger',
+      path: `/admin/workspace/${workspaceId}/coding/response-analysis`
+    };
+    const result = await request(triggerEndpoint, { method: 'POST' });
+    console.log(JSON.stringify({ trigger: result }, null, 2));
+  }
+
+  const startedAt = performance.now();
+  const workerResults = await Promise.all(
+    Array.from({ length: currentConcurrency }, (_, index) => runWorker(index + 1, rounds))
+  );
+  const results = workerResults.flat();
+  const durationMs = performance.now() - startedAt;
+
+  return {
+    baseUrl,
+    workspaceId,
+    endpointSet,
+    concurrency: currentConcurrency,
+    rounds,
+    totalRequests: results.length,
+    durationMs: Math.round(durationMs),
+    summary: summarize(results)
+  };
+}
+
+const stages = concurrencyLevels.length ? concurrencyLevels : [concurrency];
+const stageResults = [];
+
+for (const stageConcurrency of stages) {
+  const result = await runStage(stageConcurrency);
+  stageResults.push(result);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  stages: stageResults
+};
+
+if (outputJson) {
+  await writeFile(outputJson, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+}

--- a/scripts/repro/redis-cache-hygiene.md
+++ b/scripts/repro/redis-cache-hygiene.md
@@ -1,0 +1,75 @@
+# Redis cache hygiene notes
+
+Use `scripts/repro/redis-cache-inventory.mjs` before deleting Redis data. The
+script is read-only and reports key counts, `MEMORY USAGE`, TTL distribution,
+and the largest keys grouped by Kodierbox/Bull prefix.
+
+## Current local finding
+
+Measured on the local scale-test Redis after the 5000-person workspace run:
+
+- `cache:responses`: about 72k keys, 1.8 GiB, all expiring. These are replay
+  response cache entries from `ResponseCacheSchedulerService`.
+- `queue:response-analysis`: 179 keys, 402 MiB, mostly without expiry. These
+  are Bull job hashes. Completed response-analysis jobs used to retain large
+  job return values.
+- `cache:response-analysis`: 39 keys, 108 MiB. These are application result
+  caches and derived page caches. Some have TTL, some are revision/run marker
+  style keys without expiry.
+- `cache:coding_applied_results_overview` and
+  `cache:workspace-overview-stats`: under 1 KiB each. They are not the Redis
+  pressure source.
+
+## Cleanup classes
+
+Safe to delete in local/performance test environments:
+
+- `coding-box:cache:responses:<workspaceId>:*`
+  Rebuilt from PostgreSQL on demand. Deleting this may make replay/unit-response
+  views cold again, but does not lose source data.
+- `coding-box:cache:response-analysis:<workspaceId>*`
+  Recomputed by response-analysis. Deleting this may trigger a new analysis.
+- Completed/stale Bull jobs in `coding-box:response-analysis:*`
+  These should not be used as the durable result store. Results live in
+  `cache:response-analysis:*`. New jobs now use `removeOnComplete` and
+  `removeOnFail` to prevent future accumulation.
+
+Do not delete blindly:
+
+- Active, waiting, or delayed Bull queue keys for imports, exports, validation,
+  coding jobs, and response-analysis. Use the process overview or Bull APIs to
+  confirm job state first.
+- `coding-box:cache:workspace_unit_variables:*` or similar workspace-file
+  derived caches while users are actively coding. They are rebuildable, but
+  deleting them can create avoidable cold UI work.
+- Revisioned overview caches for active workspaces unless invalidating after
+  data changes. They are tiny and intentionally no-expiry.
+
+## Recommended local cleanup sequence
+
+1. Run:
+
+   ```bash
+   node scripts/repro/redis-cache-inventory.mjs > /tmp/kodierbox-redis-inventory.json
+   ```
+
+2. If Redis memory pressure is local-test-only, delete expiring response cache
+   keys for the scale workspace first:
+
+   ```bash
+   docker exec kodierbox-redis-1 redis-cli --scan --pattern 'coding-box:cache:responses:54:*' \
+     | xargs -r -n 500 docker exec kodierbox-redis-1 redis-cli UNLINK
+   ```
+
+3. Clean completed response-analysis jobs through Bull/application APIs where
+   possible. Avoid raw deletion while a response-analysis job is active.
+
+4. Re-run the inventory and compare group totals.
+
+## Product follow-up
+
+- Keep `response-analysis` queue jobs small/short-lived. Completed jobs can be
+  removed because the API reads durable results from Redis cache keys.
+- Consider making the nightly response-cache warmup skip very large workspaces
+  or use a lower explicit TTL. The default 24h TTL can consume multiple GiB on
+  synthetic 5000-person data.

--- a/scripts/repro/redis-cache-inventory.mjs
+++ b/scripts/repro/redis-cache-inventory.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import Redis from 'ioredis';
+
+const host = process.env.REDIS_HOST || 'localhost';
+const port = Number.parseInt(process.env.REDIS_PORT || '6379', 10);
+const scanCount = Number.parseInt(process.env.SCAN_COUNT || '500', 10);
+const topLimit = Number.parseInt(process.env.TOP_LIMIT || '25', 10);
+const sampleLimit = Number.parseInt(process.env.SAMPLE_LIMIT || '0', 10);
+const namespacePrefix = process.env.REDIS_NAMESPACE_PREFIX || 'coding-box:';
+const cachePrefix = `${namespacePrefix}cache:`;
+
+const redis = new Redis({ host, port, lazyConnect: true, maxRetriesPerRequest: 1 });
+
+function logicalKey(key) {
+  if (key.startsWith(cachePrefix)) {
+    return key.slice(cachePrefix.length);
+  }
+  if (key.startsWith(namespacePrefix)) {
+    return key.slice(namespacePrefix.length);
+  }
+  return key;
+}
+
+function classify(key) {
+  const logical = logicalKey(key);
+  if (key.startsWith(cachePrefix)) {
+    const knownCachePrefixes = [
+      'response-analysis:',
+      'response_analysis:',
+      'response_analysis_page:',
+      'validation:v2:',
+      'responses:',
+      'manual_coding_variables:',
+      'manual_coding_scope_summary:',
+      'coding_statistics:',
+      'coding_statistics_version:',
+      'coding_applied_results_overview:',
+      'workspace-overview-stats-',
+      'flat_response_filter_options:',
+      'flat_responses_count:',
+      'flat-frequencies-',
+      'unit_variables:',
+      'workspace_unit_variables:'
+    ];
+    const match = knownCachePrefixes.find(prefix => logical.startsWith(prefix));
+    if (match) {
+      return `cache:${match.replace(/[:/-]$/, '')}`;
+    }
+    return `cache:${logical.split(/[:_-]/, 1)[0] || 'unknown'}`;
+  }
+
+  const queueMatch = logical.match(/^([^:]+):/);
+  if (queueMatch) {
+    return `queue:${queueMatch[1]}`;
+  }
+  return 'other';
+}
+
+function createStats() {
+  return {
+    keys: 0,
+    bytes: 0,
+    noExpire: 0,
+    expiring: 0,
+    missingMemory: 0,
+    minTtl: Number.POSITIVE_INFINITY,
+    maxTtl: 0
+  };
+}
+
+function addStats(stats, memoryBytes, ttl) {
+  stats.keys += 1;
+  if (Number.isFinite(memoryBytes)) {
+    stats.bytes += memoryBytes;
+  } else {
+    stats.missingMemory += 1;
+  }
+  if (ttl === -1) {
+    stats.noExpire += 1;
+  } else if (ttl > 0) {
+    stats.expiring += 1;
+    stats.minTtl = Math.min(stats.minTtl, ttl);
+    stats.maxTtl = Math.max(stats.maxTtl, ttl);
+  }
+}
+
+function humanBytes(bytes) {
+  const units = ['B', 'KiB', 'MiB', 'GiB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function serializeStats([group, stats]) {
+  return {
+    group,
+    keys: stats.keys,
+    bytes: stats.bytes,
+    humanBytes: humanBytes(stats.bytes),
+    noExpire: stats.noExpire,
+    expiring: stats.expiring,
+    minTtlSeconds: Number.isFinite(stats.minTtl) ? stats.minTtl : null,
+    maxTtlSeconds: stats.maxTtl || null,
+    missingMemory: stats.missingMemory
+  };
+}
+
+async function scanKeys() {
+  const groups = new Map();
+  const allStats = createStats();
+  const largest = [];
+  let cursor = '0';
+  let scanned = 0;
+
+  do {
+    const [nextCursor, keys] = await redis.scan(cursor, 'COUNT', scanCount);
+    cursor = nextCursor;
+    const batch = sampleLimit > 0 ?
+      keys.slice(0, Math.max(0, sampleLimit - scanned)) :
+      keys;
+    if (batch.length === 0) {
+      continue;
+    }
+    const pipeline = redis.pipeline();
+    batch.forEach(key => {
+      pipeline.memory('USAGE', key);
+      pipeline.ttl(key);
+      pipeline.type(key);
+    });
+    const replies = await pipeline.exec();
+    for (let index = 0; index < batch.length; index += 1) {
+      const key = batch[index];
+      const memoryReply = replies[index * 3];
+      const ttlReply = replies[index * 3 + 1];
+      const typeReply = replies[index * 3 + 2];
+      const memoryBytes = memoryReply?.[0] ? NaN : Number(memoryReply[1]);
+      const ttl = ttlReply?.[0] ? -2 : Number(ttlReply[1]);
+      const type = typeReply?.[0] ? 'unknown' : String(typeReply[1]);
+      const groupName = classify(key);
+      const group = groups.get(groupName) || createStats();
+
+      addStats(group, memoryBytes, ttl);
+      addStats(allStats, memoryBytes, ttl);
+      groups.set(groupName, group);
+
+      largest.push({
+        key,
+        group: groupName,
+        type,
+        ttlSeconds: ttl,
+        bytes: Number.isFinite(memoryBytes) ? memoryBytes : 0,
+        humanBytes: humanBytes(Number.isFinite(memoryBytes) ? memoryBytes : 0)
+      });
+    }
+    scanned += batch.length;
+  } while (cursor !== '0' && (sampleLimit === 0 || scanned < sampleLimit));
+
+  largest.sort((a, b) => b.bytes - a.bytes);
+  const sortedGroups = Array.from(groups.entries())
+    .map(serializeStats)
+    .sort((a, b) => b.bytes - a.bytes);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    redis: { host, port, namespacePrefix, scannedKeys: scanned },
+    totals: serializeStats(['all', allStats]),
+    groups: sortedGroups,
+    largestKeys: largest.slice(0, topLimit)
+  };
+}
+
+try {
+  await redis.connect();
+  const report = await scanKeys();
+  console.log(JSON.stringify(report, null, 2));
+} finally {
+  redis.disconnect();
+}

--- a/scripts/repro/workspace-consider-scale-load-test.mjs
+++ b/scripts/repro/workspace-consider-scale-load-test.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+
+/**
+ * Repro helper for scale tests without creating additional large workspaces.
+ *
+ * It temporarily changes persons.consider in an existing scale workspace to
+ * emulate 1k/2.5k/5k active test persons, clears relevant caches, measures
+ * selected API endpoints, and restores the original consider flags.
+ *
+ * Example:
+ * AUTH_TOKEN=... WORKSPACE_ID=54 TIERS=1000,2500,5000 CONCURRENCY_LEVELS=1,4 \
+ *   node scripts/repro/workspace-consider-scale-load-test.mjs
+ *
+ * Optional ENDPOINTS:
+ * - overview
+ * - geogebra
+ * - applied
+ * - readiness (uses forceRefresh=true and can be expensive on large workspaces)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import { performance } from 'node:perf_hooks';
+
+const authToken = process.env.AUTH_TOKEN;
+const baseUrl = process.env.BASE_URL || 'http://localhost:3333/api';
+const workspaceId = Number.parseInt(process.env.WORKSPACE_ID || '54', 10);
+const tiers = (process.env.TIERS || '1000,2500,5000')
+  .split(',')
+  .map(value => Number.parseInt(value.trim(), 10))
+  .filter(value => Number.isInteger(value) && value > 0);
+const concurrencyLevels = (process.env.CONCURRENCY_LEVELS || '1,4')
+  .split(',')
+  .map(value => Number.parseInt(value.trim(), 10))
+  .filter(value => Number.isInteger(value) && value > 0);
+const rounds = Number.parseInt(process.env.ROUNDS || '1', 10);
+const dbContainer = process.env.DB_CONTAINER || 'kodierbox-db-1';
+const redisContainer = process.env.REDIS_CONTAINER || 'kodierbox-redis-1';
+const outputJson = process.env.OUTPUT_JSON;
+const requestedEndpointNames = (process.env.ENDPOINTS || 'overview,geogebra,applied')
+  .split(',')
+  .map(value => value.trim())
+  .filter(Boolean);
+
+if (!authToken) {
+  throw new Error('AUTH_TOKEN is required.');
+}
+if (!Number.isInteger(workspaceId) || workspaceId <= 0) {
+  throw new Error('WORKSPACE_ID must be a positive integer.');
+}
+if (tiers.length === 0) {
+  throw new Error('TIERS must contain at least one positive integer.');
+}
+if (concurrencyLevels.length === 0) {
+  throw new Error('CONCURRENCY_LEVELS must contain at least one positive integer.');
+}
+if (!Number.isInteger(rounds) || rounds <= 0) {
+  throw new Error('ROUNDS must be a positive integer.');
+}
+
+const endpointCatalog = {
+  overview: {
+    name: 'test-results-overview',
+    path: `/admin/workspace/${workspaceId}/test-results/overview`
+  },
+  geogebra: {
+    name: 'geogebra-existence',
+    path: `/admin/workspace/${workspaceId}/responses/geogebra-existence`
+  },
+  readiness: {
+    name: 'coding-readiness',
+    path: `/admin/workspace/${workspaceId}/coding/readiness?autoCoderRun=1&forceRefresh=true`
+  },
+  applied: {
+    name: 'applied-results-overview',
+    path: `/admin/workspace/${workspaceId}/coding/applied-results-overview`
+  }
+};
+
+const endpoints = requestedEndpointNames.map(name => {
+  const endpoint = endpointCatalog[name];
+  if (!endpoint) {
+    throw new Error(
+      `Unknown endpoint "${name}". Supported: ${Object.keys(endpointCatalog).join(', ')}.`
+    );
+  }
+  return endpoint;
+});
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+    ...options
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} failed:\n${result.stderr || result.stdout}`
+    );
+  }
+  return result.stdout;
+}
+
+function sql(query) {
+  return run('docker', [
+    'exec',
+    dbContainer,
+    'psql',
+    '-U',
+    'root',
+    '-d',
+    'coding-box',
+    '-At',
+    '-v',
+    'ON_ERROR_STOP=1',
+    '-c',
+    query
+  ]).trim();
+}
+
+function captureOriginalConsiderState() {
+  const rows = sql(`
+    SELECT id || ':' || CASE WHEN consider THEN '1' ELSE '0' END
+    FROM persons
+    WHERE workspace_id = ${workspaceId}
+    ORDER BY id
+  `);
+  return rows ? rows.split('\n') : [];
+}
+
+function restoreOriginalConsiderState(rows) {
+  if (rows.length === 0) {
+    return;
+  }
+  const falseIds = rows
+    .filter(row => row.endsWith(':0'))
+    .map(row => Number.parseInt(row.split(':')[0], 10))
+    .filter(Number.isInteger);
+
+  sql(`UPDATE persons SET consider = true WHERE workspace_id = ${workspaceId}`);
+  if (falseIds.length > 0) {
+    sql(`
+      UPDATE persons
+      SET consider = false
+      WHERE workspace_id = ${workspaceId}
+        AND id IN (${falseIds.join(',')})
+    `);
+  }
+}
+
+function setActivePersons(activePersons) {
+  sql(`
+    WITH ranked AS (
+      SELECT id, row_number() OVER (ORDER BY id) AS rn
+      FROM persons
+      WHERE workspace_id = ${workspaceId}
+    )
+    UPDATE persons p
+    SET consider = ranked.rn <= ${activePersons}
+    FROM ranked
+    WHERE p.id = ranked.id
+  `);
+  return Number.parseInt(sql(`
+    SELECT count(*)
+    FROM persons
+    WHERE workspace_id = ${workspaceId}
+      AND consider = true
+  `), 10);
+}
+
+function redisScan(pattern) {
+  const output = run('docker', [
+    'exec',
+    redisContainer,
+    'redis-cli',
+    '--scan',
+    '--pattern',
+    pattern
+  ]);
+  return output.split('\n').map(line => line.trim()).filter(Boolean);
+}
+
+function clearRedisPattern(pattern) {
+  const keys = redisScan(pattern);
+  for (let index = 0; index < keys.length; index += 200) {
+    const chunk = keys.slice(index, index + 200);
+    if (chunk.length > 0) {
+      run('docker', ['exec', redisContainer, 'redis-cli', 'UNLINK', ...chunk]);
+    }
+  }
+  return keys.length;
+}
+
+function clearWorkspaceCaches() {
+  const patterns = [
+    `*workspace-overview-stats-${workspaceId}*`,
+    `*geogebra-existence:${workspaceId}*`,
+    `*coding_readiness:${workspaceId}*`,
+    `*coding_applied_results_overview*${workspaceId}*`,
+    `*flat_responses_count:${workspaceId}*`,
+    `*response-analysis:${workspaceId}*`
+  ];
+  return Object.fromEntries(
+    patterns.map(pattern => [pattern, clearRedisPattern(pattern)])
+  );
+}
+
+async function request(endpoint) {
+  const startedAt = performance.now();
+  const response = await fetch(`${baseUrl}${endpoint.path}`, {
+    headers: { Authorization: `Bearer ${authToken}` }
+  });
+  const text = await response.text();
+  return {
+    endpoint: endpoint.name,
+    status: response.status,
+    ok: response.ok,
+    durationMs: performance.now() - startedAt,
+    bytes: Buffer.byteLength(text)
+  };
+}
+
+function percentile(values, percent) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil((percent / 100) * sorted.length) - 1
+  );
+  return sorted[index];
+}
+
+function summarize(results) {
+  return endpoints.map(endpoint => {
+    const endpointResults = results.filter(
+      result => result.endpoint === endpoint.name
+    );
+    const durations = endpointResults.map(result => result.durationMs);
+    return {
+      endpoint: endpoint.name,
+      requests: endpointResults.length,
+      errors: endpointResults.filter(result => !result.ok).length,
+      p50Ms: Math.round(percentile(durations, 50)),
+      p95Ms: Math.round(percentile(durations, 95)),
+      maxMs: Math.round(Math.max(...durations, 0))
+    };
+  });
+}
+
+async function runStage(concurrency) {
+  const startedAt = performance.now();
+  const workers = await Promise.all(
+    Array.from({ length: concurrency }, async (_, index) => {
+      const results = [];
+      for (let round = 1; round <= rounds; round += 1) {
+        for (const endpoint of endpoints) {
+          results.push({
+            ...(await request(endpoint)),
+            workerId: index + 1,
+            round
+          });
+        }
+      }
+      return results;
+    })
+  );
+  const results = workers.flat();
+  return {
+    concurrency,
+    rounds,
+    totalRequests: results.length,
+    durationMs: Math.round(performance.now() - startedAt),
+    summary: summarize(results)
+  };
+}
+
+const originalConsiderState = captureOriginalConsiderState();
+const report = {
+  generatedAt: new Date().toISOString(),
+  baseUrl,
+  workspaceId,
+  endpoints: requestedEndpointNames,
+  tiers: []
+};
+
+try {
+  for (const tier of tiers) {
+    const activePersons = setActivePersons(tier);
+    const clearedCaches = clearWorkspaceCaches();
+    const tierResult = {
+      requestedPersons: tier,
+      activePersons,
+      clearedCaches,
+      stages: []
+    };
+    for (const concurrency of concurrencyLevels) {
+      tierResult.stages.push(await runStage(concurrency));
+    }
+    report.tiers.push(tierResult);
+    console.log(JSON.stringify(tierResult, null, 2));
+  }
+} finally {
+  restoreOriginalConsiderState(originalConsiderState);
+  clearWorkspaceCaches();
+}
+
+if (outputJson) {
+  await writeFile(outputJson, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+}


### PR DESCRIPTION
## What changed

Split the non-production tooling from #830.

- adds a Cypress performance scenario for manual coding
- adds SQL repro fixtures for scaled manual-coding workspaces
- adds API/cache hygiene and load-test helper scripts under `scripts/repro`

## Why

These files are useful for reproducing and measuring the problem, but they should not be coupled to production frontend/backend behavior changes.

## Validation

- `npx nx lint frontend --skip-nx-cache`

The Cypress scenario was not run here because it needs a seeded/manual-coding environment.
