### PR TITLE
Balance coding job distribution per item

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-job-distribution-planner.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution-planner.spec.ts
@@ -1,0 +1,105 @@
+import { CodingJobDistributionPlanner } from './coding-job-distribution-planner';
+
+type TestCoder = {
+  id: number;
+  weight: number;
+  tieBreaker: number;
+};
+
+describe('CodingJobDistributionPlanner', () => {
+  const planner = new CodingJobDistributionPlanner();
+
+  function makeCoders(count: number): TestCoder[] {
+    return Array.from({ length: count }, (_, index) => ({
+      id: index + 1,
+      weight: 1,
+      tieBreaker: planner.stableHash(`coder:${index + 1}`)
+    }));
+  }
+
+  function expectBalancedQuotaPlan(
+    coderCount: number,
+    doubleCodingCount: number
+  ): void {
+    const coders = makeCoders(coderCount);
+    const combinations = planner.getCoderCombinations(coders, 2);
+    const plan = planner.planBalancedDoubleCodingPairQuotas(
+      coders,
+      combinations,
+      doubleCodingCount,
+      'quota-invariants',
+      `item:${coderCount}:${doubleCodingCount}`,
+      new Map(coders.map(coder => [coder.id, 0])),
+      new Map()
+    );
+    const quotas = [...plan.pairQuotas.values()];
+    const coderDegrees = new Map(coders.map(coder => [coder.id, 0]));
+
+    combinations.forEach(combination => {
+      const quota = plan.pairQuotas.get(planner.getPairKey(combination)) || 0;
+      combination.forEach(coder => {
+        coderDegrees.set(coder.id, (coderDegrees.get(coder.id) || 0) + quota);
+      });
+    });
+
+    expect(quotas.reduce((sum, quota) => sum + quota, 0)).toBe(
+      doubleCodingCount
+    );
+    expect(Math.max(...quotas) - Math.min(...quotas)).toBeLessThanOrEqual(1);
+    expect(
+      Math.max(...coderDegrees.values()) - Math.min(...coderDegrees.values())
+    ).toBeLessThanOrEqual(1);
+  }
+
+  it('balances unavoidable item remainders across global coder and pair loads', () => {
+    const coders = makeCoders(3);
+    const combinations = planner.getCoderCombinations(coders, 2);
+    let plannedCoderAssignments = new Map(coders.map(coder => [coder.id, 0]));
+    let plannedPairCounts = new Map<string, number>();
+
+    ['item:1', 'item:2', 'item:3'].forEach(itemKey => {
+      const plan = planner.planBalancedDoubleCodingPairQuotas(
+        coders,
+        combinations,
+        1,
+        'small-items',
+        itemKey,
+        plannedCoderAssignments,
+        plannedPairCounts
+      );
+      plannedCoderAssignments = plan.plannedCoderAssignments;
+      plannedPairCounts = plan.plannedPairCounts;
+    });
+
+    expect(Object.fromEntries(plannedCoderAssignments)).toEqual({
+      1: 2,
+      2: 2,
+      3: 2
+    });
+    expect(Object.fromEntries(plannedPairCounts)).toEqual({
+      '1-2': 1,
+      '1-3': 1,
+      '2-3': 1
+    });
+  });
+
+  it('keeps pair quotas and coder degrees balanced across small plans', () => {
+    for (let coderCount = 2; coderCount <= 12; coderCount += 1) {
+      const pairCount = (coderCount * (coderCount - 1)) / 2;
+      for (
+        let doubleCodingCount = 1;
+        doubleCodingCount <= pairCount;
+        doubleCodingCount += 1
+      ) {
+        expectBalancedQuotaPlan(coderCount, doubleCodingCount);
+      }
+    }
+  });
+
+  it.each([1, 24, 25, 49, 612, 1224, 1225])(
+    'keeps pair quotas and coder degrees balanced for 50 coders and %i cases',
+    doubleCodingCount => {
+      expectBalancedQuotaPlan(50, doubleCodingCount);
+    }
+  );
+});

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution-planner.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution-planner.ts
@@ -1,0 +1,339 @@
+export type DistributionCoderLoad = {
+  tasks: number;
+  doubleTasks: number;
+};
+
+type DistributionPlannerCoder = {
+  id: number;
+  weight: number;
+  tieBreaker: number;
+};
+
+export type BalancedDoubleCodingPairQuotaPlan = {
+  pairQuotas: Map<string, number>;
+  plannedCoderAssignments: Map<number, number>;
+  plannedPairCounts: Map<string, number>;
+};
+
+export class CodingJobDistributionPlanner {
+  stableHash(value: string): number {
+    let hash = 0;
+
+    for (let i = 0; i < value.length; i += 1) {
+      hash = (hash * 31 + value.charCodeAt(i)) % 4294967291;
+    }
+
+    return hash;
+  }
+
+  chooseSingleCoder<T extends DistributionPlannerCoder>(
+    coders: T[],
+    itemCoderLoads: Map<number, DistributionCoderLoad>,
+    coderLoads: Map<number, DistributionCoderLoad>,
+    seed: string,
+    responseId: number,
+    taskCount = 1
+  ): T {
+    return coders
+      .map(coder => {
+        const itemLoad = itemCoderLoads.get(coder.id) || {
+          tasks: 0,
+          doubleTasks: 0
+        };
+        const load = coderLoads.get(coder.id) || {
+          tasks: 0,
+          doubleTasks: 0
+        };
+
+        return {
+          coder,
+          itemRatio: (itemLoad.tasks + taskCount) / coder.weight,
+          itemTasks: itemLoad.tasks,
+          globalRatio: (load.tasks + taskCount) / coder.weight,
+          globalTasks: load.tasks,
+          tie: this.stableHash(`${seed}:single:${responseId}:${coder.id}`)
+        };
+      })
+      .reduce((best, candidate) => {
+        const comparison =
+          candidate.itemRatio - best.itemRatio ||
+          candidate.itemTasks - best.itemTasks ||
+          candidate.globalRatio - best.globalRatio ||
+          candidate.globalTasks - best.globalTasks ||
+          candidate.tie - best.tie ||
+          candidate.coder.tieBreaker - best.coder.tieBreaker;
+
+        return comparison < 0 ? candidate : best;
+      }).coder;
+  }
+
+  getCoderCombinations<T>(
+    coders: T[],
+    size: number,
+    startIndex = 0,
+    prefix: T[] = []
+  ): T[][] {
+    if (prefix.length === size) {
+      return [prefix];
+    }
+
+    const combinations: T[][] = [];
+
+    for (let i = startIndex; i < coders.length; i += 1) {
+      combinations.push(
+        ...this.getCoderCombinations(coders, size, i + 1, [
+          ...prefix,
+          coders[i]
+        ])
+      );
+    }
+
+    return combinations;
+  }
+
+  getPairKey(coders: Array<{ id: number }>): string {
+    return coders
+      .map(coder => coder.id)
+      .sort((a, b) => a - b)
+      .join('-');
+  }
+
+  planBalancedDoubleCodingPairQuotas<T extends DistributionPlannerCoder>(
+    coders: T[],
+    coderCombinations: T[][],
+    doubleCodingCount: number,
+    seed: string,
+    itemKey: string,
+    plannedCoderAssignments: ReadonlyMap<number, number>,
+    plannedPairCounts: ReadonlyMap<string, number>
+  ): BalancedDoubleCodingPairQuotaPlan {
+    const pairQuotas = new Map<string, number>();
+    if (coderCombinations.length === 0) {
+      return this.completePairQuotaPlan(
+        coderCombinations,
+        pairQuotas,
+        plannedCoderAssignments,
+        plannedPairCounts
+      );
+    }
+
+    const basePairQuota = Math.floor(
+      doubleCodingCount / coderCombinations.length
+    );
+    coderCombinations.forEach(combination => {
+      pairQuotas.set(this.getPairKey(combination), basePairQuota);
+    });
+
+    const remainingPairs = doubleCodingCount % coderCombinations.length;
+    if (remainingPairs === 0) {
+      return this.completePairQuotaPlan(
+        coderCombinations,
+        pairQuotas,
+        plannedCoderAssignments,
+        plannedPairCounts
+      );
+    }
+
+    const totalRemainingCoderAssignments = remainingPairs * 2;
+    const baseRemainingCoderDegree = Math.floor(
+      totalRemainingCoderAssignments / coders.length
+    );
+    const higherDegreeCoderCount =
+      totalRemainingCoderAssignments % coders.length;
+    const plannedLoadRatio = (coder: T): number => (plannedCoderAssignments.get(coder.id) || 0) / coder.weight;
+    const degreeOrder = [...coders].sort(
+      (a, b) => plannedLoadRatio(a) - plannedLoadRatio(b) ||
+        this.stableHash(`${seed}:${itemKey}:pair-plan:coder:${a.id}`) -
+          this.stableHash(`${seed}:${itemKey}:pair-plan:coder:${b.id}`) ||
+        a.id - b.id
+    );
+    const higherDegreeCoderIds = new Set(
+      degreeOrder.slice(0, higherDegreeCoderCount).map(coder => coder.id)
+    );
+    const remainingDegrees = coders.map(coder => ({
+      coder,
+      degree:
+        baseRemainingCoderDegree + (higherDegreeCoderIds.has(coder.id) ? 1 : 0),
+      tieBreaker: this.stableHash(
+        `${seed}:${itemKey}:pair-plan:node:${coder.id}`
+      )
+    }));
+    const extraPairs = new Set<string>();
+
+    while (remainingDegrees.some(node => node.degree > 0)) {
+      remainingDegrees.sort(
+        (a, b) => b.degree - a.degree ||
+          a.tieBreaker - b.tieBreaker ||
+          a.coder.id - b.coder.id
+      );
+      const node = remainingDegrees[0];
+      const requiredDegree = node.degree;
+      if (requiredDegree === 0) {
+        break;
+      }
+
+      const candidates = remainingDegrees
+        .slice(1)
+        .filter(
+          candidate => candidate.degree > 0 &&
+            !extraPairs.has(this.getPairKey([node.coder, candidate.coder]))
+        )
+        .sort((a, b) => {
+          const pairKeyA = this.getPairKey([node.coder, a.coder]);
+          const pairKeyB = this.getPairKey([node.coder, b.coder]);
+
+          return (
+            b.degree - a.degree ||
+            (plannedPairCounts.get(pairKeyA) || 0) -
+              (plannedPairCounts.get(pairKeyB) || 0) ||
+            this.stableHash(`${seed}:${itemKey}:pair-plan:edge:${pairKeyA}`) -
+              this.stableHash(
+                `${seed}:${itemKey}:pair-plan:edge:${pairKeyB}`
+              ) ||
+            a.coder.id - b.coder.id
+          );
+        });
+
+      if (candidates.length < requiredDegree) {
+        throw new Error('Could not build balanced double-coding pair quotas.');
+      }
+
+      node.degree = 0;
+      candidates.slice(0, requiredDegree).forEach(candidate => {
+        const pairKey = this.getPairKey([node.coder, candidate.coder]);
+        extraPairs.add(pairKey);
+        candidate.degree -= 1;
+        pairQuotas.set(pairKey, (pairQuotas.get(pairKey) || 0) + 1);
+      });
+    }
+
+    return this.completePairQuotaPlan(
+      coderCombinations,
+      pairQuotas,
+      plannedCoderAssignments,
+      plannedPairCounts
+    );
+  }
+
+  chooseDoubleCodingCoders<T extends DistributionPlannerCoder>(
+    coderCombinations: T[][],
+    itemCoderLoads: Map<number, DistributionCoderLoad>,
+    coderLoads: Map<number, DistributionCoderLoad>,
+    itemPairCounts: Map<string, number>,
+    pairCounts: Map<string, number>,
+    seed: string,
+    responseId: number,
+    taskCount = 1
+  ): T[] {
+    return coderCombinations
+      .map(combination => {
+        const projectedItemRatios = combination.map(coder => {
+          const load = itemCoderLoads.get(coder.id) || {
+            tasks: 0,
+            doubleTasks: 0
+          };
+          return (load.tasks + taskCount) / coder.weight;
+        });
+        const projectedItemDoubleRatios = combination.map(coder => {
+          const load = itemCoderLoads.get(coder.id) || {
+            tasks: 0,
+            doubleTasks: 0
+          };
+          return (load.doubleTasks + taskCount) / coder.weight;
+        });
+        const projectedGlobalRatios = combination.map(coder => {
+          const load = coderLoads.get(coder.id) || {
+            tasks: 0,
+            doubleTasks: 0
+          };
+          return (load.tasks + taskCount) / coder.weight;
+        });
+        const projectedGlobalDoubleRatios = combination.map(coder => {
+          const load = coderLoads.get(coder.id) || {
+            tasks: 0,
+            doubleTasks: 0
+          };
+          return (load.doubleTasks + taskCount) / coder.weight;
+        });
+        const pairKey = this.getPairKey(combination);
+
+        return {
+          combination,
+          score: {
+            maxItemLoad: Math.max(...projectedItemRatios),
+            itemPairCount: itemPairCounts.get(pairKey) || 0,
+            maxItemDoubleLoad: Math.max(...projectedItemDoubleRatios),
+            totalItemLoad: projectedItemRatios.reduce(
+              (sum, value) => sum + value,
+              0
+            ),
+            maxGlobalLoad: Math.max(...projectedGlobalRatios),
+            globalPairCount: pairCounts.get(pairKey) || 0,
+            maxGlobalDoubleLoad: Math.max(...projectedGlobalDoubleRatios),
+            totalGlobalLoad: projectedGlobalRatios.reduce(
+              (sum, value) => sum + value,
+              0
+            ),
+            tie: this.stableHash(`${seed}:double:${responseId}:${pairKey}`)
+          }
+        };
+      })
+      .reduce((best, candidate) => {
+        const comparison =
+          candidate.score.maxItemLoad - best.score.maxItemLoad ||
+          candidate.score.itemPairCount - best.score.itemPairCount ||
+          candidate.score.maxItemDoubleLoad -
+            best.score.maxItemDoubleLoad ||
+          candidate.score.totalItemLoad - best.score.totalItemLoad ||
+          candidate.score.maxGlobalLoad - best.score.maxGlobalLoad ||
+          candidate.score.globalPairCount - best.score.globalPairCount ||
+          candidate.score.maxGlobalDoubleLoad -
+            best.score.maxGlobalDoubleLoad ||
+          candidate.score.totalGlobalLoad - best.score.totalGlobalLoad ||
+          candidate.score.tie - best.score.tie;
+
+        return comparison < 0 ? candidate : best;
+      }).combination;
+  }
+
+  private completePairQuotaPlan<T extends DistributionPlannerCoder>(
+    coderCombinations: T[][],
+    pairQuotas: Map<string, number>,
+    plannedCoderAssignments: ReadonlyMap<number, number>,
+    plannedPairCounts: ReadonlyMap<string, number>
+  ): BalancedDoubleCodingPairQuotaPlan {
+    const nextCoderAssignments = new Map(plannedCoderAssignments);
+    const nextPairCounts = new Map(plannedPairCounts);
+    const combinationsByPairKey = new Map(
+      coderCombinations.map(combination => [
+        this.getPairKey(combination),
+        combination
+      ])
+    );
+
+    pairQuotas.forEach((quota, pairKey) => {
+      if (quota === 0) {
+        return;
+      }
+
+      const combination = combinationsByPairKey.get(pairKey);
+      if (!combination) {
+        throw new Error(`Missing coder combination for pair ${pairKey}.`);
+      }
+
+      nextPairCounts.set(pairKey, (nextPairCounts.get(pairKey) || 0) + quota);
+      combination.forEach(coder => {
+        nextCoderAssignments.set(
+          coder.id,
+          (nextCoderAssignments.get(coder.id) || 0) + quota
+        );
+      });
+    });
+
+    return {
+      pairQuotas,
+      plannedCoderAssignments: nextCoderAssignments,
+      plannedPairCounts: nextPairCounts
+    };
+  }
+}

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -22,6 +22,19 @@ type SlimResponseForTest = {
   variableBundleId?: number;
 };
 
