### PR TITLE
Fix job definition refresh availability checks

### DIFF
--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -1950,6 +1950,185 @@ describe('JobDefinitionService', () => {
     );
   });
 
+  it('allows update refresh previews when validation omits reusable current cases', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValueOnce([]);
+    codingJobService.calculateDistributionVariableUsageByStatusBatch.mockResolvedValueOnce(new Map([
+      ['requested', new Map([['Unit 1::Var 1', { regular: 4, deriveError: 0, total: 4 }]])],
+      ['available', new Map([['Unit 1::Var 1', { regular: 5, deriveError: 0, total: 5 }]])]
+    ]));
+
+    await expect(service.previewJobDefinitionUpdateRefresh(2, 7, {
+      maxCodingCases: 4
+    })).resolves.toMatchObject({
+      canApply: true
+    });
+
+    expect(codingValidationService.getCodingIncompleteVariables).toHaveBeenCalledWith(
+      7,
+      undefined,
+      undefined,
+      false,
+      2
+    );
+    expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).toHaveBeenCalledWith(7, expect.arrayContaining([
+      expect.objectContaining({
+        key: 'requested',
+        excludeJobDefinitionId: 2,
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        maxCodingCases: 4
+      }),
+      expect.objectContaining({
+        key: 'available',
+        excludeJobDefinitionId: 2,
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        maxCodingCases: null
+      })
+    ]));
+    expect(codingJobService.previewJobDefinitionRefresh).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        jobDefinitionId: 2,
+        maxCodingCases: 4,
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }]
+      })
+    );
+  });
+
+  it('rejects update refresh previews when another unstarted definition reserves the remaining cases', async () => {
+    const selectedVariable = { unitName: 'Unit 1', variableId: 'Var 1' };
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [selectedVariable],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2'
+    };
+    const otherDefinition = {
+      id: 3,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [selectedVariable],
+      assigned_variable_bundles: [],
+      assigned_coders: [2],
+      duration_seconds: 1,
+      max_coding_cases: 2,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-3'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition, otherDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([
+      [2, 1],
+      [3, 0]
+    ]));
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValueOnce([]);
+    codingJobService.calculateDistributionVariableUsageByStatusBatch.mockResolvedValueOnce(
+      new Map<string | number, Map<string, DistributionVariableUsageByStatus>>([
+        ['requested', new Map([['Unit 1::Var 1', { regular: 4, deriveError: 0, total: 4 }]])],
+        [3, new Map([['Unit 1::Var 1', { regular: 2, deriveError: 0, total: 2 }]])],
+        ['available', new Map([['Unit 1::Var 1', { regular: 5, deriveError: 0, total: 5 }]])]
+      ])
+    );
+
+    await expect(service.previewJobDefinitionUpdateRefresh(2, 7, {
+      maxCodingCases: 4
+    })).rejects.toThrow(/Unit 1:Var 1/);
+
+    expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).toHaveBeenCalledWith(7, expect.arrayContaining([
+      expect.objectContaining({
+        key: 3,
+        jobDefinitionId: 3,
+        selectedVariables: [selectedVariable],
+        maxCodingCases: 2
+      })
+    ]));
+    expect(codingJobService.previewJobDefinitionRefresh).not.toHaveBeenCalled();
+  });
+
+  it('rejects update refresh previews when added variables are missing from validation availability', async () => {
+    const existingVariable = { unitName: 'Unit 1', variableId: 'Var 1' };
+    const addedVariable = { unitName: 'Unit 2', variableId: 'Var 2' };
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [existingVariable],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValueOnce([]);
+    codingJobService.calculateDistributionVariableUsageByStatusBatch.mockResolvedValueOnce(new Map([
+      ['requested', new Map([
+        ['Unit 1::Var 1', { regular: 4, deriveError: 0, total: 4 }],
+        ['Unit 2::Var 2', { regular: 1, deriveError: 0, total: 1 }]
+      ])],
+      ['available', new Map([
+        ['Unit 1::Var 1', { regular: 4, deriveError: 0, total: 4 }],
+        ['Unit 2::Var 2', { regular: 1, deriveError: 0, total: 1 }]
+      ])]
+    ]));
+
+    await expect(service.previewJobDefinitionUpdateRefresh(2, 7, {
+      assignedVariables: [existingVariable, addedVariable]
+    })).rejects.toThrow(/Unit 2:Var 2/);
+
+    expect(codingJobService.previewJobDefinitionRefresh).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown bundle ids before update refresh previews', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    variableBundleRepository.find.mockResolvedValue([]);
+
+    await expect(service.previewJobDefinitionUpdateRefresh(2, 7, {
+      assignedVariableBundles: [{ id: 99, name: 'Missing Bundle' }]
+    })).rejects.toThrow(/Unknown variable bundle IDs: 99/);
+
+    expect(codingJobService.previewJobDefinitionRefresh).not.toHaveBeenCalled();
+  });
+
   it('keeps bundle order while applying proposed bundle mode changes in update refresh previews', async () => {
     const existingDefinition = {
       id: 2,
@@ -2098,6 +2277,206 @@ describe('JobDefinitionService', () => {
         })
       ]
     }));
