### PR TITLE
Add backend request monitoring

### DIFF
--- a/apps/backend/src/app/http/request-monitoring.middleware.spec.ts
+++ b/apps/backend/src/app/http/request-monitoring.middleware.spec.ts
@@ -1,0 +1,134 @@
+import { EventEmitter } from 'events';
+import { Response } from 'express';
+import {
+  DEFAULT_SLOW_REQUEST_THRESHOLD_MS,
+  createRequestMonitoringMiddleware,
+  parseSlowRequestThresholdMs
+} from './request-monitoring.middleware';
+import { RequestWithRequestId } from './request-id';
+
+describe('requestMonitoringMiddleware', () => {
+  const createRequest = (request: Partial<RequestWithRequestId> = {}) => ({
+    method: 'GET',
+    url: '/api/admin/workspace/3/coding/incomplete-variables/scope-summary?_t=123',
+    originalUrl: '/api/admin/workspace/3/coding/incomplete-variables/scope-summary?_t=123',
+    requestId: 'request-1',
+    ...request
+  } as RequestWithRequestId);
+
+  const createResponse = (statusCode: number) => {
+    const response = new EventEmitter() as Response & EventEmitter;
+    response.statusCode = statusCode;
+    return response;
+  };
+
+  const createClock = (...times: bigint[]) => {
+    const values = [...times];
+    return jest.fn(() => values.shift() ?? times[times.length - 1]);
+  };
+
+  it('should warn about slow successful requests', () => {
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn()
+    };
+    const now = createClock(BigInt(0), BigInt(1500000000));
+    const middleware = createRequestMonitoringMiddleware({
+      logger,
+      now,
+      slowRequestThresholdMs: 1000
+    });
+    const response = createResponse(200);
+    const next = jest.fn();
+
+    middleware(createRequest(), response, next);
+    response.emit('finish');
+
+    expect(next).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[request-1] GET /api/admin/workspace/3/coding/incomplete-variables/scope-summary ' +
+      'completed with 200 in 1500 ms (slow request; threshold 1000 ms)'
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('should not log fast successful requests', () => {
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn()
+    };
+    const now = createClock(BigInt(0), BigInt(999000000));
+    const middleware = createRequestMonitoringMiddleware({
+      logger,
+      now,
+      slowRequestThresholdMs: 1000
+    });
+    const response = createResponse(200);
+
+    middleware(createRequest(), response, jest.fn());
+    response.emit('finish');
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('should log failed requests even when they are fast', () => {
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn()
+    };
+    const now = createClock(BigInt(0), BigInt(100000000));
+    const middleware = createRequestMonitoringMiddleware({
+      logger,
+      now,
+      slowRequestThresholdMs: 1000
+    });
+    const response = createResponse(500);
+
+    middleware(createRequest(), response, jest.fn());
+    response.emit('finish');
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[request-1] GET /api/admin/workspace/3/coding/incomplete-variables/scope-summary failed with 500 in 100 ms'
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should normalize repeated slashes in monitored paths', () => {
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn()
+    };
+    const now = createClock(BigInt(0), BigInt(1500000000));
+    const middleware = createRequestMonitoringMiddleware({
+      logger,
+      now,
+      slowRequestThresholdMs: 1000
+    });
+    const response = createResponse(200);
+
+    middleware(createRequest({
+      originalUrl: '/api//admin///workspace/3/coding?_t=123',
+      url: '/api/admin/workspace/3/coding?_t=123'
+    }), response, jest.fn());
+    response.emit('finish');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[request-1] GET /api/admin/workspace/3/coding ' +
+      'completed with 200 in 1500 ms (slow request; threshold 1000 ms)'
+    );
+  });
+});
+
+describe('parseSlowRequestThresholdMs', () => {
+  it('should parse positive millisecond values', () => {
+    expect(parseSlowRequestThresholdMs('2500')).toBe(2500);
+    expect(parseSlowRequestThresholdMs(1200.9)).toBe(1200);
+  });
+
+  it('should fall back to the default threshold for invalid values', () => {
+    expect(parseSlowRequestThresholdMs('not-a-number')).toBe(DEFAULT_SLOW_REQUEST_THRESHOLD_MS);
+    expect(parseSlowRequestThresholdMs(0)).toBe(DEFAULT_SLOW_REQUEST_THRESHOLD_MS);
+    expect(parseSlowRequestThresholdMs(undefined)).toBe(DEFAULT_SLOW_REQUEST_THRESHOLD_MS);
+  });
+});

