### PR TITLE
Support exact and regex filters in test results table

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-test-results-analysis.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-test-results-analysis.controller.spec.ts
@@ -1,0 +1,88 @@
+import { Repository } from 'typeorm';
+import { CacheService } from '../../cache/cache.service';
+import { Setting } from '../../database/entities/setting.entity';
+import { WorkspaceTestResultsService } from '../../database/services/test-results';
+import { WorkspaceTestResultsAnalysisController } from './workspace-test-results-analysis.controller';
+
+describe('WorkspaceTestResultsAnalysisController', () => {
+  let controller: WorkspaceTestResultsAnalysisController;
+  let workspaceTestResultsService: {
+    findFlatResponses: jest.Mock;
+  };
+  let settingRepository: {
+    findOne: jest.Mock;
+  };
+
+  beforeEach(() => {
+    workspaceTestResultsService = {
+      findFlatResponses: jest.fn().mockResolvedValue([[], 0])
+    };
+    settingRepository = {
+      findOne: jest.fn()
+    };
+    controller = new WorkspaceTestResultsAnalysisController(
+      workspaceTestResultsService as unknown as WorkspaceTestResultsService,
+      {} as CacheService,
+      settingRepository as unknown as Repository<Setting>
+    );
+  });
+
+  it('enables regex only when the workspace setting is enabled', async () => {
+    settingRepository.findOne.mockResolvedValue({
+      content: JSON.stringify({ enabled: true })
+    });
+
+    await controller.findFlatResponses(
+      1,
+      1,
+      50,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      '^VAR$',
+      'true'
+    );
+
+    expect(workspaceTestResultsService.findFlatResponses).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        response: '^VAR$',
+        regexSearch: true
+      })
+    );
+  });
+
+  it('ignores the regex request when the workspace setting is disabled', async () => {
+    settingRepository.findOne.mockResolvedValue(null);
+
+    await controller.findFlatResponses(
+      1,
+      1,
+      50,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      '^VAR$',
+      'true'
+    );
+
+    expect(workspaceTestResultsService.findFlatResponses).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ regexSearch: false })
+    );
+  });
+
+  it('does not read the workspace setting when regex was not requested', async () => {
+    await controller.findFlatResponses(1, 1, 50);
+
+    expect(settingRepository.findOne).not.toHaveBeenCalled();
+    expect(workspaceTestResultsService.findFlatResponses).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ regexSearch: false })
+    );
+  });
+});

--- a/apps/backend/src/app/admin/workspace/workspace-test-results-analysis.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-test-results-analysis.controller.ts
@@ -11,26 +11,33 @@ import {
   ParseFloatPipe,
   DefaultValuePipe
 } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags,
   ApiBadRequestResponse
 } from '@nestjs/swagger';
+import { Repository } from 'typeorm';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { AccessLevelGuard, RequireAccessLevel } from './access-level.guard';
 import { WorkspaceGuard } from './workspace.guard';
 import { WorkspaceTestResultsService } from '../../database/services/test-results';
 import { FlatResponseFrequenciesRequest, FlatResponseFilterOptions } from './dto/workspace-test-results.interfaces';
 import { CacheService } from '../../cache/cache.service';
+import { Setting } from '../../database/entities/setting.entity';
+import { getWorkspaceRegexSearchEnabled } from '../../utils/regex-search.util';
 
 @ApiTags('Admin Workspace Test Results')
 @Controller('admin/workspace')
 export class WorkspaceTestResultsAnalysisController {
   constructor(
     private workspaceTestResultsService: WorkspaceTestResultsService,
-    private cacheService: CacheService
+    private cacheService: CacheService,
+    @InjectRepository(Setting)
+    private readonly settingRepository: Repository<Setting>
   ) { }
 
   @Get(':workspace_id/test-results/flat-responses')
@@ -48,6 +55,12 @@ export class WorkspaceTestResultsAnalysisController {
     description: 'Flat responses retrieved successfully.'
   })
   @ApiBadRequestResponse({ description: 'Failed to retrieve flat responses' })
