### PR TITLE
Keep training filters focused during reload

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.html
@@ -178,7 +178,15 @@
       </div>
     </div>
 
-    <div class="loading-container" *ngIf="isLoading">
+    <div
+      class="loading-container"
+      *ngIf="
+        isLoading &&
+        !hasComparisonRows() &&
+        !hasNoSelectedCodersState() &&
+        !hasFilterEmptyState()
+      "
+    >
       <mat-progress-spinner
         mode="indeterminate"
         diameter="50"
@@ -189,7 +197,6 @@
     <div
       class="comparison-table"
       *ngIf="
-        !isLoading &&
         (((comparisonMode === 'between-trainings' &&
           selectedTrainings.selected.length >= 2) ||
           (comparisonMode === 'within-training' &&
@@ -583,7 +590,7 @@
           <input
             matInput
             [(ngModel)]="tableFilters.unitName"
-            (ngModelChange)="applyTableFilters()"
+            (ngModelChange)="onTextTableFilterChange()"
           />
           <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('unitName')">
             {{ 'search-filter.invalid-regex' | translate }}
@@ -595,7 +602,7 @@
           <input
             matInput
             [(ngModel)]="tableFilters.variableId"
-            (ngModelChange)="applyTableFilters()"
+            (ngModelChange)="onTextTableFilterChange()"
           />
           <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('variableId')">
             {{ 'search-filter.invalid-regex' | translate }}
@@ -607,7 +614,7 @@
           <input
             matInput
             [(ngModel)]="tableFilters.personLogin"
-            (ngModelChange)="applyTableFilters()"
+            (ngModelChange)="onTextTableFilterChange()"
           />
           <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('personLogin')">
             {{ 'search-filter.invalid-regex' | translate }}
@@ -619,7 +626,7 @@
           <input
             matInput
             [(ngModel)]="tableFilters.personGroup"
-            (ngModelChange)="applyTableFilters()"
+            (ngModelChange)="onTextTableFilterChange()"
           />
           <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('personGroup')">
             {{ 'search-filter.invalid-regex' | translate }}
@@ -631,7 +638,7 @@
           <input
             matInput
             [(ngModel)]="tableFilters.bookletName"
-            (ngModelChange)="applyTableFilters()"
+            (ngModelChange)="onTextTableFilterChange()"
           />
           <mat-hint class="regex-filter-error" *ngIf="isTableRegexFilterInvalid('bookletName')">
             {{ 'search-filter.invalid-regex' | translate }}
@@ -665,6 +672,14 @@
         <button mat-stroked-button type="button" (click)="resetTableFilters()">
           Filter zurücksetzen
         </button>
+      </div>
+
+      <div class="comparison-refresh-indicator" *ngIf="isLoading && (hasComparisonRows() || hasFilterEmptyState())">
+        <mat-progress-spinner
+          mode="indeterminate"
+          diameter="20"
+        ></mat-progress-spinner>
+        <span>Aktualisiere Vergleichsdaten...</span>
       </div>
 
       <div class="comparison-empty-state" *ngIf="hasNoSelectedCodersState()">

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.scss
@@ -212,6 +212,17 @@
       }
     }
 
+    .comparison-refresh-indicator {
+      display: inline-flex;
+      align-items: center;
+      align-self: flex-start;
+      gap: 8px;
+      min-height: 28px;
+      margin: -4px 0 12px;
+      color: #455a64;
+      font-size: 13px;
+    }
+
     .comparison-warning-list {
       display: flex;
       flex-direction: column;

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts
@@ -202,6 +202,7 @@ describe('CodingResultsComparisonComponent', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -262,6 +263,79 @@ describe('CodingResultsComparisonComponent', () => {
     expect(codingTrainingBackendService.getTrainingCohensKappa).not.toHaveBeenCalled();
     expect(component.withinTrainingData).toHaveLength(1);
     expect(component.isLoading).toBe(false);
+  });
+
+  it('should keep filter controls visible while comparison data reloads', () => {
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.availableCoders = [
+      { jobId: 1, coderName: 'Coder 1' },
+      { jobId: 2, coderName: 'Coder 2' }
+    ];
+    component.codersFormControl.setValue([1, 2]);
+    component.totalItems = 1;
+    component.withinTrainingData = [
+      {
+        responseId: 1,
+        unitName: 'Unit1',
+        variableId: 'Var1',
+        testperson: 'Test1',
+        personLogin: 'login',
+        personCode: 'code',
+        personGroup: 'group',
+        bookletName: 'booklet',
+        givenAnswer: 'answer',
+        replayCode: null,
+        replayScore: null,
+        discussionCode: null,
+        discussionScore: null,
+        discussionNotes: null,
+        discussionManagerUserId: null,
+        discussionManagerName: null,
+        discussionSource: null,
+        coders: [
+          {
+            jobId: 1,
+            coderName: 'Coder 1',
+            code: '7',
+            score: 2,
+            notes: null,
+            codingIssueOption: null
+          },
+          {
+            jobId: 2,
+            coderName: 'Coder 2',
+            code: '7',
+            score: 2,
+            notes: null,
+            codingIssueOption: null
+          }
+        ]
+      }
+    ];
+    component.dataSource.data = component.withinTrainingData;
+    component.isLoading = true;
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.table-filters input')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.comparison-refresh-indicator')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.comparison-container > .loading-container')).toBeNull();
+  });
+
+  it('should show refresh indicator while reloading from an empty filter state', () => {
+    component.comparisonMode = 'within-training';
+    component.selectedTrainingForWithin = 5;
+    component.codersFormControl.setValue([1, 2]);
+    component.tableFilters.unitName = 'MDV001';
+    component.totalItems = 0;
+    component.isLoading = true;
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.comparison-refresh-indicator')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.comparison-empty-state')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.comparison-container > .loading-container')).toBeNull();
   });
 
   it('should ignore stale within-training comparison responses after a training switch', () => {
@@ -828,6 +902,37 @@ describe('CodingResultsComparisonComponent', () => {
     }));
     expect(component.totalComparisons).toBe(1);
     expect(component.matchingComparisons).toBe(0);
+  });
+
+  it('should debounce text table filter changes before reloading comparison data', () => {
+    jest.useFakeTimers();
+    component.comparisonMode = 'between-trainings';
+    component.selectedTrainings.select(1, 2);
+    component.codersFromTrainingsFormControl.setValue(['1_101', '2_201']);
+    component.selectedCodersFromTrainings = new Set(['1_101', '2_201']);
+    (component as unknown as { hasInitializedBetweenCoderSelection: boolean }).hasInitializedBetweenCoderSelection = true;
+    codingTrainingBackendService.compareTrainingCodingResults.mockReturnValue(of(betweenComparisonPage([])));
+
+    component.tableFilters.unitName = 'M';
+    component.onTextTableFilterChange();
+    component.tableFilters.unitName = 'MD';
+    component.onTextTableFilterChange();
+
+    jest.advanceTimersByTime(399);
+    expect(codingTrainingBackendService.compareTrainingCodingResults).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+
+    expect(codingTrainingBackendService.compareTrainingCodingResults).toHaveBeenCalledTimes(1);
+    expect(codingTrainingBackendService.compareTrainingCodingResults).toHaveBeenCalledWith(
+      1,
+      '1,2',
+      expect.objectContaining({
+        filters: expect.objectContaining({
+          unitName: 'MD'
+        })
+      })
+    );
   });
 
   it('should apply regex filters when workspace regex search is enabled', () => {

--- a/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.ts
@@ -30,7 +30,9 @@ import { CommonModule } from '@angular/common';
 import { SelectionModel } from '@angular/cdk/collections';
 
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Subject, takeUntil } from 'rxjs';
+import {
+  debounceTime, distinctUntilChanged, Subject, takeUntil
+} from 'rxjs';
 import { normalizeTestperson } from '../../../replay/utils/token-utils';
 import { PostMessage, PostMessageService } from '../../../core/services/post-message.service';
 import { CodingTrainingBackendService } from '../../services/coding-training-backend.service';
@@ -237,6 +239,8 @@ const EMPTY_COMPARISON_SUMMARY: TrainingComparisonSummaryDto = {
   completionRate: 0
 };
 
+const TABLE_FILTER_DEBOUNCE_MS = 400;
+
 interface ModalValueDisplay {
   valueText: string;
   deviationText: string;
@@ -289,6 +293,7 @@ export class CodingResultsComparisonComponent implements OnInit {
   private ngUnsubscribe = new Subject<void>();
   private comparisonRequestCancel$ = new Subject<void>();
   private kappaRequestCancel$ = new Subject<void>();
+  private tableFilterChanges$ = new Subject<string>();
   private comparisonRequestId = 0;
   private kappaRequestId = 0;
   private coderTrainingsRequestId = 0;
@@ -405,6 +410,7 @@ export class CodingResultsComparisonComponent implements OnInit {
 
   ngOnInit(): void {
     this.setupFilterPredicate();
+    this.setupTableFilterChanges();
     this.discussionManagerLabel = this.appService.authData.userName || this.appService.loggedUser?.preferred_username || 'Diskussion';
     this.comparisonMode = this.data.initialMode || 'between-trainings';
 
@@ -439,9 +445,10 @@ export class CodingResultsComparisonComponent implements OnInit {
   ngOnDestroy(): void {
     this.cancelComparisonRequest();
     this.cancelKappaRequest();
+    this.ngUnsubscribe.next();
     this.comparisonRequestCancel$.complete();
     this.kappaRequestCancel$.complete();
-    this.ngUnsubscribe.next();
+    this.tableFilterChanges$.complete();
     this.ngUnsubscribe.complete();
   }
 
@@ -534,12 +541,33 @@ export class CodingResultsComparisonComponent implements OnInit {
     };
   }
 
+  private setupTableFilterChanges(): void {
+    this.tableFilterChanges$
+      .pipe(
+        debounceTime(TABLE_FILTER_DEBOUNCE_MS),
+        distinctUntilChanged(),
+        takeUntil(this.ngUnsubscribe)
+      )
+      .subscribe(() => this.applyTableFilters());
+  }
+
+  private getTableFilterSignature(): string {
+    return JSON.stringify({
+      ...this.tableFilters,
+      regexSearch: this.enableRegexSearch
+    });
+  }
+
   applyTableFilters(): void {
     if (this.hasInvalidTableRegexFilters()) {
       return;
     }
 
     this.reloadComparisonFirstPage();
+  }
+
+  onTextTableFilterChange(): void {
+    this.tableFilterChanges$.next(this.getTableFilterSignature());
   }
 
   resetTableFilters(): void {
@@ -557,6 +585,10 @@ export class CodingResultsComparisonComponent implements OnInit {
 
   private getCurrentComparisonRows(): Array<TrainingComparison | WithinTrainingComparison> {
     return this.comparisonMode === 'between-trainings' ? this.comparisonData : this.withinTrainingData;
+  }
+
+  hasComparisonRows(): boolean {
+    return this.getCurrentComparisonRows().length > 0;
   }
 
   getFilteredRowsCount(): number {
@@ -1594,6 +1626,7 @@ export class CodingResultsComparisonComponent implements OnInit {
     this.codersFromTrainingsFormControl.setValue([]);
     this.selectedCodersFromTrainings.clear();
     if (this.comparisonMode === 'between-trainings' && this.selectedTrainings.selected.length >= 2) {
+      this.clearComparisonRows();
       this.reloadComparisonFirstPage();
     } else {
       this.cancelComparisonRequest();
@@ -1612,6 +1645,7 @@ export class CodingResultsComparisonComponent implements OnInit {
       this.codersFormControl.setValue([]);
       this.selectedCoderIds.clear();
       this.updateDisplayedColumns();
+      this.clearComparisonRows();
       this.reloadComparisonFirstPage();
     } else {
       this.cancelComparisonRequest();
@@ -1915,8 +1949,6 @@ export class CodingResultsComparisonComponent implements OnInit {
       const requestId = this.startComparisonRequest();
       const trainingId = this.selectedTrainingForWithin;
       this.resetKappaState();
-      this.withinTrainingData = [];
-      this.dataSource.data = [];
       this.codingTrainingBackendService.getCachedWithinTrainingCodingResults(
         this.data.workspaceId,
         trainingId,


### PR DESCRIPTION
## Summary

Related to #876.

This keeps the training comparison filter controls mounted while comparison data reloads, so text inputs such as `Aufgabe` retain focus while users type. Text filters now debounce reloads, existing rows stay visible during refreshes, and a compact refresh indicator appears for both existing rows and empty filter states.

## Root cause

The comparison table and filters were hidden behind the global loading state, and text filter changes triggered an immediate reload for every keystroke. In within-training mode the current rows were also cleared before each request, which made the dialog flicker and removed the focused input.

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/coding/components/coding-results-comparison/coding-results-comparison.component.spec.ts --runInBand`
- `npx nx lint frontend`
- `npx nx test frontend --runInBand`
- Manual UI check in the running Docker app: `Manuelle Kodierung` -> `Schulung` -> `Diskussion`, selected `UI Replay Notes Test 2026-06-24`, typed `MGB162` slowly into `Aufgabe`; focus stayed in the input and the table/filter area remained visible.