### PR TITLE
Cache autocoding readiness status

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
@@ -15,7 +15,10 @@ describe('WorkspaceCodingStatisticsController', () => {
     getCodedVariablesForKappa: jest.Mock;
   };
   let codingReplayService: { generateReplayUrlsForItemsBulk: jest.Mock };
-  let codingReadinessService: { getReadiness: jest.Mock };
+  let codingReadinessService: {
+    getReadiness: jest.Mock;
+    getReadinessFromCache: jest.Mock;
+  };
   let controller: WorkspaceCodingStatisticsController;
   const request = {
     protocol: 'http',
@@ -71,7 +74,8 @@ describe('WorkspaceCodingStatisticsController', () => {
         validResponses: 0,
         codeableResponses: 0,
         invalidVariableSamples: []
-      })
+      }),
+      getReadinessFromCache: jest.fn().mockResolvedValue(null)
     };
 
     controller = new WorkspaceCodingStatisticsController(
@@ -154,6 +158,16 @@ describe('WorkspaceCodingStatisticsController', () => {
       autoCoderRun: 2,
       forceRefresh: true
     });
+  });
+
+  it('delegates cache-only autocoding readiness requests without recalculating', async () => {
+    await controller.getAutocodingReadiness(5, '1', undefined, 'true');
+
+    expect(codingReadinessService.getReadinessFromCache).toHaveBeenCalledWith(5, {
+      autoCoderRun: 1,
+      forceRefresh: false
+    });
+    expect(codingReadinessService.getReadiness).not.toHaveBeenCalled();
   });
 
   it('adds weighted mean kappa per variable to detailed kappa statistics', async () => {

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -1065,7 +1065,12 @@ export class WorkspaceCodingStatisticsController {
   @ApiQuery({
     name: 'forceRefresh',
     required: false,
-    description: 'Ignore the short-lived readiness cache and recalculate.'
+    description: 'Ignore the readiness cache and recalculate.'
+  })
+  @ApiQuery({
+    name: 'cacheOnly',
+    required: false,
+    description: 'Return cached readiness only and do not recalculate.'
   })
   @ApiOkResponse({
     description: 'Auto-coding readiness diagnostics retrieved successfully.'
@@ -1073,12 +1078,19 @@ export class WorkspaceCodingStatisticsController {
   async getAutocodingReadiness(
     @WorkspaceId() workspace_id: number,
       @Query('autoCoderRun') autoCoderRun?: string | string[],
-      @Query('forceRefresh') forceRefresh?: string | string[]
-  ): Promise<AutocodingReadinessDto> {
-    return this.codingReadinessService.getReadiness(workspace_id, {
+      @Query('forceRefresh') forceRefresh?: string | string[],
+      @Query('cacheOnly') cacheOnly?: string | string[]
+  ): Promise<AutocodingReadinessDto | null> {
+    const options = {
       autoCoderRun: this.parseAutoCoderRun(autoCoderRun),
       forceRefresh: this.parseBooleanQuery(forceRefresh)
-    });
+    };
+
+    if (this.parseBooleanQuery(cacheOnly)) {
+      return this.codingReadinessService.getReadinessFromCache(workspace_id, options);
+    }
+
+    return this.codingReadinessService.getReadiness(workspace_id, options);
   }
 
   @Post(':workspace_id/coding/freshness/code')

--- a/apps/backend/src/app/cache/cache.service.spec.ts
+++ b/apps/backend/src/app/cache/cache.service.spec.ts
@@ -1,7 +1,13 @@
 import { CacheService } from './cache.service';
 
+type RedisMock = Record<string, jest.Mock> & {
+  options?: {
+    keyPrefix?: string;
+  };
+};
+
 describe('CacheService', () => {
-  let redis: Record<string, jest.Mock>;
+  let redis: RedisMock;
   let service: CacheService;
 
   beforeEach(() => {
@@ -138,5 +144,35 @@ describe('CacheService', () => {
 
     redis.scan.mockRejectedValueOnce(new Error('redis down'));
     await expect(service.deleteByPattern('prefix:*')).resolves.toBeUndefined();
+  });
+
+  it('deletes matching keys by scan pattern with redis key prefixing enabled', async () => {
+    redis.options = {
+      keyPrefix: 'coding-box:cache:'
+    };
+    redis.scan
+      .mockResolvedValueOnce([
+        '0',
+        [
+          'coding-box:cache:coding_readiness:v2:1:1:abc',
+          'coding-box:cache:coding_readiness:v2:1:2:def'
+        ]
+      ]);
+
+    await service.deleteByPattern('coding_readiness:v2:1:*');
+
+    expect(redis.scan)
+      .toHaveBeenCalledWith(
+        '0',
+        'MATCH',
+        'coding-box:cache:coding_readiness:v2:1:*',
+        'COUNT',
+        100
+      );
+    expect(redis.del)
+      .toHaveBeenCalledWith(
+        'coding_readiness:v2:1:1:abc',
+        'coding_readiness:v2:1:2:def'
+      );
   });
 });

--- a/apps/backend/src/app/cache/cache.service.ts
+++ b/apps/backend/src/app/cache/cache.service.ts
@@ -333,11 +333,13 @@ export class CacheService {
    */
   async deleteByPattern(pattern: string): Promise<void> {
     try {
+      const keyPrefix = this.getKeyPrefix();
+      const scanPattern = keyPrefix ? `${keyPrefix}${pattern}` : pattern;
       let cursor = '0';
       do {
-        const reply = await this.redis.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+        const reply = await this.redis.scan(cursor, 'MATCH', scanPattern, 'COUNT', 100);
         cursor = reply[0];
-        const keys = reply[1];
+        const keys = this.toLogicalKeys(reply[1], keyPrefix);
         if (keys.length > 0) {
           await this.redis.del(...keys);
         }
@@ -348,5 +350,20 @@ export class CacheService {
         error.stack
       );
     }
+  }
+
+  private getKeyPrefix(): string {
+    const keyPrefix = this.redis.options?.keyPrefix;
+    return typeof keyPrefix === 'string' ? keyPrefix : '';
+  }
+
+  private toLogicalKeys(keys: string[], keyPrefix: string): string[] {
+    if (!keyPrefix) {
+      return keys;
+    }
+
+    return keys
+      .filter(key => key.startsWith(keyPrefix))
+      .map(key => key.slice(keyPrefix.length));
   }
 }

--- a/apps/backend/src/app/database/services/coding/coding-readiness-cache-invalidator.token.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness-cache-invalidator.token.ts
@@ -2,5 +2,5 @@ export const CODING_READINESS_CACHE_INVALIDATOR =
   'CODING_READINESS_CACHE_INVALIDATOR';
 
 export interface CodingReadinessCacheInvalidator {
-  invalidateWorkspaceReadinessCache(workspaceId: number): void;
+  invalidateWorkspaceReadinessCache(workspaceId: number): Promise<void>;
 }

--- a/apps/backend/src/app/database/services/coding/coding-readiness-cache-key.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness-cache-key.util.ts
@@ -1,0 +1,17 @@
+export const CODING_READINESS_CACHE_PREFIX = 'coding_readiness:v2';
+
+export function getCodingReadinessCacheKey(
+  workspaceId: number,
+  autoCoderRun: 1 | 2,
+  signatureHash: string
+): string {
+  return `${CODING_READINESS_CACHE_PREFIX}:${workspaceId}:${autoCoderRun}:${signatureHash}`;
+}
+
+export function getCodingReadinessCachePattern(workspaceId: number): string {
+  return `${CODING_READINESS_CACHE_PREFIX}:${workspaceId}:*`;
+}
+
+export function getCodingReadinessCacheVersionKey(workspaceId: number): string {
+  return `${CODING_READINESS_CACHE_PREFIX}:version:${workspaceId}`;
+}

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts
@@ -2,6 +2,10 @@ import FileUpload from '../../entities/file_upload.entity';
 import { ResponseEntity } from '../../entities/response.entity';
 import { Unit } from '../../entities/unit.entity';
 import { CodingReadinessService } from './coding-readiness.service';
+import {
+  getCodingReadinessCachePattern,
+  getCodingReadinessCacheVersionKey
+} from './coding-readiness-cache-key.util';
 
 type QueryBuilderMock = {
   leftJoin: jest.Mock;
@@ -35,6 +39,13 @@ type ReadinessQueryMocks = {
   unitQuery: QueryBuilderMock;
   countQuery: QueryBuilderMock;
   candidateQuery: QueryBuilderMock;
+  cacheService: {
+    get: jest.Mock;
+    set: jest.Mock;
+    getNumber: jest.Mock;
+    incr: jest.Mock;
+    deleteByPattern: jest.Mock;
+  };
 };
 
 const createQueryBuilderMock = (): QueryBuilderMock => {
@@ -150,13 +161,34 @@ const createService = (
       testletIgnoredUnits: []
     })
   };
+  const cacheValues = new Map<string, unknown>();
+  const cacheService = {
+    get: jest.fn(async (key: string) => cacheValues.get(key) ?? null),
+    set: jest.fn(async (key: string, value: unknown) => {
+      cacheValues.set(key, value);
+      return true;
+    }),
+    getNumber: jest.fn().mockResolvedValue(0),
+    incr: jest.fn().mockResolvedValue(1),
+    deleteByPattern: jest.fn(async (pattern: string) => {
+      const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;
+      Array.from(cacheValues.keys())
+        .filter(key => key.startsWith(prefix))
+        .forEach(key => cacheValues.delete(key));
+    })
+  };
+
+  Object.assign(queryMocks || {}, {
+    cacheService
+  });
 
   return new CodingReadinessService(
     responseRepository as never,
     unitRepository as never,
     fileUploadRepository as never,
     workspaceFilesService as never,
-    workspaceExclusionService as never
+    workspaceExclusionService as never,
+    cacheService as never
   );
 };
 
@@ -209,32 +241,231 @@ describe('CodingReadinessService', () => {
       'unit.id = ANY(:unitIds)',
       { unitIds: [1, 2] }
     );
+    expect(queryMocks.cacheService?.set)
+      .toHaveBeenCalledWith(expect.any(String), expect.any(Object), 600);
   });
 
-  it('invalidates cached and in-flight readiness entries for a workspace', () => {
+  it('invalidates cached and in-flight readiness entries for a workspace', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
     const service = createService({
       units: [],
       rawResponsesTotal: 0,
       candidateRows: [],
       unitFiles: [],
       unitVariableMap: new Map()
-    });
+    }, queryMocks);
     const internals = service as unknown as {
-      readinessCache: Map<string, unknown>;
       readinessInFlight: Map<string, unknown>;
-      cacheRevisionByWorkspace: Map<number, number>;
     };
-    internals.readinessCache.set('1|1|1|files|0|scope', {});
-    internals.readinessCache.set('2|1|1|files|0|scope', {});
     internals.readinessInFlight.set('1|1|1|files|0|scope', Promise.resolve({}));
-    internals.cacheRevisionByWorkspace.set(1, 4);
 
-    service.invalidateWorkspaceReadinessCache(1);
+    await service.invalidateWorkspaceReadinessCache(1);
 
-    expect(internals.readinessCache.has('1|1|1|files|0|scope')).toBe(false);
-    expect(internals.readinessCache.has('2|1|1|files|0|scope')).toBe(true);
     expect(internals.readinessInFlight.has('1|1|1|files|0|scope')).toBe(false);
-    expect(internals.cacheRevisionByWorkspace.get(1)).toBe(5);
+    expect(queryMocks.cacheService?.incr)
+      .toHaveBeenCalledWith(getCodingReadinessCacheVersionKey(1));
+    expect(queryMocks.cacheService?.deleteByPattern)
+      .toHaveBeenCalledWith(getCodingReadinessCachePattern(1));
+  });
+
+  it('returns cached readiness while the cache signature is unchanged', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 1,
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 1 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+
+    const first = await service.getReadiness(1);
+    const second = await service.getReadiness(1);
+
+    expect(first.fromCache).toBe(false);
+    expect(second.fromCache).toBe(true);
+    expect(second.readiness).toBe('READY');
+    expect(queryMocks.countQuery?.getCount).toHaveBeenCalledTimes(1);
+    expect(queryMocks.candidateQuery?.getRawMany).toHaveBeenCalledTimes(1);
+    expect(queryMocks.cacheService?.set).toHaveBeenCalledTimes(1);
+    expect(queryMocks.cacheService?.set)
+      .toHaveBeenCalledWith(expect.any(String), expect.any(Object), 0);
+  });
+
+  it('returns cached readiness without recomputing diagnostics', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 1,
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 1 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+
+    await service.getReadiness(1);
+    queryMocks.countQuery?.getCount.mockClear();
+    queryMocks.candidateQuery?.getRawMany.mockClear();
+
+    const cached = await service.getReadinessFromCache(1);
+
+    expect(cached?.fromCache).toBe(true);
+    expect(cached?.readiness).toBe('READY');
+    expect(queryMocks.countQuery?.getCount).not.toHaveBeenCalled();
+    expect(queryMocks.candidateQuery?.getRawMany).not.toHaveBeenCalled();
+  });
+
+  it('returns null for cache-only readiness misses', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 1,
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 1 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+
+    const cached = await service.getReadinessFromCache(1);
+
+    expect(cached).toBeNull();
+    expect(queryMocks.countQuery?.getCount).not.toHaveBeenCalled();
+    expect(queryMocks.candidateQuery?.getRawMany).not.toHaveBeenCalled();
+    expect(queryMocks.cacheService?.set).not.toHaveBeenCalled();
+  });
+
+  it('does not cache readiness when the cache signature changes during computation', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const service = createService({
+      units: [
+        createUnit(1, 'UNIT_OK')
+      ],
+      rawResponsesTotal: 1,
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 1 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+    const cacheService = queryMocks.cacheService as ReadinessQueryMocks['cacheService'];
+    cacheService.getNumber
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(1);
+
+    const readiness = await service.getReadiness(1);
+
+    expect(readiness.readiness).toBe('READY');
+    expect(readiness.fromCache).toBe(false);
+    expect(cacheService.set).not.toHaveBeenCalled();
+  });
+
+  it('does not cache readiness when the scoped units change during computation', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const originalScope = [
+      createUnit(1, 'UNIT_OK')
+    ];
+    const updatedScope = [
+      createUnit(1, 'UNIT_OK'),
+      createUnit(2, 'UNIT_NEW')
+    ];
+    const service = createService({
+      units: originalScope,
+      rawResponsesTotal: 1,
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 1 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+    const unitQuery = queryMocks.unitQuery as QueryBuilderMock;
+    const cacheService = queryMocks.cacheService as ReadinessQueryMocks['cacheService'];
+    unitQuery.getMany
+      .mockResolvedValueOnce(originalScope)
+      .mockResolvedValueOnce(updatedScope);
+
+    const readiness = await service.getReadiness(1);
+
+    expect(readiness.readiness).toBe('READY');
+    expect(readiness.fromCache).toBe(false);
+    expect(cacheService.set).not.toHaveBeenCalled();
+  });
+
+  it('returns computed readiness without caching when cache revalidation fails', async () => {
+    const queryMocks: Partial<ReadinessQueryMocks> = {};
+    const originalScope = [
+      createUnit(1, 'UNIT_OK')
+    ];
+    const service = createService({
+      units: originalScope,
+      rawResponsesTotal: 1,
+      candidateRows: [
+        { unitid: 1, variableid: 'var1', response_count: 1 }
+      ],
+      unitFiles: [
+        createFile('UNIT_OK', '<Unit><codingSchemeRef>SCHEME_OK</codingSchemeRef></Unit>')
+      ],
+      codingSchemeFiles: [
+        createFile('SCHEME_OK', createCodingScheme('var1'))
+      ],
+      unitVariableMap: new Map([
+        ['UNIT_OK', new Set(['var1'])]
+      ])
+    }, queryMocks);
+    const unitQuery = queryMocks.unitQuery as QueryBuilderMock;
+    const cacheService = queryMocks.cacheService as ReadinessQueryMocks['cacheService'];
+    unitQuery.getMany
+      .mockResolvedValueOnce(originalScope)
+      .mockRejectedValueOnce(new Error('scope revalidation failed'));
+
+    const readiness = await service.getReadiness(1);
+
+    expect(readiness.readiness).toBe('READY');
+    expect(readiness.fromCache).toBe(false);
+    expect(cacheService.set).not.toHaveBeenCalled();
   });
 
   it('keeps missing files as diagnostics without blocking partially codeable data', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-readiness.service.ts
@@ -25,6 +25,12 @@ import {
   getCodingVariableIdCandidateSql,
   isCodingVariableIdCandidate
 } from './coding-response-candidate.util';
+import { CacheService } from '../../../cache/cache.service';
+import {
+  getCodingReadinessCacheKey,
+  getCodingReadinessCachePattern,
+  getCodingReadinessCacheVersionKey
+} from './coding-readiness-cache-key.util';
 
 export type AutocodingReadinessOptions = {
   personIds?: string[];
@@ -41,7 +47,7 @@ type ReadinessCacheSignature = {
 };
 
 type ReadinessCacheEntry = {
-  expiresAt: number;
+  signature: ReadinessCacheSignature;
   readiness: AutocodingReadinessDto;
 };
 
@@ -88,10 +94,8 @@ export class CodingReadinessService {
   private readonly logger = new Logger(CodingReadinessService.name);
   private readonly maxSamplesPerUnit = 8;
   private readonly maxSampleUnits = 10;
-  private readonly cacheTtlMs = 60_000;
-  private readonly readinessCache = new Map<string, ReadinessCacheEntry>();
+  private readonly scopedCacheTtlSeconds = 600;
   private readonly readinessInFlight = new Map<string, Promise<AutocodingReadinessDto>>();
-  private readonly cacheRevisionByWorkspace = new Map<number, number>();
 
   constructor(
     @InjectRepository(ResponseEntity)
@@ -101,7 +105,8 @@ export class CodingReadinessService {
     @InjectRepository(FileUpload)
     private readonly fileUploadRepository: Repository<FileUpload>,
     private readonly workspaceFilesService: WorkspaceFilesService,
-    private readonly workspaceExclusionService: WorkspaceExclusionService
+    private readonly workspaceExclusionService: WorkspaceExclusionService,
+    private readonly cacheService: CacheService
   ) {}
 
   async getReadiness(
@@ -121,7 +126,7 @@ export class CodingReadinessService {
         {
           sourceRevision: 0,
           fileRevision: '0:',
-          cacheRevision: this.getWorkspaceCacheRevision(workspaceId),
+          cacheRevision: await this.getWorkspaceCacheRevision(workspaceId),
           scopedUnitHash: ''
         }
       );
@@ -129,14 +134,15 @@ export class CodingReadinessService {
 
     const cacheSignature = await this.getCacheSignature(workspaceId, unitIds, options);
     const cacheKey = this.buildCacheKey(workspaceId, autoCoderRun, cacheSignature);
+    const inFlightKey = this.buildInFlightKey(workspaceId, autoCoderRun, cacheSignature);
     if (!options.forceRefresh) {
-      const cached = this.getCachedReadiness(cacheKey);
+      const cached = await this.getCachedReadiness(cacheKey, cacheSignature);
       if (cached) {
         return cached;
       }
     }
 
-    const inFlight = this.readinessInFlight.get(cacheKey);
+    const inFlight = this.readinessInFlight.get(inFlightKey);
     if (inFlight) {
       return inFlight;
     }
@@ -150,12 +156,30 @@ export class CodingReadinessService {
       cacheSignature,
       cacheKey
     );
-    this.readinessInFlight.set(cacheKey, readinessPromise);
+    this.readinessInFlight.set(inFlightKey, readinessPromise);
     try {
       return await readinessPromise;
     } finally {
-      this.readinessInFlight.delete(cacheKey);
+      this.readinessInFlight.delete(inFlightKey);
     }
+  }
+
+  async getReadinessFromCache(
+    workspaceId: number,
+    options: AutocodingReadinessOptions = {}
+  ): Promise<AutocodingReadinessDto | null> {
+    const autoCoderRun = options.autoCoderRun || 1;
+    const units = await this.getScopedUnits(workspaceId, options);
+    const unitIds = units.map(unit => unit.id);
+    if (unitIds.length === 0) {
+      return null;
+    }
+
+    const cacheSignature = await this.getCacheSignature(workspaceId, unitIds, options);
+    return this.getCachedReadiness(
+      this.buildCacheKey(workspaceId, autoCoderRun, cacheSignature),
+      cacheSignature
+    );
   }
 
   async assertAutoCodingCanProcess(
@@ -173,22 +197,15 @@ export class CodingReadinessService {
     throw new BadRequestException(this.buildBlockedMessage(readiness));
   }
 
-  invalidateWorkspaceReadinessCache(workspaceId: number): void {
+  async invalidateWorkspaceReadinessCache(workspaceId: number): Promise<void> {
     const workspaceKeyPrefix = `${workspaceId}|`;
-    for (const key of Array.from(this.readinessCache.keys())) {
-      if (key.startsWith(workspaceKeyPrefix)) {
-        this.readinessCache.delete(key);
-      }
-    }
     for (const key of Array.from(this.readinessInFlight.keys())) {
       if (key.startsWith(workspaceKeyPrefix)) {
         this.readinessInFlight.delete(key);
       }
     }
-    this.cacheRevisionByWorkspace.set(
-      workspaceId,
-      this.getWorkspaceCacheRevision(workspaceId) + 1
-    );
+    await this.cacheService.incr(getCodingReadinessCacheVersionKey(workspaceId));
+    await this.cacheService.deleteByPattern(getCodingReadinessCachePattern(workspaceId));
   }
 
   async filterResponsesValidVariables(
@@ -300,7 +317,14 @@ export class CodingReadinessService {
       invalidVariableSamples: variableDiagnostics.invalidVariableSamples
     }, startedAt, false, cacheSignature);
 
-    this.setCachedReadiness(cacheKey, readiness);
+    await this.setCachedReadinessIfCurrent(
+      workspaceId,
+      units.map(unit => unit.id),
+      options,
+      cacheKey,
+      cacheSignature,
+      readiness
+    );
     this.logger.debug(
       `Computed autocoding readiness for workspace ${workspaceId}, run ${autoCoderRun} ` +
       `in ${readiness.computationMs}ms: ${readiness.readiness}.`
@@ -857,13 +881,16 @@ export class CodingReadinessService {
     return {
       sourceRevision,
       fileRevision,
-      cacheRevision: this.getWorkspaceCacheRevision(workspaceId),
+      cacheRevision: await this.getWorkspaceCacheRevision(workspaceId),
       scopedUnitHash: this.hashScope(unitIds, options)
     };
   }
 
-  private getWorkspaceCacheRevision(workspaceId: number): number {
-    return this.cacheRevisionByWorkspace.get(workspaceId) || 0;
+  private async getWorkspaceCacheRevision(workspaceId: number): Promise<number> {
+    return this.cacheService.getNumber(
+      getCodingReadinessCacheVersionKey(workspaceId),
+      0
+    );
   }
 
   private hashScope(
@@ -922,6 +949,23 @@ export class CodingReadinessService {
     autoCoderRun: 1 | 2,
     signature: ReadinessCacheSignature
   ): string {
+    return getCodingReadinessCacheKey(
+      workspaceId,
+      autoCoderRun,
+      this.hashValues([
+        signature.sourceRevision,
+        signature.fileRevision,
+        signature.cacheRevision,
+        signature.scopedUnitHash
+      ])
+    );
+  }
+
+  private buildInFlightKey(
+    workspaceId: number,
+    autoCoderRun: 1 | 2,
+    signature: ReadinessCacheSignature
+  ): string {
     return [
       workspaceId,
       autoCoderRun,
@@ -932,14 +976,12 @@ export class CodingReadinessService {
     ].join('|');
   }
 
-  private getCachedReadiness(cacheKey: string): AutocodingReadinessDto | null {
-    const entry = this.readinessCache.get(cacheKey);
-    if (!entry) {
-      return null;
-    }
-
-    if (entry.expiresAt <= Date.now()) {
-      this.readinessCache.delete(cacheKey);
+  private async getCachedReadiness(
+    cacheKey: string,
+    signature: ReadinessCacheSignature
+  ): Promise<AutocodingReadinessDto | null> {
+    const entry = await this.cacheService.get<ReadinessCacheEntry>(cacheKey);
+    if (!entry?.signature || !this.isSameSignature(entry.signature, signature)) {
       return null;
     }
 
@@ -949,14 +991,86 @@ export class CodingReadinessService {
     };
   }
 
+  private async setCachedReadinessIfCurrent(
+    workspaceId: number,
+    unitIds: number[],
+    options: AutocodingReadinessOptions,
+    cacheKey: string,
+    signature: ReadinessCacheSignature,
+    readiness: AutocodingReadinessDto
+  ): Promise<boolean> {
+    try {
+      const currentUnitIds = (await this.getScopedUnits(workspaceId, options))
+        .map(unit => unit.id);
+      if (!this.hasSameUnitScope(unitIds, currentUnitIds)) {
+        this.logger.debug(
+          `Skipped caching autocoding readiness for workspace ${workspaceId}; ` +
+          'scoped units changed while computing.'
+        );
+        return false;
+      }
+
+      const currentSignature = await this.getCacheSignature(workspaceId, currentUnitIds, options);
+      if (!this.isSameSignature(signature, currentSignature)) {
+        this.logger.debug(
+          `Skipped caching autocoding readiness for workspace ${workspaceId}; ` +
+          'cache signature changed while computing.'
+        );
+        return false;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Skipped caching autocoding readiness for workspace ${workspaceId}; ` +
+        `could not revalidate cache signature: ${message}`
+      );
+      return false;
+    }
+
+    return this.setCachedReadiness(cacheKey, signature, readiness, options);
+  }
+
+  private hasSameUnitScope(
+    previousUnitIds: number[],
+    currentUnitIds: number[]
+  ): boolean {
+    const previous = this.uniquePositiveIds(previousUnitIds).sort((a, b) => a - b);
+    const current = this.uniquePositiveIds(currentUnitIds).sort((a, b) => a - b);
+    return previous.length === current.length &&
+      previous.every((unitId, index) => unitId === current[index]);
+  }
+
   private setCachedReadiness(
     cacheKey: string,
-    readiness: AutocodingReadinessDto
-  ): void {
-    this.readinessCache.set(cacheKey, {
-      expiresAt: Date.now() + this.cacheTtlMs,
+    signature: ReadinessCacheSignature,
+    readiness: AutocodingReadinessDto,
+    options: AutocodingReadinessOptions
+  ): Promise<boolean> {
+    return this.cacheService.set(cacheKey, {
+      signature,
       readiness
-    });
+    }, this.getCacheTtlSeconds(options));
+  }
+
+  private getCacheTtlSeconds(options: AutocodingReadinessOptions): number {
+    return this.isScopedReadiness(options) ? this.scopedCacheTtlSeconds : 0;
+  }
+
+  private isScopedReadiness(options: AutocodingReadinessOptions): boolean {
+    return this.uniquePositiveIds(
+      (options.personIds || []).map(id => Number(id))
+    ).length > 0 ||
+      this.uniquePositiveIds(options.unitIds || []).length > 0;
+  }
+
+  private isSameSignature(
+    cached: ReadinessCacheSignature,
+    current: ReadinessCacheSignature
+  ): boolean {
+    return cached.sourceRevision === current.sourceRevision &&
+      cached.fileRevision === current.fileRevision &&
+      cached.cacheRevision === current.cacheRevision &&
+      cached.scopedUnitHash === current.scopedUnitHash;
   }
 
   private withComputationMetadata(

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -97,6 +97,7 @@ describe('WorkspaceTestResultsService', () => {
     set: jest.Mock;
     delete: jest.Mock;
     deleteByPattern: jest.Mock;
+    incr: jest.Mock;
   };
   let dataSource: DataSource;
 
@@ -147,7 +148,8 @@ describe('WorkspaceTestResultsService', () => {
       get: jest.fn().mockResolvedValue(null),
       set: jest.fn().mockResolvedValue(undefined),
       delete: jest.fn().mockResolvedValue(undefined),
-      deleteByPattern: jest.fn().mockResolvedValue(undefined)
+      deleteByPattern: jest.fn().mockResolvedValue(undefined),
+      incr: jest.fn().mockResolvedValue(1)
     };
 
     personsRepository = {
@@ -2048,6 +2050,8 @@ describe('WorkspaceTestResultsService', () => {
       expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(workspaceId);
       expect(cacheService.delete).toHaveBeenCalledWith(`workspace-overview-stats-${workspaceId}`);
       expect(cacheService.deleteByPattern).toHaveBeenCalledWith(`flat-frequencies-${workspaceId}-*`);
+      expect(cacheService.incr).toHaveBeenCalledWith(`coding_readiness:v2:version:${workspaceId}`);
+      expect(cacheService.deleteByPattern).toHaveBeenCalledWith(`coding_readiness:v2:${workspaceId}:*`);
     });
 
     it('deleteUnit should invalidate cache', async () => {
@@ -2073,6 +2077,8 @@ describe('WorkspaceTestResultsService', () => {
       expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(workspaceId);
       expect(cacheService.delete).toHaveBeenCalledWith(`workspace-overview-stats-${workspaceId}`);
       expect(cacheService.deleteByPattern).toHaveBeenCalledWith(`flat-frequencies-${workspaceId}-*`);
+      expect(cacheService.incr).toHaveBeenCalledWith(`coding_readiness:v2:version:${workspaceId}`);
+      expect(cacheService.deleteByPattern).toHaveBeenCalledWith(`coding_readiness:v2:${workspaceId}:*`);
     });
 
     it('deleteResponse should invalidate cache', async () => {
@@ -2111,6 +2117,8 @@ describe('WorkspaceTestResultsService', () => {
       expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(workspaceId);
       expect(cacheService.delete).toHaveBeenCalledWith(`workspace-overview-stats-${workspaceId}`);
       expect(cacheService.deleteByPattern).toHaveBeenCalledWith(`flat-frequencies-${workspaceId}-*`);
+      expect(cacheService.incr).toHaveBeenCalledWith(`coding_readiness:v2:version:${workspaceId}`);
+      expect(cacheService.deleteByPattern).toHaveBeenCalledWith(`coding_readiness:v2:${workspaceId}:*`);
     });
   });
 

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -76,6 +76,10 @@ import {
   TestResultsTimestampSource
 } from '../../../../../../../api-dto/test-results/test-results-deletion.dto';
 import {
+  getCodingReadinessCachePattern,
+  getCodingReadinessCacheVersionKey
+} from '../coding/coding-readiness-cache-key.util';
+import {
   assertValidRegexSearchPattern,
   toRegexSearchException,
   withRegexSearchStatementTimeout
@@ -1632,7 +1636,9 @@ export class WorkspaceTestResultsService {
       this.cacheService.delete(`${OVERVIEW_STATS_CACHE_PREFIX}${workspaceId}`),
       this.cacheService.deleteByPattern(`${FLAT_FREQUENCIES_CACHE_PREFIX}${workspaceId}-*`),
       this.cacheService.delete(`flat_response_filter_options:version:${workspaceId}`),
-      this.cacheService.deleteByPattern(`flat_response_filter_options:${workspaceId}:*`)
+      this.cacheService.deleteByPattern(`flat_response_filter_options:${workspaceId}:*`),
+      this.cacheService.incr(getCodingReadinessCacheVersionKey(workspaceId)),
+      this.cacheService.deleteByPattern(getCodingReadinessCachePattern(workspaceId))
     ]);
   }
 

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
@@ -91,6 +91,7 @@ describe('WorkspaceCoreService', () => {
     });
     await expect(service.patch({ id: 1, name: 'Patched', settings: { a: true } } as never)).resolves.toBeUndefined();
     expect(cacheService.delete).toHaveBeenCalled();
+    expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
     await expect(service.remove([])).resolves.toBeUndefined();
     await expect(service.remove([1])).resolves.toBeUndefined();
     expect(queryRunner.commitTransaction).toHaveBeenCalled();

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
@@ -120,6 +120,7 @@ export class WorkspaceCoreService {
       await this.workspaceRepository.save(workspaceGroupToUpdate);
       await this.cacheService.delete(`${EXCLUSION_CACHE_PREFIX}${workspaceData.id}`);
       if (workspaceData.settings) {
+        await this.workspaceTestResultsService.invalidateWorkspaceStatsCache(workspaceData.id);
         await this.invalidateCachesAffectedByExclusions(workspaceData.id);
       }
     }

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
@@ -242,8 +242,8 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
   const mockCodingFreshnessService = {
     markUnitsStaleAfterCodingSchemeChange: jest.fn().mockResolvedValue(undefined)
   };
-  const mockCodingReadinessCacheInvalidator = {
-    invalidateWorkspaceReadinessCache: jest.fn()
+  const mockWorkspaceTestResultsService = {
+    invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined)
   };
   const mockWorkspaceFileParsingService = {
     extractUnitInfo: jest.fn().mockResolvedValue({
@@ -266,12 +266,11 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
       {} as unknown as CtorParams[8],
       {} as unknown as CtorParams[9],
       { delete: jest.fn() } as unknown as CtorParams[10],
-      { invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined) } as unknown as CtorParams[11],
+      mockWorkspaceTestResultsService as unknown as CtorParams[11],
       undefined,
       mockCodingFreshnessService as unknown as CtorParams[13],
       undefined,
-      undefined,
-      mockCodingReadinessCacheInvalidator as unknown as CtorParams[16]
+      undefined
     );
   }
 
@@ -441,7 +440,7 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
     expect(mockCodingStatisticsService.invalidateCache).not.toHaveBeenCalled();
     expect(mockCodingStatisticsService.invalidateIncompleteVariablesCache)
       .toHaveBeenCalledWith(1);
-    expect(mockCodingReadinessCacheInvalidator.invalidateWorkspaceReadinessCache)
+    expect(mockWorkspaceTestResultsService.invalidateWorkspaceStatsCache)
       .toHaveBeenCalledWith(1);
   });
 
@@ -614,12 +613,12 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
     ]);
   });
 
-  it('invalidates auto-coding readiness cache when workspace file caches are invalidated', async () => {
+  it('invalidates workspace stats caches when workspace file caches are invalidated', async () => {
     const service = makeService();
 
     await service.invalidateWorkspaceFileCaches(1);
 
-    expect(mockCodingReadinessCacheInvalidator.invalidateWorkspaceReadinessCache)
+    expect(mockWorkspaceTestResultsService.invalidateWorkspaceStatsCache)
       .toHaveBeenCalledWith(1);
   });
 });

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -58,10 +58,6 @@ import {
   CODING_PROCESS_CACHE_INVALIDATOR,
   CodingProcessCacheInvalidator
 } from '../coding/coding-process-cache-invalidator.token';
-import {
-  CODING_READINESS_CACHE_INVALIDATOR,
-  CodingReadinessCacheInvalidator
-} from '../coding/coding-readiness-cache-invalidator.token';
 import { WorkspaceXmlSchemaValidationService } from './workspace-xml-schema-validation.service';
 import { WorkspaceFileStorageService } from './workspace-file-storage.service';
 import { WorkspaceFileParsingService } from './workspace-file-parsing.service';
@@ -207,10 +203,7 @@ export class WorkspaceFilesService implements OnModuleInit {
     private readonly codingFileCacheService?: CodingFileCacheService,
     @Optional()
     @Inject(CODING_PROCESS_CACHE_INVALIDATOR)
-    private readonly codingProcessCacheInvalidator?: CodingProcessCacheInvalidator,
-    @Optional()
-    @Inject(CODING_READINESS_CACHE_INVALIDATOR)
-    private readonly codingReadinessCacheInvalidator?: CodingReadinessCacheInvalidator
+    private readonly codingProcessCacheInvalidator?: CodingProcessCacheInvalidator
   ) {}
 
   private normalizeFileUnitId(value: string | null | undefined): string {
@@ -4187,7 +4180,6 @@ ${bookletRefs}
     );
     this.codingFileCacheService?.clearCaches();
     this.codingProcessCacheInvalidator?.invalidateWorkspaceCaches(workspaceId);
-    this.codingReadinessCacheInvalidator?.invalidateWorkspaceReadinessCache(workspaceId);
     this.logger.log(
       `Invalidated workspace files caches for workspace ${workspaceId} in Redis`
     );

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -123,6 +123,7 @@ describe('CodingManagementComponent', () => {
         currentRevision: 0,
         items: []
       })),
+      getCachedAutocodingReadiness: jest.fn().mockReturnValue(of(null)),
       getAutocodingReadiness: jest.fn().mockReturnValue(of({
         workspaceId: 1,
         autoCoderRun: 1,
@@ -323,8 +324,46 @@ describe('CodingManagementComponent', () => {
 
     it('should only load lightweight coding freshness on init when auto-refresh is enabled', () => {
       expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getCachedAutocodingReadiness).toHaveBeenCalledWith(1, 1);
       expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+    });
+
+    it('should use cached autocoding readiness on init when available', () => {
+      fixture.destroy();
+      (mockTestPersonCodingService.getCachedAutocodingReadiness as jest.Mock)
+        .mockReturnValueOnce(of({
+          workspaceId: 1,
+          autoCoderRun: 1,
+          readiness: 'READY',
+          blockers: [],
+          rawResponsesTotal: 10,
+          rawResponsesWithRelevantStatus: 10,
+          resultUnitsTotal: 2,
+          resultUnitKeysTotal: 2,
+          matchedUnitFiles: 2,
+          missingUnitFiles: [],
+          matchedCodingSchemes: 1,
+          missingCodingSchemes: [],
+          invalidCodingSchemes: [],
+          validVariablePairs: 1,
+          validResponses: 10,
+          codeableResponses: 10,
+          invalidVariableSamples: [],
+          fromCache: true
+        }));
+
+      const isolatedFixture = TestBed.createComponent(CodingManagementComponent);
+      const isolatedComponent = isolatedFixture.componentInstance;
+      isolatedFixture.detectChanges();
+
+      expect(mockTestPersonCodingService.getCachedAutocodingReadiness).toHaveBeenCalledWith(1, 1);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+      expect(isolatedComponent.autocodingReadiness?.readiness).toBe('READY');
+      expect(isolatedComponent.shouldShowManualCodingStatusRefresh()).toBe(false);
+      expect(isolatedComponent.isCodingStatusOverviewPendingManualRefresh).toBe(false);
+
+      isolatedFixture.destroy();
     });
 
     it('should keep the manual full status refresh available after the initial light load', () => {
@@ -333,7 +372,7 @@ describe('CodingManagementComponent', () => {
 
       component.refreshCodingStatusOverview();
 
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
       expect(component.shouldShowManualCodingStatusRefresh()).toBe(false);
       expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(false);
     });
@@ -371,7 +410,7 @@ describe('CodingManagementComponent', () => {
       component.refreshCodingStatusOverview();
 
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
     });
 
     it('should refresh coding status overview when requested by query param', () => {
@@ -387,7 +426,7 @@ describe('CodingManagementComponent', () => {
       expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalled();
       expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
       expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
     });
 
     it('should defer manual coding status refresh while a guarded background job is running', () => {
@@ -412,7 +451,7 @@ describe('CodingManagementComponent', () => {
       expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
       expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
       expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
     });
 
     it('should defer automatic coding status refresh while a guarded background job is running', () => {
@@ -1047,7 +1086,7 @@ describe('CodingManagementComponent', () => {
         expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
         expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
         expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
-        expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+        expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
       } finally {
         component.ngOnDestroy();
         jest.useRealTimers();
@@ -1109,7 +1148,7 @@ describe('CodingManagementComponent', () => {
         expect(mockCodingManagementService.fetchCodingStatistics).toHaveBeenCalledTimes(1);
         expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
         expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
-        expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, true);
+        expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
       } finally {
         component.ngOnDestroy();
         jest.useRealTimers();

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -528,6 +528,29 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       });
   }
 
+  private loadCachedAutocodingReadiness(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      return;
+    }
+
+    if (this.codingBackgroundJobsService.isStatusCheckGuardActive(workspaceId)) {
+      return;
+    }
+
+    this.testPersonCodingService.getCachedAutocodingReadiness(workspaceId, 1)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(readiness => {
+        if (!readiness) {
+          return;
+        }
+
+        this.autocodingReadiness = readiness;
+        this.autocodingReadinessLoadFailed = false;
+        this.hasLoadedFullCodingStatusOverview = true;
+      });
+  }
+
   refreshAutocodingReadiness(): void {
     this.loadAutocodingReadiness(true);
   }
@@ -540,10 +563,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     this.performCodingStatusOverviewRefresh(true);
   }
 
-  private performCodingStatusOverviewRefresh(forceAutocodingReadiness = false): void {
+  private performCodingStatusOverviewRefresh(includeAutocodingReadiness = false): void {
     this.invalidateCodingStatusOverviewCache();
     this.fetchCodingStatistics();
-    this.loadCodingStatusOverview(forceAutocodingReadiness);
+    this.loadCodingStatusOverview(includeAutocodingReadiness);
     this.refreshTableData();
   }
 
@@ -568,18 +591,18 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     }
   }
 
-  loadCodingStatusOverview(forceAutocodingReadiness = false): void {
-    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(forceAutocodingReadiness)) {
+  loadCodingStatusOverview(includeAutocodingReadiness = false): void {
+    if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(includeAutocodingReadiness)) {
       return;
     }
 
-    if (forceAutocodingReadiness) {
+    if (includeAutocodingReadiness) {
       this.hasLoadedFullCodingStatusOverview = false;
     }
     this.loadCodingFreshness();
     this.loadManualAppliedResultsOverview();
-    if (forceAutocodingReadiness) {
-      this.loadAutocodingReadiness(true);
+    if (includeAutocodingReadiness) {
+      this.loadAutocodingReadiness(false);
     }
   }
 
@@ -590,6 +613,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
     this.hasLoadedFullCodingStatusOverview = false;
     this.loadCodingFreshness(false);
+    this.loadCachedAutocodingReadiness();
   }
 
   private scheduleAutomaticCodingStatusOverviewRefresh(): void {

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -1227,6 +1227,141 @@ describe('TestPersonCodingService', () => {
       )).flush(mockResponse);
     });
 
+    it('should request cached autocoding readiness with cache-only params', () => {
+      const mockResponse = {
+        workspaceId: mockWorkspaceId,
+        autoCoderRun: 1,
+        readiness: 'READY',
+        blockers: [],
+        rawResponsesTotal: 10,
+        rawResponsesWithRelevantStatus: 10,
+        resultUnitsTotal: 2,
+        resultUnitKeysTotal: 2,
+        matchedUnitFiles: 2,
+        missingUnitFiles: [],
+        matchedCodingSchemes: 1,
+        missingCodingSchemes: [],
+        invalidCodingSchemes: [],
+        validVariablePairs: 1,
+        validResponses: 10,
+        codeableResponses: 10,
+        invalidVariableSamples: [],
+        fromCache: true
+      };
+      let cachedResponse: unknown;
+
+      service.getCachedAutocodingReadiness(mockWorkspaceId, 1)
+        .subscribe(response => {
+          expect(response).toEqual(mockResponse);
+        });
+
+      const req = httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        request.params.get('cacheOnly') === 'true' &&
+        !request.params.has('forceRefresh')
+      ));
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+
+      service.getCachedAutocodingReadiness(mockWorkspaceId, 1)
+        .subscribe(response => {
+          cachedResponse = response;
+        });
+      httpMock.expectNone(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1'
+      ));
+      expect(cachedResponse).toEqual(mockResponse);
+    });
+
+    it('should ignore stale cache-only autocoding readiness responses after invalidation', () => {
+      const mockResponse = {
+        workspaceId: mockWorkspaceId,
+        autoCoderRun: 1,
+        readiness: 'READY',
+        blockers: [],
+        rawResponsesTotal: 10,
+        rawResponsesWithRelevantStatus: 10,
+        resultUnitsTotal: 2,
+        resultUnitKeysTotal: 2,
+        matchedUnitFiles: 2,
+        missingUnitFiles: [],
+        matchedCodingSchemes: 1,
+        missingCodingSchemes: [],
+        invalidCodingSchemes: [],
+        validVariablePairs: 1,
+        validResponses: 10,
+        codeableResponses: 10,
+        invalidVariableSamples: [],
+        fromCache: true
+      };
+      let staleResponse: unknown = 'unset';
+
+      service.getCachedAutocodingReadiness(mockWorkspaceId, 1)
+        .subscribe(response => {
+          staleResponse = response;
+        });
+      const req = httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        request.params.get('cacheOnly') === 'true'
+      ));
+
+      service.invalidateCodingStatusCache(mockWorkspaceId);
+      req.flush(mockResponse);
+
+      expect(staleResponse).toBeNull();
+    });
+
+    it('should not let cache-only autocoding readiness misses block full readiness requests', () => {
+      const mockResponse = {
+        workspaceId: mockWorkspaceId,
+        autoCoderRun: 1,
+        readiness: 'READY',
+        blockers: [],
+        rawResponsesTotal: 10,
+        rawResponsesWithRelevantStatus: 10,
+        resultUnitsTotal: 2,
+        resultUnitKeysTotal: 2,
+        matchedUnitFiles: 2,
+        missingUnitFiles: [],
+        matchedCodingSchemes: 1,
+        missingCodingSchemes: [],
+        invalidCodingSchemes: [],
+        validVariablePairs: 1,
+        validResponses: 10,
+        codeableResponses: 10,
+        invalidVariableSamples: []
+      };
+      let cacheOnlyResponse: unknown = 'unset';
+      let fullResponse: unknown;
+
+      service.getCachedAutocodingReadiness(mockWorkspaceId, 1)
+        .subscribe(response => {
+          cacheOnlyResponse = response;
+        });
+      httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        request.params.get('cacheOnly') === 'true'
+      )).flush(null);
+
+      service.getAutocodingReadiness(mockWorkspaceId, 1)
+        .subscribe(response => {
+          fullResponse = response;
+        });
+      httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/coding/readiness` &&
+        request.params.get('autoCoderRun') === '1' &&
+        !request.params.has('cacheOnly') &&
+        !request.params.has('forceRefresh')
+      )).flush(mockResponse);
+
+      expect(cacheOnlyResponse).toBeNull();
+      expect(fullResponse).toEqual(mockResponse);
+    });
+
     it('should keep force-refreshed autocoding readiness cached when stale requests finish later', () => {
       const staleResponse = {
         workspaceId: mockWorkspaceId,

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -6,6 +6,7 @@ import {
   Subject,
   catchError,
   finalize,
+  map,
   of,
   shareReplay,
   tap,
@@ -250,6 +251,7 @@ export class TestPersonCodingService {
   private codingFreshnessRequests = new Map<number, Observable<CodingFreshnessSummaryDto>>();
   private autocodingReadinessCache = new Map<string, AutocodingReadinessDto>();
   private autocodingReadinessRequests = new Map<string, Observable<AutocodingReadinessDto>>();
+  private autocodingReadinessCacheOnlyRequests = new Map<string, Observable<AutocodingReadinessDto | null>>();
   private codingFreshnessScopeCache = new Map<string, CodingFreshnessScopeDto>();
   private codingFreshnessScopeRequests = new Map<string, Observable<CodingFreshnessScopeDto>>();
   private appliedResultsOverviewCache = new Map<number, AppliedResultsOverview | null>();
@@ -314,6 +316,7 @@ export class TestPersonCodingService {
       this.codingFreshnessRequests.clear();
       this.autocodingReadinessCache.clear();
       this.autocodingReadinessRequests.clear();
+      this.autocodingReadinessCacheOnlyRequests.clear();
       this.codingFreshnessScopeCache.clear();
       this.codingFreshnessScopeRequests.clear();
       this.appliedResultsOverviewCache.clear();
@@ -327,6 +330,7 @@ export class TestPersonCodingService {
     this.appliedResultsOverviewRequests.delete(workspaceId);
     this.deleteCacheKeysForWorkspace(this.autocodingReadinessCache, workspaceId);
     this.deleteCacheKeysForWorkspace(this.autocodingReadinessRequests, workspaceId);
+    this.deleteCacheKeysForWorkspace(this.autocodingReadinessCacheOnlyRequests, workspaceId);
     this.deleteCacheKeysForWorkspace(this.codingFreshnessScopeCache, workspaceId);
     this.deleteCacheKeysForWorkspace(this.codingFreshnessScopeRequests, workspaceId);
   }
@@ -686,6 +690,63 @@ export class TestPersonCodingService {
       );
 
     this.autocodingReadinessRequests.set(cacheKey, request$);
+    return request$;
+  }
+
+  getCachedAutocodingReadiness(
+    workspaceId: number,
+    autoCoderRun: 1 | 2 = 1
+  ): Observable<AutocodingReadinessDto | null> {
+    const cacheKey = `${workspaceId}:${autoCoderRun}`;
+    const cached = this.autocodingReadinessCache.get(cacheKey);
+    if (cached) {
+      return of(cached);
+    }
+
+    if (this.codingBackgroundJobsService.isStatusCheckGuardActive(workspaceId)) {
+      return of(null);
+    }
+
+    const pendingRequest = this.autocodingReadinessCacheOnlyRequests.get(cacheKey);
+    if (pendingRequest) {
+      return pendingRequest;
+    }
+
+    const params = new HttpParams()
+      .set('autoCoderRun', autoCoderRun.toString())
+      .set('cacheOnly', 'true');
+    const requestGeneration = this.codingStatusCacheGeneration;
+    const request$ = this.http
+      .get<AutocodingReadinessDto | null>(
+      `${this.serverUrl}admin/workspace/${workspaceId}/coding/readiness`,
+      {
+        headers: this.authHeader,
+        params,
+        context: suppressGlobalHttpErrorContext()
+      }
+    )
+      .pipe(
+        map(readiness => (
+          this.codingStatusCacheGeneration === requestGeneration ? readiness : null
+        )),
+        tap(readiness => {
+          if (
+            readiness &&
+            this.autocodingReadinessCacheOnlyRequests.get(cacheKey) === request$
+          ) {
+            this.autocodingReadinessCache.set(cacheKey, readiness);
+          }
+        }),
+        catchError(() => of(null)),
+        finalize(() => {
+          if (this.autocodingReadinessCacheOnlyRequests.get(cacheKey) === request$) {
+            this.autocodingReadinessCacheOnlyRequests.delete(cacheKey);
+          }
+        }),
+        shareReplay({ bufferSize: 1, refCount: false })
+      );
+
+    this.autocodingReadinessCacheOnlyRequests.set(cacheKey, request$);
     return request$;
   }
 


### PR DESCRIPTION
## Summary
- add Redis-backed auto-coding readiness cache keys and invalidation with workspace result/file cache changes
- add a cache-only readiness endpoint path and frontend hydration on initial coding management load
- avoid stale cache-only frontend responses after local coding status cache invalidation

## Validation
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-readiness.service.spec.ts`
- `npx nx test backend --testFile=apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts`
- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts`
- `npx nx lint backend`
- `npx nx test backend --runInBand`
- `npx nx lint frontend`
- `npx nx test frontend --runInBand`
- `git diff --check`