### PR TITLE
Fix job definition update route IDs

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
@@ -8,6 +8,7 @@ import {
   UseGuards,
   Body,
   ValidationPipe,
+  ParseIntPipe,
   Res,
   Query
 } from '@nestjs/common';
@@ -359,7 +360,7 @@ export class WorkspaceCodingJobDefinitionController {
   })
   async updateJobDefinition(
     @WorkspaceId() workspace_id: number,
-      @Param('id') id: number,
+      @Param('id', ParseIntPipe) id: number,
       @Body(new ValidationPipe({ transform: true, whitelist: true })) updateDto: UpdateJobDefinitionDto
   ): Promise<JobDefinition> {
     return this.jobDefinitionService.updateJobDefinition(id, workspace_id, updateDto);

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -912,7 +912,7 @@ describe('JobDefinitionService', () => {
     });
   });
 
-  it('allows updating a pending definition when its own retained cases are excluded from reservations', async () => {
+  it('allows updating a pending definition when its route id arrives as a string', async () => {
     const retainedVariable = { unitName: 'Unit 1', variableId: 'Var 1' };
     const addedVariable = { unitName: 'Unit 2', variableId: 'Var 2' };
     const existingDefinition = {
@@ -935,7 +935,7 @@ describe('JobDefinitionService', () => {
       { unitName: 'Unit 2', variableId: 'Var 2', availableCases: 1 }
     ]);
 
-    await expect(service.updateJobDefinition(74, 7, {
+    await expect(service.updateJobDefinition('74' as unknown as number, 7, {
       assignedVariables: [retainedVariable, addedVariable],
       assignedVariableBundles: [],
       maxCodingCases: null,

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -1837,8 +1837,9 @@ export class JobDefinitionService {
   }
 
   async updateJobDefinition(id: number, workspaceId: number, updateDto: UpdateJobDefinitionDto): Promise<JobDefinition> {
+    const normalizedId = Number(id);
     const preparedUpdate = await this.prepareJobDefinitionUpdate(
-      id,
+      normalizedId,
       workspaceId,
       updateDto
     );
@@ -1847,7 +1848,7 @@ export class JobDefinitionService {
       preparedUpdate.changedExistingJobBoundFields.length > 0
     ) {
       throw new BadRequestException(
-        `Cannot update job definition ${id} because existing coding jobs must be refreshed for changes to: ${preparedUpdate.changedExistingJobBoundFields.join(', ')}`
+        `Cannot update job definition ${normalizedId} because existing coding jobs must be refreshed for changes to: ${preparedUpdate.changedExistingJobBoundFields.join(', ')}`
       );
     }
 
@@ -1866,7 +1867,7 @@ export class JobDefinitionService {
 
         await this.codingJobService.updateCodingJobDisplayOptionsByDefinitionId(
           workspaceId,
-          id,
+          normalizedId,
           {
             showScore: updateDto.showScore,
             allowComments: updateDto.allowComments,


### PR DESCRIPTION
## What changed

- parse job definition update route IDs with `ParseIntPipe`
- normalize the ID defensively at the service boundary
- cover the runtime string-ID case in the existing self-reservation regression test

## Why

Nest route parameters arrive as strings unless they are transformed. The update controller declared `id` as a number but did not parse it. During availability validation, the string ID did not strictly equal the numeric database ID, so an unmaterialized job definition was not excluded and reserved its own cases. Distribution-relevant edits therefore failed with a misleading `no remaining cases` response.

This keeps the current availability protection intact while ensuring the edited definition is excluded from its own reservation calculation.

Refs #681.

## Validation

- `npx nx test backend --runTestsByPath apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts --runInBand`
- `npx nx lint backend`
