### PR TITLE
Fix manual refresh and training kappa

### DIFF
--- a/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.spec.ts
@@ -3173,6 +3173,7 @@ describe('CoderTrainingService', () => {
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
+        addGroupBy: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
         addOrderBy: jest.fn().mockReturnThis(),
         setParameter: jest.fn().mockReturnThis(),
@@ -3192,6 +3193,12 @@ describe('CoderTrainingService', () => {
           validValueCount: '2'
         },
         {
+          responseId: 101,
+          unitName: 'U2',
+          variableId: 'V2',
+          validValueCount: '2'
+        },
+        {
           responseId: 201,
           unitName: 'U2',
           variableId: 'V2',
@@ -3207,6 +3214,12 @@ describe('CoderTrainingService', () => {
         },
         {
           responseId: 101, jobId: 13, unitName: 'U1', variableId: 'V1', code: '1', score: 1
+        },
+        {
+          responseId: 101, jobId: 11, unitName: 'U2', variableId: 'V2', code: '2', score: 2
+        },
+        {
+          responseId: 101, jobId: 12, unitName: 'U2', variableId: 'V2', code: '2', score: 2
         },
         {
           responseId: 102, jobId: 11, unitName: 'U1', variableId: 'V1', code: '1', score: 1
@@ -3286,6 +3299,13 @@ describe('CoderTrainingService', () => {
       });
 
       expect(fullComparisonSpy).not.toHaveBeenCalled();
+      expect(caseQb.addSelect).toHaveBeenCalledWith('cju.unit_name', 'unitName');
+      expect(caseQb.addSelect).toHaveBeenCalledWith('cju.variable_id', 'variableId');
+      expect(caseQb.groupBy).toHaveBeenCalledWith('cju.response_id');
+      expect(caseQb.addGroupBy).toHaveBeenCalledWith('cju.unit_name');
+      expect(caseQb.addGroupBy).toHaveBeenCalledWith('cju.variable_id');
+      expect(caseQb.orderBy).toHaveBeenCalledWith('cju.unit_name', 'ASC');
+      expect(caseQb.addOrderBy).toHaveBeenCalledWith('cju.variable_id', 'ASC');
       expect(caseQb.setParameter).toHaveBeenCalledWith('withinTrainingKappaCaseSelectedJobIds', [11, 12, 13]);
       expect(valueQb.andWhere).toHaveBeenCalledWith(
         'cj.id IN (:...withinTrainingKappaValueJobIds)',
@@ -3305,10 +3325,13 @@ describe('CoderTrainingService', () => {
           }),
           expect.objectContaining({
             coder1Id: 11,
-            coder2Id: 13,
+            coder2Id: 12,
             unitName: 'U2',
             variableId: 'V2',
-            codes: [{ code1: 1, code2: null }]
+            codes: [
+              { code1: 2, code2: 2 },
+              { code1: 1, code2: null }
+            ]
           })
         ]),
         'code'
@@ -3326,13 +3349,13 @@ describe('CoderTrainingService', () => {
           unitName: 'U2',
           variableId: 'V2',
           meanKappa: null,
-          caseCount: 0,
+          caseCount: 1,
           validPairCount: 0,
           coderPairCount: 0
         })
       ]);
       expect(result.workspaceSummary).toMatchObject({
-        totalDoubleCodedResponses: 2,
+        totalDoubleCodedResponses: 3,
         totalCoderPairs: 3,
         averageKappa: 0.6,
         variablesIncluded: 2,
@@ -3367,7 +3390,7 @@ describe('CoderTrainingService', () => {
             id: 'mir', label: 'custom invalid response', code: -41, score: 2
           },
           {
-            id: 'mci', label: 'custom coding impossible', code: -42, score: 3
+            id: 'mci', label: 'custom coding impossible', code: -42, score: null
           },
           {
             id: 'custom', label: 'custom missing', code: -43, score: 4
@@ -3385,6 +3408,7 @@ describe('CoderTrainingService', () => {
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
+        addGroupBy: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
         addOrderBy: jest.fn().mockReturnThis(),
         setParameter: jest.fn().mockReturnThis(),
@@ -3442,10 +3466,12 @@ describe('CoderTrainingService', () => {
         .find(([, alias]) => alias === 'score')?.[0] as string;
       expect(caseValidCountExpression).toContain('WHEN cju.code = -3 OR cju.coding_issue_option = -3');
       expect(caseValidCountExpression).toContain('WHEN 11 THEN 2');
+      expect(caseValidCountExpression).toContain('WHEN 11 THEN NULL::integer');
       expect(caseValidCountExpression).toContain('WHEN -43 THEN 4');
       expect(caseValidCountExpression).not.toContain('AND (cju.score) IS NOT NULL');
       expect(valueScoreExpression).toContain('WHEN cju.code = -3 OR cju.coding_issue_option = -3');
       expect(valueScoreExpression).toContain('WHEN 11 THEN 2');
+      expect(valueScoreExpression).toContain('WHEN 11 THEN NULL::integer');
       expect(valueScoreExpression).toContain('WHEN -43 THEN 4');
       expect(valueScoreExpression).not.toBe('cju.score');
       expect(codingStatisticsService.calculateCohensKappa).toHaveBeenCalledWith(

--- a/apps/backend/src/app/database/services/coding/coder-training.service.ts
+++ b/apps/backend/src/app/database/services/coding/coder-training.service.ts
@@ -1358,7 +1358,7 @@ export class CoderTrainingService {
   }
 
   private toSqlScoreLiteral(score: number | null): string {
-    return score === null ? 'NULL' : score.toString();
+    return score === null ? 'NULL::integer' : score.toString();
   }
 
   private buildComparisonMissingScoreByJobSqlExpression(
@@ -1876,8 +1876,8 @@ export class CoderTrainingService {
       .createQueryBuilder('cju')
       .innerJoin('cju.coding_job', 'cj')
       .select('cju.response_id', 'responseId')
-      .addSelect('MIN(cju.unit_name)', 'unitName')
-      .addSelect('MIN(cju.variable_id)', 'variableId')
+      .addSelect('cju.unit_name', 'unitName')
+      .addSelect('cju.variable_id', 'variableId')
       .addSelect(
         `COUNT(DISTINCT cj.id) FILTER (
           WHERE cj.id IN (:...${selectedJobParameterName})
@@ -1888,8 +1888,10 @@ export class CoderTrainingService {
       .where('cj.workspace_id = :workspaceId', { workspaceId })
       .andWhere('cj.training_id = :trainingId', { trainingId })
       .groupBy('cju.response_id')
-      .orderBy('MIN(cju.unit_name)', 'ASC')
-      .addOrderBy('MIN(cju.variable_id)', 'ASC')
+      .addGroupBy('cju.unit_name')
+      .addGroupBy('cju.variable_id')
+      .orderBy('cju.unit_name', 'ASC')
+      .addOrderBy('cju.variable_id', 'ASC')
       .addOrderBy('cju.response_id', 'ASC')
       .setParameter(selectedJobParameterName, selectedJobIds);
 
@@ -1992,10 +1994,18 @@ export class CoderTrainingService {
         return;
       }
 
-      valuesByResponseAndJob.set(`${responseId}:${jobId}`, {
-        code: this.toKappaCode(row.code),
-        score: this.toNullableScore(row.score)
-      });
+      valuesByResponseAndJob.set(
+        this.getTrainingKappaValueKey(
+          responseId,
+          row.unitName,
+          row.variableId,
+          jobId
+        ),
+        {
+          code: this.toKappaCode(row.code),
+          score: this.toNullableScore(row.score)
+        }
+      );
     });
 
     const casesByVariable = new Map<string, WithinTrainingKappaCase[]>();
@@ -2023,8 +2033,22 @@ export class CoderTrainingService {
           const scores: Array<{ score1: number | null; score2: number | null }> = [];
 
           variableCases.forEach(item => {
-            const coder1Value = valuesByResponseAndJob.get(`${item.responseId}:${coder1.id}`);
-            const coder2Value = valuesByResponseAndJob.get(`${item.responseId}:${coder2.id}`);
+            const coder1Value = valuesByResponseAndJob.get(
+              this.getTrainingKappaValueKey(
+                item.responseId,
+                item.unitName,
+                item.variableId,
+                coder1.id
+              )
+            );
+            const coder2Value = valuesByResponseAndJob.get(
+              this.getTrainingKappaValueKey(
+                item.responseId,
+                item.unitName,
+                item.variableId,
+                coder2.id
+              )
+            );
             codes.push({
               code1: coder1Value?.code ?? null,
               code2: coder2Value?.code ?? null
@@ -4257,6 +4281,15 @@ export class CoderTrainingService {
 
   private getTrainingKappaVariableKey(unitName: string, variableId: string): string {
     return `${unitName}:${variableId}`;
+  }
+
+  private getTrainingKappaValueKey(
+    responseId: number,
+    unitName: string,
+    variableId: string,
+    jobId: number
+  ): string {
+    return `${responseId}:${unitName}:${variableId}:${jobId}`;
   }
 
   private createEmptyTrainingKappaStatistics(

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -1512,6 +1512,22 @@
             </button>
           </div>
 
+          <div
+            *ngIf="shouldShowManualTabLoadHint('execution')"
+            class="info-alert manual-refresh-hint"
+          >
+            <mat-icon class="info-alert-icon">refresh</mat-icon>
+            <div class="info-alert-content">
+              <strong>{{
+                'coding-management-manual.manual-load-hint.title' | translate
+              }}</strong>
+              <span>{{
+                'coding-management-manual.manual-load-hint.execution'
+                  | translate
+              }}</span>
+            </div>
+          </div>
+
           <coding-box-coding-jobs
             *ngIf="shouldRenderManualTabData('execution')"
             #productiveCodingJobs
@@ -2026,6 +2042,21 @@
               <mat-icon>refresh</mat-icon>
               {{ 'coding-management-manual.buttons.refresh' | translate }}
             </button>
+          </div>
+          <div
+            *ngIf="shouldShowManualTabLoadHint('training')"
+            class="info-alert manual-refresh-hint"
+          >
+            <mat-icon class="info-alert-icon">refresh</mat-icon>
+            <div class="info-alert-content">
+              <strong>{{
+                'coding-management-manual.manual-load-hint.title' | translate
+              }}</strong>
+              <span>{{
+                'coding-management-manual.manual-load-hint.training'
+                  | translate
+              }}</span>
+            </div>
           </div>
           <coding-box-coder-trainings-list
             *ngIf="shouldRenderManualTabData('training')"

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.scss
@@ -1076,6 +1076,15 @@
     }
   }
 
+  .manual-refresh-hint {
+    background-color: #fff8e1;
+    border-left-color: #f9a825;
+
+    .info-alert-icon {
+      color: #f9a825;
+    }
+  }
+
   .case-coverage-info {
     background-color: #fff3e0;
     border-left-color: #f57c00;

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -356,6 +356,36 @@ describe('CodingManagementManualComponent', () => {
     expect(loadCodingFreshnessSpy).toHaveBeenCalledWith({ force: true });
   });
 
+  it('should keep a suppressed manual refresh forced after a background guard clears', () => {
+    component.selectedManualTabIndex = 3;
+    const componentInternals = component as unknown as {
+      pendingManualStateRefreshAfterBackgroundJob: boolean;
+      pendingForcedManualStateRefreshAfterBackgroundJob: boolean;
+      refreshPendingManualStatusAfterBackgroundJob(): void;
+      loadManualTabData(
+        tab: string,
+        options?: { reloadCodingJobs?: boolean; forceRefresh?: boolean }
+      ): void;
+      loadCodingFreshness(options?: { force?: boolean }): void;
+    };
+    componentInternals.pendingManualStateRefreshAfterBackgroundJob = true;
+    componentInternals.pendingForcedManualStateRefreshAfterBackgroundJob = true;
+    const loadManualTabDataSpy = jest
+      .spyOn(componentInternals, 'loadManualTabData')
+      .mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+
+    componentInternals.refreshPendingManualStatusAfterBackgroundJob();
+
+    expect(loadManualTabDataSpy).toHaveBeenCalledWith('execution', {
+      reloadCodingJobs: false,
+      forceRefresh: true
+    });
+    expect(loadCodingFreshnessSpy).toHaveBeenCalled();
+  });
+
   it('should flag duplicate findings as diagnostic when aggregation is disabled', () => {
     component.responseAnalysis = {
       emptyResponses: { total: 0, totalUncoded: 0, items: [] },
@@ -1960,6 +1990,79 @@ describe('CodingManagementManualComponent', () => {
     component.refreshManualCodingPlanning();
 
     expect(reloadCodingJobsListSpy).toHaveBeenCalledTimes(1);
+    expect(reloadCodingJobsListSpy).toHaveBeenCalledWith('active');
+  });
+
+  it('should still reveal execution data when a background guard suppresses status checks', () => {
+    component.selectedManualTabIndex = 3;
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      hasLoadedManualCodingJobRefreshSetting: boolean;
+      pendingManualStateRefreshAfterBackgroundJob: boolean;
+      shouldSuppressCodingStatusChecks(): boolean;
+      loadCodingProgressOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadWorkspaceKappaSummary(): void;
+      loadCodingFreshness(options?: { force?: boolean }): void;
+      reloadCodingJobsList(reloadScope?: string): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.hasLoadedManualCodingJobRefreshSetting = true;
+    jest
+      .spyOn(componentInternals, 'shouldSuppressCodingStatusChecks')
+      .mockReturnValue(true);
+    const codingProgressSpy = jest
+      .spyOn(componentInternals, 'loadCodingProgressOverview')
+      .mockImplementation();
+    const caseCoverageSpy = jest
+      .spyOn(componentInternals, 'loadCaseCoverageOverview')
+      .mockImplementation();
+    const kappaSummarySpy = jest
+      .spyOn(componentInternals, 'loadWorkspaceKappaSummary')
+      .mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+    const reloadCodingJobsListSpy = jest
+      .spyOn(componentInternals, 'reloadCodingJobsList')
+      .mockImplementation();
+
+    component.refreshManualCodingPlanning();
+
+    expect(component.shouldRenderManualTabData('execution')).toBe(true);
+    expect(componentInternals.pendingManualStateRefreshAfterBackgroundJob).toBe(true);
+    expect(codingProgressSpy).not.toHaveBeenCalled();
+    expect(caseCoverageSpy).not.toHaveBeenCalled();
+    expect(kappaSummarySpy).not.toHaveBeenCalled();
+    expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
+    expect(reloadCodingJobsListSpy).toHaveBeenCalledWith('active');
+  });
+
+  it('should still reveal training data when a background guard suppresses status checks', () => {
+    component.selectedManualTabIndex = 2;
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      hasLoadedManualCodingJobRefreshSetting: boolean;
+      pendingManualStateRefreshAfterBackgroundJob: boolean;
+      shouldSuppressCodingStatusChecks(): boolean;
+      reloadCodingJobsList(reloadScope?: string): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.hasLoadedManualCodingJobRefreshSetting = true;
+    jest
+      .spyOn(componentInternals, 'shouldSuppressCodingStatusChecks')
+      .mockReturnValue(true);
+    const reloadCodingJobsListSpy = jest
+      .spyOn(componentInternals, 'reloadCodingJobsList')
+      .mockImplementation();
+
+    component.refreshManualCodingPlanning();
+
+    expect(component.shouldRenderManualTabData('training')).toBe(true);
+    expect(component.shouldShowManualTabLoadHint('training')).toBe(false);
+    expect(componentInternals.pendingManualStateRefreshAfterBackgroundJob).toBe(true);
     expect(reloadCodingJobsListSpy).toHaveBeenCalledWith('active');
   });
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -266,6 +266,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private readonly pendingCodingJobsReloadScopes =
     new Set<ConcreteCodingJobsReloadScope>();
 
+  private pendingCodingJobsReloadTimer?: ReturnType<typeof setTimeout>;
+
   private readonly manualCodingTabsWithoutCompletion: ManualCodingTab[] = [
     'preparation',
     'planning',
@@ -326,6 +328,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private responseAnalysisGuardWorkspaceId: number | null = null;
   private hasShownResponseAnalysisPollingError = false;
   private pendingManualStateRefreshAfterBackgroundJob = false;
+  private pendingForcedManualStateRefreshAfterBackgroundJob = false;
   private pendingCodingFreshnessRefreshAfterBackgroundJob = false;
   private pendingForcedCodingFreshnessRefreshAfterBackgroundJob = false;
   private readonly handleWindowFocus = () => {
@@ -609,6 +612,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.responseAnalysisRequestCancel$.complete();
     this.finalizeResponseAnalysisGuardOnDestroy();
     this.document.defaultView?.removeEventListener('focus', this.handleWindowFocus);
+    if (this.pendingCodingJobsReloadTimer) {
+      clearTimeout(this.pendingCodingJobsReloadTimer);
+      this.pendingCodingJobsReloadTimer = undefined;
+    }
     this.destroy$.next();
     this.destroy$.complete();
 
@@ -714,6 +721,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.hasLoadedManualCodingJobRefreshSetting &&
       (this.activeManualTab === 'planning' ||
         !this.autoRefreshManualCodingJobs);
+  }
+
+  shouldShowManualTabLoadHint(tab: ManualCodingTab): boolean {
+    return (tab === 'training' || tab === 'execution') &&
+      this.isManualTab(tab) &&
+      this.shouldShowManualRefreshButton() &&
+      !this.shouldRenderManualTabData(tab);
   }
 
   shouldShowPlanningOverview(): boolean {
@@ -1686,10 +1700,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   reloadCodingJobsList(reloadScope: CodingJobsReloadScope = 'active'): void {
     const concreteReloadScopes =
       this.getConcreteCodingJobsReloadScopes(reloadScope);
-    this.getCodingJobsComponentsForReload(reloadScope)
-      .forEach(component => component.loadCodingJobs());
     concreteReloadScopes.forEach(scope => {
-      this.pendingCodingJobsReloadScopes.delete(scope);
+      const component = this.getCodingJobsComponentForScope(scope);
+      if (component) {
+        component.loadCodingJobs();
+        this.pendingCodingJobsReloadScopes.delete(scope);
+      } else {
+        this.pendingCodingJobsReloadScopes.add(scope);
+      }
     });
     if (this.shouldReloadCoderTrainings(reloadScope) &&
       this.coderTrainingsListComponent) {
@@ -1698,13 +1716,26 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   refreshManualCodingPlanning(): void {
+    const activeTab = this.activeManualTab;
     if (this.shouldSuppressCodingStatusChecks()) {
       this.pendingManualStateRefreshAfterBackgroundJob = true;
+      this.pendingForcedManualStateRefreshAfterBackgroundJob = true;
+      if (activeTab !== 'planning') {
+        this.pendingCodingFreshnessRefreshAfterBackgroundJob = true;
+        this.pendingForcedCodingFreshnessRefreshAfterBackgroundJob = true;
+      }
+      if (this.shouldLoadManualTabWhileStatusChecksAreSuppressed(activeTab)) {
+        this.loadManualTabData(activeTab, {
+          forceRefresh: true,
+          reloadCodingJobs: true,
+          codingJobsReloadScope: 'active',
+          deferStatusChecks: true
+        });
+      }
       return;
     }
 
     this.invalidateCodingStatusCache();
-    const activeTab = this.activeManualTab;
     this.loadManualTabData(activeTab, {
       forceRefresh: true,
       reloadCodingJobs: true,
@@ -1731,15 +1762,32 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private refreshManualStateAfterExternalChange(
-    options: { forceCodingFreshness?: boolean } = {}
+    options: {
+      forceCodingFreshness?: boolean;
+      forceManualTabData?: boolean;
+    } = {}
   ): void {
     if (this.shouldSuppressCodingStatusChecks()) {
       this.pendingManualStateRefreshAfterBackgroundJob = true;
+      if (options.forceManualTabData) {
+        this.pendingForcedManualStateRefreshAfterBackgroundJob = true;
+      }
+      if (options.forceCodingFreshness) {
+        this.pendingCodingFreshnessRefreshAfterBackgroundJob = true;
+        this.pendingForcedCodingFreshnessRefreshAfterBackgroundJob = true;
+      }
       return;
     }
 
     const activeTab = this.activeManualTab;
-    this.loadManualTabData(activeTab, { reloadCodingJobs: false });
+    const loadOptions: {
+      reloadCodingJobs: boolean;
+      forceRefresh?: boolean;
+    } = { reloadCodingJobs: false };
+    if (options.forceManualTabData) {
+      loadOptions.forceRefresh = true;
+    }
+    this.loadManualTabData(activeTab, loadOptions);
     if (activeTab !== 'planning') {
       if (options.forceCodingFreshness) {
         this.loadCodingFreshness({ force: true });
@@ -1760,18 +1808,21 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private refreshPendingManualStatusAfterBackgroundJob(): void {
     const shouldRefreshManualState = this.pendingManualStateRefreshAfterBackgroundJob;
+    const forceManualTabData = this.pendingForcedManualStateRefreshAfterBackgroundJob;
     const shouldRefreshCodingFreshness = this.pendingCodingFreshnessRefreshAfterBackgroundJob ||
       this.pendingForcedCodingFreshnessRefreshAfterBackgroundJob;
     const forceCodingFreshness = this.pendingForcedCodingFreshnessRefreshAfterBackgroundJob;
     const activeTab = this.activeManualTab;
 
     this.pendingManualStateRefreshAfterBackgroundJob = false;
+    this.pendingForcedManualStateRefreshAfterBackgroundJob = false;
     this.pendingCodingFreshnessRefreshAfterBackgroundJob = false;
     this.pendingForcedCodingFreshnessRefreshAfterBackgroundJob = false;
 
     if (shouldRefreshManualState) {
       this.refreshManualStateAfterExternalChange({
-        forceCodingFreshness: shouldRefreshCodingFreshness && forceCodingFreshness
+        forceCodingFreshness: shouldRefreshCodingFreshness && forceCodingFreshness,
+        forceManualTabData
       });
     }
 
@@ -1911,25 +1962,21 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return tab === 'preparation';
   }
 
-  private getCodingJobsComponentsForReload(
-    reloadScope: CodingJobsReloadScope
-  ): CodingJobsComponent[] {
-    return this.uniqueCodingJobsComponents(
-      this.getConcreteCodingJobsReloadScopes(reloadScope)
-        .map(scope => this.getCodingJobsComponentForScope(scope))
-    );
-  }
+  private schedulePendingCodingJobsReloadForTab(tab: ManualCodingTab): void {
+    const hasPendingReloadForTab = this.getCodingJobsScopeForTab(tab)
+      .some(scope => this.pendingCodingJobsReloadScopes.has(scope));
+    if (!hasPendingReloadForTab) {
+      return;
+    }
 
-  private uniqueCodingJobsComponents(
-    candidateComponents: Array<CodingJobsComponent | undefined>
-  ): CodingJobsComponent[] {
-    const uniqueComponents: CodingJobsComponent[] = [];
-    candidateComponents.forEach(component => {
-      if (component && !uniqueComponents.includes(component)) {
-        uniqueComponents.push(component);
-      }
-    });
-    return uniqueComponents;
+    if (this.pendingCodingJobsReloadTimer) {
+      clearTimeout(this.pendingCodingJobsReloadTimer);
+    }
+
+    this.pendingCodingJobsReloadTimer = setTimeout(() => {
+      this.pendingCodingJobsReloadTimer = undefined;
+      this.reloadPendingCodingJobsForTab(tab);
+    }, 0);
   }
 
   private getProductiveCodingJobsComponent(): CodingJobsComponent | undefined {
@@ -2005,6 +2052,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private shouldReloadCoderTrainings(reloadScope: CodingJobsReloadScope): boolean {
     return this.getConcreteCodingJobsReloadScopes(reloadScope)
       .includes('training');
+  }
+
+  private shouldLoadManualTabWhileStatusChecksAreSuppressed(
+    tab: ManualCodingTab
+  ): boolean {
+    return tab === 'training' || tab === 'execution';
   }
 
   isAnyPlanningDataLoading(): boolean {
@@ -3140,6 +3193,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       reloadCodingJobs?: boolean;
       codingJobsReloadScope?: CodingJobsReloadScope;
       forceRefresh?: boolean;
+      deferStatusChecks?: boolean;
     } = {}
   ): void {
     if (!this.isManualTabAvailable(tab)) {
@@ -3150,6 +3204,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const reloadCodingJobs = options.reloadCodingJobs ?? false;
     const codingJobsReloadScope = options.codingJobsReloadScope ?? 'active';
     const forceRefresh = options.forceRefresh ?? false;
+    const deferStatusChecks = options.deferStatusChecks ?? false;
     if (this.shouldSkipAutomaticManualTabLoad(forceRefresh, tab)) {
       return;
     }
@@ -3161,23 +3216,27 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.loadResponseAnalysis();
         return;
       case 'planning':
-        if (forceRefresh) {
+        if (forceRefresh && !deferStatusChecks) {
           this.loadPlanningDataBundle(forceRefresh);
         }
         return;
       case 'training':
         if (reloadCodingJobs) {
           this.reloadCodingJobsList(codingJobsReloadScope);
+          this.schedulePendingCodingJobsReloadForTab(tab);
         } else {
           this.reloadPendingCodingJobsForTab(tab);
         }
         return;
       case 'execution':
-        this.loadCodingProgressOverview();
-        this.loadCaseCoverageOverview();
-        this.loadWorkspaceKappaSummary();
+        if (!deferStatusChecks) {
+          this.loadCodingProgressOverview();
+          this.loadCaseCoverageOverview();
+          this.loadWorkspaceKappaSummary();
+        }
         if (reloadCodingJobs) {
           this.reloadCodingJobsList(codingJobsReloadScope);
+          this.schedulePendingCodingJobsReloadForTab(tab);
         } else {
           this.reloadPendingCodingJobsForTab(tab);
         }

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1932,6 +1932,11 @@
       "show-more-manual-code-warnings": "+{{count}} weitere anzeigen",
       "show-fewer-manual-code-warnings": "Weniger anzeigen"
     },
+    "manual-load-hint": {
+      "title": "Daten manuell laden",
+      "training": "Die Schulungsdaten wurden noch nicht geladen. Klicken Sie auf Aktualisieren, um Schulungen und Kodierjobs zu laden.",
+      "execution": "Die Durchführungsdaten wurden noch nicht geladen. Klicken Sie auf Aktualisieren, um Kodierjobs und Statusdaten zu laden."
+    },
     "table": {
       "headers": {
         "unit-key": "Unit-Schlüssel",


### PR DESCRIPTION
## Summary

Related to #813.

This PR fixes two issues from manual testing:

- Manual refresh on the manual coding workflow now still reveals and reloads the Training and Execution tabs while background status checks are temporarily suppressed after Planning work.
- Within-training Cohen's kappa now uses stable response/unit/variable keys and emits typed SQL NULL score literals so PostgreSQL can evaluate missing-score CASE expressions.

## Root Cause

The manual refresh flow deferred too much work while a background status-check guard was active, so Training and Execution could stay hidden after Planning was loaded.

The training kappa value query selected score values even for code-level kappa. For missings whose score mapped to SQL NULL, PostgreSQL inferred an untyped/null CASE branch as text and raised `CASE types integer and text cannot be matched`.

## Validation

- `npx nx test frontend --runInBand --testPathPattern=coding-management-manual.component.spec.ts`
- `npx nx test backend --testFile=apps/backend/src/app/database/services/coding/coder-training.service.spec.ts --runInBand`
- `npx nx lint frontend`
- `npx nx lint backend`
- `npx nx test backend --runInBand`
- `git diff --check`
- Read-only production PostgreSQL check for the failing CASE expression
- Local Docker smoke: backend and frontend services restarted, health checks passed, targeted frontend/backend tests passed in containers, local authenticated kappa API returned `200`
