### PR TITLE
Fence manual coding cache refreshes

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
@@ -1,3 +1,18 @@
 export function getCodingIncompleteVariablesCacheKey(workspaceId: number): string {
   return `coding_incomplete_variables_v8:${workspaceId}`;
 }
+
+export function getCodingIncompleteVariablesScopeCacheKey(workspaceId: number): string {
+  return `coding_incomplete_variables_scope_v1:${workspaceId}`;
+}
+
+export function getCodingIncompleteVariablesCacheVersionKey(workspaceId: number): string {
+  return `coding_incomplete_variables_version:${workspaceId}`;
+}
+
+export function getCodingIncompleteVariablesCacheKeys(workspaceId: number): string[] {
+  return [
+    getCodingIncompleteVariablesCacheKey(workspaceId),
+    getCodingIncompleteVariablesScopeCacheKey(workspaceId)
+  ];
+}

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -85,7 +85,7 @@ describe('CodingJobService distribution from job definitions', () => {
   let workspaceFilesService: { getDerivedVariableMap: jest.Mock };
   let codingJobRepository: ReturnType<typeof createRepo>;
   let jobDefinitionRepository: ReturnType<typeof createRepo>;
-  let cacheService: { delete: jest.Mock };
+  let cacheService: { delete: jest.Mock; incr: jest.Mock };
 
   beforeEach(() => {
     codingJobRepository = createRepo();
@@ -108,7 +108,10 @@ describe('CodingJobService distribution from job definitions', () => {
         }
       }))
     };
-    cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1)
+    };
     workspaceFilesService = {
       getDerivedVariableMap: jest.fn().mockResolvedValue(new Map())
     };
@@ -237,7 +240,9 @@ describe('CodingJobService distribution from job definitions', () => {
     });
 
     expect(result.success).toBe(true);
