### PR TITLE
Avoid automatic coding job reloads

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
@@ -751,7 +751,14 @@ describe('CodingJobsComponent', () => {
     expect(matSnackBarMock.open).toHaveBeenCalled();
   }));
 
-  it('should handle window focus', () => {
+  it('should ignore window focus by default', () => {
+    const loadSpy = jest.spyOn(component, 'loadCodingJobs');
+    window.dispatchEvent(new Event('focus'));
+    expect(loadSpy).not.toHaveBeenCalled();
+  });
+
+  it('should handle window focus when auto reload is enabled', () => {
+    component.autoReloadOnFocus = true;
     const loadSpy = jest.spyOn(component, 'loadCodingJobs');
     window.dispatchEvent(new Event('focus'));
     expect(loadSpy).toHaveBeenCalled();

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
@@ -226,7 +226,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
   @Input() showTransferAction = true;
   @Input() showApplyActions = true;
   @Input() showBulkDeleteAction = true;
-  @Input() autoReloadOnFocus = true;
+  @Input() autoReloadOnFocus = false;
 
   private handleWindowFocus = () => {
     if (!this.autoReloadOnFocus || this.isLoading) {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -1146,7 +1146,8 @@
         </div>
 
         <div
-          *ngIf="isManualTab('planning')"
+          *ngIf="shouldRenderManualTab('planning')"
+          [hidden]="!isManualTab('planning')"
           id="manual-planning"
           class="job-definitions-container"
         >
@@ -1163,8 +1164,8 @@
             </button>
           </div>
           <coding-box-coding-job-definitions
-            (bulkCreationCompleted)="reloadCodingJobsList()"
-            (jobDefinitionChanged)="onJobDefinitionChanged()"
+            (bulkCreationCompleted)="reloadCodingJobsList('productive')"
+            (jobDefinitionChanged)="onJobDefinitionChanged('productive')"
           ></coding-box-coding-job-definitions>
         </div>
 
@@ -1396,7 +1397,8 @@
         </div>
 
         <div
-          *ngIf="isManualTab('execution')"
+          *ngIf="shouldRenderManualTab('execution')"
+          [hidden]="!isManualTab('execution')"
           id="manual-execution"
           class="coding-jobs-container manual-section-block"
         >
@@ -1471,13 +1473,14 @@
           </div>
 
           <coding-box-coding-jobs
+            #productiveCodingJobs
             [jobScope]="'productive'"
             [showTrainingFilter]="false"
             [showComparisonActions]="false"
             [showTransferAction]="false"
             [showApplyActions]="false"
-            [autoReloadOnFocus]="autoRefreshManualCodingJobs"
-            (jobsChanged)="onJobDefinitionChanged()"
+            [autoReloadOnFocus]="false"
+            (jobsChanged)="onJobDefinitionChanged('productive')"
           ></coding-box-coding-jobs>
         </div>
 
@@ -1881,7 +1884,8 @@
         </div>
 
         <div
-          *ngIf="isManualTab('training')"
+          *ngIf="shouldRenderManualTab('training')"
+          [hidden]="!isManualTab('training')"
           id="manual-support"
           class="coder-training-list-container manual-section-block"
         >
@@ -1977,13 +1981,14 @@
           <div class="coding-jobs-container manual-section-block">
             <h3 class="manual-section-title">Kodierjobs</h3>
             <coding-box-coding-jobs
+              #trainingCodingJobs
               [jobScope]="'training'"
               [showTrainingFilter]="true"
               [showComparisonActions]="false"
               [showTransferAction]="false"
               [showApplyActions]="false"
-              [autoReloadOnFocus]="autoRefreshManualCodingJobs"
-              (jobsChanged)="onJobDefinitionChanged()"
+              [autoReloadOnFocus]="false"
+              (jobsChanged)="onJobDefinitionChanged('training')"
             ></coding-box-coding-jobs>
           </div>
         </div>

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -640,15 +640,15 @@ describe('CodingManagementManualComponent', () => {
         codedUnits: 5
       }
     ];
-    component.codingJobsComponent = {
+    component.productiveCodingJobsComponent = {
       canApplyResults: false
-    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
 
     expect(component.canShowCompletedJobApplyActions()).toBe(false);
 
-    component.codingJobsComponent = {
+    component.productiveCodingJobsComponent = {
       canApplyResults: true
-    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
 
     expect(component.canShowCompletedJobApplyActions()).toBe(true);
   });
@@ -834,9 +834,9 @@ describe('CodingManagementManualComponent', () => {
     (snackBar.open as jest.Mock).mockClear();
     component.canApplyManualCodingResults = false;
     component.canManageManualCodingJobs = false;
-    component.codingJobsComponent = {
+    component.productiveCodingJobsComponent = {
       openTransferCodingCasesDialog
-    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
 
     component.openExecutionTransferCases();
 
@@ -873,9 +873,9 @@ describe('CodingManagementManualComponent', () => {
     (snackBar.open as jest.Mock).mockClear();
     component.canManageManualCodingJobs = true;
     component.canApplyManualCodingResults = false;
-    component.codingJobsComponent = {
+    component.productiveCodingJobsComponent = {
       openTransferCodingCasesDialog
-    } as unknown as CodingManagementManualComponent['codingJobsComponent'];
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
 
     component.openExecutionTransferCases();
 
@@ -1268,7 +1268,7 @@ describe('CodingManagementManualComponent', () => {
       loadCodingFreshness(): void;
       refreshAllStatistics(): void;
       loadResponseAnalysis(): void;
-      reloadCodingJobsList(): void;
+      refreshCodingJobsAfterDataChange(reloadScope: string): void;
       appService: { selectedWorkspaceId: number };
       testPersonCodingService: {
         notifyTestResultsChanged: jest.Mock;
@@ -1284,8 +1284,8 @@ describe('CodingManagementManualComponent', () => {
     const refreshAllStatisticsSpy = jest
       .spyOn(componentInternals, 'refreshAllStatistics')
       .mockImplementation();
-    const reloadCodingJobsListSpy = jest
-      .spyOn(componentInternals, 'reloadCodingJobsList')
+    const refreshCodingJobsAfterDataChangeSpy = jest
+      .spyOn(componentInternals, 'refreshCodingJobsAfterDataChange')
       .mockImplementation();
     const loadResponseAnalysisSpy = jest
       .spyOn(componentInternals, 'loadResponseAnalysis')
@@ -1300,7 +1300,7 @@ describe('CodingManagementManualComponent', () => {
     expect(refreshAllStatisticsSpy).toHaveBeenCalled();
     expect(loadResponseAnalysisSpy).toHaveBeenCalled();
     expect(loadCodingFreshnessSpy).toHaveBeenCalled();
-    expect(reloadCodingJobsListSpy).toHaveBeenCalled();
+    expect(refreshCodingJobsAfterDataChangeSpy).toHaveBeenCalledWith('productive');
   });
 
   it('should load all planning metrics when the planning tab is opened', () => {
@@ -1442,6 +1442,189 @@ describe('CodingManagementManualComponent', () => {
     component.onManualTabChanged(1);
 
     expect(loadManualTabDataSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not reload coding jobs when switching to the execution tab', () => {
+    component.selectedManualTabIndex = 1;
+    const componentInternals = component as unknown as {
+      loadCodingProgressOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadWorkspaceKappaSummary(): void;
+      reloadCodingJobsList(): void;
+    };
+    jest
+      .spyOn(componentInternals, 'loadCodingProgressOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCaseCoverageOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadWorkspaceKappaSummary')
+      .mockImplementation();
+    const reloadCodingJobsListSpy = jest
+      .spyOn(componentInternals, 'reloadCodingJobsList')
+      .mockImplementation();
+
+    component.onManualTabChanged(3);
+
+    expect(component.selectedManualTabIndex).toBe(3);
+    expect(component.renderedManualTabs.execution).toBe(true);
+    expect(reloadCodingJobsListSpy).not.toHaveBeenCalled();
+  });
+
+  it('should reload coding jobs when execution data is manually refreshed', () => {
+    component.selectedManualTabIndex = 3;
+    const componentInternals = component as unknown as {
+      loadCodingProgressOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadWorkspaceKappaSummary(): void;
+      loadCodingFreshness(options?: { force?: boolean }): void;
+      reloadCodingJobsList(reloadScope?: string): void;
+      loadJobDefinitionsForExport(): void;
+    };
+    jest
+      .spyOn(componentInternals, 'loadCodingProgressOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCaseCoverageOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadWorkspaceKappaSummary')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadJobDefinitionsForExport')
+      .mockImplementation();
+    const reloadCodingJobsListSpy = jest
+      .spyOn(componentInternals, 'reloadCodingJobsList')
+      .mockImplementation();
+
+    component.refreshManualCodingPlanning();
+
+    expect(reloadCodingJobsListSpy).toHaveBeenCalledTimes(1);
+    expect(reloadCodingJobsListSpy).toHaveBeenCalledWith('active');
+  });
+
+  it('should reload only the targeted coding jobs table', () => {
+    const productiveLoadCodingJobs = jest.fn();
+    const trainingLoadCodingJobs = jest.fn();
+    const loadCoderTrainings = jest.fn();
+    component.productiveCodingJobsComponent = {
+      loadCodingJobs: productiveLoadCodingJobs
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
+    component.trainingCodingJobsComponent = {
+      loadCodingJobs: trainingLoadCodingJobs
+    } as unknown as CodingManagementManualComponent['trainingCodingJobsComponent'];
+    component.coderTrainingsListComponent = {
+      loadCoderTrainings
+    } as unknown as CodingManagementManualComponent['coderTrainingsListComponent'];
+
+    component.reloadCodingJobsList('productive');
+
+    expect(productiveLoadCodingJobs).toHaveBeenCalledTimes(1);
+    expect(trainingLoadCodingJobs).not.toHaveBeenCalled();
+    expect(loadCoderTrainings).not.toHaveBeenCalled();
+
+    productiveLoadCodingJobs.mockClear();
+
+    component.reloadCodingJobsList('training');
+
+    expect(productiveLoadCodingJobs).not.toHaveBeenCalled();
+    expect(trainingLoadCodingJobs).toHaveBeenCalledTimes(1);
+    expect(loadCoderTrainings).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reload only the active coding jobs table by default', () => {
+    const productiveLoadCodingJobs = jest.fn();
+    const trainingLoadCodingJobs = jest.fn();
+    component.productiveCodingJobsComponent = {
+      loadCodingJobs: productiveLoadCodingJobs
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
+    component.trainingCodingJobsComponent = {
+      loadCodingJobs: trainingLoadCodingJobs
+    } as unknown as CodingManagementManualComponent['trainingCodingJobsComponent'];
+
+    component.selectedManualTabIndex = 3;
+    component.reloadCodingJobsList();
+
+    expect(productiveLoadCodingJobs).toHaveBeenCalledTimes(1);
+    expect(trainingLoadCodingJobs).not.toHaveBeenCalled();
+
+    productiveLoadCodingJobs.mockClear();
+
+    component.selectedManualTabIndex = 2;
+    component.reloadCodingJobsList();
+
+    expect(productiveLoadCodingJobs).not.toHaveBeenCalled();
+    expect(trainingLoadCodingJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('should defer coding jobs reloads for hidden tabs after aggregation changes', () => {
+    component.selectedManualTabIndex = 1;
+    const productiveLoadCodingJobs = jest.fn();
+    const trainingLoadCodingJobs = jest.fn();
+    component.productiveCodingJobsComponent = {
+      loadCodingJobs: productiveLoadCodingJobs
+    } as unknown as CodingManagementManualComponent['productiveCodingJobsComponent'];
+    component.trainingCodingJobsComponent = {
+      loadCodingJobs: trainingLoadCodingJobs
+    } as unknown as CodingManagementManualComponent['trainingCodingJobsComponent'];
+    const componentInternals = component as unknown as {
+      refreshAggregationDependentViews(includeResponseAnalysis?: boolean): void;
+      loadManualTabData(tab: 'execution' | 'training'): void;
+      loadVariableCoverageOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadCodingProgressOverview(): void;
+      loadCodingIncompleteVariables(): void;
+      loadStatusDistributionV2(): void;
+      loadJobDefinitionsForExport(): void;
+      loadWorkspaceKappaSummary(): void;
+    };
+    jest
+      .spyOn(componentInternals, 'loadVariableCoverageOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCaseCoverageOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCodingProgressOverview')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadCodingIncompleteVariables')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadStatusDistributionV2')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadJobDefinitionsForExport')
+      .mockImplementation();
+    jest
+      .spyOn(componentInternals, 'loadWorkspaceKappaSummary')
+      .mockImplementation();
+
+    componentInternals.refreshAggregationDependentViews(false);
+
+    expect(productiveLoadCodingJobs).not.toHaveBeenCalled();
+    expect(trainingLoadCodingJobs).not.toHaveBeenCalled();
+
+    component.selectedManualTabIndex = 3;
+    componentInternals.loadManualTabData('execution');
+
+    expect(productiveLoadCodingJobs).toHaveBeenCalledTimes(1);
+    expect(trainingLoadCodingJobs).not.toHaveBeenCalled();
+
+    productiveLoadCodingJobs.mockClear();
+
+    componentInternals.loadManualTabData('execution');
+
+    expect(productiveLoadCodingJobs).not.toHaveBeenCalled();
+
+    component.selectedManualTabIndex = 2;
+    componentInternals.loadManualTabData('training');
+
+    expect(trainingLoadCodingJobs).toHaveBeenCalledTimes(1);
   });
 
   it('should refresh the active manual workflow tab without reloading jobs when the window regains focus', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -142,6 +142,8 @@ type PlanningStatusState =
   'complete';
 
 type ManualCodingTab = 'preparation' | 'planning' | 'training' | 'execution' | 'completion';
+type ConcreteCodingJobsReloadScope = 'productive' | 'training';
+type CodingJobsReloadScope = 'active' | 'productive' | 'training' | 'rendered';
 
 interface ManualFreshnessJobSummary {
   activeTrainingJobs: number;
@@ -188,6 +190,13 @@ interface ManualFreshnessTarget {
 })
 export class CodingManagementManualComponent implements OnInit, OnDestroy {
   @ViewChild(CodingJobsComponent) codingJobsComponent?: CodingJobsComponent;
+
+  @ViewChild('productiveCodingJobs')
+    productiveCodingJobsComponent?: CodingJobsComponent;
+
+  @ViewChild('trainingCodingJobs')
+    trainingCodingJobsComponent?: CodingJobsComponent;
+
   @ViewChild(CodingJobDefinitionsComponent)
     codingJobDefinitionsComponent?: CodingJobDefinitionsComponent;
 
@@ -226,6 +235,17 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     'execution',
     'completion'
   ];
+
+  renderedManualTabs: Record<ManualCodingTab, boolean> = {
+    preparation: true,
+    planning: false,
+    training: false,
+    execution: false,
+    completion: false
+  };
+
+  private readonly pendingCodingJobsReloadScopes =
+    new Set<ConcreteCodingJobsReloadScope>();
 
   private readonly manualCodingTabsWithoutCompletion: ManualCodingTab[] = [
     'preparation',
@@ -301,7 +321,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   duplicatePageSize = 50;
 
   // Debouncing for job definition changes
-  private jobDefinitionChangeSubject = new Subject<void>();
+  private jobDefinitionChangeSubject = new Subject<CodingJobsReloadScope>();
 
   private thresholdChangeSubject = new Subject<number>();
 
@@ -461,12 +481,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     // Set up debounced statistics refresh
     this.jobDefinitionChangeSubject
       .pipe(debounceTime(500), takeUntil(this.destroy$))
-      .subscribe(() => {
+      .subscribe(reloadScope => {
         this.loadJobDefinitionsForExport();
         this.loadManualTabData(this.activeManualTab);
-        if (this.coderTrainingsListComponent) {
-          this.coderTrainingsListComponent.loadCoderTrainings();
-        }
+        this.refreshCodingJobsAfterDataChange(reloadScope);
       });
 
     // Reload aggregation-dependent data when threshold changes.
@@ -517,7 +535,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.refreshAllStatistics();
         this.loadCodingFreshness();
         this.loadResponseAnalysis();
-        this.reloadCodingJobsList();
+        this.refreshCodingJobsAfterDataChange('rendered');
         this.loadJobDefinitionsForExport();
         if (this.codingJobDefinitionsComponent) {
           this.codingJobDefinitionsComponent.refresh();
@@ -577,6 +595,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   isManualTab(tab: ManualCodingTab): boolean {
     return this.activeManualTab === tab;
+  }
+
+  shouldRenderManualTab(tab: ManualCodingTab): boolean {
+    return this.renderedManualTabs[tab] || this.isManualTab(tab);
   }
 
   onManualTabChanged(index: number): void {
@@ -1122,8 +1144,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (this.codingJobsComponent) {
-      this.codingJobsComponent.openTransferCodingCasesDialog();
+    const executionCodingJobsComponent = this.getExecutionCodingJobsComponent();
+    if (executionCodingJobsComponent) {
+      executionCodingJobsComponent.openTransferCodingCasesDialog();
       return;
     }
 
@@ -1488,8 +1511,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
    * Event handler for job definition changes (create, update, delete)
    * Uses debouncing to prevent excessive API calls
    */
-  onJobDefinitionChanged(): void {
-    this.jobDefinitionChangeSubject.next();
+  onJobDefinitionChanged(reloadScope: CodingJobsReloadScope = 'active'): void {
+    this.jobDefinitionChangeSubject.next(reloadScope);
   }
 
   /**
@@ -1507,24 +1530,33 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.loadManualFreshnessDecisionData();
   }
 
-  reloadCodingJobsList(): void {
-    if (this.codingJobsComponent) {
-      this.codingJobsComponent.loadCodingJobs();
-    }
-    if (this.coderTrainingsListComponent) {
+  reloadCodingJobsList(reloadScope: CodingJobsReloadScope = 'active'): void {
+    const concreteReloadScopes =
+      this.getConcreteCodingJobsReloadScopes(reloadScope);
+    this.getCodingJobsComponentsForReload(reloadScope)
+      .forEach(component => component.loadCodingJobs());
+    concreteReloadScopes.forEach(scope => {
+      this.pendingCodingJobsReloadScopes.delete(scope);
+    });
+    if (this.shouldReloadCoderTrainings(reloadScope) &&
+      this.coderTrainingsListComponent) {
       this.coderTrainingsListComponent.loadCoderTrainings();
     }
   }
 
   refreshManualCodingPlanning(): void {
     const activeTab = this.activeManualTab;
-    this.loadManualTabData(activeTab, { forceRefresh: true });
+    this.loadManualTabData(activeTab, {
+      forceRefresh: true,
+      reloadCodingJobs: true,
+      codingJobsReloadScope: 'active'
+    });
     this.loadJobDefinitionsForExport();
     if (activeTab !== 'planning') {
       this.loadCodingFreshness({ force: true });
     }
     if (this.shouldReloadCodingJobsAfterManualTabData(activeTab)) {
-      this.reloadCodingJobsList();
+      this.reloadCodingJobsList('active');
     }
 
     if (this.codingJobDefinitionsComponent) {
@@ -1546,12 +1578,108 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.loadCodingFreshness();
     }
     if (this.shouldReloadCodingJobsAfterManualTabData(activeTab)) {
-      this.reloadCodingJobsList();
+      this.reloadCodingJobsList('active');
     }
   }
 
   private shouldReloadCodingJobsAfterManualTabData(tab: ManualCodingTab): boolean {
     return tab === 'preparation';
+  }
+
+  private getCodingJobsComponentsForReload(
+    reloadScope: CodingJobsReloadScope
+  ): CodingJobsComponent[] {
+    return this.uniqueCodingJobsComponents(
+      this.getConcreteCodingJobsReloadScopes(reloadScope)
+        .map(scope => this.getCodingJobsComponentForScope(scope))
+    );
+  }
+
+  private uniqueCodingJobsComponents(
+    candidateComponents: Array<CodingJobsComponent | undefined>
+  ): CodingJobsComponent[] {
+    const uniqueComponents: CodingJobsComponent[] = [];
+    candidateComponents.forEach(component => {
+      if (component && !uniqueComponents.includes(component)) {
+        uniqueComponents.push(component);
+      }
+    });
+    return uniqueComponents;
+  }
+
+  private getProductiveCodingJobsComponent(): CodingJobsComponent | undefined {
+    return this.productiveCodingJobsComponent ??
+      (this.activeManualTab === 'execution' ? this.codingJobsComponent : undefined);
+  }
+
+  private getTrainingCodingJobsComponent(): CodingJobsComponent | undefined {
+    return this.trainingCodingJobsComponent ??
+      (this.activeManualTab === 'training' ? this.codingJobsComponent : undefined);
+  }
+
+  private getExecutionCodingJobsComponent(): CodingJobsComponent | undefined {
+    return this.getProductiveCodingJobsComponent();
+  }
+
+  private getConcreteCodingJobsReloadScopes(
+    reloadScope: CodingJobsReloadScope
+  ): ConcreteCodingJobsReloadScope[] {
+    switch (reloadScope) {
+      case 'productive':
+        return ['productive'];
+      case 'training':
+        return ['training'];
+      case 'rendered':
+        return ['productive', 'training'];
+      case 'active':
+      default:
+        return this.getCodingJobsScopeForTab(this.activeManualTab);
+    }
+  }
+
+  private getCodingJobsScopeForTab(
+    tab: ManualCodingTab
+  ): ConcreteCodingJobsReloadScope[] {
+    switch (tab) {
+      case 'execution':
+        return ['productive'];
+      case 'training':
+        return ['training'];
+      default:
+        return [];
+    }
+  }
+
+  private getCodingJobsComponentForScope(
+    reloadScope: ConcreteCodingJobsReloadScope
+  ): CodingJobsComponent | undefined {
+    return reloadScope === 'productive' ?
+      this.getProductiveCodingJobsComponent() :
+      this.getTrainingCodingJobsComponent();
+  }
+
+  private refreshCodingJobsAfterDataChange(
+    reloadScope: CodingJobsReloadScope
+  ): void {
+    this.getConcreteCodingJobsReloadScopes(reloadScope)
+      .forEach(scope => {
+        if (this.getCodingJobsScopeForTab(this.activeManualTab).includes(scope)) {
+          this.reloadCodingJobsList(scope);
+          return;
+        }
+        this.pendingCodingJobsReloadScopes.add(scope);
+      });
+  }
+
+  private reloadPendingCodingJobsForTab(tab: ManualCodingTab): void {
+    this.getCodingJobsScopeForTab(tab)
+      .filter(scope => this.pendingCodingJobsReloadScopes.has(scope))
+      .forEach(scope => this.reloadCodingJobsList(scope));
+  }
+
+  private shouldReloadCoderTrainings(reloadScope: CodingJobsReloadScope): boolean {
+    return this.getConcreteCodingJobsReloadScopes(reloadScope)
+      .includes('training');
   }
 
   isAnyPlanningDataLoading(): boolean {
@@ -1818,7 +1946,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   canApplyCompletedJobResults(): boolean {
-    return this.codingJobsComponent?.canApplyResults ??
+    return this.getExecutionCodingJobsComponent()?.canApplyResults ??
       this.canApplyManualCodingResults;
   }
 
@@ -2583,7 +2711,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.loadCodingProgressOverview();
     this.loadCodingIncompleteVariables();
     this.loadStatusDistributionV2();
-    this.reloadCodingJobsList();
+    this.refreshCodingJobsAfterDataChange('rendered');
     this.loadJobDefinitionsForExport();
 
     if (this.codingJobDefinitionsComponent) {
@@ -2628,13 +2756,19 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private loadManualTabData(
     tab: ManualCodingTab,
-    options: { reloadCodingJobs?: boolean; forceRefresh?: boolean } = {}
+    options: {
+      reloadCodingJobs?: boolean;
+      codingJobsReloadScope?: CodingJobsReloadScope;
+      forceRefresh?: boolean;
+    } = {}
   ): void {
     if (!this.isManualTabAvailable(tab)) {
       return;
     }
 
-    const reloadCodingJobs = options.reloadCodingJobs ?? true;
+    this.renderedManualTabs[tab] = true;
+    const reloadCodingJobs = options.reloadCodingJobs ?? false;
+    const codingJobsReloadScope = options.codingJobsReloadScope ?? 'active';
     const forceRefresh = options.forceRefresh ?? false;
     switch (tab) {
       case 'preparation':
@@ -2651,7 +2785,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         return;
       case 'training':
         if (reloadCodingJobs) {
-          this.reloadCodingJobsList();
+          this.reloadCodingJobsList(codingJobsReloadScope);
+        } else {
+          this.reloadPendingCodingJobsForTab(tab);
         }
         return;
       case 'execution':
@@ -2659,7 +2795,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.loadCaseCoverageOverview();
         this.loadWorkspaceKappaSummary();
         if (reloadCodingJobs) {
-          this.reloadCodingJobsList();
+          this.reloadCodingJobsList(codingJobsReloadScope);
+        } else {
+          this.reloadPendingCodingJobsForTab(tab);
         }
         return;
       case 'completion':
@@ -2795,7 +2933,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.resultsApplied) {
         this.refreshAllStatistics();
-        this.reloadCodingJobsList();
+        this.refreshCodingJobsAfterDataChange('productive');
       }
     });
   }
@@ -3674,7 +3812,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.refreshAllStatistics();
     this.loadResponseAnalysis();
     this.loadCodingFreshness();
-    this.reloadCodingJobsList();
+    this.refreshCodingJobsAfterDataChange('productive');
   }
 
   private formatApplyCodingResultsMessage(
@@ -3770,7 +3908,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           );
           this.closeCoderTraining();
           this.refreshAllStatistics();
-          this.reloadCodingJobsList();
+          this.refreshCodingJobsAfterDataChange('training');
         },
         error: () => {
           this.showError('Fehler beim Generieren der Kodierer-Schulungspakete');


### PR DESCRIPTION
## Summary
- disable automatic coding job reloads on browser focus by default
- keep manual coding job tabs mounted after first render, but refresh hidden job tables only after real data changes and on next activation
- scope productive and training job reloads so unrelated tables and coder training lists are not refreshed unnecessarily

## Motivation
The manual coding area could trigger expensive reload cascades when users switched tabs or returned focus to the browser. This change keeps normal navigation lightweight while preserving freshness after actual job, definition, aggregation, autocoding, or training changes.

## Validation
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts --runInBand --skip-nx-cache`
- `npx nx lint frontend --skip-nx-cache`
- `npx nx test frontend --runInBand --skip-nx-cache`
- `git diff --check`