### PR TITLE
Guard coding status checks during background jobs

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -167,6 +167,126 @@ describe('CodingManagementManualComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should keep tracking the response-analysis guard after destroy while analysis is calculating', () => {
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        setResponseAnalysisGuardRunning: (
+          workspaceId: number,
+          isRunning: boolean
+        ) => void;
+        trackResponseAnalysisGuardUntilComplete: (
+          workspaceId: number,
+          threshold?: number
+        ) => void;
+      };
+      setResponseAnalysisGuardActive: (isActive: boolean) => void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    const setGuardSpy = jest
+      .spyOn(componentInternals.testPersonCodingService, 'setResponseAnalysisGuardRunning')
+      .mockImplementation(() => undefined);
+    const trackGuardSpy = jest
+      .spyOn(componentInternals.testPersonCodingService, 'trackResponseAnalysisGuardUntilComplete')
+      .mockImplementation(() => undefined);
+
+    componentInternals.setResponseAnalysisGuardActive(true);
+    component.ngOnDestroy();
+
+    expect(setGuardSpy).toHaveBeenCalledWith(5, true);
+    expect(trackGuardSpy).toHaveBeenCalledWith(5, 2);
+  });
+
+  it('should not clear the response-analysis guard on destroy when it is not owned by this component', () => {
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        setResponseAnalysisGuardRunning: (
+          workspaceId: number,
+          isRunning: boolean
+        ) => void;
+      };
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    const setGuardSpy = jest
+      .spyOn(componentInternals.testPersonCodingService, 'setResponseAnalysisGuardRunning')
+      .mockImplementation(() => undefined);
+
+    component.ngOnDestroy();
+
+    expect(setGuardSpy).not.toHaveBeenCalledWith(5, false);
+  });
+
+  it('should keep the response-analysis guard active after a transient polling error', () => {
+    jest.useFakeTimers();
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        getResponseAnalysis: jest.Mock;
+        setResponseAnalysisGuardRunning: (
+          workspaceId: number,
+          isRunning: boolean
+        ) => void;
+      };
+      setResponseAnalysisGuardActive: (isActive: boolean) => void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    const setGuardSpy = jest
+      .spyOn(componentInternals.testPersonCodingService, 'setResponseAnalysisGuardRunning')
+      .mockImplementation(() => undefined);
+    const getResponseAnalysisSpy = jest
+      .spyOn(componentInternals.testPersonCodingService, 'getResponseAnalysis')
+      .mockReturnValueOnce(throwError(() => new Error('temporary polling error')))
+      .mockReturnValueOnce(of({
+        emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+        duplicateValues: { total: 0, totalResponses: 0, groups: [] },
+        matchingFlags: [],
+        isCalculating: false
+      }));
+
+    try {
+      componentInternals.setResponseAnalysisGuardActive(true);
+      setGuardSpy.mockClear();
+
+      component.loadResponseAnalysis();
+
+      expect(getResponseAnalysisSpy).toHaveBeenCalledTimes(1);
+      expect(setGuardSpy).not.toHaveBeenCalledWith(5, false);
+
+      jest.advanceTimersByTime(5000);
+
+      expect(getResponseAnalysisSpy).toHaveBeenCalledTimes(2);
+      expect(setGuardSpy).toHaveBeenLastCalledWith(5, false);
+    } finally {
+      component.ngOnDestroy();
+      jest.useRealTimers();
+    }
+  });
+
+  it('should run pending manual state and forced freshness refresh after a background guard clears', () => {
+    component.selectedManualTabIndex = 1;
+    const componentInternals = component as unknown as {
+      pendingManualStateRefreshAfterBackgroundJob: boolean;
+      pendingForcedCodingFreshnessRefreshAfterBackgroundJob: boolean;
+      refreshPendingManualStatusAfterBackgroundJob(): void;
+      loadManualTabData(tab: string, options?: { reloadCodingJobs?: boolean }): void;
+      loadCodingFreshness(options?: { force?: boolean }): void;
+    };
+    componentInternals.pendingManualStateRefreshAfterBackgroundJob = true;
+    componentInternals.pendingForcedCodingFreshnessRefreshAfterBackgroundJob = true;
+    const loadManualTabDataSpy = jest
+      .spyOn(componentInternals, 'loadManualTabData')
+      .mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+
+    componentInternals.refreshPendingManualStatusAfterBackgroundJob();
+
+    expect(loadManualTabDataSpy).toHaveBeenCalledWith('planning', { reloadCodingJobs: false });
+    expect(loadCodingFreshnessSpy).toHaveBeenCalledWith({ force: true });
+  });
+
   it('should flag duplicate findings as diagnostic when aggregation is disabled', () => {
     component.responseAnalysis = {
       emptyResponses: { total: 0, totalUncoded: 0, items: [] },

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -120,6 +120,7 @@ import {
 } from '../manual-coding-export-dialog/manual-coding-export-dialog.component';
 import { CohensKappaStatisticsComponent } from '../cohens-kappa-statistics/cohens-kappa-statistics.component';
 import { DoubleCodedReviewComponent } from '../double-coded-review/double-coded-review.component';
+import { CodingBackgroundJobsService } from '../../services/coding-background-jobs.service';
 
 interface SavedCodeProgress {
   id?: number;
@@ -217,6 +218,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private exportJobService = inject(ExportJobService);
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
+  private codingBackgroundJobsService = inject(CodingBackgroundJobsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private document = inject(DOCUMENT);
@@ -314,6 +316,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private lastWindowFocusRefreshAt = 0;
   private lastCodingFreshnessRefreshAt = 0;
   private codingFreshnessRequestGeneration = 0;
+  private responseAnalysisGuardActive = false;
+  private responseAnalysisGuardWorkspaceId: number | null = null;
+  private hasShownResponseAnalysisPollingError = false;
+  private pendingManualStateRefreshAfterBackgroundJob = false;
+  private pendingCodingFreshnessRefreshAfterBackgroundJob = false;
+  private pendingForcedCodingFreshnessRefreshAfterBackgroundJob = false;
   private readonly handleWindowFocus = () => {
     if (!this.shouldRefreshManualStateOnFocus()) {
       return;
@@ -321,6 +329,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
     const now = Date.now();
     if (now - this.lastWindowFocusRefreshAt < this.windowFocusRefreshThrottleMs) {
+      return;
+    }
+
+    if (this.shouldSuppressCodingStatusChecks()) {
+      this.pendingManualStateRefreshAfterBackgroundJob = true;
       return;
     }
 
@@ -570,6 +583,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         }
       });
 
+    this.codingBackgroundJobsService.statusGuardCleared$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => {
+        if (event.workspaceId === this.appService.selectedWorkspaceId) {
+          this.refreshPendingManualStatusAfterBackgroundJob();
+        }
+      });
+
     this.loadInitialManualCodingState();
     this.loadManualCodingJobRefreshSetting();
     this.loadManualCodingApplyPermission();
@@ -580,6 +601,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     if (this.analysisPollingTimer) {
       clearTimeout(this.analysisPollingTimer);
     }
+    this.finalizeResponseAnalysisGuardOnDestroy();
     this.document.defaultView?.removeEventListener('focus', this.handleWindowFocus);
     this.destroy$.next();
     this.destroy$.complete();
@@ -1566,6 +1588,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
    * Refreshes all statistics with individual loading states
    */
   refreshAllStatistics(): void {
+    if (this.shouldSuppressCodingStatusChecks()) {
+      this.pendingManualStateRefreshAfterBackgroundJob = true;
+      return;
+    }
+
     this.invalidateCodingStatusCache();
     this.hasLoadedPlanningDataBundle = true;
     this.loadCodingProgressOverview();
@@ -1594,6 +1621,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   refreshManualCodingPlanning(): void {
+    if (this.shouldSuppressCodingStatusChecks()) {
+      this.pendingManualStateRefreshAfterBackgroundJob = true;
+      return;
+    }
+
     this.invalidateCodingStatusCache();
     const activeTab = this.activeManualTab;
     this.loadManualTabData(activeTab, {
@@ -1621,15 +1653,165 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.activeManualTab === 'completion');
   }
 
-  private refreshManualStateAfterExternalChange(): void {
+  private refreshManualStateAfterExternalChange(
+    options: { forceCodingFreshness?: boolean } = {}
+  ): void {
+    if (this.shouldSuppressCodingStatusChecks()) {
+      this.pendingManualStateRefreshAfterBackgroundJob = true;
+      return;
+    }
+
     const activeTab = this.activeManualTab;
     this.loadManualTabData(activeTab, { reloadCodingJobs: false });
     if (activeTab !== 'planning') {
-      this.loadCodingFreshness();
+      if (options.forceCodingFreshness) {
+        this.loadCodingFreshness({ force: true });
+      } else {
+        this.loadCodingFreshness();
+      }
     }
     if (this.shouldReloadCodingJobsAfterManualTabData(activeTab)) {
       this.reloadCodingJobsList('active');
     }
+  }
+
+  private shouldSuppressCodingStatusChecks(): boolean {
+    return this.codingBackgroundJobsService.isStatusCheckGuardActive(
+      this.appService.selectedWorkspaceId
+    );
+  }
+
+  private refreshPendingManualStatusAfterBackgroundJob(): void {
+    const shouldRefreshManualState = this.pendingManualStateRefreshAfterBackgroundJob;
+    const shouldRefreshCodingFreshness = this.pendingCodingFreshnessRefreshAfterBackgroundJob ||
+      this.pendingForcedCodingFreshnessRefreshAfterBackgroundJob;
+    const forceCodingFreshness = this.pendingForcedCodingFreshnessRefreshAfterBackgroundJob;
+    const activeTab = this.activeManualTab;
+
+    this.pendingManualStateRefreshAfterBackgroundJob = false;
+    this.pendingCodingFreshnessRefreshAfterBackgroundJob = false;
+    this.pendingForcedCodingFreshnessRefreshAfterBackgroundJob = false;
+
+    if (shouldRefreshManualState) {
+      this.refreshManualStateAfterExternalChange({
+        forceCodingFreshness: shouldRefreshCodingFreshness && forceCodingFreshness
+      });
+    }
+
+    if (shouldRefreshCodingFreshness &&
+      (!shouldRefreshManualState || activeTab === 'planning')) {
+      this.loadCodingFreshness({ force: forceCodingFreshness });
+    }
+  }
+
+  private setManualResponseAnalysisGuardRunning(
+    workspaceId: number,
+    isActive: boolean
+  ): void {
+    const guardService = this.testPersonCodingService as unknown as {
+      setResponseAnalysisGuardRunning?: (
+        guardedWorkspaceId: number,
+        guardedIsActive: boolean
+      ) => void;
+    };
+
+    if (guardService.setResponseAnalysisGuardRunning) {
+      guardService.setResponseAnalysisGuardRunning(workspaceId, isActive);
+      return;
+    }
+
+    this.codingBackgroundJobsService.setJobRunning(
+      workspaceId,
+      'response-analysis',
+      isActive,
+      'manual-response-analysis'
+    );
+  }
+
+  private trackManualResponseAnalysisGuardUntilComplete(
+    workspaceId: number | null | undefined,
+    threshold: number
+  ): void {
+    if (!workspaceId) {
+      return;
+    }
+
+    const guardService = this.testPersonCodingService as unknown as {
+      trackResponseAnalysisGuardUntilComplete?: (
+        guardedWorkspaceId: number,
+        guardedThreshold?: number
+      ) => void;
+    };
+
+    if (guardService.trackResponseAnalysisGuardUntilComplete) {
+      guardService.trackResponseAnalysisGuardUntilComplete(workspaceId, threshold);
+      return;
+    }
+
+    this.setManualResponseAnalysisGuardRunning(workspaceId, true);
+  }
+
+  private setResponseAnalysisGuardActive(isActive: boolean): void {
+    if (!isActive && !this.responseAnalysisGuardActive) {
+      return;
+    }
+
+    const workspaceId = isActive ?
+      this.appService.selectedWorkspaceId :
+      this.responseAnalysisGuardWorkspaceId;
+    if (!workspaceId ||
+      (this.responseAnalysisGuardActive === isActive &&
+        this.responseAnalysisGuardWorkspaceId === workspaceId)) {
+      return;
+    }
+
+    if (isActive &&
+      this.responseAnalysisGuardActive &&
+      this.responseAnalysisGuardWorkspaceId &&
+      this.responseAnalysisGuardWorkspaceId !== workspaceId) {
+      this.setManualResponseAnalysisGuardRunning(
+        this.responseAnalysisGuardWorkspaceId,
+        false
+      );
+    }
+
+    this.responseAnalysisGuardActive = isActive;
+    this.responseAnalysisGuardWorkspaceId = isActive ? workspaceId : null;
+    this.setManualResponseAnalysisGuardRunning(
+      workspaceId,
+      isActive
+    );
+  }
+
+  private finalizeResponseAnalysisGuardOnDestroy(): void {
+    if (!this.responseAnalysisGuardActive) {
+      return;
+    }
+
+    this.trackManualResponseAnalysisGuardUntilComplete(
+      this.responseAnalysisGuardWorkspaceId || this.appService.selectedWorkspaceId,
+      this.normalizeAggregationThreshold(this.duplicateAggregationThreshold)
+    );
+  }
+
+  private shouldKeepResponseAnalysisGuardAfterPollingError(
+    workspaceId: number
+  ): boolean {
+    return this.responseAnalysisGuardActive &&
+      this.responseAnalysisGuardWorkspaceId === workspaceId;
+  }
+
+  private scheduleResponseAnalysisPollingRetry(workspaceId: number): void {
+    if (this.analysisPollingTimer) {
+      clearTimeout(this.analysisPollingTimer);
+    }
+
+    this.analysisPollingTimer = setTimeout(() => {
+      this.analysisPollingTimer = undefined;
+      if (this.shouldKeepResponseAnalysisGuardAfterPollingError(workspaceId)) {
+        this.loadResponseAnalysis();
+      }
+    }, 5000);
   }
 
   private shouldSkipAutomaticManualTabLoad(
@@ -3260,10 +3442,6 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (options.force) {
-      this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
-    }
-
     if (!options.force && !this.hasLoadedManualCodingJobRefreshSetting) {
       this.codingFreshnessRequestGeneration += 1;
       this.isLoadingCodingFreshness = false;
@@ -3274,6 +3452,20 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.codingFreshnessRequestGeneration += 1;
       this.isLoadingCodingFreshness = false;
       return;
+    }
+
+    if (this.shouldSuppressCodingStatusChecks()) {
+      this.pendingCodingFreshnessRefreshAfterBackgroundJob = true;
+      if (options.force) {
+        this.pendingForcedCodingFreshnessRefreshAfterBackgroundJob = true;
+      }
+      this.codingFreshnessRequestGeneration += 1;
+      this.isLoadingCodingFreshness = false;
+      return;
+    }
+
+    if (options.force) {
+      this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
     }
 
     const now = Date.now();
@@ -4373,6 +4565,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   loadResponseAnalysis(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      this.setResponseAnalysisGuardActive(false);
       this.isLoadingResponseAnalysis = false;
       return;
     }
@@ -4399,6 +4592,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.responseAnalysis = analysis;
           this.responseAnalysisError = null;
           this.isLoadingResponseAnalysis = false;
+          this.hasShownResponseAnalysisPollingError = false;
+          this.setResponseAnalysisGuardActive(analysis.isCalculating === true);
           this.focusManualFreshnessTargetIfReady();
 
           if (analysis.isCalculating) {
@@ -4413,8 +4608,23 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         error: error => {
           this.isLoadingResponseAnalysis = false;
           this.focusManualFreshnessTargetIfReady();
+          const responseAnalysisError = `Fehler beim Laden der Antwortanalyse: ${error.message || error}`;
+          if (this.shouldKeepResponseAnalysisGuardAfterPollingError(workspaceId)) {
+            if (!this.hasShownResponseAnalysisPollingError) {
+              this.hasShownResponseAnalysisPollingError = true;
+              this.snackBar.open(
+                responseAnalysisError,
+                'OK',
+                { duration: 3000 }
+              );
+            }
+            this.scheduleResponseAnalysisPollingRetry(workspaceId);
+            return;
+          }
+
+          this.setResponseAnalysisGuardActive(false);
           this.responseAnalysis = null;
-          this.responseAnalysisError = `Fehler beim Laden der Antwortanalyse: ${error.message || error}`;
+          this.responseAnalysisError = responseAnalysisError;
           this.snackBar.open(
             this.responseAnalysisError,
             'OK',
@@ -4464,6 +4674,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       )
       .subscribe({
         next: () => {
+          this.setResponseAnalysisGuardActive(true);
           this.snackBar.open('Antwortanalyse wurde gestartet.', 'OK', { duration: 3000 });
           if (shouldRefreshAggregationDependentViews) {
             this.refreshAggregationDependentViews(false);
@@ -4471,6 +4682,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.loadResponseAnalysis(); // Start polling
         },
         error: error => {
+          this.setResponseAnalysisGuardActive(false);
           this.isLoadingResponseAnalysis = false;
           if (settingsReadyForAnalysis) {
             this.snackBar.open(

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -23,6 +23,10 @@ import {
   TestPersonCodingService,
   TestResultsChangedEvent
 } from '../../services/test-person-coding.service';
+import {
+  CodingBackgroundJobsService,
+  CodingStatusGuardClearedEvent
+} from '../../services/coding-background-jobs.service';
 import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
 import { Success } from '../../models/success.model';
@@ -37,10 +41,12 @@ describe('CodingManagementComponent', () => {
   let mockAppService: jest.Mocked<Partial<AppService>>;
   let mockWorkspaceSettingsService: jest.Mocked<Partial<WorkspaceSettingsService>>;
   let mockTestPersonCodingService: jest.Mocked<Partial<TestPersonCodingService>>;
+  let mockCodingBackgroundJobsService: jest.Mocked<Partial<CodingBackgroundJobsService>>;
   let mockRouter: jest.Mocked<Partial<Router>>;
   let mockSnackBar: jest.Mocked<Partial<MatSnackBar>>;
   let autoCodingCompletedSubject: Subject<{ jobId?: string }>;
   let testResultsChangedSubject: Subject<TestResultsChangedEvent>;
+  let statusGuardClearedSubject: Subject<CodingStatusGuardClearedEvent>;
   let resetProgressSubject: Subject<number | null>;
   let queryParamMapSubject: BehaviorSubject<ParamMap>;
   let fakeActivatedRoute: ActivatedRoute;
@@ -171,7 +177,15 @@ describe('CodingManagementComponent', () => {
         groupNames: []
       })),
       getJobStatus: jest.fn(),
+      trackFreshnessCodingGuardUntilComplete: jest.fn(),
       notifyAutoCodingCompleted: jest.fn()
+    };
+
+    statusGuardClearedSubject = new Subject<CodingStatusGuardClearedEvent>();
+    mockCodingBackgroundJobsService = {
+      isStatusCheckGuardActive: jest.fn().mockReturnValue(false),
+      setJobRunning: jest.fn(),
+      statusGuardCleared$: statusGuardClearedSubject.asObservable()
     };
 
     mockRouter = {
@@ -220,6 +234,10 @@ describe('CodingManagementComponent', () => {
         {
           provide: TestPersonCodingService,
           useValue: mockTestPersonCodingService
+        },
+        {
+          provide: CodingBackgroundJobsService,
+          useValue: mockCodingBackgroundJobsService
         },
         {
           provide: Router,
@@ -322,6 +340,145 @@ describe('CodingManagementComponent', () => {
       expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
       expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+    });
+
+    it('should defer manual coding status refresh while a guarded background job is running', () => {
+      (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
+        .mockReturnValue(true);
+      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+      component.refreshCodingStatusOverview();
+
+      expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+
+      (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
+        .mockReturnValue(false);
+      statusGuardClearedSubject.next({ workspaceId: 1 });
+
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+    });
+
+    it('should defer automatic coding status refresh while a guarded background job is running', () => {
+      (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
+        .mockReturnValue(true);
+      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+      autoCodingCompletedSubject.next({});
+
+      expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+
+      (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
+        .mockReturnValue(false);
+      statusGuardClearedSubject.next({ workspaceId: 1 });
+
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
+    });
+
+    it('should not refresh twice when freshness completion clears a pending guarded refresh', () => {
+      let guardActive = true;
+      (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
+        .mockImplementation(() => guardActive);
+      (mockCodingBackgroundJobsService.setJobRunning as jest.Mock)
+        .mockImplementation(() => {
+          guardActive = false;
+          statusGuardClearedSubject.next({ workspaceId: 1 });
+        });
+      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+      component.refreshCodingStatusOverview();
+      component.activeFreshnessJobId = 'freshness-job-1';
+      autoCodingCompletedSubject.next({ jobId: 'freshness-job-1' });
+
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not refresh twice when a child freshness dialog clears the guard before completion is emitted', () => {
+      let guardActive = true;
+      (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
+        .mockImplementation(() => guardActive);
+      (mockCodingBackgroundJobsService.setJobRunning as jest.Mock)
+        .mockImplementation((_workspaceId, _kind, isRunning, jobId) => {
+          if (!isRunning && guardActive) {
+            guardActive = false;
+            statusGuardClearedSubject.next({
+              workspaceId: 1,
+              kind: 'freshness-coding',
+              jobId
+            });
+          }
+        });
+      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+      component.refreshCodingStatusOverview();
+      component.activeFreshnessJobId = 'freshness-job-1';
+      mockCodingBackgroundJobsService.setJobRunning?.(
+        1,
+        'freshness-coding',
+        false,
+        'freshness-job-1'
+      );
+      autoCodingCompletedSubject.next({ jobId: 'freshness-job-1' });
+
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
+      expect(component.activeFreshnessJobId).toBeNull();
+    });
+
+    it('should not refresh twice when reset progress clears after a guarded pending refresh was handled', () => {
+      let guardActive = true;
+      (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
+        .mockImplementation(() => guardActive);
+      resetProgressSubject.next(50);
+      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+      component.refreshCodingStatusOverview();
+
+      expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+
+      guardActive = false;
+      statusGuardClearedSubject.next({
+        workspaceId: 1,
+        kind: 'autocoder-reset',
+        jobId: 'reset-job-1'
+      });
+      resetProgressSubject.next(null);
+
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledTimes(1);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
     });
 
     it('should not auto-fetch coding overview statistics when global auto-refresh is disabled', () => {
@@ -741,6 +898,24 @@ describe('CodingManagementComponent', () => {
       }
     });
 
+    it('should keep tracking an active freshness job guard after destroy', () => {
+      (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
+        totalResponses: 42,
+        statusCounts: {},
+        jobId: 'freshness-job-1',
+        message: 'Processing in background',
+        unitCount: 7,
+        personCount: 3,
+        groupNames: ['TG1']
+      }));
+
+      component.startFreshnessCoding('v1');
+      component.ngOnDestroy();
+
+      expect(mockTestPersonCodingService.trackFreshnessCodingGuardUntilComplete)
+        .toHaveBeenCalledWith(1, 'freshness-job-1');
+    });
+
     it('should not resume parent freshness polling when the dialog reports a terminal status for the started job', () => {
       jest.useFakeTimers();
       const afterClosed$ = new Subject<{ initialJobId: string; jobId: string; jobStatus: 'failed' }>();
@@ -771,6 +946,160 @@ describe('CodingManagementComponent', () => {
 
         expect(jest.getTimerCount()).toBe(0);
         expect(component.activeFreshnessJobId).toBeNull();
+      } finally {
+        component.ngOnDestroy();
+        jest.useRealTimers();
+      }
+    });
+
+    it('should refresh status overview when parent freshness polling observes a failed job', () => {
+      jest.useFakeTimers();
+      const afterClosed$ = new Subject<void>();
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(afterClosed$),
+        close: jest.fn()
+      };
+
+      try {
+        (mockDialog.open as jest.Mock).mockReturnValueOnce(dialogRef);
+        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
+          totalResponses: 42,
+          statusCounts: {},
+          jobId: 'freshness-job-1',
+          message: 'Processing in background',
+          unitCount: 7,
+          personCount: 3,
+          groupNames: ['TG1']
+        }));
+        (mockTestPersonCodingService.getJobStatus as jest.Mock).mockReturnValue(of({
+          status: 'failed',
+          progress: 100,
+          error: 'failed'
+        }));
+
+        component.startFreshnessCoding('v1');
+        afterClosed$.next();
+        afterClosed$.complete();
+        (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+        jest.advanceTimersByTime(2000);
+
+        expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
+        expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
+        expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
+        expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+      } finally {
+        component.ngOnDestroy();
+        jest.useRealTimers();
+      }
+    });
+
+    it('should keep the freshness guard active after a transient parent polling error', () => {
+      jest.useFakeTimers();
+      const afterClosed$ = new Subject<void>();
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(afterClosed$),
+        close: jest.fn()
+      };
+
+      try {
+        (mockDialog.open as jest.Mock).mockReturnValueOnce(dialogRef);
+        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
+          totalResponses: 42,
+          statusCounts: {},
+          jobId: 'freshness-job-1',
+          message: 'Processing in background',
+          unitCount: 7,
+          personCount: 3,
+          groupNames: ['TG1']
+        }));
+        (mockTestPersonCodingService.getJobStatus as jest.Mock)
+          .mockReturnValueOnce(of({ error: 'temporary status error' }))
+          .mockReturnValueOnce(of({
+            status: 'completed',
+            progress: 100
+          }));
+
+        component.startFreshnessCoding('v1');
+        afterClosed$.next();
+        afterClosed$.complete();
+        (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+        jest.advanceTimersByTime(2000);
+
+        expect(mockCodingBackgroundJobsService.setJobRunning).not.toHaveBeenCalledWith(
+          1,
+          'freshness-coding',
+          false,
+          'freshness-job-1'
+        );
+        expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(2000);
+
+        expect(mockCodingBackgroundJobsService.setJobRunning).toHaveBeenLastCalledWith(
+          1,
+          'freshness-coding',
+          false,
+          'freshness-job-1'
+        );
+        expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
+        expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
+        expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
+        expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+      } finally {
+        component.ngOnDestroy();
+        jest.useRealTimers();
+      }
+    });
+
+    it('should refresh completed freshness jobs once even when automatic refresh is disabled', () => {
+      jest.useFakeTimers();
+      const afterClosed$ = new Subject<void>();
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(afterClosed$),
+        close: jest.fn()
+      };
+
+      try {
+        component.autoRefreshManualCodingJobs = false;
+        (mockDialog.open as jest.Mock).mockReturnValueOnce(dialogRef);
+        (mockTestPersonCodingService.startFreshnessCoding as jest.Mock).mockReturnValueOnce(of({
+          totalResponses: 42,
+          statusCounts: {},
+          jobId: 'freshness-job-1',
+          message: 'Processing in background',
+          unitCount: 7,
+          personCount: 3,
+          groupNames: ['TG1']
+        }));
+        (mockTestPersonCodingService.getJobStatus as jest.Mock).mockReturnValue(of({
+          status: 'completed',
+          progress: 100
+        }));
+        (mockTestPersonCodingService.notifyAutoCodingCompleted as jest.Mock)
+          .mockImplementation(jobId => autoCodingCompletedSubject.next({ jobId }));
+
+        component.startFreshnessCoding('v1');
+        afterClosed$.next();
+        afterClosed$.complete();
+        (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+        jest.advanceTimersByTime(2000);
+
+        expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
+        expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledTimes(1);
+        expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledTimes(1);
+        expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
       } finally {
         component.ngOnDestroy();
         jest.useRealTimers();

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -46,6 +46,10 @@ import {
   TestPersonCodingService,
   TestResultsChangedEvent
 } from '../../services/test-person-coding.service';
+import {
+  CodingBackgroundJobsService,
+  CodingStatusGuardClearedEvent
+} from '../../services/coding-background-jobs.service';
 import { ExportCodingBookComponent } from '../export-coding-book/export-coding-book.component';
 import { VariableAnalysisDialogComponent } from '../variable-analysis-dialog/variable-analysis-dialog.component';
 import { CodingVariablesDialogComponent } from '../../../coding-management/coding-variables-dialog/coding-variables-dialog.component';
@@ -125,6 +129,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private dialog = inject(MatDialog);
   private codingManagementService = inject(CodingManagementService);
   private testPersonCodingService = inject(TestPersonCodingService);
+  private codingBackgroundJobsService = inject(CodingBackgroundJobsService);
   private uiService = inject(CodingManagementUiService);
   private translateService = inject(TranslateService);
   private router = inject(Router);
@@ -206,8 +211,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
   private freshnessJobPollingInterval: number | null = null;
+  private activeFreshnessJobWorkspaceId: number | null = null;
   private lastResetProgress: number | null | undefined;
   private hasLoadedManualCodingJobRefreshSetting = false;
+  private pendingAutomaticCodingStatusRefreshAfterBackgroundJob = false;
+  private pendingForcedCodingStatusRefreshAfterBackgroundJob = false;
+  private freshnessJobCompletionRefreshHandledIds = new Set<string>();
+  private resetCompletionRefreshHandledAfterGuardClear = false;
+  private hasShownFreshnessJobStatusPollingError = false;
 
   ngOnInit(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
@@ -248,6 +259,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         .subscribe(available => {
           this.isGeogebraAvailable = available;
         });
+
+      this.codingBackgroundJobsService.statusGuardCleared$
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(event => {
+          if (event.workspaceId === this.appService.selectedWorkspaceId) {
+            this.refreshPendingCodingStatusOverviewAfterBackgroundJob(event);
+          }
+        });
     }
 
     // Subscribe to service state
@@ -287,6 +306,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         if (previousProgress !== undefined &&
           previousProgress !== null &&
           progress === null) {
+          if (this.resetCompletionRefreshHandledAfterGuardClear) {
+            this.resetCompletionRefreshHandledAfterGuardClear = false;
+            return;
+          }
           this.refreshCodingStatusOverviewAfterChange();
         }
       });
@@ -307,8 +330,21 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.testPersonCodingService.autoCodingCompleted$
       .pipe(takeUntil(this.destroy$))
       .subscribe(event => {
+        if (event?.jobId &&
+          this.consumeHandledFreshnessJobCompletionRefresh(event.jobId)) {
+          if (event.jobId === this.activeFreshnessJobId) {
+            this.finishFreshnessCodingJob(event.jobId);
+            this.stopFreshnessJobPolling();
+          }
+          return;
+        }
+
         if (event?.jobId && event.jobId === this.activeFreshnessJobId) {
+          const pendingRefreshHandled = this.finishFreshnessCodingJob(event.jobId);
           this.stopFreshnessJobPolling();
+          if (pendingRefreshHandled) {
+            return;
+          }
         }
         this.refreshCodingStatusOverviewAfterChange();
       });
@@ -332,6 +368,12 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    if (this.activeFreshnessJobId) {
+      this.testPersonCodingService.trackFreshnessCodingGuardUntilComplete(
+        this.activeFreshnessJobWorkspaceId || this.appService.selectedWorkspaceId,
+        this.activeFreshnessJobId
+      );
+    }
     this.stopFreshnessJobPolling();
     this.destroy$.next();
     this.destroy$.complete();
@@ -375,12 +417,20 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   fetchCodingStatistics(): void {
+    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(false)) {
+      return;
+    }
+
     this.codingManagementService.fetchCodingStatistics(this.selectedStatisticsVersion);
   }
 
   loadCodingFreshness(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      return;
+    }
+
+    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(false)) {
       return;
     }
 
@@ -423,6 +473,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return;
     }
 
+    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(false)) {
+      return;
+    }
+
     this.isLoadingManualAppliedResultsOverview = true;
     this.manualAppliedResultsOverviewLoadFailed = false;
     this.testPersonCodingService.getAppliedResultsOverview(workspaceId)
@@ -441,6 +495,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   loadAutocodingReadiness(forceRefresh = false): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
+      return;
+    }
+
+    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(forceRefresh)) {
       return;
     }
 
@@ -469,9 +527,17 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   refreshCodingStatusOverview(): void {
+    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(true)) {
+      return;
+    }
+
+    this.performCodingStatusOverviewRefresh(true);
+  }
+
+  private performCodingStatusOverviewRefresh(forceAutocodingReadiness = false): void {
     this.invalidateCodingStatusOverviewCache();
     this.fetchCodingStatistics();
-    this.loadCodingStatusOverview(true);
+    this.loadCodingStatusOverview(forceAutocodingReadiness);
     this.refreshTableData();
   }
 
@@ -481,10 +547,11 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.invalidateCodingStatusOverviewCache();
-    this.fetchCodingStatistics();
-    this.loadCodingStatusOverview();
-    this.refreshTableData();
+    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(false)) {
+      return;
+    }
+
+    this.performCodingStatusOverviewRefresh();
   }
 
   private invalidateCodingStatusOverviewCache(): void {
@@ -495,10 +562,72 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   loadCodingStatusOverview(forceAutocodingReadiness = false): void {
+    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(forceAutocodingReadiness)) {
+      return;
+    }
+
     this.hasRequestedCodingStatusOverview = true;
     this.loadCodingFreshness();
     this.loadManualAppliedResultsOverview();
     this.loadAutocodingReadiness(forceAutocodingReadiness);
+  }
+
+  private deferCodingStatusRefreshIfBackgroundJobIsRunning(forceRefresh: boolean): boolean {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!this.codingBackgroundJobsService.isStatusCheckGuardActive(workspaceId)) {
+      return false;
+    }
+
+    if (forceRefresh) {
+      this.pendingForcedCodingStatusRefreshAfterBackgroundJob = true;
+    } else {
+      this.pendingAutomaticCodingStatusRefreshAfterBackgroundJob = true;
+    }
+    return true;
+  }
+
+  private hasPendingCodingStatusOverviewRefreshAfterBackgroundJob(): boolean {
+    return this.pendingForcedCodingStatusRefreshAfterBackgroundJob ||
+      this.pendingAutomaticCodingStatusRefreshAfterBackgroundJob;
+  }
+
+  private refreshPendingCodingStatusOverviewAfterBackgroundJob(
+    event?: CodingStatusGuardClearedEvent
+  ): void {
+    const forceRefresh = this.pendingForcedCodingStatusRefreshAfterBackgroundJob;
+    const shouldRefresh = this.hasPendingCodingStatusOverviewRefreshAfterBackgroundJob();
+
+    this.pendingForcedCodingStatusRefreshAfterBackgroundJob = false;
+    this.pendingAutomaticCodingStatusRefreshAfterBackgroundJob = false;
+
+    if (!shouldRefresh) {
+      return;
+    }
+
+    if (forceRefresh) {
+      this.performCodingStatusOverviewRefresh(true);
+      this.rememberGuardClearedCompletionRefresh(event);
+      return;
+    }
+
+    this.refreshCodingStatusOverviewAfterChange();
+    this.rememberGuardClearedCompletionRefresh(event);
+  }
+
+  private rememberGuardClearedCompletionRefresh(
+    event?: CodingStatusGuardClearedEvent
+  ): void {
+    if (event?.kind === 'freshness-coding' && event.jobId) {
+      this.freshnessJobCompletionRefreshHandledIds.add(event.jobId);
+    }
+
+    if (event?.kind === 'autocoder-reset') {
+      this.resetCompletionRefreshHandledAfterGuardClear = true;
+    }
+  }
+
+  private consumeHandledFreshnessJobCompletionRefresh(jobId: string): boolean {
+    return this.freshnessJobCompletionRefreshHandledIds.delete(jobId);
   }
 
   shouldShowManualCodingStatusRefresh(): boolean {
@@ -543,7 +672,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
           return;
         }
 
+        this.codingBackgroundJobsService.setJobRunning(
+          workspaceId,
+          'freshness-coding',
+          true,
+          result.jobId
+        );
         this.activeFreshnessJobId = result.jobId;
+        this.activeFreshnessJobWorkspaceId = workspaceId;
         this.activeFreshnessJobProgress = 0;
         const dialogRef = this.openTestPersonCodingDialog({
           initialJobId: result.jobId,
@@ -560,15 +696,17 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
               dialogResult.jobStatus :
               null;
             if (this.isTerminalJobStatus(dialogStatus)) {
+              const alreadyRefreshed =
+                this.consumeHandledFreshnessJobCompletionRefresh(result.jobId);
+              const pendingRefreshHandled = this.finishFreshnessCodingJob(result.jobId);
               this.stopFreshnessJobPolling();
-              this.invalidateCodingStatusOverviewCache();
-              this.loadCodingFreshness();
-              this.loadManualAppliedResultsOverview();
-              this.loadAutocodingReadiness(true);
+              if (!alreadyRefreshed && !pendingRefreshHandled) {
+                this.performCodingStatusOverviewRefresh(true);
+              }
               return;
             }
 
-            this.startFreshnessJobPolling(result.jobId);
+            this.startFreshnessJobPolling(result.jobId, workspaceId);
           });
         this.snackBar.open(
           `Auto-Coding für ${result.unitCount} betroffene Einträge gestartet.`,
@@ -1056,28 +1194,38 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     return getCodingFreshnessAutoCodingButtonLabel(this.autoCodingFreshnessWarnings, version);
   }
 
-  private startFreshnessJobPolling(jobId: string): void {
+  private startFreshnessJobPolling(
+    jobId: string,
+    workspaceId = this.activeFreshnessJobWorkspaceId || this.appService.selectedWorkspaceId
+  ): void {
     this.stopFreshnessJobPolling();
+    this.activeFreshnessJobId = jobId;
+    this.activeFreshnessJobWorkspaceId = workspaceId;
     this.freshnessJobPollingInterval = window.setInterval(() => {
-      const workspaceId = this.appService.selectedWorkspaceId;
-      if (!workspaceId) {
+      const currentWorkspaceId = this.activeFreshnessJobWorkspaceId || this.appService.selectedWorkspaceId;
+      if (!currentWorkspaceId) {
         this.stopFreshnessJobPolling();
         return;
       }
 
-      this.testPersonCodingService.getJobStatus(workspaceId, jobId)
+      this.testPersonCodingService.getJobStatus(currentWorkspaceId, jobId)
         .pipe(takeUntil(this.destroy$))
         .subscribe(status => {
           if (!('status' in status)) {
-            this.snackBar.open(status.error, 'Schließen', { duration: 5000 });
-            this.stopFreshnessJobPolling();
+            if (!this.hasShownFreshnessJobStatusPollingError) {
+              this.hasShownFreshnessJobStatusPollingError = true;
+              this.snackBar.open(status.error, 'Schließen', { duration: 5000 });
+            }
             return;
           }
 
+          this.hasShownFreshnessJobStatusPollingError = false;
           this.activeFreshnessJobProgress = status.progress;
           if (['completed', 'failed', 'cancelled', 'paused'].includes(status.status)) {
+            const pendingRefreshHandled = this.finishFreshnessCodingJob(jobId);
             this.stopFreshnessJobPolling();
             if (status.status === 'completed') {
+              this.freshnessJobCompletionRefreshHandledIds.add(jobId);
               this.testPersonCodingService.notifyAutoCodingCompleted(jobId);
               this.snackBar.open(
                 'Betroffene Ergebnisse wurden kodiert.',
@@ -1091,12 +1239,25 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
                 { duration: 6000 }
               );
             }
-            this.loadCodingFreshness();
-            this.loadManualAppliedResultsOverview();
-            this.loadAutocodingReadiness(true);
+            if (!pendingRefreshHandled) {
+              this.performCodingStatusOverviewRefresh(true);
+            }
           }
         });
     }, 2000);
+  }
+
+  private finishFreshnessCodingJob(jobId: string): boolean {
+    const workspaceId = this.activeFreshnessJobWorkspaceId || this.appService.selectedWorkspaceId;
+    const hadPendingRefresh = this.hasPendingCodingStatusOverviewRefreshAfterBackgroundJob();
+    this.codingBackgroundJobsService.setJobRunning(
+      workspaceId,
+      'freshness-coding',
+      false,
+      jobId
+    );
+    return hadPendingRefresh &&
+      !this.codingBackgroundJobsService.isStatusCheckGuardActive(workspaceId);
   }
 
   private get allCodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
@@ -1127,6 +1288,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       this.freshnessJobPollingInterval = null;
     }
     this.activeFreshnessJobId = null;
+    this.activeFreshnessJobWorkspaceId = null;
     this.activeFreshnessJobProgress = null;
   }
 

--- a/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.spec.ts
@@ -7,6 +7,7 @@ import { of } from 'rxjs';
 import { AppService } from '../../../core/services/app.service';
 import { TestResultService } from '../../../shared/services/test-result/test-result.service';
 import { BackendMessageTranslatorService } from '../../services/backend-message-translator.service';
+import { CodingBackgroundJobsService } from '../../services/coding-background-jobs.service';
 import {
   JobStatus,
   TestPersonCodingService
@@ -17,11 +18,18 @@ describe('TestPersonCodingComponent', () => {
   let fixture: ComponentFixture<TestPersonCodingComponent>;
   let component: TestPersonCodingComponent;
   let mockTestPersonCodingService: jest.Mocked<Partial<TestPersonCodingService>>;
+  let codingBackgroundJobsService: CodingBackgroundJobsService;
 
   beforeEach(async () => {
     mockTestPersonCodingService = {
       getAllJobs: jest.fn().mockReturnValue(of([])),
       getWorkspaceGroups: jest.fn().mockReturnValue(of([])),
+      getCodingStatistics: jest.fn().mockReturnValue(
+        of({
+          totalResponses: 0,
+          statusCounts: {}
+        })
+      ),
       getJobStatus: jest.fn(),
       notifyAutoCodingCompleted: jest.fn()
     };
@@ -62,6 +70,7 @@ describe('TestPersonCodingComponent', () => {
 
     fixture = TestBed.createComponent(TestPersonCodingComponent);
     component = fixture.componentInstance;
+    codingBackgroundJobsService = TestBed.inject(CodingBackgroundJobsService);
   });
 
   afterEach(() => {
@@ -86,6 +95,67 @@ describe('TestPersonCodingComponent', () => {
       expect(component.getLastObservedJobStatus('freshness-job-1')).toBe('failed');
       expect(jest.getTimerCount()).toBe(0);
     } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should keep freshness job polling active after a transient status error', () => {
+    jest.useFakeTimers();
+    try {
+      const setJobRunningSpy = jest.spyOn(
+        codingBackgroundJobsService,
+        'setJobRunning'
+      );
+      const completedStatus: JobStatus = {
+        status: 'completed',
+        progress: 100
+      };
+
+      component.initialJobId = 'freshness-job-1';
+      codingBackgroundJobsService.setJobRunning(
+        1,
+        'freshness-coding',
+        true,
+        'freshness-job-1'
+      );
+      (mockTestPersonCodingService.getJobStatus as jest.Mock)
+        .mockReturnValueOnce(of({ error: 'temporary status error' }))
+        .mockReturnValueOnce(of(completedStatus));
+
+      component.startJobStatusPolling('freshness-job-1');
+
+      expect(component.activeJobId).toBe('freshness-job-1');
+      expect(codingBackgroundJobsService.isStatusCheckGuardActive(1)).toBe(true);
+      expect(jest.getTimerCount()).toBe(1);
+      expect(setJobRunningSpy).not.toHaveBeenCalledWith(
+        1,
+        'freshness-coding',
+        false,
+        'freshness-job-1'
+      );
+
+      jest.advanceTimersByTime(2000);
+
+      expect(setJobRunningSpy).toHaveBeenCalledWith(
+        1,
+        'freshness-coding',
+        false,
+        'freshness-job-1'
+      );
+      expect(component.activeJobId).toBeNull();
+      expect(codingBackgroundJobsService.isStatusCheckGuardActive(1)).toBe(false);
+      expect(jest.getTimerCount()).toBe(0);
+      expect(
+        mockTestPersonCodingService.notifyAutoCodingCompleted
+      ).toHaveBeenCalledWith('freshness-job-1');
+    } finally {
+      component.stopJobStatusPolling();
+      codingBackgroundJobsService.setJobRunning(
+        1,
+        'freshness-coding',
+        false,
+        'freshness-job-1'
+      );
       jest.useRealTimers();
     }
   });

--- a/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.ts
+++ b/apps/frontend/src/app/coding/components/test-person-coding/test-person-coding.component.ts
@@ -40,6 +40,7 @@ import {
   TestPersonCodingService,
   WorkspaceGroupCodingStats
 } from '../../services/test-person-coding.service';
+import { CodingBackgroundJobsService } from '../../services/coding-background-jobs.service';
 import { AppService } from '../../../core/services/app.service';
 import { TestResultService } from '../../../shared/services/test-result/test-result.service';
 import { BackendMessageTranslatorService } from '../../services/backend-message-translator.service';
@@ -81,6 +82,7 @@ export class TestPersonCodingComponent implements OnInit {
   private translateService = inject(TranslateService);
   private backendMessageTranslator = inject(BackendMessageTranslatorService);
   private dialog = inject(MatDialog);
+  private codingBackgroundJobsService = inject(CodingBackgroundJobsService);
   @Input() initialJobId: string | null = null;
   @Input() initialAutoCoderRun: 1 | 2 | null = null;
 
@@ -117,6 +119,7 @@ export class TestPersonCodingComponent implements OnInit {
   jobStatusInterval: number | null = null;
   lastObservedJobId: string | null = null;
   private observedJobStatuses = new Map<string, JobStatus['status']>();
+  private hasShownJobStatusPollingError = false;
 
   allJobs: JobInfo[] = [];
   jobsLoading = false;
@@ -136,6 +139,7 @@ export class TestPersonCodingComponent implements OnInit {
 
     if (this.initialJobId) {
       this.activeJobId = this.initialJobId;
+      this.setFreshnessCodingGuard(this.initialJobId, true);
       this.startJobStatusPolling(this.initialJobId);
     }
 
@@ -178,6 +182,7 @@ export class TestPersonCodingComponent implements OnInit {
             if (activeJob) {
               this.rememberJobStatus(activeJob.jobId, activeJob);
               this.jobStatus = activeJob;
+              this.updateFreshnessCodingGuardFromStatus(activeJob.jobId, activeJob);
               if (
                 ['completed', 'failed', 'cancelled', 'paused'].includes(
                   activeJob.status
@@ -316,6 +321,7 @@ export class TestPersonCodingComponent implements OnInit {
 
     this.activeJobId = jobId;
     this.jobStatus = null;
+    this.hasShownJobStatusPollingError = false;
     this.jobStatusInterval = window.setInterval(() => {
       this.loadJobStatus(jobId);
     }, 2000);
@@ -327,19 +333,29 @@ export class TestPersonCodingComponent implements OnInit {
       .getJobStatus(this.workspaceId, jobId)
       .subscribe(status => {
         if (!('status' in status)) {
-          this.snackBar.open(
-            this.translateService.instant('test-person-coding.job-error', {
-              error: status.error
-            }),
-            this.translateService.instant('close'),
-            { duration: 5000 }
-          );
+          if (!this.hasShownJobStatusPollingError) {
+            this.hasShownJobStatusPollingError = true;
+            this.snackBar.open(
+              this.translateService.instant('test-person-coding.job-error', {
+                error: status.error
+              }),
+              this.translateService.instant('close'),
+              { duration: 5000 }
+            );
+          }
+
+          if (this.isFreshnessCodingJob(jobId)) {
+            return;
+          }
+
           this.stopJobStatusPolling();
           return;
         }
 
+        this.hasShownJobStatusPollingError = false;
         this.jobStatus = status;
         this.rememberJobStatus(jobId, status);
+        this.updateFreshnessCodingGuardFromStatus(jobId, status);
 
         if (
           ['completed', 'failed', 'cancelled', 'paused'].includes(
@@ -406,6 +422,7 @@ export class TestPersonCodingComponent implements OnInit {
     }
     this.activeJobId = null;
     this.jobStatus = null;
+    this.hasShownJobStatusPollingError = false;
   }
 
   private rememberJobStatus(jobId: string, status: JobStatus): void {
@@ -419,11 +436,36 @@ export class TestPersonCodingComponent implements OnInit {
         return;
       }
       this.lastNotifiedCompletedJobId = jobId;
+      this.setFreshnessCodingGuard(jobId, false);
     }
 
     this.loadStatistics();
     this.loadWorkspaceGroups();
     this.testPersonCodingService.notifyAutoCodingCompleted(jobId);
+  }
+
+  private updateFreshnessCodingGuardFromStatus(jobId: string, status: JobStatus): void {
+    if (!this.isFreshnessCodingJob(jobId, status)) {
+      return;
+    }
+
+    this.setFreshnessCodingGuard(
+      jobId,
+      !['completed', 'failed', 'cancelled', 'paused'].includes(status.status)
+    );
+  }
+
+  private isFreshnessCodingJob(jobId: string, status?: JobStatus): boolean {
+    return jobId === this.initialJobId || status?.source === 'coding-freshness';
+  }
+
+  private setFreshnessCodingGuard(jobId: string, isRunning: boolean): void {
+    this.codingBackgroundJobsService.setJobRunning(
+      this.workspaceId,
+      'freshness-coding',
+      isRunning,
+      jobId
+    );
   }
 
   cancelJob(jobId?: string): void {

--- a/apps/frontend/src/app/coding/services/coding-background-jobs.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-background-jobs.service.spec.ts
@@ -1,0 +1,36 @@
+import {
+  CodingBackgroundJobsService,
+  CodingStatusGuardClearedEvent
+} from './coding-background-jobs.service';
+
+describe('CodingBackgroundJobsService', () => {
+  let service: CodingBackgroundJobsService;
+
+  beforeEach(() => {
+    service = new CodingBackgroundJobsService();
+  });
+
+  it('should keep the status guard active until all tracked jobs finish', () => {
+    const clearedEvents: CodingStatusGuardClearedEvent[] = [];
+    service.statusGuardCleared$.subscribe(event => clearedEvents.push(event));
+
+    service.setJobRunning(1, 'autocoder-reset', true, 'reset-1');
+    service.setJobRunning(1, 'response-analysis', true, 'analysis-1');
+
+    expect(service.isStatusCheckGuardActive(1)).toBe(true);
+
+    service.setJobRunning(1, 'autocoder-reset', false, 'reset-1');
+
+    expect(service.isStatusCheckGuardActive(1)).toBe(true);
+    expect(clearedEvents).toEqual([]);
+
+    service.setJobRunning(1, 'response-analysis', false, 'analysis-1');
+
+    expect(service.isStatusCheckGuardActive(1)).toBe(false);
+    expect(clearedEvents).toEqual([{
+      workspaceId: 1,
+      kind: 'response-analysis',
+      jobId: 'analysis-1'
+    }]);
+  });
+});

--- a/apps/frontend/src/app/coding/services/coding-background-jobs.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-background-jobs.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
+
+export type CodingBackgroundJobKind =
+  | 'autocoder-reset'
+  | 'response-analysis'
+  | 'freshness-coding';
+
+export interface CodingStatusGuardClearedEvent {
+  workspaceId: number;
+  kind?: CodingBackgroundJobKind;
+  jobId?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CodingBackgroundJobsService {
+  private readonly activeJobsByWorkspace = new Map<number, Map<CodingBackgroundJobKind, Set<string>>>();
+  private readonly activeJobSnapshot$ = new BehaviorSubject<Map<number, Set<CodingBackgroundJobKind>>>(new Map());
+  private readonly statusGuardClearedSubject = new Subject<CodingStatusGuardClearedEvent>();
+
+  readonly statusGuardCleared$ = this.statusGuardClearedSubject.asObservable();
+
+  setJobRunning(
+    workspaceId: number | null | undefined,
+    kind: CodingBackgroundJobKind,
+    isRunning: boolean,
+    jobId = 'default'
+  ): void {
+    if (!workspaceId) {
+      return;
+    }
+
+    const wasGuardActive = this.isStatusCheckGuardActive(workspaceId);
+    const workspaceJobs = this.getWorkspaceJobs(workspaceId);
+    const jobIds = workspaceJobs.get(kind) || new Set<string>();
+
+    if (isRunning) {
+      jobIds.add(jobId);
+      workspaceJobs.set(kind, jobIds);
+    } else {
+      jobIds.delete(jobId);
+      if (jobIds.size === 0) {
+        workspaceJobs.delete(kind);
+      } else {
+        workspaceJobs.set(kind, jobIds);
+      }
+    }
+
+    if (workspaceJobs.size === 0) {
+      this.activeJobsByWorkspace.delete(workspaceId);
+    }
+
+    this.emitSnapshot();
+
+    if (wasGuardActive && !this.isStatusCheckGuardActive(workspaceId)) {
+      this.statusGuardClearedSubject.next({ workspaceId, kind, jobId });
+    }
+  }
+
+  isStatusCheckGuardActive(workspaceId: number | null | undefined): boolean {
+    if (!workspaceId) {
+      return false;
+    }
+
+    return (this.activeJobsByWorkspace.get(workspaceId)?.size || 0) > 0;
+  }
+
+  isStatusCheckGuardActive$(
+    workspaceId: number
+  ): Observable<boolean> {
+    return this.activeJobSnapshot$.pipe(
+      map(snapshot => (snapshot.get(workspaceId)?.size || 0) > 0),
+      distinctUntilChanged()
+    );
+  }
+
+  private getWorkspaceJobs(
+    workspaceId: number
+  ): Map<CodingBackgroundJobKind, Set<string>> {
+    const existing = this.activeJobsByWorkspace.get(workspaceId);
+    if (existing) {
+      return existing;
+    }
+
+    const created = new Map<CodingBackgroundJobKind, Set<string>>();
+    this.activeJobsByWorkspace.set(workspaceId, created);
+    return created;
+  }
+
+  private emitSnapshot(): void {
+    const snapshot = new Map<number, Set<CodingBackgroundJobKind>>();
+    this.activeJobsByWorkspace.forEach((jobs, workspaceId) => {
+      snapshot.set(workspaceId, new Set(jobs.keys()));
+    });
+    this.activeJobSnapshot$.next(snapshot);
+  }
+}

--- a/apps/frontend/src/app/coding/services/coding-management.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-management.service.spec.ts
@@ -13,10 +13,14 @@ import {
 import { CodingExecutionService } from './coding-execution.service';
 import { CodingStatisticsService } from './coding-statistics.service';
 import { CodingExportService } from './coding-export.service';
-import { CodingVersionService } from './coding-version.service';
+import {
+  CodingVersionService,
+  RESET_VERSION_JOB_STATUS_POLL_ERROR
+} from './coding-version.service';
 import { ResponseService } from '../../shared/services/response/response.service';
 import { AppService } from '../../core/services/app.service';
 import { CodingStatistics } from '../../../../../../api-dto/coding/coding-statistics';
+import { CodingBackgroundJobsService } from './coding-background-jobs.service';
 
 describe('CodingManagementService', () => {
   let service: CodingManagementService;
@@ -28,6 +32,7 @@ describe('CodingManagementService', () => {
   let appServiceMock: jest.Mocked<AppService>;
   let translateServiceMock: jest.Mocked<TranslateService>;
   let snackBarMock: jest.Mocked<MatSnackBar>;
+  let codingBackgroundJobsService: CodingBackgroundJobsService;
 
   const mockCodingStatistics: CodingStatistics = {
     totalResponses: 100,
@@ -62,7 +67,9 @@ describe('CodingManagementService', () => {
     } as unknown as jest.Mocked<CodingExportService>;
 
     versionServiceMock = {
-      resetCodingVersion: jest.fn()
+      resetCodingVersion: jest.fn(),
+      getActiveResetVersionJob: jest.fn(),
+      getResetVersionJobStatus: jest.fn()
     } as unknown as jest.Mocked<CodingVersionService>;
 
     responseServiceMock = {
@@ -96,6 +103,7 @@ describe('CodingManagementService', () => {
     });
 
     service = TestBed.inject(CodingManagementService);
+    codingBackgroundJobsService = TestBed.inject(CodingBackgroundJobsService);
   });
 
   it('should be created', () => {
@@ -162,6 +170,61 @@ describe('CodingManagementService', () => {
 
       expect(statisticsServiceMock.getCodingStatistics).toHaveBeenCalledWith(1, 'v1');
     });
+  });
+
+  describe('resetCodingVersion', () => {
+    it('should keep the reset guard active after a transient polling error', fakeAsync(() => {
+      const setJobRunningSpy = jest.spyOn(codingBackgroundJobsService, 'setJobRunning');
+      versionServiceMock.resetCodingVersion.mockReturnValue(of({
+        jobId: 'reset-job-1',
+        message: 'started'
+      }));
+      versionServiceMock.getResetVersionJobStatus
+        .mockReturnValueOnce(of({
+          status: 'failed',
+          progress: 0,
+          error: RESET_VERSION_JOB_STATUS_POLL_ERROR
+        }))
+        .mockReturnValueOnce(of({
+          status: 'completed',
+          progress: 100,
+          result: {
+            affectedResponseCount: 3,
+            cascadeResetVersions: [],
+            message: 'completed'
+          }
+        }));
+
+      service.resetCodingVersion('v1');
+
+      expect(setJobRunningSpy).toHaveBeenCalledWith(
+        1,
+        'autocoder-reset',
+        true,
+        'reset-job-1'
+      );
+      expect(codingBackgroundJobsService.isStatusCheckGuardActive(1)).toBe(true);
+
+      tick(0);
+
+      expect(setJobRunningSpy).not.toHaveBeenCalledWith(
+        1,
+        'autocoder-reset',
+        false,
+        'reset-job-1'
+      );
+      expect(codingBackgroundJobsService.isStatusCheckGuardActive(1)).toBe(true);
+
+      tick(2000);
+
+      expect(setJobRunningSpy).toHaveBeenLastCalledWith(
+        1,
+        'autocoder-reset',
+        false,
+        'reset-job-1'
+      );
+      expect(codingBackgroundJobsService.isStatusCheckGuardActive(1)).toBe(false);
+    }));
   });
 
   describe('searchResponses', () => {

--- a/apps/frontend/src/app/coding/services/coding-management.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-management.service.ts
@@ -3,13 +3,17 @@ import {
   BehaviorSubject, Observable, of, forkJoin, timer, OperatorFunction, Subscription
 } from 'rxjs';
 import {
-  catchError, map, switchMap, takeWhile, finalize
+  catchError, map, switchMap, takeWhile, finalize, filter
 } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { CodingExecutionService } from './coding-execution.service';
 import { CodingStatisticsService } from './coding-statistics.service';
-import { CodingVersionService, ResetVersionJobStatus } from './coding-version.service';
+import {
+  CodingVersionService,
+  RESET_VERSION_JOB_STATUS_POLL_ERROR,
+  ResetVersionJobStatus
+} from './coding-version.service';
 import { CodingExportService } from './coding-export.service';
 import { ResponseService } from '../../shared/services/response/response.service';
 import {
@@ -23,6 +27,7 @@ import { AppService } from '../../core/services/app.service';
 import { CodingStatistics } from '../../../../../../api-dto/coding/coding-statistics';
 import { ResponseEntity } from '../../shared/models/response-entity.model';
 import { ExportFormat } from '../components/export-dialog/export-dialog.component';
+import { CodingBackgroundJobsService } from './coding-background-jobs.service';
 
 export type StatisticsVersion = 'v1' | 'v2' | 'v3';
 export type ResponseSource = 'base' | 'derived' | 'all';
@@ -90,6 +95,7 @@ export class CodingManagementService {
   private appService = inject(AppService);
   private translateService = inject(TranslateService);
   private snackBar = inject(MatSnackBar);
+  private codingBackgroundJobsService = inject(CodingBackgroundJobsService);
 
   private _codingStatistics = new BehaviorSubject<CodingStatistics | null>(null);
 
@@ -318,6 +324,12 @@ export class CodingManagementService {
 
     this.versionService.getActiveResetVersionJob(workspaceId).subscribe(activeJob => {
       if (activeJob.hasActiveJob && activeJob.jobId) {
+        this.codingBackgroundJobsService.setJobRunning(
+          workspaceId,
+          'autocoder-reset',
+          true,
+          activeJob.jobId
+        );
         this._resetJobId.next(activeJob.jobId);
         this._resetProgress.next(activeJob.progress ?? 0);
         this.startResetPolling(workspaceId, activeJob.jobId);
@@ -331,6 +343,12 @@ export class CodingManagementService {
 
     this.versionService.resetCodingVersion(workspaceId, version).subscribe({
       next: ({ jobId }) => {
+        this.codingBackgroundJobsService.setJobRunning(
+          workspaceId,
+          'autocoder-reset',
+          true,
+          jobId
+        );
         this._resetJobId.next(jobId);
         this._resetProgress.next(0);
         this.startResetPolling(workspaceId, jobId);
@@ -349,7 +367,12 @@ export class CodingManagementService {
     this.stopResetPolling();
 
     this.resetPollingSubscription = timer(0, 2000).pipe(
-      switchMap(() => this.versionService.getResetVersionJobStatus(workspaceId, jobId)),
+      switchMap(() => this.versionService.getResetVersionJobStatus(workspaceId, jobId)
+        .pipe(catchError(() => of(null)))),
+      filter((status): status is ResetVersionJobStatus => (
+        status !== null &&
+        !this.isTransientResetStatusPollingError(status)
+      )),
       takeWhile(
         (status: ResetVersionJobStatus) => ['pending', 'processing'].includes(status.status),
         true
@@ -358,6 +381,12 @@ export class CodingManagementService {
       this._resetProgress.next(status.progress);
 
       if (status.status === 'completed') {
+        this.codingBackgroundJobsService.setJobRunning(
+          workspaceId,
+          'autocoder-reset',
+          false,
+          jobId
+        );
         this._resetProgress.next(null);
         this._resetJobId.next(null);
 
@@ -373,11 +402,31 @@ export class CodingManagementService {
           );
         }
       } else if (status.status === 'failed') {
+        this.codingBackgroundJobsService.setJobRunning(
+          workspaceId,
+          'autocoder-reset',
+          false,
+          jobId
+        );
         this._resetProgress.next(null);
         this._resetJobId.next(null);
         this.showErrorSnackbar('coding-management.descriptions.error-reset');
+      } else if (!['pending', 'processing'].includes(status.status)) {
+        this.codingBackgroundJobsService.setJobRunning(
+          workspaceId,
+          'autocoder-reset',
+          false,
+          jobId
+        );
+        this._resetProgress.next(null);
+        this._resetJobId.next(null);
       }
     });
+  }
+
+  private isTransientResetStatusPollingError(status: ResetVersionJobStatus): boolean {
+    return status.status === 'failed' &&
+      status.error === RESET_VERSION_JOB_STATUS_POLL_ERROR;
   }
 
   private stopResetPolling(): void {

--- a/apps/frontend/src/app/coding/services/coding-version.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-version.service.ts
@@ -4,6 +4,8 @@ import { Observable, catchError, of } from 'rxjs';
 import { SERVER_URL } from '../../injection-tokens';
 import { suppressGlobalHttpErrorContext } from '../../core/interceptors/http-error-context';
 
+export const RESET_VERSION_JOB_STATUS_POLL_ERROR = 'Failed to get reset job status';
+
 export interface ResetVersionJobStatus {
   status: 'pending' | 'processing' | 'completed' | 'failed' | 'not_found';
   progress: number;
@@ -60,7 +62,7 @@ export class CodingVersionService {
         catchError(() => of({
           status: 'failed' as const,
           progress: 0,
-          error: 'Failed to get reset job status'
+          error: RESET_VERSION_JOB_STATUS_POLL_ERROR
         }))
       );
   }

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -12,10 +12,12 @@ import {
 } from './test-person-coding.service';
 import { SERVER_URL } from '../../injection-tokens';
 import { ResponseMatchingFlag } from '../../ws-admin/services/workspace-settings.service';
+import { CodingBackgroundJobsService } from './coding-background-jobs.service';
 
 describe('TestPersonCodingService', () => {
   let service: TestPersonCodingService;
   let httpMock: HttpTestingController;
+  let codingBackgroundJobsService: CodingBackgroundJobsService;
   let keycloak: { authenticated: boolean; token?: string; updateToken: jest.Mock };
   let fetchMock: jest.Mock;
   let originalFetch: typeof globalThis.fetch | undefined;
@@ -50,6 +52,7 @@ describe('TestPersonCodingService', () => {
     });
 
     service = TestBed.inject(TestPersonCodingService);
+    codingBackgroundJobsService = TestBed.inject(CodingBackgroundJobsService);
     httpMock = TestBed.inject(HttpTestingController);
   });
 
@@ -374,6 +377,32 @@ describe('TestPersonCodingService', () => {
       httpMock.expectOne(url).flush(mockResponse);
       expect(secondResponse).toEqual(mockResponse);
     });
+
+    it('should return null without requesting applied results overview while the status guard is active', () => {
+      const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/applied-results-overview`;
+      let response: AppliedResultsOverview | null | undefined;
+
+      codingBackgroundJobsService.setJobRunning(
+        mockWorkspaceId,
+        'response-analysis',
+        true,
+        'analysis-1'
+      );
+
+      service.getAppliedResultsOverview(mockWorkspaceId).subscribe(result => {
+        response = result;
+      });
+
+      httpMock.expectNone(url);
+      expect(response).toBeNull();
+
+      codingBackgroundJobsService.setJobRunning(
+        mockWorkspaceId,
+        'response-analysis',
+        false,
+        'analysis-1'
+      );
+    });
   });
 
   describe('getResponseAnalysis', () => {
@@ -414,6 +443,61 @@ describe('TestPersonCodingService', () => {
         { message: 'analysis failed' },
         { status: 500, statusText: 'Server Error' }
       );
+    });
+
+    it('should keep the response-analysis guard after transient polling errors', () => {
+      jest.useFakeTimers();
+      const setJobRunningSpy = jest.spyOn(codingBackgroundJobsService, 'setJobRunning');
+      const invalidateCacheSpy = jest.spyOn(service, 'invalidateCodingStatusCache');
+      const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/response-analysis`;
+
+      try {
+        service.trackResponseAnalysisGuardUntilComplete(mockWorkspaceId, 2);
+
+        expect(setJobRunningSpy).toHaveBeenCalledWith(
+          mockWorkspaceId,
+          'response-analysis',
+          true,
+          'manual-response-analysis'
+        );
+
+        jest.advanceTimersByTime(5000);
+        httpMock.expectOne(request => (
+          request.url === url &&
+          request.params.get('threshold') === '2'
+        )).flush(
+          { message: 'temporary error' },
+          { status: 500, statusText: 'Server Error' }
+        );
+        expect(setJobRunningSpy).not.toHaveBeenCalledWith(
+          mockWorkspaceId,
+          'response-analysis',
+          false,
+          'manual-response-analysis'
+        );
+
+        jest.advanceTimersByTime(5000);
+        httpMock.expectOne(request => (
+          request.url === url &&
+          request.params.get('threshold') === '2'
+        )).flush({
+          emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+          duplicateValues: { total: 0, totalResponses: 0, groups: [] },
+          matchingFlags: [],
+          analysisTimestamp: '2026-05-14T00:00:00.000Z',
+          isCalculating: false
+        });
+
+        expect(invalidateCacheSpy).toHaveBeenCalledWith(mockWorkspaceId);
+        expect(setJobRunningSpy).toHaveBeenLastCalledWith(
+          mockWorkspaceId,
+          'response-analysis',
+          false,
+          'manual-response-analysis'
+        );
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 
@@ -1026,6 +1110,41 @@ describe('TestPersonCodingService', () => {
       expect(secondResponse).toEqual(mockResponse);
     });
 
+    it('should return a fallback without requesting coding freshness while the status guard is active', () => {
+      let response: unknown;
+      const complete = jest.fn();
+      const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/freshness`;
+
+      codingBackgroundJobsService.setJobRunning(
+        mockWorkspaceId,
+        'response-analysis',
+        true,
+        'analysis-1'
+      );
+
+      service.getCodingFreshness(mockWorkspaceId).subscribe({
+        next: result => {
+          response = result;
+        },
+        complete
+      });
+
+      httpMock.expectNone(url);
+      expect(response).toEqual({
+        workspaceId: mockWorkspaceId,
+        currentRevision: 0,
+        items: []
+      });
+      expect(complete).toHaveBeenCalled();
+
+      codingBackgroundJobsService.setJobRunning(
+        mockWorkspaceId,
+        'response-analysis',
+        false,
+        'analysis-1'
+      );
+    });
+
     it('should request autocoding readiness with run and force-refresh params', () => {
       const mockResponse = {
         workspaceId: mockWorkspaceId,
@@ -1342,6 +1461,59 @@ describe('TestPersonCodingService', () => {
         states: ['PENDING', 'STALE']
       });
       req.flush(mockResponse);
+    });
+
+    it('should keep the freshness-coding guard until the job reaches a terminal status', () => {
+      jest.useFakeTimers();
+      const setJobRunningSpy = jest.spyOn(codingBackgroundJobsService, 'setJobRunning');
+      const invalidateCacheSpy = jest.spyOn(service, 'invalidateCodingStatusCache');
+      const jobId = 'freshness-job-1';
+      const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/job/${jobId}`;
+
+      try {
+        service.trackFreshnessCodingGuardUntilComplete(mockWorkspaceId, jobId);
+
+        expect(setJobRunningSpy).toHaveBeenCalledWith(
+          mockWorkspaceId,
+          'freshness-coding',
+          true,
+          jobId
+        );
+
+        jest.advanceTimersByTime(5000);
+        httpMock.expectOne(url).flush(
+          { message: 'temporary error' },
+          { status: 500, statusText: 'Server Error' }
+        );
+        expect(setJobRunningSpy).not.toHaveBeenCalledWith(
+          mockWorkspaceId,
+          'freshness-coding',
+          false,
+          jobId
+        );
+
+        jest.advanceTimersByTime(5000);
+        httpMock.expectOne(url).flush({
+          status: 'processing',
+          progress: 50
+        });
+
+        jest.advanceTimersByTime(5000);
+        httpMock.expectOne(url).flush({
+          status: 'completed',
+          progress: 100
+        });
+
+        expect(invalidateCacheSpy).toHaveBeenCalledWith(mockWorkspaceId);
+        expect(setJobRunningSpy).toHaveBeenLastCalledWith(
+          mockWorkspaceId,
+          'freshness-coding',
+          false,
+          jobId
+        );
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import {
+  EMPTY,
   Observable,
   Subject,
   catchError,
@@ -32,6 +33,7 @@ import {
 } from '../../../../../../api-dto/coding/coding-freshness.dto';
 import { AutocodingReadinessDto } from '../../../../../../api-dto/coding/autocoding-readiness.dto';
 import { ResponseMatchingFlag } from '../../ws-admin/services/workspace-settings.service';
+import { CodingBackgroundJobsService } from './coding-background-jobs.service';
 
 interface ExternalCodingImportWithPreviewDto {
   file: string;
@@ -240,6 +242,7 @@ export class TestPersonCodingService {
   readonly serverUrl = inject(SERVER_URL);
   private http = inject(HttpClient);
   private keycloak = inject(Keycloak, { optional: true });
+  private codingBackgroundJobsService = inject(CodingBackgroundJobsService);
   private autoCodingCompletedSubject = new Subject<AutoCodingCompletedEvent>();
   private testResultsChangedSubject = new Subject<TestResultsChangedEvent>();
   private pendingStatisticsVersions = new Map<number, CodingStatisticsVersion>();
@@ -251,6 +254,12 @@ export class TestPersonCodingService {
   private codingFreshnessScopeRequests = new Map<string, Observable<CodingFreshnessScopeDto>>();
   private appliedResultsOverviewCache = new Map<number, AppliedResultsOverview | null>();
   private appliedResultsOverviewRequests = new Map<number, Observable<AppliedResultsOverview | null>>();
+  private responseAnalysisGuardPollTimers = new Map<number, ReturnType<typeof setTimeout>>();
+  private responseAnalysisGuardThresholds = new Map<number, number | undefined>();
+  private freshnessCodingGuardPollTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly responseAnalysisGuardPollIntervalMs = 5000;
+  private readonly freshnessCodingGuardPollIntervalMs = 5000;
+  private readonly responseAnalysisGuardJobId = 'manual-response-analysis';
   private codingStatusCacheGeneration = 0;
   autoCodingCompleted$ = this.autoCodingCompletedSubject.asObservable();
   testResultsChanged$ = this.testResultsChangedSubject.asObservable();
@@ -320,6 +329,66 @@ export class TestPersonCodingService {
     this.deleteCacheKeysForWorkspace(this.autocodingReadinessRequests, workspaceId);
     this.deleteCacheKeysForWorkspace(this.codingFreshnessScopeCache, workspaceId);
     this.deleteCacheKeysForWorkspace(this.codingFreshnessScopeRequests, workspaceId);
+  }
+
+  private createCodingFreshnessFallback(workspaceId: number): CodingFreshnessSummaryDto {
+    return {
+      workspaceId,
+      currentRevision: 0,
+      items: []
+    };
+  }
+
+  private createAutocodingReadinessFallback(
+    workspaceId: number,
+    autoCoderRun: 1 | 2
+  ): AutocodingReadinessDto {
+    return {
+      workspaceId,
+      autoCoderRun,
+      readiness: 'NO_RESULTS',
+      blockers: [],
+      rawResponsesTotal: 0,
+      rawResponsesWithRelevantStatus: 0,
+      resultUnitsTotal: 0,
+      resultUnitKeysTotal: 0,
+      matchedUnitFiles: 0,
+      missingUnitFiles: [],
+      matchedCodingSchemes: 0,
+      missingCodingSchemes: [],
+      invalidCodingSchemes: [],
+      validVariablePairs: 0,
+      validResponses: 0,
+      codeableResponses: 0,
+      invalidVariableSamples: []
+    };
+  }
+
+  private createCodingFreshnessScopeFallback(
+    workspaceId: number,
+    version?: CodingFreshnessVersion,
+    states?: CodingFreshnessState[]
+  ): CodingFreshnessScopeDto {
+    return {
+      workspaceId,
+      currentRevision: 0,
+      versions: version ?
+        [version] :
+        (['v1', 'v2', 'v3'] as CodingFreshnessVersion[]),
+      states: states || ([
+        'PENDING',
+        'STALE',
+        'MANUAL_REVIEW_REQUIRED'
+      ] as CodingFreshnessState[]),
+      unitCount: 0,
+      personCount: 0,
+      groupCount: 0,
+      affectedResponseCount: 0,
+      unitIds: [],
+      personIds: [],
+      groupNames: [],
+      groups: []
+    };
   }
 
   codeTestPersons(workspaceId: number, testPersonIds: string, autoCoderRun: number = 1): Observable<CodingStatisticsWithJob> {
@@ -520,6 +589,10 @@ export class TestPersonCodingService {
 
   getCodingFreshness(workspaceId: number): Observable<CodingFreshnessSummaryDto> {
     const cached = this.codingFreshnessCache.get(workspaceId);
+    if (this.codingBackgroundJobsService.isStatusCheckGuardActive(workspaceId)) {
+      return of(cached || this.createCodingFreshnessFallback(workspaceId));
+    }
+
     if (cached) {
       return of(cached);
     }
@@ -544,11 +617,7 @@ export class TestPersonCodingService {
             this.codingFreshnessCache.set(workspaceId, summary);
           }
         }),
-        catchError(() => of({
-          workspaceId,
-          currentRevision: 0,
-          items: []
-        })),
+        catchError(() => of(this.createCodingFreshnessFallback(workspaceId))),
         finalize(() => {
           if (this.codingFreshnessRequests.get(workspaceId) === request$) {
             this.codingFreshnessRequests.delete(workspaceId);
@@ -567,8 +636,12 @@ export class TestPersonCodingService {
     forceRefresh = false
   ): Observable<AutocodingReadinessDto> {
     const cacheKey = `${workspaceId}:${autoCoderRun}`;
+    const cached = this.autocodingReadinessCache.get(cacheKey);
+    if (this.codingBackgroundJobsService.isStatusCheckGuardActive(workspaceId)) {
+      return of(cached || this.createAutocodingReadinessFallback(workspaceId, autoCoderRun));
+    }
+
     if (!forceRefresh) {
-      const cached = this.autocodingReadinessCache.get(cacheKey);
       if (cached) {
         return of(cached);
       }
@@ -627,6 +700,10 @@ export class TestPersonCodingService {
       states?.join(',') || 'all'
     ].join(':');
     const cached = this.codingFreshnessScopeCache.get(cacheKey);
+    if (this.codingBackgroundJobsService.isStatusCheckGuardActive(workspaceId)) {
+      return of(cached || this.createCodingFreshnessScopeFallback(workspaceId, version, states));
+    }
+
     if (cached) {
       return of(cached);
     }
@@ -660,29 +737,7 @@ export class TestPersonCodingService {
             this.codingFreshnessScopeCache.set(cacheKey, scope);
           }
         }),
-        catchError(() => {
-          const fallback: CodingFreshnessScopeDto = {
-            workspaceId,
-            currentRevision: 0,
-            versions: version ?
-              [version] :
-              (['v1', 'v2', 'v3'] as CodingFreshnessVersion[]),
-            states: states || ([
-              'PENDING',
-              'STALE',
-              'MANUAL_REVIEW_REQUIRED'
-            ] as CodingFreshnessState[]),
-            unitCount: 0,
-            personCount: 0,
-            groupCount: 0,
-            affectedResponseCount: 0,
-            unitIds: [],
-            personIds: [],
-            groupNames: [],
-            groups: []
-          };
-          return of(fallback);
-        }),
+        catchError(() => of(this.createCodingFreshnessScopeFallback(workspaceId, version, states))),
         finalize(() => {
           if (this.codingFreshnessScopeRequests.get(cacheKey) === request$) {
             this.codingFreshnessScopeRequests.delete(cacheKey);
@@ -938,6 +993,12 @@ export class TestPersonCodingService {
   }
 
   getAppliedResultsOverview(workspaceId: number): Observable<AppliedResultsOverview | null> {
+    if (this.codingBackgroundJobsService.isStatusCheckGuardActive(workspaceId)) {
+      return this.appliedResultsOverviewCache.has(workspaceId) ?
+        of(this.appliedResultsOverviewCache.get(workspaceId) ?? null) :
+        of(null);
+    }
+
     if (this.appliedResultsOverviewCache.has(workspaceId)) {
       return of(this.appliedResultsOverviewCache.get(workspaceId) ?? null);
     }
@@ -1135,6 +1196,172 @@ export class TestPersonCodingService {
           coveredSourceResponseCount: 0
         }))
       );
+  }
+
+  setResponseAnalysisGuardRunning(
+    workspaceId: number | null | undefined,
+    isRunning: boolean
+  ): void {
+    if (!workspaceId) {
+      return;
+    }
+
+    if (!isRunning) {
+      this.clearResponseAnalysisGuardPolling(workspaceId);
+    }
+
+    this.codingBackgroundJobsService.setJobRunning(
+      workspaceId,
+      'response-analysis',
+      isRunning,
+      this.responseAnalysisGuardJobId
+    );
+  }
+
+  trackResponseAnalysisGuardUntilComplete(
+    workspaceId: number | null | undefined,
+    threshold?: number
+  ): void {
+    if (!workspaceId) {
+      return;
+    }
+
+    this.responseAnalysisGuardThresholds.set(workspaceId, threshold);
+    this.setResponseAnalysisGuardRunning(workspaceId, true);
+    this.scheduleResponseAnalysisGuardPoll(workspaceId);
+  }
+
+  private scheduleResponseAnalysisGuardPoll(workspaceId: number): void {
+    if (this.responseAnalysisGuardPollTimers.has(workspaceId)) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      this.responseAnalysisGuardPollTimers.delete(workspaceId);
+      this.pollResponseAnalysisGuard(workspaceId);
+    }, this.responseAnalysisGuardPollIntervalMs);
+    this.responseAnalysisGuardPollTimers.set(workspaceId, timeoutId);
+  }
+
+  private pollResponseAnalysisGuard(workspaceId: number): void {
+    const threshold = this.responseAnalysisGuardThresholds.get(workspaceId);
+    this.getResponseAnalysis(workspaceId, threshold)
+      .pipe(catchError(() => {
+        this.scheduleResponseAnalysisGuardPoll(workspaceId);
+        return EMPTY;
+      }))
+      .subscribe(analysis => {
+        if (analysis?.isCalculating === true) {
+          this.scheduleResponseAnalysisGuardPoll(workspaceId);
+          return;
+        }
+
+        this.invalidateCodingStatusCache(workspaceId);
+        this.setResponseAnalysisGuardRunning(workspaceId, false);
+      });
+  }
+
+  private clearResponseAnalysisGuardPolling(workspaceId: number): void {
+    const timeoutId = this.responseAnalysisGuardPollTimers.get(workspaceId);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      this.responseAnalysisGuardPollTimers.delete(workspaceId);
+    }
+    this.responseAnalysisGuardThresholds.delete(workspaceId);
+  }
+
+  setFreshnessCodingGuardRunning(
+    workspaceId: number | null | undefined,
+    jobId: string | null | undefined,
+    isRunning: boolean
+  ): void {
+    if (!workspaceId || !jobId) {
+      return;
+    }
+
+    if (!isRunning) {
+      this.clearFreshnessCodingGuardPolling(workspaceId, jobId);
+    }
+
+    this.codingBackgroundJobsService.setJobRunning(
+      workspaceId,
+      'freshness-coding',
+      isRunning,
+      jobId
+    );
+  }
+
+  trackFreshnessCodingGuardUntilComplete(
+    workspaceId: number | null | undefined,
+    jobId: string | null | undefined
+  ): void {
+    if (!workspaceId || !jobId) {
+      return;
+    }
+
+    this.setFreshnessCodingGuardRunning(workspaceId, jobId, true);
+    this.scheduleFreshnessCodingGuardPoll(workspaceId, jobId);
+  }
+
+  private scheduleFreshnessCodingGuardPoll(
+    workspaceId: number,
+    jobId: string
+  ): void {
+    const pollKey = this.createFreshnessCodingGuardPollKey(workspaceId, jobId);
+    if (this.freshnessCodingGuardPollTimers.has(pollKey)) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      this.freshnessCodingGuardPollTimers.delete(pollKey);
+      this.pollFreshnessCodingGuard(workspaceId, jobId);
+    }, this.freshnessCodingGuardPollIntervalMs);
+    this.freshnessCodingGuardPollTimers.set(pollKey, timeoutId);
+  }
+
+  private pollFreshnessCodingGuard(
+    workspaceId: number,
+    jobId: string
+  ): void {
+    this.getJobStatus(workspaceId, jobId)
+      .pipe(catchError(() => of({ error: `Failed to get status for job ${jobId}` })))
+      .subscribe(status => {
+        if (!('status' in status)) {
+          this.scheduleFreshnessCodingGuardPoll(workspaceId, jobId);
+          return;
+        }
+
+        if (!this.isTerminalCodingJobStatus(status.status)) {
+          this.scheduleFreshnessCodingGuardPoll(workspaceId, jobId);
+          return;
+        }
+
+        this.invalidateCodingStatusCache(workspaceId);
+        this.setFreshnessCodingGuardRunning(workspaceId, jobId, false);
+      });
+  }
+
+  private clearFreshnessCodingGuardPolling(
+    workspaceId: number,
+    jobId: string
+  ): void {
+    const pollKey = this.createFreshnessCodingGuardPollKey(workspaceId, jobId);
+    const timeoutId = this.freshnessCodingGuardPollTimers.get(pollKey);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      this.freshnessCodingGuardPollTimers.delete(pollKey);
+    }
+  }
+
+  private createFreshnessCodingGuardPollKey(
+    workspaceId: number,
+    jobId: string
+  ): string {
+    return `${workspaceId}:${jobId}`;
+  }
+
+  private isTerminalCodingJobStatus(status: JobStatus['status']): boolean {
+    return ['completed', 'failed', 'cancelled', 'paused'].includes(status);
   }
 
   getResponseAnalysis(

--- a/apps/frontend/src/app/shared/services/response/variable-analysis.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/response/variable-analysis.service.spec.ts
@@ -9,10 +9,14 @@ import {
 } from '@angular/common/http';
 import { VariableAnalysisService } from './variable-analysis.service';
 import { SERVER_URL } from '../../../injection-tokens';
+import { CodingBackgroundJobsService } from '../../../coding/services/coding-background-jobs.service';
+import { TestPersonCodingService } from '../../../coding/services/test-person-coding.service';
 
 describe('VariableAnalysisService', () => {
   let service: VariableAnalysisService;
   let httpMock: HttpTestingController;
+  let codingBackgroundJobsService: CodingBackgroundJobsService;
+  let testPersonCodingService: TestPersonCodingService;
 
   const mockServerUrl = 'http://localhost/api/';
   const mockWorkspaceId = 1;
@@ -36,6 +40,8 @@ describe('VariableAnalysisService', () => {
 
     service = TestBed.inject(VariableAnalysisService);
     httpMock = TestBed.inject(HttpTestingController);
+    codingBackgroundJobsService = TestBed.inject(CodingBackgroundJobsService);
+    testPersonCodingService = TestBed.inject(TestPersonCodingService);
   });
 
   afterEach(() => {
@@ -44,6 +50,70 @@ describe('VariableAnalysisService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should keep the response-analysis guard until active variable analysis jobs finish', () => {
+    jest.useFakeTimers();
+    const setJobRunningSpy = jest.spyOn(codingBackgroundJobsService, 'setJobRunning');
+    const invalidateCacheSpy = jest.spyOn(testPersonCodingService, 'invalidateCodingStatusCache');
+    const url = `${mockServerUrl}admin/workspace/${mockWorkspaceId}/variable-analysis/jobs`;
+
+    try {
+      service.trackVariableAnalysisGuardUntilComplete(mockWorkspaceId);
+
+      expect(setJobRunningSpy).toHaveBeenCalledWith(
+        mockWorkspaceId,
+        'response-analysis',
+        true,
+        'variable-analysis-dialog'
+      );
+
+      jest.advanceTimersByTime(5000);
+      httpMock.expectOne(url).flush(
+        { message: 'temporary error' },
+        { status: 500, statusText: 'Server Error' }
+      );
+      expect(setJobRunningSpy).not.toHaveBeenCalledWith(
+        mockWorkspaceId,
+        'response-analysis',
+        false,
+        'variable-analysis-dialog'
+      );
+
+      jest.advanceTimersByTime(5000);
+      httpMock.expectOne(url).flush([
+        {
+          id: 1,
+          workspace_id: mockWorkspaceId,
+          type: 'variable-analysis',
+          status: 'processing',
+          created_at: new Date(),
+          updated_at: new Date()
+        }
+      ]);
+
+      jest.advanceTimersByTime(5000);
+      httpMock.expectOne(url).flush([
+        {
+          id: 1,
+          workspace_id: mockWorkspaceId,
+          type: 'variable-analysis',
+          status: 'completed',
+          created_at: new Date(),
+          updated_at: new Date()
+        }
+      ]);
+
+      expect(invalidateCacheSpy).toHaveBeenCalledWith(mockWorkspaceId);
+      expect(setJobRunningSpy).toHaveBeenLastCalledWith(
+        mockWorkspaceId,
+        'response-analysis',
+        false,
+        'variable-analysis-dialog'
+      );
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   describe('createAnalysisJob', () => {

--- a/apps/frontend/src/app/shared/services/response/variable-analysis.service.ts
+++ b/apps/frontend/src/app/shared/services/response/variable-analysis.service.ts
@@ -1,8 +1,11 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { EMPTY, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { SERVER_URL } from '../../../injection-tokens';
 import { VariableAnalysisJobDto } from '../../../models/variable-analysis-job.dto';
+import { CodingBackgroundJobsService } from '../../../coding/services/coding-background-jobs.service';
+import { TestPersonCodingService } from '../../../coding/services/test-person-coding.service';
 
 export interface JobCancelResult {
   success: boolean;
@@ -137,6 +140,16 @@ export interface VariableAnalysisExportOptions {
 export class VariableAnalysisService {
   readonly serverUrl = inject(SERVER_URL);
   private http = inject(HttpClient);
+  private codingBackgroundJobsService = inject(CodingBackgroundJobsService);
+  private testPersonCodingService = inject(TestPersonCodingService);
+  private variableAnalysisGuardPollTimers = new Map<number, ReturnType<typeof setTimeout>>();
+  private readonly variableAnalysisGuardJobId = 'variable-analysis-dialog';
+  private readonly variableAnalysisGuardPollIntervalMs = 5000;
+  private readonly activeJobStatuses = new Set<VariableAnalysisJobDto['status']>([
+    'pending',
+    'waiting',
+    'processing'
+  ]);
 
   get authHeader() {
     return {};
@@ -257,6 +270,79 @@ export class VariableAnalysisService {
       `${this.serverUrl}admin/workspace/${workspaceId}/variable-analysis/jobs`,
       { headers: this.authHeader }
     );
+  }
+
+  setVariableAnalysisGuardRunning(
+    workspaceId: number | null | undefined,
+    isRunning: boolean
+  ): void {
+    if (!workspaceId) {
+      return;
+    }
+
+    if (!isRunning) {
+      this.clearVariableAnalysisGuardPolling(workspaceId);
+    }
+
+    this.codingBackgroundJobsService.setJobRunning(
+      workspaceId,
+      'response-analysis',
+      isRunning,
+      this.variableAnalysisGuardJobId
+    );
+  }
+
+  trackVariableAnalysisGuardUntilComplete(
+    workspaceId: number | null | undefined
+  ): void {
+    if (!workspaceId) {
+      return;
+    }
+
+    this.setVariableAnalysisGuardRunning(workspaceId, true);
+    this.scheduleVariableAnalysisGuardPoll(workspaceId);
+  }
+
+  private scheduleVariableAnalysisGuardPoll(workspaceId: number): void {
+    if (this.variableAnalysisGuardPollTimers.has(workspaceId)) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      this.variableAnalysisGuardPollTimers.delete(workspaceId);
+      this.pollVariableAnalysisGuard(workspaceId);
+    }, this.variableAnalysisGuardPollIntervalMs);
+    this.variableAnalysisGuardPollTimers.set(workspaceId, timeoutId);
+  }
+
+  private pollVariableAnalysisGuard(workspaceId: number): void {
+    this.getAllJobs(workspaceId)
+      .pipe(catchError(() => {
+        this.scheduleVariableAnalysisGuardPoll(workspaceId);
+        return EMPTY;
+      }))
+      .subscribe(jobs => {
+        const hasActiveAnalysisJob = jobs.some(job => (
+          job.type === 'variable-analysis' &&
+          this.activeJobStatuses.has(job.status)
+        ));
+
+        if (hasActiveAnalysisJob) {
+          this.scheduleVariableAnalysisGuardPoll(workspaceId);
+          return;
+        }
+
+        this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
+        this.setVariableAnalysisGuardRunning(workspaceId, false);
+      });
+  }
+
+  private clearVariableAnalysisGuardPolling(workspaceId: number): void {
+    const timeoutId = this.variableAnalysisGuardPollTimers.get(workspaceId);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      this.variableAnalysisGuardPollTimers.delete(workspaceId);
+    }
   }
 
   cancelJob(

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.spec.ts
@@ -107,7 +107,9 @@ describe('VariableAnalysisDialogComponent', () => {
           pageSize: 50,
           totalPages: 0
         })
-      )
+      ),
+      setVariableAnalysisGuardRunning: jest.fn(),
+      trackVariableAnalysisGuardUntilComplete: jest.fn()
     } as unknown as jest.Mocked<VariableAnalysisService>;
 
     mockSnackBar = {
@@ -145,6 +147,16 @@ describe('VariableAnalysisDialogComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should keep tracking the response-analysis guard after destroy while a job is active', () => {
+    expect(component.activeJob).toBeDefined();
+
+    component.ngOnDestroy();
+
+    expect(
+      mockVariableAnalysisService.trackVariableAnalysisGuardUntilComplete
+    ).toHaveBeenCalledWith(1);
   });
 
   describe('analyzeVariables', () => {
@@ -333,6 +345,30 @@ describe('VariableAnalysisDialogComponent', () => {
       component.refreshJobs();
       expect(mockSnackBar.open).toHaveBeenCalled();
     });
+
+    it('should not clear the response-analysis guard when the initial job load fails', () => {
+      fixture.destroy();
+      mockVariableAnalysisService.getAllJobs.mockReturnValue(
+        throwError(() => new Error('network error'))
+      );
+      mockVariableAnalysisService.setVariableAnalysisGuardRunning.mockClear();
+      mockVariableAnalysisService
+        .trackVariableAnalysisGuardUntilComplete
+        .mockClear();
+
+      const failingFixture = TestBed.createComponent(
+        VariableAnalysisDialogComponent
+      );
+      failingFixture.detectChanges();
+      failingFixture.destroy();
+
+      expect(
+        mockVariableAnalysisService.setVariableAnalysisGuardRunning
+      ).not.toHaveBeenCalledWith(1, false);
+      expect(
+        mockVariableAnalysisService.trackVariableAnalysisGuardUntilComplete
+      ).not.toHaveBeenCalled();
+    });
   });
 
   describe('startNewAnalysis', () => {
@@ -343,6 +379,35 @@ describe('VariableAnalysisDialogComponent', () => {
         mockVariableAnalysisService.createAnalysisJob
       ).toHaveBeenCalledWith(1, 10);
       expect(mockVariableAnalysisService.getAllJobs).toHaveBeenCalled();
+    });
+
+    it('should keep the response-analysis guard active if refreshing jobs fails after starting analysis', () => {
+      const startedJob: VariableAnalysisJobDto = {
+        ...mockJobs[0],
+        id: 2,
+        status: 'pending'
+      };
+      component.activeJob = undefined;
+      component.jobs = [];
+      mockVariableAnalysisService.createAnalysisJob.mockReturnValueOnce(
+        of(startedJob)
+      );
+      mockVariableAnalysisService.getAllJobs.mockClear();
+      mockVariableAnalysisService.getAllJobs.mockReturnValueOnce(
+        throwError(() => new Error('network error'))
+      );
+      mockVariableAnalysisService.setVariableAnalysisGuardRunning.mockClear();
+
+      component.startNewAnalysis();
+
+      expect(component.activeJob).toEqual(startedJob);
+      expect(mockVariableAnalysisService.getAllJobs).toHaveBeenCalledTimes(1);
+      expect(
+        mockVariableAnalysisService.setVariableAnalysisGuardRunning
+      ).toHaveBeenCalledWith(1, true);
+      expect(
+        mockVariableAnalysisService.setVariableAnalysisGuardRunning
+      ).not.toHaveBeenCalledWith(1, false);
     });
   });
 

--- a/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/variable-analysis-dialog/variable-analysis-dialog.component.ts
@@ -258,6 +258,8 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
 
   activeJob: VariableAnalysisJobDto | undefined;
   private refreshSubscription: Subscription | undefined;
+  private hasLoadedJobsSuccessfully = false;
+  private responseAnalysisGuardActive = false;
   private readonly POLLING_INTERVAL = 5000;
   private readonly ACTIVE_JOB_STATUSES = [
     'pending',
@@ -315,7 +317,6 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
       error: () => {
         this.isJobsLoading = false;
         this.isInitializing = false;
-        this.updatePollingState();
       }
     });
   }
@@ -337,6 +338,9 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
   }
 
   private updatePollingState(): void {
+    this.setResponseAnalysisGuardActive(
+      Boolean(this.activeJob || this.isStartingJob)
+    );
     if (this.activeJob || this.isStartingJob) {
       this.startPolling();
       return;
@@ -353,6 +357,7 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
     jobs: VariableAnalysisJobDto[],
     autoStartIfEmpty = false
   ): void {
+    this.hasLoadedJobsSuccessfully = true;
     const previousActiveJob = this.activeJob;
     this.jobs = jobs.filter(job => job.type === 'variable-analysis');
     this.activeJob = this.jobs.find(job => this.isActiveJob(job));
@@ -852,7 +857,6 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
           );
         }
         this.isJobsLoading = false;
-        this.updatePollingState();
       }
     });
   }
@@ -860,6 +864,7 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
   startNewAnalysis(): void {
     if (this.isStartingJob || this.activeJob) return;
     this.isStartingJob = true;
+    this.setResponseAnalysisGuardActive(true);
     this.hasAutoStarted = true;
     this.isJobsLoading = true;
     const loadingSnackBar = this.snackBar.open(
@@ -876,6 +881,7 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (job: VariableAnalysisJobDto) => {
           this.isStartingJob = false;
+          this.applyStartedJob(job);
           this.isJobsLoading = false; // Reset loading flag here too
           loadingSnackBar.dismiss();
           this.snackBar.open(
@@ -889,6 +895,7 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
         },
         error: error => {
           this.isStartingJob = false;
+          this.setResponseAnalysisGuardActive(Boolean(this.activeJob));
           loadingSnackBar.dismiss();
           const errorMessage = error?.error?.message || error?.message || '';
           this.snackBar.open(
@@ -900,6 +907,17 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
           this.updatePollingState();
         }
       });
+  }
+
+  private applyStartedJob(job: VariableAnalysisJobDto): void {
+    if (job.type === 'variable-analysis') {
+      this.jobs = [
+        job,
+        ...this.jobs.filter(existingJob => existingJob.id !== job.id)
+      ];
+    }
+    this.activeJob = this.isActiveJob(job) ? job : undefined;
+    this.updatePollingState();
   }
 
   cancelJob(jobId: number | string): void {
@@ -1219,6 +1237,14 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
     }
   }
 
+  private setResponseAnalysisGuardActive(isActive: boolean): void {
+    this.responseAnalysisGuardActive = isActive;
+    this.variableAnalysisService.setVariableAnalysisGuardRunning(
+      this.data.workspaceId,
+      isActive
+    );
+  }
+
   formatDate(date: Date): string {
     if (!date) return '';
     return new Date(date).toLocaleString();
@@ -1226,6 +1252,16 @@ export class VariableAnalysisDialogComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.stopPolling();
+    if (this.activeJob || this.isStartingJob) {
+      this.variableAnalysisService.trackVariableAnalysisGuardUntilComplete(
+        this.data.workspaceId
+      );
+    } else if (
+      this.hasLoadedJobsSuccessfully ||
+      this.responseAnalysisGuardActive
+    ) {
+      this.setResponseAnalysisGuardActive(false);
+    }
     this.searchSubscription?.unsubscribe();
   }
 


### PR DESCRIPTION
## Summary

- Adds a shared frontend guard for coding-status checks while background jobs are running.
- Tracks Autocoder reset, response analysis, variable analysis, and freshness coding jobs so automatic status refreshes are deferred until completion.
- Performs one targeted refresh after the guard clears and avoids duplicate refreshes from follow-up completion events.
- Keeps guards active through transient polling failures and continues tracking after dialogs/components are destroyed.

## Context

This addresses the remaining background-job guard behavior discussed in #813: additional status checks should be suppressed during Autocoder reset, Antwortanalyse, and Freshness-Coding, with a targeted refresh after completion.

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/services/coding-background-jobs.service.spec.ts`
- `npx nx lint frontend`
- `npx nx test frontend`
- `git diff --check`