### PR TITLE
Fix coding scheme alias collisions

### DIFF
--- a/apps/backend/src/app/database/services/coding/codebook-generation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/codebook-generation.service.spec.ts
@@ -175,6 +175,52 @@ describe('CodebookGenerationService', () => {
     ]);
   });
 
+  it('prefers public aliases over colliding technical ids when filtering codebook variables', async () => {
+    repository.find.mockResolvedValue([
+      {
+        id: 1,
+        file_id: 'DHB003.VOCS',
+        filename: 'DHB003.vocs',
+        data: JSON.stringify({
+          version: '3.0',
+          variableCodings: [
+            {
+              id: '04',
+              alias: '02',
+              sourceType: 'BASE',
+              codes: []
+            },
+            {
+              id: '07',
+              alias: '04',
+              sourceType: 'BASE',
+              codes: []
+            }
+          ]
+        }),
+        structured_data: null
+      }
+    ]);
+    jobDefinitionRepository.findOne.mockResolvedValue({
+      assigned_variables: [
+        { unitName: 'DHB003', variableId: '04' }
+      ],
+      assigned_variable_bundles: []
+    });
+    variableBundleRepository.find.mockResolvedValue([]);
+
+    await service.generateCodebook(7, 0, {
+      ...contentOptions,
+      jobDefinitionId: 12
+    }, [1]);
+
+    const scopedUnits = (CodebookGenerator.generateCodebook as jest.Mock)
+      .mock.calls[0][0] as Array<{ key: string; scheme: string }>;
+    expect(JSON.parse(scopedUnits[0].scheme).variableCodings).toEqual([
+      expect.objectContaining({ id: '07', alias: '04' })
+    ]);
+  });
+
   it('limits generated codebook variables to selected variable bundles', async () => {
     repository.find.mockResolvedValue([
       {

--- a/apps/backend/src/app/database/services/coding/codebook-generation.service.ts
+++ b/apps/backend/src/app/database/services/coding/codebook-generation.service.ts
@@ -385,9 +385,10 @@ export class CodebookGenerationService {
         return null;
       }
 
-      const variableCodings = scheme.variableCodings.filter(variableCoding => (
-        this.matchesAllowedVariable(variableCoding, allowedVariables)
-      ));
+      const variableCodings = this.filterVariableCodingsByAllowedVariables(
+        scheme.variableCodings,
+        allowedVariables
+      );
 
       if (variableCodings.length === 0) {
         return null;
@@ -408,13 +409,35 @@ export class CodebookGenerationService {
     }
   }
 
-  private matchesAllowedVariable(
-    variableCoding: { id?: string; alias?: string },
+  private filterVariableCodingsByAllowedVariables(
+    variableCodings: Array<{ id?: string; alias?: string }>,
     allowedVariables: Set<string>
-  ): boolean {
-    return [variableCoding.id, variableCoding.alias]
-      .map(value => this.normalizeVariableId(value))
-      .some(value => value !== '' && allowedVariables.has(value));
+  ): Array<{ id?: string; alias?: string }> {
+    const aliasesInScheme = new Set(
+      variableCodings
+        .map(variableCoding => this.normalizeVariableId(variableCoding.alias))
+        .filter(alias => alias !== '')
+    );
+    const allowedAliasVariables = new Set<string>();
+    const allowedIdVariables = new Set<string>();
+
+    allowedVariables.forEach(variableId => {
+      if (aliasesInScheme.has(variableId)) {
+        allowedAliasVariables.add(variableId);
+      } else {
+        allowedIdVariables.add(variableId);
+      }
+    });
+
+    return variableCodings.filter(variableCoding => {
+      const alias = this.normalizeVariableId(variableCoding.alias);
+      if (alias && allowedAliasVariables.has(alias)) {
+        return true;
+      }
+
+      const id = this.normalizeVariableId(variableCoding.id);
+      return id !== '' && allowedIdVariables.has(id);
+    });
   }
 
   private normalizeUnitKey(value: string | undefined): string {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -3400,6 +3400,86 @@ describe('CodingJobService', () => {
     );
   });
 
+  it('prefers coding scheme aliases over colliding technical ids when saving progress', async () => {
+    const job = { id: 1, workspace_id: 3 };
+    const unit = {
+      coding_job_id: 1,
+      unit_name: 'DHB003',
+      unit_alias: 'DHB003',
+      variable_id: '04',
+      person_login: 'login',
+      person_code: 'code',
+      booklet_name: 'booklet',
+      is_open: false,
+      code: null,
+      score: null,
+      coding_issue_option: null,
+      notes: null
+    };
+    codingJobRepository.findOne.mockResolvedValue(job);
+    codingJobUnitRepository.findOne.mockResolvedValue(unit);
+    fileUploadRepository.find
+      .mockResolvedValueOnce([
+        {
+          file_id: 'DHB003',
+          data: '<Unit><CodingSchemeRef>DHB003</CodingSchemeRef></Unit>'
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          file_id: 'DHB003.VOCS',
+          data: {
+            variableCodings: [
+              {
+                id: '04',
+                alias: '02',
+                codes: [
+                  {
+                    id: 2,
+                    code: '2',
+                    label: 'Visible 02',
+                    score: 2,
+                    manualInstruction: '<p>Manual 02</p>'
+                  }
+                ]
+              },
+              {
+                id: '07',
+                alias: '04',
+                codes: [
+                  {
+                    id: 4,
+                    code: '4',
+                    label: 'Visible 04',
+                    score: 4,
+                    manualInstruction: '<p>Manual 04</p>'
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]);
+    (
+      service as unknown as { checkAndUpdateCodingJobCompletion: jest.Mock }
+    ).checkAndUpdateCodingJobCompletion = jest.fn();
+
+    await service.saveCodingProgress(1, {
+      testPerson: 'login@code@booklet',
+      unitId: 'DHB003',
+      variableId: '04',
+      selectedCode: { id: 4, score: 999 }
+    } as never);
+
+    expect(codingJobUnitRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 4,
+        score: 4,
+        is_open: false
+      })
+    );
+  });
+
   it('uses the group segment when saving grouped test person progress', async () => {
     const job = { id: 1, workspace_id: 3 };
     const unit = {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -3872,8 +3872,16 @@ export class CodingJobService {
     codingScheme: CodingScheme,
     variableId: string
   ): CodingSchemeVariableCoding | undefined {
-    return codingScheme.variableCodings?.find(
-      vc => vc.id === variableId || vc.alias === variableId
+    const normalizedVariableId = String(variableId || '').trim();
+    if (!normalizedVariableId) {
+      return undefined;
+    }
+
+    const variableCodings = codingScheme.variableCodings || [];
+    return variableCodings.find(
+      vc => String(vc.alias || '').trim() === normalizedVariableId
+    ) || variableCodings.find(
+      vc => String(vc.id || '').trim() === normalizedVariableId
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -264,6 +264,53 @@ describe('ExternalCodingImportService', () => {
     });
   });
 
+  it('prefers coding scheme aliases over colliding technical ids when validating imported codes', async () => {
+    const service = new ExternalCodingImportService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      { delete: jest.fn().mockResolvedValue(undefined) } as never,
+      { markManualCodingCurrent: jest.fn().mockResolvedValue(undefined) } as never
+    );
+    jest.spyOn(service as unknown as {
+      getCodingSchemeForUnit: () => Promise<unknown>;
+    }, 'getCodingSchemeForUnit')
+      .mockResolvedValue({
+        variableCodings: [
+          {
+            id: '04',
+            alias: '02',
+            codes: [{ id: 4, score: 99 }]
+          },
+          {
+            id: '07',
+            alias: '04',
+            codes: [{ id: 4, score: 4 }]
+          }
+        ]
+      });
+
+    const result = await (service as unknown as {
+      validateCodeAgainstScheme: (
+        unit: unknown,
+        variableId: string,
+        code: number | null
+      ) => Promise<{ isValid: boolean; score: number | null; status: string }>;
+    }).validateCodeAgainstScheme(
+      { id: 1, name: 'DHB003', alias: 'DHB003' },
+      '04',
+      4
+    );
+
+    expect(result).toEqual({
+      isValid: true,
+      score: 4,
+      status: 'CODING_COMPLETE'
+    });
+  });
+
   it('rejects unchanged coding-list exports with status_v1 as coding lists, not coding-results', async () => {
     const service = new ExternalCodingImportService(
       {} as never,

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
@@ -1045,7 +1045,7 @@ export class ExternalCodingImportService {
       }
 
       const variableCoding = Array.isArray(codingScheme.variableCodings) ?
-        codingScheme.variableCodings.find(vc => vc.id === variableId) : null;
+        this.findVariableCoding(codingScheme.variableCodings, variableId) : null;
 
       if (!variableCoding) {
         // Variable not found in coding scheme, leave as CODING_INCOMPLETE
@@ -1102,6 +1102,22 @@ export class ExternalCodingImportService {
       .trim()
       .toLowerCase()
       .replace(/[\s-]+/g, '_');
+  }
+
+  private findVariableCoding<T extends { id?: string | number; alias?: string | number }>(
+    variableCodings: T[],
+    variableId: string
+  ): T | undefined {
+    const normalizedVariableId = String(variableId || '').trim();
+    if (!normalizedVariableId) {
+      return undefined;
+    }
+
+    return variableCodings.find(variableCoding => (
+      String(variableCoding.alias || '').trim() === normalizedVariableId
+    )) || variableCodings.find(variableCoding => (
+      String(variableCoding.id || '').trim() === normalizedVariableId
+    ));
   }
 
   private normalizeCellValue(value: unknown): string {

--- a/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.spec.ts
@@ -418,6 +418,53 @@ describe('VariableAnalysisReplayService', () => {
     expect(result.data[0].replayUrl).toContain('/MDB002/2/02?auth=token&workspaceId=7');
   });
 
+  it('prefers coding scheme aliases over colliding technical ids for analysis metadata', async () => {
+    fileUploadRepository.find.mockResolvedValueOnce([
+      {
+        file_id: 'MDB002.VOCS',
+        data: JSON.stringify({
+          variableCodings: [
+            {
+              id: '02',
+              alias: '01',
+              sourceType: 'BASE',
+              label: 'Technische Variable 02'
+            },
+            {
+              id: '07',
+              alias: '02',
+              sourceType: 'DERIVED',
+              label: 'Sichtbare Variable 02'
+            }
+          ]
+        })
+      }
+    ]);
+    workspaceFilesService.getUnitVariableMap.mockResolvedValueOnce(new Map([
+      ['MDB002', new Set(['02'])]
+    ]));
+
+    const result = await service.getVariableAnalysis(
+      7,
+      'token',
+      'http://server',
+      1,
+      10,
+      undefined,
+      undefined,
+      'derived'
+    );
+
+    expect(result.total).toBe(1);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toMatchObject({
+      unitId: 'MDB002',
+      variableId: '02',
+      derivation: 'DERIVED',
+      description: 'Sichtbare Variable 02'
+    });
+  });
+
   it('uses a regex variable filter when requested', async () => {
     const result = await service.getVariableAnalysis(
       7,

--- a/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.ts
+++ b/apps/backend/src/app/database/services/test-results/variable-analysis-replay.service.ts
@@ -20,6 +20,7 @@ import { generateReplayUrl } from '../../../utils/replay-url.util';
 interface CodingScheme {
   variableCodings?: {
     id: string;
+    alias?: string;
     sourceType?: string;
     label?: string;
   }[];
@@ -447,13 +448,18 @@ export class VariableAnalysisReplayService {
     codingSchemeMap: Map<string, CodingScheme>,
     unitId: string,
     variableId: string
-  ): { id: string; sourceType?: string; label?: string } | undefined {
+  ): { id: string; alias?: string; sourceType?: string; label?: string } | undefined {
     const codingScheme = codingSchemeMap.get(unitId);
     if (!codingScheme?.variableCodings || !Array.isArray(codingScheme.variableCodings)) {
       return undefined;
     }
 
-    return codingScheme.variableCodings.find(vc => vc.id === variableId);
+    const normalizedVariableId = String(variableId || '').trim();
+    return codingScheme.variableCodings.find(vc => (
+      String(vc.alias || '').trim() === normalizedVariableId
+    )) || codingScheme.variableCodings.find(vc => (
+      String(vc.id || '').trim() === normalizedVariableId
+    ));
   }
 
   private toVariablePairKey(unitId: string, variableId: string): string {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -308,6 +308,70 @@ describe('CodeSelectorComponent', () => {
     });
   });
 
+  it('prefers variable aliases over colliding technical ids when loading codes', () => {
+    const collisionCodingScheme: CodingScheme = {
+      version: '1.0',
+      variableCodings: [
+        {
+          id: '04',
+          alias: '02',
+          label: 'Visible 02',
+          sourceType: 'BASE',
+          processing: [],
+          codeModel: 'MANUAL_AND_RULES',
+          manualInstruction: '',
+          codes: [
+            {
+              id: 2,
+              type: 'FULL_CREDIT',
+              label: 'Code for visible 02',
+              score: 2,
+              ruleSetOperatorAnd: false,
+              ruleSets: [],
+              manualInstruction: '<p>Manual 02</p>'
+            }
+          ]
+        },
+        {
+          id: '07',
+          alias: '04',
+          label: 'Visible 04',
+          sourceType: 'BASE',
+          processing: [],
+          codeModel: 'MANUAL_AND_RULES',
+          manualInstruction: '',
+          codes: [
+            {
+              id: 4,
+              type: 'FULL_CREDIT',
+              label: 'Code for visible 04',
+              score: 4,
+              ruleSetOperatorAnd: false,
+              ruleSets: [],
+              manualInstruction: '<p>Manual 04</p>'
+            }
+          ]
+        }
+      ]
+    };
+    const emitSpy = jest.spyOn(component.codeSelected, 'emit');
+
+    component.codingScheme = collisionCodingScheme;
+    component.variableId = '04';
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, collisionCodingScheme, false),
+      variableId: new SimpleChange(null, '04', false)
+    });
+    component.onSelect(4);
+
+    expect(component.regularCodes.map(code => code.id)).toEqual([4]);
+    expect(emitSpy).toHaveBeenCalledWith({
+      variableId: '04',
+      code: collisionCodingScheme.variableCodings[1].codes[0],
+      codingIssueOption: null
+    });
+  });
+
   it('shows review coder badges for codes selected by previous coders', () => {
     const translateService = TestBed.inject(TranslateService);
     translateService.setTranslation('de', {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -28,10 +28,10 @@ import {
   CodeSelectedEvent,
   CodingScheme,
   SelectableItem,
-  CodingIssueDto,
-  VariableCoding
+  CodingIssueDto
 } from '../../../models/coding-interfaces';
 import { hasManualInstruction } from '../../utils/manual-coding.util';
+import { findVariableCodingByPublicId } from '../../utils/coding-scheme.util';
 
 interface NavigationItem {
   key: string;
@@ -171,9 +171,7 @@ export class CodeSelectorComponent implements OnChanges {
     }
     this.hasResolvedCodingScheme = true;
 
-    const variableCoding = scheme.variableCodings.find(
-      (v: VariableCoding) => v.alias === this.variableId || v.id === this.variableId
-    );
+    const variableCoding = findVariableCodingByPublicId(scheme, this.variableId);
     if (variableCoding) {
       this.variableManualInstruction = variableCoding.manualInstruction || null;
       this.allRegularCodeItems = variableCoding.codes

--- a/apps/frontend/src/app/coding/components/export-coding-book/export-coding-book.component.ts
+++ b/apps/frontend/src/app/coding/components/export-coding-book/export-coding-book.component.ts
@@ -637,14 +637,14 @@ export class ExportCodingBookComponent implements OnInit, OnDestroy {
       const scheme = JSON.parse(unit.unitData) as {
         variableCodings?: Array<{ id?: string; alias?: string }>;
       };
-      const matchingVariableCoding = (scheme.variableCodings || [])
-        .find(variableCoding => (
-          variableCoding.id?.trim() === variableId ||
-          variableCoding.alias?.trim() === variableId
-        ));
+      const variableCodings = scheme.variableCodings || [];
+      const matchingVariableCoding = variableCodings
+        .find(variableCoding => variableCoding.alias?.trim() === variableId) ||
+        variableCodings
+          .find(variableCoding => variableCoding.id?.trim() === variableId);
 
-      return matchingVariableCoding?.id?.trim() ||
-        matchingVariableCoding?.alias?.trim() ||
+      return matchingVariableCoding?.alias?.trim() ||
+        matchingVariableCoding?.id?.trim() ||
         variableId;
     } catch {
       return variableId;

--- a/apps/frontend/src/app/coding/utils/coding-scheme.util.spec.ts
+++ b/apps/frontend/src/app/coding/utils/coding-scheme.util.spec.ts
@@ -1,0 +1,21 @@
+import { CodingScheme } from '../../models/coding-interfaces';
+import { findVariableCodingByPublicId } from './coding-scheme.util';
+
+describe('findVariableCodingByPublicId', () => {
+  const collisionScheme = {
+    version: '1.0',
+    variableCodings: [
+      { id: '04', alias: '02', codes: [] },
+      { id: '07', alias: '04', codes: [] }
+    ]
+  } as unknown as CodingScheme;
+
+  it('prefers public aliases over colliding technical ids', () => {
+    expect(findVariableCodingByPublicId(collisionScheme, '02')?.id).toBe('04');
+    expect(findVariableCodingByPublicId(collisionScheme, '04')?.id).toBe('07');
+  });
+
+  it('falls back to technical ids when no alias matches', () => {
+    expect(findVariableCodingByPublicId(collisionScheme, '07')?.alias).toBe('04');
+  });
+});

--- a/apps/frontend/src/app/coding/utils/coding-scheme.util.ts
+++ b/apps/frontend/src/app/coding/utils/coding-scheme.util.ts
@@ -1,0 +1,19 @@
+import { CodingScheme, VariableCoding } from '../../models/coding-interfaces';
+
+export function findVariableCodingByPublicId(
+  codingScheme: Pick<CodingScheme, 'variableCodings'> | null | undefined,
+  variableId: string | null | undefined
+): VariableCoding | undefined {
+  const normalizedVariableId = String(variableId || '').trim();
+  if (!normalizedVariableId) {
+    return undefined;
+  }
+
+  const variableCodings = codingScheme?.variableCodings || [];
+
+  return variableCodings.find(variableCoding => (
+    String(variableCoding.alias || '').trim() === normalizedVariableId
+  )) || variableCodings.find(variableCoding => (
+    String(variableCoding.id || '').trim() === normalizedVariableId
+  ));
+}

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -43,6 +43,7 @@ import { ReplayCodingService } from '../../services/replay-coding.service';
 import { base64ToUtf8 } from '../../../shared/utils/common-utils';
 import { CodingJobBackendService } from '../../../coding/services/coding-job-backend.service';
 import { hasManualInstruction } from '../../../coding/utils/manual-coding.util';
+import { findVariableCodingByPublicId } from '../../../coding/utils/coding-scheme.util';
 import {
   CODING_JOB_WORKSPACE_TOKEN_SCOPES,
   REPLAY_WORKSPACE_TOKEN_SCOPES,
@@ -1463,11 +1464,12 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         keyboardEvent.preventDefault();
         const codeId = parseInt(keyboardEvent.key, 10);
         if (this.codingService.codingScheme) {
-          const variableCoding = this.codingService.codingScheme.variableCodings.find(
-            (v: any) => v.alias === this.codingService.currentVariableId || v.id === this.codingService.currentVariableId
+          const variableCoding = findVariableCodingByPublicId(
+            this.codingService.codingScheme,
+            this.codingService.currentVariableId
           );
           if (variableCoding) {
-            const code = variableCoding.codes.find((c: any) => c.id === codeId && hasManualInstruction(c));
+            const code = variableCoding.codes.find(c => c.id === codeId && hasManualInstruction(c));
             if (code) {
               this.onCodeSelected({
                 variableId: this.codingService.currentVariableId,

--- a/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
@@ -382,6 +382,32 @@ describe('ReplayCodingService', () => {
     });
   });
 
+  describe('findCodeById', () => {
+    it('prefers variable aliases over colliding technical ids', () => {
+      service.currentVariableId = '04';
+      service.codingScheme = {
+        version: '1.0',
+        variableCodings: [
+          {
+            id: '04',
+            alias: '02',
+            codes: [{ id: 2, label: 'Code for visible 02', score: 2 }]
+          },
+          {
+            id: '07',
+            alias: '04',
+            codes: [{ id: 4, label: 'Code for visible 04', score: 4 }]
+          }
+        ]
+      } as never;
+
+      expect(service.findCodeById(4)).toEqual(
+        expect.objectContaining({ label: 'Code for visible 04' })
+      );
+      expect(service.findCodeById(2)).toBeNull();
+    });
+  });
+
   describe('handleCodeSelected', () => {
     it('persists deselection before clearing local progress', async () => {
       codingJobBackendServiceMock.saveCodingProgress.mockReturnValue(of({} as CodingJob));

--- a/apps/frontend/src/app/replay/services/replay-coding.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.ts
@@ -4,8 +4,9 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { firstValueFrom } from 'rxjs';
 import { CodingJobBackendService } from '../../coding/services/coding-job-backend.service';
 import {
-  Code, VariableCoding, CodingScheme, CodeSelectedEvent
+  Code, CodingScheme, CodeSelectedEvent
 } from '../../models/coding-interfaces';
+import { findVariableCodingByPublicId } from '../../coding/utils/coding-scheme.util';
 import { UnitsReplay, UnitsReplayUnit } from './units-replay.service';
 
 interface SavedCode {
@@ -205,8 +206,9 @@ export class ReplayCodingService {
       return null;
     }
 
-    const variableCoding = this.codingScheme.variableCodings?.find(
-      (v: VariableCoding) => v.alias === this.currentVariableId || v.id === this.currentVariableId
+    const variableCoding = findVariableCodingByPublicId(
+      this.codingScheme,
+      this.currentVariableId
     );
     if (variableCoding) {
       return variableCoding.codes?.find((c: Code) => c.id === codeId) || null;


### PR DESCRIPTION
## What changed

- Resolve coding scheme variable lookups alias-first, with technical `id` only as fallback.
- Use the shared frontend helper in manual code selection and replay code lookup.
- Apply the same alias-first behavior in backend coding progress validation, external coding import validation, replay analysis metadata, and codebook variable filtering.
- Add regression tests for DHB003-style collisions, where one variable has `id=04, alias=02` and another has `id=07, alias=04`.

## Why

DHB003 exposes public variable IDs through `alias`, while the VOCS file also contains technical IDs that can collide with those public IDs. Several places previously matched `alias === variableId || id === variableId`, so a visible variable such as `04` could resolve to the technical `id=04` entry instead of the public `alias=04` entry.

This fixes future resolution for manual coding jobs, code selectors, replay metadata, codebook export filtering, and imported manual coding results.

## Operational note

This does not rewrite existing `coding_job_unit` rows or existing response status/code values. Existing DHB003 training/jobs created before the fix should be recreated after deployment where needed.

The DHB003_02 case count discrepancy remains intentionally separate: if only 8 instead of about 630 cases are considered coding-needed after a fresh Autocoder-1 run, that needs status/autocoder-result analysis rather than UI alias resolution.

Refs #803

## Checks

- `npx nx lint frontend`
- `npx nx lint backend`
- `npx nx test frontend --testPathPattern=... --runInBand` (ran the frontend suite: 186 passed, 1653 tests)
- `npx nx test backend --runTestsByPath apps/backend/src/app/database/services/coding/codebook-generation.service.spec.ts` (ran the backend suite: 134 passed, 1 skipped; 1953 tests passed)