+    expect(cacheService.incr).toHaveBeenCalledWith('coding_incomplete_variables_version:5');
     expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v8:5');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v1:5');
     expect(result.distribution).toEqual(preview.distribution);
     expect(result.doubleCodingInfo).toEqual(preview.doubleCodingInfo);
     expect(result.jobsCreated).toBe(createdJobCalls.length);

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -99,7 +99,7 @@ describe('CodingJobService', () => {
   let fileUploadRepository: ReturnType<typeof createRepo>;
   let settingRepository: ReturnType<typeof createRepo>;
   let connection: { transaction: jest.Mock };
-  let cacheService: { delete: jest.Mock };
+  let cacheService: { delete: jest.Mock; incr: jest.Mock };
   let codingFreshnessService: { reconcileAppliedManualCodingJobs: jest.Mock };
   let codingFileCacheService: { getVariablePageMap: jest.Mock };
   let missingsProfilesService: {
@@ -198,7 +198,10 @@ describe('CodingJobService', () => {
       })
       )
     };
-    cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1)
+    };
     jobDefinitionRepository.createQueryBuilder.mockReturnValue({
       setLock: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
@@ -1754,8 +1757,14 @@ describe('CodingJobService', () => {
     expect(codingJobRepository.create.mock.calls[0][0]).not.toHaveProperty(
       'job_definition_id'
     );
+    expect(cacheService.incr).toHaveBeenCalledWith(
+      'coding_incomplete_variables_version:7'
+    );
     expect(cacheService.delete).toHaveBeenCalledWith(
       'coding_incomplete_variables_v8:7'
+    );
+    expect(cacheService.delete).toHaveBeenCalledWith(
+      'coding_incomplete_variables_scope_v1:7'
     );
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -68,7 +68,10 @@ import {
 } from '../../../../../../../api-dto/coding/job-refresh.dto';
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
 import { CodingFreshnessService } from './coding-freshness.service';
-import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingIncompleteVariablesCacheKeys,
+  getCodingIncompleteVariablesCacheVersionKey
+} from './coding-incomplete-variables-cache-key.util';
 import { CodingFileCacheService } from './coding-file-cache.service';
 import { CodingReplayAnchorService } from './coding-replay-anchor.service';
 import {
@@ -2939,8 +2942,13 @@ export class CodingJobService {
   private async invalidateIncompleteVariablesCache(
     workspaceId: number
   ): Promise<void> {
-    const cacheKey = getCodingIncompleteVariablesCacheKey(workspaceId);
-    await this.cacheService.delete(cacheKey);
+    await this.cacheService.incr(
+      getCodingIncompleteVariablesCacheVersionKey(workspaceId)
+    );
+    await Promise.all(
+      getCodingIncompleteVariablesCacheKeys(workspaceId)
+        .map(cacheKey => this.cacheService.delete(cacheKey))
+    );
     this.logger.log(
       `Invalidated manual coding variables cache for workspace ${workspaceId}`
     );

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
@@ -36,7 +36,8 @@ describe('CodingStatisticsService', () => {
     mockCacheService = {
       get: jest.fn(),
       set: jest.fn(),
-      delete: jest.fn()
+      delete: jest.fn(),
+      incr: jest.fn().mockResolvedValue(1)
     } as unknown as jest.Mocked<CacheService>;
 
     mockJobQueueService = {
@@ -337,8 +338,14 @@ describe('CodingStatisticsService', () => {
 
       await service.invalidateIncompleteVariablesCache(1);
 
+      expect(mockCacheService.incr).toHaveBeenCalledWith(
+        'coding_incomplete_variables_version:1'
+      );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
         'coding_incomplete_variables_v8:1'
+      );
+      expect(mockCacheService.delete).toHaveBeenCalledWith(
+        'coding_incomplete_variables_scope_v1:1'
       );
     });
 

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
@@ -27,7 +27,10 @@ import {
   getCodingStatisticsCacheKey,
   type CodingStatisticsVersion
 } from './coding-statistics-cache-key.util';
-import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingIncompleteVariablesCacheKeys,
+  getCodingIncompleteVariablesCacheVersionKey
+} from './coding-incomplete-variables-cache-key.util';
 import { getEffectiveCodingStatusExpression } from '../../utils/effective-coding-status-expression.util';
 
 export interface KappaCalculationResult {
@@ -304,8 +307,13 @@ export class CodingStatisticsService implements OnApplicationBootstrap {
   }
 
   async invalidateIncompleteVariablesCache(workspace_id: number): Promise<void> {
-    const cacheKey = getCodingIncompleteVariablesCacheKey(workspace_id);
-    await this.cacheService.delete(cacheKey);
+    await this.cacheService.incr(
+      getCodingIncompleteVariablesCacheVersionKey(workspace_id)
+    );
+    await Promise.all(
+      getCodingIncompleteVariablesCacheKeys(workspace_id)
+        .map(cacheKey => this.cacheService.delete(cacheKey))
+    );
     this.logger.log(`Invalidated incomplete variables cache for workspace ${workspace_id}`);
   }
 

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -123,7 +123,9 @@ describe('CodingValidationService', () => {
       storeValidationResults: jest.fn(),
       get: jest.fn(),
       set: jest.fn(),
-      delete: jest.fn()
+      delete: jest.fn(),
+      getNumber: jest.fn().mockResolvedValue(0),
+      incr: jest.fn().mockResolvedValue(1)
     } as unknown as jest.Mocked<CacheService>;
 
     mockWorkspaceFilesService = {
@@ -545,6 +547,73 @@ describe('CodingValidationService', () => {
       );
     });
 
+    it('should ignore cached variables from an older invalidation version', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'fresh-var', responseCount: '1' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([]);
+      const casesInJobsQb = createQueryBuilderMock([]);
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+
+      mockCacheService.getNumber.mockResolvedValue(2);
+      mockCacheService.get.mockImplementation(async key => (
+        key === 'coding_incomplete_variables_v8:1' ?
+          {
+            invalidationVersion: 1,
+            data: [
+              {
+                unitName: 'unit1',
+                variableId: 'stale-var',
+                responseCount: 9,
+                deriveErrorResponseCount: 0,
+                casesInJobs: 0,
+                availableCases: 9,
+                uniqueCasesAfterAggregation: 9,
+                isDerived: false,
+                coderTrainingRequired: false
+              }
+            ]
+          } :
+          null
+      ));
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['fresh-var'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
+        createSlimResponses('unit1', 'fresh-var', 1) as never
+      );
+
+      const result = await service.getCodingIncompleteVariables(1);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'unit1',
+          variableId: 'fresh-var',
+          responseCount: 1
+        })
+      ]);
+      expect(mockCacheService.set).toHaveBeenCalledWith(
+        'coding_incomplete_variables_v8:1',
+        {
+          invalidationVersion: 2,
+          data: result
+        },
+        300
+      );
+    });
+
     it('should include INTENDED_INCOMPLETE variables even when they are defined in the scheme', async () => {
       const codingIncompleteQb = createQueryBuilderMock([
         { unitName: 'unit1', variableId: 'var1', responseCount: '5' }
@@ -602,9 +671,71 @@ describe('CodingValidationService', () => {
       ]);
       expect(mockCacheService.set).toHaveBeenCalledWith(
         'coding_incomplete_variables_v8:1',
-        result,
+        {
+          invalidationVersion: 0,
+          data: result
+        },
         300
       );
+      expect(mockCacheService.set).toHaveBeenCalledWith(
+        'coding_incomplete_variables_scope_v1:1',
+        expect.objectContaining({
+          invalidationVersion: 0,
+          data: expect.objectContaining({
+            variables: expect.arrayContaining([
+              expect.objectContaining({
+                unitName: 'unit1',
+                variableId: 'var1'
+              })
+            ])
+          })
+        }),
+        300
+      );
+    });
+
+    it('should not cache variables when invalidated while the query is running', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '1' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([]);
+      const casesInJobsQb = createQueryBuilderMock([]);
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock).mockReturnValue(casesInJobsQb);
+
+      mockCacheService.getNumber
+        .mockResolvedValueOnce(5)
+        .mockResolvedValueOnce(6)
+        .mockResolvedValueOnce(6);
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue(
+        createSlimResponses('unit1', 'var1', 1) as never
+      );
+
+      const result = await service.getCodingIncompleteVariables(1);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'unit1',
+          variableId: 'var1',
+          responseCount: 1
+        })
+      ]);
+      expect(mockCacheService.set).not.toHaveBeenCalled();
     });
 
     it('should exclude INTENDED_INCOMPLETE variables without manual instruction', async () => {
@@ -807,6 +938,55 @@ describe('CodingValidationService', () => {
           }
         ]
       });