+type DistributionPlanForTest = {
+  distributionByCoderId: Record<string, Record<string, number>>;
+  doubleCodingInfo: Record<string, {
+    doubleCodedCasesPerCoderId: Record<string, number>;
+  }>;
+  plannedCases: Array<{
+    item: { itemKey: string };
+    isDoubleCoded: boolean;
+    assignedCoderIds: number[];
+  }>;
+  tasksPerCoder: Record<string, number>;
+};
+
 const createRepo = () => ({
   count: jest.fn().mockResolvedValue(0),
   find: jest.fn(),
@@ -172,6 +185,38 @@ describe('CodingJobService distribution from job definitions', () => {
       service as unknown as { getAssignedResponseIdsForVariables: () => Promise<Set<number>> },
       'getAssignedResponseIdsForVariables'
     ).mockResolvedValue(new Set());
+  }
+
+  function buildDistributionPlanForTest(
+    request: unknown
+  ): Promise<DistributionPlanForTest> {
+    return (
+      service as unknown as {
+        buildDistributionPlan: (
+          workspaceId: number,
+          planRequest: unknown
+        ) => Promise<DistributionPlanForTest>;
+      }
+    ).buildDistributionPlan(5, request);
+  }
+
+  function getDoubleCodingPairCounts(
+    plan: DistributionPlanForTest,
+    itemKey: string
+  ): Record<string, number> {
+    const pairCounts = new Map<string, number>();
+    plan.plannedCases
+      .filter(plannedCase => (
+        plannedCase.item.itemKey === itemKey && plannedCase.isDoubleCoded
+      ))
+      .forEach(plannedCase => {
+        const pairKey = [...plannedCase.assignedCoderIds]
+          .sort((a, b) => a - b)
+          .join('-');
+        pairCounts.set(pairKey, (pairCounts.get(pairKey) || 0) + 1);
+      });
+
+    return Object.fromEntries(pairCounts);
   }
 
   it('keeps preview distribution and created jobs aligned for capped double-coded mixed definitions', async () => {
@@ -535,6 +580,164 @@ describe('CodingJobService distribution from job definitions', () => {
     ).toBe(35);
   });
 
+  it('balances coder loads and double-coding pairs within every variable', async () => {
+    const variables = [
+      { unitName: 'Unit 1', variableId: 'Var 1' },
+      { unitName: 'Unit 2', variableId: 'Var 2' },
+      { unitName: 'Unit 3', variableId: 'Var 3' }
+    ];
+    const responses = variables.flatMap((variable, variableIndex) => Array.from(
+      { length: 30 },
+      (_, caseIndex) => makeResponse(
+        variableIndex * 100 + caseIndex + 1,
+        variable.unitName,
+        variable.variableId
+      )
+    ));
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+
+    const plan = await buildDistributionPlanForTest({
+      selectedVariables: variables,
+      selectedCoders: [
+        { id: 1, name: 'Ada', username: 'ada' },
+        { id: 2, name: 'Bea', username: 'bea' },
+        { id: 3, name: 'Chris', username: 'chris' }
+      ],
+      doubleCodingPercentage: 20,
+      caseOrderingMode: 'continuous',
+      distributionSeed: 'job-definition:1'
+    });
+
+    variables.forEach(variable => {
+      const itemKey = `${variable.unitName}::${variable.variableId}`;
+      expect(plan.distributionByCoderId[itemKey]).toEqual({
+        1: 12,
+        2: 12,
+        3: 12
+      });
+      expect(
+        plan.doubleCodingInfo[itemKey].doubleCodedCasesPerCoderId
+      ).toEqual({
+        1: 4,
+        2: 4,
+        3: 4
+      });
+
+      expect(getDoubleCodingPairCounts(plan, itemKey)).toEqual({
+        '1-2': 2,
+        '1-3': 2,
+        '2-3': 2
+      });
+    });
+    expect(plan.tasksPerCoder).toEqual({ 1: 36, 2: 36, 3: 36 });
+  });
+
+  it.each([
+    [
+      '300 cases, three coders and 10 percent double coding',
+      300,
+      3,
+      { doubleCodingPercentage: 10 },
+      [110, 110, 110],
+      [10, 10, 10]
+    ],
+    [
+      '30 cases, three coders and 20 percent double coding',
+      30,
+      3,
+      { doubleCodingPercentage: 20 },
+      [12, 12, 12],
+      [2, 2, 2]
+    ],
+    [
+      '300 cases, four coders and 50 double-coded cases',
+      300,
+      4,
+      { doubleCodingAbsolute: 50 },
+      [87, 87, 88, 88],
+      [8, 8, 8, 8, 9, 9]
+    ]
+  ])('matches the issue distribution example: %s', async (
+    _label,
+    caseCount,
+    coderCount,
+    doubleCoding,
+    expectedCoderLoads,
+    expectedPairCounts
+  ) => {
+    const itemKey = 'Unit 1::Var 1';
+    const responses = Array.from(
+      { length: caseCount as number },
+      (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1')
+    );
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+
+    const plan = await buildDistributionPlanForTest({
+      selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      selectedCoders: Array.from(
+        { length: coderCount as number },
+        (_, index) => ({
+          id: index + 1,
+          name: `Coder ${index + 1}`,
+          username: `coder-${index + 1}`
+        })
+      ),
+      ...(doubleCoding as Record<string, number>),
+      caseOrderingMode: 'continuous',
+      distributionSeed: 'issue-896-examples'
+    });
+
+    expect(
+      Object.values(plan.distributionByCoderId[itemKey]).sort((a, b) => a - b)
+    ).toEqual(expectedCoderLoads);
+    expect(
+      Object.values(getDoubleCodingPairCounts(plan, itemKey))
+        .sort((a, b) => a - b)
+    ).toEqual(expectedPairCounts);
+  });
+
+  it('balances pair quotas when six coders double-code six cases', async () => {
+    const itemKey = 'Unit 1::Var 1';
+    const responses = Array.from(
+      { length: 6 },
+      (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1')
+    );
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+
+    const plan = await buildDistributionPlanForTest({
+      selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      selectedCoders: Array.from({ length: 6 }, (_, index) => ({
+        id: index + 1,
+        name: `Coder ${index + 1}`,
+        username: `coder-${index + 1}`
+      })),
+      doubleCodingAbsolute: 6,
+      caseOrderingMode: 'continuous',
+      distributionSeed: 'six-coder-pair-balance'
+    });
+    const pairCounts = getDoubleCodingPairCounts(plan, itemKey);
+
+    expect(plan.distributionByCoderId[itemKey]).toEqual({
+      1: 2,
+      2: 2,
+      3: 2,
+      4: 2,
+      5: 2,
+      6: 2
+    });
+    expect(Object.keys(pairCounts)).toHaveLength(6);
+    expect(Object.values(pairCounts)).toEqual([1, 1, 1, 1, 1, 1]);
+  });
+
   it('ignores unsupported requests for more than two coders per double-coded case', async () => {
     const responses = Array.from({ length: 4 }, (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1'));
     const createdJobCalls: Array<{ subset: SlimResponseForTest[] }> = [];
@@ -639,6 +842,40 @@ describe('CodingJobService distribution from job definitions', () => {
     expect(preview.tasksPerCoder['1'] + preview.tasksPerCoder['2']).toBe(8);
     expect(preview.tasksPerCoder['2']).toBeGreaterThan(preview.tasksPerCoder['1']);
     expect(preview.coderWeights).toEqual({ 1: 1, 2: 3 });
+  });
+
+  it('applies coder weights within each selected variable', async () => {
+    const responses = [
+      ...Array.from({ length: 8 }, (_, index) => makeResponse(index + 1, 'Unit 1', 'Var 1')),
+      ...Array.from({ length: 8 }, (_, index) => makeResponse(index + 101, 'Unit 2', 'Var 2'))
+    ];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+
+    const preview = await service.calculateDistribution(5, {
+      selectedVariables: [
+        { unitName: 'Unit 1', variableId: 'Var 1' },
+        { unitName: 'Unit 2', variableId: 'Var 2' }
+      ],
+      selectedCoders: [
+        {
+          id: 1, name: 'Ada', username: 'ada', weight: 1
+        },
+        {
+          id: 2, name: 'Bea', username: 'bea', weight: 3
+        }
+      ],
+      caseOrderingMode: 'continuous',
+      distributionSeed: 'weighted-per-variable'
+    });
+
+    expect(preview.distributionByCoderId).toEqual({
+      'Unit 1::Var 1': { 1: 2, 2: 6 },
+      'Unit 2::Var 2': { 1: 2, 2: 6 }
+    });
+    expect(preview.tasksPerCoder).toEqual({ 1: 4, 2: 12 });
   });
 
   it.each([

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -635,6 +635,50 @@ describe('CodingJobService distribution from job definitions', () => {
     expect(plan.tasksPerCoder).toEqual({ 1: 36, 2: 36, 3: 36 });
   });
 
+  it('balances unavoidable double-coding remainders across variables', async () => {
+    const variables = [
+      { unitName: 'Unit 1', variableId: 'Var 1' },
+      { unitName: 'Unit 2', variableId: 'Var 2' },
+      { unitName: 'Unit 3', variableId: 'Var 3' }
+    ];
+    const responses = variables.map((variable, index) => makeResponse(
+      index + 1,
+      variable.unitName,
+      variable.variableId
+    ));
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+
+    const plan = await buildDistributionPlanForTest({
+      selectedVariables: variables,
+      selectedCoders: [
+        { id: 1, name: 'Ada', username: 'ada' },
+        { id: 2, name: 'Bea', username: 'bea' },
+        { id: 3, name: 'Chris', username: 'chris' }
+      ],
+      doubleCodingAbsolute: 1,
+      caseOrderingMode: 'continuous',
+      distributionSeed: 'small-items'
+    });
+
+    variables.forEach(variable => {
+      const itemKey = `${variable.unitName}::${variable.variableId}`;
+      expect(
+        Object.values(plan.distributionByCoderId[itemKey]).sort((a, b) => a - b)
+      ).toEqual([0, 1, 1]);
+    });
+    expect(plan.tasksPerCoder).toEqual({ 1: 2, 2: 2, 3: 2 });
+    expect(
+      plan.plannedCases
+        .map(plannedCase => [...plannedCase.assignedCoderIds]
+          .sort((a, b) => a - b)
+          .join('-'))
+        .sort()
+    ).toEqual(['1-2', '1-3', '2-3']);
+  });
+
   it.each([
     [
       '300 cases, three coders and 10 percent double coding',

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -91,6 +91,10 @@ import {
 } from './coding-job-type.util';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { hasVisibleManualInstruction } from '../../../utils/manual-instruction.util';
+import {
+  CodingJobDistributionPlanner,
+  DistributionCoderLoad
+} from './coding-job-distribution-planner';
 
 function isSafeKey(key: string): boolean {
   return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
@@ -163,11 +167,6 @@ type NormalizedDistributionCoder = {
   weight: number;
   displayKey: string;
   tieBreaker: number;
-};
-
-type DistributionCoderLoad = {
-  tasks: number;
-  doubleTasks: number;
 };
 
 type DistributionDoubleCodingInfo = {
@@ -450,6 +449,8 @@ const INCLUDE_DERIVE_ERROR_IN_MANUAL_CODING_SETTING_KEY =
 @Injectable()
 export class CodingJobService {
   private readonly logger = new Logger(CodingJobService.name);
+
+  private readonly distributionPlanner = new CodingJobDistributionPlanner();
 
   constructor(
     @InjectRepository(CodingJob)
@@ -6041,16 +6042,6 @@ export class CodingJobService {
     return `workspace:${workspaceId}:distributed-coding`;
   }
 
-  private stableHash(value: string): number {
-    let hash = 0;
-
-    for (let i = 0; i < value.length; i += 1) {
-      hash = (hash * 31 + value.charCodeAt(i)) % 4294967291;
-    }
-
-    return hash;
-  }
-
   private compareResponsesByMode(
     mode: 'continuous' | 'alternating',
     a: SlimResponse,
@@ -6165,8 +6156,12 @@ export class CodingJobService {
         ))
       }))
       .sort((a, b) => {
-        const hashA = this.stableHash(`${seed}:${itemKey}:stratum:${a.key}`);
-        const hashB = this.stableHash(`${seed}:${itemKey}:stratum:${b.key}`);
+        const hashA = this.distributionPlanner.stableHash(
+          `${seed}:${itemKey}:stratum:${a.key}`
+        );
+        const hashB = this.distributionPlanner.stableHash(
+          `${seed}:${itemKey}:stratum:${b.key}`
+        );
         return hashA - hashB || a.key.localeCompare(b.key);
       });
 
@@ -6313,7 +6308,9 @@ export class CodingJobService {
           username: coder.username,
           weight,
           displayKey,
-          tieBreaker: this.stableHash(`${seed}:coder:${coder.id}`)
+          tieBreaker: this.distributionPlanner.stableHash(
+            `${seed}:coder:${coder.id}`
+          )
         };
       })
       .sort((a, b) => a.name.localeCompare(b.name) || a.id - b.id);
@@ -6546,241 +6543,6 @@ export class CodingJobService {
 
   private getResponseVariableKey(response: SlimResponse): string {
     return `${response.unitName}::${response.variableid}`;
-  }
-
-  private chooseSingleCoder(
-    coders: NormalizedDistributionCoder[],
-    itemCoderLoads: Map<number, DistributionCoderLoad>,
-    coderLoads: Map<number, DistributionCoderLoad>,
-    seed: string,
-    response: SlimResponse,
-    taskCount = 1
-  ): NormalizedDistributionCoder {
-    return [...coders].sort((a, b) => {
-      const itemLoadA = itemCoderLoads.get(a.id) || { tasks: 0, doubleTasks: 0 };
-      const itemLoadB = itemCoderLoads.get(b.id) || { tasks: 0, doubleTasks: 0 };
-      const loadA = coderLoads.get(a.id) || { tasks: 0, doubleTasks: 0 };
-      const loadB = coderLoads.get(b.id) || { tasks: 0, doubleTasks: 0 };
-      const itemRatioA = (itemLoadA.tasks + taskCount) / a.weight;
-      const itemRatioB = (itemLoadB.tasks + taskCount) / b.weight;
-      const globalRatioA = (loadA.tasks + taskCount) / a.weight;
-      const globalRatioB = (loadB.tasks + taskCount) / b.weight;
-      const tieA = this.stableHash(`${seed}:single:${response.id}:${a.id}`);
-      const tieB = this.stableHash(`${seed}:single:${response.id}:${b.id}`);
-
-      return (
-        itemRatioA - itemRatioB ||
-        itemLoadA.tasks - itemLoadB.tasks ||
-        globalRatioA - globalRatioB ||
-        loadA.tasks - loadB.tasks ||
-        tieA - tieB ||
-        a.tieBreaker - b.tieBreaker
-      );
-    })[0];
-  }
-
-  private getCoderCombinations(
-    coders: NormalizedDistributionCoder[],
-    size: number,
-    startIndex = 0,
-    prefix: NormalizedDistributionCoder[] = []
-  ): NormalizedDistributionCoder[][] {
-    if (prefix.length === size) {
-      return [prefix];
-    }
-
-    const combinations: NormalizedDistributionCoder[][] = [];
-
-    for (let i = startIndex; i < coders.length; i += 1) {
-      combinations.push(
-        ...this.getCoderCombinations(coders, size, i + 1, [
-          ...prefix,
-          coders[i]
-        ])
-      );
-    }
-
-    return combinations;
-  }
-
-  private getDistributionPairKey(
-    coders: NormalizedDistributionCoder[]
-  ): string {
-    return coders
-      .map(coder => coder.id)
-      .sort((a, b) => a - b)
-      .join('-');
-  }
-
-  private buildBalancedDoubleCodingPairQuotas(
-    coders: NormalizedDistributionCoder[],
-    coderCombinations: NormalizedDistributionCoder[][],
-    doubleCodingCount: number,
-    seed: string,
-    itemKey: string
-  ): Map<string, number> {
-    const pairQuotas = new Map<string, number>();
-    if (coderCombinations.length === 0) {
-      return pairQuotas;
-    }
-
-    const basePairQuota = Math.floor(
-      doubleCodingCount / coderCombinations.length
-    );
-    coderCombinations.forEach(combination => {
-      pairQuotas.set(
-        this.getDistributionPairKey(combination),
-        basePairQuota
-      );
-    });
-
-    const remainingPairs =
-      doubleCodingCount % coderCombinations.length;
-    if (remainingPairs === 0) {
-      return pairQuotas;
-    }
-
-    const totalRemainingCoderAssignments = remainingPairs * 2;
-    const baseRemainingCoderDegree = Math.floor(
-      totalRemainingCoderAssignments / coders.length
-    );
-    const higherDegreeCoderCount =
-      totalRemainingCoderAssignments % coders.length;
-    const degreeOrder = [...coders].sort((a, b) => (
-      this.stableHash(`${seed}:${itemKey}:pair-plan:coder:${a.id}`) -
-      this.stableHash(`${seed}:${itemKey}:pair-plan:coder:${b.id}`) ||
-      a.id - b.id
-    ));
-    const higherDegreeCoderIds = new Set(
-      degreeOrder
-        .slice(0, higherDegreeCoderCount)
-        .map(coder => coder.id)
-    );
-    const remainingDegrees = coders.map(coder => ({
-      coder,
-      degree:
-        baseRemainingCoderDegree +
-        (higherDegreeCoderIds.has(coder.id) ? 1 : 0),
-      tieBreaker: this.stableHash(
-        `${seed}:${itemKey}:pair-plan:node:${coder.id}`
-      )
-    }));
-    const extraPairs = new Set<string>();
-
-    while (remainingDegrees.some(node => node.degree > 0)) {
-      remainingDegrees.sort((a, b) => (
-        b.degree - a.degree ||
-        a.tieBreaker - b.tieBreaker ||
-        a.coder.id - b.coder.id
-      ));
-      const node = remainingDegrees[0];
-      const requiredDegree = node.degree;
-      if (requiredDegree === 0) {
-        break;
-      }
-
-      const candidates = remainingDegrees
-        .slice(1)
-        .filter(candidate => (
-          candidate.degree > 0 &&
-          !extraPairs.has(this.getDistributionPairKey([
-            node.coder,
-            candidate.coder
-          ]))
-        ))
-        .sort((a, b) => (
-          b.degree - a.degree ||
-          this.stableHash(
-            `${seed}:${itemKey}:pair-plan:edge:${this.getDistributionPairKey([
-              node.coder,
-              a.coder
-            ])}`
-          ) -
-          this.stableHash(
-            `${seed}:${itemKey}:pair-plan:edge:${this.getDistributionPairKey([
-              node.coder,
-              b.coder
-            ])}`
-          ) ||
-          a.coder.id - b.coder.id
-        ));
-
-      if (candidates.length < requiredDegree) {
-        throw new Error('Could not build balanced double-coding pair quotas.');
-      }
-
-      node.degree = 0;
-      candidates.slice(0, requiredDegree).forEach(candidate => {
-        const pairKey = this.getDistributionPairKey([
-          node.coder,
-          candidate.coder
-        ]);
-        extraPairs.add(pairKey);
-        candidate.degree -= 1;
-        pairQuotas.set(pairKey, (pairQuotas.get(pairKey) || 0) + 1);
-      });
-    }
-
-    return pairQuotas;
-  }
-
-  private chooseDoubleCodingCoders(
-    coderCombinations: NormalizedDistributionCoder[][],
-    itemCoderLoads: Map<number, DistributionCoderLoad>,
-    coderLoads: Map<number, DistributionCoderLoad>,
-    itemPairCounts: Map<string, number>,
-    pairCounts: Map<string, number>,
-    seed: string,
-    response: SlimResponse,
-    taskCount = 1
-  ): NormalizedDistributionCoder[] {
-    return [...coderCombinations].sort((a, b) => {
-      const score = (combination: NormalizedDistributionCoder[]) => {
-        const projectedItemRatios = combination.map(coder => {
-          const load = itemCoderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-          return (load.tasks + taskCount) / coder.weight;
-        });
-        const projectedItemDoubleRatios = combination.map(coder => {
-          const load = itemCoderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-          return (load.doubleTasks + taskCount) / coder.weight;
-        });
-        const projectedGlobalRatios = combination.map(coder => {
-          const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-          return (load.tasks + taskCount) / coder.weight;
-        });
-        const projectedGlobalDoubleRatios = combination.map(coder => {
-          const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-          return (load.doubleTasks + taskCount) / coder.weight;
-        });
-        const pairKey = this.getDistributionPairKey(combination);
-
-        return {
-          maxItemLoad: Math.max(...projectedItemRatios),
-          itemPairCount: itemPairCounts.get(pairKey) || 0,
-          maxItemDoubleLoad: Math.max(...projectedItemDoubleRatios),
-          totalItemLoad: projectedItemRatios.reduce((sum, value) => sum + value, 0),
-          maxGlobalLoad: Math.max(...projectedGlobalRatios),
-          globalPairCount: pairCounts.get(pairKey) || 0,
-          maxGlobalDoubleLoad: Math.max(...projectedGlobalDoubleRatios),
-          totalGlobalLoad: projectedGlobalRatios.reduce((sum, value) => sum + value, 0),
-          tie: this.stableHash(`${seed}:double:${response.id}:${pairKey}`)
-        };
-      };
-      const scoreA = score(a);
-      const scoreB = score(b);
-
-      return (
-        scoreA.maxItemLoad - scoreB.maxItemLoad ||
-        scoreA.itemPairCount - scoreB.itemPairCount ||
-        scoreA.maxItemDoubleLoad - scoreB.maxItemDoubleLoad ||
-        scoreA.totalItemLoad - scoreB.totalItemLoad ||
-        scoreA.maxGlobalLoad - scoreB.maxGlobalLoad ||
-        scoreA.globalPairCount - scoreB.globalPairCount ||
-        scoreA.maxGlobalDoubleLoad - scoreB.maxGlobalDoubleLoad ||
-        scoreA.totalGlobalLoad - scoreB.totalGlobalLoad ||
-        scoreA.tie - scoreB.tie
-      );
-    })[0];
   }
 
   private buildEmptyDoubleCodingInfo(
@@ -7026,7 +6788,10 @@ export class CodingJobService {
     const plannedCases: DistributionPlanCase[] = [];
     const doubleCodingCoderCombinations =
       totalDoubleCodingCount > 0 ?
-        this.getCoderCombinations(coders, codersPerDoubleCodedCase) :
+        this.distributionPlanner.getCoderCombinations(
+          coders,
+          codersPerDoubleCodedCase
+        ) :
         [];
     const codersHaveEqualWeights = coders.every(
       coder => coder.weight === coders[0]?.weight
@@ -7035,19 +6800,29 @@ export class CodingJobService {
     string,
     Map<string, number>
     >();
+    let plannedDoubleCoderAssignments = new Map(
+      coders.map(coder => [coder.id, 0])
+    );
+    let plannedDoublePairCounts = new Map<string, number>();
     if (codersHaveEqualWeights) {
-      doubleCodingCountsByItemKey.forEach((doubleCodingCount, itemKey) => {
-        doubleCodingPairQuotasByItemKey.set(
-          itemKey,
-          this.buildBalancedDoubleCodingPairQuotas(
+      for (const [itemKey, doubleCodingCount] of doubleCodingCountsByItemKey) {
+        const quotaPlan =
+          this.distributionPlanner.planBalancedDoubleCodingPairQuotas(
             coders,
             doubleCodingCoderCombinations,
             doubleCodingCount,
             distributionSeed,
-            itemKey
-          )
+            itemKey,
+            plannedDoubleCoderAssignments,
+            plannedDoublePairCounts
+          );
+        doubleCodingPairQuotasByItemKey.set(
+          itemKey,
+          quotaPlan.pairQuotas
         );
-      });
+        plannedDoubleCoderAssignments = quotaPlan.plannedCoderAssignments;
+        plannedDoublePairCounts = quotaPlan.plannedPairCounts;
+      }
     }
     const assignedDoubleCodingCountsByItemKey = new Map<string, number>();
     const selectedCaseAssignments = selectedCases.map(selectedCase => {
@@ -7085,46 +6860,50 @@ export class CodingJobService {
           const itemPairCounts = pairCountsByItemKey.get(itemKey) ||
             new Map<string, number>();
           const taskCount = selectedCase.caseGroup.responses.length;
-          const pairQuotas = doubleCodingPairQuotasByItemKey.get(itemKey);
-          const availableDoubleCodingCombinations = pairQuotas ?
-            doubleCodingCoderCombinations.filter(combination => {
-              const pairKey = this.getDistributionPairKey(combination);
-              return (
-                (itemPairCounts.get(pairKey) || 0) <
-                (pairQuotas.get(pairKey) || 0)
+          let assignedCoders: NormalizedDistributionCoder[];
+
+          if (isDoubleCoded) {
+            const pairQuotas = doubleCodingPairQuotasByItemKey.get(itemKey);
+            const availableDoubleCodingCombinations = pairQuotas ?
+              doubleCodingCoderCombinations.filter(combination => {
+                const pairKey =
+                  this.distributionPlanner.getPairKey(combination);
+                return (
+                  (itemPairCounts.get(pairKey) || 0) <
+                  (pairQuotas.get(pairKey) || 0)
+                );
+              }) :
+              doubleCodingCoderCombinations;
+
+            if (availableDoubleCodingCombinations.length === 0) {
+              throw new Error('No planned double-coding pair is available.');
+            }
+            assignedCoders =
+              this.distributionPlanner.chooseDoubleCodingCoders(
+                availableDoubleCodingCombinations,
+                itemCoderLoads,
+                coderLoads,
+                itemPairCounts,
+                pairCounts,
+                distributionSeed,
+                selectedCase.caseGroup.representativeResponse.id,
+                taskCount
               );
-            }) :
-            doubleCodingCoderCombinations;
-          if (
-            isDoubleCoded &&
-            availableDoubleCodingCombinations.length === 0
-          ) {
-            throw new Error('No planned double-coding pair is available.');
-          }
-          const assignedCoders = isDoubleCoded ?
-            this.chooseDoubleCodingCoders(
-              availableDoubleCodingCombinations,
-              itemCoderLoads,
-              coderLoads,
-              itemPairCounts,
-              pairCounts,
-              distributionSeed,
-              selectedCase.caseGroup.representativeResponse,
-              taskCount
-            ) :
-            [
-              this.chooseSingleCoder(
+          } else {
+            assignedCoders = [
+              this.distributionPlanner.chooseSingleCoder(
                 coders,
                 itemCoderLoads,
                 coderLoads,
                 distributionSeed,
-                selectedCase.caseGroup.representativeResponse,
+                selectedCase.caseGroup.representativeResponse.id,
                 taskCount
               )
             ];
+          }
 
           if (isDoubleCoded) {
-            const pairKey = this.getDistributionPairKey(assignedCoders);
+            const pairKey = this.distributionPlanner.getPairKey(assignedCoders);
             itemPairCounts.set(
               pairKey,
               (itemPairCounts.get(pairKey) || 0) + 1

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -165,6 +165,11 @@ type NormalizedDistributionCoder = {
   tieBreaker: number;
 };
 
+type DistributionCoderLoad = {
+  tasks: number;
+  doubleTasks: number;
+};
+
 type DistributionDoubleCodingInfo = {
   totalCases: number;
   distinctCases: number;
@@ -6545,21 +6550,28 @@ export class CodingJobService {
 
   private chooseSingleCoder(
     coders: NormalizedDistributionCoder[],
-    coderLoads: Map<number, { tasks: number; doubleTasks: number }>,
+    itemCoderLoads: Map<number, DistributionCoderLoad>,
+    coderLoads: Map<number, DistributionCoderLoad>,
     seed: string,
     response: SlimResponse,
     taskCount = 1
   ): NormalizedDistributionCoder {
     return [...coders].sort((a, b) => {
+      const itemLoadA = itemCoderLoads.get(a.id) || { tasks: 0, doubleTasks: 0 };
+      const itemLoadB = itemCoderLoads.get(b.id) || { tasks: 0, doubleTasks: 0 };
       const loadA = coderLoads.get(a.id) || { tasks: 0, doubleTasks: 0 };
       const loadB = coderLoads.get(b.id) || { tasks: 0, doubleTasks: 0 };
-      const ratioA = (loadA.tasks + taskCount) / a.weight;
-      const ratioB = (loadB.tasks + taskCount) / b.weight;
+      const itemRatioA = (itemLoadA.tasks + taskCount) / a.weight;
+      const itemRatioB = (itemLoadB.tasks + taskCount) / b.weight;
+      const globalRatioA = (loadA.tasks + taskCount) / a.weight;
+      const globalRatioB = (loadB.tasks + taskCount) / b.weight;
       const tieA = this.stableHash(`${seed}:single:${response.id}:${a.id}`);
       const tieB = this.stableHash(`${seed}:single:${response.id}:${b.id}`);
 
       return (
-        ratioA - ratioB ||
+        itemRatioA - itemRatioB ||
+        itemLoadA.tasks - itemLoadB.tasks ||
+        globalRatioA - globalRatioB ||
         loadA.tasks - loadB.tasks ||
         tieA - tieB ||
         a.tieBreaker - b.tieBreaker
@@ -6591,9 +6603,132 @@ export class CodingJobService {
     return combinations;
   }
 
+  private getDistributionPairKey(
+    coders: NormalizedDistributionCoder[]
+  ): string {
+    return coders
+      .map(coder => coder.id)
+      .sort((a, b) => a - b)
+      .join('-');
+  }
+
+  private buildBalancedDoubleCodingPairQuotas(
+    coders: NormalizedDistributionCoder[],
+    coderCombinations: NormalizedDistributionCoder[][],
+    doubleCodingCount: number,
+    seed: string,
+    itemKey: string
+  ): Map<string, number> {
+    const pairQuotas = new Map<string, number>();
+    if (coderCombinations.length === 0) {
+      return pairQuotas;
+    }
+
+    const basePairQuota = Math.floor(
+      doubleCodingCount / coderCombinations.length
+    );
+    coderCombinations.forEach(combination => {
+      pairQuotas.set(
+        this.getDistributionPairKey(combination),
+        basePairQuota
+      );
+    });
+
+    const remainingPairs =
+      doubleCodingCount % coderCombinations.length;
+    if (remainingPairs === 0) {
+      return pairQuotas;
+    }
+
+    const totalRemainingCoderAssignments = remainingPairs * 2;
+    const baseRemainingCoderDegree = Math.floor(
+      totalRemainingCoderAssignments / coders.length
+    );
+    const higherDegreeCoderCount =
+      totalRemainingCoderAssignments % coders.length;
+    const degreeOrder = [...coders].sort((a, b) => (
+      this.stableHash(`${seed}:${itemKey}:pair-plan:coder:${a.id}`) -
+      this.stableHash(`${seed}:${itemKey}:pair-plan:coder:${b.id}`) ||
+      a.id - b.id
+    ));
+    const higherDegreeCoderIds = new Set(
+      degreeOrder
+        .slice(0, higherDegreeCoderCount)
+        .map(coder => coder.id)
+    );
+    const remainingDegrees = coders.map(coder => ({
+      coder,
+      degree:
+        baseRemainingCoderDegree +
+        (higherDegreeCoderIds.has(coder.id) ? 1 : 0),
+      tieBreaker: this.stableHash(
+        `${seed}:${itemKey}:pair-plan:node:${coder.id}`
+      )
+    }));
+    const extraPairs = new Set<string>();
+
+    while (remainingDegrees.some(node => node.degree > 0)) {
+      remainingDegrees.sort((a, b) => (
+        b.degree - a.degree ||
+        a.tieBreaker - b.tieBreaker ||
+        a.coder.id - b.coder.id
+      ));
+      const node = remainingDegrees[0];
+      const requiredDegree = node.degree;
+      if (requiredDegree === 0) {
+        break;
+      }
+
+      const candidates = remainingDegrees
+        .slice(1)
+        .filter(candidate => (
+          candidate.degree > 0 &&
+          !extraPairs.has(this.getDistributionPairKey([
+            node.coder,
+            candidate.coder
+          ]))
+        ))
+        .sort((a, b) => (
+          b.degree - a.degree ||
+          this.stableHash(
+            `${seed}:${itemKey}:pair-plan:edge:${this.getDistributionPairKey([
+              node.coder,
+              a.coder
+            ])}`
+          ) -
+          this.stableHash(
+            `${seed}:${itemKey}:pair-plan:edge:${this.getDistributionPairKey([
+              node.coder,
+              b.coder
+            ])}`
+          ) ||
+          a.coder.id - b.coder.id
+        ));
+
+      if (candidates.length < requiredDegree) {
+        throw new Error('Could not build balanced double-coding pair quotas.');
+      }
+
+      node.degree = 0;
+      candidates.slice(0, requiredDegree).forEach(candidate => {
+        const pairKey = this.getDistributionPairKey([
+          node.coder,
+          candidate.coder
+        ]);
+        extraPairs.add(pairKey);
+        candidate.degree -= 1;
+        pairQuotas.set(pairKey, (pairQuotas.get(pairKey) || 0) + 1);
+      });
+    }
+
+    return pairQuotas;
+  }
+
   private chooseDoubleCodingCoders(
     coderCombinations: NormalizedDistributionCoder[][],
-    coderLoads: Map<number, { tasks: number; doubleTasks: number }>,
+    itemCoderLoads: Map<number, DistributionCoderLoad>,
+    coderLoads: Map<number, DistributionCoderLoad>,
+    itemPairCounts: Map<string, number>,
     pairCounts: Map<string, number>,
     seed: string,
     response: SlimResponse,
@@ -6601,24 +6736,33 @@ export class CodingJobService {
   ): NormalizedDistributionCoder[] {
     return [...coderCombinations].sort((a, b) => {
       const score = (combination: NormalizedDistributionCoder[]) => {
-        const projectedRatios = combination.map(coder => {
+        const projectedItemRatios = combination.map(coder => {
+          const load = itemCoderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
+          return (load.tasks + taskCount) / coder.weight;
+        });
+        const projectedItemDoubleRatios = combination.map(coder => {
+          const load = itemCoderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
+          return (load.doubleTasks + taskCount) / coder.weight;
+        });
+        const projectedGlobalRatios = combination.map(coder => {
           const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
           return (load.tasks + taskCount) / coder.weight;
         });
-        const projectedDoubleRatios = combination.map(coder => {
+        const projectedGlobalDoubleRatios = combination.map(coder => {
           const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
           return (load.doubleTasks + taskCount) / coder.weight;
         });
-        const pairKey = combination
-          .map(coder => coder.id)
-          .sort((x, y) => x - y)
-          .join('-');
+        const pairKey = this.getDistributionPairKey(combination);
 
         return {
-          maxLoad: Math.max(...projectedRatios),
-          totalLoad: projectedRatios.reduce((sum, value) => sum + value, 0),
-          maxDoubleLoad: Math.max(...projectedDoubleRatios),
-          pairCount: pairCounts.get(pairKey) || 0,
+          maxItemLoad: Math.max(...projectedItemRatios),
+          itemPairCount: itemPairCounts.get(pairKey) || 0,
+          maxItemDoubleLoad: Math.max(...projectedItemDoubleRatios),
+          totalItemLoad: projectedItemRatios.reduce((sum, value) => sum + value, 0),
+          maxGlobalLoad: Math.max(...projectedGlobalRatios),
+          globalPairCount: pairCounts.get(pairKey) || 0,
+          maxGlobalDoubleLoad: Math.max(...projectedGlobalDoubleRatios),
+          totalGlobalLoad: projectedGlobalRatios.reduce((sum, value) => sum + value, 0),
           tie: this.stableHash(`${seed}:double:${response.id}:${pairKey}`)
         };
       };
@@ -6626,10 +6770,14 @@ export class CodingJobService {
       const scoreB = score(b);
 
       return (
-        scoreA.maxLoad - scoreB.maxLoad ||
-        scoreA.pairCount - scoreB.pairCount ||
-        scoreA.maxDoubleLoad - scoreB.maxDoubleLoad ||
-        scoreA.totalLoad - scoreB.totalLoad ||
+        scoreA.maxItemLoad - scoreB.maxItemLoad ||
+        scoreA.itemPairCount - scoreB.itemPairCount ||
+        scoreA.maxItemDoubleLoad - scoreB.maxItemDoubleLoad ||
+        scoreA.totalItemLoad - scoreB.totalItemLoad ||
+        scoreA.maxGlobalLoad - scoreB.maxGlobalLoad ||
+        scoreA.globalPairCount - scoreB.globalPairCount ||
+        scoreA.maxGlobalDoubleLoad - scoreB.maxGlobalDoubleLoad ||
+        scoreA.totalGlobalLoad - scoreB.totalGlobalLoad ||
         scoreA.tie - scoreB.tie
       );
     })[0];
@@ -6857,10 +7005,22 @@ export class CodingJobService {
       );
     }
 
-    const coderLoads = new Map<number, { tasks: number; doubleTasks: number }>(
+    const coderLoads = new Map<number, DistributionCoderLoad>(
       coders.map(coder => [coder.id, { tasks: 0, doubleTasks: 0 }])
     );
+    const coderLoadsByItemKey = new Map<
+    string,
+    Map<number, DistributionCoderLoad>
+    >(
+      planItems.map(item => [
+        item.itemKey,
+        new Map(coders.map(coder => [coder.id, { tasks: 0, doubleTasks: 0 }]))
+      ])
+    );
     const pairCounts = new Map<string, number>();
+    const pairCountsByItemKey = new Map<string, Map<string, number>>(
+      planItems.map(item => [item.itemKey, new Map<string, number>()])
+    );
     const coderById = new Map(coders.map(coder => [coder.id, coder]));
     const jobsByItemAndCoder = new Map<string, Map<number, SlimResponse[]>>();
     const plannedCases: DistributionPlanCase[] = [];
@@ -6868,52 +7028,149 @@ export class CodingJobService {
       totalDoubleCodingCount > 0 ?
         this.getCoderCombinations(coders, codersPerDoubleCodedCase) :
         [];
+    const codersHaveEqualWeights = coders.every(
+      coder => coder.weight === coders[0]?.weight
+    );
+    const doubleCodingPairQuotasByItemKey = new Map<
+    string,
+    Map<string, number>
+    >();
+    if (codersHaveEqualWeights) {
+      doubleCodingCountsByItemKey.forEach((doubleCodingCount, itemKey) => {
+        doubleCodingPairQuotasByItemKey.set(
+          itemKey,
+          this.buildBalancedDoubleCodingPairQuotas(
+            coders,
+            doubleCodingCoderCombinations,
+            doubleCodingCount,
+            distributionSeed,
+            itemKey
+          )
+        );
+      });
+    }
     const assignedDoubleCodingCountsByItemKey = new Map<string, number>();
-
-    selectedCases.forEach(selectedCase => {
-      const taskCount = selectedCase.caseGroup.responses.length;
+    const selectedCaseAssignments = selectedCases.map(selectedCase => {
+      const itemKey = selectedCase.item.itemKey;
       const assignedDoubleCodingCount =
-        assignedDoubleCodingCountsByItemKey.get(selectedCase.item.itemKey) || 0;
+        assignedDoubleCodingCountsByItemKey.get(itemKey) || 0;
       const isDoubleCoded =
         assignedDoubleCodingCount <
-        (doubleCodingCountsByItemKey.get(selectedCase.item.itemKey) || 0);
-      const assignedCoders = isDoubleCoded ?
-        this.chooseDoubleCodingCoders(
-          doubleCodingCoderCombinations,
-          coderLoads,
-          pairCounts,
-          distributionSeed,
-          selectedCase.caseGroup.representativeResponse,
-          taskCount
-        ) :
-        [
-          this.chooseSingleCoder(
-            coders,
-            coderLoads,
-            distributionSeed,
-            selectedCase.caseGroup.representativeResponse,
-            taskCount
-          )
-        ];
-      const assignedCoderIds = assignedCoders.map(coder => coder.id);
+        (doubleCodingCountsByItemKey.get(itemKey) || 0);
 
       if (isDoubleCoded) {
         assignedDoubleCodingCountsByItemKey.set(
-          selectedCase.item.itemKey,
+          itemKey,
           assignedDoubleCodingCount + 1
         );
-        const pairKey = [...assignedCoderIds].sort((a, b) => a - b).join('-');
-        pairCounts.set(pairKey, (pairCounts.get(pairKey) || 0) + 1);
       }
 
-      assignedCoders.forEach(coder => {
-        const load = coderLoads.get(coder.id) || { tasks: 0, doubleTasks: 0 };
-        load.tasks += taskCount;
-        if (isDoubleCoded) {
-          load.doubleTasks += taskCount;
-        }
-        coderLoads.set(coder.id, load);
+      return { selectedCase, isDoubleCoded };
+    });
+    const assignmentsByCaseGroup = new Map<
+    DistributionPlanCaseGroup,
+    {
+      isDoubleCoded: boolean;
+      assignedCoders: NormalizedDistributionCoder[];
+    }
+    >();
 
+    [true, false].forEach(assignDoubleCodedCases => {
+      selectedCaseAssignments
+        .filter(({ isDoubleCoded }) => isDoubleCoded === assignDoubleCodedCases)
+        .forEach(({ selectedCase, isDoubleCoded }) => {
+          const itemKey = selectedCase.item.itemKey;
+          const itemCoderLoads = coderLoadsByItemKey.get(itemKey) ||
+            new Map<number, DistributionCoderLoad>();
+          const itemPairCounts = pairCountsByItemKey.get(itemKey) ||
+            new Map<string, number>();
+          const taskCount = selectedCase.caseGroup.responses.length;
+          const pairQuotas = doubleCodingPairQuotasByItemKey.get(itemKey);
+          const availableDoubleCodingCombinations = pairQuotas ?
+            doubleCodingCoderCombinations.filter(combination => {
+              const pairKey = this.getDistributionPairKey(combination);
+              return (
+                (itemPairCounts.get(pairKey) || 0) <
+                (pairQuotas.get(pairKey) || 0)
+              );
+            }) :
+            doubleCodingCoderCombinations;
+          if (
+            isDoubleCoded &&
+            availableDoubleCodingCombinations.length === 0
+          ) {
+            throw new Error('No planned double-coding pair is available.');
+          }
+          const assignedCoders = isDoubleCoded ?
+            this.chooseDoubleCodingCoders(
+              availableDoubleCodingCombinations,
+              itemCoderLoads,
+              coderLoads,
+              itemPairCounts,
+              pairCounts,
+              distributionSeed,
+              selectedCase.caseGroup.representativeResponse,
+              taskCount
+            ) :
+            [
+              this.chooseSingleCoder(
+                coders,
+                itemCoderLoads,
+                coderLoads,
+                distributionSeed,
+                selectedCase.caseGroup.representativeResponse,
+                taskCount
+              )
+            ];
+
+          if (isDoubleCoded) {
+            const pairKey = this.getDistributionPairKey(assignedCoders);
+            itemPairCounts.set(
+              pairKey,
+              (itemPairCounts.get(pairKey) || 0) + 1
+            );
+            pairCounts.set(pairKey, (pairCounts.get(pairKey) || 0) + 1);
+          }
+
+          assignedCoders.forEach(coder => {
+            const itemLoad = itemCoderLoads.get(coder.id) || {
+              tasks: 0,
+              doubleTasks: 0
+            };
+            const load = coderLoads.get(coder.id) || {
+              tasks: 0,
+              doubleTasks: 0
+            };
+
+            itemLoad.tasks += taskCount;
+            load.tasks += taskCount;
+            if (isDoubleCoded) {
+              itemLoad.doubleTasks += taskCount;
+              load.doubleTasks += taskCount;
+            }
+            itemCoderLoads.set(coder.id, itemLoad);
+            coderLoads.set(coder.id, load);
+          });
+
+          coderLoadsByItemKey.set(itemKey, itemCoderLoads);
+          pairCountsByItemKey.set(itemKey, itemPairCounts);
+          assignmentsByCaseGroup.set(selectedCase.caseGroup, {
+            isDoubleCoded,
+            assignedCoders
+          });
+        });
+    });
+
+    selectedCases.forEach(selectedCase => {
+      const assignment = assignmentsByCaseGroup.get(selectedCase.caseGroup);
+      if (!assignment) {
+        throw new Error('Missing distribution assignment.');
+      }
+
+      const { isDoubleCoded, assignedCoders } = assignment;
+      const assignedCoderIds = assignedCoders.map(coder => coder.id);
+
+      assignedCoders.forEach(coder => {
         if (isSafeKey(coder.displayKey)) {
           distribution[selectedCase.item.itemKey][coder.displayKey] += 1;
         }


### PR DESCRIPTION
## Zusammenfassung

- gleicht die Coder-Auslastung für jede Variable beziehungsweise jedes Bundle separat aus
- verteilt Doppelcodierungen bei gleichen Kapazitäten möglichst gleichmäßig auf alle Coder-Paare
- berücksichtigt weiterhin unterschiedliche Coder-Kapazitäten
- ergänzt Regressionstests für die Beispiele aus Issue #896 und für sechs gleich gewichtete Coder

## Ursache

Die bisherige Auswahl verwendete globale Coder- und Paarlasten. Dadurch konnte die Gesamtverteilung ausgeglichen aussehen, obwohl einzelne Variablen stark ungleich verteilt waren. Außerdem konnte die greedy Paarwahl bei mehr Codern einzelne Paare wiederholen, obwohl noch ungenutzte Paare vorhanden waren.

## Auswirkung

Job-Definitionen verteilen Fälle nun pro ausgewähltem Element gleichmäßiger. Einzelcodierungen kompensieren die Last aus Doppelcodierungen; bei gleichen Kapazitäten unterscheiden sich die Häufigkeiten der Coder-Paare höchstens um eins.

## Validierung

- `npx nx lint backend`
- `npx nx test backend` (135 Suites, 2029 Tests erfolgreich; 1 Suite und 7 Tests übersprungen)
- `git diff --check`
- zusätzliche Prüfung der Paarquoten für 20.825 Kombinationen mit 2 bis 50 Codern

Fixes #896