+  });
+
+  it('allows applying update refreshes when validation omits reusable current cases', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      assigned_coder_configs: [{ coderId: 1, capacityPercent: 100 }],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValueOnce([]);
+    codingJobService.calculateDistributionVariableUsageByStatusBatch.mockResolvedValueOnce(new Map([
+      ['requested', new Map([['Unit 1::Var 1', { regular: 4, deriveError: 0, total: 4 }]])],
+      ['available', new Map([['Unit 1::Var 1', { regular: 5, deriveError: 0, total: 5 }]])]
+    ]));
+
+    await expect(service.refreshCodingJobFromUpdatedDefinition(2, 7, {
+      maxCodingCases: 4
+    })).resolves.toMatchObject({
+      success: true
+    });
+
+    expect(codingValidationService.getCodingIncompleteVariables).toHaveBeenCalledWith(
+      7,
+      undefined,
+      undefined,
+      false,
+      2
+    );
+    expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).toHaveBeenCalledWith(7, expect.arrayContaining([
+      expect.objectContaining({
+        key: 'requested',
+        excludeJobDefinitionId: 2,
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        maxCodingCases: 4
+      }),
+      expect.objectContaining({
+        key: 'available',
+        excludeJobDefinitionId: 2,
+        selectedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+        maxCodingCases: null
+      })
+    ]));
+    expect(codingJobService.refreshDistributedCodingJobs).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        jobDefinitionId: 2,
+        maxCodingCases: 4,
+        distributionSeed: 'seed-2'
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('rejects applying update refreshes when another unstarted definition reserves the remaining cases', async () => {
+    const selectedVariable = { unitName: 'Unit 1', variableId: 'Var 1' };
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [selectedVariable],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      assigned_coder_configs: [{ coderId: 1, capacityPercent: 100 }],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
+    };
+    const otherDefinition = {
+      id: 3,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [selectedVariable],
+      assigned_variable_bundles: [],
+      assigned_coders: [2],
+      assigned_coder_configs: [{ coderId: 2, capacityPercent: 100 }],
+      duration_seconds: 1,
+      max_coding_cases: 2,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-3'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition, otherDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([
+      [2, 1],
+      [3, 0]
+    ]));
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValueOnce([]);
+    codingJobService.calculateDistributionVariableUsageByStatusBatch.mockResolvedValueOnce(
+      new Map<string | number, Map<string, DistributionVariableUsageByStatus>>([
+        ['requested', new Map([['Unit 1::Var 1', { regular: 4, deriveError: 0, total: 4 }]])],
+        [3, new Map([['Unit 1::Var 1', { regular: 2, deriveError: 0, total: 2 }]])],
+        ['available', new Map([['Unit 1::Var 1', { regular: 5, deriveError: 0, total: 5 }]])]
+      ])
+    );
+
+    await expect(service.refreshCodingJobFromUpdatedDefinition(2, 7, {
+      maxCodingCases: 4
+    })).rejects.toThrow(/Unit 1:Var 1/);
+
+    expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).toHaveBeenCalledWith(7, expect.arrayContaining([
+      expect.objectContaining({
+        key: 3,
+        jobDefinitionId: 3,
+        selectedVariables: [selectedVariable],
+        maxCodingCases: 2
+      })
+    ]));
+    expect(codingJobService.refreshDistributedCodingJobs).not.toHaveBeenCalled();
+    expect(jobDefinitionRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects applying update refreshes when added variables are missing from validation availability', async () => {
+    const existingVariable = { unitName: 'Unit 1', variableId: 'Var 1' };
+    const addedVariable = { unitName: 'Unit 2', variableId: 'Var 2' };
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [existingVariable],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      assigned_coder_configs: [{ coderId: 1, capacityPercent: 100 }],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(new Map([[2, 1]]));
+    codingValidationService.getCodingIncompleteVariables.mockResolvedValueOnce([]);
+    codingJobService.calculateDistributionVariableUsageByStatusBatch.mockResolvedValueOnce(new Map([
+      ['requested', new Map([
+        ['Unit 1::Var 1', { regular: 4, deriveError: 0, total: 4 }],
+        ['Unit 2::Var 2', { regular: 1, deriveError: 0, total: 1 }]
+      ])],
+      ['available', new Map([
+        ['Unit 1::Var 1', { regular: 4, deriveError: 0, total: 4 }],
+        ['Unit 2::Var 2', { regular: 1, deriveError: 0, total: 1 }]
+      ])]
+    ]));
+
+    await expect(service.refreshCodingJobFromUpdatedDefinition(2, 7, {
+      assignedVariables: [existingVariable, addedVariable]
+    })).rejects.toThrow(/Unit 2:Var 2/);
+
+    expect(codingJobService.refreshDistributedCodingJobs).not.toHaveBeenCalled();
+    expect(jobDefinitionRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown bundle ids before applying update refreshes', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      status: 'approved',
+      assigned_variables: [],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      assigned_coder_configs: [{ coderId: 1, capacityPercent: 100 }],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2',
+      show_score: false,
+      allow_comments: true,
+      suppress_general_instructions: false
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    variableBundleRepository.find.mockResolvedValue([]);
+
+    await expect(service.refreshCodingJobFromUpdatedDefinition(2, 7, {
+      assignedVariableBundles: [{ id: 99, name: 'Missing Bundle' }]
+    })).rejects.toThrow(/Unknown variable bundle IDs: 99/);
+
+    expect(codingJobService.refreshDistributedCodingJobs).not.toHaveBeenCalled();
+    expect(jobDefinitionRepository.save).not.toHaveBeenCalled();
   });
 
   it('allows saving an unchanged existing definition with created jobs without rechecking availability', async () => {

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -2054,7 +2054,7 @@ describe('JobDefinitionService', () => {
 
     await expect(service.previewJobDefinitionUpdateRefresh(2, 7, {
       maxCodingCases: 4
-    })).rejects.toThrow(/Unit 1:Var 1/);
+    })).rejects.toThrow(/UNIT 1:Var 1/);
 
     expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).toHaveBeenCalledWith(7, expect.arrayContaining([
       expect.objectContaining({
@@ -2100,7 +2100,7 @@ describe('JobDefinitionService', () => {
 
     await expect(service.previewJobDefinitionUpdateRefresh(2, 7, {
       assignedVariables: [existingVariable, addedVariable]
-    })).rejects.toThrow(/Unit 2:Var 2/);
+    })).rejects.toThrow(/UNIT 2:Var 2/);
 
     expect(codingJobService.previewJobDefinitionRefresh).not.toHaveBeenCalled();
   });
@@ -2393,7 +2393,7 @@ describe('JobDefinitionService', () => {
 
     await expect(service.refreshCodingJobFromUpdatedDefinition(2, 7, {
       maxCodingCases: 4
-    })).rejects.toThrow(/Unit 1:Var 1/);
+    })).rejects.toThrow(/UNIT 1:Var 1/);
 
     expect(codingJobService.calculateDistributionVariableUsageByStatusBatch).toHaveBeenCalledWith(7, expect.arrayContaining([
       expect.objectContaining({
@@ -2444,7 +2444,7 @@ describe('JobDefinitionService', () => {
 
     await expect(service.refreshCodingJobFromUpdatedDefinition(2, 7, {
       assignedVariables: [existingVariable, addedVariable]
-    })).rejects.toThrow(/Unit 2:Var 2/);
+    })).rejects.toThrow(/UNIT 2:Var 2/);
 
     expect(codingJobService.refreshDistributedCodingJobs).not.toHaveBeenCalled();
     expect(jobDefinitionRepository.save).not.toHaveBeenCalled();

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -121,6 +121,10 @@ interface PreparedJobDefinitionUpdate {
   changedExistingJobBoundFields: ExistingJobBoundUpdateField[];
 }
 
+interface PrepareJobDefinitionUpdateOptions {
+  ignoreMissingValidationAvailabilityForExistingVariables?: boolean;
+}
+
 interface VariableConflictCheckRequest {
   jobDefinitionId?: number;
   assignedVariables: JobDefinitionVariable[];
@@ -130,6 +134,7 @@ interface VariableConflictCheckRequest {
   distributionSeed?: string;
   excludeJobDefinitionId?: number;
   requireAssignedBundles?: boolean;
+  ignoreMissingValidationAvailabilityForVariableKeys?: Set<string>;
 }
 
 type PlannedVariableUsageBatchRequest = {
@@ -372,7 +377,11 @@ export class JobDefinitionService {
       );
       const remainingCases = plannerAvailableCases - reservedCases;
 
-      if (availableCases === undefined || remainingCases <= 0 || requestedCases > remainingCases) {
+      const missingValidationAvailability =
+        availableCases === undefined &&
+        !request.ignoreMissingValidationAvailabilityForVariableKeys?.has(variableKey);
+
+      if (missingValidationAvailability || remainingCases <= 0 || requestedCases > remainingCases) {
         unavailableVariables.push(variableKey.replace('::', ':'));
       }
     });
@@ -477,6 +486,29 @@ export class JobDefinitionService {
 
   private makeVariableKey(unitName: string, variableId: string): string {
     return `${unitName.toUpperCase()}::${variableId}`;
+  }
+
+  private async getDistributionVariableKeysForDefinition(
+    jobDefinition: JobDefinition
+  ): Promise<Set<string>> {
+    const hydratedBundles = await this.hydrateVariableBundles(
+      jobDefinition.assigned_variable_bundles || []
+    );
+    const variableSelection = this.buildDistributionVariableSelection(
+      jobDefinition.assigned_variables || [],
+      hydratedBundles
+    );
+
+    return new Set([
+      ...variableSelection.selectedVariables.map(
+        variable => this.makeVariableKey(variable.unitName, variable.variableId)
+      ),
+      ...variableSelection.selectedVariableBundles.flatMap(bundle => (
+        bundle.variables.map(
+          variable => this.makeVariableKey(variable.unitName, variable.variableId)
+        )
+      ))
+    ]);
   }
 
   private buildDistributionVariableSelection(
@@ -599,6 +631,12 @@ export class JobDefinitionService {
         bundle.variables || []
       )
     }));
+  }
+
+  private async assertAssignedVariableBundlesExist(
+    assignedVariableBundles?: JobDefinitionVariableBundle[]
+  ): Promise<void> {
+    await this.hydrateVariableBundles(assignedVariableBundles, true);
   }
 
   private mergeSavedBundleVariableOptions(
@@ -1710,7 +1748,8 @@ export class JobDefinitionService {
   private async prepareJobDefinitionUpdate(
     id: number,
     workspaceId: number,
-    updateDto: UpdateJobDefinitionDto
+    updateDto: UpdateJobDefinitionDto,
+    options: PrepareJobDefinitionUpdateOptions = {}
   ): Promise<PreparedJobDefinitionUpdate> {
     const jobDefinition = await this.getJobDefinition(id, workspaceId);
     const existingCoderAssignments = this.getStoredCoderAssignments(jobDefinition);
@@ -1755,6 +1794,9 @@ export class JobDefinitionService {
 
     this.validateStatusTransition(jobDefinition.status, updateDto.status);
     this.validateDefinitionState(nextState);
+    if (updateDto.assignedVariableBundles !== undefined) {
+      await this.assertAssignedVariableBundlesExist(nextState.assignedVariableBundles);
+    }
 
     if (
       updateDto.assignedVariables !== undefined ||
@@ -1787,6 +1829,10 @@ export class JobDefinitionService {
       currentMissingsProfileId,
       nextMissingsProfileId
     );
+    const ignoreMissingValidationAvailabilityForVariableKeys =
+      options.ignoreMissingValidationAvailabilityForExistingVariables ?
+        await this.getDistributionVariableKeysForDefinition(jobDefinition) :
+        undefined;
 
     if (this.hasDistributionRelevantChanges(changedExistingJobBoundFields)) {
       const conflicts = await this.checkVariableConflicts(
@@ -1799,7 +1845,8 @@ export class JobDefinitionService {
           caseOrderingMode: nextState.caseOrderingMode,
           distributionSeed,
           excludeJobDefinitionId: id,
-          requireAssignedBundles: updateDto.assignedVariableBundles !== undefined
+          requireAssignedBundles: updateDto.assignedVariableBundles !== undefined,
+          ignoreMissingValidationAvailabilityForVariableKeys
         }
       );
 
@@ -2154,7 +2201,8 @@ export class JobDefinitionService {
     const preparedUpdate = await this.prepareJobDefinitionUpdate(
       jobDefinitionId,
       workspaceId,
-      updateDto
+      updateDto,
+      { ignoreMissingValidationAvailabilityForExistingVariables: true }
     );
 
     this.assertUpdateRefreshIsRequired(jobDefinitionId, preparedUpdate);
@@ -2209,7 +2257,8 @@ export class JobDefinitionService {
     const preparedUpdate = await this.prepareJobDefinitionUpdate(
       jobDefinitionId,
       workspaceId,
-      updateDto
+      updateDto,
+      { ignoreMissingValidationAvailabilityForExistingVariables: true }
     );
 
     this.assertUpdateRefreshIsRequired(jobDefinitionId, preparedUpdate);


### PR DESCRIPTION
## Summary

- Preserve reusable cases owned by the current job definition during update and refresh validation.
- Continue subtracting cases reserved by other unstarted job definitions.
- Validate selected variable bundle IDs before previewing or applying changes.
- Add regression coverage for preview and apply flows, new variables, competing reservations, and unknown bundle IDs.

## Root cause

Validation availability does not include cases already assigned to the definition being updated. That produced false negatives during refresh preview and apply. The fix combines planner usage with a targeted exception for existing definition keys, while retaining checks for newly selected variables and reservations owned by other definitions.

## Checks

- `npx nx lint backend`
- `npx nx test backend --runInBand`