### PR TITLE
Derive missing by design from booklet structure

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.spec.ts
@@ -1,3 +1,4 @@
+import * as ExcelJS from 'exceljs';
 import { CodingItemMatrixExportService } from './coding-item-matrix-export.service';
 
 const collectStream = (stream: NodeJS.ReadableStream): Promise<string> => (
@@ -44,7 +45,11 @@ describe('CodingItemMatrixExportService', () => {
         header: 'Alias1__VAR1',
         unitName: 'UNIT1',
         variableId: 'VAR1'
-      }]
+      }],
+      bookletUnits: new Map([['BOOKLET-1', new Set(['UNIT1'])]]),
+      mbdMissing: {
+        id: 'mbd', label: 'missing by design', code: -94, score: null
+      }
     });
     (service as never as { getResponseValuesForRows: jest.Mock }).getResponseValuesForRows =
       jest.fn().mockResolvedValue(new Map([
@@ -55,6 +60,105 @@ describe('CodingItemMatrixExportService', () => {
 
     expect(output).toContain('person_login;person_code;person_group;booklet_name;Alias1__VAR1');
     expect(output).toContain('login-1;code-1;group-1;BOOKLET-1;2');
+  });
+
+  it('exports mbd only for units outside the row booklet in code and score matrices', async () => {
+    const service = createService();
+    (service as never as {
+      buildMatrixContext: jest.Mock;
+      getResponseValuesForRows: jest.Mock;
+    }).buildMatrixContext = jest.fn().mockResolvedValue({
+      rows: [{
+        bookletId: 10,
+        bookletName: 'BOOKLET-1',
+        personLogin: 'login-1',
+        personCode: 'code-1',
+        personGroup: 'group-1'
+      }],
+      columns: [
+        {
+          key: 'UNIT1\u001FVAR1',
+          header: 'UNIT1__VAR1',
+          unitName: 'UNIT1',
+          variableId: 'VAR1'
+        },
+        {
+          key: 'UNIT2\u001FVAR1',
+          header: 'UNIT2__VAR1',
+          unitName: 'UNIT2',
+          variableId: 'VAR1'
+        }
+      ],
+      bookletUnits: new Map([['BOOKLET-1', new Set(['UNIT1'])]]),
+      mbdMissing: {
+        id: 'mbd', label: 'missing by design', code: -94, score: null
+      }
+    });
+    (service as never as { getResponseValuesForRows: jest.Mock }).getResponseValuesForRows =
+      jest.fn().mockResolvedValue(new Map());
+
+    const codeOutput = await collectStream(service.exportItemMatrixAsCsvStream(7, 'code'));
+    const scoreOutput = await collectStream(service.exportItemMatrixAsCsvStream(7, 'score'));
+    const excelBuffer = await service.exportItemMatrixAsExcel(7, 'score');
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(excelBuffer);
+    const excelRow = workbook.getWorksheet('Itemmatrix')!.getRow(2);
+
+    expect(codeOutput).toContain('login-1;code-1;group-1;BOOKLET-1;;-94');
+    expect(scoreOutput).toContain('login-1;code-1;group-1;BOOKLET-1;;NA');
+    expect(excelRow.getCell(5).value).toBeNull();
+    expect(excelRow.getCell(6).value).toBe('NA');
+  });
+
+  it('loads and normalizes expected units from booklet XML', async () => {
+    const fileUploadRepository = {
+      find: jest.fn().mockResolvedValue([{
+        file_id: 'Booklet-1',
+        data: '<Booklet><Testlet><Unit id="unit1.xml"/><Unit id="UNIT2"/></Testlet></Booklet>'
+      }])
+    };
+    const service = new CodingItemMatrixExportService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      fileUploadRepository as never
+    );
+
+    const bookletUnits = await (service as never as {
+      getBookletUnits: (workspaceId: number) => Promise<Map<string, Set<string>>>;
+    }).getBookletUnits(7);
+
+    expect(fileUploadRepository.find).toHaveBeenCalledWith({
+      where: { workspace_id: 7, file_type: 'Booklet' },
+      select: ['file_id', 'data']
+    });
+    expect(bookletUnits.get('BOOKLET-1')).toEqual(new Set(['UNIT1', 'UNIT2']));
+  });
+
+  it('fails before matrix creation when mbd is missing from the profile', async () => {
+    const missingsProfilesService = {
+      getMissingByIdForProfileOrDefault: jest.fn().mockRejectedValue(
+        new Error("Missing 'mbd' not found in profile 3")
+      )
+    };
+    const service = createService(missingsProfilesService);
+    (service as never as {
+      getRows: jest.Mock;
+      getColumns: jest.Mock;
+      getBookletUnits: jest.Mock;
+    }).getRows = jest.fn().mockResolvedValue([]);
+    (service as never as { getColumns: jest.Mock }).getColumns = jest.fn().mockResolvedValue([]);
+    (service as never as { getBookletUnits: jest.Mock }).getBookletUnits =
+      jest.fn().mockResolvedValue(new Map());
+
+    await expect((service as never as {
+      buildMatrixContext: (workspaceId: number) => Promise<unknown>;
+    }).buildMatrixContext(7)).rejects.toThrow("Missing 'mbd' not found in profile 3");
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault)
+      .toHaveBeenCalledWith(7, null, 'mbd');
   });
 
   it('checks cancellation before writing item matrix rows', async () => {
@@ -125,7 +229,11 @@ describe('CodingItemMatrixExportService', () => {
         header: 'UNIT1__VAR1',
         unitName: 'UNIT1',
         variableId: 'VAR1'
-      }]
+      }],
+      bookletUnits: new Map([['BOOKLET-1', new Set(['UNIT1'])]]),
+      mbdMissing: {
+        id: 'mbd', label: 'missing by design', code: -94, score: null
+      }
     });
     (service as never as { getResponseValuesForRows: jest.Mock }).getResponseValuesForRows =
       jest.fn().mockResolvedValue(new Map([
@@ -163,7 +271,11 @@ describe('CodingItemMatrixExportService', () => {
         header: 'UNIT1__VAR1',
         unitName: 'UNIT1',
         variableId: 'VAR1'
-      }]
+      }],
+      bookletUnits: new Map([['BOOKLET-1', new Set(['UNIT1'])]]),
+      mbdMissing: {
+        id: 'mbd', label: 'missing by design', code: -94, score: null
+      }
     });
     (service as never as { getResponseValuesForRows: jest.Mock }).getResponseValuesForRows =
       jest.fn().mockResolvedValue(new Map([

--- a/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.ts
@@ -1,15 +1,18 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import * as cheerio from 'cheerio';
 import * as ExcelJS from 'exceljs';
 import * as fastCsv from 'fast-csv';
 import * as fs from 'fs';
 import { PassThrough } from 'stream';
 import { Repository } from 'typeorm';
 import { Booklet } from '../../entities/booklet.entity';
+import FileUpload from '../../entities/file_upload.entity';
 import { ResponseEntity } from '../../entities/response.entity';
 import { Unit } from '../../entities/unit.entity';
 import {
   isExcludedByResolvedExclusions,
+  normalizeExclusionBookletId,
   normalizeExclusionUnitId,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
@@ -80,7 +83,10 @@ export class CodingItemMatrixExportService {
     private readonly workspaceFilesService: WorkspaceFilesService,
     private readonly workspaceExclusionService: WorkspaceExclusionService,
     @Optional()
-    private readonly missingsProfilesService?: MissingsProfilesService
+    private readonly missingsProfilesService?: MissingsProfilesService,
+    @Optional()
+    @InjectRepository(FileUpload)
+    private readonly fileUploadRepository?: Repository<FileUpload>
   ) {}
 
   private async yieldToEventLoop(): Promise<void> {
@@ -129,6 +135,8 @@ export class CodingItemMatrixExportService {
           workspaceId,
           context.rows,
           context.columns,
+          context.bookletUnits,
+          context.mbdMissing,
           value,
           version,
           async row => {
@@ -190,6 +198,8 @@ export class CodingItemMatrixExportService {
       workspaceId,
       context.rows,
       context.columns,
+      context.bookletUnits,
+      context.mbdMissing,
       value,
       version,
       async row => {
@@ -239,6 +249,8 @@ export class CodingItemMatrixExportService {
         workspaceId,
         context.rows,
         context.columns,
+        context.bookletUnits,
+        context.mbdMissing,
         value,
         version,
         async row => {
@@ -269,20 +281,91 @@ export class CodingItemMatrixExportService {
   ): Promise<{
       rows: MatrixRow[];
       columns: MatrixColumn[];
+      bookletUnits: Map<string, Set<string>>;
+      mbdMissing: ResolvedMissingValue;
     }> {
     this.missingValueCache.clear();
     await checkCancellation?.();
-    const [rows, columns] = await Promise.all([
+    const [rows, columns, bookletUnits, mbdMissing] = await Promise.all([
       this.getRows(workspaceId, checkCancellation),
-      this.getColumns(workspaceId, checkCancellation)
+      this.getColumns(workspaceId, checkCancellation),
+      this.getBookletUnits(workspaceId, checkCancellation),
+      this.resolveMbdMissing(workspaceId)
     ]);
     await checkCancellation?.();
+
+    const missingBookletStructures = Array.from(new Set(rows
+      .map(row => row.bookletName)
+      .filter(bookletName => !bookletUnits.has(normalizeExclusionBookletId(bookletName)))));
+    if (missingBookletStructures.length > 0) {
+      throw new Error(
+        `Booklet structure not found for item-matrix export: ${missingBookletStructures.join(', ')}`
+      );
+    }
 
     this.logger.log(
       `Prepared item matrix context for workspace ${workspaceId}: ${rows.length} rows, ${columns.length} columns`
     );
 
-    return { rows, columns };
+    return {
+      rows, columns, bookletUnits, mbdMissing
+    };
+  }
+
+  private async getBookletUnits(
+    workspaceId: number,
+    checkCancellation?: () => Promise<void>
+  ): Promise<Map<string, Set<string>>> {
+    if (!this.fileUploadRepository) {
+      throw new Error('Booklet file repository is unavailable for item-matrix export');
+    }
+
+    await checkCancellation?.();
+    const bookletFiles = await this.fileUploadRepository.find({
+      where: { workspace_id: workspaceId, file_type: 'Booklet' },
+      select: ['file_id', 'data']
+    });
+    await checkCancellation?.();
+
+    const bookletUnits = new Map<string, Set<string>>();
+    for (let index = 0; index < bookletFiles.length; index += 1) {
+      if (this.shouldYieldExportItem(index)) {
+        await checkCancellation?.();
+        await this.yieldToEventLoop();
+      }
+
+      const bookletFile = bookletFiles[index];
+      const bookletId = normalizeExclusionBookletId(bookletFile.file_id);
+      try {
+        const $ = cheerio.load(bookletFile.data, { xmlMode: true });
+        const units = new Set<string>();
+        $('Unit, unit').each((_, element) => {
+          const unitId = normalizeExclusionUnitId($(element).attr('id'));
+          if (unitId) {
+            units.add(unitId);
+          }
+        });
+        bookletUnits.set(bookletId, units);
+      } catch (error) {
+        throw new Error(
+          `Could not parse booklet structure '${bookletFile.file_id}' for item-matrix export: ${error.message}`
+        );
+      }
+    }
+
+    return bookletUnits;
+  }
+
+  private async resolveMbdMissing(workspaceId: number): Promise<ResolvedMissingValue> {
+    if (!this.missingsProfilesService) {
+      throw new Error("Missing profile service is unavailable; cannot resolve 'mbd'");
+    }
+
+    return this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+      workspaceId,
+      null,
+      'mbd'
+    );
   }
 
   private getHeaders(columns: MatrixColumn[]): string[] {
@@ -443,6 +526,8 @@ export class CodingItemMatrixExportService {
     workspaceId: number,
     rows: MatrixRow[],
     columns: MatrixColumn[],
+    bookletUnits: Map<string, Set<string>>,
+    mbdMissing: ResolvedMissingValue,
     value: ItemMatrixValue,
     version: ItemMatrixVersion,
     writeRow: (row: Record<string, string | number>) => Promise<void>,
@@ -478,6 +563,10 @@ export class CodingItemMatrixExportService {
           booklet_name: row.bookletName
         };
         const rowValues = responseValues.get(row.bookletId) || new Map<string, ResponseValue>();
+        const expectedUnits = bookletUnits.get(normalizeExclusionBookletId(row.bookletName));
+        if (!expectedUnits) {
+          throw new Error(`Booklet structure not found for item-matrix export: ${row.bookletName}`);
+        }
 
         for (let columnIndex = 0; columnIndex < columns.length; columnIndex += 1) {
           if (this.shouldYieldExportItem(columnIndex)) {
@@ -487,9 +576,13 @@ export class CodingItemMatrixExportService {
 
           const column = columns[columnIndex];
           const cellValue = rowValues.get(column.key);
-          exportRow[column.header] = cellValue ?
-            await this.resolveExportCellValue(workspaceId, cellValue, value) :
-            '';
+          if (!expectedUnits.has(normalizeExclusionUnitId(column.unitName))) {
+            exportRow[column.header] = this.getResolvedMissingExportValue(mbdMissing, value);
+          } else if (cellValue) {
+            exportRow[column.header] = await this.resolveExportCellValue(workspaceId, cellValue, value);
+          } else {
+            exportRow[column.header] = '';
+          }
         }
 
         await writeRow(exportRow);
@@ -626,6 +719,16 @@ export class CodingItemMatrixExportService {
     }
 
     return missing?.code ?? mapCodeForExport(value.code) ?? '';
+  }
+
+  private getResolvedMissingExportValue(
+    missing: ResolvedMissingValue,
+    requestedValue: ItemMatrixValue
+  ): string | number {
+    if (requestedValue === 'score') {
+      return missing.score === null ? 'NA' : missing.score;
+    }
+    return missing.code;
   }
 
   private async resolveMissingValue(


### PR DESCRIPTION
## Summary

- derive the expected unit set for each booklet from its uploaded `booklet.xml`
- export `mbd` for unit/variable cells that are not part of a person's booklet
- preserve empty cells for expected units without a response
- resolve the `mbd` code and score through the missing profile before writing the matrix
- export an explicit `null` score as `NA` and fail clearly for missing or incomplete `mbd` configuration
- use the same row-generation path for CSV and Excel exports

## Why

The item matrix previously left every absent response cell empty. It could not distinguish an expected but missing response from an item that was never presented because of the test design. This change uses the booklet structure to make that distinction without modifying stored responses.

Closes #778.

## Validation

- `npx nx test backend --runInBand --testFile=apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.spec.ts`
- full backend test suite: 2042 passed, 7 skipped
- `npx nx lint backend`
- `npx nx build backend`
- implementation diff reviewed with no remaining P0-P3 findings

