### PR TITLE
Fix detailed export batching

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-export.golden.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.golden.spec.ts
@@ -74,7 +74,9 @@ function chainableQueryBuilder(overrides: Partial<QueryBuilderMock> = {}): Query
     'orderBy',
     'addOrderBy',
     'skip',
-    'take'
+    'take',
+    'offset',
+    'limit'
   ].forEach(method => {
     queryBuilder[method] = jest.fn(() => queryBuilder);
   });
@@ -143,7 +145,7 @@ function createCodingJobUnitRepository(
     createQueryBuilder: jest
       .fn()
       .mockReturnValueOnce(totalCountQueryBuilder)
-      .mockReturnValueOnce(unitsBatchQueryBuilder)
+      .mockReturnValue(unitsBatchQueryBuilder)
   } as unknown as Repository<CodingJobUnit>;
 }
 

--- a/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
@@ -40,20 +40,13 @@ function createServiceWithDetailedMocks(
   codingIssueOption: number,
   overrides: {
     unit?: Record<string, unknown>,
+    units?: Record<string, unknown>[],
     discussionResults?: Record<string, unknown>[],
     users?: Record<string, unknown>[],
     totalCount?: number,
     missingsProfilesService?: { getMissingByIdForProfileOrDefault: jest.Mock }
   } = {}
 ) {
-  const totalCountQueryBuilder = {
-    innerJoin: jest.fn().mockReturnThis(),
-    leftJoin: jest.fn().mockReturnThis(),
-    where: jest.fn().mockReturnThis(),
-    andWhere: jest.fn().mockReturnThis(),
-    getCount: jest.fn().mockResolvedValue(overrides.totalCount ?? 1)
-  };
-
   const defaultUnit = {
     code: 7,
     coding_issue_option: codingIssueOption,
@@ -119,7 +112,7 @@ function createServiceWithDetailedMocks(
       notes: unit.notes ?? null,
       codingIssueOption: unit.coding_issue_option ?? null,
       updatedAt: unit.updated_at ?? null,
-      coderName: codingJob?.codingJobCoders?.[0]?.user?.username ?? null,
+      coderName: unit.coderName ?? unit.coder_name ?? codingJob?.codingJobCoders?.[0]?.user?.username ?? null,
       statusV1: response?.status_v1 ?? null,
       bookletName: response?.unit?.booklet?.bookletinfo?.name ?? null,
       personLogin: response?.unit?.booklet?.person?.login ?? null,
@@ -128,7 +121,23 @@ function createServiceWithDetailedMocks(
     };
   };
 
-  const unitsBatchQueryBuilder = {
+  const rawRows = (overrides.units || [overrides.unit || defaultUnit]).map(toDetailedRawRow);
+  const unitIdRows = Array.from(
+    new Map(rawRows.map(row => [String(row.id), row])).values()
+  );
+  let idOffsetValue = 0;
+  let idLimitValue = unitIdRows.length;
+  let currentBatchIds: number[] = [];
+
+  const totalCountQueryBuilder = {
+    innerJoin: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getCount: jest.fn().mockResolvedValue(overrides.totalCount ?? unitIdRows.length)
+  };
+
+  const unitIdsBatchQueryBuilder = {
     innerJoin: jest.fn().mockReturnThis(),
     innerJoinAndSelect: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
@@ -138,19 +147,66 @@ function createServiceWithDetailedMocks(
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
-    getMany: jest.fn().mockResolvedValue([overrides.unit || defaultUnit]),
-    getRawMany: jest.fn().mockResolvedValue([
-      toDetailedRawRow(overrides.unit || defaultUnit)
-    ])
+    offset: jest.fn((value: number) => {
+      idOffsetValue = value;
+      return unitIdsBatchQueryBuilder;
+    }),
+    limit: jest.fn((value: number) => {
+      idLimitValue = value;
+      return unitIdsBatchQueryBuilder;
+    }),
+    getRawMany: jest.fn().mockImplementation(() => Promise.resolve(
+      unitIdRows
+        .slice(idOffsetValue, idOffsetValue + idLimitValue)
+        .map(row => ({ id: row.id }))
+    ))
   };
 
+  const captureBatchIds = (
+    _condition: string,
+    params?: { batchIds?: number[] }
+  ) => {
+    if (params?.batchIds) {
+      currentBatchIds = params.batchIds;
+    }
+    return unitsBatchQueryBuilder;
+  };
+
+  const unitsBatchQueryBuilder = {
+    innerJoin: jest.fn().mockReturnThis(),
+    innerJoinAndSelect: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn(captureBatchIds),
+    andWhere: jest.fn(captureBatchIds),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue(overrides.units || [overrides.unit || defaultUnit]),
+    getRawMany: jest.fn().mockImplementation(() => Promise.resolve(
+      currentBatchIds.length > 0 ?
+        rawRows.filter(row => currentBatchIds.includes(Number(row.id))) :
+        rawRows
+    ))
+  };
+
+  let codingJobUnitQueryBuilderCalls = 0;
   const codingJobUnitRepository: MockedRepo<CodingJobUnit> = {
-    createQueryBuilder: jest
-      .fn()
-      .mockReturnValueOnce(totalCountQueryBuilder)
-      .mockReturnValueOnce(unitsBatchQueryBuilder)
+    createQueryBuilder: jest.fn(() => {
+      codingJobUnitQueryBuilderCalls += 1;
+      if (codingJobUnitQueryBuilderCalls === 1) return totalCountQueryBuilder;
+      return codingJobUnitQueryBuilderCalls % 2 === 0 ?
+        unitIdsBatchQueryBuilder :
+        unitsBatchQueryBuilder;
+    })
   };
 
   const workspaceExclusionService = {
@@ -181,7 +237,12 @@ function createServiceWithDetailedMocks(
     overrides.missingsProfilesService as never
   );
 
-  return { service, totalCountQueryBuilder, unitsBatchQueryBuilder };
+  return {
+    service,
+    totalCountQueryBuilder,
+    unitIdsBatchQueryBuilder,
+    unitsBatchQueryBuilder
+  };
 }
 
 describe('CodingExportService (WS-Admin export smoke)', () => {
@@ -252,6 +313,178 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
       '(resp.status_v1 IS NULL OR resp.status_v1 NOT IN (:...excludedStatuses))',
       { excludedStatuses: [0, 1, 2, 10] }
     );
+  });
+
+  it('paginates detailed raw export batches without repeating rows', async () => {
+    const units = Array.from({ length: 501 }, (_, index) => ({
+      id: index + 1,
+      code: index % 10,
+      coding_issue_option: 0,
+      notes: '',
+      updated_at: new Date('2026-04-14T10:00:00.000Z'),
+      response_id: 1000 + index,
+      unit_name: 'U1',
+      variable_id: `V${index + 1}`,
+      coding_job: {
+        training_id: null,
+        codingJobCoders: [{ user: { username: 'coder1' } }]
+      },
+      response: {
+        status_v1: 8,
+        unit: {
+          name: 'U1',
+          booklet: {
+            person: {
+              login: `p-login-${index + 1}`,
+              code: `p-code-${index + 1}`,
+              group: 'G1'
+            },
+            bookletinfo: {
+              name: 'B1'
+            }
+          }
+        }
+      }
+    }));
+    const { service, unitIdsBatchQueryBuilder, unitsBatchQueryBuilder } = createServiceWithDetailedMocks(0, {
+      units,
+      totalCount: units.length
+    });
+
+    const buffer = await service.exportCodingResultsDetailed(1, false, false, false, false);
+    const dataRows = buffer.toString('utf-8').trimEnd().split('\n').slice(1);
+
+    expect(dataRows).toHaveLength(501);
+    expect(new Set(dataRows).size).toBe(501);
+    expect(unitsBatchQueryBuilder.getRawMany).toHaveBeenCalledTimes(2);
+    expect(unitIdsBatchQueryBuilder.getRawMany).toHaveBeenCalledTimes(2);
+    expect(unitIdsBatchQueryBuilder.offset).toHaveBeenNthCalledWith(1, 0);
+    expect(unitIdsBatchQueryBuilder.offset).toHaveBeenNthCalledWith(2, 500);
+    expect(unitIdsBatchQueryBuilder.limit).toHaveBeenCalledWith(500);
+    expect(unitsBatchQueryBuilder.offset).not.toHaveBeenCalled();
+    expect(unitsBatchQueryBuilder.limit).not.toHaveBeenCalled();
+    expect(unitsBatchQueryBuilder.skip).not.toHaveBeenCalled();
+    expect(unitsBatchQueryBuilder.take).not.toHaveBeenCalled();
+  });
+
+  it('exports all detailed rows when coding-unit batches fan out through assigned coders', async () => {
+    const units = Array.from({ length: 300 }, (_, index) => [
+      'coder-a',
+      'coder-b'
+    ].map(coderName => ({
+      id: index + 1,
+      coderName,
+      code: index % 10,
+      coding_issue_option: 0,
+      notes: '',
+      updated_at: new Date('2026-04-14T10:00:00.000Z'),
+      response_id: 2000 + index,
+      unit_name: 'U1',
+      variable_id: `V${index + 1}`,
+      coding_job: {
+        training_id: null,
+        codingJobCoders: [{ user: { username: coderName } }]
+      },
+      response: {
+        status_v1: 8,
+        unit: {
+          name: 'U1',
+          booklet: {
+            person: {
+              login: `p-login-${index + 1}`,
+              code: `p-code-${index + 1}`,
+              group: 'G1'
+            },
+            bookletinfo: {
+              name: 'B1'
+            }
+          }
+        }
+      }
+    }))).flat();
+    const { service, unitIdsBatchQueryBuilder, unitsBatchQueryBuilder } = createServiceWithDetailedMocks(0, {
+      units,
+      totalCount: 300
+    });
+
+    const buffer = await service.exportCodingResultsDetailed(1, false, false, false, false);
+    const dataRows = buffer.toString('utf-8').trimEnd().split('\n').slice(1);
+
+    expect(dataRows).toHaveLength(600);
+    expect(new Set(dataRows).size).toBe(600);
+    expect(dataRows.filter(row => row.includes('"coder-a"'))).toHaveLength(300);
+    expect(dataRows.filter(row => row.includes('"coder-b"'))).toHaveLength(300);
+    expect(unitIdsBatchQueryBuilder.getRawMany).toHaveBeenCalledTimes(1);
+    expect(unitsBatchQueryBuilder.getRawMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits one training manager row when a case spans detailed export batches', async () => {
+    const units = Array.from({ length: 501 }, (_, index) => ({
+      id: index + 1,
+      code: 7,
+      coding_issue_option: 0,
+      notes: '',
+      updated_at: new Date('2026-04-14T10:00:00.000Z'),
+      response_id: 123,
+      unit_name: 'U1',
+      variable_id: `V${index + 1}`,
+      coding_job: {
+        training_id: 5,
+        codingJobCoders: [{ user: { username: 'coder1' } }]
+      },
+      response: {
+        status_v1: 8,
+        unit: {
+          name: 'U1',
+          booklet: {
+            person: {
+              login: 'p-login',
+              code: 'p-code',
+              group: 'G1'
+            },
+            bookletinfo: {
+              name: 'B1'
+            }
+          }
+        }
+      }
+    }));
+    const { service, unitIdsBatchQueryBuilder } = createServiceWithDetailedMocks(0, {
+      units,
+      totalCount: units.length,
+      discussionResults: [{
+        training_id: 5,
+        response_id: 123,
+        code: 4,
+        score: 2,
+        notes: 'Manager note',
+        manager_user_id: 2,
+        manager_name: 'stored-manager',
+        updated_at: new Date('2026-04-14T11:00:00.000Z')
+      }],
+      users: [{ id: 2, username: 'manager1' }]
+    });
+
+    const buffer = await service.exportCodingResultsDetailed(
+      1,
+      false,
+      false,
+      false,
+      false,
+      '',
+      undefined,
+      false,
+      undefined,
+      undefined,
+      [5]
+    );
+    const dataRows = buffer.toString('utf-8').trimEnd().split('\n').slice(1);
+
+    expect(dataRows).toHaveLength(502);
+    expect(dataRows.filter(row => row.includes('"coder1"'))).toHaveLength(501);
+    expect(dataRows.filter(row => row.includes('"manager1"'))).toHaveLength(1);
+    expect(unitIdsBatchQueryBuilder.offset).toHaveBeenNthCalledWith(1, 0);
+    expect(unitIdsBatchQueryBuilder.offset).toHaveBeenNthCalledWith(2, 500);
   });
 
   it('does not resolve manual missing profiles for regular detailed export codes', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.ts
@@ -3660,9 +3660,111 @@ export class CodingExportService {
       const pseudoCoderMappings = new Map<string, Map<string, string>>();
       const escapeCsvField = (field: string): string => `"${field?.toString().replace(/"/g, '""') || ''}"`;
       let exportedRowCount = 0;
+      let batchCsv = '';
+      const discussionResultMap = new Map<string, TrainingDiscussionExportResult>();
+      let currentCaseKey: string | null = null;
+      let currentCaseRepresentative: DetailedCodingResultRawRow | null = null;
+      let emittedManagerForCurrentCase = false;
+      const emittedManagerCaseKeys = new Set<string>();
+
+      const flushManagerRowIfNeeded = async (): Promise<boolean> => {
+        if (!includeDiscussionResult) return false;
+        if (!currentCaseRepresentative) return false;
+        if (emittedManagerForCurrentCase) return false;
+
+        const trainingId = this.toIntegerOrNull(currentCaseRepresentative.trainingId);
+        const responseId = this.toIntegerOrNull(currentCaseRepresentative.responseId);
+        if (!trainingId || !responseId) return false;
+
+        const caseKey = `${trainingId}|${responseId}`;
+        if (emittedManagerCaseKeys.has(caseKey)) return false;
+
+        const discussion = discussionResultMap.get(caseKey);
+        if (!discussion) return false;
+        if (!discussion.managerUsername) return false;
+
+        const personLogin = currentCaseRepresentative.personLogin || '';
+        const personCode = currentCaseRepresentative.personCode || '';
+        const personGroup = currentCaseRepresentative.personGroup || '';
+        const unitName = currentCaseRepresentative.unitName || currentCaseRepresentative.responseUnitName || '';
+        const managerDisplayName = discussion.managerUsername;
+        const discussionTimestamp = discussion.updatedAt ? new Date(discussion.updatedAt).toLocaleString('de-DE').replace(',', '') : '';
+        const mappedDiscussionCode = mapCodeForExport(discussion.code);
+        const discussionCodeValue = mappedDiscussionCode === null ? '' : mappedDiscussionCode.toString();
+        const discussionNoteValue = discussion.notes || '';
+
+        const discussionRowFields = [
+          escapeCsvField(personLogin),
+          escapeCsvField(personCode),
+          escapeCsvField(personGroup),
+          escapeCsvField(managerDisplayName),
+          escapeCsvField(unitName),
+          escapeCsvField(currentCaseRepresentative.variableId),
+          escapeCsvField(discussionNoteValue),
+          escapeCsvField(discussionTimestamp),
+          escapeCsvField(discussionCodeValue),
+          escapeCsvField('')
+        ];
+
+        if (includeReplayUrl && (req || serverUrl)) {
+          const bookletName = currentCaseRepresentative.bookletName || '';
+          const replayUnitName = currentCaseRepresentative.responseUnitName || unitName;
+          const replayUrl = await this.generateReplayUrlWithPageLookup(req, personLogin, personCode, personGroup, bookletName, replayUnitName, currentCaseRepresentative.variableId, workspaceId, authToken, serverUrl);
+          discussionRowFields.push(escapeCsvField(replayUrl));
+        }
+
+        batchCsv += `${discussionRowFields.join(';')}\n`;
+        emittedManagerForCurrentCase = true;
+        emittedManagerCaseKeys.add(caseKey);
+        return true;
+      };
 
       for (let i = 0; i < totalCount; i += batchSize) {
         if (checkCancellation) await checkCancellation();
+
+        const unitIdsBatchQuery = this.codingJobUnitRepository.createQueryBuilder('cju')
+          .innerJoin('cju.coding_job', 'cj')
+          .select('cju.id', 'id')
+          .leftJoin('cju.response', 'resp')
+          .where('cj.workspace_id = :workspaceId', { workspaceId });
+
+        if (includeDiscussionResult) {
+          unitIdsBatchQuery
+            .orderBy('cj.training_id', 'ASC')
+            .addOrderBy('cju.response_id', 'ASC')
+            .addOrderBy('cju.variable_id', 'ASC')
+            .addOrderBy('cju.updated_at', 'ASC')
+            .addOrderBy('cju.id', 'ASC');
+        } else {
+          unitIdsBatchQuery
+            .orderBy('cju.created_at', 'ASC')
+            .addOrderBy('cju.id', 'ASC');
+        }
+        unitIdsBatchQuery
+          .offset(i)
+          .limit(batchSize);
+
+        this.applyJobFilters(
+          unitIdsBatchQuery,
+          normalizedJobDefinitionIds,
+          normalizedCoderTrainingIds,
+          normalizedCoderIds,
+          'cju'
+        );
+        if (normalizedCoderTrainingIds.length === 0) {
+          unitIdsBatchQuery.andWhere('cj.training_id IS NULL');
+        }
+        unitIdsBatchQuery.andWhere(
+          '(resp.status_v1 IS NULL OR resp.status_v1 NOT IN (:...excludedStatuses))',
+          { excludedStatuses: EXCLUDED_STATUSES }
+        );
+
+        const unitIdRows = await unitIdsBatchQuery.getRawMany<{ id: number | string }>();
+        const batchIds = unitIdRows
+          .map(row => this.toIntegerOrNull(row.id))
+          .filter((id): id is number => id !== null);
+        if (batchIds.length === 0) break;
+
         const unitsBatchQuery = this.codingJobUnitRepository.createQueryBuilder('cju')
           .innerJoin('cju.coding_job', 'cj')
           .leftJoin('cj.codingJobCoders', 'cjc')
@@ -3691,9 +3793,22 @@ export class CodingExportService {
           .addSelect('person.code', 'personCode')
           .addSelect('person.group', 'personGroup')
           .where('cj.workspace_id = :workspaceId', { workspaceId })
-          .orderBy('cju.created_at', 'ASC')
-          .skip(i)
-          .take(batchSize);
+          .andWhere('cju.id IN (:...batchIds)', { batchIds });
+
+        if (includeDiscussionResult) {
+          unitsBatchQuery
+            .orderBy('cj.training_id', 'ASC')
+            .addOrderBy('cju.response_id', 'ASC')
+            .addOrderBy('cju.variable_id', 'ASC')
+            .addOrderBy('cju.updated_at', 'ASC')
+            .addOrderBy('cju.id', 'ASC')
+            .addOrderBy('cjc.id', 'ASC');
+        } else {
+          unitsBatchQuery
+            .orderBy('cju.created_at', 'ASC')
+            .addOrderBy('cju.id', 'ASC')
+            .addOrderBy('cjc.id', 'ASC');
+        }
 
         this.applyJobFilters(
           unitsBatchQuery,
@@ -3712,7 +3827,6 @@ export class CodingExportService {
         const unitsBatch = await unitsBatchQuery.getRawMany<DetailedCodingResultRawRow>();
         await checkCancellation?.();
 
-        let discussionResultMap = new Map<string, TrainingDiscussionExportResult>();
         if (includeDiscussionResult && unitsBatch.length > 0) {
           const trainingIdSet = new Set<number>();
           const responseIdSet = new Set<number>();
@@ -3724,16 +3838,19 @@ export class CodingExportService {
           }
 
           if (trainingIdSet.size > 0 && responseIdSet.size > 0) {
-            discussionResultMap = await this.getTrainingDiscussionResultsMap(
+            const batchDiscussionResultMap = await this.getTrainingDiscussionResultsMap(
               workspaceId,
               Array.from(trainingIdSet),
               Array.from(responseIdSet)
             );
+            batchDiscussionResultMap.forEach((discussion, key) => {
+              discussionResultMap.set(key, discussion);
+            });
             await checkCancellation?.();
           }
         }
 
-        let batchCsv = '';
+        batchCsv = '';
 
         // Ensure that all coder rows for the same case (training_id + response_id) are emitted first,
         // then a single coding manager row at the end of that case.
@@ -3749,58 +3866,6 @@ export class CodingExportService {
           const bUpdated = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
           return aUpdated - bUpdated;
         });
-
-        let currentCaseKey: string | null = null;
-        let currentCaseRepresentative: DetailedCodingResultRawRow | null = null;
-        let emittedManagerForCurrentCase = false;
-
-        const flushManagerRowIfNeeded = async (): Promise<boolean> => {
-          if (!includeDiscussionResult) return false;
-          if (!currentCaseRepresentative) return false;
-          if (emittedManagerForCurrentCase) return false;
-
-          const trainingId = this.toIntegerOrNull(currentCaseRepresentative.trainingId);
-          const responseId = this.toIntegerOrNull(currentCaseRepresentative.responseId);
-          if (!trainingId || !responseId) return false;
-
-          const discussion = discussionResultMap.get(`${trainingId}|${responseId}`);
-          if (!discussion) return false;
-          if (!discussion.managerUsername) return false;
-
-          const personLogin = currentCaseRepresentative.personLogin || '';
-          const personCode = currentCaseRepresentative.personCode || '';
-          const personGroup = currentCaseRepresentative.personGroup || '';
-          const unitName = currentCaseRepresentative.unitName || currentCaseRepresentative.responseUnitName || '';
-          const managerDisplayName = discussion.managerUsername;
-          const discussionTimestamp = discussion.updatedAt ? new Date(discussion.updatedAt).toLocaleString('de-DE').replace(',', '') : '';
-          const mappedDiscussionCode = mapCodeForExport(discussion.code);
-          const discussionCodeValue = mappedDiscussionCode === null ? '' : mappedDiscussionCode.toString();
-          const discussionNoteValue = discussion.notes || '';
-
-          const discussionRowFields = [
-            escapeCsvField(personLogin),
-            escapeCsvField(personCode),
-            escapeCsvField(personGroup),
-            escapeCsvField(managerDisplayName),
-            escapeCsvField(unitName),
-            escapeCsvField(currentCaseRepresentative.variableId),
-            escapeCsvField(discussionNoteValue),
-            escapeCsvField(discussionTimestamp),
-            escapeCsvField(discussionCodeValue),
-            escapeCsvField('')
-          ];
-
-          if (includeReplayUrl && (req || serverUrl)) {
-            const bookletName = currentCaseRepresentative.bookletName || '';
-            const replayUnitName = currentCaseRepresentative.responseUnitName || unitName;
-            const replayUrl = await this.generateReplayUrlWithPageLookup(req, personLogin, personCode, personGroup, bookletName, replayUnitName, currentCaseRepresentative.variableId, workspaceId, authToken, serverUrl);
-            discussionRowFields.push(escapeCsvField(replayUrl));
-          }
-
-          batchCsv += `${discussionRowFields.join(';')}\n`;
-          emittedManagerForCurrentCase = true;
-          return true;
-        };
 
         for (let rowIndex = 0; rowIndex < sortedUnitsBatch.length; rowIndex += 1) {
           if (rowIndex > 0 && rowIndex % 100 === 0) {
@@ -3895,8 +3960,6 @@ export class CodingExportService {
           exportedRowCount += 1;
         }
 
-        // Flush last case in this batch
-        if (await flushManagerRowIfNeeded()) exportedRowCount += 1;
         if (outputFilePath) {
           await fs.promises.appendFile(outputFilePath, batchCsv, 'utf-8');
         } else {
@@ -3904,6 +3967,16 @@ export class CodingExportService {
         }
         await checkCancellation?.();
         await this.yieldToEventLoop();
+      }
+
+      batchCsv = '';
+      if (await flushManagerRowIfNeeded()) exportedRowCount += 1;
+      if (batchCsv) {
+        if (outputFilePath) {
+          await fs.promises.appendFile(outputFilePath, batchCsv, 'utf-8');
+        } else {
+          chunks.push(Buffer.from(batchCsv, 'utf-8'));
+        }
       }
 
       if (exportedRowCount === 0 && hasScopedJobFilters) {


### PR DESCRIPTION
## Summary

Fixes duplicate rows in the detailed coding export by changing batching to page over `coding_job_unit` IDs first, then loading the joined raw export rows for those IDs.

## Root cause

The detailed export batched a raw joined query directly with `skip`/`take`. In production this could repeat the same result set per batch, producing duplicated CSV rows. Direct raw-row pagination also risks mismatching the counted `coding_job_unit` rows when joins fan out through assigned coders.

## Changes

- Page detailed exports over stable `coding_job_unit` IDs with `offset`/`limit`.
- Load all joined raw export rows for each ID batch.
- Keep training discussion manager row state across batch boundaries so manager rows are emitted once per case.
- Add regression coverage for 501-row batching, coder fanout, and training cases that span batches.

## Validation

- `npx nx test backend --testFile=src/app/database/services/coding/coding-export.service.spec.ts`
- `npx nx test backend --testFile=src/app/database/services/coding/coding-export.golden.spec.ts`
- `npx nx test backend --testFile=src/app/database/services/coding/coding-export.high-coverage.spec.ts`
- `npx nx lint backend`
- `git diff --check`