+    });
+
+    it('should return manual coding scope summary from cache without querying responses', async () => {
+      mockCacheService.get.mockImplementation(async key => (
+        key === 'coding_incomplete_variables_scope_v1:1' ?
+          {
+            variables: [
+              {
+                unitName: 'unit1',
+                variableId: 'var1',
+                responseCount: 5,
+                deriveErrorResponseCount: 0,
+                isDerived: false,
+                coderTrainingRequired: false
+              }
+            ],
+            excludedSourceSummary: {
+              coveredSourceVariableCount: 1,
+              coveredSourceResponseCount: 3,
+              coveredSourceVariables: [
+                {
+                  unitName: 'unit1',
+                  variableId: 'source-var',
+                  responseCount: 3,
+                  derivedVariableIds: ['var1']
+                }
+              ]
+            }
+          } :
+          null
+      ));
+
+      const summary = await service.getManualCodingScopeSummary(1);
+
+      expect(summary).toEqual({
+        manualVariableCount: 1,
+        manualResponseCount: 5,
+        coveredSourceVariableCount: 1,
+        coveredSourceResponseCount: 3,
+        coveredSourceVariables: [
+          {
+            unitName: 'unit1',
+            variableId: 'source-var',
+            responseCount: 3,
+            derivedVariableIds: ['var1']
+          }
+        ]
+      });
+      expect(mockResponseRepository.createQueryBuilder).not.toHaveBeenCalled();
     });
 
     it('should not collapse empty responses when counting unique cases after aggregation', async () => {
@@ -1612,6 +1792,62 @@ describe('CodingValidationService', () => {
         warnings: []
       });
     });
