### PR TITLE
Fix auto-coding freshness candidate counts

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.spec.ts
@@ -242,11 +242,19 @@ describe('CodingFreshnessService', () => {
         }
       ])
     });
+    const autoCodingCandidateV1Qb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([{ unitId: 10, count: '2' }])
+    });
+    const autoCodingCandidateV3Qb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([{ unitId: 10, count: '2' }])
+    });
 
     (responseRepository.createQueryBuilder as jest.Mock)
-      .mockReturnValueOnce(responseCountsQb)
       .mockReturnValueOnce(workspacePresenceQb)
-      .mockReturnValueOnce(unitPresenceQb);
+      .mockReturnValueOnce(unitPresenceQb)
+      .mockReturnValueOnce(responseCountsQb)
+      .mockReturnValueOnce(autoCodingCandidateV1Qb)
+      .mockReturnValueOnce(autoCodingCandidateV3Qb);
 
     await service.markUnitsStaleAfterResultChange(1, [10], 'RESULT_UPDATED');
 
@@ -275,6 +283,45 @@ describe('CodingFreshnessService', () => {
       ]),
       ['workspace_id', 'unit_id', 'version']
     );
+  });
+
+  it('closes auto-coding freshness as current when changed units have no auto-coding candidates', async () => {
+    (connection.query as jest.Mock).mockResolvedValue([{ revision: 14 }]);
+
+    const workspacePresenceQb = queryBuilder({
+      getRawOne: jest.fn().mockResolvedValue({ v1: true, v2: false, v3: false })
+    });
+    const unitPresenceQb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([{
+        unitId: 10,
+        v1: true,
+        v2: false,
+        v3: false
+      }])
+    });
+    const autoCodingCandidateQb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([])
+    });
+    (responseRepository.createQueryBuilder as jest.Mock)
+      .mockReturnValueOnce(workspacePresenceQb)
+      .mockReturnValueOnce(unitPresenceQb)
+      .mockReturnValueOnce(autoCodingCandidateQb);
+
+    await service.markUnitsStaleAfterResultChange(1, [10], 'RESULT_DELETED');
+
+    expect(freshnessRepository.upsert).toHaveBeenCalledWith(
+      [expect.objectContaining({
+        unit_id: 10,
+        version: 'v1',
+        state: 'CURRENT',
+        reason: 'RESULT_DELETED',
+        affected_response_count: 0,
+        source_revision: 14,
+        coded_revision: 14
+      })],
+      ['workspace_id', 'unit_id', 'version']
+    );
+    expect(responseRepository.createQueryBuilder).toHaveBeenCalledTimes(3);
   });
 
   it('marks coding scheme rule changes stale for auto-coding and manual review', async () => {
@@ -1168,9 +1215,6 @@ describe('CodingFreshnessService', () => {
   it('keeps changed uncoded units pending for the first auto-coding run', async () => {
     (connection.query as jest.Mock).mockResolvedValue([{ revision: 8 }]);
 
-    const responseCountsQb = queryBuilder({
-      getRawMany: jest.fn().mockResolvedValue([{ unitId: 10, count: '5' }])
-    });
     const workspacePresenceQb = queryBuilder({
       getRawOne: jest.fn().mockResolvedValue({ v1: false, v2: false, v3: false })
     });
@@ -1182,10 +1226,13 @@ describe('CodingFreshnessService', () => {
         v3: false
       }])
     });
+    const autoCodingCandidateQb = queryBuilder({
+      getRawMany: jest.fn().mockResolvedValue([{ unitId: 10, count: '5' }])
+    });
     (responseRepository.createQueryBuilder as jest.Mock)
-      .mockReturnValueOnce(responseCountsQb)
       .mockReturnValueOnce(workspacePresenceQb)
-      .mockReturnValueOnce(unitPresenceQb);
+      .mockReturnValueOnce(unitPresenceQb)
+      .mockReturnValueOnce(autoCodingCandidateQb);
 
     await service.markUnitsStaleAfterResultChange(1, [10], 'RESULT_UPDATED');
 

--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
@@ -33,6 +33,7 @@ import { CodingJobFreshnessStatus } from '../../../../../../../api-dto/coding/jo
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { IQB_STANDARD_MISSING_CODES, MissingsProfilesService } from './missings-profiles.service';
 import { getNonCodingIssueReviewJobSqlCondition } from './coding-job-type.util';
+import { getCodingVariableIdCandidateSql } from './coding-response-candidate.util';
 
 type UnitCodingPresence = Record<CodingFreshnessVersion, boolean>;
 
@@ -420,24 +421,40 @@ export class CodingFreshnessService {
     }
 
     const revision = await this.incrementRevision(workspaceId);
-    const responseCounts = await this.getResponseCountsByUnit(workspaceId, ids);
     const workspacePresence = await this.getWorkspaceCodingPresence(workspaceId);
     const unitPresence = await this.getUnitCodingPresence(workspaceId, ids);
+    const manualReviewUnitIds = ids.filter(unitId => unitPresence.get(unitId)?.v2);
+    const manualResponseCounts = manualReviewUnitIds.length > 0 ?
+      await this.getResponseCountsByUnit(workspaceId, manualReviewUnitIds) :
+      new Map<number, number>();
+    const autoCodingVersionsToRefresh = this.getAutoCodingVersionsToRefresh(workspacePresence);
+    const autoCodingResponseCountsByVersion = new Map<CodingFreshnessVersion, Map<number, number>>();
     const rows: FreshnessUpsert[] = [];
 
-    this.getAutoCodingVersionsToRefresh(workspacePresence).forEach(version => {
+    for (const version of autoCodingVersionsToRefresh) {
+      autoCodingResponseCountsByVersion.set(
+        version,
+        await this.getAutoCodingCandidateResponseCountsByUnit(workspaceId, ids, version)
+      );
+    }
+
+    autoCodingVersionsToRefresh.forEach(version => {
       ids.forEach(unitId => {
-        const state: CodingFreshnessState =
-          unitPresence.get(unitId)?.[version] ? 'STALE' : 'PENDING';
+        const autoCodingResponseCount =
+          autoCodingResponseCountsByVersion.get(version)?.get(unitId) || 0;
+        let state: CodingFreshnessState = 'CURRENT';
+        if (autoCodingResponseCount > 0) {
+          state = unitPresence.get(unitId)?.[version] ? 'STALE' : 'PENDING';
+        }
         rows.push(this.buildRow(
           workspaceId,
           unitId,
           version,
           state,
           reason,
-          responseCounts.get(unitId) || 0,
+          autoCodingResponseCount,
           revision,
-          null
+          state === 'CURRENT' ? revision : null
         ));
       });
     });
@@ -450,7 +467,7 @@ export class CodingFreshnessService {
           'v2',
           'MANUAL_REVIEW_REQUIRED',
           reason,
-          responseCounts.get(unitId) || 0,
+          manualResponseCounts.get(unitId) || 0,
           revision,
           null
         ));
@@ -2048,6 +2065,80 @@ export class CodingFreshnessService {
 
     countRows.forEach(row => result.set(Number(row.unitId), Number(row.count || 0)));
     return result;
+  }
+
+  private async getAutoCodingCandidateResponseCountsByUnit(
+    workspaceId: number,
+    unitIds: number[],
+    version: CodingFreshnessVersion,
+    manager?: EntityManager
+  ): Promise<Map<number, number>> {
+    const ids = this.uniquePositiveIds(unitIds);
+    const result = new Map<number, number>();
+    ids.forEach(id => result.set(id, 0));
+    if (ids.length === 0) {
+      return result;
+    }
+
+    const autoCoderRun = version === 'v3' ? 2 : 1;
+    const responseRepository = manager ?
+      manager.getRepository(ResponseEntity) :
+      this.responseRepository;
+    const countRows = await this.collectChunked(ids, this.ID_QUERY_BATCH_SIZE, async chunkIds => {
+      const query = responseRepository
+        .createQueryBuilder('response')
+        .select('response.unitid', 'unitId')
+        .addSelect('COUNT(response.id)', 'count')
+        .innerJoin('response.unit', 'unit')
+        .innerJoin('unit.booklet', 'booklet')
+        .innerJoin('booklet.bookletinfo', 'bookletinfo')
+        .innerJoin('booklet.person', 'person')
+        .where('person.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('person.consider = :consider', { consider: true })
+        .andWhere('response.unitid IN (:...unitIds)', { unitIds: chunkIds })
+        .andWhere(
+          new Brackets(qb => {
+            qb.where('response.status IN (:...statuses)', {
+              statuses: [3, 2, 1]
+            }).orWhere('response.status_v1 = :derivePending', {
+              derivePending: statusStringToNumber('DERIVE_PENDING') as number
+            });
+          })
+        )
+        .andWhere(getCodingVariableIdCandidateSql('response'))
+        .groupBy('response.unitid');
+
+      this.applyAutoCodingSourceFilter(query, autoCoderRun);
+      await this.applyWorkspaceExclusions(workspaceId, query);
+
+      return query.getRawMany<{ unitId: number | string; count: string }>();
+    });
+
+    countRows.forEach(row => result.set(Number(row.unitId), Number(row.count || 0)));
+    return result;
+  }
+
+  private applyAutoCodingSourceFilter(
+    query: SelectQueryBuilder<ResponseEntity>,
+    autoCoderRun: 1 | 2
+  ): void {
+    if (autoCoderRun === 1) {
+      query.andWhere('response.is_autocoder_generated IS NOT TRUE');
+      return;
+    }
+
+    query.andWhere(
+      new Brackets(qb => {
+        qb.where('response.is_autocoder_generated IS NOT TRUE').orWhere(
+          `response.is_autocoder_generated = :generatedWithSourceCoding
+            AND (
+              response.status_v1 IS NOT NULL
+              OR response.status_v2 IS NOT NULL
+            )`,
+          { generatedWithSourceCoding: true }
+        );
+      })
+    );
   }
 
   private existsVersionExpression(version: CodingFreshnessVersion): string {


### PR DESCRIPTION
## Summary
- count auto-coding freshness impact using the same candidate filters as auto-coding readiness
- close auto-coding freshness rows as current when changed units have no codeable auto-coding candidates
- avoid the broad manual response count query unless v2 manual review freshness is actually affected

## Root Cause
After result deletions, non-codeable response variables such as image/text leftovers could still keep auto-coding freshness open. Starting the freshness auto-coding job then found no codeable responses and failed with a 400 instead of treating the auto-coding scope as already current.

## Validation
- `npx nx test backend --runTestsByPath apps/backend/src/app/database/services/coding/coding-freshness.service.spec.ts --runInBand`
- `npx nx lint backend`
- `npx nx build backend`