### PR TITLE
Keep coding job filters focused

### DIFF
--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.html
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.html
@@ -237,7 +237,8 @@
         </div>
 
         <div class="bundle-variable-config" style="margin-top: 24px;">
-          <div *ngFor="let bundleGroup of groupedVariables.bundles" class="bundle-variable-group">
+          <div *ngFor="let bundleGroup of groupedVariables.bundles; trackBy: trackBundleGroupById"
+            class="bundle-variable-group">
             <div class="bundle-header">
               <h4 class="bundle-title">
                 <mat-icon>inventory_2</mat-icon>

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.spec.ts
@@ -191,6 +191,31 @@ describe('CoderTrainingComponent', () => {
     expect(codingTrainingBackendService.createCoderTrainingJobs).toHaveBeenCalled();
   });
 
+  it('keeps the bundle sample input mounted while updating its value', () => {
+    component.onBundleSelectionChange([5]);
+    fixture.detectChanges();
+    const bundleGroup = component.groupedVariables.bundles[0];
+    const sampleInput = fixture.nativeElement.querySelector(
+      '.bundle-sample-field input'
+    ) as HTMLInputElement;
+    sampleInput.focus();
+    sampleInput.value = '3';
+
+    sampleInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(component.groupedVariables.bundles[0]).toBe(bundleGroup);
+    expect(
+      fixture.nativeElement.querySelector('.bundle-sample-field input')
+    ).toBe(sampleInput);
+    expect(document.activeElement).toBe(sampleInput);
+    expect(
+      component.variablesFormArray.controls
+        .filter(control => control.get('bundleId')?.value === 5)
+        .map(control => control.get('sampleCount')?.value)
+    ).toEqual([3, 3]);
+  });
+
   it('renders coder selection as toggle cards without checkboxes', () => {
     fixture.detectChanges();
 

--- a/apps/frontend/src/app/coding/components/coder-training/coder-training.component.ts
+++ b/apps/frontend/src/app/coding/components/coder-training/coder-training.component.ts
@@ -1388,6 +1388,13 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
     this.changeDetectorRef.markForCheck();
   }
 
+  trackBundleGroupById(
+    _index: number,
+    bundleGroup: VariableGrouping['bundles'][number]
+  ): number {
+    return bundleGroup.bundle.id;
+  }
+
   updateBundleSampleCount(bundleId: number, newSampleCount: number | string): void {
     const parsedSampleCount = Number(newSampleCount);
     if (Number.isNaN(parsedSampleCount) || parsedSampleCount < 1 || parsedSampleCount > 1000) {
@@ -1397,11 +1404,13 @@ export class CoderTrainingComponent implements OnInit, OnDestroy {
 
     this.variablesFormArray.controls.forEach(control => {
       if (control.get('bundleId')?.value === bundleId) {
-        control.get('sampleCount')?.setValue(parsedSampleCount);
+        control.get('sampleCount')?.setValue(parsedSampleCount, {
+          emitEvent: false
+        });
       }
     });
 
-    this.updateGroupedVariables();
+    this.variablesFormArray.updateValueAndValidity();
     this.changeDetectorRef.markForCheck();
   }
 

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.html
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.html
@@ -1,8 +1,8 @@
 <div class="fx-column-start-start fx-gap-10 container">
-  @if (isLoading) {
+  @if (isLoading && !hasLoadedJobs) {
     <mat-spinner></mat-spinner>
   }
-  @if (!isLoading) {
+  @if (hasLoadedJobs) {
     <div class="fx-row-center-center-stretch fx-gap-16 header-row">
       <div class="fx-row-center-center fx-gap-16 filters-row">
         <mat-form-field appearance="outline" class="filter-field">
@@ -121,6 +121,13 @@
         </div>
       </div>
     </div>
+
+    @if (isLoading) {
+      <div class="coding-jobs-refresh-indicator" aria-live="polite">
+        <mat-spinner diameter="20"></mat-spinner>
+        <span>{{ 'coding.jobs.refreshing' | translate }}</span>
+      </div>
+    }
 
     <mat-table
       [dataSource]="dataSource"

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.scss
@@ -79,6 +79,16 @@
   min-width: 0;
 }
 
+.coding-jobs-refresh-indicator {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 8px;
+  min-height: 28px;
+  color: #455a64;
+  font-size: 13px;
+}
+
 .button-create-coding-job {
   display: flex;
   align-items: center;

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.spec.ts
@@ -10,7 +10,7 @@ import { ActivatedRoute } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { CodingJobsComponent } from './coding-jobs.component';
 import { CodingJobBackendService } from '../../services/coding-job-backend.service';
@@ -397,6 +397,86 @@ describe('CodingJobsComponent', () => {
       expect.objectContaining({ status: 'active' })
     );
   }));
+
+  it('keeps filters and table mounted while coding jobs refresh', () => {
+    const response$ = new Subject<{
+      data: CodingJob[];
+      total: number;
+      page: number;
+      limit: number;
+    }>();
+    (codingJobBackendServiceMock.getCodingJobs as jest.Mock)
+      .mockReturnValueOnce(response$);
+    const filterInput = fixture.nativeElement.querySelector(
+      '.filters-row input'
+    ) as HTMLInputElement;
+    const table = fixture.nativeElement.querySelector('.coding-jobs-table');
+    filterInput.focus();
+
+    component.loadCodingJobs();
+    fixture.detectChanges();
+
+    expect(component.isLoading).toBe(true);
+    expect(fixture.nativeElement.querySelector('.filters-row input')).toBe(
+      filterInput
+    );
+    expect(fixture.nativeElement.querySelector('.coding-jobs-table')).toBe(
+      table
+    );
+    expect(
+      fixture.nativeElement.querySelector('.coding-jobs-refresh-indicator')
+    ).not.toBeNull();
+    expect(document.activeElement).toBe(filterInput);
+
+    response$.next({
+      data: mockCodingJobs as CodingJob[],
+      total: mockCodingJobs.length,
+      page: 1,
+      limit: 50
+    });
+    fixture.detectChanges();
+
+    expect(component.isLoading).toBe(false);
+    expect(
+      fixture.nativeElement.querySelector('.coding-jobs-refresh-indicator')
+    ).toBeNull();
+  });
+
+  it('uses the full spinner only for the initial coding jobs load', () => {
+    const initialResponse$ = new Subject<{
+      data: CodingJob[];
+      total: number;
+      page: number;
+      limit: number;
+    }>();
+    (codingJobBackendServiceMock.getCodingJobs as jest.Mock)
+      .mockReturnValueOnce(initialResponse$);
+    const initialFixture = TestBed.createComponent(CodingJobsComponent);
+
+    initialFixture.detectChanges();
+
+    expect(initialFixture.componentInstance.hasLoadedJobs).toBe(false);
+    expect(
+      initialFixture.nativeElement.querySelector('mat-spinner')
+    ).not.toBeNull();
+    expect(
+      initialFixture.nativeElement.querySelector('.filters-row')
+    ).toBeNull();
+
+    initialResponse$.next({
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 50
+    });
+    initialFixture.detectChanges();
+
+    expect(initialFixture.componentInstance.hasLoadedJobs).toBe(true);
+    expect(
+      initialFixture.nativeElement.querySelector('.filters-row')
+    ).not.toBeNull();
+    initialFixture.destroy();
+  });
 
   it('should handle loading coding jobs failure', fakeAsync(() => {
     (

--- a/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-jobs/coding-jobs.component.ts
@@ -201,6 +201,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
   dataSource = new MatTableDataSource<CodingJob>([]);
   selection = new SelectionModel<CodingJob>(true, []);
   isLoading = false;
+  hasLoadedJobs = false;
 
   coderTrainings: CoderTraining[] = [];
   selectedTrainingId: number | string | null = null;
@@ -319,6 +320,7 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
       this.isLoading = false;
+      this.hasLoadedJobs = true;
       return;
     }
 
@@ -340,12 +342,14 @@ export class CodingJobsComponent implements OnInit, OnDestroy {
           this.updateCoderNamesMap(processedData);
 
           this.jobDetailsCache.clear();
+          this.hasLoadedJobs = true;
           this.isLoading = false;
         },
         error: () => {
           this.snackBar.open('Fehler beim Laden der Kodierjobs', 'Schließen', {
             duration: 3000
           });
+          this.hasLoadedJobs = true;
           this.isLoading = false;
         }
       });

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -923,6 +923,7 @@
         "status": "Status",
         "units": "Aufgaben"
       },
+      "refreshing": "Kodierjobs werden aktualisiert...",
       "issue-tooltip": {
         "no-review-issues": "Keine prüfpflichtigen Kodierungsprobleme",
         "open-no-review-issues-singular": "{{count}} offene Aufgabe, keine prüfpflichtigen Kodierungsprobleme",


### PR DESCRIPTION
## Summary

Keeps the coding-job filter controls and result table mounted while a refresh is in progress.

## Root cause

The loading state replaced the full coding-jobs UI, which destroyed the active filter input after a debounced search request. Updating a bundle sample count also rebuilt its grouping, recreating the input.

## Changes

- distinguish the initial full-page load from subsequent refreshes and display a compact refresh indicator
- preserve bundle group identity while changing sample counts
- add regression tests for input focus and DOM stability

## Validation

- `npx nx lint frontend`
- `npx nx test frontend --runInBand`
- targeted component tests
- manual UI verification in the Docker environment for Schulung and Durchführung

Related to #897.