+
+    it('should reuse an in-flight validation for identical manual code availability requests', async () => {
+      mockCacheService.get.mockImplementation(async key => (
+        key === 'coding_incomplete_variables_v8:1' ?
+          [
+            {
+              unitName: 'unit1',
+              variableId: 'var1',
+              responseCount: 5,
+              deriveErrorResponseCount: 0,
+              casesInJobs: 0,
+              availableCases: 5,
+              uniqueCasesAfterAggregation: 5,
+              isDerived: false,
+              coderTrainingRequired: false
+            }
+          ] :
+          null
+      ));
+      let resolveDetails!: (details: unknown[]) => void;
+      const detailsPromise = new Promise<unknown[]>(resolve => {
+        resolveDetails = resolve;
+      });
+      mockWorkspaceFilesService.getUnitVariableDetails
+        .mockReturnValue(detailsPromise as never);
+
+      const first = service.validateManualCodeAvailability(1);
+      const second = service.validateManualCodeAvailability(1);
+      resolveDetails([
+        {
+          unitName: 'unit1',
+          unitId: 'unit1',
+          variables: [
+            {
+              id: 'var1',
+              alias: 'var1',
+              type: 'string',
+              hasCodingScheme: true,
+              codes: [
+                {
+                  id: 1,
+                  label: 'Manual',
+                  manualInstruction: '<p>Manuell auswählbar</p>'
+                }
+              ]
+            }
+          ]
+        }
+      ]);
+
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+
+      expect(firstResult).toEqual(secondResult);
+      expect(mockWorkspaceFilesService.getUnitVariableDetails)
+        .toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('getVariableCasesInJobs', () => {
@@ -1647,13 +1883,19 @@ describe('CodingValidationService', () => {
   });
 
   describe('invalidateIncompleteVariablesCache', () => {
-    it('should delete cache key for workspace', async () => {
+    it('should increment version and delete cache keys for workspace', async () => {
       mockCacheService.delete.mockResolvedValue(true);
 
       await service.invalidateIncompleteVariablesCache(1);
 
+      expect(mockCacheService.incr).toHaveBeenCalledWith(
+        'coding_incomplete_variables_version:1'
+      );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
         'coding_incomplete_variables_v8:1'
+      );
+      expect(mockCacheService.delete).toHaveBeenCalledWith(
+        'coding_incomplete_variables_scope_v1:1'
       );
     });
   });

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -29,7 +29,12 @@ import {
   countEffectiveManualCodingCases,
   ManualCodingDeduplicationResponse
 } from './aggregation-metrics.util';
-import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingIncompleteVariablesCacheKey,
+  getCodingIncompleteVariablesCacheKeys,
+  getCodingIncompleteVariablesCacheVersionKey,
+  getCodingIncompleteVariablesScopeCacheKey
+} from './coding-incomplete-variables-cache-key.util';
 import {
   getCoveredSourceKeysForManualDerivedVariables,
   isCoveredSourceVariable,
@@ -111,9 +116,18 @@ type ManualCodingVariableWithCaseInfo = {
   coderTrainingRequired: boolean;
 };
 
+type VersionedCodingCacheValue<T> = {
+  invalidationVersion: number;
+  data: T;
+};
+
 @Injectable()
 export class CodingValidationService {
   private readonly logger = new Logger(CodingValidationService.name);
+  private readonly incompleteVariablesCacheTtlSeconds = 300;
+  private readonly incompleteVariablesInFlight = new Map<string, Promise<ManualCodingVariableWithCaseInfo[]>>();
+  private readonly manualCodingScopeInFlight = new Map<string, Promise<ManualCodingScopeFromDb>>();
+  private readonly manualCodeAvailabilityInFlight = new Map<string, Promise<ManualCodeAvailabilityValidationDto>>();
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -528,9 +542,69 @@ export class CodingValidationService {
     > {
     try {
       if (
+        !unitName &&
+        trainingRequired === undefined &&
+        !includeDeriveErrorOnly &&
+        excludeJobDefinitionId === undefined
+      ) {
+        return await this.getDefaultCodingIncompleteVariables(workspaceId);
+      }
+
+      if (
+        unitName &&
+        trainingRequired === undefined &&
+        !includeDeriveErrorOnly &&
+        excludeJobDefinitionId === undefined
+      ) {
+        const cachedDefaultVariables =
+          await this.getCachedDefaultCodingIncompleteVariables(workspaceId);
+        if (cachedDefaultVariables) {
+          return this.filterManualCodingVariables(
+            cachedDefaultVariables,
+            unitName
+          );
+        }
+      }
+
+      if (includeDeriveErrorOnly) {
+        const queryDetails = [
+          unitName ? ` and unit ${unitName}` : '',
+          trainingRequired !== undefined ? ` (trainingRequired: ${trainingRequired})` : '',
+          excludeJobDefinitionId !== undefined ? ` excluding job definition ${excludeJobDefinitionId}` : ''
+        ].join('');
+        this.logger.log(
+          `Querying manual coding variables including DERIVE_ERROR cases for workspace ${workspaceId}${queryDetails} (not cached)`
+        );
+        const variables = await this.fetchCodingIncompleteVariablesFromDb(
+          workspaceId,
+          unitName,
+          trainingRequired,
+          true
+        );
+        return await this.enrichVariablesWithCaseInfo(
+          workspaceId,
+          variables,
+          true,
+          excludeJobDefinitionId
+        );
+      }
+
+      const reusableDefaultScope =
+        !unitName &&
+        trainingRequired === undefined &&
+        excludeJobDefinitionId !== undefined;
+      const variables = reusableDefaultScope ?
+        (await this.getDefaultManualCodingScope(workspaceId)).variables :
+        await this.fetchCodingIncompleteVariablesFromDb(
+          workspaceId,
+          unitName,
+          trainingRequired,
+          false
+        );
+
+      if (
         unitName ||
         trainingRequired !== undefined ||
-        includeDeriveErrorOnly ||
         excludeJobDefinitionId !== undefined
       ) {
         const queryDetails = [
@@ -539,68 +613,16 @@ export class CodingValidationService {
           excludeJobDefinitionId !== undefined ? ` excluding job definition ${excludeJobDefinitionId}` : ''
         ].join('');
         this.logger.log(
-          `Querying manual coding variables for workspace ${workspaceId}${queryDetails} (not cached)`
-        );
-        const variables = await this.fetchCodingIncompleteVariablesFromDb(
-          workspaceId,
-          unitName,
-          trainingRequired,
-          includeDeriveErrorOnly
+          `Querying manual coding variables for workspace ${workspaceId}${queryDetails}${reusableDefaultScope ? ' (scope cache reusable)' : ' (not cached)'}`
         );
         return await this.enrichVariablesWithCaseInfo(
           workspaceId,
           variables,
-          includeDeriveErrorOnly,
+          false,
           excludeJobDefinitionId
         );
       }
-      const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
-      const cachedResult = await this.cacheService.get<
-      {
-        unitName: string;
-        variableId: string;
-        responseCount: number;
-        deriveErrorResponseCount: number;
-        casesInJobs: number;
-        availableCases: number;
-        uniqueCasesAfterAggregation: number;
-        availableCasesWithDeriveError?: number;
-        uniqueCasesAfterAggregationWithDeriveError?: number;
-        isDerived: boolean;
-        coderTrainingRequired: boolean;
-      }[]
-      >(cacheKey);
-      if (cachedResult) {
-        this.logger.log(
-          `Retrieved ${cachedResult.length} manual coding variables from cache for workspace ${workspaceId}`
-        );
-        return cachedResult;
-      }
-      this.logger.log(
-        `Cache miss: Querying manual coding variables for workspace ${workspaceId}`
-      );
-      const variables = await this.fetchCodingIncompleteVariablesFromDb(
-        workspaceId,
-        undefined,
-        undefined,
-        includeDeriveErrorOnly
-      );
-      const result = await this.enrichVariablesWithCaseInfo(
-        workspaceId,
-        variables
-      );
-
-      const cacheSet = await this.cacheService.set(cacheKey, result, 300); // Cache for 5 minutes
-      if (cacheSet) {
-        this.logger.log(
-          `Cached ${result.length} manual coding variables for workspace ${workspaceId}`
-        );
-      } else {
-        this.logger.warn(
-          `Failed to cache manual coding variables for workspace ${workspaceId}`
-        );
-      }
-      return result;
+      return await this.enrichVariablesWithCaseInfo(workspaceId, variables);
     } catch (error) {
       this.logger.error(
         `Error getting manual coding variables: ${error.message}`,
@@ -618,11 +640,13 @@ export class CodingValidationService {
     trainingRequired?: boolean
   ): Promise<ManualCodingScopeSummary> {
     try {
-      const scope = await this.fetchManualCodingScopeFromDb(
-        workspaceId,
-        unitName,
-        trainingRequired
-      );
+      const scope = (!unitName && trainingRequired === undefined) ?
+        await this.getDefaultManualCodingScope(workspaceId) :
+        await this.fetchManualCodingScopeFromDb(
+          workspaceId,
+          unitName,
+          trainingRequired
+        );
 
       return {
         manualVariableCount: scope.variables.length,
@@ -644,6 +668,40 @@ export class CodingValidationService {
   }
 
   async validateManualCodeAvailability(
+    workspaceId: number,
+    unitName?: string,
+    trainingRequired?: boolean
+  ): Promise<ManualCodeAvailabilityValidationDto> {
+    const cacheVersion =
+      await this.getIncompleteVariablesCacheVersion(workspaceId);
+    const inFlightKey = this.generateManualCodeAvailabilityInFlightKey(
+      workspaceId,
+      unitName,
+      trainingRequired,
+      cacheVersion
+    );
+    const inFlight = this.manualCodeAvailabilityInFlight.get(inFlightKey);
+    if (inFlight) {
+      this.logger.log(
+        `Reusing in-flight manual code availability validation for workspace ${workspaceId}`
+      );
+      return inFlight;
+    }
+
+    const request = this.computeManualCodeAvailability(
+      workspaceId,
+      unitName,
+      trainingRequired
+    ).finally(() => {
+      if (this.manualCodeAvailabilityInFlight.get(inFlightKey) === request) {
+        this.manualCodeAvailabilityInFlight.delete(inFlightKey);
+      }
+    });
+    this.manualCodeAvailabilityInFlight.set(inFlightKey, request);
+    return request;
+  }
+
+  private async computeManualCodeAvailability(
     workspaceId: number,
     unitName?: string,
     trainingRequired?: boolean
@@ -705,6 +763,284 @@ export class CodingValidationService {
         'Could not validate manual code availability. Please check the coding schemes.'
       );
     }
+  }
+
+  private async getDefaultCodingIncompleteVariables(
+    workspaceId: number
+  ): Promise<ManualCodingVariableWithCaseInfo[]> {
+    const cacheVersion =
+      await this.getIncompleteVariablesCacheVersion(workspaceId);
+    const cachedResult = await this.getCachedDefaultCodingIncompleteVariables(
+      workspaceId,
+      cacheVersion
+    );
+    if (cachedResult) {
+      return cachedResult;
+    }
+
+    const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
+    const inFlightKey = this.generateVersionedInFlightKey(
+      cacheKey,
+      cacheVersion
+    );
+    const inFlight = this.incompleteVariablesInFlight.get(inFlightKey);
+    if (inFlight) {
+      this.logger.log(
+        `Reusing in-flight manual coding variables query for workspace ${workspaceId}`
+      );
+      return inFlight;
+    }
+
+    const request = this.fetchDefaultCodingIncompleteVariables(
+      workspaceId,
+      cacheVersion
+    )
+      .finally(() => {
+        if (this.incompleteVariablesInFlight.get(inFlightKey) === request) {
+          this.incompleteVariablesInFlight.delete(inFlightKey);
+        }
+      });
+    this.incompleteVariablesInFlight.set(inFlightKey, request);
+    return request;
+  }
+
+  private async getCachedDefaultCodingIncompleteVariables(
+    workspaceId: number,
+    cacheVersion?: number
+  ): Promise<ManualCodingVariableWithCaseInfo[] | null> {
+    const expectedCacheVersion =
+      cacheVersion ?? await this.getIncompleteVariablesCacheVersion(workspaceId);
+    const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
+    const inFlightKey = this.generateVersionedInFlightKey(
+      cacheKey,
+      expectedCacheVersion
+    );
+    const inFlight = this.incompleteVariablesInFlight.get(inFlightKey);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const cachedResult = this.getVersionedCachedData(
+      await this.cacheService.get<
+      VersionedCodingCacheValue<ManualCodingVariableWithCaseInfo[]> |
+      ManualCodingVariableWithCaseInfo[]
+      >(cacheKey),
+      expectedCacheVersion
+    );
+    if (cachedResult) {
+      this.logger.log(
+        `Retrieved ${cachedResult.length} manual coding variables from cache for workspace ${workspaceId}`
+      );
+    }
+    return cachedResult;
+  }
+
+  private async fetchDefaultCodingIncompleteVariables(
+    workspaceId: number,
+    cacheVersion: number
+  ): Promise<ManualCodingVariableWithCaseInfo[]> {
+    this.logger.log(
+      `Cache miss: Querying manual coding variables for workspace ${workspaceId}`
+    );
+    const scope = await this.getDefaultManualCodingScope(
+      workspaceId,
+      cacheVersion
+    );
+    const result = await this.enrichVariablesWithCaseInfo(
+      workspaceId,
+      scope.variables
+    );
+
+    const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
+    const cacheSet = await this.setVersionedCodingCache(
+      workspaceId,
+      cacheKey,
+      result,
+      cacheVersion
+    );
+    if (cacheSet) {
+      this.logger.log(
+        `Cached ${result.length} manual coding variables for workspace ${workspaceId}`
+      );
+    } else {
+      this.logger.warn(
+        `Failed to cache manual coding variables for workspace ${workspaceId}`
+      );
+    }
+    return result;
+  }
+
+  private async getDefaultManualCodingScope(
+    workspaceId: number,
+    cacheVersion?: number
+  ): Promise<ManualCodingScopeFromDb> {
+    const expectedCacheVersion =
+      cacheVersion ?? await this.getIncompleteVariablesCacheVersion(workspaceId);
+    const cacheKey = this.generateManualCodingScopeCacheKey(workspaceId);
+    const cachedScope = this.getVersionedCachedData(
+      await this.cacheService.get<
+      VersionedCodingCacheValue<ManualCodingScopeFromDb> |
+      ManualCodingScopeFromDb
+      >(cacheKey),
+      expectedCacheVersion
+    );
+    if (cachedScope) {
+      this.logger.log(
+        `Retrieved manual coding scope summary data from cache for workspace ${workspaceId}`
+      );
+      return cachedScope;
+    }
+
+    const inFlightKey = this.generateVersionedInFlightKey(
+      cacheKey,
+      expectedCacheVersion
+    );
+    const inFlight = this.manualCodingScopeInFlight.get(inFlightKey);
+    if (inFlight) {
+      this.logger.log(
+        `Reusing in-flight manual coding scope query for workspace ${workspaceId}`
+      );
+      return inFlight;
+    }
+
+    const request = this.fetchDefaultManualCodingScope(
+      workspaceId,
+      expectedCacheVersion
+    )
+      .finally(() => {
+        if (this.manualCodingScopeInFlight.get(inFlightKey) === request) {
+          this.manualCodingScopeInFlight.delete(inFlightKey);
+        }
+      });
+    this.manualCodingScopeInFlight.set(inFlightKey, request);
+    return request;
+  }
+
+  private async fetchDefaultManualCodingScope(
+    workspaceId: number,
+    cacheVersion: number
+  ): Promise<ManualCodingScopeFromDb> {
+    const scope = await this.fetchManualCodingScopeFromDb(workspaceId);
+    const cacheKey = this.generateManualCodingScopeCacheKey(workspaceId);
+    const cacheSet = await this.setVersionedCodingCache(
+      workspaceId,
+      cacheKey,
+      scope,
+      cacheVersion
+    );
+    if (cacheSet) {
+      this.logger.log(
+        `Cached manual coding scope summary data for workspace ${workspaceId}`
+      );
+    } else {
+      this.logger.warn(
+        `Failed to cache manual coding scope summary data for workspace ${workspaceId}`
+      );
+    }
+    return scope;
+  }
+
+  private filterManualCodingVariables<T extends {
+    unitName: string;
+    coderTrainingRequired?: boolean;
+  }>(
+    variables: T[],
+    unitName?: string,
+    trainingRequired?: boolean
+  ): T[] {
+    return variables.filter(variable => (
+      (!unitName || variable.unitName === unitName) &&
+      (
+        trainingRequired === undefined ||
+        variable.coderTrainingRequired === trainingRequired
+      )
+    ));
+  }
+
+  private async getIncompleteVariablesCacheVersion(
+    workspaceId: number
+  ): Promise<number> {
+    return this.cacheService.getNumber(
+      getCodingIncompleteVariablesCacheVersionKey(workspaceId),
+      0
+    );
+  }
+
+  private async setVersionedCodingCache<T>(
+    workspaceId: number,
+    cacheKey: string,
+    data: T,
+    cacheVersion: number
+  ): Promise<boolean> {
+    const currentCacheVersion =
+      await this.getIncompleteVariablesCacheVersion(workspaceId);
+    if (currentCacheVersion !== cacheVersion) {
+      this.logger.log(
+        `Skipped caching ${cacheKey} because workspace ${workspaceId} was invalidated while the query was running`
+      );
+      return false;
+    }
+
+    return this.cacheService.set<VersionedCodingCacheValue<T>>(
+      cacheKey,
+      {
+        invalidationVersion: cacheVersion,
+        data
+      },
+      this.incompleteVariablesCacheTtlSeconds
+    );
+  }
+
+  private getVersionedCachedData<T>(
+    cachedValue: VersionedCodingCacheValue<T> | T | null,
+    expectedCacheVersion: number
+  ): T | null {
+    if (!cachedValue) {
+      return null;
+    }
+
+    if (this.isVersionedCodingCacheValue(cachedValue)) {
+      return cachedValue.invalidationVersion === expectedCacheVersion ?
+        cachedValue.data :
+        null;
+    }
+
+    return expectedCacheVersion === 0 ? cachedValue : null;
+  }
+
+  private isVersionedCodingCacheValue<T>(
+    value: VersionedCodingCacheValue<T> | T
+  ): value is VersionedCodingCacheValue<T> {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'invalidationVersion' in value &&
+      'data' in value
+    );
+  }
+
+  private generateVersionedInFlightKey(
+    cacheKey: string,
+    cacheVersion: number
+  ): string {
+    return `${cacheKey}:version:${cacheVersion}`;
+  }
+
+  private generateManualCodingScopeCacheKey(workspaceId: number): string {
+    return getCodingIncompleteVariablesScopeCacheKey(workspaceId);
+  }
+
+  private generateManualCodeAvailabilityInFlightKey(
+    workspaceId: number,
+    unitName?: string,
+    trainingRequired?: boolean,
+    cacheVersion = 0
+  ): string {
+    const unitKey = unitName ? encodeURIComponent(unitName) : 'all';
+    const trainingKey = trainingRequired === undefined ?
+      'all' :
+      String(trainingRequired);
+    return `${workspaceId}:${cacheVersion}:${trainingKey}:${unitKey}`;
   }
 
   /**
@@ -1282,10 +1618,39 @@ export class CodingValidationService {
 
   async invalidateIncompleteVariablesCache(workspaceId: number): Promise<void> {
     const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
-    await this.cacheService.delete(cacheKey);
+    const scopeCacheKey = this.generateManualCodingScopeCacheKey(workspaceId);
+    await this.cacheService.incr(
+      getCodingIncompleteVariablesCacheVersionKey(workspaceId)
+    );
+    await Promise.all(
+      getCodingIncompleteVariablesCacheKeys(workspaceId)
+        .map(key => this.cacheService.delete(key))
+    );
+    this.deleteInFlightEntriesForCacheKey(
+      this.incompleteVariablesInFlight,
+      cacheKey
+    );
+    this.deleteInFlightEntriesForCacheKey(
+      this.manualCodingScopeInFlight,
+      scopeCacheKey
+    );
+    const availabilityKeyPrefix = `${workspaceId}:`;
+    Array.from(this.manualCodeAvailabilityInFlight.keys())
+      .filter(key => key.startsWith(availabilityKeyPrefix))
+      .forEach(key => this.manualCodeAvailabilityInFlight.delete(key));
     this.logger.log(
       `Invalidated manual coding variables cache for workspace ${workspaceId}`
     );
+  }
+
+  private deleteInFlightEntriesForCacheKey<T>(
+    inFlightEntries: Map<string, Promise<T>>,
+    cacheKey: string
+  ): void {
+    const keyPrefix = `${cacheKey}:version:`;
+    Array.from(inFlightEntries.keys())
+      .filter(key => key.startsWith(keyPrefix))
+      .forEach(key => inFlightEntries.delete(key));
   }
 
   /**

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -51,7 +51,10 @@ describe('ExternalCodingImportService', () => {
         }
       }
     };
-    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1)
+    };
     const codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };
@@ -102,7 +105,9 @@ describe('ExternalCodingImportService', () => {
     expect(queryRunner.commitTransaction).toHaveBeenCalled();
     expect(queryRunner.rollbackTransaction).not.toHaveBeenCalled();
     expect(queryRunner.release).toHaveBeenCalled();
+    expect(cacheService.incr).toHaveBeenCalledWith('coding_incomplete_variables_version:17');
     expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v8:17');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v1:17');
   });
 
   it('imports DERIVE_ERROR without turning it into completed false coding', async () => {
@@ -140,7 +145,10 @@ describe('ExternalCodingImportService', () => {
         }
       }
     };
-    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1)
+    };
     const codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };
@@ -221,7 +229,10 @@ describe('ExternalCodingImportService', () => {
         }
       }
     };
-    const cacheService = { delete: jest.fn().mockResolvedValue(undefined) };
+    const cacheService = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1)
+    };
     const codingFreshnessService = {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.ts
@@ -14,7 +14,10 @@ import { statusStringToNumber, statusNumberToString } from '../../utils/response
 import FileUpload from '../../entities/file_upload.entity';
 import { CodingFreshnessService } from './coding-freshness.service';
 import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspace-test-results-lock.util';
-import { getCodingIncompleteVariablesCacheKey } from './coding-incomplete-variables-cache-key.util';
+import {
+  getCodingIncompleteVariablesCacheKeys,
+  getCodingIncompleteVariablesCacheVersionKey
+} from './coding-incomplete-variables-cache-key.util';
 
 interface ExternalCodingRow {
   unit_key?: string;
@@ -1256,18 +1259,19 @@ export class ExternalCodingImportService {
     return results;
   }
 
-  private generateIncompleteVariablesCacheKey(workspaceId: number): string {
-    return getCodingIncompleteVariablesCacheKey(workspaceId);
-  }
-
   /**
    * Clear the manual coding variables cache for a specific workspace
    * Should be called whenever coding status changes for the workspace
    * @param workspaceId The workspace ID to clear cache for
    */
   async invalidateIncompleteVariablesCache(workspaceId: number): Promise<void> {
-    const cacheKey = this.generateIncompleteVariablesCacheKey(workspaceId);
-    await this.cacheService.delete(cacheKey);
+    await this.cacheService.incr(
+      getCodingIncompleteVariablesCacheVersionKey(workspaceId)
+    );
+    await Promise.all(
+      getCodingIncompleteVariablesCacheKeys(workspaceId)
+        .map(cacheKey => this.cacheService.delete(cacheKey))
+    );
     this.logger.log(`Invalidated manual coding variables cache for workspace ${workspaceId}`);
   }
 }

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
@@ -14,7 +14,7 @@ const createRepo = () => ({
 
 describe('WorkspaceCoreService', () => {
   let repo: ReturnType<typeof createRepo>;
-  let cacheService: { delete: jest.Mock; deleteByPattern: jest.Mock };
+  let cacheService: { delete: jest.Mock; deleteByPattern: jest.Mock; incr: jest.Mock };
   let workspaceTestResultsService: { invalidateWorkspaceStatsCache: jest.Mock };
   let queryRunner: {
     connect: jest.Mock;
@@ -29,7 +29,11 @@ describe('WorkspaceCoreService', () => {
 
   beforeEach(() => {
     repo = createRepo();
-    cacheService = { delete: jest.fn(), deleteByPattern: jest.fn() };
+    cacheService = {
+      delete: jest.fn(),
+      deleteByPattern: jest.fn(),
+      incr: jest.fn().mockResolvedValue(1)
+    };
     workspaceTestResultsService = { invalidateWorkspaceStatsCache: jest.fn() };
     queryRunner = {
       connect: jest.fn(),
@@ -124,6 +128,9 @@ describe('WorkspaceCoreService', () => {
     expect(cacheService.delete).toHaveBeenCalledWith('coding-statistics:schema-v4:1:v1');
     expect(cacheService.delete).toHaveBeenCalledWith('coding-statistics:schema-v4:1:v2');
     expect(cacheService.delete).toHaveBeenCalledWith('coding-statistics:schema-v4:1:v3');
+    expect(cacheService.incr).toHaveBeenCalledWith('coding_incomplete_variables_version:1');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v8:1');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v1:1');
     expect(cacheService.delete).toHaveBeenCalledWith('flat_response_filter_options:version:1');
     expect(cacheService.deleteByPattern).toHaveBeenCalledWith('response-analysis:1_*');
     expect(cacheService.deleteByPattern).toHaveBeenCalledWith('responses:1:*');

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
@@ -20,7 +20,10 @@ import {
   CODING_STATISTICS_CACHE_VERSIONS,
   getCodingStatisticsCacheKey
 } from '../coding/coding-statistics-cache-key.util';
-import { getCodingIncompleteVariablesCacheKey } from '../coding/coding-incomplete-variables-cache-key.util';
+import {
+  getCodingIncompleteVariablesCacheKeys,
+  getCodingIncompleteVariablesCacheVersionKey
+} from '../coding/coding-incomplete-variables-cache-key.util';
 
 @Injectable()
 export class WorkspaceCoreService {
@@ -198,11 +201,15 @@ export class WorkspaceCoreService {
   }
 
   private async invalidateCachesAffectedByExclusions(workspaceId: number): Promise<void> {
+    await this.cacheService.incr(
+      getCodingIncompleteVariablesCacheVersionKey(workspaceId)
+    );
     await Promise.all([
       ...CODING_STATISTICS_CACHE_VERSIONS.map(version => (
         this.cacheService.delete(getCodingStatisticsCacheKey(workspaceId, version))
       )),
-      this.cacheService.delete(getCodingIncompleteVariablesCacheKey(workspaceId)),
+      ...getCodingIncompleteVariablesCacheKeys(workspaceId)
+        .map(cacheKey => this.cacheService.delete(cacheKey)),
       this.cacheService.delete(`flat_response_filter_options:version:${workspaceId}`),
       this.cacheService.deleteByPattern(`response-analysis:${workspaceId}_*`),
       this.cacheService.deleteByPattern(`responses:${workspaceId}:*`),


### PR DESCRIPTION
## Summary

- cache default manual coding incomplete variables and scope summaries with a shared invalidation version
- deduplicate in-flight incomplete-variable, scope-summary, and code-availability requests
- invalidate both manual-coding cache keys and bump the version from all affected backend paths
- add regression coverage for stale cache payloads and invalidation during running queries

## Why

The manual coding analysis endpoints can run expensive database queries. Caching and in-flight reuse reduce repeated work, while the version fence prevents older running requests from writing stale data after an invalidation.

## Validation

- `npx nx lint backend`
- `npx nx test backend --runInBand`
- targeted backend specs for coding validation, statistics, import, job, distribution, and workspace core