### PR TITLE
Optimize coding management refresh workload

### DIFF
--- a/apps/backend/src/app/database/entities/response.entity.ts
+++ b/apps/backend/src/app/database/entities/response.entity.ts
@@ -10,6 +10,8 @@ import { Unit } from './unit.entity';
 @Index(['unitid', 'status']) // Composite index for filtering by status
 @Index(['status']) // Index for filtering by status distribution
 @Index(['status_v1']) // Index for filtering by coded status
+@Index(['status_v2']) // Index for filtering by second coding status
+@Index(['status_v3']) // Index for filtering by third coding status
 @Index(['is_autocoder_generated'])
 export class ResponseEntity {
   @PrimaryGeneratedColumn()

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -101,6 +101,12 @@ describe('CodingProgressService variable coverage conflicts', () => {
     getDerivedVariablesBySourceMap: jest.Mock;
     getManualInstructionVariableMap: jest.Mock;
   };
+  let cacheService: {
+    get: jest.Mock;
+    set: jest.Mock;
+    delete: jest.Mock;
+    getNumber: jest.Mock;
+  };
   let service: CodingProgressService;
 
   beforeEach(() => {
@@ -124,6 +130,12 @@ describe('CodingProgressService variable coverage conflicts', () => {
         testletIgnoredUnits: []
       })
     };
+    cacheService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(true),
+      delete: jest.fn().mockResolvedValue(true),
+      getNumber: jest.fn().mockResolvedValue(0)
+    };
 
     service = new CodingProgressService(
       responseRepository as never,
@@ -132,7 +144,8 @@ describe('CodingProgressService variable coverage conflicts', () => {
       variableBundleRepository as never,
       settingRepository as never,
       workspaceFilesService as never,
-      workspaceExclusionService as never
+      workspaceExclusionService as never,
+      cacheService as never
     );
   });
 
@@ -324,6 +337,67 @@ describe('CodingProgressService variable coverage conflicts', () => {
       deriveErrorAppliedResponses: 1,
       deriveErrorRemainingResponses: 0
     });
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'coding-progress:applied-results-overview:v1:5',
+      expect.objectContaining({
+        cacheVersion: 0,
+        data: expect.objectContaining({
+          rawTotalIncompleteResponses: 2,
+          rawAppliedResponses: 1,
+          deriveErrorRawTotalResponses: 1,
+          deriveErrorRawAppliedResponses: 1
+        })
+      }),
+      0
+    );
+  });
+
+  it('returns cached applied result progress without querying responses', async () => {
+    const cachedOverview = {
+      totalIncompleteResponses: 3,
+      appliedResponses: 2,
+      remainingResponses: 1,
+      completionPercentage: 66.67,
+      rawTotalIncompleteResponses: 4,
+      rawAppliedResponses: 2,
+      rawCompletionPercentage: 50,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0,
+      statusTotalIncompleteResponses: 4,
+      coveredSourceVariableCount: 0,
+      coveredSourceResponseCount: 0,
+      deriveErrorTotalResponses: 1,
+      deriveErrorAppliedResponses: 1,
+      deriveErrorRemainingResponses: 0,
+      deriveErrorRawTotalResponses: 1,
+      deriveErrorRawAppliedResponses: 1
+    };
+    cacheService.get.mockResolvedValueOnce({
+      cacheVersion: 0,
+      data: cachedOverview
+    });
+
+    const result = await service.getAppliedResultsOverview(5);
+
+    expect(result).toBe(cachedOverview);
+    expect(cacheService.getNumber).toHaveBeenCalledWith(
+      'coding_incomplete_variables_version:5',
+      0
+    );
+    expect(cacheService.get).toHaveBeenCalledWith(
+      'coding-progress:applied-results-overview:v1:5'
+    );
+    expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
+    expect(cacheService.set).not.toHaveBeenCalled();
+  });
+
+  it('invalidates cached applied result progress for the workspace', async () => {
+    await service.invalidateAppliedResultsOverviewCache(5);
+
+    expect(cacheService.delete).toHaveBeenCalledWith(
+      'coding-progress:applied-results-overview:v1:5'
+    );
   });
 
   it('limits manual pool existence checks to non-training coding jobs', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -14,6 +14,7 @@ import {
   applyResolvedExclusionsToQuery,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
+import { CacheService } from '../../../cache/cache.service';
 import {
   buildAggregationGroups,
   countEffectiveManualCodingCases,
@@ -32,6 +33,7 @@ import {
   applyNonCodingIssueReviewJobFilter,
   getNonCodingIssueReviewJobSqlCondition
 } from './coding-job-type.util';
+import { getCodingIncompleteVariablesCacheVersionKey } from './coding-incomplete-variables-cache-key.util';
 
 type ResponseMatchingFlag =
   | 'NO_AGGREGATION'
@@ -88,6 +90,32 @@ interface DeriveErrorManualProgress {
   deriveErrorRawAppliedResponses: number;
 }
 
+interface AppliedResultsOverview {
+  totalIncompleteResponses: number;
+  appliedResponses: number;
+  remainingResponses: number;
+  completionPercentage: number;
+  rawTotalIncompleteResponses: number;
+  rawAppliedResponses: number;
+  rawCompletionPercentage: number;
+  aggregationActive: boolean;
+  aggregationThreshold: number | null;
+  aggregatedDuplicateCases: number;
+  statusTotalIncompleteResponses: number;
+  coveredSourceVariableCount: number;
+  coveredSourceResponseCount: number;
+  deriveErrorTotalResponses: number;
+  deriveErrorAppliedResponses: number;
+  deriveErrorRemainingResponses: number;
+  deriveErrorRawTotalResponses: number;
+  deriveErrorRawAppliedResponses: number;
+}
+
+interface CachedAppliedResultsOverview {
+  cacheVersion: number;
+  data: AppliedResultsOverview;
+}
+
 interface ManualProgressStatusQuery {
   where: (condition: string | Brackets, parameters?: Record<string, unknown>) => unknown;
   andWhere: (condition: string | Brackets, parameters?: Record<string, unknown>) => unknown;
@@ -124,6 +152,8 @@ interface ManualCodingVariableLookups {
 export class CodingProgressService {
   private readonly logger = new Logger(CodingProgressService.name);
 
+  private readonly APPLIED_RESULTS_OVERVIEW_CACHE_TTL_SECONDS = 0;
+
   constructor(
     @InjectRepository(ResponseEntity)
     private responseRepository: Repository<ResponseEntity>,
@@ -137,6 +167,7 @@ export class CodingProgressService {
     private settingRepository: Repository<Setting>,
     private workspaceFilesService: WorkspaceFilesService,
     private workspaceExclusionService: WorkspaceExclusionService,
+    private cacheService: CacheService,
     @Optional()
     private missingsProfilesService?: MissingsProfilesService
   ) { }
@@ -208,26 +239,63 @@ export class CodingProgressService {
     };
   }
 
-  async getAppliedResultsOverview(workspaceId: number): Promise<{
-    totalIncompleteResponses: number;
-    appliedResponses: number;
-    remainingResponses: number;
-    completionPercentage: number;
-    rawTotalIncompleteResponses: number;
-    rawAppliedResponses: number;
-    rawCompletionPercentage: number;
-    aggregationActive: boolean;
-    aggregationThreshold: number | null;
-    aggregatedDuplicateCases: number;
-    statusTotalIncompleteResponses: number;
-    coveredSourceVariableCount: number;
-    coveredSourceResponseCount: number;
-    deriveErrorTotalResponses: number;
-    deriveErrorAppliedResponses: number;
-    deriveErrorRemainingResponses: number;
-    deriveErrorRawTotalResponses: number;
-    deriveErrorRawAppliedResponses: number;
-  }> {
+  async getAppliedResultsOverview(workspaceId: number, skipCache = false): Promise<AppliedResultsOverview> {
+    const cacheKey = this.getAppliedResultsOverviewCacheKey(workspaceId);
+    const cacheVersion = await this.getAppliedResultsOverviewCacheVersion(workspaceId);
+
+    if (!skipCache) {
+      const cachedOverview = await this.cacheService.get<CachedAppliedResultsOverview>(cacheKey);
+      if (this.isFreshAppliedResultsOverviewCache(cachedOverview, cacheVersion)) {
+        this.logger.log(`Returning cached applied results overview for workspace ${workspaceId}`);
+        return cachedOverview.data;
+      }
+    }
+
+    const overview = await this.computeAppliedResultsOverview(workspaceId);
+    await this.cacheService.set(
+      cacheKey,
+      {
+        cacheVersion,
+        data: overview
+      },
+      this.APPLIED_RESULTS_OVERVIEW_CACHE_TTL_SECONDS
+    );
+    return overview;
+  }
+
+  async refreshAppliedResultsOverview(workspaceId: number): Promise<AppliedResultsOverview> {
+    return this.getAppliedResultsOverview(workspaceId, true);
+  }
+
+  async invalidateAppliedResultsOverviewCache(workspaceId: number): Promise<void> {
+    const cacheKey = this.getAppliedResultsOverviewCacheKey(workspaceId);
+    await this.cacheService.delete(cacheKey);
+    this.logger.log(`Invalidated applied results overview cache for workspace ${workspaceId}`);
+  }
+
+  private getAppliedResultsOverviewCacheKey(workspaceId: number): string {
+    return `coding-progress:applied-results-overview:v1:${workspaceId}`;
+  }
+
+  private async getAppliedResultsOverviewCacheVersion(workspaceId: number): Promise<number> {
+    return this.cacheService.getNumber(
+      getCodingIncompleteVariablesCacheVersionKey(workspaceId),
+      0
+    );
+  }
+
+  private isFreshAppliedResultsOverviewCache(
+    cachedOverview: CachedAppliedResultsOverview | null,
+    cacheVersion: number
+  ): cachedOverview is CachedAppliedResultsOverview {
+    return Boolean(
+      cachedOverview &&
+      cachedOverview.cacheVersion === cacheVersion &&
+      cachedOverview.data
+    );
+  }
+
+  private async computeAppliedResultsOverview(workspaceId: number): Promise<AppliedResultsOverview> {
     const responseScope = await this.getCoverageResponseScope(workspaceId);
     const responses = responseScope.manualResponses;
     const appliedResponseIds = new Set(

--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -197,6 +197,7 @@ describe('CodingReviewService', () => {
       variableBundleRepository as never,
       {} as never,
       {} as never,
+      {} as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
       } as never,
@@ -362,6 +363,7 @@ describe('CodingReviewService', () => {
       codingJobUnitRepository as never,
       jobDefinitionRepository as never,
       variableBundleRepository as never,
+      {} as never,
       {} as never,
       {} as never,
       {
@@ -1448,6 +1450,9 @@ describe('CodingReviewService', () => {
     const codingAnalysisService = {
       invalidateCache: jest.fn().mockResolvedValue(undefined)
     };
+    const codingValidationService = {
+      invalidateIncompleteVariablesCache: jest.fn().mockResolvedValue(undefined)
+    };
     const localService = new CodingReviewService(
       responseRepository as never,
       codingJobUnitRepository as never,
@@ -1455,6 +1460,7 @@ describe('CodingReviewService', () => {
       variableBundleRepository as never,
       codingStatisticsService as never,
       codingAnalysisService as never,
+      codingValidationService as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
       } as never,
@@ -1507,6 +1513,7 @@ describe('CodingReviewService', () => {
     });
     expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(workspaceId);
     expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(workspaceId);
+    expect(codingValidationService.invalidateIncompleteVariablesCache).toHaveBeenCalledWith(workspaceId);
   });
 
   it('skips explicit replay decisions with codes unsupported by the coding scheme', async () => {
@@ -1533,6 +1540,7 @@ describe('CodingReviewService', () => {
       codingJobUnitRepository as never,
       jobDefinitionRepository as never,
       variableBundleRepository as never,
+      {} as never,
       {} as never,
       {} as never,
       {
@@ -1581,6 +1589,7 @@ describe('CodingReviewService', () => {
       codingJobUnitRepository as never,
       jobDefinitionRepository as never,
       variableBundleRepository as never,
+      {} as never,
       {} as never,
       {} as never,
       {
@@ -1658,6 +1667,7 @@ describe('CodingReviewService', () => {
       jobDefinitionRepository as never,
       variableBundleRepository as never,
       codingStatisticsService as never,
+      {} as never,
       {} as never,
       {
         resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)

--- a/apps/backend/src/app/database/services/coding/coding-review.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.ts
@@ -20,6 +20,7 @@ import {
 } from './coding-job-type.util';
 import { CodingJobService } from './coding-job.service';
 import { CodingAnalysisService } from './coding-analysis.service';
+import { CodingValidationService } from './coding-validation.service';
 
 type JobDefinitionBundleScope = {
   bundleIds: number[];
@@ -108,6 +109,7 @@ export class CodingReviewService {
     private variableBundleRepository: Repository<VariableBundle>,
     private codingStatisticsService: CodingStatisticsService,
     private codingAnalysisService: CodingAnalysisService,
+    private codingValidationService: CodingValidationService,
     private workspaceExclusionService: WorkspaceExclusionService,
     private codingJobService: CodingJobService,
     @Optional()
@@ -1235,6 +1237,12 @@ export class CodingReviewService {
       }
       if (appliedCount > 0 && typeof this.codingAnalysisService.invalidateCache === 'function') {
         await this.codingAnalysisService.invalidateCache(workspaceId);
+      }
+      if (
+        appliedCount > 0 &&
+        typeof this.codingValidationService.invalidateIncompleteVariablesCache === 'function'
+      ) {
+        await this.codingValidationService.invalidateIncompleteVariablesCache(workspaceId);
       }
 
       const message = `Applied ${appliedCount} resolutions successfully. ${failedCount > 0 ? `${failedCount} failed.` : ''

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConflictException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -43,6 +44,7 @@ describe('CodingStatisticsService', () => {
     mockJobQueueService = {
       getTestPersonCodingJob: jest.fn(),
       getCodingStatisticsJob: jest.fn(),
+      getActiveCodingStatisticsJob: jest.fn().mockResolvedValue(undefined),
       addCodingStatisticsJob: jest.fn(),
       cancelTestPersonCodingJob: jest.fn(),
       deleteTestPersonCodingJob: jest.fn(),
@@ -486,6 +488,70 @@ describe('CodingStatisticsService', () => {
       expect(mockCacheService.get).toHaveBeenCalledWith(
         'coding-statistics:schema-v4:1:v1'
       );
+    });
+
+    it('should return an active statistics job for the same workspace and version', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+      const mockJob: Partial<Job> = { id: 'job-active' };
+      mockJobQueueService.getActiveCodingStatisticsJob.mockResolvedValue(
+        mockJob as Job
+      );
+
+      const result = await service.createCodingStatisticsJob(1, 'v1');
+
+      expect(result).toEqual({
+        jobId: 'job-active',
+        message: 'Using active coding statistics job'
+      });
+      expect(mockJobQueueService.assertNoDependencyConflicts)
+        .toHaveBeenCalledWith('coding-statistics', 1);
+      expect(mockJobQueueService.getActiveCodingStatisticsJob)
+        .toHaveBeenCalledWith(1, 'v1');
+      expect(
+        mockJobQueueService.assertNoDependencyConflicts.mock.invocationCallOrder[0]
+      ).toBeLessThan(
+        mockJobQueueService.getActiveCodingStatisticsJob.mock.invocationCallOrder[0]
+      );
+      expect(mockCacheService.delete).not.toHaveBeenCalled();
+      expect(mockJobQueueService.addCodingStatisticsJob).not.toHaveBeenCalled();
+    });
+
+    it('should not reuse an active statistics job when dependency conflicts exist', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+      const conflict = new ConflictException('Auto-coding is still active');
+      const mockJob: Partial<Job> = { id: 'job-active' };
+      mockJobQueueService.assertNoDependencyConflicts.mockRejectedValue(conflict);
+      mockJobQueueService.getActiveCodingStatisticsJob.mockResolvedValue(
+        mockJob as Job
+      );
+
+      await expect(service.createCodingStatisticsJob(1, 'v1'))
+        .rejects.toBe(conflict);
+
+      expect(mockJobQueueService.assertNoDependencyConflicts)
+        .toHaveBeenCalledWith('coding-statistics', 1);
+      expect(mockJobQueueService.getActiveCodingStatisticsJob)
+        .not.toHaveBeenCalled();
+      expect(mockCacheService.delete).not.toHaveBeenCalled();
+      expect(mockJobQueueService.addCodingStatisticsJob).not.toHaveBeenCalled();
+    });
+
+    it('should reuse an in-flight statistics job request for the same workspace and version', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.delete.mockResolvedValue(true);
+      const mockJob: Partial<Job> = { id: 'job-123' };
+      mockJobQueueService.addCodingStatisticsJob.mockResolvedValue(
+        mockJob as Job
+      );
+
+      const [firstResult, secondResult] = await Promise.all([
+        service.createCodingStatisticsJob(1, 'v1'),
+        service.createCodingStatisticsJob(1, 'v1')
+      ]);
+
+      expect(firstResult).toEqual(secondResult);
+      expect(mockCacheService.get).toHaveBeenCalledTimes(1);
+      expect(mockJobQueueService.addCodingStatisticsJob).toHaveBeenCalledTimes(1);
     });
 
     it('should read coding statistics job status only from the statistics queue', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.ts
@@ -58,6 +58,9 @@ export interface KappaVariableSummary {
 export class CodingStatisticsService implements OnApplicationBootstrap {
   private readonly logger = new Logger(CodingStatisticsService.name);
   private readonly CACHE_TTL_SECONDS = 0; // No expiration (TTL=0 means no EX flag in Redis) - persist until explicitly invalidated
+  private readonly STATISTICS_PRELOAD_CONCURRENCY = 2;
+  private readonly statisticsJobRequests =
+    new Map<string, Promise<{ jobId: string; message: string }>>();
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -82,16 +85,35 @@ export class CodingStatisticsService implements OnApplicationBootstrap {
       const workspaceIds = await this.getWorkspaceIdsWithResponses();
       this.logger.log(`Found ${workspaceIds.length} workspaces with responses, preloading statistics...`);
 
-      const preloadPromises = workspaceIds.map(workspaceId => this.getCodingStatistics(workspaceId).catch(error => {
-        this.logger.error(`Failed to preload statistics for workspace ${workspaceId}: ${error.message}`);
-      })
-      );
-
-      await Promise.allSettled(preloadPromises);
+      await this.preloadStatisticsForWorkspaces(workspaceIds);
       this.logger.log('Finished preloading coding statistics for all workspaces');
     } catch (error) {
       this.logger.error(`Error during application bootstrap: ${error.message}`);
     }
+  }
+
+  private async preloadStatisticsForWorkspaces(workspaceIds: number[]): Promise<void> {
+    const workerCount = Math.min(
+      this.STATISTICS_PRELOAD_CONCURRENCY,
+      workspaceIds.length
+    );
+    let nextIndex = 0;
+
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (nextIndex < workspaceIds.length) {
+        const workspaceId = workspaceIds[nextIndex];
+        nextIndex += 1;
+        try {
+          await this.getCodingStatistics(workspaceId);
+        } catch (error) {
+          this.logger.error(
+            `Failed to preload statistics for workspace ${workspaceId}: ${error.message}`
+          );
+        }
+      }
+    });
+
+    await Promise.allSettled(workers);
   }
 
   private async getWorkspaceIdsWithResponses(): Promise<number[]> {
@@ -416,6 +438,26 @@ export class CodingStatisticsService implements OnApplicationBootstrap {
     workspaceId: number,
     version: CodingStatisticsVersion = 'v1'
   ): Promise<{ jobId: string; message: string }> {
+    const requestKey = `${workspaceId}:${version}`;
+    const inFlightRequest = this.statisticsJobRequests.get(requestKey);
+    if (inFlightRequest) {
+      return inFlightRequest;
+    }
+
+    const request = this.createCodingStatisticsJobInternal(workspaceId, version)
+      .finally(() => {
+        if (this.statisticsJobRequests.get(requestKey) === request) {
+          this.statisticsJobRequests.delete(requestKey);
+        }
+      });
+    this.statisticsJobRequests.set(requestKey, request);
+    return request;
+  }
+
+  private async createCodingStatisticsJobInternal(
+    workspaceId: number,
+    version: CodingStatisticsVersion
+  ): Promise<{ jobId: string; message: string }> {
     try {
       const cacheKey = getCodingStatisticsCacheKey(workspaceId, version);
       const cachedResult = await this.cacheService.get<CodingStatistics>(
@@ -427,13 +469,24 @@ export class CodingStatisticsService implements OnApplicationBootstrap {
         );
         return { jobId: '', message: 'Using cached coding statistics' };
       }
-      // We don't delete the cache here because we just checked it. If it was there, we returned.
-      // If it's not there, we don't need to delete it.
-      // However, the original code deleted it. Let's keep deleting it just in case of race conditions or partial writes?
-      // Actually, if we are starting a job, we should probably clear any stale cache just to be sure.
-      await this.cacheService.delete(cacheKey);
 
       await this.jobQueueService.assertNoDependencyConflicts('coding-statistics', workspaceId);
+
+      const activeJob = await this.jobQueueService.getActiveCodingStatisticsJob(
+        workspaceId,
+        version
+      );
+      if (activeJob) {
+        this.logger.log(
+          `Reusing active coding statistics job ${activeJob.id} for workspace ${workspaceId} (version: ${version})`
+        );
+        return {
+          jobId: activeJob.id.toString(),
+          message: 'Using active coding statistics job'
+        };
+      }
+
+      await this.cacheService.delete(cacheKey);
 
       this.logger.log(
         `No cached coding statistics for workspace ${workspaceId} (version: ${version}), creating job to recalculate`

--- a/apps/backend/src/app/database/services/workspace/workspace-coding.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-coding.service.spec.ts
@@ -174,7 +174,8 @@ describe('WorkspaceCodingService', () => {
   const mockCodingProgressService = {
     getCodingProgressOverview: jest.fn(),
     getVariableCoverageOverview: jest.fn(),
-    getCaseCoverageOverview: jest.fn()
+    getCaseCoverageOverview: jest.fn(),
+    invalidateAppliedResultsOverviewCache: jest.fn()
   };
 
   const mockCodingReplayService = {

--- a/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
@@ -64,6 +64,7 @@ export class WorkspaceCodingService {
     );
 
     await this.invalidateIncompleteVariablesCache(workspace_id);
+    await this.codingProgressService.invalidateAppliedResultsOverviewCache(workspace_id);
     await this.codingAnalysisService.invalidateCache(workspace_id);
     await this.codingStatisticsService.invalidateCache(workspace_id);
     await this.codingStatisticsService.refreshStatistics(
@@ -272,6 +273,7 @@ export class WorkspaceCodingService {
       }>;
     }> {
     await this.codingAnalysisService.invalidateCache(workspaceId);
+    await this.codingProgressService.invalidateAppliedResultsOverviewCache(workspaceId);
     return this.externalCodingImportService.importExternalCodingWithProgress(
       workspaceId,
       body,
@@ -303,6 +305,7 @@ export class WorkspaceCodingService {
       }>;
     }> {
     await this.codingAnalysisService.invalidateCache(workspaceId);
+    await this.codingProgressService.invalidateAppliedResultsOverviewCache(workspaceId);
     return this.externalCodingImportService.importExternalCoding(
       workspaceId,
       body
@@ -392,6 +395,7 @@ export class WorkspaceCodingService {
       messageParams?: Record<string, unknown>;
     }> {
     await this.codingAnalysisService.invalidateCache(workspaceId);
+    await this.codingProgressService.invalidateAppliedResultsOverviewCache(workspaceId);
     return this.codingJobOperationsService.applyCodingResults(
       workspaceId,
       codingJobId
@@ -504,6 +508,7 @@ export class WorkspaceCodingService {
     }>;
   }> {
     await this.codingAnalysisService.invalidateCache(workspaceId);
+    await this.codingProgressService.invalidateAppliedResultsOverviewCache(workspaceId);
     return this.codingJobOperationsService.bulkApplyCodingResults(workspaceId);
   }
 
@@ -639,6 +644,7 @@ export class WorkspaceCodingService {
       skippedCount: number;
       message: string;
     }> {
+    await this.codingProgressService.invalidateAppliedResultsOverviewCache(workspaceId);
     return this.codingReviewService.applyDoubleCodedResolutions(
       workspaceId,
       decisions
@@ -694,6 +700,7 @@ export class WorkspaceCodingService {
       message: string;
     }> {
     await this.codingAnalysisService.invalidateCache(workspaceId);
+    await this.codingProgressService.invalidateAppliedResultsOverviewCache(workspaceId);
     return this.codingVersionService.resetCodingVersion(
       workspaceId,
       version,

--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -1,7 +1,10 @@
 import { ConflictException } from '@nestjs/common';
 import { JobQueueService } from './job-queue.service';
 
-const createJob = (data: Record<string, unknown> = { workspaceId: 1, taskId: 7 }, state = 'waiting') => ({
+const createJob = (
+  data: Record<string, unknown> | null = { workspaceId: 1, taskId: 7 },
+  state = 'waiting'
+) => ({
   id: 'job-1',
   data,
   failedReason: undefined,
@@ -103,6 +106,17 @@ describe('JobQueueService', () => {
     await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).rejects.toBeInstanceOf(ConflictException);
     await expect(service.addValidationTaskJob({ taskId: 7 })).rejects.toBeInstanceOf(ConflictException);
     await expect(service.addExternalCodingImportJob({ workspaceId: 1, tempFilePath: '/tmp/a', fileName: 'a.csv' })).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('reuses active coding statistics jobs for the same workspace and version', async () => {
+    const activeStatisticsJob = createJob({ workspaceId: 1, version: 'v2' });
+    queues[1].getJobs.mockResolvedValue([activeStatisticsJob]);
+
+    await expect(service.addCodingStatisticsJob(1, 'v2'))
+      .resolves.toBe(activeStatisticsJob);
+    await expect(service.getActiveCodingStatisticsJob(1, 'v2'))
+      .resolves.toBe(activeStatisticsJob);
+    expect(queues[1].add).not.toHaveBeenCalled();
   });
 
   it('allows jobs when no duplicate active job exists', async () => {
@@ -267,6 +281,23 @@ describe('JobQueueService', () => {
     await expect(service.getVariableAnalysisJobs(1)).resolves.toHaveLength(1);
     await expect(service.getActiveCodingAnalysisJob(1)).resolves.toHaveProperty('id', 'job-1');
     await expect(service.getActiveResetCodingVersionJob(1)).resolves.toHaveProperty('id', 'job-1');
+  });
+
+  it('ignores stale null jobs when listing export jobs', async () => {
+    queues[2].getJobs.mockResolvedValue([
+      null,
+      createJob(null),
+      createJob({ workspaceId: 2, exportType: 'test-results' }),
+      createJob({ workspaceId: 1, exportType: 'test-results' })
+    ] as never);
+
+    const exportJobs = await service.getExportJobs(1);
+
+    expect(exportJobs).toHaveLength(1);
+    expect(exportJobs[0].data).toMatchObject({
+      workspaceId: 1,
+      exportType: 'test-results'
+    });
   });
 
   it('covers all registered process overview queues', async () => {

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -91,6 +91,11 @@ export interface ValidationTaskJobData {
   taskId: number;
 }
 
+export interface CodingStatisticsJobData {
+  workspaceId: number;
+  version?: 'v1' | 'v2' | 'v3';
+}
+
 export interface CodingAnalysisJobData {
   workspaceId: number;
   matchingFlags: string[]; // passed as string array, converted in processor if needed or kept as is
@@ -307,6 +312,22 @@ export class JobQueueService {
     ]);
   }
 
+  private jobMatchesWorkspace(
+    job: Pick<Job, 'data'> | null | undefined,
+    workspaceId: number
+  ): boolean {
+    const jobWorkspaceId = Number(
+      (job?.data as { workspaceId?: unknown } | undefined)?.workspaceId
+    );
+    return Number.isFinite(jobWorkspaceId) && jobWorkspaceId === Number(workspaceId);
+  }
+
+  private normalizeCodingStatisticsVersion(
+    version?: 'v1' | 'v2' | 'v3'
+  ): 'v1' | 'v2' | 'v3' {
+    return version || 'v1';
+  }
+
   private mapBullStateToProcessStatus(state: string): ProcessDto['status'] {
     if (
       state === 'active' ||
@@ -386,8 +407,7 @@ export class JobQueueService {
       return tasks.some(task => Number(task.workspace_id) === Number(workspaceId));
     }
 
-    const jobWorkspaceId = Number((job.data as { workspaceId?: number } | undefined)?.workspaceId);
-    return Boolean(jobWorkspaceId) && jobWorkspaceId === Number(workspaceId);
+    return this.jobMatchesWorkspace(job, workspaceId);
   }
 
   private async cancelKnownJob(queueName: string, job: Job): Promise<boolean> {
@@ -489,7 +509,7 @@ export class JobQueueService {
               Number(validationTaskMap.get(Number(j.data?.taskId))?.workspace_id) === Number(workspaceId)
             ));
           } else {
-            matchedJobs = existingJobs.filter(j => j.data && j.data.workspaceId === workspaceId);
+            matchedJobs = existingJobs.filter(j => this.jobMatchesWorkspace(j, workspaceId));
           }
 
           const mappedPromises = matchedJobs.map(async job => {
@@ -627,7 +647,7 @@ export class JobQueueService {
       return jobs.find(j => taskWorkspaceMap.get(j.data?.taskId) === workspaceId);
     }
 
-    return jobs.find(j => j.data?.workspaceId === workspaceId);
+    return jobs.find(j => this.jobMatchesWorkspace(j, workspaceId));
   }
 
   async assertNoDependencyConflicts(
@@ -650,7 +670,7 @@ export class JobQueueService {
     matchFn: (data: T) => boolean
   ): Promise<Job<T> | undefined> {
     const jobs = (await queue.getJobs(['active', 'waiting', 'delayed'])).filter(Boolean);
-    return jobs.find(job => matchFn(job.data));
+    return jobs.find(job => job.data && matchFn(job.data));
   }
 
   async addTestPersonCodingJob(
@@ -682,25 +702,51 @@ export class JobQueueService {
     workspaceId: number,
     version?: 'v1' | 'v2' | 'v3',
     options?: JobOptions
-  ): Promise<Job<{ workspaceId: number; version?: 'v1' | 'v2' | 'v3' }>> {
-    const existing = await this.findActiveJob<{ workspaceId: number }>(
+  ): Promise<Job<CodingStatisticsJobData>> {
+    const requestedVersion = this.normalizeCodingStatisticsVersion(version);
+    const existing = await this.findActiveJob<CodingStatisticsJobData>(
       this.codingStatisticsQueue,
-      d => d.workspaceId === workspaceId
+      d => Number(d.workspaceId) === Number(workspaceId)
     );
     if (existing) {
+      const existingVersion = this.normalizeCodingStatisticsVersion(
+        existing.data?.version
+      );
+      if (existingVersion === requestedVersion) {
+        this.logger.log(
+          `Reusing coding statistics job ${existing.id} for workspace ${workspaceId} (version: ${requestedVersion})`
+        );
+        return existing;
+      }
       throw new ConflictException(
-        `A coding statistics job is already running for workspace ${workspaceId} (job ${existing.id})`
+        `A coding statistics job is already running for workspace ${workspaceId} ` +
+        `(version: ${existingVersion}, job ${existing.id})`
       );
     }
     this.logger.log(
-      `Adding coding statistics job for workspace ${workspaceId} (version: ${version || 'v1'})`
+      `Adding coding statistics job for workspace ${workspaceId} (version: ${requestedVersion})`
     );
-    return this.codingStatisticsQueue.add({ workspaceId, version }, options);
+    return this.codingStatisticsQueue.add(
+      { workspaceId, version: requestedVersion },
+      options
+    );
+  }
+
+  async getActiveCodingStatisticsJob(
+    workspaceId: number,
+    version?: 'v1' | 'v2' | 'v3'
+  ): Promise<Job<CodingStatisticsJobData> | undefined> {
+    const requestedVersion = this.normalizeCodingStatisticsVersion(version);
+    return this.findActiveJob<CodingStatisticsJobData>(
+      this.codingStatisticsQueue,
+      d => Number(d.workspaceId) === Number(workspaceId) &&
+        this.normalizeCodingStatisticsVersion(d.version) === requestedVersion
+    );
   }
 
   async getCodingStatisticsJob(
     jobId: string
-  ): Promise<Job<{ workspaceId: number }>> {
+  ): Promise<Job<CodingStatisticsJobData>> {
     return this.codingStatisticsQueue.getJob(jobId);
   }
 
@@ -771,7 +817,7 @@ export class JobQueueService {
       'delayed'
     ]);
     this.logger.log(`Found ${jobs.length} jobs in total`);
-    return jobs.filter(job => job.data.workspaceId === workspaceId);
+    return jobs.filter(job => this.jobMatchesWorkspace(job, workspaceId));
   }
 
   async cancelTestPersonCodingJob(jobId: string): Promise<boolean> {
@@ -866,7 +912,7 @@ export class JobQueueService {
       'delayed'
     ]);
     this.logger.log(`Found ${jobs.length} export jobs in total`);
-    return jobs.filter(job => job.data.workspaceId === workspaceId);
+    return jobs.filter(job => this.jobMatchesWorkspace(job, workspaceId));
   }
 
   createExportJobCancellationSignal(jobId: string): AbortSignal {
@@ -968,7 +1014,7 @@ export class JobQueueService {
       if (!job) {
         return false;
       }
-      return job.data.isCancelled === true;
+      return job.data?.isCancelled === true;
     } catch (error) {
       this.logger.error(
         `Error checking export job cancellation: ${error.message}`,
@@ -1093,7 +1139,7 @@ export class JobQueueService {
       'waiting',
       'delayed'
     ]);
-    return jobs.find(job => job.data.workspaceId === workspaceId) || null;
+    return jobs.find(job => this.jobMatchesWorkspace(job, workspaceId)) || null;
   }
 
   async addVariableAnalysisJob(
@@ -1125,7 +1171,7 @@ export class JobQueueService {
       'waiting',
       'delayed'
     ]);
-    return jobs.filter(job => job.data.workspaceId === workspaceId);
+    return jobs.filter(job => this.jobMatchesWorkspace(job, workspaceId));
   }
 
   async deleteVariableAnalysisJob(jobId: string): Promise<boolean> {
@@ -1201,7 +1247,7 @@ export class JobQueueService {
       'waiting',
       'delayed'
     ]);
-    return jobs.find(job => job.data.workspaceId === workspaceId) || null;
+    return jobs.find(job => this.jobMatchesWorkspace(job, workspaceId)) || null;
   }
 
   async checkRedisConnection(): Promise<RedisConnectionStatus> {

--- a/apps/backend/src/app/workspace/workspace-settings.controller.spec.ts
+++ b/apps/backend/src/app/workspace/workspace-settings.controller.spec.ts
@@ -15,6 +15,20 @@ describe('WorkspaceSettingsController', () => {
     );
   });
 
+  it('returns the default coding statistics auto-fetch setting disabled when it is missing', async () => {
+    settingRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      controller.getWorkspaceSetting(5, 'auto-fetch-coding-statistics')
+    ).resolves.toEqual({
+      id: 0,
+      key: 'workspace-5-auto-fetch-coding-statistics',
+      value: JSON.stringify({ enabled: false }),
+      description:
+        'Controls whether coding statistics are automatically fetched in the coding management component'
+    });
+  });
+
   it('returns the default manual coding job auto-refresh setting when it is missing', async () => {
     settingRepository.findOne.mockResolvedValue(null);
 

--- a/apps/backend/src/app/workspace/workspace-settings.controller.ts
+++ b/apps/backend/src/app/workspace/workspace-settings.controller.ts
@@ -34,7 +34,7 @@ export class WorkspaceSettingsController {
         return {
           id: 0,
           key: settingKey,
-          value: JSON.stringify({ enabled: true }),
+          value: JSON.stringify({ enabled: false }),
           description:
             'Controls whether coding statistics are automatically fetched in the coding management component'
         };

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -270,7 +270,7 @@ describe('CodingManagementComponent', () => {
           'title-not-started': 'Kodierung noch nicht gestartet',
           'title-manual-coding-open': 'Manuelle Kodierung abschließen',
           'title-not-checked': 'Kodierstand nicht automatisch geprüft',
-          'manual-refresh-required': 'Die automatische Aktualisierung ist deaktiviert. Aktualisieren Sie den Status bei Bedarf manuell.',
+          'manual-refresh-required': 'Der vollständige Kodierstand wurde noch nicht geprüft. Aktualisieren Sie den Status bei Bedarf manuell.',
           summary: '{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus, aber {{codeableResponses}} kodierbare Antworten.',
           'details-result-units': '{{count}} Ergebnis-Units',
           'details-unit-files': '{{count}} passende Unit-Dateien',
@@ -319,6 +319,50 @@ describe('CodingManagementComponent', () => {
 
     it('should check manual coding auto-refresh setting on init', () => {
       expect(mockWorkspaceSettingsService.getAutoRefreshManualCodingJobs).toHaveBeenCalledWith(1);
+    });
+
+    it('should only load lightweight coding freshness on init when auto-refresh is enabled', () => {
+      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+    });
+
+    it('should keep the manual full status refresh available after the initial light load', () => {
+      expect(component.shouldShowManualCodingStatusRefresh()).toBe(true);
+      expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(true);
+
+      component.refreshCodingStatusOverview();
+
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+      expect(component.shouldShowManualCodingStatusRefresh()).toBe(false);
+      expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(false);
+    });
+
+    it('should load manual applied results on init when second auto-coding freshness is open', () => {
+      fixture.destroy();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock)
+        .mockReturnValueOnce(of({
+          workspaceId: 1,
+          currentRevision: 2,
+          items: [{
+            version: 'v3',
+            state: 'PENDING',
+            unitCount: 12,
+            affectedResponseCount: 34
+          }]
+        }));
+      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getCodingFreshnessScope as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+      const isolatedFixture = TestBed.createComponent(CodingManagementComponent);
+      isolatedFixture.detectChanges();
+
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getCodingFreshnessScope).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+
+      isolatedFixture.destroy();
     });
 
     it('should defer autocoding readiness until a forced coding status refresh', () => {
@@ -612,7 +656,7 @@ describe('CodingManagementComponent', () => {
   describe('Coding Freshness', () => {
     it('should show pending manual status refresh as an attention state', () => {
       component.autoRefreshManualCodingJobs = false;
-      component.hasRequestedCodingStatusOverview = false;
+      component.hasLoadedFullCodingStatusOverview = false;
 
       expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(true);
       expect(component.hasCodingFreshnessAttention).toBe(true);
@@ -665,8 +709,11 @@ describe('CodingManagementComponent', () => {
       );
 
       fixture.detectChanges();
-      const actionPanel = fixture.nativeElement.querySelector('.coding-freshness-actions') as HTMLElement | null;
-      const manualActionButton = Array.from(actionPanel?.querySelectorAll('button') || [])
+      const manualActionButton = Array.from(
+        fixture.nativeElement.querySelectorAll(
+          '.coding-freshness-actions button'
+        ) as NodeListOf<HTMLButtonElement>
+      )
         .find(button => button.textContent?.includes('Manuelle Kodierung öffnen')) as HTMLButtonElement | undefined;
       expect(manualActionButton).toBeTruthy();
 

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -321,9 +321,13 @@ describe('CodingManagementComponent', () => {
       expect(mockWorkspaceSettingsService.getAutoRefreshManualCodingJobs).toHaveBeenCalledWith(1);
     });
 
-    it('should load autocoding readiness for the first autocoder run', () => {
+    it('should defer autocoding readiness until a forced coding status refresh', () => {
+      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+
+      component.refreshCodingStatusOverview();
+
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
     });
 
     it('should refresh coding status overview when requested by query param', () => {
@@ -368,28 +372,34 @@ describe('CodingManagementComponent', () => {
     });
 
     it('should defer automatic coding status refresh while a guarded background job is running', () => {
-      (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
-        .mockReturnValue(true);
-      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
-      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
-      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
-      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+      jest.useFakeTimers();
+      try {
+        (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
+          .mockReturnValue(true);
+        (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+        (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
 
-      autoCodingCompletedSubject.next({});
+        autoCodingCompletedSubject.next({});
 
-      expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
-      expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
-      expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
-      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+        expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+        expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
+        expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
+        expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
 
-      (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
-        .mockReturnValue(false);
-      statusGuardClearedSubject.next({ workspaceId: 1 });
+        (mockCodingBackgroundJobsService.isStatusCheckGuardActive as jest.Mock)
+          .mockReturnValue(false);
+        statusGuardClearedSubject.next({ workspaceId: 1 });
+        jest.advanceTimersByTime(250);
 
-      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
-      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
-      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
+        expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
+        expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
+        expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
+        expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('should not refresh twice when freshness completion clears a pending guarded refresh', () => {
@@ -481,7 +491,7 @@ describe('CodingManagementComponent', () => {
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
     });
 
-    it('should not auto-fetch coding overview statistics when global auto-refresh is disabled', () => {
+    it('should still auto-fetch coding statistics when status auto-refresh is disabled', () => {
       fixture.destroy();
       (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
       (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
@@ -497,7 +507,7 @@ describe('CodingManagementComponent', () => {
       isolatedFixture.detectChanges();
 
       expect(isolatedComponent.autoRefreshManualCodingJobs).toBe(false);
-      expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v1');
       expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
@@ -536,7 +546,7 @@ describe('CodingManagementComponent', () => {
 
       manualRefreshSetting$.next(false);
 
-      expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v2');
       expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
@@ -1175,13 +1185,22 @@ describe('CodingManagementComponent', () => {
     });
 
     it('should switch to changed statistics version when test results change', () => {
-      (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
+      jest.useFakeTimers();
+      try {
+        (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
 
-      testResultsChangedSubject.next({ workspaceId: 1, statisticsVersion: 'v2' });
+        testResultsChangedSubject.next({ workspaceId: 1, statisticsVersion: 'v2' });
 
-      expect(component.selectedStatisticsVersion).toBe('v2');
-      expect(component.filterParams.version).toBe('v2');
-      expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v2');
+        expect(component.selectedStatisticsVersion).toBe('v2');
+        expect(component.filterParams.version).toBe('v2');
+        expect(mockCodingManagementService.fetchCodingStatistics).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(250);
+
+        expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledWith('v2');
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('should ignore changed test results from a different workspace', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -216,9 +216,11 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private hasLoadedManualCodingJobRefreshSetting = false;
   private pendingAutomaticCodingStatusRefreshAfterBackgroundJob = false;
   private pendingForcedCodingStatusRefreshAfterBackgroundJob = false;
+  private scheduledAutomaticCodingStatusRefresh: number | null = null;
   private freshnessJobCompletionRefreshHandledIds = new Set<string>();
   private resetCompletionRefreshHandledAfterGuardClear = false;
   private hasShownFreshnessJobStatusPollingError = false;
+  private readonly automaticCodingStatusRefreshDebounceMs = 250;
 
   ngOnInit(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
@@ -238,14 +240,13 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         .subscribe(([autoFetch, autoRefresh]) => {
           this.hasLoadedManualCodingJobRefreshSetting = true;
           this.autoRefreshManualCodingJobs = autoRefresh;
-          if (!autoRefresh) {
-            return;
-          }
 
           if (autoFetch || pendingStatisticsVersion) {
             this.fetchCodingStatistics();
           }
-          this.loadCodingStatusOverview();
+          if (autoRefresh) {
+            this.loadCodingStatusOverview();
+          }
         });
       this.workspaceSettingsService
         .getEnableRegexSearch(workspaceId)
@@ -375,6 +376,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       );
     }
     this.stopFreshnessJobPolling();
+    this.clearScheduledAutomaticCodingStatusRefresh();
     this.destroy$.next();
     this.destroy$.complete();
   }
@@ -551,7 +553,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.performCodingStatusOverviewRefresh();
+    this.scheduleAutomaticCodingStatusOverviewRefresh();
   }
 
   private invalidateCodingStatusOverviewCache(): void {
@@ -569,7 +571,30 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.hasRequestedCodingStatusOverview = true;
     this.loadCodingFreshness();
     this.loadManualAppliedResultsOverview();
-    this.loadAutocodingReadiness(forceAutocodingReadiness);
+    if (forceAutocodingReadiness) {
+      this.loadAutocodingReadiness(true);
+    }
+  }
+
+  private scheduleAutomaticCodingStatusOverviewRefresh(): void {
+    if (this.scheduledAutomaticCodingStatusRefresh !== null) {
+      return;
+    }
+
+    this.scheduledAutomaticCodingStatusRefresh = window.setTimeout(() => {
+      this.scheduledAutomaticCodingStatusRefresh = null;
+      if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(false)) {
+        return;
+      }
+      this.performCodingStatusOverviewRefresh();
+    }, this.automaticCodingStatusRefreshDebounceMs);
+  }
+
+  private clearScheduledAutomaticCodingStatusRefresh(): void {
+    if (this.scheduledAutomaticCodingStatusRefresh !== null) {
+      clearTimeout(this.scheduledAutomaticCodingStatusRefresh);
+      this.scheduledAutomaticCodingStatusRefresh = null;
+    }
   }
 
   private deferCodingStatusRefreshIfBackgroundJobIsRunning(forceRefresh: boolean): boolean {
@@ -1459,8 +1484,13 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
     dialogRef.afterClosed()
       .pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.fetchCodingStatistics();
+      .subscribe(dialogResult => {
+        if (data?.initialJobId) {
+          return;
+        }
+        if (this.isTerminalJobStatus(dialogResult?.jobStatus)) {
+          this.refreshCodingStatusOverviewAfterChange();
+        }
       });
 
     return dialogRef;

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -188,7 +188,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   manualAppliedResultsOverviewLoadFailed = false;
   enableRegexSearch = false;
   autoRefreshManualCodingJobs = true;
-  hasRequestedCodingStatusOverview = false;
+  hasLoadedFullCodingStatusOverview = false;
   isStartingFreshnessCoding = false;
   activeFreshnessJobId: string | null = null;
   activeFreshnessJobProgress: number | null = null;
@@ -245,7 +245,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
             this.fetchCodingStatistics();
           }
           if (autoRefresh) {
-            this.loadCodingStatusOverview();
+            this.loadInitialCodingStatusOverview();
           }
         });
       this.workspaceSettingsService
@@ -426,7 +426,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.codingManagementService.fetchCodingStatistics(this.selectedStatisticsVersion);
   }
 
-  loadCodingFreshness(): void {
+  loadCodingFreshness(loadScopeOnWarnings = true): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
       return;
@@ -446,10 +446,13 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       )
       .subscribe(summary => {
         this.codingFreshnessSummary = summary;
-        if (this.hasCodingFreshnessWarnings) {
+        if (loadScopeOnWarnings && this.hasCodingFreshnessWarnings) {
           this.loadCodingFreshnessScope();
         } else {
           this.codingFreshnessScope = null;
+        }
+        if (!loadScopeOnWarnings && this.hasSecondAutocodingFreshnessWarnings) {
+          this.loadManualAppliedResultsOverview();
         }
       });
   }
@@ -516,6 +519,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       .subscribe({
         next: readiness => {
           this.autocodingReadiness = readiness;
+          this.hasLoadedFullCodingStatusOverview = true;
         },
         error: () => {
           this.autocodingReadiness = null;
@@ -559,6 +563,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private invalidateCodingStatusOverviewCache(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (workspaceId) {
+      this.hasLoadedFullCodingStatusOverview = false;
       this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
     }
   }
@@ -568,12 +573,23 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.hasRequestedCodingStatusOverview = true;
+    if (forceAutocodingReadiness) {
+      this.hasLoadedFullCodingStatusOverview = false;
+    }
     this.loadCodingFreshness();
     this.loadManualAppliedResultsOverview();
     if (forceAutocodingReadiness) {
       this.loadAutocodingReadiness(true);
     }
+  }
+
+  private loadInitialCodingStatusOverview(): void {
+    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(false)) {
+      return;
+    }
+
+    this.hasLoadedFullCodingStatusOverview = false;
+    this.loadCodingFreshness(false);
   }
 
   private scheduleAutomaticCodingStatusOverviewRefresh(): void {
@@ -656,7 +672,12 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   shouldShowManualCodingStatusRefresh(): boolean {
-    return !this.autoRefreshManualCodingJobs;
+    if (this.isStartingFreshnessCoding || this.activeFreshnessJobId) {
+      return false;
+    }
+
+    return !this.autoRefreshManualCodingJobs ||
+      !this.hasLoadedFullCodingStatusOverview;
   }
 
   startFreshnessCoding(version: 'v1' | 'v3'): void {
@@ -987,7 +1008,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get hasImportedResultsWithoutCoding(): boolean {
-    return !this.hasCodingFreshnessWarnings &&
+    return this.statisticsLoaded &&
+      !this.hasCodingFreshnessWarnings &&
       (this.codingFreshnessSummary?.currentRevision || 0) > 0 &&
       (this.codingFreshnessSummary?.items || []).length === 0 &&
       (this.codingStatistics.totalResponses || 0) === 0;
@@ -1010,8 +1032,12 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   get isCodingStatusOverviewPendingManualRefresh(): boolean {
-    return !this.hasRequestedCodingStatusOverview &&
-      this.shouldShowManualCodingStatusRefresh();
+    return !this.hasLoadedFullCodingStatusOverview &&
+      this.shouldShowManualCodingStatusRefresh() &&
+      !this.hasAutocodingReadinessLoadFailed &&
+      !this.isAutocodingReadinessBlocked &&
+      !this.hasCodingFreshnessWarnings &&
+      !this.hasImportedResultsWithoutCoding;
   }
 
   get autoCodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
@@ -1292,6 +1318,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   private get secondAutocodingFreshnessWarnings(): CodingFreshnessSummaryItemDto[] {
     return getSecondAutocodingFreshnessWarnings(this.allCodingFreshnessWarnings);
+  }
+
+  private get hasSecondAutocodingFreshnessWarnings(): boolean {
+    return this.secondAutocodingFreshnessWarnings.length > 0;
   }
 
   private get isSecondAutocodingWaitingForManualCoding(): boolean {

--- a/apps/frontend/src/app/coding/services/coding-execution.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-execution.service.ts
@@ -120,10 +120,7 @@ export class CodingExecutionService {
       .post<{ jobId: string; message: string }>(
       `${this.serverUrl}admin/workspace/${workspace_id}/coding/statistics/job`,
       {},
-      { params }
-    )
-      .pipe(
-        catchError(() => of({ jobId: '', message: 'Failed to create job' }))
-      );
+      { params, context: suppressGlobalHttpErrorContext() }
+    );
   }
 }

--- a/apps/frontend/src/app/coding/services/coding-management.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-management.service.spec.ts
@@ -161,14 +161,33 @@ describe('CodingManagementService', () => {
       expect(executionServiceMock.createCodingStatisticsJob).not.toHaveBeenCalled();
     });
 
-    it('should handle failure to create job', () => {
+    it('should not start duplicate statistics jobs for the same workspace and version while one is active', () => {
+      const jobStart$ = new Subject<{ jobId: string; message: string }>();
+      executionServiceMock.createCodingStatisticsJob.mockReturnValue(jobStart$);
+
+      service.fetchCodingStatistics('v1');
+      service.fetchCodingStatistics('v1');
+
+      expect(executionServiceMock.createCodingStatisticsJob).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not synchronously fetch statistics when job creation fails', () => {
       executionServiceMock.createCodingStatisticsJob.mockReturnValue(throwError(() => new Error('Failed')));
-      // Expect it to call handleNoJobIdStatistics -> getCodingStatistics
       statisticsServiceMock.getCodingStatistics.mockReturnValue(of(mockCodingStatistics));
+      let isLoading: boolean | undefined;
+      service.isLoadingStatistics$.subscribe(value => {
+        isLoading = value;
+      });
 
       service.fetchCodingStatistics('v1');
 
-      expect(statisticsServiceMock.getCodingStatistics).toHaveBeenCalledWith(1, 'v1');
+      expect(statisticsServiceMock.getCodingStatistics).not.toHaveBeenCalled();
+      expect(snackBarMock.open).toHaveBeenCalledWith(
+        'coding-management.loading.creating-coding-statistics',
+        'close',
+        { duration: 5000, panelClass: ['error-snackbar'] }
+      );
+      expect(isLoading).toBe(false);
     });
   });
 

--- a/apps/frontend/src/app/coding/services/coding-management.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-management.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import {
-  BehaviorSubject, Observable, of, forkJoin, timer, OperatorFunction, Subscription
+  BehaviorSubject, Observable, of, forkJoin, timer, OperatorFunction, Subscription, EMPTY
 } from 'rxjs';
 import {
   catchError, map, switchMap, takeWhile, finalize, filter
@@ -119,11 +119,19 @@ export class CodingManagementService {
   resetJobId$ = this._resetJobId.asObservable();
 
   private resetPollingSubscription: Subscription | null = null;
+  private readonly activeStatisticsFetches = new Set<string>();
+  private readonly statisticsPollingSubscriptions = new Map<string, Subscription>();
   private activeDownloads = new Map<DownloadOperationKind, ActiveDownloadOperation>();
 
   fetchCodingStatistics(version: StatisticsVersion): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) return;
+
+    const fetchKey = this.getStatisticsFetchKey(workspaceId, version);
+    if (this.activeStatisticsFetches.has(fetchKey)) {
+      return;
+    }
+    this.activeStatisticsFetches.add(fetchKey);
 
     this._isLoadingStatistics.next(true);
     // Reset reference stats
@@ -132,21 +140,26 @@ export class CodingManagementService {
 
     this.executionService.createCodingStatisticsJob(workspaceId, version)
       .pipe(
-        catchError(() => of({
-          jobId: '' as string,
-          message: this.translateService.instant('coding-management.loading.creating-coding-statistics')
-        }))
+        catchError(() => {
+          this.showErrorSnackbar('coding-management.loading.creating-coding-statistics');
+          this.finishStatisticsFetch(fetchKey);
+          return EMPTY;
+        })
       )
       .subscribe(({ jobId }) => {
         if (!jobId) {
-          this.handleNoJobIdStatistics(workspaceId, version);
+          this.handleNoJobIdStatistics(workspaceId, version, fetchKey);
         } else {
-          this.pollStatisticsJob(workspaceId, jobId, version);
+          this.pollStatisticsJob(workspaceId, jobId, version, fetchKey);
         }
       });
   }
 
-  private handleNoJobIdStatistics(workspaceId: number, version: StatisticsVersion): void {
+  private handleNoJobIdStatistics(
+    workspaceId: number,
+    version: StatisticsVersion,
+    fetchKey: string
+  ): void {
     if (version === 'v2') {
       // v2 compares to v1
       forkJoin({
@@ -154,7 +167,7 @@ export class CodingManagementService {
         reference: this.statisticsService.getCodingStatistics(workspaceId, 'v1')
       }).pipe(
         this.handleStatisticsError({ current: this.emptyStats, reference: this.emptyStats }),
-        finalize(() => this._isLoadingStatistics.next(false))
+        finalize(() => this.finishStatisticsFetch(fetchKey))
       ).subscribe((result: { current: CodingStatistics; reference: CodingStatistics }) => {
         const { current, reference } = result;
         this._codingStatistics.next(current);
@@ -173,7 +186,7 @@ export class CodingManagementService {
           v2Stats: this.emptyStats,
           v1Stats: this.emptyStats
         }),
-        finalize(() => this._isLoadingStatistics.next(false))
+        finalize(() => this.finishStatisticsFetch(fetchKey))
       ).subscribe((result: { current: CodingStatistics; v2Stats: CodingStatistics; v1Stats: CodingStatistics }) => {
         const { current, v2Stats, v1Stats } = result;
         this._codingStatistics.next(current);
@@ -192,7 +205,7 @@ export class CodingManagementService {
             this.showErrorSnackbar('coding-management.descriptions.error-statistics');
             return of({ totalResponses: 0, statusCounts: {} });
           }),
-          finalize(() => this._isLoadingStatistics.next(false))
+          finalize(() => this.finishStatisticsFetch(fetchKey))
         )
         .subscribe(statistics => {
           this._codingStatistics.next(statistics);
@@ -200,11 +213,21 @@ export class CodingManagementService {
     }
   }
 
-  private pollStatisticsJob(workspaceId: number, jobId: string, version: StatisticsVersion): void {
-    timer(0, 2000).pipe(
+  private pollStatisticsJob(
+    workspaceId: number,
+    jobId: string,
+    version: StatisticsVersion,
+    fetchKey: string
+  ): void {
+    const pollingSubscription = timer(0, 2000).pipe(
       switchMap(() => this.executionService.getCodingStatisticsJobStatus(workspaceId, jobId)),
       takeWhile(status => ['pending', 'processing'].includes(status.status), true),
-      finalize(() => this._isLoadingStatistics.next(false))
+      finalize(() => {
+        if (this.statisticsPollingSubscriptions.get(fetchKey) === pollingSubscription) {
+          this.statisticsPollingSubscriptions.delete(fetchKey);
+        }
+        this.finishStatisticsFetch(fetchKey);
+      })
     ).subscribe((status: CodingJobStatus) => {
       if (status.status === 'completed' && status.result) {
         this._codingStatistics.next(status.result);
@@ -213,6 +236,16 @@ export class CodingManagementService {
         this.snackBar.open(`Statistik-Job ${status.status}`, 'Schließen', { duration: 5000, panelClass: ['error-snackbar'] });
       }
     });
+    this.statisticsPollingSubscriptions.set(fetchKey, pollingSubscription);
+  }
+
+  private getStatisticsFetchKey(workspaceId: number, version: StatisticsVersion): string {
+    return `${workspaceId}:${version}`;
+  }
+
+  private finishStatisticsFetch(fetchKey: string): void {
+    this.activeStatisticsFetches.delete(fetchKey);
+    this._isLoadingStatistics.next(this.activeStatisticsFetches.size > 0);
   }
 
   private fetchReferenceStatisticsAfterJob(workspaceId: number, version: StatisticsVersion): void {

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
@@ -117,9 +117,9 @@ describe('WorkspaceSettingsService', () => {
       req.flush({ value: '{"enabled":true}' });
     });
 
-    it('should return true on error', () => {
+    it('should return false on error', () => {
       service.getAutoFetchCodingStatistics(1).subscribe(val => {
-        expect(val).toBe(true);
+        expect(val).toBe(false);
       });
       const req = httpMock.expectOne(`${mockServerUrl}/workspace/1/settings/auto-fetch-coding-statistics`);
       req.flush({}, { status: 404, statusText: 'Not Found' });

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
@@ -144,14 +144,14 @@ export class WorkspaceSettingsService {
         next: setting => {
           try {
             const parsed = JSON.parse(setting.value);
-            observer.next(parsed.enabled ?? true);
+            observer.next(parsed.enabled ?? false);
           } catch {
-            observer.next(true);
+            observer.next(false);
           }
           observer.complete();
         },
         error: () => {
-          observer.next(true);
+          observer.next(false);
           observer.complete();
         }
       });

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1385,7 +1385,7 @@
       "title-manual-coding-open": "Manuelle Kodierung abschließen",
       "title-not-checked": "Kodierstand nicht automatisch geprüft",
       "checking": "Zustand wird geprüft...",
-      "manual-refresh-required": "Die automatische Aktualisierung ist deaktiviert. Aktualisieren Sie den Status bei Bedarf manuell.",
+      "manual-refresh-required": "Der vollständige Kodierstand wurde noch nicht geprüft. Aktualisieren Sie den Status bei Bedarf manuell.",
       "summary": "{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus, aber {{codeableResponses}} kodierbare Antworten.",
       "details-result-units": "{{count}} Ergebnis-Units",
       "details-unit-files": "{{count}} passende Unit-Dateien",

--- a/database/changelog/coding-box.changelog-1.16.4.sql
+++ b/database/changelog/coding-box.changelog-1.16.4.sql
@@ -1,0 +1,15 @@
+-- liquibase formatted sql
+
+-- changeset jurei733:1 runInTransaction:false
+-- comment: Add index for response status_v2 filtering without blocking writes
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_response_status_v2"
+  ON "public"."response" ("status_v2");
+
+-- rollback DROP INDEX CONCURRENTLY IF EXISTS "public"."idx_response_status_v2";
+
+-- changeset jurei733:2 runInTransaction:false
+-- comment: Add index for response status_v3 filtering without blocking writes
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_response_status_v3"
+  ON "public"."response" ("status_v3");
+
+-- rollback DROP INDEX CONCURRENTLY IF EXISTS "public"."idx_response_status_v3";

--- a/database/changelog/coding-box.changelog-root.xml
+++ b/database/changelog/coding-box.changelog-root.xml
@@ -42,4 +42,5 @@
   <include file="coding-box.changelog-1.16.1.sql"/>
   <include file="coding-box.changelog-1.16.2.sql"/>
   <include file="coding-box.changelog-1.16.3.sql"/>
+  <include file="coding-box.changelog-1.16.4.sql"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- Cache the applied-results overview and keep manual coding status refreshes from over-invalidating shared status data.
- Reduce the coding-management initial load to lightweight freshness checks; full readiness, overview, and statistics now run on manual refresh or concrete follow-up events.
- Deduplicate coding statistics job creation/fetches, reuse compatible active jobs after dependency checks, and throttle backend statistics preload.
- Disable automatic coding-statistics fetch by default and add response status_v2/status_v3 indexes via Liquibase.

## Validation
- npx nx lint frontend
- npx nx test frontend --runTestsByPath apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
- npx nx lint backend
- npx nx test backend --runTestsByPath apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
- REGISTRY_PATH= make dev-db-validate-changelog
- git diff --check