### PR TITLE
Fix training manual export variables

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
@@ -283,17 +283,72 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
 
     const references = await (service as unknown as {
       getManualCodingVariableReferences: (
-        workspaceId: number
+        workspaceId: number,
+        jobDefinitionIds?: number[],
+        coderTrainingIds?: number[],
+        coderIds?: number[]
       ) => Promise<Array<{ unitName: string; variableId: string; includeDeriveError?: boolean }>>
     }).getManualCodingVariableReferences(13);
 
     expect(references).toEqual([{ unitName: 'UNIT', variableId: 'VAR', includeDeriveError: undefined }]);
-    expect(manualJobVariablesQuery.select).toHaveBeenCalledWith('coding_job_unit.unit_name', 'unitName');
+    expect(manualJobVariablesQuery.select).toHaveBeenCalledWith('cju.unit_name', 'unitName');
     expect(manualJobVariablesQuery.select).not.toHaveBeenCalledWith(
       expect.stringContaining('DISTINCT'),
       expect.anything()
     );
     expect(manualJobVariablesQuery.distinct).toHaveBeenCalledWith(true);
+  });
+
+  it('includes selected training job variables in manual-only export references', async () => {
+    const manualJobVariablesQuery = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      distinct: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([{ unitName: 'DHB011', variableId: '10' }])
+    };
+    const codingJobUnitRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(manualJobVariablesQuery)
+    };
+    const codingListService = {
+      getCodingListVariables: jest.fn().mockResolvedValue([])
+    };
+    const workspaceExclusionService = {
+      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+        globalIgnoredUnits: [],
+        ignoredBooklets: [],
+        testletIgnoredUnits: []
+      })
+    };
+    const service = new CodingExportService(
+      {} as Repository<ResponseEntity>,
+      {} as Repository<CodingJob>,
+      {} as Repository<CodingJobVariable>,
+      codingJobUnitRepository as unknown as Repository<CodingJobUnit>,
+      {} as Repository<CoderTrainingDiscussionResult>,
+      {} as Repository<User>,
+      codingListService as unknown as CodingListService,
+      {} as WorkspaceCoreService,
+      workspaceExclusionService as unknown as WorkspaceExclusionService
+    );
+
+    const references = await (service as unknown as {
+      getManualCodingVariableReferences: (
+        workspaceId: number,
+        jobDefinitionIds?: number[],
+        coderTrainingIds?: number[],
+        coderIds?: number[]
+      ) => Promise<Array<{ unitName: string; variableId: string; includeDeriveError?: boolean }>>
+    }).getManualCodingVariableReferences(13, undefined, [21]);
+
+    expect(references).toEqual([{ unitName: 'DHB011', variableId: '10', includeDeriveError: undefined }]);
+    expect(manualJobVariablesQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('cj.training_id IN (:...coderTrainingIds)'),
+      { coderTrainingIds: [21] }
+    );
+    expect(manualJobVariablesQuery.andWhere).not.toHaveBeenCalledWith('cj.training_id IS NULL');
   });
 
   it('keeps code value and writes code hint when coding_issue_option is set', async () => {
@@ -1806,7 +1861,7 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
       {} as Repository<CodingJob>,
       {} as Repository<CodingJobVariable>,
       codingJobUnitRepository as unknown as Repository<CodingJobUnit>,
-      { find: jest.fn() } as unknown as Repository<CoderTrainingDiscussionResult>,
+      { find: jest.fn().mockResolvedValue([]) } as unknown as Repository<CoderTrainingDiscussionResult>,
       { findBy: jest.fn() } as unknown as Repository<User>,
       codingListService as unknown as CodingListService,
       {} as WorkspaceCoreService,
@@ -1832,12 +1887,127 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
 
     expect(statusStringToNumber('DERIVE_ERROR')).not.toBeNull();
     expect(codingListService.getCodingListVariables).toHaveBeenCalledWith(7);
-    expect(manualJobVariablesQuery.andWhere).toHaveBeenCalledWith('coding_job.training_id IS NULL');
+    expect(manualJobVariablesQuery.andWhere).toHaveBeenCalledWith('cj.training_id IS NULL');
     expect(variableRecordsQuery.andWhere).toHaveBeenCalledWith('cj.training_id IS NULL');
     expect(manualCodingQuery.andWhere).toHaveBeenCalledWith('cj.training_id IS NULL');
     expect(worksheet?.getRow(1).getCell(4).value).toBe('UNIT_DERIVED');
     expect(worksheet?.getRow(1).getCell(5).value).toBeNull();
     expect(worksheet?.getRow(2).getCell(4).value).toBe('4');
+  });
+
+  it('includes selected training job variables in the manual-only aggregated export', async () => {
+    const createQueryBuilder = (rawRows: unknown[] = []) => {
+      const qb = {
+        innerJoin: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        distinct: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        addGroupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rawRows)
+      };
+      return qb;
+    };
+
+    const manualJobVariablesQuery = createQueryBuilder([{
+      unitName: 'DHB011',
+      variableId: '10'
+    }]);
+    const variableRecordsQuery = createQueryBuilder([{
+      unitName: 'DHB011',
+      variableId: '10',
+      bookletName: 'BOOKLET-A'
+    }]);
+    const manualCodingQuery = createQueryBuilder([{
+      personId: '10',
+      unitName: 'DHB011',
+      variableId: '10',
+      cju_code: '1',
+      coding_issue_option: null,
+      code_v1: null,
+      code_v2: null,
+      code_v3: null,
+      notes: null,
+      username: 'Coder A',
+      jobId: '1',
+      trainingId: '21',
+      missingsProfileId: null,
+      responseId: '100'
+    }]);
+    const personResultsQuery = createQueryBuilder([{
+      id: '10',
+      login: 'login-a',
+      code: 'code-a',
+      group: 'group-a',
+      bookletName: 'BOOKLET-A'
+    }]);
+    const responseRepository = {
+      createQueryBuilder: jest.fn().mockReturnValueOnce(personResultsQuery)
+    };
+    const codingJobUnitRepository = {
+      createQueryBuilder: jest.fn()
+        .mockReturnValueOnce(manualJobVariablesQuery)
+        .mockReturnValueOnce(variableRecordsQuery)
+        .mockReturnValueOnce(manualCodingQuery)
+    };
+    const codingListService = {
+      getCodingListVariables: jest.fn().mockResolvedValue([])
+    };
+    const workspaceExclusionService = {
+      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+        globalIgnoredUnits: [],
+        ignoredBooklets: [],
+        testletIgnoredUnits: []
+      })
+    };
+
+    const service = new CodingExportService(
+      responseRepository as unknown as Repository<ResponseEntity>,
+      {} as Repository<CodingJob>,
+      {} as Repository<CodingJobVariable>,
+      codingJobUnitRepository as unknown as Repository<CodingJobUnit>,
+      { find: jest.fn().mockResolvedValue([]) } as unknown as Repository<CoderTrainingDiscussionResult>,
+      { findBy: jest.fn() } as unknown as Repository<User>,
+      codingListService as unknown as CodingListService,
+      {} as WorkspaceCoreService,
+      workspaceExclusionService as unknown as WorkspaceExclusionService
+    );
+
+    const buffer = await service.exportCodingResultsAggregated(
+      7,
+      false,
+      false,
+      false,
+      false,
+      'most-frequent',
+      false,
+      false,
+      '',
+      undefined,
+      true,
+      undefined,
+      undefined,
+      [21]
+    );
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer);
+    const worksheet = workbook.getWorksheet('Coding Results');
+
+    expect(codingListService.getCodingListVariables).toHaveBeenCalledWith(7);
+    expect(manualJobVariablesQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('cj.training_id IN (:...coderTrainingIds)'),
+      { coderTrainingIds: [21] }
+    );
+    expect(manualJobVariablesQuery.andWhere).not.toHaveBeenCalledWith('cj.training_id IS NULL');
+    expect(variableRecordsQuery.andWhere).not.toHaveBeenCalledWith('cj.training_id IS NULL');
+    expect(manualCodingQuery.andWhere).not.toHaveBeenCalledWith('cj.training_id IS NULL');
+    expect(worksheet?.getRow(1).getCell(4).value).toBe('DHB011_10');
+    expect(worksheet?.getRow(2).getCell(4).value).toBe('1');
   });
 
   it('rejects coding-times export when scoped filters match no coded units', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.ts
@@ -296,21 +296,36 @@ export class CodingExportService {
     return (bookletName: string, unitName: string) => !unitName || isExcludedByResolvedExclusions(exclusions, bookletName, unitName);
   }
 
-  private async getManualCodingVariableReferences(workspaceId: number): Promise<ManualCodingVariableReference[]> {
+  private async getManualCodingVariableReferences(
+    workspaceId: number,
+    jobDefinitionIds?: number[],
+    coderTrainingIds?: number[],
+    coderIds?: number[]
+  ): Promise<ManualCodingVariableReference[]> {
+    const {
+      jobDefinitionIds: normalizedJobDefinitionIds,
+      coderTrainingIds: normalizedCoderTrainingIds,
+      coderIds: normalizedCoderIds
+    } = this.normalizeJobFilters(jobDefinitionIds, coderTrainingIds, coderIds);
     const codingListVariables = await this.codingListService.getCodingListVariables(workspaceId);
     const manualJobVariables = await this.codingJobUnitRepository
-      .createQueryBuilder('coding_job_unit')
-      .select('coding_job_unit.unit_name', 'unitName')
-      .addSelect('coding_job_unit.variable_id', 'variableId')
-      .innerJoin('coding_job_unit.coding_job', 'coding_job')
-      .where('coding_job.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('coding_job.training_id IS NULL')
+      .createQueryBuilder('cju')
+      .select('cju.unit_name', 'unitName')
+      .addSelect('cju.variable_id', 'variableId')
+      .innerJoin('cju.coding_job', 'cj')
+      .where('cj.workspace_id = :workspaceId', { workspaceId })
       .distinct(true);
-    applyNonCodingIssueReviewJobFilter(
+    this.applyJobFilters(
       manualJobVariables,
-      'coding_job',
-      'manualCodingVariablesReviewJobType'
+      normalizedJobDefinitionIds,
+      normalizedCoderTrainingIds,
+      normalizedCoderIds,
+      'cju'
     );
+    if (normalizedCoderTrainingIds.length === 0) {
+      manualJobVariables.andWhere('cj.training_id IS NULL');
+    }
+
     const manualJobVariableRows =
       await manualJobVariables.getRawMany<{
         unitName: string;
@@ -330,8 +345,18 @@ export class CodingExportService {
     return manualCodingVariables;
   }
 
-  private async getManualCodingVariableSet(workspaceId: number): Promise<Set<string>> {
-    const manualCodingVariables = await this.getManualCodingVariableReferences(workspaceId);
+  private async getManualCodingVariableSet(
+    workspaceId: number,
+    jobDefinitionIds?: number[],
+    coderTrainingIds?: number[],
+    coderIds?: number[]
+  ): Promise<Set<string>> {
+    const manualCodingVariables = await this.getManualCodingVariableReferences(
+      workspaceId,
+      jobDefinitionIds,
+      coderTrainingIds,
+      coderIds
+    );
     return createManualCodingVariablePairKeySet(manualCodingVariables);
   }
 
@@ -997,7 +1022,12 @@ export class CodingExportService {
 
     let manualCodingVariableSet: Set<string> | null = null;
     if (excludeAutoCoded) {
-      manualCodingVariableSet = await this.getManualCodingVariableSet(workspaceId);
+      manualCodingVariableSet = await this.getManualCodingVariableSet(
+        workspaceId,
+        normalizedJobDefinitionIds,
+        normalizedCoderTrainingIds,
+        normalizedCoderIds
+      );
     }
 
     // 1. Get all variables to define columns
@@ -1425,7 +1455,12 @@ export class CodingExportService {
 
     let manualCodingVariableSet: Set<string> | null = null;
     if (excludeAutoCoded) {
-      manualCodingVariableSet = await this.getManualCodingVariableSet(workspaceId);
+      manualCodingVariableSet = await this.getManualCodingVariableSet(
+        workspaceId,
+        jobDefinitionIds,
+        coderTrainingIds,
+        coderIds
+      );
     }
 
     const variableRecordsQuery = this.codingJobUnitRepository.createQueryBuilder('cju')
@@ -1833,7 +1868,12 @@ export class CodingExportService {
 
     let manualCodingVariableSet: Set<string> | null = null;
     if (excludeAutoCoded) {
-      manualCodingVariableSet = await this.getManualCodingVariableSet(workspaceId);
+      manualCodingVariableSet = await this.getManualCodingVariableSet(
+        workspaceId,
+        jobDefinitionIds,
+        coderTrainingIds,
+        coderIds
+      );
     }
 
     // 1. Get all coders to build mapping
@@ -2326,7 +2366,12 @@ export class CodingExportService {
     const isExcluded = await this.getExclusionChecker(workspaceId);
     let manualCodingVariableSet: Set<string> | null = null;
     if (excludeAutoCoded) {
-      manualCodingVariableSet = await this.getManualCodingVariableSet(workspaceId);
+      manualCodingVariableSet = await this.getManualCodingVariableSet(
+        workspaceId,
+        normalizedJobDefinitionIds,
+        normalizedCoderTrainingIds,
+        normalizedCoderIds
+      );
     }
 
     const { workbook, chunks } = this.createStreamingWorkbookTarget(outputFilePath);
@@ -3142,7 +3187,12 @@ export class CodingExportService {
     if (checkCancellation) await checkCancellation();
 
     const manualCodingVariableSet = excludeAutoCoded ?
-      await this.getManualCodingVariableSet(workspaceId) :
+      await this.getManualCodingVariableSet(
+        workspaceId,
+        normalizedJobDefinitionIds,
+        normalizedCoderTrainingIds,
+        normalizedCoderIds
+      ) :
       null;
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     const globalCoderMapping = await this.getCompactByVariableCoderMapping(
@@ -3595,7 +3645,12 @@ export class CodingExportService {
     try {
       let manualCodingVariableSet: Set<string> | null = null;
       if (excludeAutoCoded) {
-        manualCodingVariableSet = await this.getManualCodingVariableSet(workspaceId);
+        manualCodingVariableSet = await this.getManualCodingVariableSet(
+          workspaceId,
+          normalizedJobDefinitionIds,
+          normalizedCoderTrainingIds,
+          normalizedCoderIds
+        );
       }
 
       const isExcluded = await this.getExclusionChecker(workspaceId);
@@ -4063,7 +4118,12 @@ export class CodingExportService {
 
     let manualCodingVariableSet: Set<string> | null = null;
     if (excludeAutoCoded) {
-      manualCodingVariableSet = await this.getManualCodingVariableSet(workspaceId);
+      manualCodingVariableSet = await this.getManualCodingVariableSet(
+        workspaceId,
+        normalizedJobDefinitionIds,
+        normalizedCoderTrainingIds,
+        normalizedCoderIds
+      );
     }
 
     try {


### PR DESCRIPTION
## Summary

- Include selected training job variables when building the manual-only export variable allowlist.
- Preserve the previous non-training behavior when no training filter is selected.
- Add regression coverage for the helper and the public aggregated export path so training variable `DHB011_10` is present in the generated workbook.

## Root Cause

Manual-only exports filtered export rows against an allowlist built from coding-list variables plus non-training coding job variables. When the export was scoped to a coder training, training-only variables such as alias `10` were missing from that allowlist and were therefore dropped from some exports.

## Validation

- `npx tsc -p apps/backend/tsconfig.spec.json --noEmit --pretty false`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coding-export.service.spec.ts --runInBand`
- `npx nx lint backend`
- `npx nx test backend --runInBand`
- Read-only production data check on `iqb-kodierbox.de` confirmed that affected training `variable_id = 10` pairs are absent from the old non-training allowlist.

Related: #879