### PR TITLE
Abort obsolete coding requests

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -263,6 +263,75 @@ describe('CodingManagementManualComponent', () => {
     }
   });
 
+  it('should cancel response analysis when leaving the preparation flow', () => {
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        getResponseAnalysis: jest.Mock;
+        setResponseAnalysisGuardRunning: (
+          workspaceId: number,
+          isRunning: boolean
+        ) => void;
+      };
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    component.selectedManualTabIndex = 0;
+    let responseAnalysisUnsubscribed = false;
+    jest
+      .spyOn(componentInternals.testPersonCodingService, 'setResponseAnalysisGuardRunning')
+      .mockImplementation(() => undefined);
+    jest
+      .spyOn(componentInternals.testPersonCodingService, 'getResponseAnalysis')
+      .mockReturnValue(new Observable(() => (
+        () => {
+          responseAnalysisUnsubscribed = true;
+        }
+      )));
+
+    component.loadResponseAnalysis();
+    expect(component.isLoadingResponseAnalysis).toBe(true);
+
+    component.onManualTabChanged(2);
+
+    expect(responseAnalysisUnsubscribed).toBe(true);
+    expect(component.isLoadingResponseAnalysis).toBe(false);
+  });
+
+  it('should hand off the response-analysis guard when leaving the preparation flow while analysis is calculating', () => {
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        setResponseAnalysisGuardRunning: (
+          workspaceId: number,
+          isRunning: boolean
+        ) => void;
+        trackResponseAnalysisGuardUntilComplete: (
+          workspaceId: number,
+          threshold?: number
+        ) => void;
+      };
+      setResponseAnalysisGuardActive: (isActive: boolean) => void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    component.selectedManualTabIndex = 0;
+    const setGuardSpy = jest
+      .spyOn(componentInternals.testPersonCodingService, 'setResponseAnalysisGuardRunning')
+      .mockImplementation(() => undefined);
+    const trackGuardSpy = jest
+      .spyOn(componentInternals.testPersonCodingService, 'trackResponseAnalysisGuardUntilComplete')
+      .mockImplementation(() => undefined);
+
+    componentInternals.setResponseAnalysisGuardActive(true);
+    setGuardSpy.mockClear();
+
+    component.onManualTabChanged(2);
+    component.ngOnDestroy();
+
+    expect(trackGuardSpy).toHaveBeenCalledTimes(1);
+    expect(trackGuardSpy).toHaveBeenCalledWith(5, 2);
+    expect(setGuardSpy).not.toHaveBeenCalledWith(5, false);
+  });
+
   it('should run pending manual state and forced freshness refresh after a background guard clears', () => {
     component.selectedManualTabIndex = 1;
     const componentInternals = component as unknown as {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -310,6 +310,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   // Duplicate aggregation state
   duplicateAggregationThreshold = 2;
   isApplyingDuplicateAggregation = false;
+  private readonly responseAnalysisRequestCancel$ = new Subject<void>();
+  private responseAnalysisRequestId = 0;
   private analysisPollingTimer?: ReturnType<typeof setTimeout>;
   private readonly windowFocusRefreshThrottleMs = 30000;
   private readonly codingFreshnessRefreshThrottleMs = 30000;
@@ -594,9 +596,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    if (this.analysisPollingTimer) {
-      clearTimeout(this.analysisPollingTimer);
-    }
+    this.cancelResponseAnalysisRequest();
+    this.responseAnalysisRequestCancel$.complete();
     this.finalizeResponseAnalysisGuardOnDestroy();
     this.document.defaultView?.removeEventListener('focus', this.handleWindowFocus);
     this.destroy$.next();
@@ -608,6 +609,51 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   get activeManualTab(): ManualCodingTab {
     return this.visibleManualCodingTabs[this.selectedManualTabIndex] || 'preparation';
+  }
+
+  private isResponseAnalysisTab(tab: ManualCodingTab): boolean {
+    return tab === 'preparation' || tab === 'planning';
+  }
+
+  private cancelResponseAnalysisRequest(
+    options: { markNotLoading?: boolean } = {}
+  ): void {
+    this.responseAnalysisRequestId += 1;
+    if (this.analysisPollingTimer) {
+      clearTimeout(this.analysisPollingTimer);
+      this.analysisPollingTimer = undefined;
+    }
+    this.responseAnalysisRequestCancel$.next();
+    if (options.markNotLoading !== false) {
+      this.isLoadingResponseAnalysis = false;
+    }
+  }
+
+  private shouldAcceptResponseAnalysisResult(
+    requestId: number,
+    workspaceId: number
+  ): boolean {
+    return requestId === this.responseAnalysisRequestId &&
+      this.appService.selectedWorkspaceId === workspaceId &&
+      this.isResponseAnalysisTab(this.activeManualTab);
+  }
+
+  private handOffResponseAnalysisGuardUntilComplete(): void {
+    if (!this.responseAnalysisGuardActive) {
+      return;
+    }
+
+    this.trackManualResponseAnalysisGuardUntilComplete(
+      this.responseAnalysisGuardWorkspaceId || this.appService.selectedWorkspaceId,
+      this.normalizeAggregationThreshold(this.duplicateAggregationThreshold)
+    );
+    this.responseAnalysisGuardActive = false;
+    this.responseAnalysisGuardWorkspaceId = null;
+  }
+
+  private stopResponseAnalysisView(): void {
+    this.cancelResponseAnalysisRequest();
+    this.handOffResponseAnalysisGuardUntilComplete();
   }
 
   get workspaceId(): number {
@@ -671,7 +717,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
+    const previousTab = this.activeManualTab;
     this.selectedManualTabIndex = index;
+    if (this.isResponseAnalysisTab(previousTab) &&
+      !this.isResponseAnalysisTab(this.activeManualTab)) {
+      this.stopResponseAnalysisView();
+    }
     this.loadManualTabData(this.activeManualTab);
   }
 
@@ -682,7 +733,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     if (this.selectedManualTabIndex !== tabIndex) {
+      const previousTab = this.activeManualTab;
       this.selectedManualTabIndex = tabIndex;
+      if (this.isResponseAnalysisTab(previousTab) &&
+        !this.isResponseAnalysisTab(tab)) {
+        this.stopResponseAnalysisView();
+      }
       this.loadManualTabData(tab);
     }
 
@@ -4583,11 +4639,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (this.analysisPollingTimer) {
-      clearTimeout(this.analysisPollingTimer);
-      this.analysisPollingTimer = undefined;
+    if (!this.isResponseAnalysisTab(this.activeManualTab)) {
+      this.stopResponseAnalysisView();
+      return;
     }
 
+    this.cancelResponseAnalysisRequest({
+      markNotLoading: false
+    });
+    const requestId = this.responseAnalysisRequestId + 1;
+    this.responseAnalysisRequestId = requestId;
     this.isLoadingResponseAnalysis = true;
     this.responseAnalysisError = null;
     this.testPersonCodingService
@@ -4599,9 +4660,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.duplicatePageIndex + 1,
         this.duplicatePageSize
       )
-      .pipe(takeUntil(this.destroy$))
+      .pipe(
+        takeUntil(this.responseAnalysisRequestCancel$),
+        takeUntil(this.destroy$)
+      )
       .subscribe({
         next: (analysis: ResponseAnalysisDto & { isCalculating?: boolean }) => {
+          if (!this.shouldAcceptResponseAnalysisResult(requestId, workspaceId)) {
+            return;
+          }
+
           this.responseAnalysis = analysis;
           this.responseAnalysisError = null;
           this.isLoadingResponseAnalysis = false;
@@ -4612,13 +4680,19 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           if (analysis.isCalculating) {
             // Poll every 5 seconds if calculating
             this.analysisPollingTimer = setTimeout(() => {
-              if (this.responseAnalysis?.isCalculating) {
+              this.analysisPollingTimer = undefined;
+              if (this.responseAnalysis?.isCalculating &&
+                this.shouldAcceptResponseAnalysisResult(requestId, workspaceId)) {
                 this.loadResponseAnalysis();
               }
             }, 5000);
           }
         },
         error: error => {
+          if (!this.shouldAcceptResponseAnalysisResult(requestId, workspaceId)) {
+            return;
+          }
+
           this.isLoadingResponseAnalysis = false;
           this.focusManualFreshnessTargetIfReady();
           const responseAnalysisError = `Fehler beim Laden der Antwortanalyse: ${error.message || error}`;

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -9,7 +9,9 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { of, Subject, throwError } from 'rxjs';
+import {
+  Observable, of, Subject, throwError
+} from 'rxjs';
 import { CodingTrainingBackendService } from '../../services/coding-training-backend.service';
 import { CodingResultsComparisonComponent } from './coding-results-comparison.component';
 import { SERVER_URL } from '../../../injection-tokens';
@@ -213,9 +215,17 @@ describe('CodingResultsComparisonComponent', () => {
   it('should ignore stale within-training comparison responses after a training switch', () => {
     const firstTrainingResponse$ = new Subject<unknown[]>();
     const secondTrainingResponse$ = new Subject<unknown[]>();
+    let firstTrainingUnsubscribed = false;
+    const firstTrainingResponse = new Observable<unknown[]>(subscriber => {
+      const subscription = firstTrainingResponse$.subscribe(subscriber);
+      return () => {
+        firstTrainingUnsubscribed = true;
+        subscription.unsubscribe();
+      };
+    });
     codingTrainingBackendService.getCachedWithinTrainingCodingResults.mockImplementation(
       (_workspaceId: number, trainingId: number) => (
-        trainingId === 5 ? firstTrainingResponse$.asObservable() : secondTrainingResponse$.asObservable()
+        trainingId === 5 ? firstTrainingResponse : secondTrainingResponse$.asObservable()
       )
     );
     component.comparisonMode = 'within-training';
@@ -224,6 +234,7 @@ describe('CodingResultsComparisonComponent', () => {
 
     component.selectedTrainingForWithin = 6;
     component.loadComparison();
+    expect(firstTrainingUnsubscribed).toBe(true);
     secondTrainingResponse$.next([
       {
         responseId: 2,

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -269,6 +269,8 @@ export class CodingResultsComparisonComponent implements OnInit {
   private dialog = inject(MatDialog);
   private testPersonCodingService = inject(TestPersonCodingService);
   private ngUnsubscribe = new Subject<void>();
+  private comparisonRequestCancel$ = new Subject<void>();
+  private kappaRequestCancel$ = new Subject<void>();
   private comparisonRequestId = 0;
   private kappaRequestId = 0;
   private coderTrainingsRequestId = 0;
@@ -408,12 +410,42 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   ngOnDestroy(): void {
+    this.cancelComparisonRequest();
+    this.cancelKappaRequest();
+    this.comparisonRequestCancel$.complete();
+    this.kappaRequestCancel$.complete();
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
   }
 
   ngAfterViewInit(): void {
     this.dataSource.sort = this.sort;
+  }
+
+  private cancelComparisonRequest(): void {
+    this.comparisonRequestId += 1;
+    this.comparisonRequestCancel$.next();
+    this.isLoading = false;
+  }
+
+  private startComparisonRequest(): number {
+    this.comparisonRequestCancel$.next();
+    this.comparisonRequestId += 1;
+    this.isLoading = true;
+    return this.comparisonRequestId;
+  }
+
+  private cancelKappaRequest(): void {
+    this.kappaRequestId += 1;
+    this.kappaRequestCancel$.next();
+    this.isLoadingKappa = false;
+  }
+
+  private startKappaRequest(): number {
+    this.kappaRequestCancel$.next();
+    this.kappaRequestId += 1;
+    this.isLoadingKappa = true;
+    return this.kappaRequestId;
   }
 
   private getSelectedCoderResults(comparison: TrainingComparison | WithinTrainingComparison): ComparisonCoderResult[] {
@@ -1515,8 +1547,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   onModeChange(): void {
-    this.comparisonRequestId += 1;
-    this.isLoading = false;
+    this.cancelComparisonRequest();
     this.resetKappaState();
     this.selectedTrainings.clear();
     this.filteredTrainings = [...this.availableTrainings];
@@ -1539,8 +1570,7 @@ export class CodingResultsComparisonComponent implements OnInit {
     if (this.comparisonMode === 'between-trainings' && this.selectedTrainings.selected.length >= 2) {
       this.loadComparison();
     } else {
-      this.comparisonRequestId += 1;
-      this.isLoading = false;
+      this.cancelComparisonRequest();
       this.comparisonData = [];
       this.availableCodersFromTrainings = [];
       this.codersFromTrainingsFormControl.setValue([]);
@@ -1556,8 +1586,7 @@ export class CodingResultsComparisonComponent implements OnInit {
     if (this.comparisonMode === 'within-training' && this.selectedTrainingForWithin) {
       this.loadComparison();
     } else {
-      this.comparisonRequestId += 1;
-      this.isLoading = false;
+      this.cancelComparisonRequest();
       this.withinTrainingData = [];
       this.availableCoders = [];
       this.codersFormControl.setValue([]);
@@ -1687,13 +1716,14 @@ export class CodingResultsComparisonComponent implements OnInit {
         return;
       }
 
-      this.comparisonRequestId += 1;
-      const requestId = this.comparisonRequestId;
-      this.isLoading = true;
+      const requestId = this.startComparisonRequest();
       this.resetKappaState();
       const trainingIds = this.selectedTrainings.selected.join(',');
       this.codingTrainingBackendService.compareTrainingCodingResults(this.data.workspaceId, trainingIds)
-        .pipe(takeUntil(this.ngUnsubscribe))
+        .pipe(
+          takeUntil(this.comparisonRequestCancel$),
+          takeUntil(this.ngUnsubscribe)
+        )
         .subscribe({
           next: data => {
             if (requestId !== this.comparisonRequestId ||
@@ -1760,10 +1790,8 @@ export class CodingResultsComparisonComponent implements OnInit {
         return;
       }
 
-      this.comparisonRequestId += 1;
-      const requestId = this.comparisonRequestId;
+      const requestId = this.startComparisonRequest();
       const trainingId = this.selectedTrainingForWithin;
-      this.isLoading = true;
       this.resetKappaState();
       this.withinTrainingData = [];
       this.availableCoders = [];
@@ -1771,7 +1799,10 @@ export class CodingResultsComparisonComponent implements OnInit {
       this.selectedCoderIds.clear();
       this.dataSource.data = [];
       this.codingTrainingBackendService.getCachedWithinTrainingCodingResults(this.data.workspaceId, trainingId)
-        .pipe(takeUntil(this.ngUnsubscribe))
+        .pipe(
+          takeUntil(this.comparisonRequestCancel$),
+          takeUntil(this.ngUnsubscribe)
+        )
         .subscribe({
           next: data => {
             if (requestId !== this.comparisonRequestId ||
@@ -1890,10 +1921,8 @@ export class CodingResultsComparisonComponent implements OnInit {
     }
 
     this.resetKappaState();
-    this.kappaRequestId += 1;
-    const requestId = this.kappaRequestId;
+    const requestId = this.startKappaRequest();
     const trainingId = this.selectedTrainingForWithin;
-    this.isLoadingKappa = true;
     const level = this.useCodeLevel ? 'code' : 'score';
     this.codingTrainingBackendService
       .getTrainingCohensKappa(
@@ -1902,7 +1931,10 @@ export class CodingResultsComparisonComponent implements OnInit {
         this.useWeightedMean,
         level
       )
-      .pipe(takeUntil(this.ngUnsubscribe))
+      .pipe(
+        takeUntil(this.kappaRequestCancel$),
+        takeUntil(this.ngUnsubscribe)
+      )
       .subscribe({
         next: stats => {
           if (requestId !== this.kappaRequestId ||
@@ -2130,11 +2162,10 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   private resetKappaState(): void {
-    this.kappaRequestId += 1;
+    this.cancelKappaRequest();
     this.kappaStatistics = null;
     this.originalKappaStatistics = null;
     this.variableKappaSummaries = [];
-    this.isLoadingKappa = false;
   }
 
   toggleKappaStatistics(): void {

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -210,7 +210,7 @@ export class CodingTrainingBackendService {
             this.coderTrainingsInFlight.delete(workspaceId);
           }
         }),
-        shareReplay({ bufferSize: 1, refCount: false })
+        shareReplay({ bufferSize: 1, refCount: true })
       );
 
     this.coderTrainingsInFlight.set(workspaceId, request$);

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -627,7 +627,7 @@ export class TestPersonCodingService {
             this.codingFreshnessRequests.delete(workspaceId);
           }
         }),
-        shareReplay({ bufferSize: 1, refCount: false })
+        shareReplay({ bufferSize: 1, refCount: true })
       );
 
     this.codingFreshnessRequests.set(workspaceId, request$);
@@ -686,7 +686,7 @@ export class TestPersonCodingService {
             this.autocodingReadinessRequests.delete(cacheKey);
           }
         }),
-        shareReplay({ bufferSize: 1, refCount: false })
+        shareReplay({ bufferSize: 1, refCount: true })
       );
 
     this.autocodingReadinessRequests.set(cacheKey, request$);
@@ -743,7 +743,7 @@ export class TestPersonCodingService {
             this.autocodingReadinessCacheOnlyRequests.delete(cacheKey);
           }
         }),
-        shareReplay({ bufferSize: 1, refCount: false })
+        shareReplay({ bufferSize: 1, refCount: true })
       );
 
     this.autocodingReadinessCacheOnlyRequests.set(cacheKey, request$);
@@ -804,7 +804,7 @@ export class TestPersonCodingService {
             this.codingFreshnessScopeRequests.delete(cacheKey);
           }
         }),
-        shareReplay({ bufferSize: 1, refCount: false })
+        shareReplay({ bufferSize: 1, refCount: true })
       );
 
     this.codingFreshnessScopeRequests.set(cacheKey, request$);
@@ -1087,7 +1087,7 @@ export class TestPersonCodingService {
             this.appliedResultsOverviewRequests.delete(workspaceId);
           }
         }),
-        shareReplay({ bufferSize: 1, refCount: false })
+        shareReplay({ bufferSize: 1, refCount: true })
       );
 
     this.appliedResultsOverviewRequests.set(workspaceId, request$);


### PR DESCRIPTION
## Summary

- cancel obsolete response-analysis and comparison requests when users switch tabs, modes, or selections
- keep an active response-analysis background guard alive after leaving the preparation/planning view until the backend job finishes
- make relevant in-flight status/training request caches ref-counted so abandoned subscribers can cancel underlying HTTP work

## Why

Old view-bound requests could continue running after the UI context changed. In heavier coding workflows this could keep unnecessary background work alive and allow stale responses to update component state unless guarded carefully.

## Validation

- `npx nx test frontend --runTestsByPath=apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts` (188 suites, 1752 tests passed; existing Jest worker teardown warning)
- `npx nx lint frontend`
- `git diff --check`