### PR TITLE
Decouple coding status checks from tab changes

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
@@ -20,6 +20,7 @@ import { CoderService } from '../../services/coder.service';
 import { CodingJob } from '../../models/coding-job.model';
 import { Coder } from '../../models/coder.model';
 import { UserBackendService } from '../../../shared/services/user/user-backend.service';
+import { TestPersonCodingService } from '../../services/test-person-coding.service';
 
 describe('CodingJobsComponent', () => {
   let component: CodingJobsComponent;
@@ -31,6 +32,7 @@ describe('CodingJobsComponent', () => {
   let matSnackBarMock: Partial<MatSnackBar>;
   let matDialogMock: Partial<MatDialog>;
   let userBackendServiceMock: Partial<UserBackendService>;
+  let testPersonCodingServiceMock: { notifyTestResultsChanged: jest.Mock };
   let overlayContainer: OverlayContainer;
 
   const mockCodingJobs: Partial<CodingJob>[] = [
@@ -139,6 +141,10 @@ describe('CodingJobsComponent', () => {
       getUsers: jest.fn().mockReturnValue(of([{ id: 1, accessLevel: 3 }]))
     };
 
+    testPersonCodingServiceMock = {
+      notifyTestResultsChanged: jest.fn()
+    };
+
     coderServiceMock = {
       getCoders: jest.fn().mockReturnValue(of(mockCoders))
     };
@@ -166,6 +172,7 @@ describe('CodingJobsComponent', () => {
         { provide: AppService, useValue: appServiceMock },
         { provide: UserBackendService, useValue: userBackendServiceMock },
         { provide: CoderService, useValue: coderServiceMock },
+        { provide: TestPersonCodingService, useValue: testPersonCodingServiceMock },
         { provide: MatSnackBar, useValue: matSnackBarMock },
         { provide: MatDialog, useValue: matDialogMock },
         {
@@ -188,6 +195,7 @@ describe('CodingJobsComponent', () => {
             { provide: AppService, useValue: appServiceMock },
             { provide: UserBackendService, useValue: userBackendServiceMock },
             { provide: CoderService, useValue: coderServiceMock },
+            { provide: TestPersonCodingService, useValue: testPersonCodingServiceMock },
             { provide: MatSnackBar, useValue: matSnackBarMock },
             { provide: MatDialog, useValue: matDialogMock }
           ]
@@ -928,6 +936,31 @@ describe('CodingJobsComponent', () => {
       'Schließen',
       expect.objectContaining({})
     );
+    expect(testPersonCodingServiceMock.notifyTestResultsChanged)
+      .toHaveBeenCalledWith({
+        workspaceId: 1,
+        statisticsVersion: 'v2'
+      });
+  });
+
+  it('should notify status consumers when coding results were applied in the result dialog', () => {
+    const job = mockCodingJobs[0] as CodingJob;
+    (matDialogMock.open as jest.Mock).mockReturnValue({
+      backdropClick: () => of(),
+      keydownEvents: () => of(),
+      afterClosed: () => of({ resultsApplied: true }),
+      componentInstance: {
+        closeDialog: jest.fn()
+      }
+    });
+
+    component.viewCodingResults(job);
+
+    expect(testPersonCodingServiceMock.notifyTestResultsChanged)
+      .toHaveBeenCalledWith({
+        workspaceId: 1,
+        statisticsVersion: 'v2'
+      });
   });
 
   it('should handle bulk apply coding results', () => {
@@ -988,6 +1021,11 @@ describe('CodingJobsComponent', () => {
     expect(
       codingJobBackendServiceMock.bulkApplyCodingResults
     ).toHaveBeenCalledWith(1);
+    expect(testPersonCodingServiceMock.notifyTestResultsChanged)
+      .toHaveBeenCalledWith({
+        workspaceId: 1,
+        statisticsVersion: 'v2'
+      });
     expect(matSnackBarMock.open).toHaveBeenCalledWith(
       expect.stringContaining('Massenanwendung abgeschlossen'),
       'Schließen',

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
@@ -60,6 +60,7 @@ import {
   CodingJobBackendService
 } from '../../services/coding-job-backend.service';
 import { CodingTrainingBackendService } from '../../services/coding-training-backend.service';
+import { TestPersonCodingService } from '../../services/test-person-coding.service';
 
 import {
   CodingJob,
@@ -165,6 +166,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
   private snackBar = inject(MatSnackBar);
   private dialog = inject(MatDialog);
   private coderService = inject(CoderService);
+  private testPersonCodingService = inject(TestPersonCodingService);
 
   canApplyResults = false;
   canReviewCodingJobs = false;
@@ -1242,6 +1244,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result?.resultsApplied) {
+        this.notifyCodingResultsApplied(workspaceId);
         this.loadCodingJobs();
         this.jobsChanged.emit();
       }
@@ -1510,6 +1513,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
                   { duration: 6000 }
                 );
                 this.loadCodingJobs(); // Refresh the list to show updated status
+                this.notifyCodingResultsApplied(workspaceId);
                 this.jobsChanged.emit();
               } else {
                 this.snackBar.open(
@@ -1596,6 +1600,13 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
     }
   }
 
+  private notifyCodingResultsApplied(workspaceId: number): void {
+    this.testPersonCodingService.notifyTestResultsChanged({
+      workspaceId,
+      statisticsVersion: 'v2'
+    });
+  }
+
   bulkApplyCodingResults(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
@@ -1672,6 +1683,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
             { duration: 5000 }
           );
           this.loadCodingJobs(); // Refresh the list
+          this.notifyCodingResultsApplied(workspaceId);
           this.jobsChanged.emit();
         } else {
           this.snackBar.open(

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -1546,6 +1546,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
    * Refreshes all statistics with individual loading states
    */
   refreshAllStatistics(): void {
+    this.invalidateCodingStatusCache();
     this.loadCodingProgressOverview();
     this.loadVariableCoverageOverview();
     this.loadCaseCoverageOverview();
@@ -1572,6 +1573,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   refreshManualCodingPlanning(): void {
+    this.invalidateCodingStatusCache();
     const activeTab = this.activeManualTab;
     this.loadManualTabData(activeTab, {
       forceRefresh: true,
@@ -2747,6 +2749,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private refreshAggregationDependentViews(includeResponseAnalysis = true): void {
+    this.invalidateCodingStatusCache();
     if (includeResponseAnalysis) {
       this.loadResponseAnalysis();
     }
@@ -3190,6 +3193,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.codingFreshnessSummary = null;
       this.isLoadingCodingFreshness = false;
       return;
+    }
+
+    if (options.force) {
+      this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
     }
 
     if (!options.force && !this.hasLoadedManualCodingJobRefreshSetting) {
@@ -3877,6 +3884,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.loadResponseAnalysis();
     this.loadCodingFreshness({ force: true });
     this.refreshCodingJobsAfterDataChange('productive');
+  }
+
+  private invalidateCodingStatusCache(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (workspaceId) {
+      this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
+    }
   }
 
   private formatApplyCodingResultsMessage(

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -162,6 +162,7 @@ describe('CodingManagementComponent', () => {
         aggregationThreshold: null,
         aggregatedDuplicateCases: 0
       })),
+      invalidateCodingStatusCache: jest.fn(),
       startFreshnessCoding: jest.fn().mockReturnValue(of({
         totalResponses: 0,
         statusCounts: {},

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -469,6 +469,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   refreshCodingStatusOverview(): void {
+    this.invalidateCodingStatusOverviewCache();
     this.fetchCodingStatistics();
     this.loadCodingStatusOverview(true);
     this.refreshTableData();
@@ -480,9 +481,17 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return;
     }
 
+    this.invalidateCodingStatusOverviewCache();
     this.fetchCodingStatistics();
     this.loadCodingStatusOverview();
     this.refreshTableData();
+  }
+
+  private invalidateCodingStatusOverviewCache(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (workspaceId) {
+      this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
+    }
   }
 
   loadCodingStatusOverview(forceAutocodingReadiness = false): void {
@@ -529,6 +538,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
             'Schließen',
             { duration: 5000 }
           );
+          this.invalidateCodingStatusOverviewCache();
           this.loadCodingFreshness();
           return;
         }
@@ -551,6 +561,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
               null;
             if (this.isTerminalJobStatus(dialogStatus)) {
               this.stopFreshnessJobPolling();
+              this.invalidateCodingStatusOverviewCache();
               this.loadCodingFreshness();
               this.loadManualAppliedResultsOverview();
               this.loadAutocodingReadiness(true);

--- a/apps/frontend/src/app/coding/components/import-comparison-dialog/import-comparison-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/import-comparison-dialog/import-comparison-dialog.component.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateModule } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+import {
+  ImportComparisonData,
+  ImportComparisonDialogComponent
+} from './import-comparison-dialog.component';
+import { TestPersonCodingService } from '../../services/test-person-coding.service';
+
+describe('ImportComparisonDialogComponent', () => {
+  let component: ImportComparisonDialogComponent;
+
+  const dialogRefMock = {
+    close: jest.fn()
+  };
+  const snackBarMock = {
+    open: jest.fn()
+  };
+  const testPersonCodingServiceMock = {
+    getExternalCodingImportResult: jest.fn(),
+    notifyTestResultsChanged: jest.fn()
+  };
+  const dialogData: ImportComparisonData = {
+    message: 'preview',
+    processedRows: 1,
+    updatedRows: 1,
+    errors: [],
+    affectedRows: [],
+    isPreview: true,
+    workspaceId: 12,
+    fileData: 'encoded',
+    fileName: 'coding.csv',
+    sourceVersion: 'v3'
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    testPersonCodingServiceMock.getExternalCodingImportResult.mockReturnValue(of({
+      message: 'applied',
+      processedRows: 1,
+      updatedRows: 1,
+      errors: [],
+      affectedRows: []
+    }));
+
+    await TestBed.configureTestingModule({
+      imports: [ImportComparisonDialogComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: dialogData },
+        { provide: MatDialogRef, useValue: dialogRefMock },
+        { provide: MatSnackBar, useValue: snackBarMock },
+        {
+          provide: TestPersonCodingService,
+          useValue: testPersonCodingServiceMock
+        }
+      ]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(ImportComparisonDialogComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should notify status consumers when applied import results are loaded', () => {
+    const importResult = {
+      message: 'applied',
+      processedRows: 1,
+      updatedRows: 1,
+      errors: [],
+      affectedRows: []
+    };
+    testPersonCodingServiceMock.getExternalCodingImportResult
+      .mockReturnValueOnce(of(importResult));
+
+    (component as unknown as {
+      fetchImportResult: (workspaceId: number, jobId: string) => void;
+    }).fetchImportResult(12, 'job-1');
+
+    expect(testPersonCodingServiceMock.notifyTestResultsChanged)
+      .toHaveBeenCalledWith({
+        workspaceId: 12,
+        statisticsVersion: 'v3'
+      });
+    expect(dialogRefMock.close).toHaveBeenCalledWith({
+      applied: true,
+      result: importResult
+    });
+  });
+
+  it('should notify status consumers when import finished but result loading fails', () => {
+    testPersonCodingServiceMock.getExternalCodingImportResult
+      .mockReturnValueOnce(throwError(() => new Error('result unavailable')));
+
+    (component as unknown as {
+      fetchImportResult: (workspaceId: number, jobId: string) => void;
+    }).fetchImportResult(12, 'job-1');
+
+    expect(testPersonCodingServiceMock.notifyTestResultsChanged)
+      .toHaveBeenCalledWith({
+        workspaceId: 12,
+        statisticsVersion: 'v3'
+      });
+    expect(snackBarMock.open).toHaveBeenCalledWith(
+      'Import abgeschlossen, aber Ergebnis konnte nicht geladen werden.',
+      '',
+      { duration: 5000 }
+    );
+    expect(dialogRefMock.close).toHaveBeenCalledWith({ applied: true });
+  });
+});

--- a/apps/frontend/src/app/coding/components/import-comparison-dialog/import-comparison-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/import-comparison-dialog/import-comparison-dialog.component.ts
@@ -711,11 +711,13 @@ export class ImportComparisonDialogComponent implements OnInit, OnDestroy {
       next: result => {
         this.isLoading = false;
         this.applyProgress = -1;
+        this.notifyImportApplied(workspaceId);
         this.dialogRef.close({ applied: true, result });
       },
       error: () => {
         this.isLoading = false;
         this.applyProgress = -1;
+        this.notifyImportApplied(workspaceId);
         this.snackBar.open(
           'Import abgeschlossen, aber Ergebnis konnte nicht geladen werden.',
           '',
@@ -724,5 +726,15 @@ export class ImportComparisonDialogComponent implements OnInit, OnDestroy {
         this.dialogRef.close({ applied: true });
       }
     });
+  }
+
+  private notifyImportApplied(workspaceId: number): void {
+    const event = this.data.sourceVersion ?
+      {
+        workspaceId,
+        statisticsVersion: this.data.sourceVersion
+      } :
+      { workspaceId };
+    this.testPersonCodingService.notifyTestResultsChanged(event);
   }
 }

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -314,6 +314,66 @@ describe('TestPersonCodingService', () => {
       const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/applied-results-overview`);
       req.error(new ProgressEvent('error'));
     });
+
+    it('should reuse cached applied results overview until coding status is invalidated', () => {
+      const mockResponse: AppliedResultsOverview = {
+        totalIncompleteResponses: 2,
+        appliedResponses: 1,
+        remainingResponses: 1,
+        completionPercentage: 50,
+        rawTotalIncompleteResponses: 2,
+        rawAppliedResponses: 1,
+        rawCompletionPercentage: 50,
+        aggregationActive: false,
+        aggregationThreshold: null,
+        aggregatedDuplicateCases: 0
+      };
+      const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/applied-results-overview`;
+      let cachedResponse: AppliedResultsOverview | null | undefined;
+
+      service.getAppliedResultsOverview(mockWorkspaceId).subscribe();
+      httpMock.expectOne(url).flush(mockResponse);
+
+      service.getAppliedResultsOverview(mockWorkspaceId).subscribe(response => {
+        cachedResponse = response;
+      });
+      httpMock.expectNone(url);
+      expect(cachedResponse).toEqual(mockResponse);
+
+      service.invalidateCodingStatusCache(mockWorkspaceId);
+      service.getAppliedResultsOverview(mockWorkspaceId).subscribe();
+      httpMock.expectOne(url).flush(mockResponse);
+    });
+
+    it('should not cache failed applied results overview fallbacks', () => {
+      const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/applied-results-overview`;
+      const mockResponse: AppliedResultsOverview = {
+        totalIncompleteResponses: 2,
+        appliedResponses: 1,
+        remainingResponses: 1,
+        completionPercentage: 50,
+        rawTotalIncompleteResponses: 2,
+        rawAppliedResponses: 1,
+        rawCompletionPercentage: 50,
+        aggregationActive: false,
+        aggregationThreshold: null,
+        aggregatedDuplicateCases: 0
+      };
+      let firstResponse: AppliedResultsOverview | null | undefined;
+      let secondResponse: AppliedResultsOverview | null | undefined;
+
+      service.getAppliedResultsOverview(mockWorkspaceId).subscribe(response => {
+        firstResponse = response;
+      });
+      httpMock.expectOne(url).error(new ProgressEvent('error'));
+      expect(firstResponse).toBeNull();
+
+      service.getAppliedResultsOverview(mockWorkspaceId).subscribe(response => {
+        secondResponse = response;
+      });
+      httpMock.expectOne(url).flush(mockResponse);
+      expect(secondResponse).toEqual(mockResponse);
+    });
   });
 
   describe('getResponseAnalysis', () => {
@@ -858,6 +918,114 @@ describe('TestPersonCodingService', () => {
   });
 
   describe('coding freshness', () => {
+    it('should reuse cached coding freshness until coding status is invalidated', () => {
+      const mockResponse = {
+        workspaceId: mockWorkspaceId,
+        currentRevision: 2,
+        items: [
+          {
+            version: 'v1' as const,
+            state: 'STALE' as const,
+            unitCount: 3,
+            affectedResponseCount: 12
+          }
+        ]
+      };
+      const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/freshness`;
+      let cachedResponse: unknown;
+
+      service.getCodingFreshness(mockWorkspaceId).subscribe();
+      httpMock.expectOne(url).flush(mockResponse);
+
+      service.getCodingFreshness(mockWorkspaceId).subscribe(response => {
+        cachedResponse = response;
+      });
+      httpMock.expectNone(url);
+      expect(cachedResponse).toEqual(mockResponse);
+
+      service.invalidateCodingStatusCache(mockWorkspaceId);
+      service.getCodingFreshness(mockWorkspaceId).subscribe();
+      httpMock.expectOne(url).flush(mockResponse);
+    });
+
+    it('should keep newer in-flight coding freshness requests registered when stale requests finish', () => {
+      const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/freshness`;
+      const staleResponse = {
+        workspaceId: mockWorkspaceId,
+        currentRevision: 1,
+        items: []
+      };
+      const currentResponse = {
+        workspaceId: mockWorkspaceId,
+        currentRevision: 2,
+        items: [
+          {
+            version: 'v1' as const,
+            state: 'PENDING' as const,
+            unitCount: 1,
+            affectedResponseCount: 1
+          }
+        ]
+      };
+      let currentSubscriberResponse: unknown;
+      let sharedSubscriberResponse: unknown;
+
+      service.getCodingFreshness(mockWorkspaceId).subscribe();
+      const staleRequest = httpMock.expectOne(url);
+
+      service.invalidateCodingStatusCache(mockWorkspaceId);
+      service.getCodingFreshness(mockWorkspaceId).subscribe(response => {
+        currentSubscriberResponse = response;
+      });
+      const currentRequest = httpMock.expectOne(url);
+
+      staleRequest.flush(staleResponse);
+
+      service.getCodingFreshness(mockWorkspaceId).subscribe(response => {
+        sharedSubscriberResponse = response;
+      });
+      httpMock.expectNone(url);
+
+      currentRequest.flush(currentResponse);
+
+      expect(currentSubscriberResponse).toEqual(currentResponse);
+      expect(sharedSubscriberResponse).toEqual(currentResponse);
+    });
+
+    it('should not cache failed coding freshness fallbacks', () => {
+      const mockResponse = {
+        workspaceId: mockWorkspaceId,
+        currentRevision: 2,
+        items: [
+          {
+            version: 'v1' as const,
+            state: 'STALE' as const,
+            unitCount: 3,
+            affectedResponseCount: 12
+          }
+        ]
+      };
+      const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/freshness`;
+      let firstResponse: unknown;
+      let secondResponse: unknown;
+
+      service.getCodingFreshness(mockWorkspaceId).subscribe(response => {
+        firstResponse = response;
+      });
+      httpMock.expectOne(url).error(new ProgressEvent('error'));
+      expect(firstResponse).toEqual({
+        workspaceId: mockWorkspaceId,
+        currentRevision: 0,
+        items: []
+      });
+
+      service.getCodingFreshness(mockWorkspaceId).subscribe(response => {
+        secondResponse = response;
+      });
+      httpMock.expectOne(url).flush(mockResponse);
+      expect(secondResponse).toEqual(mockResponse);
+    });
+
     it('should request autocoding readiness with run and force-refresh params', () => {
       const mockResponse = {
         workspaceId: mockWorkspaceId,
@@ -893,6 +1061,130 @@ describe('TestPersonCodingService', () => {
       req.flush(mockResponse);
     });
 
+    it('should reuse cached autocoding readiness unless force-refresh is requested', () => {
+      const mockResponse = {
+        workspaceId: mockWorkspaceId,
+        autoCoderRun: 1,
+        readiness: 'READY',
+        blockers: [],
+        rawResponsesTotal: 10,
+        rawResponsesWithRelevantStatus: 10,
+        resultUnitsTotal: 2,
+        resultUnitKeysTotal: 2,
+        matchedUnitFiles: 2,
+        missingUnitFiles: [],
+        matchedCodingSchemes: 1,
+        missingCodingSchemes: [],
+        invalidCodingSchemes: [],
+        validVariablePairs: 1,
+        validResponses: 10,
+        codeableResponses: 10,
+        invalidVariableSamples: []
+      };
+      let cachedResponse: unknown;
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1).subscribe();
+      httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        !request.params.has('forceRefresh')
+      )).flush(mockResponse);
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1).subscribe(response => {
+        cachedResponse = response;
+      });
+      httpMock.expectNone(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        !request.params.has('forceRefresh')
+      ));
+      expect(cachedResponse).toEqual(mockResponse);
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1, true).subscribe();
+      httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        request.params.get('forceRefresh') === 'true'
+      )).flush(mockResponse);
+    });
+
+    it('should keep force-refreshed autocoding readiness cached when stale requests finish later', () => {
+      const staleResponse = {
+        workspaceId: mockWorkspaceId,
+        autoCoderRun: 1,
+        readiness: 'BLOCKED',
+        blockers: ['NO_CODEABLE_RESPONSES'],
+        rawResponsesTotal: 10,
+        rawResponsesWithRelevantStatus: 10,
+        resultUnitsTotal: 2,
+        resultUnitKeysTotal: 2,
+        matchedUnitFiles: 2,
+        missingUnitFiles: [],
+        matchedCodingSchemes: 1,
+        missingCodingSchemes: [],
+        invalidCodingSchemes: [],
+        validVariablePairs: 0,
+        validResponses: 0,
+        codeableResponses: 0,
+        invalidVariableSamples: []
+      };
+      const forceResponse = {
+        workspaceId: mockWorkspaceId,
+        autoCoderRun: 1,
+        readiness: 'READY',
+        blockers: [],
+        rawResponsesTotal: 10,
+        rawResponsesWithRelevantStatus: 10,
+        resultUnitsTotal: 2,
+        resultUnitKeysTotal: 2,
+        matchedUnitFiles: 2,
+        missingUnitFiles: [],
+        matchedCodingSchemes: 1,
+        missingCodingSchemes: [],
+        invalidCodingSchemes: [],
+        validVariablePairs: 1,
+        validResponses: 10,
+        codeableResponses: 10,
+        invalidVariableSamples: []
+      };
+      let staleSubscriberResponse: unknown;
+      let forceSubscriberResponse: unknown;
+      let cachedResponse: unknown;
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1).subscribe(response => {
+        staleSubscriberResponse = response;
+      });
+      const staleRequest = httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        !request.params.has('forceRefresh')
+      ));
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1, true).subscribe(response => {
+        forceSubscriberResponse = response;
+      });
+      const forceRequest = httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        request.params.get('forceRefresh') === 'true'
+      ));
+
+      forceRequest.flush(forceResponse);
+      staleRequest.flush(staleResponse);
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1).subscribe(response => {
+        cachedResponse = response;
+      });
+      httpMock.expectNone(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1'
+      ));
+
+      expect(staleSubscriberResponse).toEqual(staleResponse);
+      expect(forceSubscriberResponse).toEqual(forceResponse);
+      expect(cachedResponse).toEqual(forceResponse);
+    });
+
     it('should request the freshness scope with version and states', () => {
       const mockResponse = {
         workspaceId: mockWorkspaceId,
@@ -921,6 +1213,106 @@ describe('TestPersonCodingService', () => {
       ));
       expect(req.request.method).toBe('GET');
       req.flush(mockResponse);
+    });
+
+    it('should reuse cached freshness scope until coding status is invalidated', () => {
+      const mockResponse = {
+        workspaceId: mockWorkspaceId,
+        currentRevision: 1,
+        versions: ['v1'],
+        states: ['PENDING', 'STALE'],
+        unitCount: 2,
+        personCount: 1,
+        groupCount: 1,
+        affectedResponseCount: 4,
+        unitIds: [10, 11],
+        personIds: [100],
+        groupNames: ['Group1'],
+        groups: []
+      };
+      let cachedResponse: unknown;
+
+      service.getCodingFreshnessScope(mockWorkspaceId, 'v1', ['PENDING', 'STALE'])
+        .subscribe();
+      httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/freshness/scope` &&
+        request.params.get('version') === 'v1' &&
+        request.params.get('state') === 'PENDING,STALE'
+      )).flush(mockResponse);
+
+      service.getCodingFreshnessScope(mockWorkspaceId, 'v1', ['PENDING', 'STALE'])
+        .subscribe(response => {
+          cachedResponse = response;
+        });
+      httpMock.expectNone(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/freshness/scope` &&
+        request.params.get('version') === 'v1' &&
+        request.params.get('state') === 'PENDING,STALE'
+      ));
+      expect(cachedResponse).toEqual(mockResponse);
+
+      service.invalidateCodingStatusCache(mockWorkspaceId);
+      service.getCodingFreshnessScope(mockWorkspaceId, 'v1', ['PENDING', 'STALE'])
+        .subscribe();
+      httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/freshness/scope` &&
+        request.params.get('version') === 'v1' &&
+        request.params.get('state') === 'PENDING,STALE'
+      )).flush(mockResponse);
+    });
+
+    it('should not cache failed freshness scope fallbacks', () => {
+      const mockResponse = {
+        workspaceId: mockWorkspaceId,
+        currentRevision: 1,
+        versions: ['v1'],
+        states: ['PENDING', 'STALE'],
+        unitCount: 2,
+        personCount: 1,
+        groupCount: 1,
+        affectedResponseCount: 4,
+        unitIds: [10, 11],
+        personIds: [100],
+        groupNames: ['Group1'],
+        groups: []
+      };
+      let firstResponse: unknown;
+      let secondResponse: unknown;
+
+      service.getCodingFreshnessScope(mockWorkspaceId, 'v1', ['PENDING', 'STALE'])
+        .subscribe(response => {
+          firstResponse = response;
+        });
+      httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/freshness/scope` &&
+        request.params.get('version') === 'v1' &&
+        request.params.get('state') === 'PENDING,STALE'
+      )).error(new ProgressEvent('error'));
+      expect(firstResponse).toEqual({
+        workspaceId: mockWorkspaceId,
+        currentRevision: 0,
+        versions: ['v1'],
+        states: ['PENDING', 'STALE'],
+        unitCount: 0,
+        personCount: 0,
+        groupCount: 0,
+        affectedResponseCount: 0,
+        unitIds: [],
+        personIds: [],
+        groupNames: [],
+        groups: []
+      });
+
+      service.getCodingFreshnessScope(mockWorkspaceId, 'v1', ['PENDING', 'STALE'])
+        .subscribe(response => {
+          secondResponse = response;
+        });
+      httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/freshness/scope` &&
+        request.params.get('version') === 'v1' &&
+        request.params.get('state') === 'PENDING,STALE'
+      )).flush(mockResponse);
+      expect(secondResponse).toEqual(mockResponse);
     });
 
     it('should start a coding freshness job', () => {

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -4,7 +4,10 @@ import {
   Observable,
   Subject,
   catchError,
+  finalize,
   of,
+  shareReplay,
+  tap,
   throwError
 } from 'rxjs';
 import Keycloak from 'keycloak-js';
@@ -240,6 +243,15 @@ export class TestPersonCodingService {
   private autoCodingCompletedSubject = new Subject<AutoCodingCompletedEvent>();
   private testResultsChangedSubject = new Subject<TestResultsChangedEvent>();
   private pendingStatisticsVersions = new Map<number, CodingStatisticsVersion>();
+  private codingFreshnessCache = new Map<number, CodingFreshnessSummaryDto>();
+  private codingFreshnessRequests = new Map<number, Observable<CodingFreshnessSummaryDto>>();
+  private autocodingReadinessCache = new Map<string, AutocodingReadinessDto>();
+  private autocodingReadinessRequests = new Map<string, Observable<AutocodingReadinessDto>>();
+  private codingFreshnessScopeCache = new Map<string, CodingFreshnessScopeDto>();
+  private codingFreshnessScopeRequests = new Map<string, Observable<CodingFreshnessScopeDto>>();
+  private appliedResultsOverviewCache = new Map<number, AppliedResultsOverview | null>();
+  private appliedResultsOverviewRequests = new Map<number, Observable<AppliedResultsOverview | null>>();
+  private codingStatusCacheGeneration = 0;
   autoCodingCompleted$ = this.autoCodingCompletedSubject.asObservable();
   testResultsChanged$ = this.testResultsChangedSubject.asObservable();
 
@@ -260,11 +272,20 @@ export class TestPersonCodingService {
     return typeof jobId === 'string' && jobId.trim().length > 0;
   }
 
+  private deleteCacheKeysForWorkspace<T>(cache: Map<string, T>, workspaceId: number): void {
+    const workspacePrefix = `${workspaceId}:`;
+    Array.from(cache.keys())
+      .filter(key => key.startsWith(workspacePrefix))
+      .forEach(key => cache.delete(key));
+  }
+
   notifyAutoCodingCompleted(jobId?: string): void {
+    this.invalidateCodingStatusCache();
     this.autoCodingCompletedSubject.next({ jobId });
   }
 
   notifyTestResultsChanged(event: TestResultsChangedEvent = {}): void {
+    this.invalidateCodingStatusCache(event.workspaceId);
     if (event.workspaceId && event.statisticsVersion) {
       this.pendingStatisticsVersions.set(event.workspaceId, event.statisticsVersion);
     }
@@ -275,6 +296,30 @@ export class TestPersonCodingService {
     const version = this.pendingStatisticsVersions.get(workspaceId) ?? null;
     this.pendingStatisticsVersions.delete(workspaceId);
     return version;
+  }
+
+  invalidateCodingStatusCache(workspaceId?: number): void {
+    this.codingStatusCacheGeneration += 1;
+    if (!workspaceId) {
+      this.codingFreshnessCache.clear();
+      this.codingFreshnessRequests.clear();
+      this.autocodingReadinessCache.clear();
+      this.autocodingReadinessRequests.clear();
+      this.codingFreshnessScopeCache.clear();
+      this.codingFreshnessScopeRequests.clear();
+      this.appliedResultsOverviewCache.clear();
+      this.appliedResultsOverviewRequests.clear();
+      return;
+    }
+
+    this.codingFreshnessCache.delete(workspaceId);
+    this.codingFreshnessRequests.delete(workspaceId);
+    this.appliedResultsOverviewCache.delete(workspaceId);
+    this.appliedResultsOverviewRequests.delete(workspaceId);
+    this.deleteCacheKeysForWorkspace(this.autocodingReadinessCache, workspaceId);
+    this.deleteCacheKeysForWorkspace(this.autocodingReadinessRequests, workspaceId);
+    this.deleteCacheKeysForWorkspace(this.codingFreshnessScopeCache, workspaceId);
+    this.deleteCacheKeysForWorkspace(this.codingFreshnessScopeRequests, workspaceId);
   }
 
   codeTestPersons(workspaceId: number, testPersonIds: string, autoCoderRun: number = 1): Observable<CodingStatisticsWithJob> {
@@ -474,7 +519,18 @@ export class TestPersonCodingService {
   }
 
   getCodingFreshness(workspaceId: number): Observable<CodingFreshnessSummaryDto> {
-    return this.http
+    const cached = this.codingFreshnessCache.get(workspaceId);
+    if (cached) {
+      return of(cached);
+    }
+
+    const pendingRequest = this.codingFreshnessRequests.get(workspaceId);
+    if (pendingRequest) {
+      return pendingRequest;
+    }
+
+    const requestGeneration = this.codingStatusCacheGeneration;
+    const request$ = this.http
       .get<CodingFreshnessSummaryDto>(
       `${this.serverUrl}admin/workspace/${workspaceId}/coding/freshness`,
       {
@@ -483,12 +539,26 @@ export class TestPersonCodingService {
       }
     )
       .pipe(
+        tap(summary => {
+          if (this.codingStatusCacheGeneration === requestGeneration) {
+            this.codingFreshnessCache.set(workspaceId, summary);
+          }
+        }),
         catchError(() => of({
           workspaceId,
           currentRevision: 0,
           items: []
-        }))
+        })),
+        finalize(() => {
+          if (this.codingFreshnessRequests.get(workspaceId) === request$) {
+            this.codingFreshnessRequests.delete(workspaceId);
+          }
+        }),
+        shareReplay({ bufferSize: 1, refCount: false })
       );
+
+    this.codingFreshnessRequests.set(workspaceId, request$);
+    return request$;
   }
 
   getAutocodingReadiness(
@@ -496,12 +566,26 @@ export class TestPersonCodingService {
     autoCoderRun: 1 | 2 = 1,
     forceRefresh = false
   ): Observable<AutocodingReadinessDto> {
+    const cacheKey = `${workspaceId}:${autoCoderRun}`;
+    if (!forceRefresh) {
+      const cached = this.autocodingReadinessCache.get(cacheKey);
+      if (cached) {
+        return of(cached);
+      }
+
+      const pendingRequest = this.autocodingReadinessRequests.get(cacheKey);
+      if (pendingRequest) {
+        return pendingRequest;
+      }
+    }
+
     let params = new HttpParams().set('autoCoderRun', autoCoderRun.toString());
     if (forceRefresh) {
       params = params.set('forceRefresh', 'true');
     }
 
-    return this.http
+    const requestGeneration = this.codingStatusCacheGeneration;
+    const request$ = this.http
       .get<AutocodingReadinessDto>(
       `${this.serverUrl}admin/workspace/${workspaceId}/coding/readiness`,
       {
@@ -511,8 +595,25 @@ export class TestPersonCodingService {
       }
     )
       .pipe(
-        catchError(error => throwError(() => error))
+        tap(readiness => {
+          if (
+            this.codingStatusCacheGeneration === requestGeneration &&
+            this.autocodingReadinessRequests.get(cacheKey) === request$
+          ) {
+            this.autocodingReadinessCache.set(cacheKey, readiness);
+          }
+        }),
+        catchError(error => throwError(() => error)),
+        finalize(() => {
+          if (this.autocodingReadinessRequests.get(cacheKey) === request$) {
+            this.autocodingReadinessRequests.delete(cacheKey);
+          }
+        }),
+        shareReplay({ bufferSize: 1, refCount: false })
       );
+
+    this.autocodingReadinessRequests.set(cacheKey, request$);
+    return request$;
   }
 
   getCodingFreshnessScope(
@@ -520,6 +621,21 @@ export class TestPersonCodingService {
     version?: 'v1' | 'v2' | 'v3',
     states?: ('PENDING' | 'STALE' | 'MANUAL_REVIEW_REQUIRED')[]
   ): Observable<CodingFreshnessScopeDto> {
+    const cacheKey = [
+      workspaceId,
+      version || 'all',
+      states?.join(',') || 'all'
+    ].join(':');
+    const cached = this.codingFreshnessScopeCache.get(cacheKey);
+    if (cached) {
+      return of(cached);
+    }
+
+    const pendingRequest = this.codingFreshnessScopeRequests.get(cacheKey);
+    if (pendingRequest) {
+      return pendingRequest;
+    }
+
     let params = new HttpParams();
     if (version) {
       params = params.set('version', version);
@@ -528,7 +644,8 @@ export class TestPersonCodingService {
       params = params.set('state', states.join(','));
     }
 
-    return this.http
+    const requestGeneration = this.codingStatusCacheGeneration;
+    const request$ = this.http
       .get<CodingFreshnessScopeDto>(
       `${this.serverUrl}admin/workspace/${workspaceId}/coding/freshness/scope`,
       {
@@ -538,6 +655,11 @@ export class TestPersonCodingService {
       }
     )
       .pipe(
+        tap(scope => {
+          if (this.codingStatusCacheGeneration === requestGeneration) {
+            this.codingFreshnessScopeCache.set(cacheKey, scope);
+          }
+        }),
         catchError(() => {
           const fallback: CodingFreshnessScopeDto = {
             workspaceId,
@@ -560,8 +682,17 @@ export class TestPersonCodingService {
             groups: []
           };
           return of(fallback);
-        })
+        }),
+        finalize(() => {
+          if (this.codingFreshnessScopeRequests.get(cacheKey) === request$) {
+            this.codingFreshnessScopeRequests.delete(cacheKey);
+          }
+        }),
+        shareReplay({ bufferSize: 1, refCount: false })
       );
+
+    this.codingFreshnessScopeRequests.set(cacheKey, request$);
+    return request$;
   }
 
   startFreshnessCoding(
@@ -807,14 +938,38 @@ export class TestPersonCodingService {
   }
 
   getAppliedResultsOverview(workspaceId: number): Observable<AppliedResultsOverview | null> {
-    return this.http
+    if (this.appliedResultsOverviewCache.has(workspaceId)) {
+      return of(this.appliedResultsOverviewCache.get(workspaceId) ?? null);
+    }
+
+    const pendingRequest = this.appliedResultsOverviewRequests.get(workspaceId);
+    if (pendingRequest) {
+      return pendingRequest;
+    }
+
+    const requestGeneration = this.codingStatusCacheGeneration;
+    const request$ = this.http
       .get<AppliedResultsOverview>(
       `${this.serverUrl}admin/workspace/${workspaceId}/coding/applied-results-overview`,
       { headers: this.authHeader }
     )
       .pipe(
-        catchError(() => of(null))
+        tap(overview => {
+          if (this.codingStatusCacheGeneration === requestGeneration) {
+            this.appliedResultsOverviewCache.set(workspaceId, overview);
+          }
+        }),
+        catchError(() => of(null)),
+        finalize(() => {
+          if (this.appliedResultsOverviewRequests.get(workspaceId) === request$) {
+            this.appliedResultsOverviewRequests.delete(workspaceId);
+          }
+        }),
+        shareReplay({ bufferSize: 1, refCount: false })
       );
+
+    this.appliedResultsOverviewRequests.set(workspaceId, request$);
+    return request$;
   }
 
   generateCoderTrainingPackages(

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
@@ -122,6 +122,7 @@ describe('TestResultsComponent', () => {
           provide: TestPersonCodingService,
           useValue: {
             notifyTestResultsChanged: jest.fn(),
+            invalidateCodingStatusCache: jest.fn(),
             getAppliedResultsOverview: jest.fn().mockReturnValue(of({
               totalIncompleteResponses: 0,
               appliedResponses: 0,
@@ -427,6 +428,11 @@ describe('TestResultsComponent', () => {
   });
 
   it('should keep manual coding status refresh visible after a manual check', () => {
+    const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
+      invalidateCodingStatusCache: jest.Mock;
+    };
+
+    testPersonCodingService.invalidateCodingStatusCache.mockClear();
     (component as unknown as {
       setAutoRefreshCodingStatus: (enabled: boolean) => void;
     }).setAutoRefreshCodingStatus(false);
@@ -434,6 +440,7 @@ describe('TestResultsComponent', () => {
     component.refreshCodingFreshnessStatusManually();
 
     expect(component.shouldShowCodingFreshnessManualNotice).toBe(true);
+    expect(testPersonCodingService.invalidateCodingStatusCache).toHaveBeenCalledWith(1);
   });
 
   it('should ignore stale manual coding status responses after status was cleared', () => {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
@@ -1497,6 +1497,10 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       return;
     }
 
+    if (options.force) {
+      this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
+    }
+
     const getCodingFreshness =
       (this.statisticsService as Partial<CodingStatisticsService>).getCodingFreshness;
     const codingFreshness$ = getCodingFreshness ?

--- a/apps/frontend/src/app/ws-admin/services/test-results-upload-state.service.spec.ts
+++ b/apps/frontend/src/app/ws-admin/services/test-results-upload-state.service.spec.ts
@@ -20,7 +20,11 @@ describe('TestResultsUploadStateService', () => {
     getLogAnomalyDetails: jest.Mock;
     requestFlatResponseFilters: jest.Mock;
   };
-  let testPersonCodingServiceMock: { getAppliedResultsOverview: jest.Mock; getCodingFreshness: jest.Mock };
+  let testPersonCodingServiceMock: {
+    getAppliedResultsOverview: jest.Mock;
+    getCodingFreshness: jest.Mock;
+    invalidateCodingStatusCache: jest.Mock;
+  };
   let dialogMock: { open: jest.Mock };
   let snackBarMock: { open: jest.Mock };
 
@@ -55,6 +59,7 @@ describe('TestResultsUploadStateService', () => {
       requestFlatResponseFilters: jest.fn()
     };
     testPersonCodingServiceMock = {
+      invalidateCodingStatusCache: jest.fn(),
       getCodingFreshness: jest.fn().mockReturnValue(of({
         workspaceId: 1,
         currentRevision: 0,
@@ -253,6 +258,7 @@ describe('TestResultsUploadStateService', () => {
     flushMicrotasks();
 
     expect(currentBatches.length).toBe(0);
+    expect(testPersonCodingServiceMock.invalidateCodingStatusCache).toHaveBeenCalledWith(1);
     expect(dialogMock.open).toHaveBeenCalled();
     expect(snackBarMock.open).toHaveBeenCalled();
 

--- a/apps/frontend/src/app/ws-admin/services/test-results-upload-state.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/test-results-upload-state.service.ts
@@ -253,6 +253,7 @@ export class TestResultsUploadStateService {
       mode: 'indeterminate'
     });
     this.testResultService.invalidateCache(batch.workspaceId);
+    this.testPersonCodingService.invalidateCodingStatusCache(batch.workspaceId);
     this.validationTaskStateService.invalidateWorkspace(batch.workspaceId);
 
     const jobStatuses$ = this.waitForCompletedJobResults(batch, finalJobStatuses);


### PR DESCRIPTION
## Summary
- cache and share expensive coding status requests for freshness, readiness, freshness scope, and applied-results overview
- invalidate the status cache on relevant data-changing paths such as uploads, coding result application, external coding imports, aggregation changes, and manual refreshes
- add regression coverage for cache reuse, fallback handling, in-flight request races, and mutation-triggered invalidation

## Validation
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/import-comparison-dialog/import-comparison-dialog.component.spec.ts --runInBand`
- `npx nx lint frontend`
- `npx nx test frontend`
