### PR TITLE
Stabilize coding status loading states

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.html
@@ -32,7 +32,7 @@
   </div>
 
 
-  <div *ngIf="isLoading" class="loading-container">
+  <div *ngIf="isLoading && jobDefinitions.length === 0" class="loading-container">
     <mat-spinner diameter="30"></mat-spinner>
     <span>{{ 'coding-job-definitions.loading' | translate }}</span>
   </div>
@@ -43,7 +43,7 @@
   </div>
 
   <div
-    *ngIf="!isLoading && jobDefinitions.length > 0"
+    *ngIf="jobDefinitions.length > 0"
     class="definition-summary"
     aria-label="Status der Jobdefinitionen">
     <div class="summary-item">
@@ -64,7 +64,10 @@
     </div>
   </div>
 
-  <div *ngIf="!isLoading && jobDefinitions.length > 0" class="job-definitions-table-wrapper">
+  <div
+    *ngIf="jobDefinitions.length > 0"
+    class="job-definitions-table-wrapper"
+    [attr.aria-busy]="isLoading">
     <table mat-table [dataSource]="jobDefinitions" class="job-definitions-table">
       <!-- Actions Column -->
       <ng-container matColumnDef="actions">

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
@@ -117,6 +117,25 @@ describe('CodingJobDefinitionsComponent', () => {
     expect(fixture.nativeElement.querySelector('.empty-state')).toBeTruthy();
   });
 