+  @ApiQuery({
+    name: 'regexSearch',
+    required: false,
+    description: 'Interpret selected text filters as case-sensitive regular expressions',
+    type: Boolean
+  })
   @UseGuards(JwtAuthGuard, WorkspaceGuard, AccessLevelGuard)
   @RequireAccessLevel(3)
   async findFlatResponses(
@@ -60,6 +73,7 @@ export class WorkspaceTestResultsAnalysisController {
                                          @Query('booklet') booklet?: string,
                                          @Query('unit') unit?: string,
                                          @Query('response') response?: string,
+                                         @Query('regexSearch') regexSearch?: string,
                                          @Query('responseStatus') responseStatus?: string,
                                          @Query('responseValue') responseValue?: string,
                                          @Query('tags') tags?: string,
@@ -87,6 +101,8 @@ export class WorkspaceTestResultsAnalysisController {
                                          @Query('sessionSpanThresholdMs', new DefaultValuePipe(86400000), ParseIntPipe) sessionSpanThresholdMs?: number,
                                          @Query('repeatedStartThreshold', new DefaultValuePipe(2), ParseIntPipe) repeatedStartThreshold?: number
   ): Promise<{ data: unknown[]; total: number; page: number; limit: number }> {
+    const effectiveRegexSearch = regexSearch === 'true' &&
+      await getWorkspaceRegexSearchEnabled(this.settingRepository, workspace_id);
     const [data, total] =
       await this.workspaceTestResultsService.findFlatResponses(workspace_id, {
         page,
@@ -97,6 +113,7 @@ export class WorkspaceTestResultsAnalysisController {
         booklet,
         unit,
         response,
+        regexSearch: effectiveRegexSearch,
         responseStatus,
         responseValue,
         tags,

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -1445,6 +1445,142 @@ describe('WorkspaceTestResultsService', () => {
       expect(qb.andWhere).toHaveBeenCalledWith('person.code ILIKE :code', { code: '%abc%' });
     });
 
+    it('should filter variable IDs exactly when wrapped in double quotes', async () => {
+      const dataQb = mockQueryBuilder();
+      const countQb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(dataQb)
+        .mockReturnValueOnce(countQb);
+
+      await service.findFlatResponses(1, {
+        page: 1,
+        limit: 10,
+        response: ' "01_unique" '
+      });
+
+      [dataQb, countQb].forEach(qb => {
+        expect(qb.andWhere).toHaveBeenCalledWith(
+          'LOWER(response.variableid) = LOWER(:responseExact)',
+          { responseExact: '01_unique' }
+        );
+        expect(qb.andWhere).not.toHaveBeenCalledWith(
+          'response.variableid ILIKE :response',
+          expect.anything()
+        );
+      });
+    });
+
+    it('should keep the default variable ID contains search', async () => {
+      const dataQb = mockQueryBuilder();
+      const countQb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(dataQb)
+        .mockReturnValueOnce(countQb);
+
+      await service.findFlatResponses(1, {
+        page: 1,
+        limit: 10,
+        response: '01'
+      });
+
+      [dataQb, countQb].forEach(qb => {
+        expect(qb.andWhere).toHaveBeenCalledWith(
+          'response.variableid ILIKE :response',
+          { response: '%01%' }
+        );
+      });
+    });
+
+    it('should apply regex filters identically to data and count queries', async () => {
+      const dataQb = mockQueryBuilder();
+      const countQb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(dataQb)
+        .mockReturnValueOnce(countQb);
+
+      await service.findFlatResponses(1, {
+        page: 1,
+        limit: 10,
+        code: '^P-',
+        group: '^G[12]$',
+        login: 'user-[0-9]+',
+        booklet: 'Booklet-[AB]',
+        unit: '^Unit',
+        response: '^VAR_\\d+$',
+        regexSearch: true
+      });
+
+      [dataQb, countQb].forEach(qb => {
+        expect(qb.andWhere).toHaveBeenCalledWith(
+          'person.code ~ :codeRegex',
+          { codeRegex: '^P-' }
+        );
+        expect(qb.andWhere).toHaveBeenCalledWith(
+          'person.group ~ :groupRegex',
+          { groupRegex: '^G[12]$' }
+        );
+        expect(qb.andWhere).toHaveBeenCalledWith(
+          'person.login ~ :loginRegex',
+          { loginRegex: 'user-[0-9]+' }
+        );
+        expect(qb.andWhere).toHaveBeenCalledWith(
+          'bookletinfo.name ~ :bookletRegex',
+          { bookletRegex: 'Booklet-[AB]' }
+        );
+        expect(qb.andWhere).toHaveBeenCalledWith(
+          '(unit.alias ~ :unitRegex OR unit.name ~ :unitRegex)',
+          { unitRegex: '^Unit' }
+        );
+        expect(qb.andWhere).toHaveBeenCalledWith(
+          'response.variableid ~ :responseRegex',
+          { responseRegex: '^VAR_\\d+$' }
+        );
+      });
+
+      const queryRunner = (dataSource.createQueryRunner as jest.Mock).mock.results[0].value;
+      expect(responseRepository.createQueryBuilder).toHaveBeenNthCalledWith(
+        1,
+        'response',
+        queryRunner
+      );
+      expect(responseRepository.createQueryBuilder).toHaveBeenNthCalledWith(
+        2,
+        'response',
+        queryRunner
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        "SET LOCAL statement_timeout = '3000ms'"
+      );
+    });
+
+    it('should reject overlong regex filters as bad requests', async () => {
+      await expect(service.findFlatResponses(1, {
+        page: 1,
+        limit: 10,
+        response: 'a'.repeat(257),
+        regexSearch: true
+      })).rejects.toThrow('pattern must not exceed 256 characters');
+    });
+
+    it('should convert PostgreSQL regex timeouts into bad request errors', async () => {
+      const dataQb = mockQueryBuilder();
+      const countQb = mockQueryBuilder();
+      countQb.getRawOne.mockRejectedValue({
+        code: '57014',
+        message: 'canceling statement due to statement timeout'
+      });
+      (responseRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(dataQb)
+        .mockReturnValueOnce(countQb);
+
+      await expect(service.findFlatResponses(1, {
+        page: 1,
+        limit: 10,
+        response: '(a+)+$',
+        regexSearch: true
+      })).rejects.toThrow('Regular expression search timed out');
+    });
+
     it('should not calculate log anomaly summaries for rows by default', async () => {
       const workspaceId = 1;
       const qb = mockQueryBuilder();

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -345,6 +345,101 @@ export class WorkspaceTestResultsService {
     };
   }
 
+  private static applyFlatResponseTextFilters(
+    query: SelectQueryBuilder<ResponseEntity>,
+    filters: {
+      code: string;
+      group: string;
+      login: string;
+      booklet: string;
+      unit: string;
+      response: string;
+      regexSearch: boolean;
+    }
+  ): void {
+    const {
+      code,
+      group,
+      login,
+      booklet,
+      unit,
+      response,
+      regexSearch
+    } = filters;
+
+    if (regexSearch) {
+      const codeRegex = assertValidRegexSearchPattern(code, 'code');
+      if (codeRegex) {
+        query.andWhere('person.code ~ :codeRegex', { codeRegex });
+      }
+
+      const groupRegex = assertValidRegexSearchPattern(group, 'group');
+      if (groupRegex) {
+        query.andWhere('person.group ~ :groupRegex', { groupRegex });
+      }
+
+      const loginRegex = assertValidRegexSearchPattern(login, 'login');
+      if (loginRegex) {
+        query.andWhere('person.login ~ :loginRegex', { loginRegex });
+      }
+
+      const bookletRegex = assertValidRegexSearchPattern(booklet, 'booklet');
+      if (bookletRegex) {
+        query.andWhere('bookletinfo.name ~ :bookletRegex', { bookletRegex });
+      }
+
+      const unitRegex = assertValidRegexSearchPattern(unit, 'unit');
+      if (unitRegex) {
+        query.andWhere(
+          '(unit.alias ~ :unitRegex OR unit.name ~ :unitRegex)',
+          { unitRegex }
+        );
+      }
+
+      const responseRegex = assertValidRegexSearchPattern(response, 'response');
+      if (responseRegex) {
+        query.andWhere('response.variableid ~ :responseRegex', {
+          responseRegex
+        });
+      }
+      return;
+    }
+
+    if (code) {
+      query.andWhere('person.code ILIKE :code', { code: `%${code}%` });
+    }
+    if (group) {
+      query.andWhere('person.group ILIKE :group', { group: `%${group}%` });
+    }
+    if (login) {
+      query.andWhere('person.login ILIKE :login', { login: `%${login}%` });
+    }
+    if (booklet) {
+      query.andWhere('bookletinfo.name ILIKE :booklet', {
+        booklet: `%${booklet}%`
+      });
+    }
+    if (unit) {
+      query.andWhere('(unit.alias ILIKE :unit OR unit.name ILIKE :unit)', {
+        unit: `%${unit}%`
+      });
+    }
+    if (response) {
+      const responseFilter =
+        WorkspaceTestResultsService.parseQuotedExactSearchFilter(response);
+      if (responseFilter.exact) {
+        query.andWhere(
+          'LOWER(response.variableid) = LOWER(:responseExact)',
+          { responseExact: responseFilter.value }
+        );
+      } else {
+        query.andWhere('response.variableid ILIKE :response', {
+          response: `%${responseFilter.value}%`
+        });
+      }
+    }
+  }
+
   private static parseStoredResponseValue(value: string | null, variableId?: string): unknown {
     const normalizedVariableId = String(variableId || '').trim();
     const isMarkingPanel = normalizedVariableId.startsWith('marking-panel_');
@@ -2520,7 +2615,9 @@ export class WorkspaceTestResultsService {
       focusLostThresholdMs?: number | string;
       sessionSpanThresholdMs?: number | string;
       repeatedStartThreshold?: number | string;
-    }
+      regexSearch?: boolean;
+    },
+    queryRunner?: QueryRunner
   ): Promise<
     [
       Array<{
@@ -2546,6 +2643,21 @@ export class WorkspaceTestResultsService {
       throw new Error('Invalid workspaceId provided');
     }
 
+    if (options.regexSearch && !queryRunner) {
+      try {
+        return await withRegexSearchStatementTimeout(
+          this.connection,
+          runner => this.findFlatResponses(workspaceId, options, runner)
+        );
+      } catch (error) {
+        const regexError = toRegexSearchException(error);
+        if (regexError) {
+          throw regexError;
+        }
+        throw error;
+      }
+    }
+
     const MAX_LIMIT = 200;
     const MAX_RESPONSE_VALUE_LEN = 2000;
     const validPage = Math.max(1, Number(options.page || 1));
@@ -2563,6 +2675,7 @@ export class WorkspaceTestResultsService {
     const responseStatus = (options.responseStatus || '').trim();
     const responseValue = (options.responseValue || '').trim();
     const tags = (options.tags || '').trim();
+    const regexSearch = options.regexSearch === true;
     const geogebra = String(options.geogebra || '')
       .trim()
       .toLowerCase();
@@ -2713,7 +2826,7 @@ export class WorkspaceTestResultsService {
     const responseStatusNum = parseResponseStatus(responseStatus);
 
     const qb = this.responseRepository
-      .createQueryBuilder('response')
+      .createQueryBuilder('response', queryRunner)
       .innerJoin('response.unit', 'unit')
       .innerJoin('unit.booklet', 'bookletEntity')
       .innerJoin('bookletEntity.person', 'person')
@@ -2726,30 +2839,15 @@ export class WorkspaceTestResultsService {
     this.applyExclusionsToQuery(qb, exclusions);
     this.excludeAutocoderGeneratedResponses(qb);
 
-    if (code) {
-      qb.andWhere('person.code ILIKE :code', { code: `%${code}%` });
-    }
-    if (group) {
-      qb.andWhere('person.group ILIKE :group', { group: `%${group}%` });
-    }
-    if (login) {
-      qb.andWhere('person.login ILIKE :login', { login: `%${login}%` });
-    }
-    if (booklet) {
-      qb.andWhere('bookletinfo.name ILIKE :booklet', {
-        booklet: `%${booklet}%`
-      });
-    }
-    if (unit) {
-      qb.andWhere('(unit.alias ILIKE :unit OR unit.name ILIKE :unit)', {
-        unit: `%${unit}%`
-      });
-    }
-    if (response) {
-      qb.andWhere('response.variableid ILIKE :response', {
-        response: `%${response}%`
-      });
-    }
+    WorkspaceTestResultsService.applyFlatResponseTextFilters(qb, {
+      code,
+      group,
+      login,
+      booklet,
+      unit,
+      response,
+      regexSearch
+    });
     if (responseStatus) {
       if (responseStatusNum === null) {
         qb.andWhere('1=0');
@@ -2964,7 +3062,7 @@ export class WorkspaceTestResultsService {
     );
 
     const countQb = this.responseRepository
-      .createQueryBuilder('response')
+      .createQueryBuilder('response', queryRunner)
       .innerJoin('response.unit', 'unit')
       .innerJoin('unit.booklet', 'bookletEntity')
       .innerJoin('bookletEntity.person', 'person')
@@ -2977,30 +3075,15 @@ export class WorkspaceTestResultsService {
     });
     this.excludeAutocoderGeneratedResponses(countQb);
 
-    if (code) {
-      countQb.andWhere('person.code ILIKE :code', { code: `%${code}%` });
-    }
-    if (group) {
-      countQb.andWhere('person.group ILIKE :group', { group: `%${group}%` });
-    }
-    if (login) {
-      countQb.andWhere('person.login ILIKE :login', { login: `%${login}%` });
-    }
-    if (booklet) {
-      countQb.andWhere('bookletinfo.name ILIKE :booklet', {
-        booklet: `%${booklet}%`
-      });
-    }
-    if (unit) {
-      countQb.andWhere('(unit.alias ILIKE :unit OR unit.name ILIKE :unit)', {
-        unit: `%${unit}%`
-      });
-    }
-    if (response) {
-      countQb.andWhere('response.variableid ILIKE :response', {
-        response: `%${response}%`
-      });
-    }
+    WorkspaceTestResultsService.applyFlatResponseTextFilters(countQb, {
+      code,
+      group,
+      login,
+      booklet,
+      unit,
+      response,
+      regexSearch
+    });
     if (responseStatus) {
       if (responseStatusNum === null) {
         countQb.andWhere('1=0');

--- a/apps/frontend/src/app/shared/services/test-result/test-result.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/test-result/test-result.service.spec.ts
@@ -83,6 +83,7 @@ describe('TestResultService', () => {
         limit: 10,
         code: 'code1',
         group: 'group1',
+        regexSearch: true,
         logAnomalies: 'critical',
         includeLogAnomalies: 'true'
       };
@@ -94,6 +95,7 @@ describe('TestResultService', () => {
       const req = httpMock.expectOne(request => request.url === `${mockServerUrl}admin/workspace/${mockWorkspaceId}/test-results/flat-responses` &&
         request.params.get('page') === '1' &&
         request.params.get('code') === 'code1' &&
+        request.params.get('regexSearch') === 'true' &&
         request.params.get('logAnomalies') === 'critical' &&
         request.params.get('includeLogAnomalies') === 'true'
       );
@@ -101,13 +103,17 @@ describe('TestResultService', () => {
       req.flush(mockResponse);
     });
 
-    it('should handle errors', () => {
+    it('should propagate errors', done => {
       const options = { page: 1, limit: 10 };
 
-      service.getFlatResponses(mockWorkspaceId, options).subscribe(res => {
-        expect(res).toEqual({
-          data: [], total: 0, page: 1, limit: 10
-        });
+      service.getFlatResponses(mockWorkspaceId, options).subscribe({
+        next: () => {
+          done.fail('Expected flat response loading to fail');
+        },
+        error: error => {
+          expect(error.status).toBe(500);
+          done();
+        }
       });
 
       const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/${mockWorkspaceId}/test-results/flat-responses?page=1&limit=10`);

--- a/apps/frontend/src/app/shared/services/test-result/test-result.service.ts
+++ b/apps/frontend/src/app/shared/services/test-result/test-result.service.ts
@@ -504,6 +504,7 @@ export class TestResultService {
       responseStatus?: string;
       responseValue?: string;
       tags?: string;
+      regexSearch?: boolean;
       geogebra?: string;
       audioLow?: string;
       hasValue?: string;
@@ -548,6 +549,9 @@ export class TestResultService {
     addIf('responseStatus', options.responseStatus);
     addIf('responseValue', options.responseValue);
     addIf('tags', options.tags);
+    if (options.regexSearch) {
+      params = params.set('regexSearch', 'true');
+    }
     addIf('geogebra', options.geogebra);
     addIf('audioLow', options.audioLow);
     addIf('hasValue', options.hasValue);
@@ -574,20 +578,10 @@ export class TestResultService {
     addIf('sessionSpanThresholdMs', options.sessionSpanThresholdMs);
     addIf('repeatedStartThreshold', options.repeatedStartThreshold);
 
-    return this.http
-      .get<FlatTestResultResponsesResponse>(
+    return this.http.get<FlatTestResultResponsesResponse>(
       `${this.serverUrl}admin/workspace/${workspaceId}/test-results/flat-responses`,
       { params }
-    )
-      .pipe(
-        catchError(() => of({
-          data: [],
-          total: 0,
-          page: options.page,
-          limit: options.limit
-        })
-        )
-      );
+    );
   }
 
   getFlatResponseFilterOptions(

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.html
@@ -8,60 +8,84 @@
 
     <div class="table-section">
       <div class="flat-filter-bar">
-        <mat-form-field appearance="outline" class="flat-filter-field flat-filter-field-sm">
+        <mat-form-field appearance="outline" class="flat-filter-field flat-filter-field-sm"
+          [class.regex-filter-invalid]="isRegexFilterInvalid('code')">
           <mat-label>Code</mat-label>
           <input matInput [(ngModel)]="flatFilters.code" (ngModelChange)="onFlatFilterChanged()"
             [matAutocomplete]="codeAuto" />
+          @if (isRegexFilterInvalid('code')) {
+          <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+          }
         </mat-form-field>
         <mat-autocomplete #codeAuto="matAutocomplete" (optionSelected)="onFlatFilterOptionSelected()">
           @for (opt of filteredCodes(); track opt) {
           <mat-option [value]="opt">{{ opt }}</mat-option>
           }
         </mat-autocomplete>
-        <mat-form-field appearance="outline" class="flat-filter-field flat-filter-field-sm">
+        <mat-form-field appearance="outline" class="flat-filter-field flat-filter-field-sm"
+          [class.regex-filter-invalid]="isRegexFilterInvalid('group')">
           <mat-label>Gruppe</mat-label>
           <input matInput [(ngModel)]="flatFilters.group" (ngModelChange)="onFlatFilterChanged()"
             [matAutocomplete]="groupAuto" />
+          @if (isRegexFilterInvalid('group')) {
+          <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+          }
         </mat-form-field>
         <mat-autocomplete #groupAuto="matAutocomplete" (optionSelected)="onFlatFilterOptionSelected()">
           @for (opt of filteredGroups(); track opt) {
           <mat-option [value]="opt">{{ opt }}</mat-option>
           }
         </mat-autocomplete>
-        <mat-form-field appearance="outline" class="flat-filter-field flat-filter-field-sm">
+        <mat-form-field appearance="outline" class="flat-filter-field flat-filter-field-sm"
+          [class.regex-filter-invalid]="isRegexFilterInvalid('login')">
           <mat-label>Login</mat-label>
           <input matInput [(ngModel)]="flatFilters.login" (ngModelChange)="onFlatFilterChanged()"
             [matAutocomplete]="loginAuto" />
+          @if (isRegexFilterInvalid('login')) {
+          <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+          }
         </mat-form-field>
         <mat-autocomplete #loginAuto="matAutocomplete" (optionSelected)="onFlatFilterOptionSelected()">
           @for (opt of filteredLogins(); track opt) {
           <mat-option [value]="opt">{{ opt }}</mat-option>
           }
         </mat-autocomplete>
-        <mat-form-field appearance="outline" class="flat-filter-field">
+        <mat-form-field appearance="outline" class="flat-filter-field"
+          [class.regex-filter-invalid]="isRegexFilterInvalid('booklet')">
           <mat-label>Testheft</mat-label>
           <input matInput [(ngModel)]="flatFilters.booklet" (ngModelChange)="onFlatFilterChanged()"
             [matAutocomplete]="bookletAuto" />
+          @if (isRegexFilterInvalid('booklet')) {
+          <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+          }
         </mat-form-field>
         <mat-autocomplete #bookletAuto="matAutocomplete" (optionSelected)="onFlatFilterOptionSelected()">
           @for (opt of filteredBooklets(); track opt) {
           <mat-option [value]="opt">{{ opt }}</mat-option>
           }
         </mat-autocomplete>
-        <mat-form-field appearance="outline" class="flat-filter-field">
+        <mat-form-field appearance="outline" class="flat-filter-field"
+          [class.regex-filter-invalid]="isRegexFilterInvalid('unit')">
           <mat-label>Aufgabe</mat-label>
           <input matInput [(ngModel)]="flatFilters.unit" (ngModelChange)="onFlatFilterChanged()"
             [matAutocomplete]="unitAuto" />
+          @if (isRegexFilterInvalid('unit')) {
+          <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+          }
         </mat-form-field>
         <mat-autocomplete #unitAuto="matAutocomplete" (optionSelected)="onFlatFilterOptionSelected()">
           @for (opt of filteredUnits(); track opt) {
           <mat-option [value]="opt">{{ opt }}</mat-option>
           }
         </mat-autocomplete>
-        <mat-form-field appearance="outline" class="flat-filter-field">
+        <mat-form-field appearance="outline" class="flat-filter-field"
+          [class.regex-filter-invalid]="isRegexFilterInvalid('response')">
           <mat-label>Variable</mat-label>
           <input matInput [(ngModel)]="flatFilters.response" (ngModelChange)="onFlatFilterChanged()"
             [matAutocomplete]="responseAuto" />
+          @if (isRegexFilterInvalid('response')) {
+          <mat-hint class="regex-filter-error">{{ 'search-filter.invalid-regex' | translate }}</mat-hint>
+          }
         </mat-form-field>
         <mat-autocomplete #responseAuto="matAutocomplete" (optionSelected)="onFlatFilterOptionSelected()">
           @for (opt of filteredResponses(); track opt + '@@' + $index) {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.scss
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.scss
@@ -33,6 +33,23 @@
   ::ng-deep .mat-mdc-form-field-subscript-wrapper {
     display: none;
   }
+
+  &.regex-filter-invalid {
+    ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+      display: block;
+    }
+
+    ::ng-deep .mdc-notched-outline__leading,
+    ::ng-deep .mdc-notched-outline__notch,
+    ::ng-deep .mdc-notched-outline__trailing {
+      border-color: #d32f2f !important;
+      border-width: 2px;
+    }
+  }
+}
+
+.regex-filter-error {
+  color: #d32f2f;
 }
 
 .flat-filter-field-sm {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.spec.ts
@@ -1,9 +1,13 @@
 import { SimpleChange } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture, fakeAsync, TestBed, tick
+} from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Subject, of } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { Subject, of, throwError } from 'rxjs';
 import { FileService } from '../../../shared/services/file/file.service';
 import { UnitNoteService } from '../../../shared/services/unit/unit-note.service';
 import { CodingStatisticsService } from '../../../coding/services/coding-statistics.service';
@@ -18,6 +22,7 @@ import { TestResultsFlatTableComponent } from './test-results-flat-table.compone
 describe('TestResultsFlatTableComponent', () => {
   let fixture: ComponentFixture<TestResultsFlatTableComponent>;
   let component: TestResultsFlatTableComponent;
+  let snackBar: { open: jest.Mock };
   let testResultService: {
     getFlatResponses: jest.Mock;
     getFlatResponseFilterOptions: jest.Mock;
@@ -42,6 +47,9 @@ describe('TestResultsFlatTableComponent', () => {
   };
 
   beforeEach(async () => {
+    snackBar = {
+      open: jest.fn().mockReturnValue({ dismiss: jest.fn() })
+    };
     testResultService = {
       getFlatResponses: jest.fn().mockReturnValue(of({
         data: [],
@@ -57,7 +65,8 @@ describe('TestResultsFlatTableComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         TestResultsFlatTableComponent,
-        NoopAnimationsModule
+        NoopAnimationsModule,
+        TranslateModule.forRoot()
       ],
       providers: [
         { provide: FileService, useValue: {} },
@@ -86,7 +95,7 @@ describe('TestResultsFlatTableComponent', () => {
         { provide: TestResultService, useValue: testResultService },
         {
           provide: MatSnackBar,
-          useValue: { open: jest.fn().mockReturnValue({ dismiss: jest.fn() }) }
+          useValue: snackBar
         },
         { provide: MatDialog, useValue: { open: jest.fn() } }
       ]
@@ -167,6 +176,70 @@ describe('TestResultsFlatTableComponent', () => {
     expect(component.flatFilters.code).toBe('person-a');
     expect(component.flatFilters.logAnomalies).toBe('');
     expect(component.mediaFilters).not.toContain('logAny');
+  });
+
+  it('should send the regex flag when the workspace setting is enabled', () => {
+    component.enableRegexSearch = true;
+
+    component.ngOnInit();
+
+    expect(testResultService.getFlatResponses).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ regexSearch: true })
+    );
+  });
+
+  it('should pass quoted exact filters unchanged in normal mode', () => {
+    component.flatFilters.response = '"01"';
+
+    component.ngOnInit();
+
+    expect(testResultService.getFlatResponses).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        response: '"01"',
+        regexSearch: false
+      })
+    );
+  });
+
+  it('should not request data while a regex filter is invalid', fakeAsync(() => {
+    component.enableRegexSearch = true;
+    component.ngOnInit();
+    testResultService.getFlatResponses.mockClear();
+    component.flatFilters.response = '[';
+
+    component.onFlatFilterChanged();
+    tick(401);
+
+    expect(component.isRegexFilterInvalid('response')).toBe(true);
+    expect(testResultService.getFlatResponses).not.toHaveBeenCalled();
+  }));
+
+  it('should disable autocomplete suggestions in regex mode', () => {
+    component.enableRegexSearch = true;
+    component.flatFilterOptions.codes = ['P-01'];
+    component.flatFilters.code = '^P-';
+
+    expect(component.filteredCodes()).toEqual([]);
+  });
+
+  it('should show a specific message when a regex query times out', () => {
+    component.enableRegexSearch = true;
+    testResultService.getFlatResponses.mockReturnValue(throwError(() => (
+      new HttpErrorResponse({
+        status: 400,
+        error: { message: 'Regular expression search timed out after 3000 ms.' }
+      })
+    )));
+
+    component.ngOnInit();
+
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'search-filter.regex-timeout',
+      'close',
+      expect.objectContaining({ duration: 5000 })
+    );
   });
 
   it('should ignore stale flat-response requests', () => {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.ts
@@ -1,4 +1,5 @@
 import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import {
   Component,
   EventEmitter,
@@ -24,6 +25,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatSelectModule } from '@angular/material/select';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   Observable,
   Subject,
@@ -61,6 +63,7 @@ import {
   TestResultsFlatTableSettingsDialogComponent,
   TestResultsFlatTableSettingsDialogResult
 } from './test-results-flat-table-settings-dialog.component';
+import { hasInvalidRegexFilter } from '../../../shared/utils/regex-filter.util';
 
 interface FlatResponseRow {
   bookletId: number;
@@ -157,6 +160,14 @@ type FlatTableMediaFilter =
   | 'logDebug'
   | 'logReloads';
 
+type RegexFlatResponseFilterField =
+  | 'code'
+  | 'group'
+  | 'login'
+  | 'booklet'
+  | 'unit'
+  | 'response';
+
 const SPECIFIC_LOG_MEDIA_FILTERS: FlatTableMediaFilter[] = [
   'logCritical',
   'logTechnical',
@@ -184,7 +195,8 @@ const SPECIFIC_LOG_MEDIA_FILTERS: FlatTableMediaFilter[] = [
     MatProgressSpinnerModule,
     MatTooltipModule,
     MatAutocompleteModule,
-    MatSelectModule
+    MatSelectModule,
+    TranslateModule
   ],
   templateUrl: './test-results-flat-table.component.html',
   styleUrls: ['./test-results-flat-table.component.scss']
@@ -198,6 +210,7 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
   private testResultService = inject(TestResultService);
   private snackBar = inject(MatSnackBar);
   private dialog = inject(MatDialog);
+  private translateService = inject(TranslateService);
 
   private readonly AUDIO_LOW_THRESHOLD_STORAGE_KEY =
     'coding-box-test-results-audio-low-threshold';
@@ -332,6 +345,7 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
   @Input() initialFilters: Partial<FlatResponseFilters> | null = null;
   @Input() showWorkspaceLogAnomalies = false;
   @Input() forceShowLogAnomalies = false;
+  @Input() enableRegexSearch = false;
   @Output() responseDeleted = new EventEmitter<void>();
 
   constructor() {
@@ -453,7 +467,9 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
     this.flatSearchSubscription = this.flatSearchSubject
       .pipe(debounceTime(this.FLAT_FILTER_DEBOUNCE_TIME))
       .subscribe(() => {
-        this.fetchFlatResponses(0, this.flatPageSize);
+        if (!this.hasInvalidRegexFilters()) {
+          this.fetchFlatResponses(0, this.flatPageSize);
+        }
       });
 
     this.workspaceCacheInvalidatedSubscription =
@@ -489,6 +505,11 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
       shouldFetch = this.updateLogAnomalyTableVisibility() || shouldFetch;
     }
 
+    if (changes.enableRegexSearch) {
+      this.flatPageIndex = 0;
+      shouldFetch = true;
+    }
+
     if (changes.initialFilters) {
       this.flatFilters = {
         ...this.createDefaultFlatFilters(),
@@ -502,7 +523,10 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
       shouldFetch = true;
     }
 
-    if (shouldFetch && this.tableInitialized && this.logAnomalyTableSettingLoaded) {
+    if (shouldFetch &&
+      this.tableInitialized &&
+      this.logAnomalyTableSettingLoaded &&
+      !this.hasInvalidRegexFilters()) {
       this.fetchFlatResponses(this.flatPageIndex, this.flatPageSize);
     }
   }
@@ -783,7 +807,14 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
     this.fetchFlatResponses(0, this.flatPageSize);
   }
 
-  private filterOptions(options: string[], value: string): string[] {
+  private filterOptions(
+    options: string[],
+    value: string,
+    disableForRegex = false
+  ): string[] {
+    if (disableForRegex && this.enableRegexSearch) {
+      return [];
+    }
     const v = (value || '').trim().toLowerCase();
     if (!v) {
       return options || [];
@@ -794,42 +825,48 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
   filteredCodes(): string[] {
     return this.filterOptions(
       this.flatFilterOptions.codes,
-      this.flatFilters.code
+      this.flatFilters.code,
+      true
     );
   }
 
   filteredGroups(): string[] {
     return this.filterOptions(
       this.flatFilterOptions.groups,
-      this.flatFilters.group
+      this.flatFilters.group,
+      true
     );
   }
 
   filteredLogins(): string[] {
     return this.filterOptions(
       this.flatFilterOptions.logins,
-      this.flatFilters.login
+      this.flatFilters.login,
+      true
     );
   }
 
   filteredBooklets(): string[] {
     return this.filterOptions(
       this.flatFilterOptions.booklets,
-      this.flatFilters.booklet
+      this.flatFilters.booklet,
+      true
     );
   }
 
   filteredUnits(): string[] {
     return this.filterOptions(
       this.flatFilterOptions.units,
-      this.flatFilters.unit
+      this.flatFilters.unit,
+      true
     );
   }
 
   filteredResponses(): string[] {
     return this.filterOptions(
       this.flatFilterOptions.responses,
-      this.flatFilters.response
+      this.flatFilters.response,
+      true
     );
   }
 
@@ -845,6 +882,25 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
       this.flatFilterOptions.tags,
       this.flatFilters.tags
     );
+  }
+
+  isRegexFilterInvalid(field: RegexFlatResponseFilterField): boolean {
+    return hasInvalidRegexFilter(
+      this.flatFilters[field],
+      this.enableRegexSearch
+    );
+  }
+
+  private hasInvalidRegexFilters(): boolean {
+    const fields: RegexFlatResponseFilterField[] = [
+      'code',
+      'group',
+      'login',
+      'booklet',
+      'unit',
+      'response'
+    ];
+    return fields.some(field => this.isRegexFilterInvalid(field));
   }
 
   openBookletInfoFromFlatRow(row: FlatResponseRow): void {
@@ -1421,6 +1477,10 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
     if (!this.logAnomalyTableSettingLoaded) {
       return;
     }
+    if (this.hasInvalidRegexFilters()) {
+      this.isLoadingFlat = false;
+      return;
+    }
     const validPage = Math.max(0, page);
     this.flatResponsesRequestSequence += 1;
     const requestSequence = this.flatResponsesRequestSequence;
@@ -1441,6 +1501,7 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
         responseStatus: this.flatFilters.responseStatus,
         responseValue: this.flatFilters.responseValue,
         tags: this.flatFilters.tags,
+        regexSearch: this.enableRegexSearch,
         geogebra: this.flatFilters.geogebra ? 'true' : '',
         audioLow: this.flatFilters.audioLow ? 'true' : '',
         hasValue: this.flatFilters.nonEmptyResponse ? 'true' : '',
@@ -1503,12 +1564,32 @@ export class TestResultsFlatTableComponent implements OnInit, OnChanges, OnDestr
           this.loadFrequenciesForCurrentPage();
           this.loadNotesPresenceForCurrentPage();
         },
-        error: () => {
+        error: (error: HttpErrorResponse) => {
           if (requestSequence === this.flatResponsesRequestSequence) {
             this.isLoadingFlat = false;
+            this.showFlatResponseLoadError(error);
           }
         }
       });
+  }
+
+  private showFlatResponseLoadError(error: HttpErrorResponse): void {
+    const backendMessage = typeof error.error?.message === 'string' ?
+      error.error.message :
+      '';
+    let messageKey = 'search-filter.test-results-load-error';
+
+    if (error.status === 400 && /timed out/i.test(backendMessage)) {
+      messageKey = 'search-filter.regex-timeout';
+    } else if (error.status === 400 && this.enableRegexSearch) {
+      messageKey = 'search-filter.invalid-postgres-regex';
+    }
+
+    this.snackBar.open(
+      this.translateService.instant(messageKey),
+      this.translateService.instant('close'),
+      { duration: 5000, panelClass: ['error-snackbar'] }
+    );
   }
 
   hasNotesForRow(row: FlatResponseRow): boolean {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.html
@@ -350,6 +350,7 @@
     [initialFilters]="quickSearchTableFilters"
     [showWorkspaceLogAnomalies]="showTestResultsLogAnomalies"
     [forceShowLogAnomalies]="forceShowLogAnomalyTableColumn"
+    [enableRegexSearch]="enableRegexSearch"
     (responseDeleted)="onFlatTableResponseDeleted()"
   ></coding-box-test-results-flat-table>
   } @else {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.spec.ts
@@ -153,6 +153,7 @@ describe('TestResultsComponent', () => {
           provide: WorkspaceSettingsService,
           useValue: {
             getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false)),
+            getEnableRegexSearch: jest.fn().mockReturnValue(of(true)),
             getAutoRefreshManualCodingJobs: jest.fn().mockReturnValue(of(true))
           }
         },
@@ -249,6 +250,10 @@ describe('TestResultsComponent', () => {
 
     expect(testResultService.getLogAnomalySummary).not.toHaveBeenCalled();
     expect(component.logAnomalySummaryRequested).toBe(false);
+  });
+
+  it('should load the workspace regex setting for the flat table', () => {
+    expect(component.enableRegexSearch).toBe(true);
   });
 
   it('should not show manual coding status controls on the test results page', () => {

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.component.ts
@@ -456,6 +456,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
   overview: TestResultsOverviewResponse | null = null;
   isLoadingOverview: boolean = false;
   showTestResultsLogAnomalies: boolean = false;
+  enableRegexSearch: boolean = false;
   logAnomalySummary: LogAnomalyDashboardSummary | null = null;
   isLoadingLogAnomalySummary: boolean = false;
   logAnomalySummaryLoadFailed: boolean = false;
@@ -536,6 +537,7 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       });
 
     this.loadTestResultsLogAnomalySetting();
+    this.loadRegexSearchSetting();
     this.loadCodingStatusAutoRefreshSetting();
     this.createTestResultsList(0, this.pageSize);
     this.loadWorkspaceOverview();
@@ -1268,6 +1270,20 @@ export class TestResultsComponent implements OnInit, OnDestroy {
       .getShowTestResultsLogAnomalies(workspaceId)
       .subscribe(enabled => {
         this.setShowTestResultsLogAnomalies(enabled);
+      });
+  }
+
+  private loadRegexSearchSetting(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      this.enableRegexSearch = false;
+      return;
+    }
+
+    this.workspaceSettingsService
+      .getEnableRegexSearch(workspaceId)
+      .subscribe(enabled => {
+        this.enableRegexSearch = enabled;
       });
   }
 

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results.polling.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results.polling.spec.ts
@@ -75,6 +75,7 @@ describe('TestResultsComponent Polling', () => {
         {
           provide: WorkspaceSettingsService,
           useValue: {
+            getEnableRegexSearch: jest.fn().mockReturnValue(of(false)),
             getShowTestResultsLogAnomalies: jest.fn().mockReturnValue(of(false)),
             getAutoRefreshManualCodingJobs: jest.fn().mockReturnValue(of(true))
           }

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -615,7 +615,10 @@
     "filter-test-persons": "Suche nach Testpersonen",
     "filter-test-groups": "Suche nach Testgruppen",
     "filter-test-files": "Suche nach Testdateien",
-    "invalid-regex": "Ungültiger regulärer Ausdruck"
+    "invalid-regex": "Ungültiger regulärer Ausdruck",
+    "invalid-postgres-regex": "Der reguläre Ausdruck ist für die Datenbanksuche ungültig.",
+    "regex-timeout": "Die Regex-Suche hat zu lange gedauert. Bitte verwenden Sie ein spezifischeres Muster.",
+    "test-results-load-error": "Testergebnisse konnten nicht geladen werden."
   },
   "access-rights": {
     "hint": "Zugriffsrechte: Bitte links Nutzer:in wählen",


### PR DESCRIPTION
## Summary

- support exact, case-insensitive variable ID searches with quoted values such as `"01"`
- preserve the existing contains search for unquoted values
- add workspace-gated PostgreSQL regex filters for code, group, login, booklet, unit, and variable ID
- enforce parameterized queries, a 256-character pattern limit, and a local statement timeout
- validate regex input in the flat table and surface database validation or timeout errors

## Root cause

The flat test-results table always applied `ILIKE` contains matching to variable IDs and did not pass the existing workspace regex-search setting to its endpoint.

## User impact

Workspace administrators can select a single variable ID precisely and, when enabled for the workspace, use the same protected regex-search behavior available in the coding overview.

## Validation

- `npx nx lint backend`
- `npx nx test backend --runInBand` (138 suites, 2059 tests passed)
- `npx nx build backend`
- `npx nx lint frontend`
- `npx nx test frontend --runInBand` (194 suites, 1851 tests passed)
- `npx nx build frontend`
- `git diff --check`

Refs #894
