### PR TITLE
Hide refresh buttons when auto-refresh is active

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.html
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.html
@@ -100,10 +100,12 @@
         </div>
 
         <div class="actions-group utility-actions">
-          <button mat-button (click)="loadCodingJobs()">
-            <mat-icon>refresh</mat-icon>
-            Aktualisieren
-          </button>
+          @if (showRefreshAction) {
+            <button mat-button (click)="loadCodingJobs()">
+              <mat-icon>refresh</mat-icon>
+              Aktualisieren
+            </button>
+          }
           @if (canManageCodingJobs && showBulkDeleteAction) {
             <button
               mat-raised-button

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
@@ -503,6 +503,21 @@ describe('CodingJobsComponent', () => {
     ).toContain('Keine Kodierjobs vorhanden');
   });
 
+  it('shows the refresh action by default', () => {
+    expect(
+      fixture.nativeElement.querySelector('.utility-actions')?.textContent
+    ).toContain('Aktualisieren');
+  });
+
+  it('hides the refresh action when manual refresh is not available', () => {
+    component.showRefreshAction = false;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('.utility-actions')?.textContent
+    ).not.toContain('Aktualisieren');
+  });
+
   it('should choose a single primary row action by job state', () => {
     component.canApplyResults = true;
 

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
@@ -226,6 +226,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
   @Input() showTransferAction = true;
   @Input() showApplyActions = true;
   @Input() showBulkDeleteAction = true;
+  @Input() showRefreshAction = true;
   @Input() autoReloadOnFocus = false;
 
   private handleWindowFocus = () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -1520,6 +1520,7 @@
             [showComparisonActions]="false"
             [showTransferAction]="false"
             [showApplyActions]="false"
+            [showRefreshAction]="shouldShowManualRefreshButton()"
             [autoReloadOnFocus]="false"
             (jobsChanged)="onJobDefinitionChanged('productive')"
           ></coding-box-coding-jobs>
@@ -2044,6 +2045,7 @@
               [showComparisonActions]="false"
               [showTransferAction]="false"
               [showApplyActions]="false"
+              [showRefreshAction]="shouldShowManualRefreshButton()"
               [autoReloadOnFocus]="false"
               (jobsChanged)="onJobDefinitionChanged('training')"
             ></coding-box-coding-jobs>


### PR DESCRIPTION
## Summary
- add a configurable refresh action to the coding jobs table
- hide productive and training job-table refresh buttons in manual coding when auto-refresh is active
- cover the refresh action visibility in the coding jobs component tests

## Context
This follows up on issue #813: manual refresh buttons should only be visible when auto-refresh is disabled, because auto-refresh owns the regular updates in that mode.

## Validation
- `npx nx test frontend --runTestsByPath=apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts --runInBand` (ran all frontend suites: 186 passed, 1680 tests passed)
- `npx nx lint frontend`