### PR TITLE
Add server paging for training comparison

### DIFF
--- a/api-dto/coding/training-comparison.dto.ts
+++ b/api-dto/coding/training-comparison.dto.ts
@@ -1,0 +1,112 @@
+export type TrainingComparisonSortBy =
+  | 'responseId'
+  | 'unitName'
+  | 'variableId'
+  | 'personLogin'
+  | 'personGroup'
+  | 'bookletName';
+
+export type TrainingComparisonSortDirection = 'asc' | 'desc';
+export type TrainingComparisonMatchFilter = 'all' | 'match' | 'differ';
+export type TrainingComparisonNotesFilter = 'all' | 'none' | 'with-notes';
+
+export interface TrainingComparisonFiltersDto {
+  unitName?: string;
+  variableId?: string;
+  personLogin?: string;
+  personGroup?: string;
+  bookletName?: string;
+  match?: TrainingComparisonMatchFilter;
+  notesMode?: TrainingComparisonNotesFilter;
+  regexSearch?: boolean;
+}
+
+export interface TrainingComparisonSummaryDto {
+  visibleRows: number;
+  comparableRows: number;
+  matchingRows: number;
+  matchingPercentage: number;
+  incompleteRows: number;
+  notComparableRows: number;
+  deviationRows: number;
+  completionRate: number;
+}
+
+export interface TrainingComparisonCoderDto {
+  trainingId: number;
+  trainingLabel: string;
+  coderId: number;
+  coderName: string;
+}
+
+export interface WithinTrainingComparisonCoderDto {
+  jobId: number;
+  coderName: string;
+}
+
+export interface TrainingComparisonCoderResultDto extends TrainingComparisonCoderDto {
+  code: string | null;
+  score: number | null;
+  notes: string | null;
+  codingIssueOption: number | null;
+}
+
+export interface WithinTrainingComparisonCoderResultDto extends WithinTrainingComparisonCoderDto {
+  code: string | null;
+  score: number | null;
+  notes: string | null;
+  codingIssueOption: number | null;
+}
+
+export interface TrainingCodingComparisonRowDto {
+  responseId: number;
+  unitName: string;
+  variableId: string;
+  personCode: string;
+  personLogin: string;
+  personGroup: string;
+  bookletName: string;
+  testPerson: string;
+  coders: TrainingComparisonCoderResultDto[];
+}
+
+export interface WithinTrainingCodingComparisonRowDto {
+  responseId: number;
+  unitName: string;
+  variableId: string;
+  personCode: string;
+  personLogin: string;
+  personGroup: string;
+  bookletName: string;
+  testPerson: string;
+  givenAnswer: string;
+  replayCode: number | null;
+  replayScore: number | null;
+  discussionCode: number | null;
+  discussionScore: number | null;
+  discussionNotes: string | null;
+  discussionManagerUserId: number | null;
+  discussionManagerName: string | null;
+  discussionSource: 'manual' | 'auto_agreement' | null;
+  coders: WithinTrainingComparisonCoderResultDto[];
+}
+
+export interface TrainingComparisonPageDto<TData, TCoder> {
+  data: TData[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  summary: TrainingComparisonSummaryDto;
+  availableCoders: TCoder[];
+}
+
+export type TrainingCodingComparisonPageDto = TrainingComparisonPageDto<
+TrainingCodingComparisonRowDto,
+TrainingComparisonCoderDto
+>;
+
+export type WithinTrainingCodingComparisonPageDto = TrainingComparisonPageDto<
+WithinTrainingCodingComparisonRowDto,
+WithinTrainingComparisonCoderDto
+>;

--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.spec.ts
@@ -8,6 +8,8 @@ import {
 describe('WorkspaceCoderTrainingController', () => {
   let controller: WorkspaceCoderTrainingController;
   let coderTrainingService: {
+    getTrainingCodingComparisonPage: jest.Mock;
+    getWithinTrainingCodingComparisonPage: jest.Mock;
     getWithinTrainingCodingComparison: jest.Mock;
     getWithinTrainingComparisonFreshness: jest.Mock;
     transformToCoderPairs: jest.Mock;
@@ -24,6 +26,8 @@ describe('WorkspaceCoderTrainingController', () => {
 
   beforeEach(() => {
     coderTrainingService = {
+      getTrainingCodingComparisonPage: jest.fn(),
+      getWithinTrainingCodingComparisonPage: jest.fn(),
       getWithinTrainingCodingComparison: jest.fn(),
       getWithinTrainingComparisonFreshness: jest.fn(),
       transformToCoderPairs: jest.fn(),
@@ -42,6 +46,132 @@ describe('WorkspaceCoderTrainingController', () => {
       coderTrainingService as unknown as CoderTrainingService,
       codingStatisticsService as unknown as CodingStatisticsService,
       coderTrainingResultsApplyService as unknown as CoderTrainingResultsApplyService
+    );
+  });
+
+  it('forwards between-training comparison paging, sorting, and filters to the service', async () => {
+    const page = {
+      data: [],
+      total: 0,
+      page: 2,
+      limit: 25,
+      totalPages: 0,
+      summary: {
+        visibleRows: 0,
+        comparableRows: 0,
+        matchingRows: 0,
+        matchingPercentage: 0,
+        incompleteRows: 0,
+        notComparableRows: 0,
+        deviationRows: 0,
+        completionRate: 0
+      },
+      availableCoders: []
+    };
+    coderTrainingService.getTrainingCodingComparisonPage.mockResolvedValue(page);
+
+    const result = await controller.compareTrainingCodingResults(
+      12,
+      '1,2',
+      '2',
+      '25',
+      'personLogin',
+      'desc',
+      '1_101,2_201',
+      'Unit',
+      'VAR',
+      'login',
+      'group',
+      'booklet',
+      'differ',
+      'with-notes',
+      'true'
+    );
+
+    expect(result).toBe(page);
+    expect(coderTrainingService.getTrainingCodingComparisonPage).toHaveBeenCalledWith(
+      12,
+      [1, 2],
+      {
+        page: 2,
+        limit: 25,
+        sortBy: 'personLogin',
+        sortDirection: 'desc',
+        selectedCoderKeys: ['1_101', '2_201'],
+        filters: {
+          unitName: 'Unit',
+          variableId: 'VAR',
+          personLogin: 'login',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          match: 'differ',
+          notesMode: 'with-notes',
+          regexSearch: true
+        }
+      }
+    );
+  });
+
+  it('forwards within-training comparison paging and selected jobs to the service', async () => {
+    const page = {
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 50,
+      totalPages: 0,
+      summary: {
+        visibleRows: 0,
+        comparableRows: 0,
+        matchingRows: 0,
+        matchingPercentage: 0,
+        incompleteRows: 0,
+        notComparableRows: 0,
+        deviationRows: 0,
+        completionRate: 0
+      },
+      availableCoders: []
+    };
+    coderTrainingService.getWithinTrainingCodingComparisonPage.mockResolvedValue(page);
+
+    const result = await controller.compareWithinTrainingCodingResults(
+      12,
+      '5',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      '11,12',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'match',
+      'none',
+      undefined
+    );
+
+    expect(result).toBe(page);
+    expect(coderTrainingService.getWithinTrainingCodingComparisonPage).toHaveBeenCalledWith(
+      12,
+      5,
+      {
+        page: 1,
+        limit: 50,
+        sortBy: undefined,
+        sortDirection: undefined,
+        selectedJobIds: [11, 12],
+        filters: {
+          unitName: undefined,
+          variableId: undefined,
+          personLogin: undefined,
+          personGroup: undefined,
+          bookletName: undefined,
+          match: 'match',
+          notesMode: 'none',
+          regexSearch: undefined
+        }
+      }
     );
   });
 

--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Get,
   Param,
@@ -35,6 +36,129 @@ import {
   TrainingDiscussionApplySource
 } from '../../../../../../api-dto/coding/training-discussion-apply.dto';
 import { TrainingComparisonFreshnessDto } from '../../../../../../api-dto/coding/training-comparison-freshness.dto';
+import {
+  TrainingCodingComparisonPageDto,
+  TrainingComparisonFiltersDto,
+  TrainingComparisonMatchFilter,
+  TrainingComparisonNotesFilter,
+  TrainingComparisonSortBy,
+  TrainingComparisonSortDirection,
+  WithinTrainingCodingComparisonPageDto
+} from '../../../../../../api-dto/coding/training-comparison.dto';
+
+const trainingComparisonSummarySchema = {
+  type: 'object',
+  properties: {
+    visibleRows: { type: 'number' },
+    comparableRows: { type: 'number' },
+    matchingRows: { type: 'number' },
+    matchingPercentage: { type: 'number' },
+    incompleteRows: { type: 'number' },
+    notComparableRows: { type: 'number' },
+    deviationRows: { type: 'number' },
+    completionRate: { type: 'number' }
+  }
+};
+
+const trainingComparisonCoderSchema = {
+  type: 'object',
+  properties: {
+    trainingId: { type: 'number', description: 'Training ID' },
+    trainingLabel: { type: 'string', description: 'Training label' },
+    coderId: { type: 'number', description: 'Coder (Job) ID' },
+    coderName: { type: 'string', description: 'Coder name' }
+  }
+};
+
+const trainingComparisonCoderResultSchema = {
+  type: 'object',
+  properties: {
+    ...trainingComparisonCoderSchema.properties,
+    code: { type: 'string', nullable: true },
+    score: { type: 'number', nullable: true },
+    notes: { type: 'string', nullable: true },
+    codingIssueOption: { type: 'number', nullable: true }
+  }
+};
+
+const withinTrainingComparisonCoderSchema = {
+  type: 'object',
+  properties: {
+    jobId: { type: 'number', description: 'Job ID' },
+    coderName: { type: 'string', description: 'Coder name' }
+  }
+};
+
+const withinTrainingComparisonCoderResultSchema = {
+  type: 'object',
+  properties: {
+    ...withinTrainingComparisonCoderSchema.properties,
+    code: { type: 'string', nullable: true },
+    score: { type: 'number', nullable: true },
+    notes: { type: 'string', nullable: true },
+    codingIssueOption: { type: 'number', nullable: true }
+  }
+};
+
+const trainingCodingComparisonRowSchema = {
+  type: 'object',
+  properties: {
+    responseId: { type: 'number' },
+    unitName: { type: 'string', description: 'Name of the unit' },
+    variableId: { type: 'string', description: 'Variable ID' },
+    personCode: { type: 'string', description: 'Person code' },
+    personLogin: { type: 'string', description: 'Person login' },
+    personGroup: { type: 'string', description: 'Person group' },
+    bookletName: { type: 'string', description: 'Test booklet name' },
+    testPerson: { type: 'string', description: 'Test person details' },
+    coders: {
+      type: 'array',
+      items: trainingComparisonCoderResultSchema
+    }
+  }
+};
+
+const withinTrainingCodingComparisonRowSchema = {
+  type: 'object',
+  properties: {
+    ...trainingCodingComparisonRowSchema.properties,
+    givenAnswer: { type: 'string', description: 'Given answer' },
+    replayCode: { type: 'number', nullable: true },
+    replayScore: { type: 'number', nullable: true },
+    discussionCode: { type: 'number', nullable: true },
+    discussionScore: { type: 'number', nullable: true },
+    discussionNotes: { type: 'string', nullable: true },
+    discussionManagerUserId: { type: 'number', nullable: true },
+    discussionManagerName: { type: 'string', nullable: true },
+    discussionSource: { type: 'string', enum: ['manual', 'auto_agreement'], nullable: true },
+    coders: {
+      type: 'array',
+      items: withinTrainingComparisonCoderResultSchema
+    }
+  }
+};
+
+const createTrainingComparisonPageSchema = (
+  dataItemSchema: Record<string, unknown>,
+  coderSchema: Record<string, unknown>
+) => ({
+  type: 'object',
+  properties: {
+    data: {
+      type: 'array',
+      items: dataItemSchema
+    },
+    total: { type: 'number' },
+    page: { type: 'number' },
+    limit: { type: 'number' },
+    totalPages: { type: 'number' },
+    summary: trainingComparisonSummarySchema,
+    availableCoders: {
+      type: 'array',
+      items: coderSchema
+    }
+  }
+});
 
 @ApiTags('Admin Workspace Coder Training')
 @Controller('admin/workspace')
@@ -76,6 +200,140 @@ export class WorkspaceCoderTrainingController {
     });
 
     return caseCountsByVariable;
+  }
+
+  private parsePositiveIntQuery(
+    value: string | undefined,
+    name: string,
+    defaultValue?: number,
+    maxValue?: number
+  ): number {
+    if (value === undefined || value === '') {
+      if (defaultValue !== undefined) {
+        return defaultValue;
+      }
+      throw new BadRequestException(`${name} must be a positive integer`);
+    }
+
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new BadRequestException(`${name} must be a positive integer`);
+    }
+
+    return maxValue ? Math.min(parsed, maxValue) : parsed;
+  }
+
+  private parsePositiveIntCsv(value: string | undefined, name: string): number[] | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value.trim() === '') {
+      return [];
+    }
+
+    return value.split(',')
+      .map(item => {
+        const parsed = Number(item.trim());
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          throw new BadRequestException(`${name} must contain positive integers`);
+        }
+        return parsed;
+      });
+  }
+
+  private parseStringCsv(value: string | undefined): string[] | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value.trim() === '') {
+      return [];
+    }
+
+    return value.split(',')
+      .map(item => item.trim())
+      .filter(item => item.length > 0);
+  }
+
+  private parseBooleanQuery(value: string | undefined): boolean | undefined {
+    if (value === undefined || value === '') {
+      return undefined;
+    }
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+    throw new BadRequestException('Boolean query values must be "true" or "false"');
+  }
+
+  private parseComparisonSortBy(value: string | undefined): TrainingComparisonSortBy | undefined {
+    if (!value) {
+      return undefined;
+    }
+    if ([
+      'responseId',
+      'unitName',
+      'variableId',
+      'personLogin',
+      'personGroup',
+      'bookletName'
+    ].includes(value)) {
+      return value as TrainingComparisonSortBy;
+    }
+    throw new BadRequestException('sortBy is not supported for training comparisons');
+  }
+
+  private parseComparisonSortDirection(value: string | undefined): TrainingComparisonSortDirection | undefined {
+    if (!value) {
+      return undefined;
+    }
+    if (value === 'asc' || value === 'desc') {
+      return value;
+    }
+    throw new BadRequestException('sortDirection must be "asc" or "desc"');
+  }
+
+  private parseComparisonMatchFilter(value: string | undefined): TrainingComparisonMatchFilter | undefined {
+    if (!value) {
+      return undefined;
+    }
+    if (value === 'all' || value === 'match' || value === 'differ') {
+      return value;
+    }
+    throw new BadRequestException('match must be one of "all", "match", or "differ"');
+  }
+
+  private parseComparisonNotesFilter(value: string | undefined): TrainingComparisonNotesFilter | undefined {
+    if (!value) {
+      return undefined;
+    }
+    if (value === 'all' || value === 'none' || value === 'with-notes') {
+      return value;
+    }
+    throw new BadRequestException('notesMode must be one of "all", "none", or "with-notes"');
+  }
+
+  private buildComparisonFilters(
+    unitName: string | undefined,
+    variableId: string | undefined,
+    personLogin: string | undefined,
+    personGroup: string | undefined,
+    bookletName: string | undefined,
+    match: string | undefined,
+    notesMode: string | undefined,
+    regexSearch: string | undefined
+  ): TrainingComparisonFiltersDto {
+    return {
+      unitName,
+      variableId,
+      personLogin,
+      personGroup,
+      bookletName,
+      match: this.parseComparisonMatchFilter(match),
+      notesMode: this.parseComparisonNotesFilter(notesMode),
+      regexSearch: this.parseBooleanQuery(regexSearch)
+    };
   }
 
   @Post(':workspace_id/coding/coder-training-packages')
@@ -451,82 +709,54 @@ export class WorkspaceCoderTrainingController {
   })
   @ApiOkResponse({
     description: 'Comparison of coding results across training components',
-    schema: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          unitName: { type: 'string', description: 'Name of the unit' },
-          variableId: { type: 'string', description: 'Variable ID' },
-          personCode: { type: 'string', description: 'Person Code' },
-          personLogin: { type: 'string', description: 'Person Login' },
-          personGroup: { type: 'string', description: 'Person Group' },
-          bookletName: { type: 'string', description: 'Test booklet name' },
-          testPerson: { type: 'string', description: 'Test Person' },
-          coders: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                trainingId: { type: 'number', description: 'Training ID' },
-                trainingLabel: {
-                  type: 'string',
-                  description: 'Training label'
-                },
-                coderId: { type: 'number', description: 'Coder (Job) ID' },
-                coderName: { type: 'string', description: 'Coder Name' },
-                code: {
-                  type: 'string',
-                  description: 'Code given by coders in this training'
-                },
-                score: {
-                  type: 'number',
-                  description: 'Score given by coders in this training'
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    schema: createTrainingComparisonPageSchema(
+      trainingCodingComparisonRowSchema,
+      trainingComparisonCoderSchema
+    )
   })
   async compareTrainingCodingResults(
     @WorkspaceId() workspace_id: number,
-      @Query('trainingIds') trainingIdsQuery: string
-  ): Promise<
-      Array<{
-        responseId: number;
-        unitName: string;
-        variableId: string;
-        personCode: string;
-        personLogin: string;
-        personGroup: string;
-        bookletName: string;
-        testPerson: string;
-        coders: Array<{
-          trainingId: number;
-          trainingLabel: string;
-          coderId: number;
-          coderName: string;
-          code: string | null;
-          score: number | null;
-          notes: string | null;
-          codingIssueOption: number | null;
-        }>;
-      }>
-      > {
-    const trainingIds = trainingIdsQuery
-      .split(',')
-      .map(id => parseInt(id.trim(), 10))
-      .filter(id => !Number.isNaN(id));
+      @Query('trainingIds') trainingIdsQuery: string | undefined,
+      @Query('page') page: string | undefined,
+      @Query('limit') limit: string | undefined,
+      @Query('sortBy') sortBy: string | undefined,
+      @Query('sortDirection') sortDirection: string | undefined,
+      @Query('coderKeys') coderKeys: string | undefined,
+      @Query('unitName') unitName: string | undefined,
+      @Query('variableId') variableId: string | undefined,
+      @Query('personLogin') personLogin: string | undefined,
+      @Query('personGroup') personGroup: string | undefined,
+      @Query('bookletName') bookletName: string | undefined,
+      @Query('match') match: string | undefined,
+      @Query('notesMode') notesMode: string | undefined,
+      @Query('regexSearch') regexSearch: string | undefined
+  ): Promise<TrainingCodingComparisonPageDto> {
+    const trainingIds = this.parsePositiveIntCsv(trainingIdsQuery, 'trainingIds') ?? [];
 
     if (trainingIds.length === 0) {
-      throw new Error('At least one valid training ID must be provided');
+      throw new BadRequestException('At least one valid training ID must be provided');
     }
 
-    return this.coderTrainingService.getTrainingCodingComparison(
+    return this.coderTrainingService.getTrainingCodingComparisonPage(
       workspace_id,
-      trainingIds
+      trainingIds,
+      {
+        page: this.parsePositiveIntQuery(page, 'page', 1),
+        limit: this.parsePositiveIntQuery(limit, 'limit', 50, 500),
+        sortBy: this.parseComparisonSortBy(sortBy),
+        sortDirection: this.parseComparisonSortDirection(sortDirection),
+        selectedCoderKeys: this.parseStringCsv(coderKeys),
+        filters: this.buildComparisonFilters(
+          unitName,
+          variableId,
+          personLogin,
+          personGroup,
+          bookletName,
+          match,
+          notesMode,
+          regexSearch
+        )
+      }
     );
   }
 
@@ -543,87 +773,53 @@ export class WorkspaceCoderTrainingController {
   @ApiOkResponse({
     description:
       'Comparison of coding results within a single training by individual coders',
-    schema: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          unitName: { type: 'string', description: 'Name of the unit' },
-          variableId: { type: 'string', description: 'Variable ID' },
-          personCode: { type: 'string', description: 'Person code' },
-          personLogin: { type: 'string', description: 'Person login' },
-          personGroup: { type: 'string', description: 'Person group' },
-          bookletName: { type: 'string', description: 'Test booklet name' },
-          testPerson: { type: 'string', description: 'Test person details' },
-          givenAnswer: { type: 'string', description: 'Given answer' },
-          discussionCode: { type: 'number', nullable: true },
-          discussionScore: { type: 'number', nullable: true },
-          discussionNotes: { type: 'string', nullable: true },
-          discussionManagerUserId: { type: 'number', nullable: true },
-          discussionManagerName: { type: 'string', nullable: true },
-          discussionSource: { type: 'string', enum: ['manual', 'auto_agreement'], nullable: true },
-          coders: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                jobId: { type: 'number', description: 'Job ID' },
-                coderName: { type: 'string', description: 'Name of the coder' },
-                code: {
-                  type: 'string',
-                  description: 'Code given by this coder'
-                },
-                score: {
-                  type: 'number',
-                  description: 'Score given by this coder'
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    schema: createTrainingComparisonPageSchema(
+      withinTrainingCodingComparisonRowSchema,
+      withinTrainingComparisonCoderSchema
+    )
   })
   async compareWithinTrainingCodingResults(
     @WorkspaceId() workspace_id: number,
-      @Query('trainingId') trainingId: number
-  ): Promise<
-      Array<{
-        responseId: number;
-        unitName: string;
-        variableId: string;
-        personCode: string;
-        personLogin: string;
-        personGroup: string;
-        bookletName: string;
-        testPerson: string;
-        givenAnswer: string;
-        replayCode: number | null;
-        replayScore: number | null;
-        discussionCode: number | null;
-        discussionScore: number | null;
-        discussionNotes: string | null;
-        discussionManagerUserId: number | null;
-        discussionManagerName: string | null;
-        discussionSource: 'manual' | 'auto_agreement' | null;
-        coders: Array<{
-          jobId: number;
-          coderName: string;
-          code: string | null;
-          score: number | null;
-          notes: string | null;
-          codingIssueOption: number | null;
-        }>;
-      }>
-      > {
+      @Query('trainingId') trainingIdParam: string,
+      @Query('page') page: string | undefined,
+      @Query('limit') limit: string | undefined,
+      @Query('sortBy') sortBy: string | undefined,
+      @Query('sortDirection') sortDirection: string | undefined,
+      @Query('jobIds') jobIds: string | undefined,
+      @Query('unitName') unitName: string | undefined,
+      @Query('variableId') variableId: string | undefined,
+      @Query('personLogin') personLogin: string | undefined,
+      @Query('personGroup') personGroup: string | undefined,
+      @Query('bookletName') bookletName: string | undefined,
+      @Query('match') match: string | undefined,
+      @Query('notesMode') notesMode: string | undefined,
+      @Query('regexSearch') regexSearch: string | undefined
+  ): Promise<WithinTrainingCodingComparisonPageDto> {
+    const trainingId = this.parsePositiveIntQuery(trainingIdParam, 'trainingId');
     if (!trainingId || trainingId <= 0) {
-      throw new Error('Valid training ID must be provided');
+      throw new BadRequestException('Valid training ID must be provided');
     }
 
-    // Get coding results for all jobs within the training
-    return this.coderTrainingService.getWithinTrainingCodingComparison(
+    return this.coderTrainingService.getWithinTrainingCodingComparisonPage(
       workspace_id,
-      trainingId
+      trainingId,
+      {
+        page: this.parsePositiveIntQuery(page, 'page', 1),
+        limit: this.parsePositiveIntQuery(limit, 'limit', 50, 500),
+        sortBy: this.parseComparisonSortBy(sortBy),
+        sortDirection: this.parseComparisonSortDirection(sortDirection),
+        selectedJobIds: this.parsePositiveIntCsv(jobIds, 'jobIds'),
+        filters: this.buildComparisonFilters(
+          unitName,
+          variableId,
+          personLogin,
+          personGroup,
+          bookletName,
+          match,
+          notesMode,
+          regexSearch
+        )
+      }
     );
   }
 
@@ -1186,7 +1382,8 @@ export class WorkspaceCoderTrainingController {
     @WorkspaceId() workspace_id: number,
       @Param('trainingId') trainingId: number,
       @Query('weightedMean') weightedMean?: string,
-      @Query('level') level?: 'code' | 'score'
+      @Query('level') level?: 'code' | 'score',
+      @Query('jobIds') jobIds?: string
   ): Promise<{
         variables: Array<{
           unitName: string;
@@ -1230,8 +1427,15 @@ export class WorkspaceCoderTrainingController {
       workspace_id,
       trainingId
     );
+    const selectedJobIds = this.parsePositiveIntCsv(jobIds, 'jobIds');
+    const filteredComparisonData = selectedJobIds === undefined ?
+      comparisonData :
+      comparisonData.map(item => ({
+        ...item,
+        coders: item.coders.filter(coder => selectedJobIds.includes(coder.jobId))
+      }));
 
-    if (comparisonData.length === 0) {
+    if (filteredComparisonData.length === 0) {
       return {
         variables: [],
         workspaceSummary: {
@@ -1246,10 +1450,10 @@ export class WorkspaceCoderTrainingController {
       };
     }
 
-    const caseCountsByVariable = this.calculateTrainingKappaCaseCountsByVariable(comparisonData, calculationLevel);
+    const caseCountsByVariable = this.calculateTrainingKappaCaseCountsByVariable(filteredComparisonData, calculationLevel);
 
     // 2. Transform to coder pairs format
-    const coderPairs = this.coderTrainingService.transformToCoderPairs(comparisonData);
+    const coderPairs = this.coderTrainingService.transformToCoderPairs(filteredComparisonData);
 
     if (coderPairs.length === 0) {
       return {

--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -1266,6 +1266,26 @@ describe('CoderTrainingService', () => {
   });
 
   describe('getTrainingCodingComparison', () => {
+    const emptyExclusions = {
+      globalIgnoredUnits: [],
+      ignoredBooklets: [],
+      testletIgnoredUnits: []
+    };
+
+    const createRawQueryBuilder = <T>(rawRows: T[]) => ({
+      innerJoin: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue(rawRows)
+    });
+
     const createComparisonUnit = (
       responseId: number,
       overrides: Partial<CodingJobUnit> = {}
@@ -1338,6 +1358,434 @@ describe('CoderTrainingService', () => {
         score: 1,
         codingIssueOption: null
       }));
+    });
+
+    it('returns a paged between-training comparison with global summary metrics', async () => {
+      const fullComparisonSpy = jest.spyOn(service, 'getTrainingCodingComparison').mockResolvedValue([]);
+      const serviceInternals = service as unknown as {
+        getTrainingComparisonAvailableCodersForJobs: () => Promise<unknown>;
+        getTrainingComparisonAggregateRows: () => Promise<unknown>;
+        getTrainingComparisonRowsForResponseIds: () => Promise<unknown>;
+      };
+      (coderTrainingRepository.find as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 1,
+          label: 'Training A',
+          codingJobs: [{
+            id: 11,
+            name: 'job-a',
+            training_id: 1,
+            missings_profile_id: null,
+            codingJobCoders: [{ user: { username: 'Coder A' } }]
+          }]
+        },
+        {
+          id: 2,
+          label: 'Training B',
+          codingJobs: [{
+            id: 21,
+            name: 'job-b',
+            training_id: 2,
+            missings_profile_id: null,
+            codingJobCoders: [{ user: { username: 'Coder B' } }]
+          }]
+        }
+      ]);
+      jest.spyOn(serviceInternals, 'getTrainingComparisonAvailableCodersForJobs').mockResolvedValue([
+        {
+          trainingId: 1,
+          trainingLabel: 'Training A',
+          coderId: 11,
+          coderName: 'Coder A'
+        },
+        {
+          trainingId: 2,
+          trainingLabel: 'Training B',
+          coderId: 21,
+          coderName: 'Coder B'
+        }
+      ]);
+      jest.spyOn(serviceInternals, 'getTrainingComparisonAggregateRows').mockResolvedValue([
+        {
+          responseId: 101,
+          unitName: 'Unit A',
+          variableId: 'VAR',
+          personCode: 'P1',
+          personLogin: 'login-a',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          completeCodeCount: 2,
+          distinctCodeCount: 2,
+          hasNotes: true
+        },
+        {
+          responseId: 102,
+          unitName: 'Unit B',
+          variableId: 'VAR',
+          personCode: 'P2',
+          personLogin: 'login-b',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          completeCodeCount: 2,
+          distinctCodeCount: 1,
+          hasNotes: false
+        },
+        {
+          responseId: 103,
+          unitName: 'Unit C',
+          variableId: 'VAR',
+          personCode: 'P3',
+          personLogin: 'login-c',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          completeCodeCount: 1,
+          distinctCodeCount: 1,
+          hasNotes: false
+        }
+      ]);
+      const pageRowsSpy = jest.spyOn(serviceInternals, 'getTrainingComparisonRowsForResponseIds').mockResolvedValue([
+        {
+          responseId: 102,
+          unitName: 'Unit B',
+          variableId: 'VAR',
+          personCode: 'P2',
+          personLogin: 'login-b',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          testPerson: 'login-b (group) - booklet',
+          coders: [
+            {
+              trainingId: 1,
+              trainingLabel: 'Training A',
+              coderId: 11,
+              coderName: 'Coder A',
+              code: '1',
+              score: 1,
+              notes: null,
+              codingIssueOption: null
+            },
+            {
+              trainingId: 2,
+              trainingLabel: 'Training B',
+              coderId: 21,
+              coderName: 'Coder B',
+              code: '1',
+              score: 1,
+              notes: null,
+              codingIssueOption: null
+            }
+          ]
+        }
+      ]);
+
+      const result = await service.getTrainingCodingComparisonPage(1, [1, 2], {
+        page: 2,
+        limit: 1,
+        sortBy: 'unitName',
+        sortDirection: 'desc',
+        selectedCoderKeys: ['1_11', '2_21']
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].responseId).toBe(102);
+      expect(result.total).toBe(3);
+      expect(result.totalPages).toBe(3);
+      expect(result.summary).toEqual({
+        visibleRows: 3,
+        comparableRows: 2,
+        matchingRows: 1,
+        matchingPercentage: 50,
+        incompleteRows: 1,
+        notComparableRows: 0,
+        deviationRows: 1,
+        completionRate: 67
+      });
+      expect(result.availableCoders).toEqual([
+        {
+          trainingId: 1,
+          trainingLabel: 'Training A',
+          coderId: 11,
+          coderName: 'Coder A'
+        },
+        {
+          trainingId: 2,
+          trainingLabel: 'Training B',
+          coderId: 21,
+          coderName: 'Coder B'
+        }
+      ]);
+      expect(fullComparisonSpy).not.toHaveBeenCalled();
+      expect(pageRowsSpy).toHaveBeenCalledWith(
+        1,
+        [1, 2],
+        [102],
+        expect.any(Array),
+        expect.any(Map),
+        expect.any(Object),
+        expect.any(Object)
+      );
+    });
+
+    it('normalizes selected coder keys before calculating between-training slots', () => {
+      const serviceInternals = service as unknown as {
+        getTrainingComparisonSelection: (
+          selectedTrainingIds: number[],
+          selectedCoderKeys: string[],
+          availableCoders: Array<{
+            trainingId: number;
+            trainingLabel: string;
+            coderId: number;
+            coderName: string;
+          }>
+        ) => { selectedJobIds: number[]; slotCount: number };
+      };
+
+      const result = serviceInternals.getTrainingComparisonSelection(
+        [1, 2, 2, 3],
+        ['1_11', '1_11', '2_21', '2_999', '4_41', 'invalid'],
+        [
+          {
+            trainingId: 1,
+            trainingLabel: 'Training A',
+            coderId: 11,
+            coderName: 'Coder A'
+          },
+          {
+            trainingId: 2,
+            trainingLabel: 'Training B',
+            coderId: 21,
+            coderName: 'Coder B'
+          }
+        ]
+      );
+
+      expect(result).toEqual({
+        selectedJobIds: [11, 21],
+        slotCount: 3
+      });
+    });
+
+    it('builds aggregate SQL for paged between-training comparison metrics', async () => {
+      const rawRows = [{
+        responseId: '101',
+        unitName: 'Unit A',
+        variableId: 'VAR',
+        personCode: 'P1',
+        personLogin: 'login-a',
+        personGroup: 'group',
+        bookletName: 'booklet',
+        completeCodeCount: '2',
+        distinctCodeCount: '1',
+        hasNotes: 'true'
+      }];
+      const qb = createRawQueryBuilder(rawRows);
+      const serviceInternals = service as unknown as {
+        getTrainingComparisonAggregateRows: (
+          workspaceId: number,
+          trainingIds: number[],
+          selectedJobIds: number[],
+          missingCodesByJobId: Map<number, {
+            mirCode: number;
+            mciCode: number;
+            negativeCodes: Set<number>;
+            scoresByCode: Map<number, number | null>;
+          }>,
+          defaultMissingCodeContext: {
+            mirCode: number;
+            mciCode: number;
+            negativeCodes: Set<number>;
+            scoresByCode: Map<number, number | null>;
+          },
+          exclusions: typeof emptyExclusions
+        ) => Promise<typeof rawRows>;
+      };
+      (mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      const result = await serviceInternals.getTrainingComparisonAggregateRows(
+        1,
+        [5],
+        [11],
+        new Map([
+          [11, {
+            mirCode: -31,
+            mciCode: -41,
+            negativeCodes: new Set([-31, -41]),
+            scoresByCode: new Map([[-31, 7], [-41, 3]])
+          }]
+        ]),
+        {
+          mirCode: -98,
+          mciCode: -97,
+          negativeCodes: new Set([-98, -97, -99]),
+          scoresByCode: new Map([[-98, 0], [-97, 0], [-99, 0]])
+        },
+        emptyExclusions
+      );
+
+      const aggregateSql = qb.addSelect.mock.calls.map(([sql]) => String(sql)).join('\n');
+      expect(result).toEqual(rawRows);
+      expect((mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder).toHaveBeenCalledWith('cju');
+      expect(qb.groupBy).toHaveBeenCalledWith('cju.response_id');
+      expect(qb.setParameter).toHaveBeenCalledWith('trainingComparisonSelectedJobIds', [11]);
+      expect(aggregateSql).toContain('COUNT(DISTINCT cj.id) FILTER');
+      expect(aggregateSql).toContain('COUNT(DISTINCT (CASE');
+      expect(aggregateSql).toContain('WHEN cju.code = -3 OR cju.coding_issue_option = -3');
+      expect(aggregateSql).toContain("WHEN 11 THEN '-31'");
+      expect(aggregateSql).toContain("ELSE '-98'");
+      expect(aggregateSql).toContain('BOOL_OR');
+    });
+
+    it('loads only requested between-training detail rows and maps display missing codes', async () => {
+      const rawRows = [
+        {
+          trainingId: 1,
+          trainingLabel: 'Training A',
+          jobId: 11,
+          coderName: null,
+          missingsProfileId: null,
+          responseId: 101,
+          unitName: 'Unit A',
+          variableId: 'VAR',
+          personCode: 'P1',
+          personLogin: 'login-a',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          code: null,
+          score: null,
+          notes: 'note',
+          codingIssueOption: -3
+        },
+        {
+          trainingId: 2,
+          trainingLabel: 'Training B',
+          jobId: 21,
+          coderName: 'Coder B',
+          missingsProfileId: null,
+          responseId: 101,
+          unitName: 'Unit A',
+          variableId: 'VAR',
+          personCode: 'P1',
+          personLogin: 'login-a',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          code: -4,
+          score: null,
+          notes: null,
+          codingIssueOption: null
+        }
+      ];
+      const qb = createRawQueryBuilder(rawRows);
+      const serviceInternals = service as unknown as {
+        getTrainingComparisonRowsForResponseIds: (
+          workspaceId: number,
+          trainingIds: number[],
+          responseIds: number[],
+          pageCandidates: Array<{
+            responseId: number;
+            unitName: string;
+            variableId: string;
+            personCode: string;
+            personLogin: string;
+            personGroup: string;
+            bookletName: string;
+            testPerson: string;
+            status: string;
+            hasNotes: boolean;
+          }>,
+          missingCodesByJobId: Map<number, {
+            mirCode: number;
+            mciCode: number;
+            negativeCodes: Set<number>;
+            scoresByCode: Map<number, number | null>;
+          }>,
+          defaultMissingCodeContext: {
+            mirCode: number;
+            mciCode: number;
+            negativeCodes: Set<number>;
+            scoresByCode: Map<number, number | null>;
+          },
+          exclusions: typeof emptyExclusions
+        ) => Promise<Array<{
+          responseId: number;
+          coders: Array<{
+            coderId: number;
+            coderName: string;
+            code: string | null;
+            score: number | null;
+            notes: string | null;
+          }>;
+        }>>;
+      };
+      (mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      const result = await serviceInternals.getTrainingComparisonRowsForResponseIds(
+        1,
+        [1, 2],
+        [101],
+        [{
+          responseId: 101,
+          unitName: 'Unit A',
+          variableId: 'VAR',
+          personCode: 'P1',
+          personLogin: 'login-a',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          testPerson: 'login-a (group) - booklet',
+          status: 'match',
+          hasNotes: true
+        }],
+        new Map([
+          [11, {
+            mirCode: -31,
+            mciCode: -41,
+            negativeCodes: new Set([-31, -41]),
+            scoresByCode: new Map([[-31, 7], [-41, 3]])
+          }]
+        ]),
+        {
+          mirCode: -98,
+          mciCode: -97,
+          negativeCodes: new Set([-98, -97, -99]),
+          scoresByCode: new Map([[-98, 0], [-97, 0], [-99, 0]])
+        },
+        emptyExclusions
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith('cju.response_id IN (:...responseIds)', { responseIds: [101] });
+      expect(result).toEqual([
+        {
+          responseId: 101,
+          unitName: 'Unit A',
+          variableId: 'VAR',
+          personCode: 'P1',
+          personLogin: 'login-a',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          testPerson: 'login-a (group) - booklet',
+          coders: [
+            {
+              trainingId: 1,
+              trainingLabel: 'Training A',
+              coderId: 11,
+              coderName: 'Job 11',
+              code: '-31',
+              score: 7,
+              notes: 'note',
+              codingIssueOption: -3
+            },
+            {
+              trainingId: 2,
+              trainingLabel: 'Training B',
+              coderId: 21,
+              coderName: 'Coder B',
+              code: '-97',
+              score: 0,
+              notes: null,
+              codingIssueOption: null
+            }
+          ]
+        }
+      ]);
     });
   });
 
@@ -2467,6 +2915,125 @@ describe('CoderTrainingService', () => {
         discussionManagerName: 'Manager',
         discussionSource: 'manual'
       });
+    });
+
+    it('filters within-training comparison pages before calculating the returned summary', async () => {
+      const fullComparisonSpy = jest.spyOn(service, 'getWithinTrainingCodingComparison').mockResolvedValue([]);
+      const serviceInternals = service as unknown as {
+        getWithinTrainingComparisonAggregateRows: () => Promise<unknown>;
+        getWithinTrainingComparisonRowsForResponseIds: () => Promise<unknown>;
+      };
+      (coderTrainingRepository.findOne as jest.Mock).mockResolvedValueOnce({
+        id: 5,
+        workspace_id: 1
+      });
+      (codingJobRepository.find as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 11,
+          name: 'job-a',
+          missings_profile_id: null,
+          codingJobCoders: [{ user: { username: 'Coder A' } }]
+        },
+        {
+          id: 12,
+          name: 'job-b',
+          missings_profile_id: null,
+          codingJobCoders: [{ user: { username: 'Coder B' } }]
+        }
+      ]);
+      const aggregateRowsSpy = jest.spyOn(serviceInternals, 'getWithinTrainingComparisonAggregateRows').mockResolvedValue([
+        {
+          responseId: 101,
+          unitName: 'Unit A',
+          variableId: 'VAR',
+          personCode: 'P1',
+          personLogin: 'login-a',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          completeCodeCount: 2,
+          distinctCodeCount: 2,
+          hasNotes: true
+        },
+        {
+          responseId: 102,
+          unitName: 'Unit B',
+          variableId: 'VAR',
+          personCode: 'P2',
+          personLogin: 'login-b',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          completeCodeCount: 2,
+          distinctCodeCount: 1,
+          hasNotes: false
+        }
+      ]);
+      const pageRowsSpy = jest.spyOn(serviceInternals, 'getWithinTrainingComparisonRowsForResponseIds').mockResolvedValue([
+        {
+          responseId: 101,
+          unitName: 'Unit A',
+          variableId: 'VAR',
+          personCode: 'P1',
+          personLogin: 'login-a',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          testPerson: 'login-a (group) - booklet',
+          givenAnswer: 'answer a',
+          replayCode: null,
+          replayScore: null,
+          discussionCode: null,
+          discussionScore: null,
+          discussionNotes: null,
+          discussionManagerUserId: null,
+          discussionManagerName: null,
+          discussionSource: null,
+          coders: []
+        }
+      ]);
+
+      const result = await service.getWithinTrainingCodingComparisonPage(1, 5, {
+        selectedJobIds: [11, 11, 12, 999],
+        filters: {
+          match: 'differ',
+          notesMode: 'with-notes'
+        }
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].responseId).toBe(101);
+      expect(result.total).toBe(1);
+      expect(result.summary).toEqual({
+        visibleRows: 1,
+        comparableRows: 1,
+        matchingRows: 0,
+        matchingPercentage: 0,
+        incompleteRows: 0,
+        notComparableRows: 0,
+        deviationRows: 1,
+        completionRate: 100
+      });
+      expect(result.availableCoders).toEqual([
+        { jobId: 11, coderName: 'Coder A' },
+        { jobId: 12, coderName: 'Coder B' }
+      ]);
+      expect(fullComparisonSpy).not.toHaveBeenCalled();
+      expect(aggregateRowsSpy).toHaveBeenCalledWith(
+        1,
+        5,
+        [11, 12],
+        expect.any(Map),
+        expect.any(Object),
+        expect.any(Object)
+      );
+      expect(pageRowsSpy).toHaveBeenCalledWith(
+        1,
+        5,
+        [101],
+        expect.any(Array),
+        expect.any(Array),
+        expect.any(Map),
+        expect.any(Object),
+        expect.any(Object)
+      );
     });
 
     it('rejects automatic missing agreement when raw comparison jobs use different missing profiles', async () => {

--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -3036,6 +3036,100 @@ describe('CoderTrainingService', () => {
       );
     });
 
+    it('treats regex-enabled comparison text filters as literal text on the backend', async () => {
+      const serviceInternals = service as unknown as {
+        getWithinTrainingComparisonAggregateRows: () => Promise<unknown>;
+        getWithinTrainingComparisonRowsForResponseIds: () => Promise<unknown>;
+      };
+      (coderTrainingRepository.findOne as jest.Mock).mockResolvedValueOnce({
+        id: 5,
+        workspace_id: 1
+      });
+      (codingJobRepository.find as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 11,
+          name: 'job-a',
+          missings_profile_id: null,
+          codingJobCoders: [{ user: { username: 'Coder A' } }]
+        },
+        {
+          id: 12,
+          name: 'job-b',
+          missings_profile_id: null,
+          codingJobCoders: [{ user: { username: 'Coder B' } }]
+        }
+      ]);
+      jest.spyOn(serviceInternals, 'getWithinTrainingComparisonAggregateRows').mockResolvedValue([
+        {
+          responseId: 201,
+          unitName: 'Unit .*',
+          variableId: 'VAR',
+          personCode: 'P1',
+          personLogin: 'login-a',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          completeCodeCount: 2,
+          distinctCodeCount: 1,
+          hasNotes: false
+        },
+        {
+          responseId: 202,
+          unitName: 'Unit ABC',
+          variableId: 'VAR',
+          personCode: 'P2',
+          personLogin: 'login-b',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          completeCodeCount: 2,
+          distinctCodeCount: 1,
+          hasNotes: false
+        }
+      ]);
+      const pageRowsSpy = jest.spyOn(serviceInternals, 'getWithinTrainingComparisonRowsForResponseIds').mockResolvedValue([
+        {
+          responseId: 201,
+          unitName: 'Unit .*',
+          variableId: 'VAR',
+          personCode: 'P1',
+          personLogin: 'login-a',
+          personGroup: 'group',
+          bookletName: 'booklet',
+          testPerson: 'login-a (group) - booklet',
+          givenAnswer: 'answer a',
+          replayCode: null,
+          replayScore: null,
+          discussionCode: null,
+          discussionScore: null,
+          discussionNotes: null,
+          discussionManagerUserId: null,
+          discussionManagerName: null,
+          discussionSource: null,
+          coders: []
+        }
+      ]);
+
+      const result = await service.getWithinTrainingCodingComparisonPage(1, 5, {
+        filters: {
+          unitName: 'Unit .*',
+          regexSearch: true
+        }
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.data[0].responseId).toBe(201);
+      expect(result.summary.visibleRows).toBe(1);
+      expect(pageRowsSpy).toHaveBeenCalledWith(
+        1,
+        5,
+        [201],
+        expect.any(Array),
+        expect.any(Array),
+        expect.any(Map),
+        expect.any(Object),
+        expect.any(Object)
+      );
+    });
+
     it('rejects automatic missing agreement when raw comparison jobs use different missing profiles', async () => {
       (coderTrainingRepository.findOne as jest.Mock).mockResolvedValueOnce({
         id: 5,

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -878,27 +878,9 @@ export class CoderTrainingService {
     return sortDirection === 'desc' ? 'desc' : 'asc';
   }
 
-  private isComparisonRegexPatternValid(pattern: string): boolean {
-    const normalizedPattern = pattern.trim();
-    if (!normalizedPattern) {
-      return true;
-    }
-    if (normalizedPattern.length > 256) {
-      return false;
-    }
-
-    try {
-      RegExp(normalizedPattern);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
   private matchesComparisonTextFilter(
     value: string | number | null | undefined,
-    filter: string | null | undefined,
-    regexSearch: boolean
+    filter: string | null | undefined
   ): boolean {
     const normalizedFilter = (filter || '').trim();
     if (!normalizedFilter) {
@@ -906,19 +888,7 @@ export class CoderTrainingService {
     }
 
     const text = String(value ?? '');
-    if (!regexSearch) {
-      return text.toLowerCase().includes(normalizedFilter.toLowerCase());
-    }
-
-    if (!this.isComparisonRegexPatternValid(normalizedFilter)) {
-      return false;
-    }
-
-    try {
-      return new RegExp(normalizedFilter).test(text);
-    } catch {
-      return false;
-    }
+    return text.toLowerCase().includes(normalizedFilter.toLowerCase());
   }
 
   private matchesComparisonTextFilters(
@@ -928,13 +898,12 @@ export class CoderTrainingService {
     >,
     filters: TrainingComparisonFiltersDto
   ): boolean {
-    const regexSearch = filters.regexSearch === true;
     return (
-      this.matchesComparisonTextFilter(row.unitName, filters.unitName, regexSearch) &&
-      this.matchesComparisonTextFilter(row.variableId, filters.variableId, regexSearch) &&
-      this.matchesComparisonTextFilter(row.personLogin, filters.personLogin, regexSearch) &&
-      this.matchesComparisonTextFilter(row.personGroup, filters.personGroup, regexSearch) &&
-      this.matchesComparisonTextFilter(row.bookletName, filters.bookletName, regexSearch)
+      this.matchesComparisonTextFilter(row.unitName, filters.unitName) &&
+      this.matchesComparisonTextFilter(row.variableId, filters.variableId) &&
+      this.matchesComparisonTextFilter(row.personLogin, filters.personLogin) &&
+      this.matchesComparisonTextFilter(row.personGroup, filters.personGroup) &&
+      this.matchesComparisonTextFilter(row.bookletName, filters.bookletName)
     );
   }
 

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -42,6 +42,19 @@ import {
   deduplicateManualCodingResponses
 } from './aggregation-metrics.util';
 import { TrainingComparisonFreshnessDto } from '../../../../../../../api-dto/coding/training-comparison-freshness.dto';
+import {
+  TrainingCodingComparisonPageDto,
+  TrainingCodingComparisonRowDto,
+  TrainingComparisonCoderDto,
+  TrainingComparisonFiltersDto,
+  TrainingComparisonNotesFilter,
+  TrainingComparisonSortBy,
+  TrainingComparisonSortDirection,
+  TrainingComparisonSummaryDto,
+  WithinTrainingCodingComparisonPageDto,
+  WithinTrainingCodingComparisonRowDto,
+  WithinTrainingComparisonCoderDto
+} from '../../../../../../../api-dto/coding/training-comparison.dto';
 
 interface CoderTrainingResponse {
   responseId: number;
@@ -175,6 +188,69 @@ type TrainingDiscussionFreshnessAggregateRow = {
 type TrainingComparisonResponseFreshnessRow = {
   responseId: number | string | null;
   responseHash: string | null;
+};
+
+type TrainingComparisonStatus = 'match' | 'differ' | 'incomplete' | 'not_comparable';
+
+type TrainingComparisonCodeSlot = {
+  code: string | null;
+  hasEntry: boolean;
+  trainingId?: number;
+};
+
+type TrainingComparisonPageOptions = {
+  page?: number;
+  limit?: number;
+  sortBy?: TrainingComparisonSortBy;
+  sortDirection?: TrainingComparisonSortDirection;
+  filters?: TrainingComparisonFiltersDto;
+  selectedCoderKeys?: string[];
+  selectedJobIds?: number[];
+};
+
+type TrainingComparisonAggregateRow = {
+  responseId: number | string;
+  unitName: string;
+  variableId: string;
+  personCode: string;
+  personLogin: string;
+  personGroup: string | null;
+  bookletName: string;
+  completeCodeCount: number | string | null;
+  distinctCodeCount: number | string | null;
+  hasNotes: boolean | string | number | null;
+};
+
+type TrainingComparisonCandidate = {
+  responseId: number;
+  unitName: string;
+  variableId: string;
+  personCode: string;
+  personLogin: string;
+  personGroup: string;
+  bookletName: string;
+  testPerson: string;
+  status: TrainingComparisonStatus;
+  hasNotes: boolean;
+};
+
+type TrainingComparisonRawUnitRow = {
+  trainingId: number | string;
+  trainingLabel: string;
+  jobId: number | string;
+  coderName: string | null;
+  missingsProfileId: number | string | null;
+  responseId: number | string;
+  unitName: string;
+  variableId: string;
+  personCode: string;
+  personLogin: string;
+  personGroup: string | null;
+  bookletName: string;
+  code: number | string | null;
+  score: number | string | null;
+  notes: string | null;
+  codingIssueOption: number | string | null;
 };
 
 type MissingCodePair = { mirCode: number; mciCode: number };
@@ -777,6 +853,893 @@ export class CoderTrainingService {
       this.makeTrainingVariableKey(variable.unit_name, variable.variable_id),
       variable
     ]));
+  }
+
+  private normalizeComparisonPage(page?: number): number {
+    const normalizedPage = Math.floor(Number(page ?? 1));
+    return Number.isFinite(normalizedPage) && normalizedPage > 0 ? normalizedPage : 1;
+  }
+
+  private normalizeComparisonLimit(limit?: number): number {
+    const normalizedLimit = Math.floor(Number(limit ?? 50));
+    if (!Number.isFinite(normalizedLimit) || normalizedLimit <= 0) {
+      return 50;
+    }
+    return Math.min(normalizedLimit, 500);
+  }
+
+  private normalizeComparisonSortBy(sortBy?: TrainingComparisonSortBy): TrainingComparisonSortBy {
+    return sortBy ?? 'unitName';
+  }
+
+  private normalizeComparisonSortDirection(
+    sortDirection?: TrainingComparisonSortDirection
+  ): TrainingComparisonSortDirection {
+    return sortDirection === 'desc' ? 'desc' : 'asc';
+  }
+
+  private isComparisonRegexPatternValid(pattern: string): boolean {
+    const normalizedPattern = pattern.trim();
+    if (!normalizedPattern) {
+      return true;
+    }
+    if (normalizedPattern.length > 256) {
+      return false;
+    }
+
+    try {
+      RegExp(normalizedPattern);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private matchesComparisonTextFilter(
+    value: string | number | null | undefined,
+    filter: string | null | undefined,
+    regexSearch: boolean
+  ): boolean {
+    const normalizedFilter = (filter || '').trim();
+    if (!normalizedFilter) {
+      return true;
+    }
+
+    const text = String(value ?? '');
+    if (!regexSearch) {
+      return text.toLowerCase().includes(normalizedFilter.toLowerCase());
+    }
+
+    if (!this.isComparisonRegexPatternValid(normalizedFilter)) {
+      return false;
+    }
+
+    try {
+      return new RegExp(normalizedFilter).test(text);
+    } catch {
+      return false;
+    }
+  }
+
+  private matchesComparisonTextFilters(
+    row: Pick<
+    TrainingCodingComparisonRowDto,
+    'unitName' | 'variableId' | 'personLogin' | 'personGroup' | 'bookletName'
+    >,
+    filters: TrainingComparisonFiltersDto
+  ): boolean {
+    const regexSearch = filters.regexSearch === true;
+    return (
+      this.matchesComparisonTextFilter(row.unitName, filters.unitName, regexSearch) &&
+      this.matchesComparisonTextFilter(row.variableId, filters.variableId, regexSearch) &&
+      this.matchesComparisonTextFilter(row.personLogin, filters.personLogin, regexSearch) &&
+      this.matchesComparisonTextFilter(row.personGroup, filters.personGroup, regexSearch) &&
+      this.matchesComparisonTextFilter(row.bookletName, filters.bookletName, regexSearch)
+    );
+  }
+
+  private getComparisonStatusFromSlots(slots: TrainingComparisonCodeSlot[]): TrainingComparisonStatus {
+    if (slots.length < 2) {
+      return 'not_comparable';
+    }
+
+    if (slots.some(slot => !slot.hasEntry || slot.code === null)) {
+      return 'incomplete';
+    }
+
+    const firstCode = slots[0].code;
+    return slots.every(slot => slot.code === firstCode) ? 'match' : 'differ';
+  }
+
+  private parseTrainingCoderKey(key: string): { trainingId: number; coderId: number } | null {
+    const [trainingIdRaw, coderIdRaw] = key.split('_');
+    const trainingId = Number(trainingIdRaw);
+    const coderId = Number(coderIdRaw);
+    if (!Number.isInteger(trainingId) || !Number.isInteger(coderId)) {
+      return null;
+    }
+    return { trainingId, coderId };
+  }
+
+  private getTrainingComparisonStatus(
+    row: TrainingCodingComparisonRowDto,
+    selectedTrainingIds: number[],
+    selectedCoderKeys: string[]
+  ): TrainingComparisonStatus {
+    const slots: TrainingComparisonCodeSlot[] = selectedCoderKeys.map(key => {
+      const parsedKey = this.parseTrainingCoderKey(key);
+      if (!parsedKey) {
+        return {
+          code: null,
+          hasEntry: false
+        };
+      }
+
+      const coder = row.coders.find(item => (
+        item.trainingId === parsedKey.trainingId &&
+        item.coderId === parsedKey.coderId
+      ));
+      return {
+        code: coder?.code ?? null,
+        hasEntry: !!coder,
+        trainingId: parsedKey.trainingId
+      };
+    });
+
+    const trainingsWithSelectedCoder = new Set(slots
+      .map(slot => slot.trainingId)
+      .filter((trainingId): trainingId is number => trainingId !== undefined));
+    selectedTrainingIds.forEach(trainingId => {
+      if (!trainingsWithSelectedCoder.has(trainingId)) {
+        slots.push({
+          code: null,
+          hasEntry: false,
+          trainingId
+        });
+      }
+    });
+
+    return this.getComparisonStatusFromSlots(slots);
+  }
+
+  private getWithinTrainingComparisonStatus(
+    row: WithinTrainingCodingComparisonRowDto,
+    selectedJobIds: number[]
+  ): TrainingComparisonStatus {
+    const slots = selectedJobIds.map(jobId => {
+      const coder = row.coders.find(item => item.jobId === jobId);
+      return {
+        code: coder?.code ?? null,
+        hasEntry: !!coder
+      };
+    });
+    return this.getComparisonStatusFromSlots(slots);
+  }
+
+  private rowHasTrainingComparisonNotes(
+    row: TrainingCodingComparisonRowDto,
+    selectedCoderKeys: string[]
+  ): boolean {
+    return selectedCoderKeys.some(key => {
+      const parsedKey = this.parseTrainingCoderKey(key);
+      if (!parsedKey) {
+        return false;
+      }
+      const coder = row.coders.find(item => (
+        item.trainingId === parsedKey.trainingId &&
+        item.coderId === parsedKey.coderId
+      ));
+      return !!coder?.notes?.trim();
+    });
+  }
+
+  private rowHasWithinTrainingComparisonNotes(
+    row: WithinTrainingCodingComparisonRowDto,
+    selectedJobIds: number[]
+  ): boolean {
+    return selectedJobIds.some(jobId => {
+      const coder = row.coders.find(item => item.jobId === jobId);
+      return !!coder?.notes?.trim();
+    });
+  }
+
+  private matchesComparisonStateFilters(
+    status: TrainingComparisonStatus,
+    hasNotes: boolean,
+    filters: TrainingComparisonFiltersDto
+  ): boolean {
+    if (filters.match === 'match' && status !== 'match') {
+      return false;
+    }
+    if (filters.match === 'differ' && status !== 'differ') {
+      return false;
+    }
+
+    const notesMode: TrainingComparisonNotesFilter = filters.notesMode ?? 'all';
+    if (notesMode === 'none') {
+      return !hasNotes;
+    }
+    if (notesMode === 'with-notes') {
+      return hasNotes;
+    }
+
+    return true;
+  }
+
+  private calculateComparisonSummary<T>(
+    rows: T[],
+    getStatus: (row: T) => TrainingComparisonStatus
+  ): TrainingComparisonSummaryDto {
+    const statuses = rows.map(row => getStatus(row));
+    const comparableRows = statuses.filter(status => status === 'match' || status === 'differ').length;
+    const matchingRows = statuses.filter(status => status === 'match').length;
+    const incompleteRows = statuses.filter(status => status === 'incomplete').length;
+    const notComparableRows = statuses.filter(status => status === 'not_comparable').length;
+    const visibleRows = rows.length;
+
+    return {
+      visibleRows,
+      comparableRows,
+      matchingRows,
+      matchingPercentage: comparableRows > 0 ? Math.round((matchingRows / comparableRows) * 100) : 0,
+      incompleteRows,
+      notComparableRows,
+      deviationRows: Math.max(comparableRows - matchingRows, 0),
+      completionRate: visibleRows > 0 ? Math.round((comparableRows / visibleRows) * 100) : 0
+    };
+  }
+
+  private getComparisonSortValue(
+    row: Pick<
+    TrainingCodingComparisonRowDto,
+    'responseId' | 'unitName' | 'variableId' | 'personLogin' | 'personGroup' | 'bookletName'
+    >,
+    sortBy: TrainingComparisonSortBy
+  ): string | number {
+    return row[sortBy] ?? '';
+  }
+
+  private compareComparisonValues(a: string | number, b: string | number): number {
+    if (typeof a === 'number' && typeof b === 'number') {
+      return a - b;
+    }
+    return String(a).localeCompare(String(b), 'de');
+  }
+
+  private sortComparisonRows<T extends Pick<
+  TrainingCodingComparisonRowDto,
+  'responseId' | 'unitName' | 'variableId' | 'personLogin' | 'personGroup' | 'bookletName'
+  >>(
+    rows: T[],
+    sortBy?: TrainingComparisonSortBy,
+    sortDirection?: TrainingComparisonSortDirection
+  ): T[] {
+    const normalizedSortBy = this.normalizeComparisonSortBy(sortBy);
+    const directionMultiplier = this.normalizeComparisonSortDirection(sortDirection) === 'desc' ? -1 : 1;
+
+    return [...rows].sort((a, b) => {
+      const primary = this.compareComparisonValues(
+        this.getComparisonSortValue(a, normalizedSortBy),
+        this.getComparisonSortValue(b, normalizedSortBy)
+      );
+      if (primary !== 0) {
+        return primary * directionMultiplier;
+      }
+
+      return (
+        this.compareComparisonValues(a.unitName, b.unitName) ||
+        this.compareComparisonValues(a.variableId, b.variableId) ||
+        this.compareComparisonValues(a.personLogin, b.personLogin) ||
+        this.compareComparisonValues(a.responseId, b.responseId)
+      );
+    });
+  }
+
+  private getTrainingComparisonAvailableCoders(
+    rows: TrainingCodingComparisonRowDto[]
+  ): TrainingComparisonCoderDto[] {
+    const codersByKey = new Map<string, TrainingComparisonCoderDto>();
+    rows.forEach(row => {
+      row.coders.forEach(coder => {
+        const key = `${coder.trainingId}_${coder.coderId}`;
+        if (!codersByKey.has(key)) {
+          codersByKey.set(key, {
+            trainingId: coder.trainingId,
+            trainingLabel: coder.trainingLabel,
+            coderId: coder.coderId,
+            coderName: coder.coderName
+          });
+        }
+      });
+    });
+
+    return Array.from(codersByKey.values()).sort((a, b) => (
+      a.trainingId - b.trainingId || a.coderName.localeCompare(b.coderName, 'de')
+    ));
+  }
+
+  private getWithinTrainingComparisonAvailableCoders(
+    rows: WithinTrainingCodingComparisonRowDto[]
+  ): WithinTrainingComparisonCoderDto[] {
+    const codersByJobId = new Map<number, WithinTrainingComparisonCoderDto>();
+    rows.forEach(row => {
+      row.coders.forEach(coder => {
+        if (!codersByJobId.has(coder.jobId)) {
+          codersByJobId.set(coder.jobId, {
+            jobId: coder.jobId,
+            coderName: coder.coderName
+          });
+        }
+      });
+    });
+
+    return Array.from(codersByJobId.values()).sort((a, b) => a.jobId - b.jobId);
+  }
+
+  private paginateComparisonRows<T>(rows: T[], page: number, limit: number): T[] {
+    return rows.slice((page - 1) * limit, page * limit);
+  }
+
+  private toBooleanValue(value: boolean | string | number | null | undefined): boolean {
+    return value === true || value === 'true' || value === 1 || value === '1';
+  }
+
+  private getComparisonStatusFromAggregate(
+    row: Pick<TrainingComparisonAggregateRow, 'completeCodeCount' | 'distinctCodeCount'>,
+    slotCount: number
+  ): TrainingComparisonStatus {
+    if (slotCount < 2) {
+      return 'not_comparable';
+    }
+
+    const completeCodeCount = this.toFreshnessNumber(row.completeCodeCount);
+    if (completeCodeCount < slotCount) {
+      return 'incomplete';
+    }
+
+    return this.toFreshnessNumber(row.distinctCodeCount) <= 1 ? 'match' : 'differ';
+  }
+
+  private toComparisonCandidate(
+    row: TrainingComparisonAggregateRow,
+    slotCount: number
+  ): TrainingComparisonCandidate {
+    const personGroup = row.personGroup || '';
+    return {
+      responseId: this.toFreshnessNumber(row.responseId),
+      unitName: row.unitName,
+      variableId: row.variableId,
+      personCode: row.personCode,
+      personLogin: row.personLogin,
+      personGroup,
+      bookletName: row.bookletName,
+      testPerson: `${row.personLogin} (${personGroup}) - ${row.bookletName}`,
+      status: this.getComparisonStatusFromAggregate(row, slotCount),
+      hasNotes: this.toBooleanValue(row.hasNotes)
+    };
+  }
+
+  private matchesComparisonCandidateFilters(
+    row: TrainingComparisonCandidate,
+    filters: TrainingComparisonFiltersDto
+  ): boolean {
+    return this.matchesComparisonTextFilters(row, filters) &&
+      this.matchesComparisonStateFilters(row.status, row.hasNotes, filters);
+  }
+
+  private calculateComparisonSummaryFromCandidates(
+    rows: TrainingComparisonCandidate[]
+  ): TrainingComparisonSummaryDto {
+    return this.calculateComparisonSummary(rows, row => row.status);
+  }
+
+  private getTrainingComparisonSelection(
+    selectedTrainingIds: number[],
+    selectedCoderKeys: string[],
+    availableCoders: TrainingComparisonCoderDto[]
+  ): { selectedJobIds: number[]; slotCount: number } {
+    const trainingIds = [...new Set(selectedTrainingIds)];
+    const selectedTrainingIdSet = new Set(trainingIds);
+    const availableCoderKeys = new Set(availableCoders.map(coder => `${coder.trainingId}_${coder.coderId}`));
+    const normalizedKeyMap = new Map<string, { trainingId: number; coderId: number }>();
+    const parsedKeys = selectedCoderKeys
+      .map(key => this.parseTrainingCoderKey(key))
+      .filter((key): key is { trainingId: number; coderId: number } => (
+        key !== null &&
+        selectedTrainingIdSet.has(key.trainingId) &&
+        availableCoderKeys.has(`${key.trainingId}_${key.coderId}`)
+      ));
+    parsedKeys.forEach(key => {
+      normalizedKeyMap.set(`${key.trainingId}_${key.coderId}`, key);
+    });
+    const normalizedKeys = [...normalizedKeyMap.values()];
+    const selectedTrainingKeys = new Set(normalizedKeys.map(key => key.trainingId));
+    const missingTrainingSlots = trainingIds
+      .filter(trainingId => !selectedTrainingKeys.has(trainingId))
+      .length;
+
+    return {
+      selectedJobIds: [...new Set(normalizedKeys.map(key => key.coderId))],
+      slotCount: normalizedKeys.length + missingTrainingSlots
+    };
+  }
+
+  private getWithinTrainingComparisonSelectedJobIds(
+    selectedJobIds: number[] | undefined,
+    jobs: Array<Pick<CodingJob, 'id'>>
+  ): number[] {
+    const availableJobIds = new Set(jobs.map(job => job.id));
+    const requestedJobIds = selectedJobIds ?? jobs.map(job => job.id);
+    return [...new Set(requestedJobIds.filter(jobId => availableJobIds.has(jobId)))];
+  }
+
+  private getTrainingJobCoderName(job: Pick<CodingJob, 'id' | 'name'> & {
+    codingJobCoders?: Array<{ user?: { username?: string | null } | null }> | null;
+  }): string {
+    return job.codingJobCoders?.[0]?.user?.username || `Job ${job.id}`;
+  }
+
+  private getWithinTrainingJobCoderName(job: Pick<CodingJob, 'id' | 'name'> & {
+    codingJobCoders?: Array<{ user?: { username?: string | null } | null }> | null;
+  }): string {
+    return job.codingJobCoders?.[0]?.user?.username || `Coder ${job.name}`;
+  }
+
+  private buildComparisonDisplayCodeSqlExpression(
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext
+  ): string {
+    const buildJobCase = (selector: (context: MissingCodeDisplayContext) => number): string => {
+      const cases = Array.from(missingCodesByJobId.entries())
+        .map(([jobId, context]) => `WHEN ${jobId} THEN '${selector(context)}'`)
+        .join(' ');
+      return `(CASE cj.id ${cases} ELSE '${selector(defaultMissingCodeContext)}' END)`;
+    };
+
+    return `CASE
+      WHEN cju.code IS NULL AND cju.coding_issue_option IS NULL THEN NULL
+      WHEN cju.code = -3 OR cju.coding_issue_option = -3 THEN ${buildJobCase(context => context.mirCode)}
+      WHEN cju.code = -4 OR cju.coding_issue_option = -4 THEN ${buildJobCase(context => context.mciCode)}
+      ELSE cju.code::text
+    END`;
+  }
+
+  private addComparisonAggregateSelects(
+    query: ReturnType<Repository<CodingJobUnit>['createQueryBuilder']>,
+    selectedJobIds: number[],
+    displayCodeExpression: string,
+    selectedJobParameterName: string
+  ): void {
+    if (selectedJobIds.length === 0) {
+      query
+        .addSelect('0', 'completeCodeCount')
+        .addSelect('0', 'distinctCodeCount')
+        .addSelect('false', 'hasNotes');
+      return;
+    }
+
+    const selectedJobCondition = `cj.id IN (:...${selectedJobParameterName})`;
+    query
+      .addSelect(
+        `COUNT(DISTINCT cj.id) FILTER (WHERE ${selectedJobCondition} AND (${displayCodeExpression}) IS NOT NULL)`,
+        'completeCodeCount'
+      )
+      .addSelect(
+        `COUNT(DISTINCT (${displayCodeExpression})) FILTER (WHERE ${selectedJobCondition} AND (${displayCodeExpression}) IS NOT NULL)`,
+        'distinctCodeCount'
+      )
+      .addSelect(
+        `COALESCE(BOOL_OR(${selectedJobCondition} AND cju.notes IS NOT NULL AND BTRIM(cju.notes) <> ''), false)`,
+        'hasNotes'
+      )
+      .setParameter(selectedJobParameterName, selectedJobIds);
+  }
+
+  private async getTrainingComparisonAvailableCodersForJobs(
+    workspaceId: number,
+    trainingIds: number[],
+    jobs: Array<Pick<CodingJob, 'id' | 'name' | 'training_id'> & {
+      training?: Pick<CoderTraining, 'id' | 'label'> | null;
+      codingJobCoders?: Array<{ user?: { username?: string | null } | null }> | null;
+    }>,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
+  ): Promise<TrainingComparisonCoderDto[]> {
+    if (jobs.length === 0) {
+      return [];
+    }
+
+    const query = this.codingJobUnitRepository
+      .createQueryBuilder('cju')
+      .innerJoin('cju.coding_job', 'cj')
+      .select('DISTINCT cj.id', 'jobId')
+      .where('cj.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('cj.training_id IN (:...trainingIds)', { trainingIds });
+
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      unitNameExpression: 'cju.unit_name',
+      bookletNameExpression: 'cju.booklet_name',
+      parameterPrefix: 'trainingComparisonAvailableCoders'
+    });
+
+    const rows = await query.getRawMany<{ jobId: number | string }>();
+    const jobIdsWithUnits = new Set(rows.map(row => this.toFreshnessNumber(row.jobId)));
+
+    return jobs
+      .filter(job => jobIdsWithUnits.has(job.id))
+      .map(job => ({
+        trainingId: job.training?.id ?? job.training_id!,
+        trainingLabel: job.training?.label ?? '',
+        coderId: job.id,
+        coderName: this.getTrainingJobCoderName(job)
+      }))
+      .sort((a, b) => (
+        a.trainingId - b.trainingId || a.coderName.localeCompare(b.coderName, 'de')
+      ));
+  }
+
+  private async getTrainingComparisonAggregateRows(
+    workspaceId: number,
+    trainingIds: number[],
+    selectedJobIds: number[],
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
+  ): Promise<TrainingComparisonAggregateRow[]> {
+    const displayCodeExpression = this.buildComparisonDisplayCodeSqlExpression(
+      missingCodesByJobId,
+      defaultMissingCodeContext
+    );
+    const query = this.codingJobUnitRepository
+      .createQueryBuilder('cju')
+      .innerJoin('cju.coding_job', 'cj')
+      .select('cju.response_id', 'responseId')
+      .addSelect('MIN(cju.unit_name)', 'unitName')
+      .addSelect('MIN(cju.variable_id)', 'variableId')
+      .addSelect('MIN(cju.person_code)', 'personCode')
+      .addSelect('MIN(cju.person_login)', 'personLogin')
+      .addSelect('MIN(cju.person_group)', 'personGroup')
+      .addSelect('MIN(cju.booklet_name)', 'bookletName')
+      .where('cj.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('cj.training_id IN (:...trainingIds)', { trainingIds })
+      .groupBy('cju.response_id');
+
+    this.addComparisonAggregateSelects(
+      query,
+      selectedJobIds,
+      displayCodeExpression,
+      'trainingComparisonSelectedJobIds'
+    );
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      unitNameExpression: 'cju.unit_name',
+      bookletNameExpression: 'cju.booklet_name',
+      parameterPrefix: 'trainingComparisonAggregate'
+    });
+
+    return query.getRawMany<TrainingComparisonAggregateRow>();
+  }
+
+  private async getTrainingComparisonRowsForResponseIds(
+    workspaceId: number,
+    trainingIds: number[],
+    responseIds: number[],
+    pageCandidates: TrainingComparisonCandidate[],
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
+  ): Promise<TrainingCodingComparisonRowDto[]> {
+    if (responseIds.length === 0) {
+      return [];
+    }
+
+    const query = this.codingJobUnitRepository
+      .createQueryBuilder('cju')
+      .innerJoin('cju.coding_job', 'cj')
+      .innerJoin('cj.training', 'ct')
+      .leftJoin('cj.codingJobCoders', 'cjc')
+      .leftJoin('cjc.user', 'coderUser')
+      .select('ct.id', 'trainingId')
+      .addSelect('ct.label', 'trainingLabel')
+      .addSelect('cj.id', 'jobId')
+      .addSelect('coderUser.username', 'coderName')
+      .addSelect('cj.missings_profile_id', 'missingsProfileId')
+      .addSelect('cju.response_id', 'responseId')
+      .addSelect('cju.unit_name', 'unitName')
+      .addSelect('cju.variable_id', 'variableId')
+      .addSelect('cju.person_code', 'personCode')
+      .addSelect('cju.person_login', 'personLogin')
+      .addSelect('cju.person_group', 'personGroup')
+      .addSelect('cju.booklet_name', 'bookletName')
+      .addSelect('cju.code', 'code')
+      .addSelect('cju.score', 'score')
+      .addSelect('cju.notes', 'notes')
+      .addSelect('cju.coding_issue_option', 'codingIssueOption')
+      .where('cj.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('cj.training_id IN (:...trainingIds)', { trainingIds })
+      .andWhere('cju.response_id IN (:...responseIds)', { responseIds })
+      .orderBy('ct.label', 'ASC')
+      .addOrderBy('cj.id', 'ASC')
+      .addOrderBy('cju.id', 'ASC');
+
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      unitNameExpression: 'cju.unit_name',
+      bookletNameExpression: 'cju.booklet_name',
+      parameterPrefix: 'trainingComparisonRows'
+    });
+
+    const rawRows = await query.getRawMany<TrainingComparisonRawUnitRow>();
+    const codersByResponseId = new Map<number, TrainingCodingComparisonRowDto['coders']>();
+    const seenSlots = new Set<string>();
+    rawRows.forEach(row => {
+      const responseId = this.toFreshnessNumber(row.responseId);
+      const jobId = this.toFreshnessNumber(row.jobId);
+      const slotKey = `${responseId}:${jobId}`;
+      if (seenSlots.has(slotKey)) {
+        return;
+      }
+      seenSlots.add(slotKey);
+
+      const code = this.toNullableScore(row.code);
+      const score = this.toNullableScore(row.score);
+      const codingIssueOption = this.toNullableScore(row.codingIssueOption);
+      const mappedDisplay = this.mapDisplayCodeAndScore(
+        code,
+        score,
+        codingIssueOption,
+        missingCodesByJobId.get(jobId) ?? defaultMissingCodeContext
+      );
+      const coders = codersByResponseId.get(responseId) ?? [];
+      coders.push({
+        trainingId: this.toFreshnessNumber(row.trainingId),
+        trainingLabel: row.trainingLabel,
+        coderId: jobId,
+        coderName: row.coderName || `Job ${jobId}`,
+        code: mappedDisplay.code,
+        score: mappedDisplay.score,
+        notes: row.notes,
+        codingIssueOption
+      });
+      codersByResponseId.set(responseId, coders);
+    });
+
+    return pageCandidates.map(candidate => ({
+      responseId: candidate.responseId,
+      unitName: candidate.unitName,
+      variableId: candidate.variableId,
+      personCode: candidate.personCode,
+      personLogin: candidate.personLogin,
+      personGroup: candidate.personGroup,
+      bookletName: candidate.bookletName,
+      testPerson: candidate.testPerson,
+      coders: codersByResponseId.get(candidate.responseId) ?? []
+    }));
+  }
+
+  private async getWithinTrainingComparisonAggregateRows(
+    workspaceId: number,
+    trainingId: number,
+    selectedJobIds: number[],
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
+  ): Promise<TrainingComparisonAggregateRow[]> {
+    const displayCodeExpression = this.buildComparisonDisplayCodeSqlExpression(
+      missingCodesByJobId,
+      defaultMissingCodeContext
+    );
+    const query = this.codingJobUnitRepository
+      .createQueryBuilder('cju')
+      .innerJoin('cju.coding_job', 'cj')
+      .select('cju.response_id', 'responseId')
+      .addSelect('MIN(cju.unit_name)', 'unitName')
+      .addSelect('MIN(cju.variable_id)', 'variableId')
+      .addSelect('MIN(cju.person_code)', 'personCode')
+      .addSelect('MIN(cju.person_login)', 'personLogin')
+      .addSelect('MIN(cju.person_group)', 'personGroup')
+      .addSelect('MIN(cju.booklet_name)', 'bookletName')
+      .where('cj.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('cj.training_id = :trainingId', { trainingId })
+      .groupBy('cju.response_id');
+
+    this.addComparisonAggregateSelects(
+      query,
+      selectedJobIds,
+      displayCodeExpression,
+      'withinTrainingComparisonSelectedJobIds'
+    );
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      unitNameExpression: 'cju.unit_name',
+      bookletNameExpression: 'cju.booklet_name',
+      parameterPrefix: 'withinTrainingComparisonAggregate'
+    });
+
+    return query.getRawMany<TrainingComparisonAggregateRow>();
+  }
+
+  private async getWithinTrainingComparisonRowsForResponseIds(
+    workspaceId: number,
+    trainingId: number,
+    responseIds: number[],
+    pageCandidates: TrainingComparisonCandidate[],
+    jobs: Array<Pick<CodingJob, 'id' | 'name' | 'missings_profile_id'> & {
+      codingJobCoders?: Array<{ user?: { username?: string | null } | null }> | null;
+    }>,
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
+  ): Promise<WithinTrainingCodingComparisonRowDto[]> {
+    if (responseIds.length === 0) {
+      return [];
+    }
+
+    const coderNameByJobId = new Map<number, string>();
+    jobs.forEach(job => {
+      coderNameByJobId.set(job.id, this.getWithinTrainingJobCoderName(job));
+    });
+
+    const query = this.codingJobUnitRepository
+      .createQueryBuilder('cju')
+      .innerJoin('cju.coding_job', 'cj')
+      .leftJoin('cju.response', 'resp')
+      .select('cj.id', 'jobId')
+      .addSelect('cju.id', 'unitRowId')
+      .addSelect('cju.response_id', 'responseId')
+      .addSelect('cju.unit_name', 'unitName')
+      .addSelect('cju.variable_id', 'variableId')
+      .addSelect('cju.person_code', 'personCode')
+      .addSelect('cju.person_login', 'personLogin')
+      .addSelect('cju.person_group', 'personGroup')
+      .addSelect('cju.booklet_name', 'bookletName')
+      .addSelect('resp.value', 'givenAnswer')
+      .addSelect('resp.code_v1', 'replayCodeV1')
+      .addSelect('resp.code_v2', 'replayCodeV2')
+      .addSelect('resp.code_v3', 'replayCodeV3')
+      .addSelect('resp.score_v1', 'replayScoreV1')
+      .addSelect('resp.score_v2', 'replayScoreV2')
+      .addSelect('resp.score_v3', 'replayScoreV3')
+      .addSelect('cju.code', 'code')
+      .addSelect('cju.score', 'score')
+      .addSelect('cju.notes', 'notes')
+      .addSelect('cju.coding_issue_option', 'codingIssueOption')
+      .where('cj.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('cj.training_id = :trainingId', { trainingId })
+      .andWhere('cju.response_id IN (:...responseIds)', { responseIds })
+      .orderBy('cju.id', 'ASC')
+      .addOrderBy('cj.id', 'ASC');
+
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      unitNameExpression: 'cju.unit_name',
+      bookletNameExpression: 'cju.booklet_name',
+      parameterPrefix: 'withinTrainingComparisonRows'
+    });
+
+    const rawRows = await query.getRawMany<WithinTrainingCodingRow>();
+    const unitsByResponseId = new Map<number, Map<number, WithinTrainingCodingRow>>();
+    const firstRowByResponseId = new Map<number, WithinTrainingCodingRow>();
+
+    rawRows.forEach(row => {
+      const responseId = this.toNullableScore(row.responseId);
+      const jobId = this.toNullableScore(row.jobId);
+      if (responseId === null || jobId === null) {
+        return;
+      }
+
+      if (!firstRowByResponseId.has(responseId)) {
+        firstRowByResponseId.set(responseId, row);
+      }
+      if (!unitsByResponseId.has(responseId)) {
+        unitsByResponseId.set(responseId, new Map<number, WithinTrainingCodingRow>());
+      }
+      unitsByResponseId.get(responseId)!.set(jobId, row);
+    });
+
+    const persistedDiscussionResults = await this.coderTrainingDiscussionResultRepository.find({
+      where: {
+        workspace_id: workspaceId,
+        training_id: trainingId,
+        response_id: In(responseIds)
+      }
+    });
+    const discussionByResponseId = new Map<number, CoderTrainingDiscussionResult>();
+    persistedDiscussionResults.forEach(result => {
+      discussionByResponseId.set(result.response_id, result);
+    });
+
+    const managerUserIds = [...new Set(persistedDiscussionResults
+      .map(result => result.manager_user_id)
+      .filter((id): id is number => id !== null && id !== undefined))];
+    const managerNameById = new Map<number, string>();
+    if (managerUserIds.length > 0) {
+      const users = await this.userRepository.find({
+        where: { id: In(managerUserIds) }
+      });
+      users.forEach(user => {
+        managerNameById.set(user.id, user.username);
+      });
+    }
+
+    const resultRows: WithinTrainingCodingComparisonRowDto[] = [];
+    for (const candidate of pageCandidates) {
+      const unitsByJobId = unitsByResponseId.get(candidate.responseId) ?? new Map<number, WithinTrainingCodingRow>();
+      const firstRow = firstRowByResponseId.get(candidate.responseId);
+      const codersData: WithinTrainingCoderResult[] = jobs.map(job => {
+        const unit = unitsByJobId.get(job.id);
+        const code = this.toNullableScore(unit?.code);
+        const score = this.toNullableScore(unit?.score);
+        const codingIssueOption = this.toNullableScore(unit?.codingIssueOption);
+        const mappedDisplay = this.mapDisplayCodeAndScore(
+          code,
+          score,
+          codingIssueOption,
+          missingCodesByJobId.get(job.id) ?? defaultMissingCodeContext
+        );
+
+        return {
+          jobId: job.id,
+          coderName: coderNameByJobId.get(job.id) ?? `Coder ${job.name}`,
+          code: mappedDisplay.code,
+          score: mappedDisplay.score,
+          notes: unit?.notes ?? null,
+          codingIssueOption
+        };
+      });
+
+      const discussionResult = discussionByResponseId.get(candidate.responseId);
+      const hasManualDiscussionResult = discussionResult?.code !== null && discussionResult?.code !== undefined;
+      const automaticDiscussionResult = hasManualDiscussionResult ?
+        null :
+        await this.deriveAutomaticDiscussionResultForRawResponse(
+          workspaceId,
+          trainingId,
+          candidate.responseId,
+          jobs,
+          unitsByJobId,
+          codersData
+        );
+      let discussionCode = automaticDiscussionResult?.code ?? null;
+      let discussionScore = automaticDiscussionResult?.score ?? null;
+      let discussionNotes: string | null = null;
+      let discussionManagerUserId: number | null = null;
+      let discussionManagerName: string | null = null;
+      let discussionSource: DiscussionSource = automaticDiscussionResult ? 'auto_agreement' : null;
+
+      if (hasManualDiscussionResult) {
+        discussionCode = discussionResult!.code;
+        discussionScore = discussionResult!.score;
+        discussionNotes = discussionResult!.notes ?? null;
+        discussionManagerUserId = discussionResult!.manager_user_id ?? null;
+        discussionManagerName = discussionResult!.manager_user_id ?
+          (managerNameById.get(discussionResult!.manager_user_id) ?? discussionResult!.manager_name ?? null) :
+          (discussionResult!.manager_name ?? null);
+        discussionSource = 'manual';
+      }
+
+      resultRows.push({
+        responseId: candidate.responseId,
+        unitName: candidate.unitName,
+        variableId: candidate.variableId,
+        personCode: candidate.personCode,
+        personLogin: candidate.personLogin,
+        personGroup: candidate.personGroup,
+        bookletName: candidate.bookletName,
+        testPerson: candidate.testPerson,
+        givenAnswer: firstRow?.givenAnswer || '',
+        replayCode: this.toNullableScore(firstRow?.replayCodeV3) ??
+          this.toNullableScore(firstRow?.replayCodeV2) ??
+          this.toNullableScore(firstRow?.replayCodeV1),
+        replayScore: this.toNullableScore(firstRow?.replayScoreV3) ??
+          this.toNullableScore(firstRow?.replayScoreV2) ??
+          this.toNullableScore(firstRow?.replayScoreV1),
+        discussionCode,
+        discussionScore,
+        discussionNotes,
+        discussionManagerUserId,
+        discussionManagerName,
+        discussionSource,
+        coders: codersData
+      });
+    }
+
+    return resultRows;
   }
 
   private mapDisplayCodeAndScore(
@@ -2245,6 +3208,101 @@ export class CoderTrainingService {
     return comparisonData;
   }
 
+  async getTrainingCodingComparisonPage(
+    workspaceId: number,
+    trainingIds: number[],
+    options: TrainingComparisonPageOptions = {}
+  ): Promise<TrainingCodingComparisonPageDto> {
+    const page = this.normalizeComparisonPage(options.page);
+    const limit = this.normalizeComparisonLimit(options.limit);
+    const filters = options.filters ?? {};
+    if (trainingIds.length === 0) {
+      return {
+        data: [],
+        total: 0,
+        page,
+        limit,
+        totalPages: 0,
+        summary: this.calculateComparisonSummaryFromCandidates([]),
+        availableCoders: []
+      };
+    }
+
+    const trainings = await this.coderTrainingRepository.find({
+      where: {
+        workspace_id: workspaceId,
+        id: In(trainingIds)
+      },
+      relations: [
+        'codingJobs',
+        'codingJobs.codingJobCoders',
+        'codingJobs.codingJobCoders.user'
+      ],
+      order: { label: 'ASC' }
+    });
+
+    if (trainings.length === 0) {
+      return {
+        data: [],
+        total: 0,
+        page,
+        limit,
+        totalPages: 0,
+        summary: this.calculateComparisonSummaryFromCandidates([]),
+        availableCoders: []
+      };
+    }
+
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const allTrainingJobs = trainings.flatMap(training => (
+      (training.codingJobs || []).map(job => ({
+        ...job,
+        training
+      }))
+    ));
+    const [missingCodesByJobId, defaultMissingCodeContext, availableCoders] = await Promise.all([
+      this.buildMissingCodesByJobId(workspaceId, allTrainingJobs),
+      this.getDefaultMissingCodeDisplayContext(workspaceId),
+      this.getTrainingComparisonAvailableCodersForJobs(workspaceId, trainingIds, allTrainingJobs, exclusions)
+    ]);
+    const selectedCoderKeys = options.selectedCoderKeys ?? availableCoders
+      .map(coder => `${coder.trainingId}_${coder.coderId}`);
+    const selection = this.getTrainingComparisonSelection(trainingIds, selectedCoderKeys, availableCoders);
+    const aggregateRows = await this.getTrainingComparisonAggregateRows(
+      workspaceId,
+      trainingIds,
+      selection.selectedJobIds,
+      missingCodesByJobId,
+      defaultMissingCodeContext,
+      exclusions
+    );
+
+    const filteredCandidates = aggregateRows
+      .map(row => this.toComparisonCandidate(row, selection.slotCount))
+      .filter(row => this.matchesComparisonCandidateFilters(row, filters));
+    const sortedCandidates = this.sortComparisonRows(filteredCandidates, options.sortBy, options.sortDirection);
+    const pageCandidates = this.paginateComparisonRows(sortedCandidates, page, limit);
+    const pageRows = await this.getTrainingComparisonRowsForResponseIds(
+      workspaceId,
+      trainingIds,
+      pageCandidates.map(row => row.responseId),
+      pageCandidates,
+      missingCodesByJobId,
+      defaultMissingCodeContext,
+      exclusions
+    );
+
+    return {
+      data: pageRows,
+      total: filteredCandidates.length,
+      page,
+      limit,
+      totalPages: Math.ceil(filteredCandidates.length / limit),
+      summary: this.calculateComparisonSummaryFromCandidates(filteredCandidates),
+      availableCoders
+    };
+  }
+
   private toFreshnessNumber(value: number | string | null | undefined): number {
     const numericValue = Number(value ?? 0);
     return Number.isFinite(numericValue) ? numericValue : 0;
@@ -2707,6 +3765,103 @@ export class CoderTrainingService {
     this.logger.log(`Generated within-training comparison data for ${comparisonData.length} unit/variable combinations across ${jobs.length} coders`);
 
     return comparisonData;
+  }
+
+  async getWithinTrainingCodingComparisonPage(
+    workspaceId: number,
+    trainingId: number,
+    options: TrainingComparisonPageOptions = {}
+  ): Promise<WithinTrainingCodingComparisonPageDto> {
+    const page = this.normalizeComparisonPage(options.page);
+    const limit = this.normalizeComparisonLimit(options.limit);
+    const filters = options.filters ?? {};
+    const training = await this.coderTrainingRepository.findOne({
+      where: {
+        workspace_id: workspaceId,
+        id: trainingId
+      }
+    });
+
+    if (!training) {
+      return {
+        data: [],
+        total: 0,
+        page,
+        limit,
+        totalPages: 0,
+        summary: this.calculateComparisonSummaryFromCandidates([]),
+        availableCoders: []
+      };
+    }
+
+    const jobs = await this.codingJobRepository.find({
+      where: {
+        workspace_id: workspaceId,
+        training_id: trainingId
+      },
+      relations: ['codingJobCoders.user'],
+      order: { id: 'ASC' }
+    });
+
+    if (jobs.length === 0) {
+      return {
+        data: [],
+        total: 0,
+        page,
+        limit,
+        totalPages: 0,
+        summary: this.calculateComparisonSummaryFromCandidates([]),
+        availableCoders: []
+      };
+    }
+
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const [missingCodesByJobId, defaultMissingCodeContext] = await Promise.all([
+      this.buildMissingCodesByJobId(workspaceId, jobs),
+      this.getDefaultMissingCodeDisplayContext(workspaceId)
+    ]);
+    const selectedJobIds = this.getWithinTrainingComparisonSelectedJobIds(options.selectedJobIds, jobs);
+    const aggregateRows = await this.getWithinTrainingComparisonAggregateRows(
+      workspaceId,
+      trainingId,
+      selectedJobIds,
+      missingCodesByJobId,
+      defaultMissingCodeContext,
+      exclusions
+    );
+    const availableCoders = aggregateRows.length > 0 ?
+      jobs.map(job => ({
+        jobId: job.id,
+        coderName: this.getWithinTrainingJobCoderName(job)
+      })) :
+      [];
+    const slotCount = selectedJobIds.length;
+
+    const filteredCandidates = aggregateRows
+      .map(row => this.toComparisonCandidate(row, slotCount))
+      .filter(row => this.matchesComparisonCandidateFilters(row, filters));
+    const sortedCandidates = this.sortComparisonRows(filteredCandidates, options.sortBy, options.sortDirection);
+    const pageCandidates = this.paginateComparisonRows(sortedCandidates, page, limit);
+    const pageRows = await this.getWithinTrainingComparisonRowsForResponseIds(
+      workspaceId,
+      trainingId,
+      pageCandidates.map(row => row.responseId),
+      pageCandidates,
+      jobs,
+      missingCodesByJobId,
+      defaultMissingCodeContext,
+      exclusions
+    );
+
+    return {
+      data: pageRows,
+      total: filteredCandidates.length,
+      page,
+      limit,
+      totalPages: Math.ceil(filteredCandidates.length / limit),
+      summary: this.calculateComparisonSummaryFromCandidates(filteredCandidates),
+      availableCoders
+    };
   }
 
   async updateCoderTraining(

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
@@ -190,10 +190,11 @@
       class="comparison-table"
       *ngIf="
         !isLoading &&
-        ((comparisonMode === 'between-trainings' &&
-          comparisonData.length > 0) ||
+        (((comparisonMode === 'between-trainings' &&
+          selectedTrainings.selected.length >= 2) ||
           (comparisonMode === 'within-training' &&
-            withinTrainingData.length > 0))
+            selectedTrainingForWithin)) &&
+          (totalItems > 0 || hasNoSelectedCodersState() || hasFilterEmptyState()))
       "
     >
       <div class="comparison-warning-list" *ngIf="getComparisonWarnings().length > 0">
@@ -692,20 +693,16 @@
           mat-table
           [dataSource]="dataSource"
           matSort
+          [matSortActive]="sortBy"
+          [matSortDirection]="sortDirection"
+          (matSortChange)="onComparisonSortChange($event)"
           class="mat-elevation-z2"
         >
           <!-- Index/Case Number Column -->
           <ng-container matColumnDef="index">
             <th mat-header-cell *matHeaderCellDef>#</th>
             <td mat-cell *matCellDef="let row; let i = index">
-              {{
-                (dataSource.paginator
-                  ? dataSource.paginator.pageIndex *
-                    dataSource.paginator.pageSize
-                  : 0) +
-                  i +
-                  1
-              }}
+              {{ pageIndex * pageSize + i + 1 }}
             </td>
           </ng-container>
 
@@ -1007,7 +1004,11 @@
         </table>
 
         <mat-paginator
+          [length]="totalItems"
+          [pageIndex]="pageIndex"
+          [pageSize]="pageSize"
           [pageSizeOptions]="[50, 100, 200, 500]"
+          (page)="onComparisonPageChange($event)"
           showFirstLastButtons
         ></mat-paginator>
       </div>
@@ -1052,8 +1053,10 @@
       *ngIf="
         !isLoading &&
         comparisonMode === 'between-trainings' &&
-        comparisonData.length === 0 &&
-        selectedTrainings.selected.length >= 2
+        totalItems === 0 &&
+        selectedTrainings.selected.length >= 2 &&
+        !hasActiveFilters() &&
+        !hasNoSelectedCodersState()
       "
     >
       <mat-icon>info</mat-icon>
@@ -1069,8 +1072,10 @@
       *ngIf="
         !isLoading &&
         comparisonMode === 'within-training' &&
-        withinTrainingData.length === 0 &&
-        selectedTrainingForWithin
+        totalItems === 0 &&
+        selectedTrainingForWithin &&
+        !hasActiveFilters() &&
+        !hasNoSelectedCodersState()
       "
     >
       <mat-icon>info</mat-icon>

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -22,6 +22,55 @@ import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-s
 import { TestPersonCodingService } from '../../services/test-person-coding.service';
 
 describe('CodingResultsComparisonComponent', () => {
+  const comparisonSummary = (visibleRows: number) => ({
+    visibleRows,
+    comparableRows: visibleRows,
+    matchingRows: visibleRows,
+    matchingPercentage: visibleRows > 0 ? 100 : 0,
+    incompleteRows: 0,
+    notComparableRows: 0,
+    deviationRows: 0,
+    completionRate: visibleRows > 0 ? 100 : 0
+  });
+  const withinComparisonPage = (
+    data: unknown[],
+    availableCoders = [{ jobId: 1, coderName: 'Coder 1' }]
+  ) => ({
+    data,
+    total: data.length,
+    page: 1,
+    limit: 50,
+    totalPages: data.length > 0 ? 1 : 0,
+    summary: comparisonSummary(data.length),
+    availableCoders
+  });
+  const betweenComparisonPage = (
+    data: unknown[],
+    summary = comparisonSummary(data.length),
+    availableCoders = [
+      {
+        trainingId: 1,
+        trainingLabel: 'Training 1',
+        coderId: 101,
+        coderName: 'Coder 101'
+      },
+      {
+        trainingId: 2,
+        trainingLabel: 'Training 2',
+        coderId: 201,
+        coderName: 'Coder 201'
+      }
+    ]
+  ) => ({
+    data,
+    total: data.length,
+    page: 1,
+    limit: 50,
+    totalPages: data.length > 0 ? 1 : 0,
+    summary,
+    availableCoders
+  });
+
   let component: CodingResultsComparisonComponent;
   let fixture: ComponentFixture<CodingResultsComparisonComponent>;
   let codingTrainingBackendService: {
@@ -169,7 +218,7 @@ describe('CodingResultsComparisonComponent', () => {
   });
 
   it('should load within-training comparison without requesting kappa while kappa section is collapsed', () => {
-    codingTrainingBackendService.getCachedWithinTrainingCodingResults.mockReturnValue(of([
+    codingTrainingBackendService.getCachedWithinTrainingCodingResults.mockReturnValue(of(withinComparisonPage([
       {
         responseId: 1,
         unitName: 'Unit1',
@@ -199,24 +248,27 @@ describe('CodingResultsComparisonComponent', () => {
           }
         ]
       }
-    ]));
+    ])));
     component.comparisonMode = 'within-training';
     component.selectedTrainingForWithin = 5;
     component.showKappaStatistics = false;
 
     component.loadComparison();
 
-    expect(codingTrainingBackendService.getCachedWithinTrainingCodingResults).toHaveBeenCalledWith(1, 5);
+    expect(codingTrainingBackendService.getCachedWithinTrainingCodingResults).toHaveBeenCalledWith(1, 5, expect.objectContaining({
+      page: 1,
+      limit: 50
+    }));
     expect(codingTrainingBackendService.getTrainingCohensKappa).not.toHaveBeenCalled();
     expect(component.withinTrainingData).toHaveLength(1);
     expect(component.isLoading).toBe(false);
   });
 
   it('should ignore stale within-training comparison responses after a training switch', () => {
-    const firstTrainingResponse$ = new Subject<unknown[]>();
-    const secondTrainingResponse$ = new Subject<unknown[]>();
+    const firstTrainingResponse$ = new Subject<unknown>();
+    const secondTrainingResponse$ = new Subject<unknown>();
     let firstTrainingUnsubscribed = false;
-    const firstTrainingResponse = new Observable<unknown[]>(subscriber => {
+    const firstTrainingResponse = new Observable<unknown>(subscriber => {
       const subscription = firstTrainingResponse$.subscribe(subscriber);
       return () => {
         firstTrainingUnsubscribed = true;
@@ -235,7 +287,7 @@ describe('CodingResultsComparisonComponent', () => {
     component.selectedTrainingForWithin = 6;
     component.loadComparison();
     expect(firstTrainingUnsubscribed).toBe(true);
-    secondTrainingResponse$.next([
+    secondTrainingResponse$.next(withinComparisonPage([
       {
         responseId: 2,
         unitName: 'Unit2',
@@ -265,9 +317,9 @@ describe('CodingResultsComparisonComponent', () => {
           }
         ]
       }
-    ]);
+    ]));
 
-    firstTrainingResponse$.next([
+    firstTrainingResponse$.next(withinComparisonPage([
       {
         responseId: 1,
         unitName: 'Unit1',
@@ -297,7 +349,7 @@ describe('CodingResultsComparisonComponent', () => {
           }
         ]
       }
-    ]);
+    ]));
 
     expect(component.selectedTrainingForWithin).toBe(6);
     expect(component.withinTrainingData).toHaveLength(1);
@@ -591,6 +643,7 @@ describe('CodingResultsComparisonComponent', () => {
       }
     ];
     component.dataSource.data = component.withinTrainingData;
+    component.calculateStatistics();
 
     (component as unknown as { updateDisplayedColumns: () => void }).updateDisplayedColumns();
     fixture.detectChanges();
@@ -750,10 +803,29 @@ describe('CodingResultsComparisonComponent', () => {
       match: 'differ',
       notesMode: 'with-notes'
     };
+    component.selectedTrainings.select(1, 2);
+    (component as unknown as { hasInitializedBetweenCoderSelection: boolean }).hasInitializedBetweenCoderSelection = true;
+    codingTrainingBackendService.compareTrainingCodingResults.mockReturnValue(of(betweenComparisonPage(
+      [component.comparisonData[1]],
+      {
+        visibleRows: 1,
+        comparableRows: 1,
+        matchingRows: 0,
+        matchingPercentage: 0,
+        incompleteRows: 0,
+        notComparableRows: 0,
+        deviationRows: 1,
+        completionRate: 100
+      }
+    )));
     component.applyTableFilters();
 
     expect(component.getFilteredRowsCount()).toBe(1);
-    expect(component.dataSource.filteredData.map(row => row.responseId)).toEqual([2]);
+    expect(component.dataSource.data.map(row => row.responseId)).toEqual([2]);
+    expect(codingTrainingBackendService.compareTrainingCodingResults).toHaveBeenCalledWith(1, '1,2', expect.objectContaining({
+      selectedCoderKeys: ['1_101', '2_201'],
+      filters: expect.objectContaining(component.tableFilters)
+    }));
     expect(component.totalComparisons).toBe(1);
     expect(component.matchingComparisons).toBe(0);
   });
@@ -828,10 +900,22 @@ describe('CodingResultsComparisonComponent', () => {
     component.dataSource.data = component.comparisonData;
     component.tableFilters.variableId = '^VAR_1';
     component.tableFilters.bookletName = 'Booklet-\\d+$';
+    component.selectedTrainings.select(1, 2);
+    (component as unknown as { hasInitializedBetweenCoderSelection: boolean }).hasInitializedBetweenCoderSelection = true;
+    codingTrainingBackendService.compareTrainingCodingResults.mockReturnValue(of(betweenComparisonPage([
+      component.comparisonData[0]
+    ])));
 
     component.applyTableFilters();
 
-    expect(component.dataSource.filteredData.map(row => row.responseId)).toEqual([1]);
+    expect(component.dataSource.data.map(row => row.responseId)).toEqual([1]);
+    expect(codingTrainingBackendService.compareTrainingCodingResults).toHaveBeenCalledWith(1, '1,2', expect.objectContaining({
+      filters: expect.objectContaining({
+        variableId: '^VAR_1',
+        bookletName: 'Booklet-\\d+$',
+        regexSearch: true
+      })
+    }));
   });
 
   it('should distinguish rows without visible coder notes from rows with visible coder notes', () => {
@@ -908,16 +992,31 @@ describe('CodingResultsComparisonComponent', () => {
       }
     ];
     component.dataSource.data = component.comparisonData;
+    component.selectedTrainings.select(1, 2);
+    (component as unknown as { hasInitializedBetweenCoderSelection: boolean }).hasInitializedBetweenCoderSelection = true;
+    const originalRows = [...component.comparisonData];
 
     component.tableFilters.notesMode = 'with-notes';
+    codingTrainingBackendService.compareTrainingCodingResults.mockReturnValueOnce(of(betweenComparisonPage([
+      originalRows[1]
+    ])));
     component.applyTableFilters();
 
-    expect(component.dataSource.filteredData.map(row => row.responseId)).toEqual([11]);
+    expect(component.dataSource.data.map(row => row.responseId)).toEqual([11]);
+    expect(codingTrainingBackendService.compareTrainingCodingResults).toHaveBeenLastCalledWith(1, '1,2', expect.objectContaining({
+      filters: expect.objectContaining({ notesMode: 'with-notes' })
+    }));
 
     component.tableFilters.notesMode = 'none';
+    codingTrainingBackendService.compareTrainingCodingResults.mockReturnValueOnce(of(betweenComparisonPage([
+      originalRows[0]
+    ])));
     component.applyTableFilters();
 
-    expect(component.dataSource.filteredData.map(row => row.responseId)).toEqual([10]);
+    expect(component.dataSource.data.map(row => row.responseId)).toEqual([10]);
+    expect(codingTrainingBackendService.compareTrainingCodingResults).toHaveBeenLastCalledWith(1, '1,2', expect.objectContaining({
+      filters: expect.objectContaining({ notesMode: 'none' })
+    }));
   });
 
   it('should render compact coding issue badges and only real note icons in coder cells', () => {
@@ -971,7 +1070,25 @@ describe('CodingResultsComparisonComponent', () => {
         ]
       }
     ];
+    component.selectedTrainings.select(1, 2);
+    component.availableCodersFromTrainings = [
+      {
+        trainingId: 1,
+        trainingLabel: 'Training A',
+        coderId: 101,
+        coderName: 'Ada'
+      },
+      {
+        trainingId: 2,
+        trainingLabel: 'Training B',
+        coderId: 201,
+        coderName: 'Ben'
+      }
+    ];
+    component.codersFromTrainingsFormControl.setValue(['1_101', '2_201']);
+    component.selectedCodersFromTrainings = new Set(['1_101', '2_201']);
     component.dataSource.data = component.comparisonData;
+    component.calculateStatistics();
 
     (component as unknown as { updateDisplayedColumns: () => void }).updateDisplayedColumns();
     fixture.detectChanges();
@@ -1086,6 +1203,7 @@ describe('CodingResultsComparisonComponent', () => {
       }
     ];
     component.dataSource.data = component.withinTrainingData;
+    component.calculateStatistics();
     component.discussionCodeByResponseId[1] = '7';
     component.discussionScoreByResponseId[1] = 2;
 
@@ -1981,11 +2099,18 @@ describe('CodingResultsComparisonComponent', () => {
         ]
       }
     ];
+    component.dataSource.data = component.withinTrainingData;
+    component.calculateStatistics();
     component.originalKappaStatistics = {
       variables: [
         {
           unitName: 'U1',
           variableId: 'V1',
+          meanKappa: 0.84,
+          meanAgreement: 0.866666,
+          caseCount: 1,
+          validPairCount: 15,
+          coderPairCount: 2,
           coderPairs: [
             {
               coder1Id: 1,
@@ -2093,6 +2218,11 @@ describe('CodingResultsComparisonComponent', () => {
       variables: [{
         unitName: 'U1',
         variableId: 'V1',
+        meanKappa: 0.85,
+        meanAgreement: 0.85,
+        caseCount: 1,
+        validPairCount: 15,
+        coderPairCount: 2,
         coderPairs: [
           {
             coder1Id: 1,

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -11,8 +11,10 @@ import {
 } from '@angular/material/dialog';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
-import { MatSort, MatSortModule } from '@angular/material/sort';
-import { MatPaginator, MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
+import {
+  MatPaginator, MatPaginatorIntl, MatPaginatorModule, PageEvent
+} from '@angular/material/paginator';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
@@ -52,6 +54,11 @@ import {
   ApplyTrainingDiscussionResultsDialogResult
 } from './apply-training-discussion-results-dialog.component';
 import { TrainingDiscussionApplySource } from '../../../../../../../api-dto/coding/training-discussion-apply.dto';
+import {
+  TrainingComparisonSummaryDto,
+  TrainingComparisonSortBy,
+  TrainingComparisonSortDirection
+} from '../../../../../../../api-dto/coding/training-comparison.dto';
 
 interface ReplayCodeSelectedMessage extends PostMessage {
   testPerson: string;
@@ -219,6 +226,17 @@ interface ModalValueSummary {
   isTie: boolean;
 }
 
+const EMPTY_COMPARISON_SUMMARY: TrainingComparisonSummaryDto = {
+  visibleRows: 0,
+  comparableRows: 0,
+  matchingRows: 0,
+  matchingPercentage: 0,
+  incompleteRows: 0,
+  notComparableRows: 0,
+  deviationRows: 0,
+  completionRate: 0
+};
+
 interface ModalValueDisplay {
   valueText: string;
   deviationText: string;
@@ -255,7 +273,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   @ViewChild(MatSort) sort!: MatSort;
   @ViewChild(MatPaginator) set matPaginator(mp: MatPaginator) {
     if (mp) {
-      this.dataSource.paginator = mp;
+      this.paginator = mp;
     }
   }
 
@@ -274,6 +292,9 @@ export class CodingResultsComparisonComponent implements OnInit {
   private comparisonRequestId = 0;
   private kappaRequestId = 0;
   private coderTrainingsRequestId = 0;
+  private paginator?: MatPaginator;
+  private hasInitializedBetweenCoderSelection = false;
+  private hasInitializedWithinCoderSelection = false;
 
   isLoading = false;
   isLoadingKappa = false;
@@ -303,6 +324,12 @@ export class CodingResultsComparisonComponent implements OnInit {
   matchingPercentage = 0;
   incompleteComparisons = 0;
   notComparableComparisons = 0;
+  totalItems = 0;
+  pageIndex = 0;
+  pageSize = 50;
+  sortBy: TrainingComparisonSortBy = 'unitName';
+  sortDirection: TrainingComparisonSortDirection = 'asc';
+  comparisonSummary: TrainingComparisonSummaryDto = { ...EMPTY_COMPARISON_SUMMARY };
 
   // Cohen's Kappa properties
   kappaStatistics: KappaStatistics | null = null;
@@ -419,7 +446,10 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   ngAfterViewInit(): void {
-    this.dataSource.sort = this.sort;
+    if (this.sort) {
+      this.sort.active = this.sortBy;
+      this.sort.direction = this.sortDirection;
+    }
   }
 
   private cancelComparisonRequest(): void {
@@ -509,12 +539,7 @@ export class CodingResultsComparisonComponent implements OnInit {
       return;
     }
 
-    this.dataSource.filter = JSON.stringify({
-      ...this.tableFilters,
-      regexSearch: this.enableRegexSearch
-    });
-    this.dataSource.paginator?.firstPage();
-    this.calculateStatistics();
+    this.reloadComparisonFirstPage();
   }
 
   resetTableFilters(): void {
@@ -535,7 +560,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   getFilteredRowsCount(): number {
-    return this.dataSource.filteredData?.length ?? this.dataSource.data.length;
+    return this.comparisonSummary.visibleRows;
   }
 
   hasActiveFilters(): boolean {
@@ -565,16 +590,17 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   hasNoSelectedCodersState(): boolean {
-    return this.getCurrentComparisonRows().length > 0 && this.getSelectedComparisonSourceCount() === 0;
+    const hasAvailableCoders = this.comparisonMode === 'between-trainings' ?
+      this.availableCodersFromTrainings.length > 0 :
+      this.availableCoders.length > 0;
+    return hasAvailableCoders && this.getSelectedComparisonSourceCount() === 0;
   }
 
   hasFilterEmptyState(): boolean {
     return (
       this.getSelectedComparisonSourceCount() > 0 &&
-      this.getCurrentComparisonRows().length > 0 &&
-      this.dataSource.data.length > 0 &&
       this.hasActiveFilters() &&
-      this.getFilteredRowsCount() === 0
+      this.totalItems === 0
     );
   }
 
@@ -614,7 +640,7 @@ export class CodingResultsComparisonComponent implements OnInit {
     const warnings: ComparisonWarning[] = [];
     const selectedSourceCount = this.getSelectedComparisonSourceCount();
 
-    if (this.getCurrentComparisonRows().length === 0) {
+    if (this.totalItems === 0 && !this.hasNoSelectedCodersState()) {
       return warnings;
     }
 
@@ -899,16 +925,11 @@ export class CodingResultsComparisonComponent implements OnInit {
   }
 
   getDeviationComparisons(): number {
-    return Math.max(this.totalComparisons - this.matchingComparisons, 0);
+    return this.comparisonSummary.deviationRows;
   }
 
   getVisibleCompletionRate(): number {
-    const visibleRows = this.getFilteredRowsCount();
-    if (visibleRows === 0) {
-      return 0;
-    }
-
-    return Math.round((this.totalComparisons / visibleRows) * 100);
+    return this.comparisonSummary.completionRate;
   }
 
   getDisplayCodeText(code: string | null, issueOption?: number | null): string {
@@ -1558,6 +1579,8 @@ export class CodingResultsComparisonComponent implements OnInit {
     this.availableCodersFromTrainings = [];
     this.codersFormControl.setValue([]);
     this.codersFromTrainingsFormControl.setValue([]);
+    this.hasInitializedBetweenCoderSelection = false;
+    this.hasInitializedWithinCoderSelection = false;
     this.selectedCodersFromTrainings.clear();
     this.selectedCoderIds.clear();
     this.dataSource.data = [];
@@ -1567,32 +1590,35 @@ export class CodingResultsComparisonComponent implements OnInit {
 
   onTrainingSelectionChange(): void {
     this.resetKappaState();
+    this.hasInitializedBetweenCoderSelection = false;
+    this.codersFromTrainingsFormControl.setValue([]);
+    this.selectedCodersFromTrainings.clear();
     if (this.comparisonMode === 'between-trainings' && this.selectedTrainings.selected.length >= 2) {
-      this.loadComparison();
+      this.reloadComparisonFirstPage();
     } else {
       this.cancelComparisonRequest();
-      this.comparisonData = [];
+      this.hasInitializedBetweenCoderSelection = false;
+      this.clearComparisonRows();
       this.availableCodersFromTrainings = [];
-      this.codersFromTrainingsFormControl.setValue([]);
-      this.selectedCodersFromTrainings.clear();
-      this.dataSource.data = [];
-      this.calculateStatistics();
       this.updateDisplayedColumns();
     }
   }
 
   onTrainingForWithinChange(): void {
     this.resetKappaState();
+    this.hasInitializedWithinCoderSelection = false;
     if (this.comparisonMode === 'within-training' && this.selectedTrainingForWithin) {
-      this.loadComparison();
-    } else {
-      this.cancelComparisonRequest();
-      this.withinTrainingData = [];
       this.availableCoders = [];
       this.codersFormControl.setValue([]);
       this.selectedCoderIds.clear();
-      this.dataSource.data = [];
-      this.calculateStatistics();
+      this.updateDisplayedColumns();
+      this.reloadComparisonFirstPage();
+    } else {
+      this.cancelComparisonRequest();
+      this.clearComparisonRows();
+      this.availableCoders = [];
+      this.codersFormControl.setValue([]);
+      this.selectedCoderIds.clear();
       this.updateDisplayedColumns();
     }
   }
@@ -1625,9 +1651,10 @@ export class CodingResultsComparisonComponent implements OnInit {
 
   onCodersFromTrainingsSelectionChange(): void {
     const selectedKeys = this.codersFromTrainingsFormControl.value || [];
+    this.hasInitializedBetweenCoderSelection = true;
     this.selectedCodersFromTrainings = new Set(selectedKeys);
     this.updateDisplayedColumns();
-    this.refreshDisplayedRows();
+    this.reloadComparisonFirstPage();
   }
 
   getCoderFromTrainingColumnName(key: string): string {
@@ -1671,17 +1698,40 @@ export class CodingResultsComparisonComponent implements OnInit {
     return this.hasCoderDisplayData(coder);
   }
 
-  calculateStatistics(): void {
-    const data = this.dataSource.filteredData || this.dataSource.data;
-    const statuses = data.map(item => this.getComparisonStatus(item));
-    const total = statuses.filter(status => status === 'match' || status === 'differ').length;
-    const matching = statuses.filter(status => status === 'match').length;
+  private applyComparisonSummary(summary: TrainingComparisonSummaryDto, total: number): void {
+    this.comparisonSummary = summary;
+    this.totalItems = total;
+    this.totalComparisons = summary.comparableRows;
+    this.matchingComparisons = summary.matchingRows;
+    this.matchingPercentage = summary.matchingPercentage;
+    this.incompleteComparisons = summary.incompleteRows;
+    this.notComparableComparisons = summary.notComparableRows;
+  }
 
-    this.totalComparisons = total;
-    this.matchingComparisons = matching;
-    this.matchingPercentage = total > 0 ? Math.round((matching / total) * 100) : 0;
-    this.incompleteComparisons = statuses.filter(status => status === 'incomplete').length;
-    this.notComparableComparisons = statuses.filter(status => status === 'not_comparable').length;
+  private resetComparisonSummary(): void {
+    this.applyComparisonSummary({ ...EMPTY_COMPARISON_SUMMARY }, 0);
+  }
+
+  calculateStatistics(): void {
+    const data = this.dataSource.data;
+    if (this.totalItems === 0 && this.comparisonSummary.visibleRows === 0 && data.length > 0) {
+      const statuses = data.map(item => this.getComparisonStatus(item));
+      const total = statuses.filter(status => status === 'match' || status === 'differ').length;
+      const matching = statuses.filter(status => status === 'match').length;
+      this.applyComparisonSummary({
+        visibleRows: data.length,
+        comparableRows: total,
+        matchingRows: matching,
+        matchingPercentage: total > 0 ? Math.round((matching / total) * 100) : 0,
+        incompleteRows: statuses.filter(status => status === 'incomplete').length,
+        notComparableRows: statuses.filter(status => status === 'not_comparable').length,
+        deviationRows: Math.max(total - matching, 0),
+        completionRate: data.length > 0 ? Math.round((total / data.length) * 100) : 0
+      }, data.length);
+      return;
+    }
+
+    this.applyComparisonSummary(this.comparisonSummary, this.totalItems);
   }
 
   private countSelectedCodes(comparison: TrainingComparison | WithinTrainingComparison): number {
@@ -1706,7 +1756,93 @@ export class CodingResultsComparisonComponent implements OnInit {
     } else {
       this.dataSource.data = this.withinTrainingData;
     }
-    this.applyTableFilters();
+  }
+
+  private canLoadCurrentComparison(): boolean {
+    return (
+      (this.comparisonMode === 'between-trainings' && this.selectedTrainings.selected.length >= 2) ||
+      (this.comparisonMode === 'within-training' && !!this.selectedTrainingForWithin)
+    );
+  }
+
+  private getComparisonQueryOptions() {
+    const baseOptions = {
+      page: this.pageIndex + 1,
+      limit: this.pageSize,
+      sortBy: this.sortBy,
+      sortDirection: this.sortDirection,
+      filters: {
+        ...this.tableFilters,
+        regexSearch: this.enableRegexSearch
+      }
+    };
+
+    if (this.comparisonMode === 'between-trainings') {
+      return {
+        ...baseOptions,
+        selectedCoderKeys: this.hasInitializedBetweenCoderSelection ?
+          (this.codersFromTrainingsFormControl.value || []) :
+          undefined
+      };
+    }
+
+    return {
+      ...baseOptions,
+      selectedJobIds: this.hasInitializedWithinCoderSelection ?
+        (this.codersFormControl.value || []) :
+        undefined
+    };
+  }
+
+  private clearComparisonRows(): void {
+    this.comparisonData = [];
+    this.withinTrainingData = [];
+    this.dataSource.data = [];
+    this.resetComparisonSummary();
+  }
+
+  private reloadComparisonFirstPage(): void {
+    this.pageIndex = 0;
+    if (this.paginator) {
+      this.paginator.pageIndex = 0;
+    }
+
+    if (this.canLoadCurrentComparison()) {
+      this.loadComparison();
+      return;
+    }
+
+    this.clearComparisonRows();
+  }
+
+  onComparisonPageChange(event: PageEvent): void {
+    this.pageIndex = event.pageIndex;
+    this.pageSize = event.pageSize;
+    if (this.canLoadCurrentComparison()) {
+      this.loadComparison();
+    }
+  }
+
+  onComparisonSortChange(sort: Sort): void {
+    if (this.isSupportedComparisonSort(sort.active) && sort.direction) {
+      this.sortBy = sort.active;
+      this.sortDirection = sort.direction;
+    } else {
+      this.sortBy = 'unitName';
+      this.sortDirection = 'asc';
+    }
+    this.reloadComparisonFirstPage();
+  }
+
+  private isSupportedComparisonSort(sortBy: string): sortBy is TrainingComparisonSortBy {
+    return [
+      'responseId',
+      'unitName',
+      'variableId',
+      'personLogin',
+      'personGroup',
+      'bookletName'
+    ].includes(sortBy);
   }
 
   loadComparison(): void {
@@ -1719,47 +1855,33 @@ export class CodingResultsComparisonComponent implements OnInit {
       const requestId = this.startComparisonRequest();
       this.resetKappaState();
       const trainingIds = this.selectedTrainings.selected.join(',');
-      this.codingTrainingBackendService.compareTrainingCodingResults(this.data.workspaceId, trainingIds)
+      this.codingTrainingBackendService.compareTrainingCodingResults(
+        this.data.workspaceId,
+        trainingIds,
+        this.getComparisonQueryOptions()
+      )
         .pipe(
           takeUntil(this.comparisonRequestCancel$),
           takeUntil(this.ngUnsubscribe)
         )
         .subscribe({
-          next: data => {
+          next: response => {
             if (requestId !== this.comparisonRequestId ||
               this.comparisonMode !== 'between-trainings' ||
               this.selectedTrainings.selected.join(',') !== trainingIds) {
               return;
             }
-            this.comparisonData = data;
-
-            // Extract all unique coders available in the data
-            const codersMap = new Map<string, { trainingId: number; trainingLabel: string; coderId: number; coderName: string }>();
-            this.comparisonData.forEach(item => {
-              item.coders.forEach(c => {
-                const key = `${c.trainingId}_${c.coderId}`;
-                if (!codersMap.has(key)) {
-                  codersMap.set(key, {
-                    trainingId: c.trainingId,
-                    trainingLabel: c.trainingLabel,
-                    coderId: c.coderId,
-                    coderName: c.coderName
-                  });
-                }
-              });
-            });
-
-            this.availableCodersFromTrainings = Array.from(codersMap.values()).sort((a, b) => {
-              if (a.trainingId !== b.trainingId) return a.trainingId - b.trainingId;
-              return a.coderName.localeCompare(b.coderName);
-            });
+            this.comparisonData = response.data;
+            this.availableCodersFromTrainings = response.availableCoders;
+            this.applyComparisonSummary(response.summary, response.total);
 
             const previousSelection = this.codersFromTrainingsFormControl.value || [];
             const allKeys = this.availableCodersFromTrainings.map(c => `${c.trainingId}_${c.coderId}`);
 
             let newSelection: string[];
-            if (previousSelection.length === 0) {
+            if (!this.hasInitializedBetweenCoderSelection) {
               newSelection = allKeys;
+              this.hasInitializedBetweenCoderSelection = true;
             } else {
               const currentlySelectedTrainings = new Set(previousSelection.map(key => key.split('_')[0]));
               newSelection = allKeys.filter(key => {
@@ -1794,22 +1916,26 @@ export class CodingResultsComparisonComponent implements OnInit {
       const trainingId = this.selectedTrainingForWithin;
       this.resetKappaState();
       this.withinTrainingData = [];
-      this.availableCoders = [];
-      this.codersFormControl.setValue([]);
-      this.selectedCoderIds.clear();
       this.dataSource.data = [];
-      this.codingTrainingBackendService.getCachedWithinTrainingCodingResults(this.data.workspaceId, trainingId)
+      this.codingTrainingBackendService.getCachedWithinTrainingCodingResults(
+        this.data.workspaceId,
+        trainingId,
+        this.getComparisonQueryOptions()
+      )
         .pipe(
           takeUntil(this.comparisonRequestCancel$),
           takeUntil(this.ngUnsubscribe)
         )
         .subscribe({
-          next: data => {
+          next: response => {
             if (requestId !== this.comparisonRequestId ||
               this.comparisonMode !== 'within-training' ||
               this.selectedTrainingForWithin !== trainingId) {
               return;
             }
+            this.availableCoders = response.availableCoders;
+            this.applyComparisonSummary(response.summary, response.total);
+            const data = response.data;
             const mappedData: WithinTrainingComparison[] = data.map(item => ({
               responseId: item.responseId,
               unitName: item.unitName,
@@ -1831,20 +1957,19 @@ export class CodingResultsComparisonComponent implements OnInit {
               coders: item.coders
             }));
 
-            // Determine available coders from all data items
-            if (mappedData.length > 0) {
-              this.availableCoders = mappedData[0].coders.map(c => ({
-                jobId: c.jobId,
-                coderName: c.coderName
-              }));
-              // Select all coders by default
+            if (this.availableCoders.length > 0) {
               const allCoderIds = this.availableCoders.map(c => c.jobId);
-              this.codersFormControl.setValue(allCoderIds);
-              this.selectedCoderIds.setSelection(...allCoderIds);
+              const currentSelection = this.codersFormControl.value || [];
+              const selectedIds = this.hasInitializedWithinCoderSelection ?
+                currentSelection.filter(jobId => allCoderIds.includes(jobId)) :
+                allCoderIds;
+              this.hasInitializedWithinCoderSelection = true;
+              this.codersFormControl.setValue(selectedIds);
+              this.selectedCoderIds.setSelection(...selectedIds);
             } else {
-              this.availableCoders = [];
               this.codersFormControl.setValue([]);
               this.selectedCoderIds.clear();
+              this.hasInitializedWithinCoderSelection = true;
             }
 
             this.withinTrainingData = mappedData;
@@ -1871,11 +1996,11 @@ export class CodingResultsComparisonComponent implements OnInit {
 
   onCoderSelectionChange(): void {
     const selectedIds = this.codersFormControl.value || [];
+    this.hasInitializedWithinCoderSelection = true;
     this.selectedCoderIds.clear();
     this.selectedCoderIds.select(...selectedIds);
     this.updateDisplayedColumns();
-    this.refreshDisplayedRows();
-    this.filterKappaStatistics();
+    this.reloadComparisonFirstPage();
   }
 
   getCoderCode(comparison: WithinTrainingComparison, jobId: number): string | null {
@@ -1929,7 +2054,8 @@ export class CodingResultsComparisonComponent implements OnInit {
         this.data.workspaceId,
         trainingId,
         this.useWeightedMean,
-        level
+        level,
+        this.codersFormControl.value || []
       )
       .pipe(
         takeUntil(this.kappaRequestCancel$),
@@ -1991,79 +2117,21 @@ export class CodingResultsComparisonComponent implements OnInit {
     return `${unitName}::${variableId}`;
   }
 
-  private countSelectedValidCoderValues(coders: WithinTrainingComparison['coders'], selectedCoderIds: number[]): number {
-    return coders.filter(coder => (
-      selectedCoderIds.includes(coder.jobId) &&
-      (this.useCodeLevel ? coder.code !== null : coder.score !== null)
-    )).length;
-  }
-
-  private countValidCasesForVariable(unitName: string, variableId: string, selectedCoderIds: number[]): number {
-    return this.withinTrainingData.filter(item => (
-      item.unitName === unitName &&
-      item.variableId === variableId &&
-      this.countSelectedValidCoderValues(item.coders, selectedCoderIds) >= 2
-    )).length;
-  }
-
   private buildVariableKappaSummaries(): void {
     if (!this.kappaStatistics) {
       this.variableKappaSummaries = [];
       return;
     }
 
-    const selectedCoderIds = this.codersFormControl.value || [];
-
-    this.variableKappaSummaries = this.kappaStatistics.variables.map(variable => {
-      let kappaSum = 0;
-      let kappaWeightedSum = 0;
-      let kappaWeight = 0;
-      let kappaCount = 0;
-      let agreementSum = 0;
-      let agreementWeightedSum = 0;
-      let agreementCount = 0;
-      let validPairCount = 0;
-
-      variable.coderPairs.forEach(pair => {
-        if (pair.validPairs > 0) {
-          agreementSum += pair.agreement;
-          agreementWeightedSum += pair.agreement * pair.validPairs;
-          agreementCount += 1;
-          validPairCount += pair.validPairs;
-        }
-
-        if (pair.kappa !== null && pair.validPairs > 0) {
-          kappaSum += pair.kappa;
-          kappaWeightedSum += pair.kappa * pair.validPairs;
-          kappaWeight += pair.validPairs;
-          kappaCount += 1;
-        }
-      });
-
-      let meanKappa: number | null = null;
-      if (this.useWeightedMean && kappaWeight > 0) {
-        meanKappa = kappaWeightedSum / kappaWeight;
-      } else if (!this.useWeightedMean && kappaCount > 0) {
-        meanKappa = kappaSum / kappaCount;
-      }
-
-      let meanAgreement: number | null = null;
-      if (this.useWeightedMean && validPairCount > 0) {
-        meanAgreement = agreementWeightedSum / validPairCount;
-      } else if (!this.useWeightedMean && agreementCount > 0) {
-        meanAgreement = agreementSum / agreementCount;
-      }
-
-      return {
-        key: this.buildVariableSummaryKey(variable.unitName, variable.variableId),
-        unitName: variable.unitName,
-        variableId: variable.variableId,
-        meanKappa,
-        meanAgreement,
-        caseCount: this.countValidCasesForVariable(variable.unitName, variable.variableId, selectedCoderIds),
-        validPairCount
-      };
-    });
+    this.variableKappaSummaries = this.kappaStatistics.variables.map(variable => ({
+      key: this.buildVariableSummaryKey(variable.unitName, variable.variableId),
+      unitName: variable.unitName,
+      variableId: variable.variableId,
+      meanKappa: variable.meanKappa ?? null,
+      meanAgreement: variable.meanAgreement ?? null,
+      caseCount: variable.caseCount ?? 0,
+      validPairCount: variable.validPairCount ?? 0
+    }));
   }
 
   getVariableSummary(variable: Pick<KappaVariable, 'unitName' | 'variableId'>): VariableKappaSummary | undefined {
@@ -2097,19 +2165,15 @@ export class CodingResultsComparisonComponent implements OnInit {
   updateSummaryFromFiltered(): void {
     if (!this.kappaStatistics) return;
 
-    // Recalculate totalDoubleCodedResponses based on selected coders and withinTrainingData
-    const selectedCoderIds = this.codersFormControl.value || [];
-    this.kappaStatistics.workspaceSummary.totalDoubleCodedResponses = this.withinTrainingData.filter(
-      d => this.countSelectedValidCoderValues(d.coders, selectedCoderIds) >= 2
-    ).length;
-
     let pairCount = 0;
     let totalKappaWeight = 0;
     let kappaPairCount = 0;
     let totalKappaWeighted = 0;
     let totalKappaSum = 0;
+    let totalDoubleCodedResponses = 0;
 
     this.kappaStatistics.variables.forEach(variable => {
+      totalDoubleCodedResponses += variable.caseCount ?? 0;
       variable.coderPairs.forEach(pair => {
         if (pair.validPairs > 0) {
           pairCount += 1;
@@ -2130,6 +2194,7 @@ export class CodingResultsComparisonComponent implements OnInit {
     this.kappaStatistics.workspaceSummary.averageKappa = this.useWeightedMean ?
       meanKappaWeighted : meanKappaArithmetic;
 
+    this.kappaStatistics.workspaceSummary.totalDoubleCodedResponses = totalDoubleCodedResponses;
     this.kappaStatistics.workspaceSummary.totalCoderPairs = pairCount;
     this.kappaStatistics.workspaceSummary.codersIncluded = this.codersFormControl.value?.length || 0;
     this.kappaStatistics.workspaceSummary.variablesIncluded = this.kappaStatistics.variables.length;

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts
@@ -330,6 +330,24 @@ describe('CodingTrainingBackendService', () => {
       discussionSource: null,
       coders: []
     }];
+    const comparisonPage = (data = comparisonData) => ({
+      data,
+      total: data.length,
+      page: 1,
+      limit: 50,
+      totalPages: data.length > 0 ? 1 : 0,
+      summary: {
+        visibleRows: data.length,
+        comparableRows: 0,
+        matchingRows: 0,
+        matchingPercentage: 0,
+        incompleteRows: 0,
+        notComparableRows: data.length,
+        deviationRows: 0,
+        completionRate: 0
+      },
+      availableCoders: []
+    });
 
     it('should reuse cached comparison data while freshness is unchanged', () => {
       const firstResults: unknown[] = [];
@@ -338,8 +356,8 @@ describe('CodingTrainingBackendService', () => {
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
         .flush(freshness('v1'));
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
-        .flush(comparisonData);
-      expect(firstResults).toEqual([comparisonData]);
+        .flush(comparisonPage());
+      expect(firstResults).toEqual([comparisonPage()]);
 
       const secondResults: unknown[] = [];
       service.getCachedWithinTrainingCodingResults(1, 5).subscribe(result => secondResults.push(result));
@@ -347,7 +365,7 @@ describe('CodingTrainingBackendService', () => {
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
         .flush(freshness('v1'));
       httpMock.expectNone(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`);
-      expect(secondResults).toEqual([comparisonData]);
+      expect(secondResults).toEqual([comparisonPage()]);
     });
 
     it('should reload comparison data when freshness changes', () => {
@@ -355,7 +373,7 @@ describe('CodingTrainingBackendService', () => {
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
         .flush(freshness('v1'));
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
-        .flush(comparisonData);
+        .flush(comparisonPage());
 
       const updatedData = [{ ...comparisonData[0], responseId: 2 }];
       const results: unknown[] = [];
@@ -364,8 +382,8 @@ describe('CodingTrainingBackendService', () => {
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
         .flush(freshness('v2'));
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
-        .flush(updatedData);
-      expect(results).toEqual([updatedData]);
+        .flush(comparisonPage(updatedData));
+      expect(results).toEqual([comparisonPage(updatedData)]);
     });
 
     it('should invalidate cached comparison data after saving a discussion result', () => {
@@ -373,7 +391,7 @@ describe('CodingTrainingBackendService', () => {
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
         .flush(freshness('v1'));
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
-        .flush(comparisonData);
+        .flush(comparisonPage());
 
       service.saveDiscussionResult(1, 5, 99, 7, 2, 'Replay note').subscribe();
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/discussion-result`)
@@ -391,7 +409,7 @@ describe('CodingTrainingBackendService', () => {
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/coder-trainings/5/comparison-freshness`)
         .flush(freshness('v1'));
       httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/compare-within-training?trainingId=5`)
-        .flush(comparisonData);
+        .flush(comparisonPage());
     });
   });
 

--- a/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-training-backend.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import {
   Observable,
   catchError,
@@ -18,6 +18,15 @@ import {
   TrainingDiscussionApplySource
 } from '../../../../../../api-dto/coding/training-discussion-apply.dto';
 import { TrainingComparisonFreshnessDto } from '../../../../../../api-dto/coding/training-comparison-freshness.dto';
+import {
+  TrainingCodingComparisonPageDto,
+  TrainingCodingComparisonRowDto,
+  TrainingComparisonFiltersDto,
+  TrainingComparisonSortBy,
+  TrainingComparisonSortDirection,
+  WithinTrainingCodingComparisonPageDto,
+  WithinTrainingCodingComparisonRowDto
+} from '../../../../../../api-dto/coding/training-comparison.dto';
 
 export interface CoderTrainingJob {
   coderId: number;
@@ -34,53 +43,17 @@ export interface CreateCoderTrainingJobsResponse {
   trainingId?: number;
 }
 
-export interface TrainingCodingResult {
-  responseId: number;
-  unitName: string;
-  variableId: string;
-  personCode: string;
-  personLogin: string;
-  personGroup: string;
-  bookletName: string;
-  testPerson: string;
-  coders: Array<{
-    trainingId: number;
-    trainingLabel: string;
-    coderId: number;
-    coderName: string;
-    code: string | null;
-    score: number | null;
-    notes: string | null;
-    codingIssueOption: number | null;
-  }>;
-}
+export type TrainingCodingResult = TrainingCodingComparisonRowDto;
+export type WithinTrainingCodingResult = WithinTrainingCodingComparisonRowDto;
 
-export interface WithinTrainingCodingResult {
-  responseId: number;
-  unitName: string;
-  variableId: string;
-  personCode: string;
-  personLogin: string;
-  personGroup: string;
-  bookletName: string;
-  testPerson: string;
-  givenAnswer: string;
-  replayCode: number | null;
-  replayScore: number | null;
-  discussionCode: number | null;
-  discussionScore: number | null;
-  discussionNotes: string | null;
-  discussionManagerUserId: number | null;
-  discussionManagerName: string | null;
-  discussionSource: 'manual' | 'auto_agreement' | null;
-  coders: Array<{
-    jobId: number;
-    coderName: string;
-    code: string | null;
-    score: number | null;
-    notes: string | null;
-    codingIssueOption: number | null;
-  }>;
+export interface TrainingComparisonQueryOptions {
+  page?: number;
+  limit?: number;
+  sortBy?: TrainingComparisonSortBy;
+  sortDirection?: TrainingComparisonSortDirection;
+  filters?: TrainingComparisonFiltersDto;
+  selectedCoderKeys?: string[];
+  selectedJobIds?: number[];
 }
 
 export interface CodingJobForTraining {
@@ -98,7 +71,7 @@ export interface CodingJobForTraining {
 
 interface WithinTrainingComparisonCacheEntry {
   freshness: TrainingComparisonFreshnessDto;
-  data: WithinTrainingCodingResult[];
+  pages: Map<string, WithinTrainingCodingComparisonPageDto>;
 }
 
 @Injectable({
@@ -303,23 +276,69 @@ export class CodingTrainingBackendService {
     );
   }
 
+  private buildTrainingComparisonParams(
+    options: TrainingComparisonQueryOptions,
+    selectedParamName?: 'coderKeys' | 'jobIds'
+  ): HttpParams {
+    let params = new HttpParams();
+
+    if (options.page !== undefined) {
+      params = params.set('page', options.page.toString());
+    }
+    if (options.limit !== undefined) {
+      params = params.set('limit', options.limit.toString());
+    }
+    if (options.sortBy) {
+      params = params.set('sortBy', options.sortBy);
+    }
+    if (options.sortDirection) {
+      params = params.set('sortDirection', options.sortDirection);
+    }
+
+    const filters = options.filters;
+    if (filters) {
+      if (filters.unitName) params = params.set('unitName', filters.unitName);
+      if (filters.variableId) params = params.set('variableId', filters.variableId);
+      if (filters.personLogin) params = params.set('personLogin', filters.personLogin);
+      if (filters.personGroup) params = params.set('personGroup', filters.personGroup);
+      if (filters.bookletName) params = params.set('bookletName', filters.bookletName);
+      if (filters.match) params = params.set('match', filters.match);
+      if (filters.notesMode) params = params.set('notesMode', filters.notesMode);
+      if (filters.regexSearch !== undefined) {
+        params = params.set('regexSearch', filters.regexSearch.toString());
+      }
+    }
+
+    if (selectedParamName === 'coderKeys' && options.selectedCoderKeys !== undefined) {
+      params = params.set('coderKeys', options.selectedCoderKeys.join(','));
+    }
+    if (selectedParamName === 'jobIds' && options.selectedJobIds !== undefined) {
+      params = params.set('jobIds', options.selectedJobIds.join(','));
+    }
+
+    return params;
+  }
+
   compareTrainingCodingResults(
     workspaceId: number,
-    trainingIds: string
-  ): Observable<TrainingCodingResult[]> {
-    const url = `${this.serverUrl
-    }admin/workspace/${workspaceId}/coding/compare-training-results?trainingIds=${encodeURIComponent(
-      trainingIds
-    )}`;
-    return this.http.get<TrainingCodingResult[]>(url, { headers: this.authHeader });
+    trainingIds: string,
+    options: TrainingComparisonQueryOptions = {}
+  ): Observable<TrainingCodingComparisonPageDto> {
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/compare-training-results`;
+    const params = this.buildTrainingComparisonParams(options, 'coderKeys')
+      .set('trainingIds', trainingIds);
+    return this.http.get<TrainingCodingComparisonPageDto>(url, { headers: this.authHeader, params });
   }
 
   compareWithinTrainingCodingResults(
     workspaceId: number,
-    trainingId: number
-  ): Observable<WithinTrainingCodingResult[]> {
-    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/compare-within-training?trainingId=${trainingId}`;
-    return this.http.get<WithinTrainingCodingResult[]>(url, { headers: this.authHeader });
+    trainingId: number,
+    options: TrainingComparisonQueryOptions = {}
+  ): Observable<WithinTrainingCodingComparisonPageDto> {
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/compare-within-training`;
+    const params = this.buildTrainingComparisonParams(options, 'jobIds')
+      .set('trainingId', trainingId.toString());
+    return this.http.get<WithinTrainingCodingComparisonPageDto>(url, { headers: this.authHeader, params });
   }
 
   getTrainingComparisonFreshness(
@@ -332,28 +351,35 @@ export class CodingTrainingBackendService {
 
   getCachedWithinTrainingCodingResults(
     workspaceId: number,
-    trainingId: number
-  ): Observable<WithinTrainingCodingResult[]> {
+    trainingId: number,
+    options: TrainingComparisonQueryOptions = {}
+  ): Observable<WithinTrainingCodingComparisonPageDto> {
     const cacheKey = this.getWithinTrainingComparisonCacheKey(workspaceId, trainingId);
+    const pageCacheKey = JSON.stringify(options);
 
     return this.getTrainingComparisonFreshness(workspaceId, trainingId).pipe(
       catchError(() => of(null)),
       switchMap(freshness => {
         if (!freshness) {
-          return this.compareWithinTrainingCodingResults(workspaceId, trainingId);
+          return this.compareWithinTrainingCodingResults(workspaceId, trainingId, options);
         }
 
         const cached = this.withinTrainingComparisonCache.get(cacheKey);
-        if (cached && cached.freshness.version === freshness.version) {
-          return of(cached.data);
+        const cachedPage = cached?.pages.get(pageCacheKey);
+        if (cached && cached.freshness.version === freshness.version && cachedPage) {
+          return of(cachedPage);
         }
 
-        return this.compareWithinTrainingCodingResults(workspaceId, trainingId).pipe(
-          tap(data => {
-            this.withinTrainingComparisonCache.set(cacheKey, {
-              freshness,
-              data
-            });
+        return this.compareWithinTrainingCodingResults(workspaceId, trainingId, options).pipe(
+          tap(page => {
+            const cacheEntry = cached && cached.freshness.version === freshness.version ?
+              cached :
+              {
+                freshness,
+                pages: new Map<string, WithinTrainingCodingComparisonPageDto>()
+              };
+            cacheEntry.pages.set(pageCacheKey, page);
+            this.withinTrainingComparisonCache.set(cacheKey, cacheEntry);
           })
         );
       })
@@ -436,7 +462,8 @@ export class CodingTrainingBackendService {
     workspaceId: number,
     trainingId: number,
     weightedMean: boolean = true,
-    level: 'code' | 'score' = 'code'
+    level: 'code' | 'score' = 'code',
+    selectedJobIds?: number[]
   ): Observable<{
       variables: Array<{
         unitName: string;
@@ -468,7 +495,13 @@ export class CodingTrainingBackendService {
         calculationLevel: 'code' | 'score';
       };
     }> {
-    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings/${trainingId}/cohens-kappa?weightedMean=${weightedMean}&level=${level}`;
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/coder-trainings/${trainingId}/cohens-kappa`;
+    let params = new HttpParams()
+      .set('weightedMean', weightedMean.toString())
+      .set('level', level);
+    if (selectedJobIds !== undefined) {
+      params = params.set('jobIds', selectedJobIds.join(','));
+    }
     return this.http.get<{
       variables: Array<{
         unitName: string;
@@ -499,6 +532,6 @@ export class CodingTrainingBackendService {
         weightingMethod: 'weighted' | 'unweighted';
         calculationLevel: 'code' | 'score';
       };
-    }>(url, { headers: this.authHeader });
+    }>(url, { headers: this.authHeader, params });
   }
 }

--- a/apps/frontend/src/app/services/facades/coding-facade.service.ts
+++ b/apps/frontend/src/app/services/facades/coding-facade.service.ts
@@ -20,8 +20,7 @@ import {
 import {
   CodingTrainingBackendService,
   CreateCoderTrainingJobsResponse,
-  TrainingCodingResult,
-  WithinTrainingCodingResult,
+  TrainingComparisonQueryOptions,
   CodingJobForTraining
 } from '../../coding/services/coding-training-backend.service';
 import { CodingExecutionService } from '../../coding/services/coding-execution.service';
@@ -41,6 +40,10 @@ import { ResponseEntity } from '../../shared/models/response-entity.model';
 import { CoderTraining } from '../../coding/models/coder-training.model';
 import { CodeBookContentSetting } from '../../../../../../api-dto/coding/codebook-content-setting';
 import { MissingsProfilesDto } from '../../../../../../api-dto/coding/missings-profiles.dto';
+import {
+  TrainingCodingComparisonPageDto,
+  WithinTrainingCodingComparisonPageDto
+} from '../../../../../../api-dto/coding/training-comparison.dto';
 
 interface PaginatedResponse<T> {
   data: T[];
@@ -281,12 +284,20 @@ export class CodingFacadeService {
     return this.codingTrainingBackendService.deleteCoderTraining(workspaceId, trainingId);
   }
 
-  compareTrainingCodingResults(workspaceId: number, trainingIds: string): Observable<TrainingCodingResult[]> {
-    return this.codingTrainingBackendService.compareTrainingCodingResults(workspaceId, trainingIds);
+  compareTrainingCodingResults(
+    workspaceId: number,
+    trainingIds: string,
+    options?: TrainingComparisonQueryOptions
+  ): Observable<TrainingCodingComparisonPageDto> {
+    return this.codingTrainingBackendService.compareTrainingCodingResults(workspaceId, trainingIds, options);
   }
 
-  compareWithinTrainingCodingResults(workspaceId: number, trainingId: number): Observable<WithinTrainingCodingResult[]> {
-    return this.codingTrainingBackendService.compareWithinTrainingCodingResults(workspaceId, trainingId);
+  compareWithinTrainingCodingResults(
+    workspaceId: number,
+    trainingId: number,
+    options?: TrainingComparisonQueryOptions
+  ): Observable<WithinTrainingCodingComparisonPageDto> {
+    return this.codingTrainingBackendService.compareWithinTrainingCodingResults(workspaceId, trainingId, options);
   }
 
   getCodingJobsForTraining(workspaceId: number, trainingId: number): Observable<CodingJobForTraining[]> {


### PR DESCRIPTION
## Summary
- add shared DTOs and backend endpoints for paged training comparison data
- compute global comparison metrics server-side while returning only the requested detail page
- wire the training comparison dialog to server-side paging, sorting, filtering, and summary data

## Impact
The training comparison view no longer needs to load the full comparison dataset before paginating. Existing full-result compatibility paths remain available where they are still used.

## Validation
- `npx tsc -p apps/backend/tsconfig.app.json --noEmit`
- `npx nx test backend --runInBand --testFile=apps/backend/src/app/database/services/coding/coder-training.service.spec.ts`
- `npx nx lint backend`
- `npx nx lint frontend`
- `npx nx test frontend --runInBand --testFile=apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts`
- `npx nx test frontend --runInBand --testFile=apps/frontend/src/app/coding/services/coding-training-backend.service.spec.ts`
- `npx nx test frontend --runInBand --testFile=apps/frontend/src/app/services/facades/coding-facade.service.spec.ts`
- `git diff --check`