### PR TITLE
Release 1.16.4

### DIFF
--- a/apps/frontend/src/app/components/home/home.component.html
+++ b/apps/frontend/src/app/components/home/home.component.html
@@ -11,7 +11,7 @@
     [appTitle]="'Web application for coding'"
     [introHtml]="'appService.appConfig.introHtml'"
     [appName]="'IQB-Kodierbox'"
-    [appVersion]="'1.16.3'"
+    [appVersion]="'1.16.4'"
     [userName]="authData.userName"
     [userLongName]="appService.userProfile.firstName + ' ' + appService.userProfile.lastName"
     [isUserLoggedIn]="Number(authData.userId) > 0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/router": "20.3.18",
         "@iqb/metadata-components": "0.2.3",
         "@iqb/metadata-resolver": "0.2.0",
-        "@iqb/responses": "^5.0.0",
+        "@iqb/responses": "^5.2.0",
         "@iqbspecs/coding-scheme": "^3.4.1",
         "@iqbspecs/metadata-profile": "^0.11.1",
         "@iqbspecs/metadata-values": "^3.0.1",
@@ -5202,9 +5202,9 @@
       }
     },
     "node_modules/@iqb/responses": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@iqb/responses/-/responses-5.0.0.tgz",
-      "integrity": "sha512-qqqzvhhnabBIHFZaIgvidV2r9OTlUg+oKTSAw9HzoTMOzd7bqK9aNXQArUar/LgJUQ5GiiwS3I7XWhdqXplCXg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@iqb/responses/-/responses-5.2.0.tgz",
+      "integrity": "sha512-Pk1s0CFA/SeAdns/RdHEKMSt/WhHYRzM7jkU7p5n/Nt+1Hpwj4zkvS8uXfofNplYhV7lkeMes1kcceqqQ2fekw==",
       "license": "CC0 1.0",
       "dependencies": {
         "mathjs": "^12.4.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coding-box",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coding-box",
-      "version": "1.16.3",
+      "version": "1.16.4",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "20.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-box",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@angular/router": "20.3.18",
     "@iqb/metadata-components": "0.2.3",
     "@iqb/metadata-resolver": "0.2.0",
-    "@iqb/responses": "^5.0.0",
+    "@iqb/responses": "^5.2.0",
     "@iqbspecs/coding-scheme": "^3.4.1",
     "@iqbspecs/metadata-profile": "^0.11.1",
     "@iqbspecs/metadata-values": "^3.0.1",


### PR DESCRIPTION
## Summary

Bumps the application release version from `1.16.3` to `1.16.4` and updates `@iqb/responses` to `5.2.0`.

## Changes

- Updates the root package version in `package.json`.
- Updates the root package version entries in `package-lock.json`.
- Updates the displayed home component app version to `1.16.4`.
- Updates `@iqb/responses` from `^5.0.0` / locked `5.0.0` to `^5.2.0` / locked `5.2.0`.

## Validation

- Parsed `package.json` and `package-lock.json` with Node to confirm the release and dependency versions.
- Reviewed the Git diff for the intended files.
- Ran `npx nx test backend`; the full parallel run had one timeout in `apps/backend/src/app/prototype-methods.spec.ts`.
- Re-ran `npx nx test backend --runTestsByPath apps/backend/src/app/prototype-methods.spec.ts --runInBand`; it passed.