--- a/apps/backend/src/app/http/request-monitoring.middleware.ts
+++ b/apps/backend/src/app/http/request-monitoring.middleware.ts
@@ -1,0 +1,91 @@
+import { Logger } from '@nestjs/common';
+import { NextFunction, Response } from 'express';
+import {
+  RequestWithRequestId,
+  createRequestId
+} from './request-id';
+
+export const DEFAULT_SLOW_REQUEST_THRESHOLD_MS = 1000;
+export const SLOW_REQUEST_THRESHOLD_ENV = 'SLOW_REQUEST_THRESHOLD_MS';
+
+interface RequestMonitoringLogger {
+  error(message: string): void;
+  warn(message: string): void;
+}
+
+interface RequestMonitoringOptions {
+  logger?: RequestMonitoringLogger;
+  now?: () => bigint;
+  slowRequestThresholdMs?: number;
+}
+
+const NANOSECONDS_PER_MILLISECOND = BigInt(1000000);
+
+export function parseSlowRequestThresholdMs(value: unknown): number {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return DEFAULT_SLOW_REQUEST_THRESHOLD_MS;
+  }
+
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue) || parsedValue < 1) {
+    return DEFAULT_SLOW_REQUEST_THRESHOLD_MS;
+  }
+
+  return Math.floor(parsedValue);
+}
+
+export function createRequestMonitoringMiddleware(options: RequestMonitoringOptions = {}) {
+  const logger = options.logger || new Logger('HttpRequestMonitoring');
+  const now = options.now || process.hrtime.bigint;
+  const slowRequestThresholdMs = parseSlowRequestThresholdMs(options.slowRequestThresholdMs);
+
+  return (
+    request: RequestWithRequestId,
+    response: Response,
+    next: NextFunction
+  ): void => {
+    const startedAt = now();
+
+    response.on('finish', () => {
+      const durationMs = getDurationMs(startedAt, now());
+      const requestId = getRequestId(request);
+      const requestDescription = `${request.method} ${getRequestPath(request)}`;
+
+      if (response.statusCode >= 500) {
+        logger.error(
+          `[${requestId}] ${requestDescription} failed with ${response.statusCode} in ${durationMs} ms`
+        );
+        return;
+      }
+
+      if (durationMs >= slowRequestThresholdMs) {
+        logger.warn(
+          `[${requestId}] ${requestDescription} completed with ${response.statusCode} in ${durationMs} ms ` +
+          `(slow request; threshold ${slowRequestThresholdMs} ms)`
+        );
+      }
+    });
+
+    next();
+  };
+}
+
+function getDurationMs(startedAt: bigint, finishedAt: bigint): number {
+  return Number((finishedAt - startedAt) / NANOSECONDS_PER_MILLISECOND);
+}
+
+function getRequestId(request: RequestWithRequestId): string {
+  if (request.requestId) {
+    return request.requestId;
+  }
+
+  const requestId = createRequestId();
+  request.requestId = requestId;
+  return requestId;
+}
+
+function getRequestPath(request: RequestWithRequestId): string {
+  const url = request.originalUrl || request.url || '/';
+  return (url.split('?', 1)[0] || '/').replace(/\/{2,}/g, '/');
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -10,6 +10,11 @@ import { AppModule } from './app/app.module';
 import { ExportWorkerModule } from './app/export-worker/export-worker.module';
 import { isExportWorkerProcess } from './app/export-worker/export-worker-role';
 import { GlobalHttpExceptionFilter } from './app/http/global-http-exception.filter';
+import {
+  SLOW_REQUEST_THRESHOLD_ENV,
+  createRequestMonitoringMiddleware,
+  parseSlowRequestThresholdMs
+} from './app/http/request-monitoring.middleware';
 import { REQUEST_ID_HEADER } from './app/http/request-id';
 import { requestIdMiddleware } from './app/http/request-id.middleware';
 
@@ -26,6 +31,9 @@ async function bootstrap() {
   const host = configService.get('API_HOST') || 'localhost';
   const port = 3333;
   const globalPrefix = 'api';
+  const slowRequestThresholdMs = parseSlowRequestThresholdMs(
+    configService.get(SLOW_REQUEST_THRESHOLD_ENV)
+  );
 
   app.use(requestIdMiddleware);
   app.useGlobalFilters(new GlobalHttpExceptionFilter());
@@ -36,6 +44,7 @@ async function bootstrap() {
     req.url = query ? `${normalizedPathname}?${query}` : normalizedPathname;
     next();
   });
+  app.use(createRequestMonitoringMiddleware({ slowRequestThresholdMs }));
 
   const packagesRoot = path.resolve('./packages');
   const packageDirectoryMap = new Map<string, string>();


### PR DESCRIPTION
## Summary

Adds server-side HTTP request monitoring for slow and failed backend requests.

- logs 5xx responses with request ID, method, normalized endpoint path, status, and duration
- logs slow successful responses above a configurable threshold
- exposes `SLOW_REQUEST_THRESHOLD_MS` with a 1000 ms default
- keeps query parameters out of monitoring paths so endpoints can be grouped more easily

## Context

Refs #813. This gives admins server-side visibility into slow endpoints and 500 responses with the same request/error ID shown to users.

## Validation

- `npx nx test backend --testFile=apps/backend/src/app/http/request-monitoring.middleware.spec.ts --runInBand`
- `npx nx lint backend`
- `npx nx test backend`
- `npx nx build backend`