### PR TITLE
Fix test results log quality and manual hints

### DIFF
--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -1494,6 +1494,86 @@ describe('WorkspaceTestResultsService', () => {
       repeatedStartThreshold: 2
     };
 
+    it('should split booklet-scoped log anomaly lookups into batches', async () => {
+      const bookletIds = Array.from({ length: 1001 }, (_, index) => index + 1);
+      const bookletLogQbs: Array<ReturnType<typeof mockQueryBuilder>> = [];
+      const sessionQbs: Array<ReturnType<typeof mockQueryBuilder>> = [];
+      const unitQbs: Array<ReturnType<typeof mockQueryBuilder>> = [];
+      (bookletLogRepository.createQueryBuilder as jest.Mock)
+        .mockImplementation(() => {
+          const qb = mockQueryBuilder();
+          bookletLogQbs.push(qb);
+          return qb;
+        });
+      (sessionRepository.createQueryBuilder as jest.Mock)
+        .mockImplementation(() => {
+          const qb = mockQueryBuilder();
+          sessionQbs.push(qb);
+          return qb;
+        });
+      (unitRepository.createQueryBuilder as jest.Mock)
+        .mockImplementation(() => {
+          const qb = mockQueryBuilder();
+          unitQbs.push(qb);
+          return qb;
+        });
+
+      const serviceWithLogAnomalyLookup =
+        service as unknown as WorkspaceTestResultsServiceWithLogAnomalyLookup;
+      await serviceWithLogAnomalyLookup.findLogAnomaliesForBooklets(
+        bookletIds,
+        thresholds
+      );
+
+      expect(bookletLogQbs).toHaveLength(2);
+      expect(sessionQbs).toHaveLength(2);
+      expect(unitQbs).toHaveLength(2);
+      expect(bookletLogQbs[0].where.mock.calls[0][1].bookletIds)
+        .toHaveLength(1000);
+      expect(bookletLogQbs[1].where.mock.calls[0][1].bookletIds)
+        .toEqual([1001]);
+    });
+
+    it('should split unit log lookups into batches', async () => {
+      const bookletLogQb = mockQueryBuilder();
+      const sessionQb = mockQueryBuilder();
+      const unitQb = mockQueryBuilder();
+      const unitLogQbs: Array<ReturnType<typeof mockQueryBuilder>> = [];
+      (bookletLogRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(bookletLogQb);
+      (sessionRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(sessionQb);
+      (unitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(unitQb);
+      (unitLogRepository.createQueryBuilder as jest.Mock)
+        .mockImplementation(() => {
+          const qb = mockQueryBuilder();
+          unitLogQbs.push(qb);
+          return qb;
+        });
+      unitQb.getMany.mockResolvedValue(
+        Array.from({ length: 1001 }, (_, index) => ({
+          id: index + 1,
+          bookletid: 1,
+          name: `unit-${index + 1}.xml`,
+          alias: `unit-${index + 1}`
+        }))
+      );
+
+      const serviceWithLogAnomalyLookup =
+        service as unknown as WorkspaceTestResultsServiceWithLogAnomalyLookup;
+      await serviceWithLogAnomalyLookup.findLogAnomaliesForBooklets(
+        [1],
+        thresholds
+      );
+
+      expect(unitLogQbs).toHaveLength(2);
+      expect(unitLogQbs[0].where.mock.calls[0][1].unitIds)
+        .toHaveLength(1000);
+      expect(unitLogQbs[1].where.mock.calls[0][1].unitIds)
+        .toEqual([1001]);
+    });
+
     it('should report long loading from unit STARTED/ENDED logs', async () => {
       const bookletLogQb = mockQueryBuilder();
       const sessionQb = mockQueryBuilder();

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -295,9 +295,20 @@ interface LogDeleteCounts {
   sessions: number;
 }
 
+type LogAnomalySessionRow = {
+  id: number;
+  bookletid: number;
+  browser: string | null;
+  os: string | null;
+  screen: string | null;
+  ts: number | null;
+  loadcompletems: number | null;
+};
+
 @Injectable()
 export class WorkspaceTestResultsService {
   private readonly logger = new Logger(WorkspaceTestResultsService.name);
+  private static readonly logAnomalyQueryBatchSize = 1000;
   private static readonly codingResponseStatuses = [
     statusStringToNumber('NOT_REACHED') || 1,
     statusStringToNumber('DISPLAYED') || 2,
@@ -955,6 +966,34 @@ export class WorkspaceTestResultsService {
     );
   }
 
+  private getLogAnomalyIdBatches(ids: number[]): number[][] {
+    const batches: number[][] = [];
+    for (
+      let index = 0;
+      index < ids.length;
+      index += WorkspaceTestResultsService.logAnomalyQueryBatchSize
+    ) {
+      batches.push(
+        ids.slice(
+          index,
+          index + WorkspaceTestResultsService.logAnomalyQueryBatchSize
+        )
+      );
+    }
+    return batches;
+  }
+
+  private async loadLogAnomalyRowsInBatches<T>(
+    ids: number[],
+    loadBatch: (batchIds: number[]) => Promise<T[]>
+  ): Promise<T[]> {
+    const rows: T[] = [];
+    for (const batchIds of this.getLogAnomalyIdBatches(ids)) {
+      rows.push(...await loadBatch(batchIds));
+    }
+    return rows;
+  }
+
   private async getBookletNamesById(
     bookletIds: number[]
   ): Promise<Map<number, string>> {
@@ -962,13 +1001,18 @@ export class WorkspaceTestResultsService {
       return new Map();
     }
 
-    const rows = await this.bookletRepository
-      .createQueryBuilder('bookletEntity')
-      .innerJoin('bookletEntity.bookletinfo', 'bookletinfo')
-      .select('bookletEntity.id', 'id')
-      .addSelect('bookletinfo.name', 'name')
-      .where('bookletEntity.id IN (:...bookletIds)', { bookletIds })
-      .getRawMany<{ id: number | string; name: string | null }>();
+    const rows = await this.loadLogAnomalyRowsInBatches(
+      bookletIds,
+      batchIds => this.bookletRepository
+        .createQueryBuilder('bookletEntity')
+        .innerJoin('bookletEntity.bookletinfo', 'bookletinfo')
+        .select('bookletEntity.id', 'id')
+        .addSelect('bookletinfo.name', 'name')
+        .where('bookletEntity.id IN (:...bookletIds)', {
+          bookletIds: batchIds
+        })
+        .getRawMany<{ id: number | string; name: string | null }>()
+    );
 
     return new Map(
       rows.map(row => [Number(row.id), String(row.name || '')])
@@ -993,15 +1037,6 @@ export class WorkspaceTestResultsService {
     thresholds: LogAnomalyThresholds,
     exclusions?: ResolvedWorkspaceExclusions
   ): Promise<Map<number, LogAnomalySummary[]>> {
-    type SessionLogRow = {
-      id: number;
-      bookletid: number;
-      browser: string | null;
-      os: string | null;
-      screen: string | null;
-      ts: number | null;
-      loadcompletems: number | null;
-    };
     let uniqueBookletIds = Array.from(
       new Set(bookletIds.map(id => Number(id)).filter(id => id > 0))
     );
@@ -1029,46 +1064,55 @@ export class WorkspaceTestResultsService {
     }
 
     const [bookletLogs, sessions, units] = await Promise.all([
-      this.bookletLogRepository
-        .createQueryBuilder('bookletLog')
-        .where('bookletLog.bookletid IN (:...bookletIds)', {
-          bookletIds: uniqueBookletIds
-        })
-        .select([
-          'bookletLog.id',
-          'bookletLog.bookletid',
-          'bookletLog.key',
-          'bookletLog.parameter',
-          'bookletLog.ts'
-        ])
-        .orderBy('bookletLog.bookletid', 'ASC')
-        .addOrderBy('bookletLog.ts', 'ASC', 'NULLS LAST')
-        .addOrderBy('bookletLog.id', 'ASC')
-        .getMany(),
-      this.sessionRepository
-        .createQueryBuilder('session')
-        .where('session.bookletid IN (:...bookletIds)', {
-          bookletIds: uniqueBookletIds
-        })
-        .select('session.id', 'id')
-        .addSelect('session.bookletid', 'bookletid')
-        .addSelect('session.browser', 'browser')
-        .addSelect('session.os', 'os')
-        .addSelect('session.screen', 'screen')
-        .addSelect('session.ts', 'ts')
-        .addSelect('session.loadcompletems', 'loadcompletems')
-        .orderBy('session.bookletid', 'ASC')
-        .addOrderBy('session.id', 'ASC')
-        .getRawMany<SessionLogRow>(),
-      this.unitRepository
-        .createQueryBuilder('unit')
-        .where('unit.bookletid IN (:...bookletIds)', {
-          bookletIds: uniqueBookletIds
-        })
-        .select(['unit.id', 'unit.bookletid', 'unit.name', 'unit.alias'])
-        .orderBy('unit.bookletid', 'ASC')
-        .addOrderBy('unit.id', 'ASC')
-        .getMany()
+      this.loadLogAnomalyRowsInBatches(
+        uniqueBookletIds,
+        batchIds => this.bookletLogRepository
+          .createQueryBuilder('bookletLog')
+          .where('bookletLog.bookletid IN (:...bookletIds)', {
+            bookletIds: batchIds
+          })
+          .select([
+            'bookletLog.id',
+            'bookletLog.bookletid',
+            'bookletLog.key',
+            'bookletLog.parameter',
+            'bookletLog.ts'
+          ])
+          .orderBy('bookletLog.bookletid', 'ASC')
+          .addOrderBy('bookletLog.ts', 'ASC', 'NULLS LAST')
+          .addOrderBy('bookletLog.id', 'ASC')
+          .getMany()
+      ),
+      this.loadLogAnomalyRowsInBatches(
+        uniqueBookletIds,
+        batchIds => this.sessionRepository
+          .createQueryBuilder('session')
+          .where('session.bookletid IN (:...bookletIds)', {
+            bookletIds: batchIds
+          })
+          .select('session.id', 'id')
+          .addSelect('session.bookletid', 'bookletid')
+          .addSelect('session.browser', 'browser')
+          .addSelect('session.os', 'os')
+          .addSelect('session.screen', 'screen')
+          .addSelect('session.ts', 'ts')
+          .addSelect('session.loadcompletems', 'loadcompletems')
+          .orderBy('session.bookletid', 'ASC')
+          .addOrderBy('session.id', 'ASC')
+          .getRawMany<LogAnomalySessionRow>()
+      ),
+      this.loadLogAnomalyRowsInBatches(
+        uniqueBookletIds,
+        batchIds => this.unitRepository
+          .createQueryBuilder('unit')
+          .where('unit.bookletid IN (:...bookletIds)', {
+            bookletIds: batchIds
+          })
+          .select(['unit.id', 'unit.bookletid', 'unit.name', 'unit.alias'])
+          .orderBy('unit.bookletid', 'ASC')
+          .addOrderBy('unit.id', 'ASC')
+          .getMany()
+      )
     ]);
 
     const visibleUnits = shouldApplyExclusions ?
@@ -1082,24 +1126,27 @@ export class WorkspaceTestResultsService {
       (units || []);
     const unitIds = visibleUnits.map(unit => Number(unit.id)).filter(id => id > 0);
     const unitLogs = unitIds.length > 0 ?
-      await this.unitLogRepository
-        .createQueryBuilder('unitLog')
-        .where('unitLog.unitid IN (:...unitIds)', { unitIds })
-        .select([
-          'unitLog.id',
-          'unitLog.unitid',
-          'unitLog.key',
-          'unitLog.parameter',
-          'unitLog.ts'
-        ])
-        .orderBy('unitLog.unitid', 'ASC')
-        .addOrderBy('unitLog.ts', 'ASC', 'NULLS LAST')
-        .addOrderBy('unitLog.id', 'ASC')
-        .getMany() :
+      await this.loadLogAnomalyRowsInBatches(
+        unitIds,
+        batchIds => this.unitLogRepository
+          .createQueryBuilder('unitLog')
+          .where('unitLog.unitid IN (:...unitIds)', { unitIds: batchIds })
+          .select([
+            'unitLog.id',
+            'unitLog.unitid',
+            'unitLog.key',
+            'unitLog.parameter',
+            'unitLog.ts'
+          ])
+          .orderBy('unitLog.unitid', 'ASC')
+          .addOrderBy('unitLog.ts', 'ASC', 'NULLS LAST')
+          .addOrderBy('unitLog.id', 'ASC')
+          .getMany()
+      ) :
       [];
 
     const logsByBooklet = new Map<number, BookletLog[]>();
-    const sessionsByBooklet = new Map<number, SessionLogRow[]>();
+    const sessionsByBooklet = new Map<number, LogAnomalySessionRow[]>();
     const unitsByBooklet = new Map<number, Unit[]>();
     const unitLogsByUnit = new Map<number, UnitLog[]>();
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -2122,6 +2122,22 @@
             </div>
           </div>
 
+          <div
+            *ngIf="shouldShowManualTabLoadHint('preparation')"
+            class="info-alert manual-refresh-hint"
+          >
+            <mat-icon class="info-alert-icon">refresh</mat-icon>
+            <div class="info-alert-content">
+              <strong>{{
+                'coding-management-manual.manual-load-hint.title' | translate
+              }}</strong>
+              <span>{{
+                'coding-management-manual.manual-load-hint.preparation'
+                  | translate
+              }}</span>
+            </div>
+          </div>
+
           <coding-box-variable-bundle-manager
             *ngIf="shouldRenderManualTabData('preparation')"
           ></coding-box-variable-bundle-manager>

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -2066,6 +2066,21 @@ describe('CodingManagementManualComponent', () => {
     expect(reloadCodingJobsListSpy).toHaveBeenCalledWith('active');
   });
 
+  it('should show a manual load hint for preparation data', () => {
+    component.selectedManualTabIndex = 0;
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      hasLoadedManualCodingJobRefreshSetting: boolean;
+      loadedManualTabData: Record<string, boolean>;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.hasLoadedManualCodingJobRefreshSetting = true;
+    componentInternals.loadedManualTabData.preparation = false;
+
+    expect(component.shouldShowManualTabLoadHint('preparation')).toBe(true);
+  });
+
   it('should reload only the targeted coding jobs table', () => {
     const productiveLoadCodingJobs = jest.fn();
     const trainingLoadCodingJobs = jest.fn();

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -724,7 +724,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   shouldShowManualTabLoadHint(tab: ManualCodingTab): boolean {
-    return (tab === 'training' || tab === 'execution') &&
+    const tabSupportsManualLoadHint =
+      tab === 'preparation' || tab === 'training' || tab === 'execution';
+
+    return tabSupportsManualLoadHint &&
       this.isManualTab(tab) &&
       this.shouldShowManualRefreshButton() &&
       !this.shouldRenderManualTabData(tab);

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.html
@@ -90,32 +90,7 @@
     </div>
   </div>
 
-  @if (shouldShowCodingFreshnessManualNotice) {
-  <div class="coding-freshness-banner manual-status">
-    <div class="coding-freshness-icon">
-      <mat-icon>sync_disabled</mat-icon>
-    </div>
-    <div class="coding-freshness-copy">
-      <div class="coding-freshness-title">
-        {{ 'test-results-page.coding-status.manual-title' | translate }}
-      </div>
-      <div class="coding-freshness-text">
-        {{ 'test-results-page.coding-status.manual-text' | translate }}
-      </div>
-    </div>
-    <button
-      mat-stroked-button
-      type="button"
-      [disabled]="isLoadingCodingFreshnessStatus"
-      (click)="refreshCodingFreshnessStatusManually()"
-    >
-      <mat-icon [class.inline-rotating-icon]="isLoadingCodingFreshnessStatus">
-        refresh
-      </mat-icon>
-      {{ 'test-results-page.coding-status.refresh' | translate }}
-    </button>
-  </div>
-  } @if (hasCodingFreshnessWarning) {
+  @if (hasCodingFreshnessWarning) {
   <div class="coding-freshness-banner">
     <div class="coding-freshness-icon">
       <mat-icon>warning</mat-icon>

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
@@ -251,6 +251,20 @@ describe('TestResultsComponent', () => {
     expect(component.logAnomalySummaryRequested).toBe(false);
   });
 
+  it('should not show manual coding status controls on the test results page', () => {
+    (component as unknown as {
+      setAutoRefreshCodingStatus: (enabled: boolean) => void;
+    }).setAutoRefreshCodingStatus(false);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain(
+      'Kodierstatus wird manuell aktualisiert'
+    );
+    expect(fixture.nativeElement.textContent).not.toContain(
+      'test-results-page.coding-status.manual-title'
+    );
+  });
+
   it('should hide log quality when disabled by workspace setting', () => {
     expect(component.showTestResultsLogAnomalies).toBe(false);
     expect(fixture.nativeElement.textContent).not.toContain('Log-Qualität');
@@ -423,24 +437,7 @@ describe('TestResultsComponent', () => {
     expect(testResultService.getWorkspaceOverview).toHaveBeenCalledWith(1);
     expect(codingStatisticsService.getCodingFreshness).not.toHaveBeenCalled();
     expect(testPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
-    expect(component.shouldShowCodingFreshnessManualNotice).toBe(true);
     expect(testPersonCodingService.notifyTestResultsChanged).toHaveBeenCalled();
-  });
-
-  it('should keep manual coding status refresh visible after a manual check', () => {
-    const testPersonCodingService = TestBed.inject(TestPersonCodingService) as unknown as {
-      invalidateCodingStatusCache: jest.Mock;
-    };
-
-    testPersonCodingService.invalidateCodingStatusCache.mockClear();
-    (component as unknown as {
-      setAutoRefreshCodingStatus: (enabled: boolean) => void;
-    }).setAutoRefreshCodingStatus(false);
-
-    component.refreshCodingFreshnessStatusManually();
-
-    expect(component.shouldShowCodingFreshnessManualNotice).toBe(true);
-    expect(testPersonCodingService.invalidateCodingStatusCache).toHaveBeenCalledWith(1);
   });
 
   it('should ignore stale manual coding status responses after status was cleared', () => {
@@ -463,7 +460,9 @@ describe('TestResultsComponent', () => {
       setAutoRefreshCodingStatus: (enabled: boolean) => void;
     }).setAutoRefreshCodingStatus(false);
 
-    component.refreshCodingFreshnessStatusManually();
+    (component as unknown as {
+      loadCodingFreshnessStatus: (options?: { force?: boolean }) => void;
+    }).loadCodingFreshnessStatus({ force: true });
     component.onFlatTableResponseDeleted();
     codingFreshness$.next({ items: [] });
     codingFreshness$.complete();

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
@@ -1540,10 +1540,6 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       });
   }
 
-  refreshCodingFreshnessStatusManually(): void {
-    this.loadCodingFreshnessStatus({ force: true });
-  }
-
   private refreshCodingFreshnessStatusAfterChange(): void {
     if (this.autoRefreshCodingStatus) {
       this.loadCodingFreshnessStatus({ force: true });
@@ -1630,10 +1626,6 @@ export class TestResultsComponent implements OnInit, OnDestroy {
   get hasCodingFreshnessWarning(): boolean {
     return this.codingFreshnessWarnings.length > 0 ||
       this.shouldShowSecondAutocodingWaitingState;
-  }
-
-  get shouldShowCodingFreshnessManualNotice(): boolean {
-    return !this.autoRefreshCodingStatus;
   }
 
   get codingFreshnessDisplayWarnings(): CodingFreshnessSummaryItemDto[] {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1175,7 +1175,7 @@
     "show-replay-statistics": "Replay-Statistiken anzeigen",
     "coding": "Kodierung",
     "evaluation-mode": "Auswertungsmodus",
-    "evaluation-mode-description": "Wenn aktiviert, werden teure automatische Aktualisierungen in der Kodierungsverwaltung ausgeschaltet. Statistiken und Übersichten werden dann gezielt per Aktualisieren-Button geladen.",
+    "evaluation-mode-description": "Wenn aktiviert, arbeitet die Kodierungsverwaltung im Manuell-laden-Modus: teure automatische Aktualisierungen werden ausgeschaltet und Statistiken, Übersichten sowie Kodierjob-Tabellen werden gezielt per Aktualisieren-Button geladen.",
     "evaluation-mode-enabled": "Auswertungsmodus aktiviert",
     "evaluation-mode-disabled": "Auswertungsmodus deaktiviert",
     "auto-fetch-coding-statistics": "Automatisches Laden der Kodierstatistiken",
@@ -1934,6 +1934,7 @@
     },
     "manual-load-hint": {
       "title": "Daten manuell laden",
+      "preparation": "Die Vorbereitungsdaten wurden noch nicht geladen. Klicken Sie auf Aktualisieren, um Variablenbündel und Vorbereitungsdaten zu laden.",
       "training": "Die Schulungsdaten wurden noch nicht geladen. Klicken Sie auf Aktualisieren, um Schulungen und Kodierjobs zu laden.",
       "execution": "Die Durchführungsdaten wurden noch nicht geladen. Klicken Sie auf Aktualisieren, um Kodierjobs und Statusdaten zu laden."
     },
@@ -2117,6 +2118,13 @@
       "validation-running": "Validierung wird durchgeführt...",
       "validation-page-progress": "Validierung wird durchgeführt (Seite {{page}})...",
       "view-results-button": "Validierungs Ergebnisse anzeigen"
+    }
+  },
+  "test-results-page": {
+    "coding-status": {
+      "manual-title": "Kodierstatus wird manuell aktualisiert",
+      "manual-text": "Automatische Statusprüfungen sind für diesen Arbeitsbereich deaktiviert. Aktualisieren Sie den Kodierstatus in der Kodierungsverwaltung bei Bedarf manuell.",
+      "refresh": "Kodierstatus aktualisieren"
     }
   },
   "coding-variables-dialog": {


### PR DESCRIPTION
## Summary

- remove the manual coding status notice from the test results page so test results no longer show the unexpected blue coding-status box
- add the missing manual-load hint for the preparation tab in manual coding
- make log anomaly summary/detail loading more robust by batching booklet and unit log lookups for large workspaces
- clarify the evaluation mode description as a manual-load/protection mode

## Root Cause

The test results page reused the manual coding status notice even though the issue expectation was that this status belongs to coding management/manual coding, not test results. The preparation tab used the same manual data loading state as training and execution, but did not render a hint when its data was not loaded. The log anomaly summary path loaded all related booklet/session/unit/unit-log rows through very large IN lists, which can become fragile on large workspaces.

## Changes

- TestResultsComponent no longer renders the manual coding status notice or exposes the manual status refresh action on the test results page.
- CodingManagementManualComponent now includes preparation in the manual-load hint flow and renders the hint above variable bundles.
- WorkspaceTestResultsService now reads log anomaly input rows in batches of 1000 IDs for booklet names, booklet logs, sessions, units, and unit logs.
- Added focused regression tests for the test results status notice, the preparation hint, and the log anomaly batching behavior.

## Validation

- npx nx lint frontend
- npx nx lint backend
- npx nx test frontend --runInBand (190 suites / 1825 tests)
- npx nx test backend --runInBand --skip-nx-cache (135 suites passed, 1 skipped / 2014 tests)
- git diff --check