### PR TITLE
Planungsdaten im Planungstab gezielt laden

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -162,7 +162,7 @@
       </div>
 
       <div
-        *ngIf="isManualTab('planning')"
+        *ngIf="shouldShowPlanningOverview()"
         class="planning-overview-grid"
         aria-label="Übersicht zur manuellen Kodierungsplanung"
       >

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -911,6 +911,27 @@ describe('CodingManagementManualComponent', () => {
     );
   });
 
+  it('should ask for an explicit planning data refresh before loading planning snapshots', () => {
+    component.selectedManualTabIndex = 1;
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      refreshManualCodingPlanning(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    const refreshManualCodingPlanningSpy = jest
+      .spyOn(componentInternals, 'refreshManualCodingPlanning')
+      .mockImplementation();
+
+    expect(component.getPlanningStatusClass()).toBe('status-ready');
+    expect(component.getPlanningStatusIcon()).toBe('refresh');
+    expect(component.getPlanningStatusTitle()).toBe('Planungsdaten aktualisieren');
+    expect(component.getPlanningNextStepActionLabel()).toBe('Aktualisieren');
+
+    component.performPlanningNextStep();
+
+    expect(refreshManualCodingPlanningSpy).toHaveBeenCalled();
+  });
+
   it('should not describe remaining applied results as open execution work without coding progress', () => {
     setCompletePlanningState();
     setAppliedResults(10, 0, 10);
@@ -1303,47 +1324,9 @@ describe('CodingManagementManualComponent', () => {
     expect(refreshCodingJobsAfterDataChangeSpy).toHaveBeenCalledWith('productive');
   });
 
-  it('should load all planning metrics when the planning tab is opened', () => {
-    const componentInternals = component as unknown as {
-      loadManualTabData(tab: 'planning'): void;
-      loadVariableCoverageOverview(): void;
-      loadCaseCoverageOverview(): void;
-      loadCodingProgressOverview(): void;
-      loadCodingIncompleteVariables(): void;
-      loadCodingFreshness(): void;
-      loadResponseAnalysis(): void;
-    };
-    const variableCoverageSpy = jest
-      .spyOn(componentInternals, 'loadVariableCoverageOverview')
-      .mockImplementation();
-    const caseCoverageSpy = jest
-      .spyOn(componentInternals, 'loadCaseCoverageOverview')
-      .mockImplementation();
-    const codingProgressSpy = jest
-      .spyOn(componentInternals, 'loadCodingProgressOverview')
-      .mockImplementation();
-    const incompleteVariablesSpy = jest
-      .spyOn(componentInternals, 'loadCodingIncompleteVariables')
-      .mockImplementation();
-    const loadCodingFreshnessSpy = jest
-      .spyOn(componentInternals, 'loadCodingFreshness')
-      .mockImplementation();
-    const loadResponseAnalysisSpy = jest
-      .spyOn(componentInternals, 'loadResponseAnalysis')
-      .mockImplementation();
-
-    componentInternals.loadManualTabData('planning');
-
-    expect(variableCoverageSpy).toHaveBeenCalled();
-    expect(caseCoverageSpy).toHaveBeenCalled();
-    expect(codingProgressSpy).toHaveBeenCalled();
-    expect(incompleteVariablesSpy).toHaveBeenCalled();
-    expect(loadCodingFreshnessSpy).toHaveBeenCalled();
-    expect(loadResponseAnalysisSpy).toHaveBeenCalled();
-  });
-
-  it('should skip automatic planning metrics when auto-refresh is disabled', () => {
-    component.autoRefreshManualCodingJobs = false;
+  it('should not load bundled planning data when the planning tab is opened', () => {
+    component.selectedManualTabIndex = 1;
+    component.autoRefreshManualCodingJobs = true;
     const componentInternals = component as unknown as {
       hasLoadedManualCodingJobRefreshSetting: boolean;
       appService: { selectedWorkspaceId: number };
@@ -1352,6 +1335,7 @@ describe('CodingManagementManualComponent', () => {
       loadCaseCoverageOverview(): void;
       loadCodingProgressOverview(): void;
       loadCodingIncompleteVariables(): void;
+      loadManualFreshnessDecisionData(): void;
       loadCodingFreshness(): void;
       loadResponseAnalysis(): void;
     };
@@ -1369,6 +1353,9 @@ describe('CodingManagementManualComponent', () => {
     const incompleteVariablesSpy = jest
       .spyOn(componentInternals, 'loadCodingIncompleteVariables')
       .mockImplementation();
+    const manualFreshnessDecisionSpy = jest
+      .spyOn(componentInternals, 'loadManualFreshnessDecisionData')
+      .mockImplementation();
     const loadCodingFreshnessSpy = jest
       .spyOn(componentInternals, 'loadCodingFreshness')
       .mockImplementation();
@@ -1382,6 +1369,58 @@ describe('CodingManagementManualComponent', () => {
     expect(caseCoverageSpy).not.toHaveBeenCalled();
     expect(codingProgressSpy).not.toHaveBeenCalled();
     expect(incompleteVariablesSpy).not.toHaveBeenCalled();
+    expect(manualFreshnessDecisionSpy).not.toHaveBeenCalled();
+    expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
+    expect(loadResponseAnalysisSpy).not.toHaveBeenCalled();
+    expect(component.shouldRenderManualTabData('planning')).toBe(true);
+    expect(component.shouldShowManualRefreshButton()).toBe(true);
+  });
+
+  it('should skip automatic planning metrics when auto-refresh is disabled', () => {
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      hasLoadedManualCodingJobRefreshSetting: boolean;
+      appService: { selectedWorkspaceId: number };
+      loadManualTabData(tab: 'planning'): void;
+      loadVariableCoverageOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadCodingProgressOverview(): void;
+      loadCodingIncompleteVariables(): void;
+      loadManualFreshnessDecisionData(): void;
+      loadCodingFreshness(): void;
+      loadResponseAnalysis(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.hasLoadedManualCodingJobRefreshSetting = true;
+    const variableCoverageSpy = jest
+      .spyOn(componentInternals, 'loadVariableCoverageOverview')
+      .mockImplementation();
+    const caseCoverageSpy = jest
+      .spyOn(componentInternals, 'loadCaseCoverageOverview')
+      .mockImplementation();
+    const codingProgressSpy = jest
+      .spyOn(componentInternals, 'loadCodingProgressOverview')
+      .mockImplementation();
+    const incompleteVariablesSpy = jest
+      .spyOn(componentInternals, 'loadCodingIncompleteVariables')
+      .mockImplementation();
+    const manualFreshnessDecisionSpy = jest
+      .spyOn(componentInternals, 'loadManualFreshnessDecisionData')
+      .mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+    const loadResponseAnalysisSpy = jest
+      .spyOn(componentInternals, 'loadResponseAnalysis')
+      .mockImplementation();
+
+    componentInternals.loadManualTabData('planning');
+
+    expect(variableCoverageSpy).not.toHaveBeenCalled();
+    expect(caseCoverageSpy).not.toHaveBeenCalled();
+    expect(codingProgressSpy).not.toHaveBeenCalled();
+    expect(incompleteVariablesSpy).not.toHaveBeenCalled();
+    expect(manualFreshnessDecisionSpy).not.toHaveBeenCalled();
     expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
     expect(loadResponseAnalysisSpy).not.toHaveBeenCalled();
     expect(component.shouldRenderManualTabData('planning')).toBe(false);
@@ -1397,6 +1436,7 @@ describe('CodingManagementManualComponent', () => {
       loadCaseCoverageOverview(): void;
       loadCodingProgressOverview(): void;
       loadCodingIncompleteVariables(): void;
+      loadManualFreshnessDecisionData(): void;
       loadCodingFreshness(options?: { force?: boolean }): void;
       loadJobDefinitionsForExport(): void;
       loadResponseAnalysis(): void;
@@ -1415,6 +1455,9 @@ describe('CodingManagementManualComponent', () => {
     const incompleteVariablesSpy = jest
       .spyOn(componentInternals, 'loadCodingIncompleteVariables')
       .mockImplementation();
+    const manualFreshnessDecisionSpy = jest
+      .spyOn(componentInternals, 'loadManualFreshnessDecisionData')
+      .mockImplementation();
     const loadCodingFreshnessSpy = jest
       .spyOn(componentInternals, 'loadCodingFreshness')
       .mockImplementation();
@@ -1431,6 +1474,7 @@ describe('CodingManagementManualComponent', () => {
     expect(caseCoverageSpy).toHaveBeenCalled();
     expect(codingProgressSpy).toHaveBeenCalled();
     expect(incompleteVariablesSpy).toHaveBeenCalled();
+    expect(manualFreshnessDecisionSpy).toHaveBeenCalled();
     expect(loadCodingFreshnessSpy).toHaveBeenCalledWith({ force: true });
     expect(component.shouldRenderManualTabData('planning')).toBe(true);
   });
@@ -1472,6 +1516,52 @@ describe('CodingManagementManualComponent', () => {
     expect(loadResponseAnalysisSpy).not.toHaveBeenCalled();
     expect(refreshCodingJobsAfterDataChangeSpy).not.toHaveBeenCalled();
     expect(loadJobDefinitionsForExportSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not load bundled planning data after auto coding completes in planning', () => {
+    component.selectedManualTabIndex = 1;
+    component.autoRefreshManualCodingJobs = true;
+    setCompletePlanningState();
+    const componentInternals = component as unknown as {
+      hasLoadedManualCodingJobRefreshSetting: boolean;
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        notifyAutoCodingCompleted(jobId?: string): void;
+      };
+      refreshAllStatistics(): void;
+      loadCodingFreshness(): void;
+      loadResponseAnalysis(): void;
+      refreshCodingJobsAfterDataChange(scope: string): void;
+      loadJobDefinitionsForExport(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.hasLoadedManualCodingJobRefreshSetting = true;
+    expect(component.shouldShowPlanningOverview()).toBe(true);
+    const refreshAllStatisticsSpy = jest
+      .spyOn(componentInternals, 'refreshAllStatistics')
+      .mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+    const loadResponseAnalysisSpy = jest
+      .spyOn(componentInternals, 'loadResponseAnalysis')
+      .mockImplementation();
+    const refreshCodingJobsAfterDataChangeSpy = jest
+      .spyOn(componentInternals, 'refreshCodingJobsAfterDataChange')
+      .mockImplementation();
+    const loadJobDefinitionsForExportSpy = jest
+      .spyOn(componentInternals, 'loadJobDefinitionsForExport')
+      .mockImplementation();
+
+    componentInternals.testPersonCodingService.notifyAutoCodingCompleted();
+
+    expect(refreshAllStatisticsSpy).not.toHaveBeenCalled();
+    expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
+    expect(loadResponseAnalysisSpy).not.toHaveBeenCalled();
+    expect(refreshCodingJobsAfterDataChangeSpy).toHaveBeenCalledWith('rendered');
+    expect(loadJobDefinitionsForExportSpy).toHaveBeenCalled();
+    expect(component.shouldShowPlanningOverview()).toBe(false);
+    expect(component.getPlanningStatusTitle()).toBe('Planungsdaten aktualisieren');
   });
 
   it('should wait for the auto-refresh setting before loading initial coding freshness', () => {
@@ -1759,7 +1849,7 @@ describe('CodingManagementManualComponent', () => {
     expect(trainingLoadCodingJobs).toHaveBeenCalledTimes(1);
   });
 
-  it('should refresh the active manual workflow tab without reloading jobs when the window regains focus', () => {
+  it('should not refresh planning data when the window regains focus', () => {
     component.selectedManualTabIndex = 1;
     const componentInternals = component as unknown as {
       loadManualTabData(tab: 'planning', options?: { reloadCodingJobs?: boolean }): void;
@@ -1778,10 +1868,7 @@ describe('CodingManagementManualComponent', () => {
 
     window.dispatchEvent(new Event('focus'));
 
-    expect(loadManualTabDataSpy).toHaveBeenCalledWith(
-      'planning',
-      { reloadCodingJobs: false }
-    );
+    expect(loadManualTabDataSpy).not.toHaveBeenCalled();
     expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
     expect(reloadCodingJobsListSpy).not.toHaveBeenCalled();
   });
@@ -2381,6 +2468,101 @@ describe('CodingManagementManualComponent', () => {
 
       expect(component.selectedManualTabIndex).toBe(3);
       expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(1, 'planning');
+      expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(2, 'execution');
+
+      jest.runOnlyPendingTimers();
+
+      expect(scrollToSectionSpy).toHaveBeenCalledWith('manual-execution');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should wait for explicit planning data before following manual freshness focus', () => {
+    jest.useFakeTimers();
+    try {
+      const componentInternals = component as unknown as {
+        appService: { selectedWorkspaceId: number };
+        pendingManualFreshnessFocus: boolean;
+        manualFreshnessPlanningRequested: boolean;
+        requestManualFreshnessFocusIfNeeded(): void;
+        focusManualFreshnessTargetIfReady(): void;
+        loadManualTabData(tab: 'planning' | 'execution'): void;
+      };
+      componentInternals.appService.selectedWorkspaceId = 5;
+      componentInternals.pendingManualFreshnessFocus = true;
+      componentInternals.manualFreshnessPlanningRequested = false;
+      component.selectedManualTabIndex = 0;
+      const loadManualTabDataSpy = jest
+        .spyOn(componentInternals, 'loadManualTabData')
+        .mockImplementation();
+      const scrollToSectionSpy = jest
+        .spyOn(component, 'scrollToSection')
+        .mockImplementation();
+
+      componentInternals.requestManualFreshnessFocusIfNeeded();
+
+      expect(component.selectedManualTabIndex).toBe(1);
+      expect(loadManualTabDataSpy).toHaveBeenCalledWith('planning');
+      expect(scrollToSectionSpy).not.toHaveBeenCalled();
+      expect(componentInternals.pendingManualFreshnessFocus).toBe(true);
+      expect(component.getPlanningStatusTitle()).toBe('Planungsdaten aktualisieren');
+
+      setCompletePlanningState();
+      setCodingProgress(10, 4);
+      setAppliedResults(10, 0, 10);
+      componentInternals.focusManualFreshnessTargetIfReady();
+
+      expect(componentInternals.pendingManualFreshnessFocus).toBe(false);
+      expect(component.selectedManualTabIndex).toBe(3);
+      expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(2, 'execution');
+
+      jest.runOnlyPendingTimers();
+
+      expect(scrollToSectionSpy).toHaveBeenCalledWith('manual-execution');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should keep manual freshness focus pending after leaving planning before data is loaded', () => {
+    jest.useFakeTimers();
+    try {
+      const componentInternals = component as unknown as {
+        appService: { selectedWorkspaceId: number };
+        pendingManualFreshnessFocus: boolean;
+        manualFreshnessPlanningRequested: boolean;
+        requestManualFreshnessFocusIfNeeded(): void;
+        focusManualFreshnessTargetIfReady(): void;
+        loadManualTabData(tab: 'planning' | 'execution'): void;
+      };
+      componentInternals.appService.selectedWorkspaceId = 5;
+      componentInternals.pendingManualFreshnessFocus = true;
+      componentInternals.manualFreshnessPlanningRequested = false;
+      component.selectedManualTabIndex = 0;
+      const loadManualTabDataSpy = jest
+        .spyOn(componentInternals, 'loadManualTabData')
+        .mockImplementation();
+      const scrollToSectionSpy = jest
+        .spyOn(component, 'scrollToSection')
+        .mockImplementation();
+
+      componentInternals.requestManualFreshnessFocusIfNeeded();
+      component.selectedManualTabIndex = 2;
+      componentInternals.focusManualFreshnessTargetIfReady();
+
+      expect(component.selectedManualTabIndex).toBe(2);
+      expect(componentInternals.pendingManualFreshnessFocus).toBe(true);
+      expect(loadManualTabDataSpy).toHaveBeenCalledTimes(1);
+      expect(scrollToSectionSpy).not.toHaveBeenCalled();
+
+      setCompletePlanningState();
+      setCodingProgress(10, 4);
+      setAppliedResults(10, 0, 10);
+      componentInternals.focusManualFreshnessTargetIfReady();
+
+      expect(componentInternals.pendingManualFreshnessFocus).toBe(false);
+      expect(component.selectedManualTabIndex).toBe(3);
       expect(loadManualTabDataSpy).toHaveBeenNthCalledWith(2, 'execution');
 
       jest.runOnlyPendingTimers();
@@ -3061,6 +3243,8 @@ describe('CodingManagementManualComponent', () => {
   });
 
   function setCompletePlanningState(): void {
+    (component as unknown as { hasLoadedPlanningDataBundle: boolean })
+      .hasLoadedPlanningDataBundle = true;
     component.variableCoverageOverview = {
       totalVariables: 2,
       coveredVariables: 2,

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -129,6 +129,7 @@ interface SavedCodeProgress {
 
 type PlanningStatusState =
   'loading' |
+  'planning-data-required' |
   'preparation-required' |
   'warning' |
   'planning-incomplete' |
@@ -251,6 +252,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     execution: false,
     completion: false
   };
+
+  private hasLoadedPlanningDataBundle = false;
 
   private pendingAutomaticManualTabLoad: ManualCodingTab | null = null;
 
@@ -491,6 +494,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.jobDefinitionChangeSubject
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(reloadScope => {
+        this.hasLoadedPlanningDataBundle = false;
         this.loadJobDefinitionsForExport();
         this.loadManualTabData(this.activeManualTab);
         this.refreshCodingJobsAfterDataChange(reloadScope);
@@ -543,6 +547,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         if (!this.hasLoadedManualCodingJobRefreshSetting ||
           !this.autoRefreshManualCodingJobs) {
+          return;
+        }
+
+        if (this.activeManualTab === 'planning') {
+          this.hasLoadedPlanningDataBundle = false;
+          this.refreshCodingJobsAfterDataChange('rendered');
+          this.loadJobDefinitionsForExport();
+          if (this.codingJobDefinitionsComponent) {
+            this.codingJobDefinitionsComponent.refresh();
+          }
           return;
         }
 
@@ -625,7 +639,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   shouldShowManualRefreshButton(): boolean {
     return !!this.appService.selectedWorkspaceId &&
       this.hasLoadedManualCodingJobRefreshSetting &&
-      !this.autoRefreshManualCodingJobs;
+      (this.activeManualTab === 'planning' ||
+        !this.autoRefreshManualCodingJobs);
+  }
+
+  shouldShowPlanningOverview(): boolean {
+    return this.isManualTab('planning') &&
+      this.hasPlanningDataBundleSnapshot();
   }
 
   onManualTabChanged(index: number): void {
@@ -1547,6 +1567,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
    */
   refreshAllStatistics(): void {
     this.invalidateCodingStatusCache();
+    this.hasLoadedPlanningDataBundle = true;
     this.loadCodingProgressOverview();
     this.loadVariableCoverageOverview();
     this.loadCaseCoverageOverview();
@@ -1596,8 +1617,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private shouldRefreshManualStateOnFocus(): boolean {
     return this.hasLoadedManualCodingJobRefreshSetting &&
       this.autoRefreshManualCodingJobs &&
-      (this.activeManualTab === 'planning' ||
-        this.activeManualTab === 'execution' ||
+      (this.activeManualTab === 'execution' ||
         this.activeManualTab === 'completion');
   }
 
@@ -1739,6 +1759,20 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingManualFreshnessJobSummary ||
       this.isLoadingDoubleCodingConflictSummary ||
       this.isLoadingMatchingMode;
+  }
+
+  private hasPlanningDataBundleSnapshot(): boolean {
+    return this.hasLoadedPlanningDataBundle;
+  }
+
+  private shouldWaitForPlanningDataBundle(): boolean {
+    return !!this.appService.selectedWorkspaceId &&
+      !this.hasPlanningDataBundleSnapshot();
+  }
+
+  private shouldRequirePlanningDataRefresh(): boolean {
+    return this.activeManualTab === 'planning' &&
+      this.shouldWaitForPlanningDataBundle();
   }
 
   getOpenCodingCases(): number {
@@ -2209,6 +2243,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'complete':
         return 'status-complete';
       case 'loading':
+      case 'planning-data-required':
       case 'planning-ready':
       case 'training-ready':
       case 'execution-ready':
@@ -2220,6 +2255,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private getPlanningStatusState(): PlanningStatusState {
     if (this.isAnyPlanningDataLoading()) {
       return 'loading';
+    }
+
+    if (this.shouldRequirePlanningDataRefresh()) {
+      return 'planning-data-required';
     }
 
     if (this.hasPreparationRefreshTarget()) {
@@ -2279,6 +2318,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     switch (this.getPlanningStatusState()) {
       case 'loading':
         return 'sync';
+      case 'planning-data-required':
+        return 'refresh';
       case 'warning':
         return 'warning';
       case 'preparation-required':
@@ -2308,6 +2349,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     switch (this.getPlanningStatusState()) {
       case 'loading':
         return 'Status wird aktualisiert';
+      case 'planning-data-required':
+        return 'Planungsdaten aktualisieren';
       case 'warning':
         return this.hasVariableCoverageConflicts() ?
           'Konflikte prüfen' :
@@ -2342,6 +2385,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
     if (planningStatusState === 'loading') {
       return 'Die Planungs- und Kodierfortschritte werden geladen.';
+    }
+
+    if (planningStatusState === 'planning-data-required') {
+      return 'Abdeckung, Kodierfortschritt und Freshness-Hinweise werden erst auf Anforderung geladen.';
     }
 
     if (planningStatusState === 'progress-unavailable') {
@@ -2410,6 +2457,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     switch (this.getPlanningStatusState()) {
       case 'loading':
         return 'Planungsstand wird geladen';
+      case 'planning-data-required':
+        return 'Planungsstand laden';
       case 'warning':
         return this.hasVariableCoverageConflicts() ?
           'Konflikte zuerst klären' :
@@ -2446,6 +2495,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     switch (this.getPlanningStatusState()) {
       case 'loading':
         return 'Warten Sie kurz, bis die Planungsdaten aktualisiert sind.';
+      case 'planning-data-required':
+        return 'Laden Sie die Planungsdaten, um Variablen- und Fallabdeckung, Kodierfortschritt, offene Variablen und Freshness-Hinweise zu prüfen.';
       case 'warning':
         if (this.hasVariableCoverageConflicts()) {
           return 'Prüfen Sie Variablen, die von mehreren Definitionen mit überlappenden Fällen verwendet werden.';
@@ -2505,6 +2556,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       case 'complete':
         return this.canShowManualCompletionTab() ? 'Abschluss ansehen' : 'Zu den Kodierjobs';
       case 'loading':
+      case 'planning-data-required':
       case 'progress-unavailable':
         return 'Aktualisieren';
       default:
@@ -2580,7 +2632,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   performPlanningNextStep(): void {
     const planningStatusState = this.getPlanningStatusState();
-    if (planningStatusState === 'loading' || planningStatusState === 'progress-unavailable') {
+    if (planningStatusState === 'loading' ||
+        planningStatusState === 'planning-data-required' ||
+        planningStatusState === 'progress-unavailable') {
       this.refreshManualCodingPlanning();
       return;
     }
@@ -2590,6 +2644,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   getPlanningNextStepIcon(): string {
     switch (this.getPlanningStatusState()) {
+      case 'planning-data-required':
+        return 'refresh';
       case 'warning':
         return 'warning';
       case 'preparation-required':
@@ -2750,6 +2806,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private refreshAggregationDependentViews(includeResponseAnalysis = true): void {
     this.invalidateCodingStatusCache();
+    this.hasLoadedPlanningDataBundle = true;
     if (includeResponseAnalysis) {
       this.loadResponseAnalysis();
     }
@@ -2828,13 +2885,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.loadResponseAnalysis();
         return;
       case 'planning':
-        this.loadVariableCoverageOverview();
-        this.loadCaseCoverageOverview();
-        this.loadCodingProgressOverview();
-        this.loadCodingIncompleteVariables();
-        this.loadManualFreshnessDecisionData();
-        this.loadCodingFreshness({ force: forceRefresh });
-        this.loadResponseAnalysisForPlanningIfNeeded();
+        if (forceRefresh) {
+          this.loadPlanningDataBundle(forceRefresh);
+        }
         return;
       case 'training':
         if (reloadCodingJobs) {
@@ -2862,6 +2915,17 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
   }
 
+  private loadPlanningDataBundle(forceRefresh: boolean): void {
+    this.hasLoadedPlanningDataBundle = true;
+    this.loadVariableCoverageOverview();
+    this.loadCaseCoverageOverview();
+    this.loadCodingProgressOverview();
+    this.loadCodingIncompleteVariables();
+    this.loadManualFreshnessDecisionData();
+    this.loadCodingFreshness({ force: forceRefresh });
+    this.loadResponseAnalysisForPlanningIfNeeded();
+  }
+
   private loadManualCodingJobRefreshSetting(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
@@ -2882,7 +2946,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
             this.pendingAutomaticManualTabLoad = null;
             if (pendingTab) {
               this.loadManualTabData(pendingTab);
-            } else {
+            } else if (this.activeManualTab !== 'planning') {
               this.loadCodingFreshness();
             }
           } else {
@@ -2896,7 +2960,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.pendingAutomaticManualTabLoad = null;
           if (pendingTab) {
             this.loadManualTabData(pendingTab);
-          } else {
+          } else if (this.activeManualTab !== 'planning') {
             this.loadCodingFreshness();
           }
         }
@@ -2971,7 +3035,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private focusManualFreshnessTargetIfReady(): void {
     if (!this.pendingManualFreshnessFocus ||
         !this.manualFreshnessPlanningRequested ||
-        this.isAnyPlanningDataLoading()) {
+        this.isAnyPlanningDataLoading() ||
+        this.shouldWaitForPlanningDataBundle()) {
       return;
     }
 


### PR DESCRIPTION
## Änderungen

- verhindert, dass der Planungstab große Datenpakete automatisch bündelt lädt
- lädt Variablen-/Fallabdeckung, Kodierfortschritt, unvollständige Variablen und Freshness-Entscheidungsdaten erst per explizitem Refresh
- invalidiert bestehende Planungssnapshots nach relevanten externen Änderungen
- hält `manual-freshness`-Fokus pending, bis die Planungsdaten explizit geladen wurden

## Hintergrund

Teil von #813: Der Planungstab soll große Datenpakete nicht mehr automatisch laden, sondern erst auf Anforderung aktualisieren.

## Validierung

- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts`
- `npx nx lint frontend`
- `npx nx test frontend`
