### PR TITLE
Fix auto-coded variable bundle status

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -4933,7 +4933,7 @@ describe('CodingJobService', () => {
     });
   });
 
-  it('uses all visible bundle units for bundle context when only open units are returned', async () => {
+  it('uses all visible bundle units and prepared results for bundle context', async () => {
     const openUnit = {
       response_id: 99,
       unit_name: 'UNIT_A',
@@ -4965,6 +4965,22 @@ describe('CodingJobService', () => {
       code: 7,
       score: 2,
       is_open: false
+    };
+    const preparedBundleUnit = {
+      response_id: 102,
+      unit_name: 'UNIT_C',
+      unit_alias: 'Unit C',
+      variable_id: 'VAR_C',
+      variable_anchor: 'VAR_C',
+      booklet_name: 'BOOKLET',
+      person_login: 'login',
+      person_code: 'code',
+      person_group: 'group',
+      notes: null,
+      variable_bundle_id: 9,
+      code: null,
+      score: null,
+      is_open: true
     };
     const responseQueryBuilder: Record<string, jest.Mock> = {};
     [
@@ -5031,6 +5047,26 @@ describe('CodingJobService', () => {
             person: { login: 'login', code: 'code', group: 'group' }
           }
         }
+      },
+      {
+        id: 102,
+        variableid: 'VAR_C',
+        is_autocoder_generated: false,
+        status_v1: 3,
+        code_v1: null,
+        score_v1: null,
+        status_v2: 5,
+        code_v2: -98,
+        score_v2: 0,
+        code_v3: null,
+        score_v3: null,
+        unit: {
+          name: 'UNIT_C',
+          booklet: {
+            bookletinfo: { name: 'BOOKLET' },
+            person: { login: 'login', code: 'code', group: 'group' }
+          }
+        }
       }
     ]);
 
@@ -5055,18 +5091,29 @@ describe('CodingJobService', () => {
         name: 'Bundle',
         variables: [
           { unitName: 'unit_a', variableId: 'VAR_A' },
-          { unitName: 'UNIT_B', variableId: 'VAR_B' }
+          { unitName: 'UNIT_B', variableId: 'VAR_B' },
+          { unitName: 'UNIT_C', variableId: 'VAR_C' }
         ]
       }
     ]);
     codingJobUnitRepository.find
       .mockResolvedValueOnce([openUnit])
-      .mockResolvedValueOnce([openUnit, closedBundleUnit])
+      .mockResolvedValueOnce([
+        openUnit,
+        closedBundleUnit,
+        preparedBundleUnit
+      ])
       .mockResolvedValueOnce([]);
     responseRepository.createQueryBuilder.mockReturnValue(responseQueryBuilder);
-    codingFileCacheService.getVariablePageMap.mockImplementation(async (unitName: string) => new Map([
-      [unitName === 'UNIT_A' ? 'VAR_A' : 'VAR_B', unitName === 'UNIT_A' ? '0' : '1']
-    ]));
+    codingFileCacheService.getVariablePageMap.mockImplementation(async (unitName: string) => {
+      const variableId = unitName.replace('UNIT_', 'VAR_');
+      const pageByUnit: Record<string, string> = {
+        UNIT_A: '0',
+        UNIT_B: '1',
+        UNIT_C: '2'
+      };
+      return new Map([[variableId, pageByUnit[unitName]]]);
+    });
 
     const result = await service.getCodingJobUnits(10, true);
 
@@ -5095,6 +5142,16 @@ describe('CodingJobService', () => {
         score: 2,
         source: 'manual',
         variablePage: '1'
+      }),
+      expect.objectContaining({
+        responseId: 102,
+        unitName: 'UNIT_C',
+        variableId: 'VAR_C',
+        status: 'auto-coded',
+        code: -98,
+        score: 0,
+        source: 'auto',
+        variablePage: '2'
       })
     ]);
   });

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -4861,6 +4861,78 @@ describe('CodingJobService', () => {
     });
   });
 