+  it('keeps existing definitions visible while refreshing', () => {
+    component.isLoading = true;
+    component.jobDefinitions = [
+      {
+        id: 1,
+        status: 'approved',
+        assignedVariables: [{ unitName: 'UNIT', variableId: 'VAR' }],
+        assignedVariableBundles: [],
+        assignedCoders: [],
+        createdJobsCount: 0
+      }
+    ];
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.loading-container')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.definition-summary')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.job-definitions-table-wrapper')).toBeTruthy();
+  });
+
   it('keeps the create action only in the empty state when no definitions exist', () => {
     component.isLoading = false;
     component.jobDefinitions = [];

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1031,6 +1031,46 @@ describe('CodingManagementManualComponent', () => {
     );
   });
 
+  it('should keep the planning status stable while polling an existing response analysis', () => {
+    setCompletePlanningState();
+    component.variableCoverageOverview = {
+      ...component.variableCoverageOverview!,
+      missingVariables: 1
+    };
+    component.responseAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 0,
+        totalResponses: 0,
+        groups: [],
+        isAggregationApplied: true
+      },
+      aggregationSummary: {
+        duplicateGroups: 0,
+        duplicateResponses: 0,
+        collapsedCases: 0,
+        rawCases: 10,
+        effectiveCases: 10,
+        threshold: 2,
+        aggregationActive: true
+      },
+      matchingFlags: [],
+      analysisTimestamp: new Date().toISOString(),
+      isCalculating: true
+    };
+    component.isLoadingResponseAnalysis = true;
+
+    expect(component.getPlanningStatusTitle()).toBe('Planung noch unvollständig');
+    expect(component.getPlanningStatusIcon()).toBe('assignment_late');
+  });
+
+  it('should show an updating status while the initial response analysis is loading', () => {
+    component.responseAnalysis = null;
+    component.isLoadingResponseAnalysis = true;
+
+    expect(component.getPlanningStatusTitle()).toBe('Status wird aktualisiert');
+  });
+
   it('should ask for an explicit planning data refresh before loading planning snapshots', () => {
     component.selectedManualTabIndex = 1;
     const componentInternals = component as unknown as {
@@ -1638,7 +1678,7 @@ describe('CodingManagementManualComponent', () => {
     expect(loadJobDefinitionsForExportSpy).not.toHaveBeenCalled();
   });
 
-  it('should not load bundled planning data after auto coding completes in planning', () => {
+  it('should not reload planning job definitions after auto coding completes in planning', () => {
     component.selectedManualTabIndex = 1;
     component.autoRefreshManualCodingJobs = true;
     setCompletePlanningState();
@@ -1654,6 +1694,10 @@ describe('CodingManagementManualComponent', () => {
       refreshCodingJobsAfterDataChange(scope: string): void;
       loadJobDefinitionsForExport(): void;
     };
+    const refreshJobDefinitionsSpy = jest.fn();
+    component.codingJobDefinitionsComponent = {
+      refresh: refreshJobDefinitionsSpy
+    } as unknown as CodingManagementManualComponent['codingJobDefinitionsComponent'];
     componentInternals.appService.selectedWorkspaceId = 5;
     componentInternals.hasLoadedManualCodingJobRefreshSetting = true;
     expect(component.shouldShowPlanningOverview()).toBe(true);
@@ -1679,7 +1723,8 @@ describe('CodingManagementManualComponent', () => {
     expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
     expect(loadResponseAnalysisSpy).not.toHaveBeenCalled();
     expect(refreshCodingJobsAfterDataChangeSpy).toHaveBeenCalledWith('rendered');
-    expect(loadJobDefinitionsForExportSpy).toHaveBeenCalled();
+    expect(loadJobDefinitionsForExportSpy).not.toHaveBeenCalled();
+    expect(refreshJobDefinitionsSpy).not.toHaveBeenCalled();
     expect(component.shouldShowPlanningOverview()).toBe(false);
     expect(component.getPlanningStatusTitle()).toBe('Planungsdaten aktualisieren');
   });

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -566,10 +566,6 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         if (this.activeManualTab === 'planning') {
           this.hasLoadedPlanningDataBundle = false;
           this.refreshCodingJobsAfterDataChange('rendered');
-          this.loadJobDefinitionsForExport();
-          if (this.codingJobDefinitionsComponent) {
-            this.codingJobDefinitionsComponent.refresh();
-          }
           return;
         }
 
@@ -1943,6 +1939,23 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingMatchingMode;
   }
 
+  private isPlanningStatusLoading(): boolean {
+    return this.isLoadingInitialResponseAnalysisForStatus() ||
+      this.isLoadingCodingProgress ||
+      this.isLoadingVariableCoverage ||
+      this.isLoadingCaseCoverage ||
+      this.isLoadingManualCodeAvailability ||
+      this.isLoadingCodingIncompleteVariables ||
+      this.isLoadingAppliedResultsOverview ||
+      this.isLoadingManualFreshnessJobSummary ||
+      this.isLoadingDoubleCodingConflictSummary ||
+      this.isLoadingMatchingMode;
+  }
+
+  private isLoadingInitialResponseAnalysisForStatus(): boolean {
+    return this.isLoadingResponseAnalysis && !this.responseAnalysis;
+  }
+
   private hasPlanningDataBundleSnapshot(): boolean {
     return this.hasLoadedPlanningDataBundle;
   }
@@ -2435,7 +2448,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private getPlanningStatusState(): PlanningStatusState {
-    if (this.isAnyPlanningDataLoading()) {
+    if (this.isPlanningStatusLoading()) {
       return 'loading';
     }
 

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.html
@@ -48,7 +48,7 @@
 
   <section class="coding-freshness-panel" [class.is-current]="!hasCodingFreshnessAttention">
     <div class="coding-freshness-main">
-      @if (isLoadingCodingFreshness || isLoadingAutocodingReadiness || isLoadingManualAppliedResultsOverview) {
+      @if (isFullCodingStatusCheckLoading) {
       <mat-spinner diameter="22" class="coding-freshness-state-spinner"></mat-spinner>
       } @else {
       <mat-icon>{{ hasCodingFreshnessAttention ? 'warning' : 'check_circle' }}</mat-icon>
@@ -58,7 +58,7 @@
           {{ codingFreshnessPanelTitle }}
         </div>
         <div class="coding-freshness-text">
-          @if (isLoadingCodingFreshness || isLoadingAutocodingReadiness || isLoadingManualAppliedResultsOverview) {
+          @if (isFullCodingStatusCheckLoading) {
           {{ 'coding-management.readiness.checking' | translate }}
           } @else if (isCodingStatusOverviewPendingManualRefresh) {
           {{ 'coding-management.readiness.manual-refresh-required' | translate }}

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -271,6 +271,7 @@ describe('CodingManagementComponent', () => {
           'title-not-started': 'Kodierung noch nicht gestartet',
           'title-manual-coding-open': 'Manuelle Kodierung abschließen',
           'title-not-checked': 'Kodierstand nicht automatisch geprüft',
+          checking: 'Zustand wird geprüft...',
           'manual-refresh-required': 'Der vollständige Kodierstand wurde noch nicht geprüft. Aktualisieren Sie den Status bei Bedarf manuell.',
           summary: '{{rawResponsesTotal}} Rohantworten vorhanden, {{rawResponsesWithRelevantStatus}} mit relevantem Antwortstatus, aber {{codeableResponses}} kodierbare Antworten.',
           'details-result-units': '{{count}} Ergebnis-Units',
@@ -327,6 +328,36 @@ describe('CodingManagementComponent', () => {
       expect(mockTestPersonCodingService.getCachedAutocodingReadiness).toHaveBeenCalledWith(1, 1);
       expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+    });
+
+    it('should not show full-check loading copy during the lightweight initial refresh', () => {
+      fixture.destroy();
+      const codingFreshnessSubject = new Subject<{
+        workspaceId: number;
+        currentRevision: number;
+        items: never[];
+      }>();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock)
+        .mockReturnValueOnce(codingFreshnessSubject.asObservable());
+
+      const isolatedFixture = TestBed.createComponent(CodingManagementComponent);
+      const isolatedComponent = isolatedFixture.componentInstance;
+      isolatedFixture.detectChanges();
+
+      const text = isolatedFixture.nativeElement.textContent;
+      expect(isolatedComponent.isLoadingCodingFreshness).toBe(true);
+      expect(isolatedComponent.isFullCodingStatusCheckLoading).toBe(false);
+      expect(text).toContain('Der vollständige Kodierstand wurde noch nicht geprüft');
+      expect(text).not.toContain('Zustand wird geprüft');
+      expect(isolatedFixture.nativeElement.querySelector('.coding-freshness-state-spinner')).toBeNull();
+
+      codingFreshnessSubject.next({
+        workspaceId: 1,
+        currentRevision: 0,
+        items: []
+      });
+      codingFreshnessSubject.complete();
+      isolatedFixture.destroy();
     });
 
     it('should use cached autocoding readiness on init when available', () => {
@@ -411,6 +442,21 @@ describe('CodingManagementComponent', () => {
 
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
+    });
+
+    it('should show full-check loading copy during a manual status refresh', () => {
+      const autocodingReadinessSubject = new Subject<never>();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock)
+        .mockReturnValueOnce(autocodingReadinessSubject.asObservable());
+
+      component.refreshCodingStatusOverview();
+      fixture.detectChanges();
+
+      expect(component.isFullCodingStatusCheckLoading).toBe(true);
+      expect(fixture.nativeElement.textContent).toContain('Zustand wird geprüft');
+      expect(fixture.nativeElement.querySelector('.coding-freshness-state-spinner')).not.toBeNull();
+
+      autocodingReadinessSubject.complete();
     });
 
     it('should refresh coding status overview when requested by query param', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -1055,6 +1055,10 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       this.hasImportedResultsWithoutCoding;
   }
 
+  get isFullCodingStatusCheckLoading(): boolean {
+    return this.isLoadingAutocodingReadiness;
+  }
+
   get isCodingStatusOverviewPendingManualRefresh(): boolean {
     return !this.hasLoadedFullCodingStatusOverview &&
       this.shouldShowManualCodingStatusRefresh() &&


### PR DESCRIPTION
## Summary

- keep coding job definitions visible while a refresh is in progress
- avoid showing the full status-check spinner/copy during lightweight freshness loading
- keep the manual planning status stable while existing response analysis data is being refreshed
- cover the adjusted loading behavior with focused frontend component tests

## Validation

- `npx nx lint frontend`
- `npx nx test frontend`