### PR TITLE
Use aggregate query for training kappa

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.spec.ts
@@ -1,8 +1,7 @@
 import { WorkspaceCoderTrainingController } from './workspace-coder-training.controller';
 import {
   CoderTrainingResultsApplyService,
-  CoderTrainingService,
-  CodingStatisticsService
+  CoderTrainingService
 } from '../../database/services/coding';
 
 describe('WorkspaceCoderTrainingController', () => {
@@ -11,13 +10,10 @@ describe('WorkspaceCoderTrainingController', () => {
     getTrainingCodingComparisonPage: jest.Mock;
     getWithinTrainingCodingComparisonPage: jest.Mock;
     getWithinTrainingCodingComparison: jest.Mock;
+    getWithinTrainingCohensKappa: jest.Mock;
     getWithinTrainingComparisonFreshness: jest.Mock;
     transformToCoderPairs: jest.Mock;
     saveDiscussionResult: jest.Mock;
-  };
-  let codingStatisticsService: {
-    calculateCohensKappa: jest.Mock;
-    calculateKappaVariableSummary: jest.Mock;
   };
   let coderTrainingResultsApplyService: {
     previewTrainingDiscussionResults: jest.Mock;
@@ -29,13 +25,10 @@ describe('WorkspaceCoderTrainingController', () => {
       getTrainingCodingComparisonPage: jest.fn(),
       getWithinTrainingCodingComparisonPage: jest.fn(),
       getWithinTrainingCodingComparison: jest.fn(),
+      getWithinTrainingCohensKappa: jest.fn(),
       getWithinTrainingComparisonFreshness: jest.fn(),
       transformToCoderPairs: jest.fn(),
       saveDiscussionResult: jest.fn()
-    };
-    codingStatisticsService = {
-      calculateCohensKappa: jest.fn(),
-      calculateKappaVariableSummary: jest.fn()
     };
     coderTrainingResultsApplyService = {
       previewTrainingDiscussionResults: jest.fn(),
@@ -44,7 +37,6 @@ describe('WorkspaceCoderTrainingController', () => {
 
     controller = new WorkspaceCoderTrainingController(
       coderTrainingService as unknown as CoderTrainingService,
-      codingStatisticsService as unknown as CodingStatisticsService,
       coderTrainingResultsApplyService as unknown as CoderTrainingResultsApplyService
     );
   });
@@ -175,137 +167,40 @@ describe('WorkspaceCoderTrainingController', () => {
     );
   });
 
-  it('returns backend-calculated variable kappa summaries for coder trainings', async () => {
-    coderTrainingService.getWithinTrainingCodingComparison.mockResolvedValue([
-      {
-        responseId: 1,
-        unitName: 'U1',
-        variableId: 'V1',
-        coders: [
-          { jobId: 1, code: '1', score: 1 },
-          { jobId: 2, code: '1', score: 1 },
-          { jobId: 3, code: '1', score: 1 }
-        ]
-      },
-      {
-        responseId: 2,
-        unitName: 'U1',
-        variableId: 'V1',
-        coders: [
-          { jobId: 1, code: '1', score: 1 },
-          { jobId: 2, code: null, score: null },
-          { jobId: 3, code: '2', score: 2 }
-        ]
-      },
-      {
-        responseId: 3,
-        unitName: 'U2',
-        variableId: 'V2',
-        coders: [
-          { jobId: 1, code: '1', score: 1 },
-          { jobId: 2, code: null, score: null },
-          { jobId: 3, code: null, score: null }
-        ]
-      }
-    ]);
-    coderTrainingService.transformToCoderPairs.mockReturnValue([
-      {
-        coder1Id: 1,
-        coder1Name: 'Coder 1',
-        coder2Id: 2,
-        coder2Name: 'Coder 2',
-        unitName: 'U1',
-        variableId: 'V1',
-        codes: []
-      }
-    ]);
-    codingStatisticsService.calculateCohensKappa.mockReturnValue([
-      {
-        coder1Id: 1,
-        coder1Name: 'Coder 1',
-        coder2Id: 2,
-        coder2Name: 'Coder 2',
-        unitName: 'U1',
-        variableId: 'V1',
-        kappa: 0.5,
-        agreement: 0.8,
-        totalItems: 10,
-        validPairs: 10,
-        interpretation: 'kappa.moderate'
-      },
-      {
-        coder1Id: 1,
-        coder1Name: 'Coder 1',
-        coder2Id: 3,
-        coder2Name: 'Coder 3',
-        unitName: 'U1',
-        variableId: 'V1',
-        kappa: 0.7,
-        agreement: 0.9,
-        totalItems: 5,
-        validPairs: 5,
-        interpretation: 'kappa.substantial'
-      },
-      {
-        coder1Id: 2,
-        coder1Name: 'Coder 2',
-        coder2Id: 3,
-        coder2Name: 'Coder 3',
-        unitName: 'U2',
-        variableId: 'V2',
-        kappa: null,
-        agreement: 0,
-        totalItems: 4,
-        validPairs: 0,
-        interpretation: 'No valid coding pairs'
-      }
-    ]);
-    codingStatisticsService.calculateKappaVariableSummary
-      .mockReturnValueOnce({
-        meanKappa: 0.6,
-        meanAgreement: 0.85,
-        validPairCount: 15,
-        coderPairCount: 2
-      })
-      .mockReturnValueOnce({
-        meanKappa: null,
-        meanAgreement: null,
-        validPairCount: 0,
-        coderPairCount: 0
-      });
-
-    const result = await controller.getTrainingCohensKappa(12, 5, 'false', 'code');
-
-    expect(result.variables).toEqual([
-      expect.objectContaining({
+  it('forwards coder-training kappa requests to the service without loading comparison rows', async () => {
+    const kappaStatistics = {
+      variables: [{
         unitName: 'U1',
         variableId: 'V1',
         meanKappa: 0.6,
         meanAgreement: 0.85,
         caseCount: 2,
         validPairCount: 15,
-        coderPairCount: 2
-      }),
-      expect.objectContaining({
-        unitName: 'U2',
-        variableId: 'V2',
-        meanKappa: null,
-        meanAgreement: null,
-        caseCount: 0,
-        validPairCount: 0,
-        coderPairCount: 0
-      })
-    ]);
-    expect(codingStatisticsService.calculateKappaVariableSummary).toHaveBeenCalledWith([
-      expect.objectContaining({ unitName: 'U1', variableId: 'V1', kappa: 0.5 }),
-      expect.objectContaining({ unitName: 'U1', variableId: 'V1', kappa: 0.7 })
-    ]);
-    expect(codingStatisticsService.calculateKappaVariableSummary).toHaveBeenCalledWith([
-      expect.objectContaining({ unitName: 'U2', variableId: 'V2', kappa: null })
-    ]);
-    expect(result.workspaceSummary.weightingMethod).toBe('unweighted');
-    expect(result.workspaceSummary.calculationLevel).toBe('code');
-    expect(result.workspaceSummary.totalDoubleCodedResponses).toBe(2);
+        coderPairCount: 2,
+        coderPairs: []
+      }],
+      workspaceSummary: {
+        totalDoubleCodedResponses: 2,
+        totalCoderPairs: 1,
+        averageKappa: 0.6,
+        variablesIncluded: 1,
+        codersIncluded: 2,
+        weightingMethod: 'unweighted' as const,
+        calculationLevel: 'score' as const
+      }
+    };
+    coderTrainingService.getWithinTrainingCohensKappa.mockResolvedValue(kappaStatistics);
+
+    const result = await controller.getTrainingCohensKappa(12, 5, 'false', 'score', '11,12');
+
+    expect(result).toBe(kappaStatistics);
+    expect(coderTrainingService.getWithinTrainingCohensKappa).toHaveBeenCalledWith(12, 5, {
+      weightedMean: false,
+      level: 'score',
+      selectedJobIds: [11, 12]
+    });
+    expect(coderTrainingService.getWithinTrainingCodingComparison).not.toHaveBeenCalled();
+    expect(coderTrainingService.transformToCoderPairs).not.toHaveBeenCalled();
   });
 
   it('forwards comparison freshness requests to the service', async () => {

--- a/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coder-training.controller.ts
@@ -24,8 +24,7 @@ import { WorkspaceGuard } from './workspace.guard';
 import { WorkspaceId } from './workspace.decorator';
 import {
   CoderTrainingResultsApplyService,
-  CoderTrainingService,
-  CodingStatisticsService
+  CoderTrainingService
 } from '../../database/services/coding';
 import { JobDefinitionVariable, JobDefinitionVariableBundle } from '../../database/entities/job-definition.entity';
 import { AccessLevelGuard, RequireAccessLevel } from './access-level.guard';
@@ -165,42 +164,8 @@ const createTrainingComparisonPageSchema = (
 export class WorkspaceCoderTrainingController {
   constructor(
     private coderTrainingService: CoderTrainingService,
-    private codingStatisticsService: CodingStatisticsService,
     private coderTrainingResultsApplyService: CoderTrainingResultsApplyService
   ) { }
-
-  private getTrainingKappaVariableKey(unitName: string, variableId: string): string {
-    return `${unitName}:${variableId}`;
-  }
-
-  private countValidCoderValuesForKappa(
-    coders: Array<{ code: string | number | null; score: number | null }>,
-    level: 'code' | 'score'
-  ): number {
-    return coders.filter(coder => (
-      level === 'score' ? coder.score !== null : coder.code !== null
-    )).length;
-  }
-
-  private calculateTrainingKappaCaseCountsByVariable(
-    comparisonData: Array<{
-      unitName: string;
-      variableId: string;
-      coders: Array<{ code: string | number | null; score: number | null }>;
-    }>,
-    level: 'code' | 'score'
-  ): Map<string, number> {
-    const caseCountsByVariable = new Map<string, number>();
-
-    comparisonData.forEach(item => {
-      if (this.countValidCoderValuesForKappa(item.coders, level) < 2) return;
-
-      const key = this.getTrainingKappaVariableKey(item.unitName, item.variableId);
-      caseCountsByVariable.set(key, (caseCountsByVariable.get(key) ?? 0) + 1);
-    });
-
-    return caseCountsByVariable;
-  }
 
   private parsePositiveIntQuery(
     value: string | undefined,
@@ -1421,123 +1386,12 @@ export class WorkspaceCoderTrainingController {
 
     const useWeightedMean = weightedMean !== 'false'; // Default true
     const calculationLevel = level || 'code'; // Default to code level
-
-    // 1. Get within-training comparison data
-    const comparisonData = await this.coderTrainingService.getWithinTrainingCodingComparison(
-      workspace_id,
-      trainingId
-    );
     const selectedJobIds = this.parsePositiveIntCsv(jobIds, 'jobIds');
-    const filteredComparisonData = selectedJobIds === undefined ?
-      comparisonData :
-      comparisonData.map(item => ({
-        ...item,
-        coders: item.coders.filter(coder => selectedJobIds.includes(coder.jobId))
-      }));
 
-    if (filteredComparisonData.length === 0) {
-      return {
-        variables: [],
-        workspaceSummary: {
-          totalDoubleCodedResponses: 0,
-          totalCoderPairs: 0,
-          averageKappa: null,
-          variablesIncluded: 0,
-          codersIncluded: 0,
-          weightingMethod: useWeightedMean ? 'weighted' : 'unweighted',
-          calculationLevel
-        }
-      };
-    }
-
-    const caseCountsByVariable = this.calculateTrainingKappaCaseCountsByVariable(filteredComparisonData, calculationLevel);
-
-    // 2. Transform to coder pairs format
-    const coderPairs = this.coderTrainingService.transformToCoderPairs(filteredComparisonData);
-
-    if (coderPairs.length === 0) {
-      return {
-        variables: [],
-        workspaceSummary: {
-          totalDoubleCodedResponses: 0,
-          totalCoderPairs: 0,
-          averageKappa: null,
-          variablesIncluded: 0,
-          codersIncluded: 0,
-          weightingMethod: useWeightedMean ? 'weighted' : 'unweighted',
-          calculationLevel
-        }
-      };
-    }
-
-    // 3. Calculate Cohen's Kappa for each pair (reuse existing logic)
-    const kappaResults = this.codingStatisticsService.calculateCohensKappa(coderPairs, calculationLevel);
-
-    // 4. Group by variable
-    const variableMap = new Map<string, { unitName: string; variableId: string; coderPairs: typeof kappaResults }>();
-
-    kappaResults.forEach(result => {
-      const key = this.getTrainingKappaVariableKey(result.unitName as string, result.variableId as string);
-      if (!variableMap.has(key)) {
-        variableMap.set(key, {
-          unitName: result.unitName as string,
-          variableId: result.variableId as string,
-          coderPairs: []
-        });
-      }
-      variableMap.get(key)!.coderPairs.push(result);
+    return this.coderTrainingService.getWithinTrainingCohensKappa(workspace_id, trainingId, {
+      weightedMean: useWeightedMean,
+      level: calculationLevel,
+      selectedJobIds
     });
-
-    const variables = Array.from(variableMap.entries()).map(([key, variable]) => ({
-      ...variable,
-      caseCount: caseCountsByVariable.get(key) ?? 0,
-      ...this.codingStatisticsService.calculateKappaVariableSummary(variable.coderPairs)
-    }));
-
-    // 5. Calculate summary statistics
-    let totalWeightedKappa = 0;
-    let totalWeight = 0;
-    let totalKappa = 0;
-    let validKappaCount = 0;
-    const uniqueCoders = new Set<number>();
-
-    for (const result of kappaResults) {
-      uniqueCoders.add(result.coder1Id);
-      uniqueCoders.add(result.coder2Id);
-
-      if (result.kappa !== null && !Number.isNaN(result.kappa)) {
-        if (useWeightedMean) {
-          const weight = result.validPairs;
-          totalWeightedKappa += result.kappa * weight;
-          totalWeight += weight;
-        } else {
-          totalKappa += result.kappa;
-          validKappaCount += 1;
-        }
-      }
-    }
-
-    let averageKappa: number | null;
-    if (useWeightedMean) {
-      averageKappa = totalWeight > 0 ? totalWeightedKappa / totalWeight : null;
-    } else {
-      averageKappa = validKappaCount > 0 ? totalKappa / validKappaCount : null;
-    }
-
-    const totalDoubleCodedResponses = Array.from(caseCountsByVariable.values())
-      .reduce((sum, caseCount) => sum + caseCount, 0);
-
-    return {
-      variables,
-      workspaceSummary: {
-        totalDoubleCodedResponses,
-        totalCoderPairs: kappaResults.length,
-        averageKappa,
-        variablesIncluded: variableMap.size,
-        codersIncluded: uniqueCoders.size,
-        weightingMethod: useWeightedMean ? 'weighted' : 'unweighted',
-        calculationLevel
-      }
-    };
   }
 }

--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -16,6 +16,7 @@ import { ResponseEntity } from '../../entities/response.entity';
 import { VariableBundle } from '../../entities/variable-bundle.entity';
 import { ChunkEntity } from '../../entities/chunk.entity';
 import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
+import { CodingStatisticsService } from './coding-statistics.service';
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import { WorkspaceExclusionService } from '../workspace/workspace-exclusion.service';
 import { CoderTrainingDiscussionResult } from '../../entities/coder-training-discussion-result.entity';
@@ -37,6 +38,10 @@ describe('CoderTrainingService', () => {
   let coderTrainingCoderRepository: Repository<CoderTrainingCoder>;
   let codingJobVariableBundleRepository: Repository<CodingJobVariableBundle>;
   let coderTrainingDiscussionResultRepository: Repository<CoderTrainingDiscussionResult>;
+  let codingStatisticsService: {
+    calculateCohensKappa: jest.Mock;
+    calculateKappaVariableSummary: jest.Mock;
+  };
   let missingsProfilesService: {
     getMissingsProfileDetails: jest.Mock;
     ensureDefaultMissingsProfile: jest.Mock;
@@ -71,6 +76,10 @@ describe('CoderTrainingService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     mockRepository.count.mockResolvedValue(0);
+    codingStatisticsService = {
+      calculateCohensKappa: jest.fn(),
+      calculateKappaVariableSummary: jest.fn()
+    };
     missingsProfilesService = {
       getMissingsProfileDetails: jest.fn(),
       ensureDefaultMissingsProfile: jest.fn().mockResolvedValue({
@@ -131,6 +140,7 @@ describe('CoderTrainingService', () => {
         { provide: CodingJobService, useValue: mockCodingJobService },
         { provide: WorkspaceFilesService, useValue: mockWorkspaceFilesService },
         { provide: MissingsProfilesService, useValue: missingsProfilesService },
+        { provide: CodingStatisticsService, useValue: codingStatisticsService },
         {
           provide: WorkspaceExclusionService,
           useValue: {
@@ -3127,6 +3137,329 @@ describe('CoderTrainingService', () => {
         expect.any(Map),
         expect.any(Object),
         expect.any(Object)
+      );
+    });
+
+    it('calculates within-training kappa from aggregate case rows and selected job values', async () => {
+      const fullComparisonSpy = jest.spyOn(service, 'getWithinTrainingCodingComparison').mockResolvedValue([]);
+      (coderTrainingRepository.findOne as jest.Mock).mockResolvedValueOnce({
+        id: 5,
+        workspace_id: 1
+      });
+      (codingJobRepository.find as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 11,
+          name: 'job-a',
+          missings_profile_id: null,
+          codingJobCoders: [{ user: { username: 'Coder A' } }]
+        },
+        {
+          id: 12,
+          name: 'job-b',
+          missings_profile_id: null,
+          codingJobCoders: [{ user: { username: 'Coder B' } }]
+        },
+        {
+          id: 13,
+          name: 'job-c',
+          missings_profile_id: null,
+          codingJobCoders: [{ user: { username: 'Coder C' } }]
+        }
+      ]);
+      const createKappaQueryBuilder = <T>(rows: T[]) => ({
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rows)
+      });
+      const caseQb = createKappaQueryBuilder([
+        {
+          responseId: 101,
+          unitName: 'U1',
+          variableId: 'V1',
+          validValueCount: '3'
+        },
+        {
+          responseId: 102,
+          unitName: 'U1',
+          variableId: 'V1',
+          validValueCount: '2'
+        },
+        {
+          responseId: 201,
+          unitName: 'U2',
+          variableId: 'V2',
+          validValueCount: '1'
+        }
+      ]);
+      const valueQb = createKappaQueryBuilder([
+        {
+          responseId: 101, jobId: 11, unitName: 'U1', variableId: 'V1', code: '1', score: 1
+        },
+        {
+          responseId: 101, jobId: 12, unitName: 'U1', variableId: 'V1', code: '1', score: 1
+        },
+        {
+          responseId: 101, jobId: 13, unitName: 'U1', variableId: 'V1', code: '1', score: 1
+        },
+        {
+          responseId: 102, jobId: 11, unitName: 'U1', variableId: 'V1', code: '1', score: 1
+        },
+        {
+          responseId: 102, jobId: 12, unitName: 'U1', variableId: 'V1', code: null, score: null
+        },
+        {
+          responseId: 102, jobId: 13, unitName: 'U1', variableId: 'V1', code: '2', score: 2
+        },
+        {
+          responseId: 201, jobId: 11, unitName: 'U2', variableId: 'V2', code: '1', score: 1
+        }
+      ]);
+      (mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(caseQb)
+        .mockReturnValueOnce(valueQb);
+      codingStatisticsService.calculateCohensKappa.mockReturnValue([
+        {
+          coder1Id: 11,
+          coder1Name: 'Coder A',
+          coder2Id: 12,
+          coder2Name: 'Coder B',
+          unitName: 'U1',
+          variableId: 'V1',
+          kappa: 0.5,
+          agreement: 0.8,
+          totalItems: 2,
+          validPairs: 1,
+          interpretation: 'kappa.moderate'
+        },
+        {
+          coder1Id: 11,
+          coder1Name: 'Coder A',
+          coder2Id: 13,
+          coder2Name: 'Coder C',
+          unitName: 'U1',
+          variableId: 'V1',
+          kappa: 0.7,
+          agreement: 0.9,
+          totalItems: 2,
+          validPairs: 2,
+          interpretation: 'kappa.substantial'
+        },
+        {
+          coder1Id: 12,
+          coder1Name: 'Coder B',
+          coder2Id: 13,
+          coder2Name: 'Coder C',
+          unitName: 'U2',
+          variableId: 'V2',
+          kappa: null,
+          agreement: 0,
+          totalItems: 1,
+          validPairs: 0,
+          interpretation: 'No valid coding pairs'
+        }
+      ]);
+      codingStatisticsService.calculateKappaVariableSummary
+        .mockReturnValueOnce({
+          meanKappa: 0.6,
+          meanAgreement: 0.85,
+          validPairCount: 3,
+          coderPairCount: 2
+        })
+        .mockReturnValueOnce({
+          meanKappa: null,
+          meanAgreement: null,
+          validPairCount: 0,
+          coderPairCount: 0
+        });
+
+      const result = await service.getWithinTrainingCohensKappa(1, 5, {
+        weightedMean: false,
+        level: 'code',
+        selectedJobIds: [11, 12, 13]
+      });
+
+      expect(fullComparisonSpy).not.toHaveBeenCalled();
+      expect(caseQb.setParameter).toHaveBeenCalledWith('withinTrainingKappaCaseSelectedJobIds', [11, 12, 13]);
+      expect(valueQb.andWhere).toHaveBeenCalledWith(
+        'cj.id IN (:...withinTrainingKappaValueJobIds)',
+        { withinTrainingKappaValueJobIds: [11, 12, 13] }
+      );
+      expect(codingStatisticsService.calculateCohensKappa).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            coder1Id: 11,
+            coder2Id: 12,
+            unitName: 'U1',
+            variableId: 'V1',
+            codes: [
+              { code1: 1, code2: 1 },
+              { code1: 1, code2: null }
+            ]
+          }),
+          expect.objectContaining({
+            coder1Id: 11,
+            coder2Id: 13,
+            unitName: 'U2',
+            variableId: 'V2',
+            codes: [{ code1: 1, code2: null }]
+          })
+        ]),
+        'code'
+      );
+      expect(result.variables).toEqual([
+        expect.objectContaining({
+          unitName: 'U1',
+          variableId: 'V1',
+          meanKappa: 0.6,
+          caseCount: 2,
+          validPairCount: 3,
+          coderPairCount: 2
+        }),
+        expect.objectContaining({
+          unitName: 'U2',
+          variableId: 'V2',
+          meanKappa: null,
+          caseCount: 0,
+          validPairCount: 0,
+          coderPairCount: 0
+        })
+      ]);
+      expect(result.workspaceSummary).toMatchObject({
+        totalDoubleCodedResponses: 2,
+        totalCoderPairs: 3,
+        averageKappa: 0.6,
+        variablesIncluded: 2,
+        codersIncluded: 3,
+        weightingMethod: 'unweighted',
+        calculationLevel: 'code'
+      });
+    });
+
+    it('uses missing profile score mapping for score-level within-training kappa', async () => {
+      (coderTrainingRepository.findOne as jest.Mock).mockResolvedValueOnce({
+        id: 5,
+        workspace_id: 1
+      });
+      (codingJobRepository.find as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 11,
+          name: 'job-a',
+          missings_profile_id: 77,
+          codingJobCoders: [{ user: { username: 'Coder A' } }]
+        },
+        {
+          id: 12,
+          name: 'job-b',
+          missings_profile_id: null,
+          codingJobCoders: [{ user: { username: 'Coder B' } }]
+        }
+      ]);
+      missingsProfilesService.getMissingsProfileDetails.mockResolvedValue({
+        parseMissings: () => [
+          {
+            id: 'mir', label: 'custom invalid response', code: -41, score: 2
+          },
+          {
+            id: 'mci', label: 'custom coding impossible', code: -42, score: 3
+          },
+          {
+            id: 'custom', label: 'custom missing', code: -43, score: 4
+          }
+        ]
+      });
+      missingsProfilesService.getNegativeMissingCodesForProfileOrDefault
+        .mockImplementation(async (_workspaceId, profileId) => (
+          profileId === 77 ? new Set([-41, -42, -43]) : new Set([-97, -98, -99])
+        ));
+      const createKappaQueryBuilder = <T>(rows: T[]) => ({
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rows)
+      });
+      const caseQb = createKappaQueryBuilder([
+        {
+          responseId: 101,
+          unitName: 'U1',
+          variableId: 'V1',
+          validValueCount: '2'
+        }
+      ]);
+      const valueQb = createKappaQueryBuilder([
+        {
+          responseId: 101, jobId: 11, unitName: 'U1', variableId: 'V1', code: '-41', score: '2'
+        },
+        {
+          responseId: 101, jobId: 12, unitName: 'U1', variableId: 'V1', code: '-98', score: '0'
+        }
+      ]);
+      (mockRepository as { createQueryBuilder?: jest.Mock }).createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(caseQb)
+        .mockReturnValueOnce(valueQb);
+      codingStatisticsService.calculateCohensKappa.mockReturnValue([
+        {
+          coder1Id: 11,
+          coder1Name: 'Coder A',
+          coder2Id: 12,
+          coder2Name: 'Coder B',
+          unitName: 'U1',
+          variableId: 'V1',
+          kappa: 1,
+          agreement: 1,
+          totalItems: 1,
+          validPairs: 1,
+          interpretation: 'kappa.almost_perfect'
+        }
+      ]);
+      codingStatisticsService.calculateKappaVariableSummary.mockReturnValue({
+        meanKappa: 1,
+        meanAgreement: 1,
+        validPairCount: 1,
+        coderPairCount: 1
+      });
+
+      await service.getWithinTrainingCohensKappa(1, 5, {
+        level: 'score',
+        selectedJobIds: [11, 12]
+      });
+
+      const caseValidCountExpression = caseQb.addSelect.mock.calls
+        .find(([, alias]) => alias === 'validValueCount')?.[0] as string;
+      const valueScoreExpression = valueQb.addSelect.mock.calls
+        .find(([, alias]) => alias === 'score')?.[0] as string;
+      expect(caseValidCountExpression).toContain('WHEN cju.code = -3 OR cju.coding_issue_option = -3');
+      expect(caseValidCountExpression).toContain('WHEN 11 THEN 2');
+      expect(caseValidCountExpression).toContain('WHEN -43 THEN 4');
+      expect(caseValidCountExpression).not.toContain('AND (cju.score) IS NOT NULL');
+      expect(valueScoreExpression).toContain('WHEN cju.code = -3 OR cju.coding_issue_option = -3');
+      expect(valueScoreExpression).toContain('WHEN 11 THEN 2');
+      expect(valueScoreExpression).toContain('WHEN -43 THEN 4');
+      expect(valueScoreExpression).not.toBe('cju.score');
+      expect(codingStatisticsService.calculateCohensKappa).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            coder1Id: 11,
+            coder2Id: 12,
+            unitName: 'U1',
+            variableId: 'V1',
+            codes: [{ code1: -41, code2: -98 }],
+            scores: [{ score1: 2, score2: 0 }]
+          })
+        ]),
+        'score'
       );
     });
 

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -55,6 +55,10 @@ import {
   WithinTrainingCodingComparisonRowDto,
   WithinTrainingComparisonCoderDto
 } from '../../../../../../../api-dto/coding/training-comparison.dto';
+import {
+  CodingStatisticsService,
+  KappaCalculationResult
+} from './coding-statistics.service';
 
 interface CoderTrainingResponse {
   responseId: number;
@@ -208,6 +212,46 @@ type TrainingComparisonPageOptions = {
   selectedJobIds?: number[];
 };
 
+type TrainingKappaCalculationLevel = 'code' | 'score';
+
+export type TrainingCohensKappaStatistics = {
+  variables: Array<{
+    unitName: string;
+    variableId: string;
+    meanKappa: number | null;
+    meanAgreement: number | null;
+    caseCount: number;
+    validPairCount: number;
+    coderPairCount: number;
+    coderPairs: Array<{
+      coder1Id: number;
+      coder1Name: string;
+      coder2Id: number;
+      coder2Name: string;
+      kappa: number | null;
+      agreement: number;
+      totalItems: number;
+      validPairs: number;
+      interpretation: string;
+    }>;
+  }>;
+  workspaceSummary: {
+    totalDoubleCodedResponses: number;
+    totalCoderPairs: number;
+    averageKappa: number | null;
+    variablesIncluded: number;
+    codersIncluded: number;
+    weightingMethod: 'weighted' | 'unweighted';
+    calculationLevel: TrainingKappaCalculationLevel;
+  };
+};
+
+type TrainingKappaOptions = {
+  weightedMean?: boolean;
+  level?: TrainingKappaCalculationLevel;
+  selectedJobIds?: number[];
+};
+
 type TrainingComparisonAggregateRow = {
   responseId: number | string;
   unitName: string;
@@ -251,6 +295,45 @@ type TrainingComparisonRawUnitRow = {
   score: number | string | null;
   notes: string | null;
   codingIssueOption: number | string | null;
+};
+
+type WithinTrainingKappaCaseRow = {
+  responseId: number | string;
+  unitName: string;
+  variableId: string;
+  validValueCount: number | string | null;
+};
+
+type WithinTrainingKappaValueRow = {
+  responseId: number | string;
+  jobId: number | string;
+  unitName: string;
+  variableId: string;
+  code: string | null;
+  score: number | string | null;
+};
+
+type WithinTrainingKappaCase = {
+  responseId: number;
+  unitName: string;
+  variableId: string;
+  validValueCount: number;
+};
+
+type KappaCoderValue = {
+  code: number | null;
+  score: number | null;
+};
+
+type TrainingKappaCoderPairInput = {
+  coder1Id: number;
+  coder1Name: string;
+  coder2Id: number;
+  coder2Name: string;
+  unitName: string;
+  variableId: string;
+  codes: Array<{ code1: number | null; code2: number | null }>;
+  scores: Array<{ score1: number | null; score2: number | null }>;
 };
 
 type MissingCodePair = { mirCode: number; mciCode: number };
@@ -305,7 +388,8 @@ export class CoderTrainingService {
     private codingJobService: CodingJobService,
     private workspaceFilesService: WorkspaceFilesService,
     private missingsProfilesService: MissingsProfilesService,
-    private workspaceExclusionService: WorkspaceExclusionService
+    private workspaceExclusionService: WorkspaceExclusionService,
+    private codingStatisticsService: CodingStatisticsService
   ) { }
 
   private async buildMissingCodesByJobId(
@@ -1273,6 +1357,70 @@ export class CoderTrainingService {
     END`;
   }
 
+  private toSqlScoreLiteral(score: number | null): string {
+    return score === null ? 'NULL' : score.toString();
+  }
+
+  private buildComparisonMissingScoreByJobSqlExpression(
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext,
+    selector: (context: MissingCodeDisplayContext) => number | null
+  ): string {
+    const cases = Array.from(missingCodesByJobId.entries())
+      .map(([jobId, context]) => `WHEN ${jobId} THEN ${this.toSqlScoreLiteral(selector(context))}`)
+      .join(' ');
+    return `(CASE cj.id ${cases} ELSE ${this.toSqlScoreLiteral(selector(defaultMissingCodeContext))} END)`;
+  }
+
+  private buildComparisonNegativeMissingScoreSqlExpression(
+    context: MissingCodeDisplayContext
+  ): string {
+    const cases = Array.from(context.negativeCodes)
+      .sort((a, b) => a - b)
+      .map(code => `WHEN ${code} THEN ${this.toSqlScoreLiteral(this.getMissingScoreFromContext(context, code))}`)
+      .join(' ');
+
+    return cases.length > 0 ? `(CASE cju.code ${cases} ELSE cju.score END)` : 'cju.score';
+  }
+
+  private buildComparisonNegativeMissingScoreByJobSqlExpression(
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext
+  ): string {
+    const cases = Array.from(missingCodesByJobId.entries())
+      .map(([jobId, context]) => `WHEN ${jobId} THEN ${this.buildComparisonNegativeMissingScoreSqlExpression(context)}`)
+      .join(' ');
+    return `(CASE cj.id ${cases} ELSE ${this.buildComparisonNegativeMissingScoreSqlExpression(defaultMissingCodeContext)} END)`;
+  }
+
+  private buildComparisonDisplayScoreSqlExpression(
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext
+  ): string {
+    const mirScoreExpression = this.buildComparisonMissingScoreByJobSqlExpression(
+      missingCodesByJobId,
+      defaultMissingCodeContext,
+      context => this.getMissingScoreFromContext(context, context.mirCode)
+    );
+    const mciScoreExpression = this.buildComparisonMissingScoreByJobSqlExpression(
+      missingCodesByJobId,
+      defaultMissingCodeContext,
+      context => this.getMissingScoreFromContext(context, context.mciCode)
+    );
+    const negativeMissingScoreExpression = this.buildComparisonNegativeMissingScoreByJobSqlExpression(
+      missingCodesByJobId,
+      defaultMissingCodeContext
+    );
+
+    return `CASE
+      WHEN cju.code IS NULL AND cju.coding_issue_option IS NULL THEN cju.score
+      WHEN cju.code = -3 OR cju.coding_issue_option = -3 THEN ${mirScoreExpression}
+      WHEN cju.code = -4 OR cju.coding_issue_option = -4 THEN ${mciScoreExpression}
+      WHEN cju.code < 0 THEN ${negativeMissingScoreExpression}
+      ELSE cju.score
+    END`;
+  }
+
   private addComparisonAggregateSelects(
     query: ReturnType<Repository<CodingJobUnit>['createQueryBuilder']>,
     selectedJobIds: number[],
@@ -1709,6 +1857,201 @@ export class CoderTrainingService {
     }
 
     return resultRows;
+  }
+
+  private async getWithinTrainingKappaCaseRows(
+    workspaceId: number,
+    trainingId: number,
+    selectedJobIds: number[],
+    calculationLevel: TrainingKappaCalculationLevel,
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
+  ): Promise<WithinTrainingKappaCaseRow[]> {
+    const selectedJobParameterName = 'withinTrainingKappaCaseSelectedJobIds';
+    const valueExpression = calculationLevel === 'score' ?
+      this.buildComparisonDisplayScoreSqlExpression(missingCodesByJobId, defaultMissingCodeContext) :
+      this.buildComparisonDisplayCodeSqlExpression(missingCodesByJobId, defaultMissingCodeContext);
+    const query = this.codingJobUnitRepository
+      .createQueryBuilder('cju')
+      .innerJoin('cju.coding_job', 'cj')
+      .select('cju.response_id', 'responseId')
+      .addSelect('MIN(cju.unit_name)', 'unitName')
+      .addSelect('MIN(cju.variable_id)', 'variableId')
+      .addSelect(
+        `COUNT(DISTINCT cj.id) FILTER (
+          WHERE cj.id IN (:...${selectedJobParameterName})
+          AND (${valueExpression}) IS NOT NULL
+        )`,
+        'validValueCount'
+      )
+      .where('cj.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('cj.training_id = :trainingId', { trainingId })
+      .groupBy('cju.response_id')
+      .orderBy('MIN(cju.unit_name)', 'ASC')
+      .addOrderBy('MIN(cju.variable_id)', 'ASC')
+      .addOrderBy('cju.response_id', 'ASC')
+      .setParameter(selectedJobParameterName, selectedJobIds);
+
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      unitNameExpression: 'cju.unit_name',
+      bookletNameExpression: 'cju.booklet_name',
+      parameterPrefix: 'withinTrainingKappaCases'
+    });
+
+    return query.getRawMany<WithinTrainingKappaCaseRow>();
+  }
+
+  private async getWithinTrainingKappaValueRows(
+    workspaceId: number,
+    trainingId: number,
+    selectedJobIds: number[],
+    missingCodesByJobId: Map<number, MissingCodeDisplayContext>,
+    defaultMissingCodeContext: MissingCodeDisplayContext,
+    exclusions: Awaited<ReturnType<WorkspaceExclusionService['resolveExclusionsForQueries']>>
+  ): Promise<WithinTrainingKappaValueRow[]> {
+    if (selectedJobIds.length === 0) {
+      return [];
+    }
+
+    const displayCodeExpression = this.buildComparisonDisplayCodeSqlExpression(
+      missingCodesByJobId,
+      defaultMissingCodeContext
+    );
+    const displayScoreExpression = this.buildComparisonDisplayScoreSqlExpression(
+      missingCodesByJobId,
+      defaultMissingCodeContext
+    );
+    const query = this.codingJobUnitRepository
+      .createQueryBuilder('cju')
+      .innerJoin('cju.coding_job', 'cj')
+      .select('cj.id', 'jobId')
+      .addSelect('cju.response_id', 'responseId')
+      .addSelect('cju.unit_name', 'unitName')
+      .addSelect('cju.variable_id', 'variableId')
+      .addSelect(displayCodeExpression, 'code')
+      .addSelect(displayScoreExpression, 'score')
+      .where('cj.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('cj.training_id = :trainingId', { trainingId })
+      .andWhere('cj.id IN (:...withinTrainingKappaValueJobIds)', {
+        withinTrainingKappaValueJobIds: selectedJobIds
+      })
+      .orderBy('cju.id', 'ASC')
+      .addOrderBy('cj.id', 'ASC');
+
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      unitNameExpression: 'cju.unit_name',
+      bookletNameExpression: 'cju.booklet_name',
+      parameterPrefix: 'withinTrainingKappaValues'
+    });
+
+    return query.getRawMany<WithinTrainingKappaValueRow>();
+  }
+
+  private normalizeWithinTrainingKappaCases(
+    rows: WithinTrainingKappaCaseRow[]
+  ): WithinTrainingKappaCase[] {
+    return rows
+      .map(row => {
+        const responseId = this.toNullableScore(row.responseId);
+        if (responseId === null) {
+          return null;
+        }
+        return {
+          responseId,
+          unitName: row.unitName,
+          variableId: row.variableId,
+          validValueCount: this.toFreshnessNumber(row.validValueCount)
+        };
+      })
+      .filter((row): row is WithinTrainingKappaCase => row !== null);
+  }
+
+  private toKappaCode(value: string | null): number | null {
+    if (value === null) {
+      return null;
+    }
+
+    const parsed = parseInt(value, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  private buildWithinTrainingKappaCoderPairs(
+    cases: WithinTrainingKappaCase[],
+    valueRows: WithinTrainingKappaValueRow[],
+    selectedJobs: Array<Pick<CodingJob, 'id' | 'name'> & {
+      codingJobCoders?: Array<{ user?: { username?: string | null } | null }> | null;
+    }>
+  ): TrainingKappaCoderPairInput[] {
+    const selectedJobIds = new Set(selectedJobs.map(job => job.id));
+    const valuesByResponseAndJob = new Map<string, KappaCoderValue>();
+    valueRows.forEach(row => {
+      const responseId = this.toNullableScore(row.responseId);
+      const jobId = this.toNullableScore(row.jobId);
+      if (responseId === null || jobId === null || !selectedJobIds.has(jobId)) {
+        return;
+      }
+
+      valuesByResponseAndJob.set(`${responseId}:${jobId}`, {
+        code: this.toKappaCode(row.code),
+        score: this.toNullableScore(row.score)
+      });
+    });
+
+    const casesByVariable = new Map<string, WithinTrainingKappaCase[]>();
+    cases.forEach(item => {
+      const key = this.getTrainingKappaVariableKey(item.unitName, item.variableId);
+      if (!casesByVariable.has(key)) {
+        casesByVariable.set(key, []);
+      }
+      casesByVariable.get(key)!.push(item);
+    });
+
+    const coderPairs: TrainingKappaCoderPairInput[] = [];
+    Array.from(casesByVariable.values()).forEach(variableCases => {
+      variableCases.sort((a, b) => a.responseId - b.responseId);
+      const firstCase = variableCases[0];
+      if (!firstCase) {
+        return;
+      }
+
+      for (let i = 0; i < selectedJobs.length; i++) {
+        for (let j = i + 1; j < selectedJobs.length; j++) {
+          const coder1 = selectedJobs[i];
+          const coder2 = selectedJobs[j];
+          const codes: Array<{ code1: number | null; code2: number | null }> = [];
+          const scores: Array<{ score1: number | null; score2: number | null }> = [];
+
+          variableCases.forEach(item => {
+            const coder1Value = valuesByResponseAndJob.get(`${item.responseId}:${coder1.id}`);
+            const coder2Value = valuesByResponseAndJob.get(`${item.responseId}:${coder2.id}`);
+            codes.push({
+              code1: coder1Value?.code ?? null,
+              code2: coder2Value?.code ?? null
+            });
+            scores.push({
+              score1: coder1Value?.score ?? null,
+              score2: coder2Value?.score ?? null
+            });
+          });
+
+          if (codes.length > 0) {
+            coderPairs.push({
+              coder1Id: coder1.id,
+              coder1Name: this.getWithinTrainingJobCoderName(coder1),
+              coder2Id: coder2.id,
+              coder2Name: this.getWithinTrainingJobCoderName(coder2),
+              unitName: firstCase.unitName,
+              variableId: firstCase.variableId,
+              codes,
+              scores
+            });
+          }
+        }
+      }
+    });
+
+    return coderPairs;
   }
 
   private mapDisplayCodeAndScore(
@@ -3830,6 +4173,200 @@ export class CoderTrainingService {
       totalPages: Math.ceil(filteredCandidates.length / limit),
       summary: this.calculateComparisonSummaryFromCandidates(filteredCandidates),
       availableCoders
+    };
+  }
+
+  async getWithinTrainingCohensKappa(
+    workspaceId: number,
+    trainingId: number,
+    options: TrainingKappaOptions = {}
+  ): Promise<TrainingCohensKappaStatistics> {
+    const useWeightedMean = options.weightedMean ?? true;
+    const calculationLevel = options.level ?? 'code';
+    const emptyStatistics = this.createEmptyTrainingKappaStatistics(useWeightedMean, calculationLevel);
+    const training = await this.coderTrainingRepository.findOne({
+      where: {
+        workspace_id: workspaceId,
+        id: trainingId
+      }
+    });
+
+    if (!training) {
+      return emptyStatistics;
+    }
+
+    const jobs = await this.codingJobRepository.find({
+      where: {
+        workspace_id: workspaceId,
+        training_id: trainingId
+      },
+      relations: ['codingJobCoders.user'],
+      order: { id: 'ASC' }
+    });
+    const selectedJobIds = this.getWithinTrainingComparisonSelectedJobIds(options.selectedJobIds, jobs);
+    const jobById = new Map(jobs.map(job => [job.id, job]));
+    const selectedJobs = selectedJobIds
+      .map(jobId => jobById.get(jobId))
+      .filter((job): job is CodingJob => job !== undefined);
+
+    if (selectedJobs.length < 2) {
+      return emptyStatistics;
+    }
+
+    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const [missingCodesByJobId, defaultMissingCodeContext] = await Promise.all([
+      this.buildMissingCodesByJobId(workspaceId, selectedJobs),
+      this.getDefaultMissingCodeDisplayContext(workspaceId)
+    ]);
+    const [caseRows, valueRows] = await Promise.all([
+      this.getWithinTrainingKappaCaseRows(
+        workspaceId,
+        trainingId,
+        selectedJobIds,
+        calculationLevel,
+        missingCodesByJobId,
+        defaultMissingCodeContext,
+        exclusions
+      ),
+      this.getWithinTrainingKappaValueRows(
+        workspaceId,
+        trainingId,
+        selectedJobIds,
+        missingCodesByJobId,
+        defaultMissingCodeContext,
+        exclusions
+      )
+    ]);
+    const cases = this.normalizeWithinTrainingKappaCases(caseRows);
+    const coderPairs = this.buildWithinTrainingKappaCoderPairs(cases, valueRows, selectedJobs);
+
+    if (coderPairs.length === 0) {
+      return emptyStatistics;
+    }
+
+    const kappaResults = this.codingStatisticsService.calculateCohensKappa(coderPairs, calculationLevel);
+    const caseCountsByVariable = this.calculateTrainingKappaCaseCountsByVariable(cases);
+
+    return this.createTrainingKappaStatistics(
+      kappaResults,
+      caseCountsByVariable,
+      useWeightedMean,
+      calculationLevel
+    );
+  }
+
+  private getTrainingKappaVariableKey(unitName: string, variableId: string): string {
+    return `${unitName}:${variableId}`;
+  }
+
+  private createEmptyTrainingKappaStatistics(
+    useWeightedMean: boolean,
+    calculationLevel: TrainingKappaCalculationLevel
+  ): TrainingCohensKappaStatistics {
+    return {
+      variables: [],
+      workspaceSummary: {
+        totalDoubleCodedResponses: 0,
+        totalCoderPairs: 0,
+        averageKappa: null,
+        variablesIncluded: 0,
+        codersIncluded: 0,
+        weightingMethod: useWeightedMean ? 'weighted' : 'unweighted',
+        calculationLevel
+      }
+    };
+  }
+
+  private calculateTrainingKappaCaseCountsByVariable(
+    cases: WithinTrainingKappaCase[]
+  ): Map<string, number> {
+    const caseCountsByVariable = new Map<string, number>();
+
+    cases.forEach(item => {
+      if (item.validValueCount < 2) return;
+
+      const key = this.getTrainingKappaVariableKey(item.unitName, item.variableId);
+      caseCountsByVariable.set(key, (caseCountsByVariable.get(key) ?? 0) + 1);
+    });
+
+    return caseCountsByVariable;
+  }
+
+  private createTrainingKappaStatistics(
+    kappaResults: KappaCalculationResult[],
+    caseCountsByVariable: Map<string, number>,
+    useWeightedMean: boolean,
+    calculationLevel: TrainingKappaCalculationLevel
+  ): TrainingCohensKappaStatistics {
+    const variableMap = new Map<string, {
+      unitName: string;
+      variableId: string;
+      coderPairs: KappaCalculationResult[];
+    }>();
+
+    kappaResults.forEach(result => {
+      const unitName = result.unitName as string;
+      const variableId = result.variableId as string;
+      const key = this.getTrainingKappaVariableKey(unitName, variableId);
+      if (!variableMap.has(key)) {
+        variableMap.set(key, {
+          unitName,
+          variableId,
+          coderPairs: []
+        });
+      }
+      variableMap.get(key)!.coderPairs.push(result);
+    });
+
+    const variables = Array.from(variableMap.entries())
+      .map(([key, variable]) => ({
+        ...variable,
+        caseCount: caseCountsByVariable.get(key) ?? 0,
+        ...this.codingStatisticsService.calculateKappaVariableSummary(variable.coderPairs)
+      }));
+
+    let totalWeightedKappa = 0;
+    let totalWeight = 0;
+    let totalKappa = 0;
+    let validKappaCount = 0;
+    const uniqueCoders = new Set<number>();
+
+    kappaResults.forEach(result => {
+      uniqueCoders.add(result.coder1Id);
+      uniqueCoders.add(result.coder2Id);
+
+      if (result.kappa !== null && !Number.isNaN(result.kappa)) {
+        if (useWeightedMean) {
+          const weight = result.validPairs;
+          totalWeightedKappa += result.kappa * weight;
+          totalWeight += weight;
+        } else {
+          totalKappa += result.kappa;
+          validKappaCount += 1;
+        }
+      }
+    });
+
+    let averageKappa: number | null;
+    if (useWeightedMean) {
+      averageKappa = totalWeight > 0 ? totalWeightedKappa / totalWeight : null;
+    } else {
+      averageKappa = validKappaCount > 0 ? totalKappa / validKappaCount : null;
+    }
+    const totalDoubleCodedResponses = Array.from(caseCountsByVariable.values())
+      .reduce((sum, caseCount) => sum + caseCount, 0);
+
+    return {
+      variables,
+      workspaceSummary: {
+        totalDoubleCodedResponses,
+        totalCoderPairs: kappaResults.length,
+        averageKappa,
+        variablesIncluded: variableMap.size,
+        codersIncluded: uniqueCoders.size,
+        weightingMethod: useWeightedMean ? 'weighted' : 'unweighted',
+        calculationLevel
+      }
     };
   }
 


### PR DESCRIPTION
## Summary
- Move training Cohen's Kappa calculation into `CoderTrainingService` using aggregate case rows and slim selected-value rows
- Preserve code/score Kappa behavior, including missing-code score mapping
- Add focused controller and service coverage for delegation, aggregate Kappa inputs, and score-level missing mappings

## Validation
- `npx nx lint backend`
- `npx nx test backend --runTestsByPath apps/backend/src/app/database/services/coding/coder-training.service.spec.ts`
- `npx nx test backend --runTestsByPath apps/backend/src/app/database/services/coding/coder-training.service.spec.ts --testNamePattern "uses missing profile score mapping"`
- Temporary Postgres CASE-expression check against `kodierbox-db-1`: PASS