+  it('prefers a prepared response result over an open bundle job unit', () => {
+    const resolveStatus = (
+      service as unknown as {
+        getCodingJobBundleVariableStatus: (
+          response: ResponseEntity,
+          manualUnit: CodingJobUnit
+        ) => {
+          status: string;
+          code: number | null;
+          score: number | null;
+          source: string;
+        };
+      }
+    ).getCodingJobBundleVariableStatus.bind(service);
+    const response = {
+      code_v1: null,
+      score_v1: null,
+      code_v2: -98,
+      score_v2: 0,
+      code_v3: null,
+      score_v3: null,
+      is_autocoder_generated: false
+    } as ResponseEntity;
+
+    expect(resolveStatus(response, {
+      code: null,
+      score: null,
+      is_open: true
+    } as CodingJobUnit)).toEqual({
+      status: 'auto-coded',
+      code: -98,
+      score: 0,
+      source: 'auto'
+    });
+  });
+
+  it('keeps a manual bundle decision authoritative over a response result', () => {
+    const resolveStatus = (
+      service as unknown as {
+        getCodingJobBundleVariableStatus: (
+          response: ResponseEntity,
+          manualUnit: CodingJobUnit
+        ) => {
+          status: string;
+          code: number | null;
+          score: number | null;
+          source: string;
+        };
+      }
+    ).getCodingJobBundleVariableStatus.bind(service);
+    const response = {
+      code_v1: null,
+      score_v1: null,
+      code_v2: -98,
+      score_v2: 0,
+      code_v3: null,
+      score_v3: null,
+      is_autocoder_generated: false
+    } as ResponseEntity;
+
+    expect(resolveStatus(response, {
+      code: 7,
+      score: 2,
+      is_open: false
+    } as CodingJobUnit)).toEqual({
+      status: 'manual-coded',
+      code: 7,
+      score: 2,
+      source: 'manual'
+    });
+  });
+
   it('uses all visible bundle units for bundle context when only open units are returned', async () => {
     const openUnit = {
       response_id: 99,

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -4564,12 +4564,38 @@ export class CodingJobService {
       score: number | null;
       source: 'manual' | 'auto' | 'none';
     } {
-    if (manualUnit) {
-      const hasManualCode =
-        manualUnit.code !== null &&
-        manualUnit.code !== undefined;
+    const latestCode = response ? getLatestCode(response) : null;
+    const hasManualCode =
+      manualUnit?.code !== null &&
+      manualUnit?.code !== undefined;
+
+    // Keep an actual manual decision authoritative. If the job unit has no
+    // decision, a response result written after job creation (for example by
+    // empty-response coding) must still be shown as automatically coded.
+    if (manualUnit && hasManualCode) {
       return {
-        status: hasManualCode || manualUnit.is_open === false ?
+        status: 'manual-coded',
+        code: manualUnit.code ?? null,
+        score: manualUnit.score ?? null,
+        source: 'manual'
+      };
+    }
+
+    if (
+      response &&
+      (response.is_autocoder_generated === true || latestCode?.code !== null)
+    ) {
+      return {
+        status: 'auto-coded',
+        code: latestCode?.code ?? null,
+        score: latestCode?.score ?? null,
+        source: 'auto'
+      };
+    }
+
+    if (manualUnit) {
+      return {
+        status: manualUnit.is_open === false ?
           'manual-coded' :
           'manual-open',
         code: manualUnit.code ?? null,
@@ -4587,21 +4613,12 @@ export class CodingJobService {
       };
     }
 
-    const latestCode = getLatestCode(response);
-    if (
-      response.is_autocoder_generated === true ||
-      latestCode.code !== null ||
-      response.status_v1 !== null
-    ) {
+    if (response.status_v1 !== null) {
       return {
-        status: latestCode.code !== null || response.is_autocoder_generated === true ?
-          'auto-coded' :
-          'not-coded',
-        code: latestCode.code ?? null,
-        score: latestCode.score ?? null,
-        source: latestCode.code !== null || response.is_autocoder_generated === true ?
-          'auto' :
-          'none'
+        status: 'not-coded',
+        code: null,
+        score: null,
+        source: 'none'
       };
     }
 


### PR DESCRIPTION
## Summary

- prefer a finalized response result when a bundle job unit has no manual decision
- keep actual manual coding decisions authoritative
- cover prepared empty responses such as code_v2 = -98 in focused and full bundle-context regression tests

## Root cause

Bundle context status resolution returned the state of an existing coding job unit before checking whether preparation had already written a completed response result. As a result, empty bundle responses coded during response analysis could still be presented as open.

## Impact

Automatically coded bundle variables are now marked consistently in manual coding and replay, including when their coding job unit existed before preparation applied the result.

## Validation

- npx nx lint backend
- npx nx test backend --runInBand
- npx nx test frontend --testFile=apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts --runInBand
- git diff --check develop...HEAD

Refs #693.