### PR TITLE
Align aggregation coverage with completed response siblings

### DIFF
--- a/apps/backend/src/app/database/services/coding/aggregation-metrics.util.spec.ts
+++ b/apps/backend/src/app/database/services/coding/aggregation-metrics.util.spec.ts
@@ -1,5 +1,10 @@
 import {
+  buildAggregationPeerLookupKeys,
+  buildAggregationPeerKeys,
+  buildAggregationPeerUnitKeys,
   buildAggregationGroups,
+  countEffectiveManualCodingCases,
+  partitionResponsesByAggregationVariable,
   summarizeAggregationGroups
 } from './aggregation-metrics.util';
 
@@ -94,5 +99,222 @@ describe('aggregation metrics', () => {
       effectiveCases: 2,
       aggregationActive: false
     });
+  });
+
+  it('normalizes unit names in completed peer lookup keys like aggregation groups', () => {
+    const peerKeys = buildAggregationPeerKeys(
+      [
+        {
+          responseId: 1,
+          unitName: 'unit_base',
+          variableId: 'answer',
+          value: 'Same\u00a0answer'
+        }
+      ],
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE'],
+      derivedVariables
+    );
+
+    expect(peerKeys).toEqual([
+      {
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        normalizedValue: 'sameanswer'
+      }
+    ]);
+  });
+
+  it('builds exact raw-value lookups only for normalized peer matches', () => {
+    const peerKeys = buildAggregationPeerKeys(
+      [{
+        responseId: 1,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'Same answer'
+      }],
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE'],
+      derivedVariables
+    );
+
+    expect(buildAggregationPeerLookupKeys(
+      peerKeys,
+      [
+        {
+          unitName: 'unit_base',
+          variableId: 'answer',
+          value: ' sameanswer '
+        },
+        {
+          unitName: 'UNIT_BASE',
+          variableId: 'answer',
+          value: 'different'
+        },
+        {
+          unitName: 'OTHER_UNIT',
+          variableId: 'answer',
+          value: 'Same answer'
+        }
+      ],
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE']
+    )).toEqual([{
+      unitName: 'unit_base',
+      variableId: 'answer',
+      value: ' sameanswer '
+    }]);
+  });
+
+  it('keeps only exact unit aliases for requested canonical peer variables', () => {
+    expect(buildAggregationPeerUnitKeys(
+      [{
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        normalizedValue: 'same'
+      }],
+      [
+        { unitName: 'unit_base', variableId: 'answer' },
+        { unitName: 'UNIT_BASE', variableId: 'answer' },
+        { unitName: 'OTHER_UNIT', variableId: 'answer' },
+        { unitName: 'UNIT_BASE', variableId: 'other' }
+      ]
+    )).toEqual([
+      { unitName: 'unit_base', variableId: 'answer' },
+      { unitName: 'UNIT_BASE', variableId: 'answer' }
+    ]);
+  });
+
+  it('assigns all unit-name case variants to one canonical variable partition', () => {
+    const responses = [
+      { unitName: 'unit_base', variableId: 'answer', responseId: 1 },
+      { unitName: 'UNIT_BASE', variableId: 'answer', responseId: 2 },
+      { unitName: 'Unit_Base', variableId: 'answer', responseId: 3 }
+    ];
+    const partitions = partitionResponsesByAggregationVariable(
+      responses,
+      [
+        { unitName: 'unit_base', variableId: 'answer' },
+        { unitName: 'UNIT_BASE', variableId: 'answer' }
+      ],
+      response => response
+    );
+
+    expect(partitions.get('UNIT_BASE::answer')?.map(r => r.responseId)).toEqual([
+      1,
+      2,
+      3
+    ]);
+    expect(partitions.size).toBe(1);
+  });
+
+  it('assigns a differently cased peer when there is one unambiguous variable', () => {
+    const responses = [
+      { unitName: 'UNIT_BASE', variableId: 'answer', responseId: 1 }
+    ];
+    const partitions = partitionResponsesByAggregationVariable(
+      responses,
+      [{ unitName: 'unit_base', variableId: 'answer' }],
+      response => response
+    );
+
+    expect(partitions.get('UNIT_BASE::answer')?.map(r => r.responseId)).toEqual([1]);
+  });
+
+  it('keeps an open sibling covered by an assigned completed aggregation group', () => {
+    const responses = [
+      {
+        responseId: 1,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'Same answer',
+        personLogin: 'person-1'
+      },
+      {
+        responseId: 2,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: ' sameanswer ',
+        personLogin: 'person-2'
+      }
+    ];
+
+    const counts = countEffectiveManualCodingCases(
+      responses,
+      new Set([1]),
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE'],
+      2,
+      derivedVariables,
+      new Set([2])
+    );
+
+    expect(counts).toEqual({ uniqueCases: 1, casesInJobs: 1 });
+  });
+
+  it('does not transfer coverage when the full group stays below the threshold', () => {
+    const responses = [
+      {
+        responseId: 1,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'Same answer',
+        personLogin: 'person-1'
+      },
+      {
+        responseId: 2,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'sameanswer',
+        personLogin: 'person-2'
+      }
+    ];
+
+    const counts = countEffectiveManualCodingCases(
+      responses,
+      new Set([1]),
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE'],
+      3,
+      derivedVariables,
+      new Set([2])
+    );
+
+    expect(counts).toEqual({ uniqueCases: 1, casesInJobs: 0 });
+  });
+
+  it('deduplicates same-person responses across unit-name case variants', () => {
+    const responses = [
+      {
+        responseId: 1,
+        unitName: 'unit_base',
+        variableId: 'answer',
+        value: 'same',
+        bookletName: 'booklet',
+        personLogin: 'person-1'
+      },
+      {
+        responseId: 2,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'same',
+        bookletName: 'booklet',
+        personLogin: 'person-1'
+      },
+      {
+        responseId: 3,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'same',
+        bookletName: 'booklet',
+        personLogin: 'person-2'
+      }
+    ];
+
+    const counts = countEffectiveManualCodingCases(
+      responses,
+      new Set([3]),
+      [],
+      3,
+      derivedVariables,
+      new Set([2])
+    );
+
+    expect(counts).toEqual({ uniqueCases: 1, casesInJobs: 0 });
   });
 });

--- a/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
+++ b/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
@@ -31,6 +31,116 @@ export interface EffectiveManualCodingCaseCounts {
   casesInJobs: number;
 }
 
+export interface AggregationPeerKey {
+  unitName: string;
+  variableId: string;
+  normalizedValue: string;
+}
+
+export interface AggregationPeerValueCandidate {
+  unitName: string;
+  variableId: string;
+  value: string | null;
+}
+
+export interface AggregationPeerUnitKey {
+  unitName: string;
+  variableId: string;
+}
+
+export interface AggregationPeerLookupKey {
+  unitName: string;
+  variableId: string;
+  value: string;
+}
+
+export function buildAggregationPeerUnitKeys(
+  peerKeys: readonly AggregationPeerKey[],
+  candidates: readonly AggregationPeerUnitKey[]
+): AggregationPeerUnitKey[] {
+  const peerVariableKeys = new Set(peerKeys.map(peerKey => (
+    getAggregationVariableKey(peerKey.unitName, peerKey.variableId)
+  )));
+  const unitKeys = new Map<string, AggregationPeerUnitKey>();
+
+  candidates.forEach(candidate => {
+    if (!peerVariableKeys.has(getAggregationVariableKey(
+      candidate.unitName,
+      candidate.variableId
+    ))) {
+      return;
+    }
+
+    unitKeys.set(
+      JSON.stringify([candidate.unitName, candidate.variableId]),
+      candidate
+    );
+  });
+
+  return Array.from(unitKeys.values());
+}
+
+export function buildAggregationPeerLookupKeys(
+  peerKeys: readonly AggregationPeerKey[],
+  candidates: readonly AggregationPeerValueCandidate[],
+  matchingFlags: readonly AggregationMatchingFlag[]
+): AggregationPeerLookupKey[] {
+  const peerKeySet = new Set(peerKeys.map(serializeAggregationPeerKey));
+  const lookupKeys = new Map<string, AggregationPeerLookupKey>();
+
+  candidates.forEach(candidate => {
+    if (!isAggregatableValue(candidate.value)) {
+      return;
+    }
+
+    const peerKey = getAggregationPeerKey(
+      candidate.unitName,
+      candidate.variableId,
+      candidate.value,
+      matchingFlags
+    );
+    if (!peerKeySet.has(serializeAggregationPeerKey(peerKey))) {
+      return;
+    }
+
+    const lookupKey = {
+      unitName: candidate.unitName,
+      variableId: candidate.variableId,
+      value: candidate.value as string
+    };
+    lookupKeys.set(JSON.stringify([
+      lookupKey.unitName,
+      lookupKey.variableId,
+      lookupKey.value
+    ]), lookupKey);
+  });
+
+  return Array.from(lookupKeys.values());
+}
+
+export function serializeAggregationPeerKey(
+  peerKey: AggregationPeerKey
+): string {
+  return JSON.stringify([
+    peerKey.unitName,
+    peerKey.variableId,
+    peerKey.normalizedValue
+  ]);
+}
+
+export function getAggregationPeerKey(
+  unitName: string,
+  variableId: string,
+  value: string | null,
+  matchingFlags: readonly AggregationMatchingFlag[]
+): AggregationPeerKey {
+  return {
+    unitName: unitName.toUpperCase(),
+    variableId,
+    normalizedValue: normalizeAggregationValue(value, matchingFlags)
+  };
+}
+
 export function normalizeAggregationValue(
   value: string | null,
   flags: readonly AggregationMatchingFlag[]
@@ -65,6 +175,78 @@ export function isDerivedAggregationVariable(
   return derivedVariableMap.get(unitName.toUpperCase())?.has(variableId) ?? false;
 }
 
+export function getAggregationVariableKey(
+  unitName: string,
+  variableId: string
+): string {
+  return `${unitName.toUpperCase()}::${variableId}`;
+}
+
+export function partitionResponsesByAggregationVariable<T>(
+  responses: readonly T[],
+  variables: readonly { unitName: string; variableId: string }[],
+  getVariableReference: (response: T) => {
+    unitName: string;
+    variableId: string;
+  }
+): Map<string, T[]> {
+  const variableKeys = new Set(
+    variables.map(variable => getAggregationVariableKey(
+      variable.unitName,
+      variable.variableId
+    ))
+  );
+
+  const partitionedResponses = new Map<string, T[]>();
+  responses.forEach(response => {
+    const reference = getVariableReference(response);
+    const variableKey = getAggregationVariableKey(
+      reference.unitName,
+      reference.variableId
+    );
+    if (!variableKeys.has(variableKey)) {
+      return;
+    }
+
+    const variableResponses = partitionedResponses.get(variableKey) || [];
+    variableResponses.push(response);
+    partitionedResponses.set(variableKey, variableResponses);
+  });
+
+  return partitionedResponses;
+}
+
+export function buildAggregationPeerKeys<T extends AggregationSourceResponse>(
+  responses: T[],
+  matchingFlags: readonly AggregationMatchingFlag[],
+  derivedVariableMap: Map<string, Set<string>>
+): AggregationPeerKey[] {
+  const keys = new Map<string, AggregationPeerKey>();
+
+  responses.forEach(response => {
+    if (
+      !isAggregatableValue(response.value) ||
+      isDerivedAggregationVariable(
+        derivedVariableMap,
+        response.unitName,
+        response.variableId
+      )
+    ) {
+      return;
+    }
+
+    const peerKey = getAggregationPeerKey(
+      response.unitName,
+      response.variableId,
+      response.value,
+      matchingFlags
+    );
+    keys.set(serializeAggregationPeerKey(peerKey), peerKey);
+  });
+
+  return Array.from(keys.values());
+}
+
 export function getManualCodingDeduplicationKey(
   response: ManualCodingDeduplicationResponse
 ): string {
@@ -74,7 +256,7 @@ export function getManualCodingDeduplicationKey(
     response.personCode || '',
     response.personGroup || '',
     response.bookletName || '',
-    response.unitName,
+    response.unitName.toUpperCase(),
     response.variableId,
     valueHash
   ].join('::');
@@ -101,7 +283,8 @@ export function countEffectiveManualCodingCases<T extends ManualCodingDeduplicat
   assignedResponseIds: ReadonlySet<number>,
   matchingFlags: readonly AggregationMatchingFlag[],
   threshold: number | null,
-  derivedVariableMap: Map<string, Set<string>>
+  derivedVariableMap: Map<string, Set<string>>,
+  activeResponseIds?: ReadonlySet<number>
 ): EffectiveManualCodingCaseCounts {
   const assignedDeduplicationKeys = new Set(
     responses
@@ -117,6 +300,19 @@ export function countEffectiveManualCodingCases<T extends ManualCodingDeduplicat
       ))
       .map(response => response.responseId)
   );
+  const activeDeduplicationKeys = activeResponseIds ? new Set(
+    responses
+      .filter(response => activeResponseIds.has(response.responseId))
+      .map(response => getManualCodingDeduplicationKey(response))
+  ) : null;
+  const activeDedupedResponseIds = activeResponseIds ? new Set(
+    dedupedResponses
+      .filter(response => (
+        activeResponseIds.has(response.responseId) ||
+        activeDeduplicationKeys?.has(getManualCodingDeduplicationKey(response))
+      ))
+      .map(response => response.responseId)
+  ) : null;
   const aggregatedGroups = buildAggregationGroups(
     dedupedResponses,
     matchingFlags,
@@ -127,6 +323,14 @@ export function countEffectiveManualCodingCases<T extends ManualCodingDeduplicat
   let casesInJobs = 0;
 
   for (const group of aggregatedGroups) {
+    const activeResponses = activeDedupedResponseIds ?
+      group.responses.filter(response => activeDedupedResponseIds.has(response.responseId)) :
+      group.responses;
+
+    if (activeResponses.length === 0) {
+      continue;
+    }
+
     if (threshold !== null && group.responses.length >= threshold) {
       uniqueCases += 1;
       if (group.responses.some(response => assignedDedupedResponseIds.has(response.responseId))) {
@@ -135,8 +339,8 @@ export function countEffectiveManualCodingCases<T extends ManualCodingDeduplicat
       continue;
     }
 
-    uniqueCases += group.responses.length;
-    casesInJobs += group.responses
+    uniqueCases += activeResponses.length;
+    casesInJobs += activeResponses
       .filter(response => assignedDedupedResponseIds.has(response.responseId))
       .length;
   }
@@ -156,7 +360,10 @@ export function buildAggregationGroups<T extends AggregationSourceResponse>(
   const groupedResponses = new Map<string, T[]>();
 
   for (const response of responses) {
-    const variableKey = `${response.unitName.toUpperCase()}::${response.variableId}`;
+    const variableKey = getAggregationVariableKey(
+      response.unitName,
+      response.variableId
+    );
     const keepSeparate =
       !aggregationActive ||
       !isAggregatableValue(response.value) ||

--- a/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
@@ -1,9 +1,9 @@
 export function getCodingIncompleteVariablesCacheKey(workspaceId: number): string {
-  return `coding_incomplete_variables_v8:${workspaceId}`;
+  return `coding_incomplete_variables_v9:${workspaceId}`;
 }
 
 export function getCodingIncompleteVariablesScopeCacheKey(workspaceId: number): string {
-  return `coding_incomplete_variables_scope_v1:${workspaceId}`;
+  return `coding_incomplete_variables_scope_v2:${workspaceId}`;
 }
 
 export function getCodingIncompleteVariablesCacheVersionKey(workspaceId: number): string {

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -286,8 +286,8 @@ describe('CodingJobService distribution from job definitions', () => {
 
     expect(result.success).toBe(true);
     expect(cacheService.incr).toHaveBeenCalledWith('coding_incomplete_variables_version:5');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v8:5');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v1:5');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v9:5');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v2:5');
     expect(result.distribution).toEqual(preview.distribution);
     expect(result.doubleCodingInfo).toEqual(preview.doubleCodingInfo);
     expect(result.jobsCreated).toBe(createdJobCalls.length);

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -1761,10 +1761,10 @@ describe('CodingJobService', () => {
       'coding_incomplete_variables_version:7'
     );
     expect(cacheService.delete).toHaveBeenCalledWith(
-      'coding_incomplete_variables_v8:7'
+      'coding_incomplete_variables_v9:7'
     );
     expect(cacheService.delete).toHaveBeenCalledWith(
-      'coding_incomplete_variables_scope_v1:7'
+      'coding_incomplete_variables_scope_v2:7'
     );
   });
 
@@ -2276,6 +2276,171 @@ describe('CodingJobService', () => {
     ).resolves.toEqual([]);
 
     expectManualCodingCandidateStatusFilter(qb);
+    expect(qb.addSelect).toHaveBeenCalledWith(
+      'response.status_v2',
+      'statusV2'
+    );
+  });
+
+  it('loads completed aggregation peers only for normalized active response values', async () => {
+    const activeQuery = createQueryBuilder([
+      {
+        id: '2',
+        variableid: 'VAR',
+        value: 'Same\u00a0answer',
+        statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+        statusV2: null,
+        unitName: 'UNIT',
+        unitAlias: null,
+        bookletName: 'BOOKLET',
+        personLogin: 'person-2',
+        personCode: 'code-2',
+        personGroup: 'group'
+      }
+    ]);
+    const peerQuery = createQueryBuilder([
+      {
+        id: '1',
+        variableid: 'VAR',
+        value: ' sameanswer ',
+        statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+        statusV2: statusStringToNumber('CODING_COMPLETE'),
+        unitName: 'UNIT',
+        unitAlias: null,
+        bookletName: 'BOOKLET',
+        personLogin: 'person-1',
+        personCode: 'code-1',
+        personGroup: 'group'
+      },
+      {
+        id: '3',
+        variableid: 'VAR',
+        value: 'Different answer',
+        statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+        statusV2: statusStringToNumber('CODING_COMPLETE'),
+        unitName: 'UNIT',
+        unitAlias: null,
+        bookletName: 'BOOKLET',
+        personLogin: 'person-3',
+        personCode: 'code-3',
+        personGroup: 'group'
+      }
+    ]);
+    const peerValueQuery = createQueryBuilder([
+      { unitName: 'UNIT', variableId: 'VAR', value: ' sameanswer ' },
+      { unitName: 'Unit', variableId: 'VAR', value: 'Same answer' }
+    ]);
+    const peerUnitQuery = createQueryBuilder([
+      { unitName: 'UNIT', variableId: 'VAR' },
+      { unitName: 'Unit', variableId: 'VAR' },
+      { unitName: 'OTHER_UNIT', variableId: 'VAR' }
+    ]);
+    responseRepository.createQueryBuilder
+      .mockReturnValueOnce(activeQuery)
+      .mockReturnValueOnce(peerUnitQuery)
+      .mockReturnValueOnce(peerValueQuery)
+      .mockReturnValueOnce(peerQuery);
+
+    const result = await service.getSlimResponsesForVariableCoverage(
+      3,
+      [{ unitName: 'UNIT', variableId: 'VAR' }],
+      [ResponseMatchingFlag.IGNORE_CASE, ResponseMatchingFlag.IGNORE_WHITESPACE],
+      2,
+      new Map()
+    );
+
+    expect(result.map(response => response.id)).toEqual([2, 1]);
+    expect(peerQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('jsonb_to_recordset'),
+      expect.objectContaining({
+        aggregationPeerKeys: expect.stringContaining('sameanswer')
+      })
+    );
+    expect(peerValueQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('aggregation_peer_unit'),
+      {
+        aggregationPeerUnits: JSON.stringify([
+          { unitName: 'UNIT', variableId: 'VAR' },
+          { unitName: 'Unit', variableId: 'VAR' }
+        ])
+      }
+    );
+    expect(peerQuery.andWhere).toHaveBeenCalledWith(
+      'response.status_v2 = :completedStatus',
+      { completedStatus: statusStringToNumber('CODING_COMPLETE') }
+    );
+    expect(peerQuery.andWhere).toHaveBeenCalledWith(
+      '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+      { aggregatedCode: -111, defaultMirCode: 99 }
+    );
+    const peerLookupCondition = peerQuery.andWhere.mock.calls.find(
+      ([condition]) => typeof condition === 'string' &&
+        condition.includes('jsonb_to_recordset')
+    )?.[0] as string;
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."value" = response.value'
+    );
+    expect(peerLookupCondition).not.toContain('UPPER(unit.name)');
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."unitName" = unit.name'
+    );
+    expect(peerQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('jsonb_to_recordset'),
+      expect.objectContaining({
+        aggregationPeerKeys: expect.stringContaining('"unitName":"Unit"')
+      })
+    );
+  });
+
+  it('filters completed aggregation peers by value in SQL for exact matching', async () => {
+    const activeQuery = createQueryBuilder([{
+      id: '2',
+      variableid: 'VAR',
+      value: 'exact answer',
+      statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+      statusV2: null,
+      unitName: 'UNIT',
+      unitAlias: null,
+      bookletName: 'BOOKLET',
+      personLogin: 'person-2',
+      personCode: 'code-2',
+      personGroup: 'group'
+    }]);
+    const peerValueQuery = createQueryBuilder([
+      { unitName: 'UNIT', variableId: 'VAR', value: 'exact answer' }
+    ]);
+    const peerUnitQuery = createQueryBuilder([
+      { unitName: 'UNIT', variableId: 'VAR' }
+    ]);
+    const peerQuery = createQueryBuilder([]);
+    responseRepository.createQueryBuilder
+      .mockReturnValueOnce(activeQuery)
+      .mockReturnValueOnce(peerUnitQuery)
+      .mockReturnValueOnce(peerValueQuery)
+      .mockReturnValueOnce(peerQuery);
+
+    await service.getSlimResponsesForVariableCoverage(
+      3,
+      [{ unitName: 'UNIT', variableId: 'VAR' }],
+      [],
+      2,
+      new Map()
+    );
+
+    const peerLookupCondition = peerQuery.andWhere.mock.calls.find(
+      ([condition]) => typeof condition === 'string' &&
+        condition.includes('jsonb_to_recordset')
+    )?.[0] as string;
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."value" = response.value'
+    );
+    const peerValueCondition = peerValueQuery.andWhere.mock.calls.find(
+      ([condition]) => typeof condition === 'string' &&
+        condition.includes('aggregation_peer_value')
+    )?.[0] as string;
+    expect(peerValueCondition).toContain(
+      'aggregation_peer_value."normalizedValue" = response.value'
+    );
   });
 
   it('includes DERIVE_ERROR responses for job-definition variables that opt into manual coding', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -50,10 +50,16 @@ import {
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
 import {
+  buildAggregationPeerLookupKeys,
+  buildAggregationPeerKeys,
+  buildAggregationPeerUnitKeys,
   buildAggregationGroups,
   deduplicateManualCodingResponses,
+  getAggregationPeerKey,
   getManualCodingDeduplicationKey,
-  ManualCodingDeduplicationResponse
+  isAggregatableValue,
+  ManualCodingDeduplicationResponse,
+  serializeAggregationPeerKey
 } from './aggregation-metrics.util';
 import {
   formatCodingTestPersonFromUnit,
@@ -87,6 +93,7 @@ import {
 import {
   applyNonCodingIssueReviewJobFilter,
   CODING_JOB_TYPE_CODING_ISSUE_REVIEW,
+  getNonCodingIssueReviewJobSqlCondition,
   isCodingIssueReviewJobType
 } from './coding-job-type.util';
 import { statusStringToNumber } from '../../utils/response-status-converter';
@@ -399,6 +406,7 @@ interface SlimResponse {
   variableid: string;
   value: string | null;
   statusV1?: number | null;
+  statusV2?: number | null;
   unitName: string;
   unitAlias: string | null;
   bookletName: string;
@@ -5753,6 +5761,7 @@ export class CodingJobService {
       .addSelect('response.variableid', 'variableid')
       .addSelect('response.value', 'value')
       .addSelect('response.status_v1', 'statusV1')
+      .addSelect('response.status_v2', 'statusV2')
       .addSelect('unit.name', 'unitName')
       .addSelect('unit.alias', 'unitAlias')
       .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
@@ -5809,6 +5818,10 @@ export class CodingJobService {
         r.statusV1 !== undefined && r.statusV1 !== null ?
           Number(r.statusV1) :
           null,
+      statusV2:
+        r.statusV2 !== undefined && r.statusV2 !== null ?
+          Number(r.statusV2) :
+          null,
       unitName: r.unitName ?? '',
       unitAlias: r.unitAlias ?? null,
       bookletName: r.bookletName ?? '',
@@ -5816,6 +5829,192 @@ export class CodingJobService {
       personCode: r.personCode ?? '',
       personGroup: r.personGroup ?? ''
     }));
+  }
+
+  async getSlimResponsesForVariableCoverage(
+    workspaceId: number,
+    variables: VariableReference[],
+    matchingFlags: ResponseMatchingFlag[],
+    aggregationThreshold: number | null,
+    derivedVariableMap: Map<string, Set<string>>
+  ): Promise<SlimResponse[]> {
+    const activeResponses = await this.getSlimResponsesForVariables(
+      workspaceId,
+      variables
+    );
+    const aggregationActive = aggregationThreshold !== null &&
+      !matchingFlags.includes(ResponseMatchingFlag.NO_AGGREGATION);
+
+    if (!aggregationActive || activeResponses.length === 0) {
+      return activeResponses;
+    }
+
+    const peerKeys = buildAggregationPeerKeys(
+      activeResponses.map(response => ({
+        responseId: response.id,
+        unitName: response.unitName,
+        variableId: response.variableid,
+        value: response.value
+      })),
+      matchingFlags,
+      derivedVariableMap
+    );
+
+    if (peerKeys.length === 0) {
+      return activeResponses;
+    }
+
+    const completedStatus = statusStringToNumber('CODING_COMPLETE');
+    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
+    const peerKeySet = new Set(
+      peerKeys.map(peerKey => serializeAggregationPeerKey(peerKey))
+    );
+    const exactValueMatching =
+      !matchingFlags.includes(ResponseMatchingFlag.IGNORE_CASE) &&
+      !matchingFlags.includes(ResponseMatchingFlag.IGNORE_WHITESPACE);
+    const createCompletedPeerQuery = (): SelectQueryBuilder<ResponseEntity> => {
+      const query = this.responseRepository
+        .createQueryBuilder('response')
+        .innerJoin('response.unit', 'unit')
+        .innerJoin('unit.booklet', 'booklet')
+        .leftJoin('booklet.bookletinfo', 'bookletinfo')
+        .innerJoin('booklet.person', 'person')
+        .where('person.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('person.consider = :consider', { consider: true })
+        .andWhere('response.status_v2 = :completedStatus', { completedStatus })
+        .andWhere(
+          '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+          { aggregatedCode: -111, defaultMirCode }
+        )
+        .andWhere(new Brackets(qb => {
+          qb.where('response.code_v2 IS NULL')
+            .orWhere(subQuery => {
+              const exists = subQuery
+                .subQuery()
+                .select('1')
+                .from('coding_job_unit', 'manual_cju')
+                .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
+                .where('manual_cju.response_id = response.id')
+                .andWhere('manual_cj.training_id IS NULL')
+                .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
+                .getQuery();
+              return `EXISTS (${exists})`;
+            });
+        }));
+      this.applyManualCodingCandidateStatusFilter(query, variables);
+      applyResolvedExclusionsToQuery(query, exclusions);
+      return query;
+    };
+
+    const peerVariableIds = Array.from(new Set(
+      peerKeys.map(peerKey => peerKey.variableId)
+    ));
+    const peerUnitQuery = createCompletedPeerQuery()
+      .select('DISTINCT unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .andWhere('response.variableid IN (:...peerVariableIds)', {
+        peerVariableIds
+      });
+    const peerUnitKeys = buildAggregationPeerUnitKeys(
+      peerKeys,
+      await peerUnitQuery.getRawMany()
+    );
+    if (peerUnitKeys.length === 0) {
+      return activeResponses;
+    }
+
+    const peerValueQuery = createCompletedPeerQuery()
+      .select('DISTINCT unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('response.value', 'value')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerUnits AS jsonb))
+            AS aggregation_peer_unit("unitName" text, "variableId" text)
+          WHERE aggregation_peer_unit."unitName" = unit.name
+            AND aggregation_peer_unit."variableId" = response.variableid
+        )`,
+        { aggregationPeerUnits: JSON.stringify(peerUnitKeys) }
+      );
+    if (exactValueMatching) {
+      peerValueQuery.andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerValues AS jsonb))
+            AS aggregation_peer_value("variableId" text, "normalizedValue" text)
+          WHERE aggregation_peer_value."variableId" = response.variableid
+            AND aggregation_peer_value."normalizedValue" = response.value
+        )`,
+        { aggregationPeerValues: JSON.stringify(peerKeys) }
+      );
+    }
+    const peerLookupKeys = buildAggregationPeerLookupKeys(
+      peerKeys,
+      await peerValueQuery.getRawMany(),
+      matchingFlags
+    );
+    if (peerLookupKeys.length === 0) {
+      return activeResponses;
+    }
+
+    const queryBuilder = createCompletedPeerQuery()
+      .select('response.id', 'id')
+      .addSelect('response.variableid', 'variableid')
+      .addSelect('response.value', 'value')
+      .addSelect('response.status_v1', 'statusV1')
+      .addSelect('response.status_v2', 'statusV2')
+      .addSelect('unit.name', 'unitName')
+      .addSelect('unit.alias', 'unitAlias')
+      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
+      .addSelect("COALESCE(person.login, '')", 'personLogin')
+      .addSelect("COALESCE(person.code, '')", 'personCode')
+      .addSelect("COALESCE(person.group, '')", 'personGroup')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerKeys AS jsonb))
+            AS aggregation_peer("unitName" text, "variableId" text, "value" text)
+          WHERE aggregation_peer."unitName" = unit.name
+            AND aggregation_peer."variableId" = response.variableid
+            AND aggregation_peer."value" = response.value
+        )`,
+        { aggregationPeerKeys: JSON.stringify(peerLookupKeys) }
+      );
+    const raw = await queryBuilder.orderBy('response.id', 'ASC').getRawMany();
+    const completedPeers: SlimResponse[] = raw.map(r => ({
+      id: Number(r.id),
+      variableid: r.variableid,
+      value: r.value ?? null,
+      statusV1:
+        r.statusV1 !== undefined && r.statusV1 !== null ?
+          Number(r.statusV1) :
+          null,
+      statusV2:
+        r.statusV2 !== undefined && r.statusV2 !== null ?
+          Number(r.statusV2) :
+          null,
+      unitName: r.unitName ?? '',
+      unitAlias: r.unitAlias ?? null,
+      bookletName: r.bookletName ?? '',
+      personLogin: r.personLogin ?? '',
+      personCode: r.personCode ?? '',
+      personGroup: r.personGroup ?? ''
+    })).filter(response => (
+      isAggregatableValue(response.value) &&
+      peerKeySet.has(serializeAggregationPeerKey(getAggregationPeerKey(
+        response.unitName,
+        response.variableid,
+        response.value,
+        matchingFlags
+      )))
+    ));
+
+    return [...activeResponses, ...completedPeers];
   }
 
   private async getAssignedResponseIdsForVariables(

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -594,6 +594,60 @@ describe('CodingProgressService variable coverage conflicts', () => {
     ]);
   });
 
+  it('merges unit-name case variants into one covered variable', async () => {
+    const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+    responseRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([
+      {
+        unitName: 'UnitA',
+        variableId: 'manual-var',
+        statusV1: String(codingIncompleteStatus),
+        caseCount: '2'
+      },
+      {
+        unitName: 'UNITA',
+        variableId: 'manual-var',
+        statusV1: String(codingIncompleteStatus),
+        caseCount: '1'
+      }
+    ]));
+    workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
+      ['UNITA', new Set(['manual-var'])]
+    ]));
+    jobDefinitionRepository.find.mockResolvedValue([{
+      id: 10,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'unita', variableId: 'manual-var' }]
+    }]);
+    const casesInJobsQuery = createQueryBuilder([
+      { unitName: 'UnitA', variableId: 'manual-var', casesInJobs: '2' },
+      { unitName: 'UNITA', variableId: 'manual-var', casesInJobs: '1' }
+    ]);
+    codingJobUnitRepository.createQueryBuilder
+      .mockReturnValueOnce(casesInJobsQuery)
+      .mockReturnValueOnce(createQueryBuilder([]));
+
+    const result = await service.getVariableCoverageOverview(5);
+
+    expect(result).toMatchObject({
+      totalVariables: 1,
+      coveredVariables: 1,
+      fullyAbgedeckteVariablen: 1,
+      statusTotalVariables: 1
+    });
+    expect(result.variableCaseCounts).toEqual([{
+      unitName: 'UnitA',
+      variableId: 'manual-var',
+      caseCount: 3
+    }]);
+    expect(casesInJobsQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('variableCasesInJobsUnitName1'),
+      expect.objectContaining({
+        variableCasesInJobsUnitName0: 'UnitA',
+        variableCasesInJobsUnitName1: 'UNITA'
+      })
+    );
+  });
+
   it('excludes intended-incomplete variables without manual instructions from case coverage', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
@@ -779,9 +833,8 @@ describe('CodingProgressService variable coverage conflicts', () => {
     expect(result.coverageByStatus.conflicted).toEqual([]);
   });
 
-  it('classifies duplicate-aggregated variable coverage on effective cases', async () => {
+  it('classifies active duplicate-aggregated variable coverage on effective cases', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
-    const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
 
     settingRepository.findOne.mockImplementation(async ({ where }: { where: { key: string } }) => {
       if (where.key === 'workspace-5-duplicate-aggregation-threshold') {
@@ -802,7 +855,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
         caseCount: '3'
       }
     ]);
-    const variableResponsesQuery = createQueryBuilder([
+    const activeResponsesQuery = createQueryBuilder([
       {
         responseId: '100',
         unitName: 'AGG_UNIT',
@@ -841,24 +894,17 @@ describe('CodingProgressService variable coverage conflicts', () => {
         personLogin: 'login-3',
         personCode: 'code-3',
         personGroup: 'group-1'
-      },
-      {
-        responseId: '103',
-        unitName: 'AGG_UNIT',
-        variableId: '01',
-        value: 'already applied answer',
-        codeV2: null,
-        statusV2: String(codingCompleteStatus),
-        statusV1: String(codingIncompleteStatus),
-        bookletName: 'BookletA',
-        personLogin: 'login-4',
-        personCode: 'code-4',
-        personGroup: 'group-1'
       }
     ]);
+    const unitNamesQuery = createQueryBuilder([
+      { unitName: 'AGG_UNIT', variableId: '01' }
+    ]);
+    const completedPeersQuery = createQueryBuilder([]);
     responseRepository.createQueryBuilder
       .mockReturnValueOnce(incompleteVariablesQuery)
-      .mockReturnValueOnce(variableResponsesQuery);
+      .mockReturnValueOnce(activeResponsesQuery)
+      .mockReturnValueOnce(unitNamesQuery)
+      .mockReturnValueOnce(completedPeersQuery);
     workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
       ['AGG_UNIT', new Set(['01'])]
     ]));
@@ -883,6 +929,104 @@ describe('CodingProgressService variable coverage conflicts', () => {
     expect(result.variableCaseCounts).toEqual([
       { unitName: 'AGG_UNIT', variableId: '01', caseCount: 3 }
     ]);
+    expect(assignedResponseIdsQuery.andWhere).toHaveBeenCalledWith(
+      'cju.response_id IN (:...responseIds)',
+      { responseIds: [100, 101, 102] }
+    );
+  });
+
+  it('keeps an open response covered after its assigned aggregation sibling completed', async () => {
+    const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+    const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
+
+    settingRepository.findOne.mockImplementation(async ({ where }: { where: { key: string } }) => {
+      if (where.key === 'workspace-5-duplicate-aggregation-threshold') {
+        return { content: '2' };
+      }
+
+      if (where.key === 'workspace-5-response-matching-mode') {
+        return { content: JSON.stringify({ flags: ['IGNORE_CASE', 'IGNORE_WHITESPACE'] }) };
+      }
+
+      return null;
+    });
+    const incompleteVariablesQuery = createQueryBuilder([
+      {
+        unitName: 'AGG_UNIT',
+        variableId: '01',
+        statusV1: String(codingIncompleteStatus),
+        caseCount: '1'
+      }
+    ]);
+    const variableResponsesQuery = createQueryBuilder([
+      {
+        responseId: '100',
+        unitName: 'AGG_UNIT',
+        variableId: '01',
+        value: 'Same answer',
+        codeV2: null,
+        statusV2: null,
+        statusV1: String(codingIncompleteStatus),
+        bookletName: 'BookletA',
+        personLogin: 'login-1',
+        personCode: 'code-1',
+        personGroup: 'group-1'
+      }
+    ]);
+    const completedPeersQuery = createQueryBuilder([
+      {
+        responseId: '103',
+        unitName: 'agg_unit',
+        variableId: '01',
+        value: ' sameanswer ',
+        codeV2: '1',
+        statusV2: String(codingCompleteStatus),
+        statusV1: String(codingIncompleteStatus),
+        bookletName: 'BookletA',
+        personLogin: 'login-4',
+        personCode: 'code-4',
+        personGroup: 'group-1'
+      }
+    ]);
+    const peerValueQuery = createQueryBuilder([
+      { unitName: 'AGG_UNIT', variableId: '01', value: 'Same answer' },
+      { unitName: 'agg_unit', variableId: '01', value: ' sameanswer ' }
+    ]);
+    const peerUnitQuery = createQueryBuilder([
+      { unitName: 'AGG_UNIT', variableId: '01' },
+      { unitName: 'agg_unit', variableId: '01' },
+      { unitName: 'OTHER_UNIT', variableId: '01' }
+    ]);
+    responseRepository.createQueryBuilder
+      .mockReturnValueOnce(incompleteVariablesQuery)
+      .mockReturnValueOnce(variableResponsesQuery)
+      .mockReturnValueOnce(peerUnitQuery)
+      .mockReturnValueOnce(peerValueQuery)
+      .mockReturnValueOnce(completedPeersQuery);
+    workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
+      ['AGG_UNIT', new Set(['01'])]
+    ]));
+    jobDefinitionRepository.find.mockResolvedValue([
+      {
+        id: 40,
+        status: 'approved',
+        assigned_variables: [{ unitName: 'AGG_UNIT', variableId: '01' }]
+      }
+    ]);
+    const assignedResponseIdsQuery = createQueryBuilder([{ responseId: '103' }]);
+    codingJobUnitRepository.createQueryBuilder
+      .mockReturnValueOnce(assignedResponseIdsQuery)
+      .mockReturnValueOnce(createQueryBuilder([]));
+
+    const result = await service.getVariableCoverageOverview(5);
+
+    expect(result.totalVariables).toBe(1);
+    expect(result.coveredVariables).toBe(1);
+    expect(result.fullyAbgedeckteVariablen).toBe(1);
+    expect(result.partiallyAbgedeckteVariablen).toBe(0);
+    expect(result.variableCaseCounts).toEqual([
+      { unitName: 'AGG_UNIT', variableId: '01', caseCount: 1 }
+    ]);
     expect(variableResponsesQuery.andWhere).toHaveBeenCalledWith(
       expect.stringContaining('unit.name = :variableCoverageResponsesUnitName0'),
       expect.objectContaining({
@@ -890,12 +1034,44 @@ describe('CodingProgressService variable coverage conflicts', () => {
         variableCoverageResponsesVariableId0: '01'
       })
     );
+    expect(variableResponsesQuery.andWhere).toHaveBeenCalledWith(
+      '(response.status_v2 IS NULL OR response.status_v2 != :completedV2Status)',
+      { completedV2Status: codingCompleteStatus }
+    );
+    expect(completedPeersQuery.andWhere).toHaveBeenCalledWith(
+      'response.status_v2 = :completedV2Status',
+      { completedV2Status: codingCompleteStatus }
+    );
+    expect(completedPeersQuery.andWhere).toHaveBeenCalledWith(
+      '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+      {
+        aggregatedCode: -111,
+        defaultMirCode: expect.any(Number)
+      }
+    );
+    const peerLookupCondition = completedPeersQuery.andWhere.mock.calls.find(
+      ([condition]) => typeof condition === 'string' &&
+        condition.includes('jsonb_to_recordset')
+    )?.[0] as string;
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."value" = response.value'
+    );
+    expect(peerLookupCondition).not.toContain('UPPER(unit.name)');
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."unitName" = unit.name'
+    );
+    expect(peerValueQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('aggregation_peer_unit'),
+      {
+        aggregationPeerUnits: JSON.stringify([
+          { unitName: 'AGG_UNIT', variableId: '01' },
+          { unitName: 'agg_unit', variableId: '01' }
+        ])
+      }
+    );
     expect(assignedResponseIdsQuery.andWhere).toHaveBeenCalledWith(
-      expect.stringContaining('cju.unit_name = :assignedVariableCoverageUnitName0'),
-      expect.objectContaining({
-        assignedVariableCoverageUnitName0: 'AGG_UNIT',
-        assignedVariableCoverageVariableId0: '01'
-      })
+      'cju.response_id IN (:...responseIds)',
+      { responseIds: [100, 103] }
     );
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
-  Brackets, In, Repository
+  Brackets, In, Repository, SelectQueryBuilder
 } from 'typeorm';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { ResponseEntity } from '../../entities/response.entity';
@@ -16,9 +16,17 @@ import {
 } from '../workspace/workspace-exclusion.service';
 import { CacheService } from '../../../cache/cache.service';
 import {
+  buildAggregationPeerLookupKeys,
+  buildAggregationPeerKeys,
+  buildAggregationPeerUnitKeys,
   buildAggregationGroups,
   countEffectiveManualCodingCases,
+  getAggregationPeerKey,
+  getAggregationVariableKey,
+  isAggregatableValue,
   ManualCodingDeduplicationResponse,
+  partitionResponsesByAggregationVariable,
+  serializeAggregationPeerKey,
   summarizeAggregationGroups
 } from './aggregation-metrics.util';
 import { IQB_STANDARD_MISSING_CODES, MissingsProfilesService } from './missings-profiles.service';
@@ -132,6 +140,36 @@ interface VariableDefinitionReference {
 
 interface VariableCaseCount extends UnitVariableReference {
   caseCount: number;
+  unitNameAliases: string[];
+}
+
+type UnitVariableReferenceWithAliases = UnitVariableReference & {
+  unitNameAliases?: string[];
+};
+
+function getCoverageVariableKey(
+  unitName: string,
+  variableId: string
+): string {
+  return `${unitName.toUpperCase()}:${variableId}`;
+}
+
+function expandUnitNameAliases(
+  variables: UnitVariableReferenceWithAliases[]
+): UnitVariableReference[] {
+  const references = new Map<string, UnitVariableReference>();
+
+  variables.forEach(variable => {
+    const unitNames = variable.unitNameAliases?.length ?
+      variable.unitNameAliases :
+      [variable.unitName];
+    unitNames.forEach(unitName => {
+      const key = `${unitName}::${variable.variableId}`;
+      references.set(key, { unitName, variableId: variable.variableId });
+    });
+  });
+
+  return Array.from(references.values());
 }
 
 interface CrossDefinitionCaseRow {
@@ -1028,21 +1066,25 @@ export class CodingProgressService {
       const variableCaseCountMap = new Map<string, VariableCaseCount>();
 
       filteredIncompleteVariablesResult.forEach(row => {
-        const variableKey = `${row.unitName}:${row.variableId}`;
+        const variableKey = getCoverageVariableKey(row.unitName, row.variableId);
         const existing = variableCaseCountMap.get(variableKey);
         if (existing) {
           existing.caseCount += parseInt(row.caseCount, 10);
+          if (!existing.unitNameAliases.includes(row.unitName)) {
+            existing.unitNameAliases.push(row.unitName);
+          }
           return;
         }
         variableCaseCountMap.set(variableKey, {
           unitName: row.unitName,
           variableId: row.variableId,
-          caseCount: parseInt(row.caseCount, 10)
+          caseCount: parseInt(row.caseCount, 10),
+          unitNameAliases: [row.unitName]
         });
       });
 
       variableCaseCountMap.forEach(row => {
-        const variableKey = `${row.unitName}:${row.variableId}`;
+        const variableKey = getCoverageVariableKey(row.unitName, row.variableId);
         variablesNeedingCoding.add(variableKey);
         variableCaseCounts.push(row);
       });
@@ -1068,7 +1110,10 @@ export class CodingProgressService {
 
         if (definition.assigned_variables) {
           definition.assigned_variables.forEach(variable => {
-            const variableKey = `${variable.unitName}:${variable.variableId}`;
+            const variableKey = getCoverageVariableKey(
+              variable.unitName,
+              variable.variableId
+            );
             if (variablesNeedingCoding.has(variableKey)) {
               definitionVariables.add(variableKey);
             }
@@ -1086,7 +1131,10 @@ export class CodingProgressService {
           variableBundles.forEach(bundle => {
             if (bundle.variables) {
               bundle.variables.forEach(variable => {
-                const variableKey = `${variable.unitName}:${variable.variableId}`;
+                const variableKey = getCoverageVariableKey(
+                  variable.unitName,
+                  variable.variableId
+                );
                 if (variablesNeedingCoding.has(variableKey)) {
                   definitionVariables.add(variableKey);
                 }
@@ -1110,7 +1158,10 @@ export class CodingProgressService {
       }
 
       const coveredVariableCaseCounts = variableCaseCounts.filter(
-        variable => coveredVariables.has(`${variable.unitName}:${variable.variableId}`)
+        variable => coveredVariables.has(getCoverageVariableKey(
+          variable.unitName,
+          variable.variableId
+        ))
       );
       const effectiveVariableCaseCoverageMap =
         await this.getEffectiveVariableCasesInJobs(workspaceId, coveredVariableCaseCounts);
@@ -1140,12 +1191,15 @@ export class CodingProgressService {
 
         // Check if variable is fully or partially covered on the effective case level.
         const variableCaseInfo = variableCaseCounts.find(
-          v => `${v.unitName}:${v.variableId}` === variableKey
+          v => getCoverageVariableKey(v.unitName, v.variableId) === variableKey
         );
 
         if (variableCaseInfo) {
           const effectiveCoverage = effectiveVariableCaseCoverageMap.get(
-            `${variableCaseInfo.unitName}::${variableCaseInfo.variableId}`
+            getAggregationVariableKey(
+              variableCaseInfo.unitName,
+              variableCaseInfo.variableId
+            )
           ) || {
             effectiveTotalCasesToCode: variableCaseInfo.caseCount,
             effectiveCasesInJobs: 0
@@ -1191,7 +1245,11 @@ export class CodingProgressService {
         partiallyAbgedeckteVariablen: partiallyAbgedeckteCount,
         fullyAbgedeckteVariablen: fullyAbgedeckteCount,
         coveragePercentage,
-        variableCaseCounts,
+        variableCaseCounts: variableCaseCounts.map(({
+          unitName,
+          variableId,
+          caseCount
+        }) => ({ unitName, variableId, caseCount })),
         coverageByStatus: {
           draft: Array.from(coverageByStatus.draft),
           pending_review: Array.from(coverageByStatus.pending_review),
@@ -1204,7 +1262,10 @@ export class CodingProgressService {
           )
         },
         statusTotalVariables: new Set(
-          incompleteVariablesResult.map(row => `${row.unitName}:${row.variableId}`)
+          incompleteVariablesResult.map(row => getCoverageVariableKey(
+            row.unitName,
+            row.variableId
+          ))
         ).size,
         coveredSourceVariableCount:
           excludedSourceSummary.coveredSourceVariableCount,
@@ -1224,7 +1285,7 @@ export class CodingProgressService {
 
   private async getVariableCasesInJobs(
     workspaceId: number,
-    variables: UnitVariableReference[]
+    variables: UnitVariableReferenceWithAliases[]
   ): Promise<Map<string, number>> {
     if (variables.length === 0) {
       return new Map<string, number>();
@@ -1245,7 +1306,7 @@ export class CodingProgressService {
       })
       .groupBy('cju.unit_name')
       .addGroupBy('cju.variable_id');
-    this.applyVariableReferenceFilter(query, variables, {
+    this.applyVariableReferenceFilter(query, expandUnitNameAliases(variables), {
       unitNameExpression: 'cju.unit_name',
       variableIdExpression: 'cju.variable_id',
       parameterPrefix: 'variableCasesInJobs'
@@ -1265,8 +1326,11 @@ export class CodingProgressService {
     const casesInJobsMap = new Map<string, number>();
 
     rawResults.forEach(row => {
-      const key = `${row.unitName}::${row.variableId}`;
-      casesInJobsMap.set(key, parseInt(row.casesInJobs, 10));
+      const key = getAggregationVariableKey(row.unitName, row.variableId);
+      casesInJobsMap.set(
+        key,
+        (casesInJobsMap.get(key) || 0) + parseInt(row.casesInJobs, 10)
+      );
     });
 
     return casesInJobsMap;
@@ -1290,7 +1354,10 @@ export class CodingProgressService {
     if (!aggregationActive) {
       const casesInJobsMap = await this.getVariableCasesInJobs(workspaceId, variables);
       variables.forEach(variable => {
-        const key = `${variable.unitName}::${variable.variableId}`;
+        const key = getAggregationVariableKey(
+          variable.unitName,
+          variable.variableId
+        );
         result.set(key, {
           effectiveTotalCasesToCode: variable.caseCount,
           effectiveCasesInJobs: casesInJobsMap.get(key) || 0
@@ -1301,34 +1368,43 @@ export class CodingProgressService {
 
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
-    const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
-    const variableKeys = new Set(
-      variables.map(variable => `${variable.unitName}:${variable.variableId}`)
-    );
-    const [responses, assignedResponseIds, derivedVariableMap] = await Promise.all([
+    const [activeResponses, derivedVariableMap] = await Promise.all([
       this.getCoverageResponsesForVariables(workspaceId, variables),
-      this.getAssignedCoverageResponseIdsForVariables(workspaceId, variables),
       this.getDerivedVariableMap(workspaceId)
     ]);
-    const responsesByVariable = new Map<string, CoverageResponse[]>();
-
-    responses
-      .filter(response => (
-        response.statusV1 === codingIncompleteStatus ||
-        response.statusV1 === intendedIncompleteStatus
-      ))
-      .filter(response => response.statusV2 !== codingCompleteStatus)
-      .filter(response => variableKeys.has(`${response.unitName}:${response.variableId}`))
-      .forEach(response => {
-        const key = `${response.unitName}::${response.variableId}`;
-        const variableResponses = responsesByVariable.get(key) || [];
-        variableResponses.push(response);
-        responsesByVariable.set(key, variableResponses);
-      });
+    const completedPeers = await this.getCompletedCoveragePeersForResponses(
+      workspaceId,
+      activeResponses,
+      matchingFlags,
+      derivedVariableMap
+    );
+    const responses = [...activeResponses, ...completedPeers];
+    const assignedResponseIds = await this.getAssignedVariableCoverageResponseIds(
+      workspaceId,
+      responses.map(response => response.responseId)
+    );
+    const activeResponseIds = new Set(
+      activeResponses.map(response => response.responseId)
+    );
+    const responsesByVariable = partitionResponsesByAggregationVariable(
+      responses
+        .filter(response => (
+          response.statusV1 === codingIncompleteStatus ||
+          response.statusV1 === intendedIncompleteStatus
+        )),
+      variables,
+      response => ({
+        unitName: response.unitName,
+        variableId: response.variableId
+      })
+    );
 
     variables.forEach(variable => {
-      const key = `${variable.unitName}::${variable.variableId}`;
-      const variableResponses = responsesByVariable.get(key) || [];
+      const resultKey = getAggregationVariableKey(
+        variable.unitName,
+        variable.variableId
+      );
+      const variableResponses = responsesByVariable.get(resultKey) || [];
       const responsesWithCaseFields: ManualCodingDeduplicationResponse[] =
         variableResponses.map(response => ({
           responseId: response.responseId,
@@ -1345,10 +1421,11 @@ export class CodingProgressService {
         assignedResponseIds,
         matchingFlags,
         aggregationThreshold,
-        derivedVariableMap
+        derivedVariableMap,
+        activeResponseIds
       );
 
-      result.set(key, {
+      result.set(resultKey, {
         effectiveTotalCasesToCode: effectiveCaseCounts.uniqueCases,
         effectiveCasesInJobs: effectiveCaseCounts.casesInJobs
       });
@@ -1359,7 +1436,7 @@ export class CodingProgressService {
 
   private async getCoverageResponsesForVariables(
     workspaceId: number,
-    variables: UnitVariableReference[]
+    variables: UnitVariableReferenceWithAliases[]
   ): Promise<CoverageResponse[]> {
     if (variables.length === 0) {
       return [];
@@ -1410,7 +1487,7 @@ export class CodingProgressService {
           });
       }))
       .orderBy('response.id', 'ASC');
-    this.applyVariableReferenceFilter(query, variables, {
+    this.applyVariableReferenceFilter(query, expandUnitNameAliases(variables), {
       unitNameExpression: 'unit.name',
       variableIdExpression: 'response.variableid',
       parameterPrefix: 'variableCoverageResponses'
@@ -1435,61 +1512,209 @@ export class CodingProgressService {
     }));
   }
 
-  private async getAssignedCoverageResponseIdsForVariables(
+  private async getCompletedCoveragePeersForResponses(
     workspaceId: number,
-    variables: UnitVariableReference[]
-  ): Promise<Set<number>> {
-    if (variables.length === 0) {
-      return new Set<number>();
+    activeResponses: CoverageResponse[],
+    matchingFlags: ResponseMatchingFlag[],
+    derivedVariableMap: Map<string, Set<string>>
+  ): Promise<CoverageResponse[]> {
+    const peerKeys = buildAggregationPeerKeys(
+      activeResponses,
+      matchingFlags,
+      derivedVariableMap
+    );
+
+    if (peerKeys.length === 0) {
+      return [];
     }
 
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-    const query = this.codingJobUnitRepository
-      .createQueryBuilder('cju')
-      .select('DISTINCT cju.response_id', 'responseId')
-      .innerJoin('cju.response', 'response')
-      .leftJoin('cju.coding_job', 'coding_job')
-      .leftJoin('response.unit', 'unit')
-      .leftJoin('unit.booklet', 'booklet')
-      .leftJoin('booklet.bookletinfo', 'bookletinfo')
-      .leftJoin('booklet.person', 'person')
-      .where('person.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('coding_job.training_id IS NULL')
-      .andWhere('(response.status_v2 IS NULL OR response.status_v2 != :completedV2Status)', {
-        completedV2Status: statusStringToNumber('CODING_COMPLETE')
-      })
-      .andWhere(new Brackets(qb => {
-        qb.where('response.code_v2 IS NULL')
-          .orWhere(subQuery => {
-            const exists = subQuery
-              .subQuery()
-              .select('1')
-              .from('coding_job_unit', 'assigned_cju')
-              .where('assigned_cju.response_id = response.id')
-              .getQuery();
-            return `EXISTS (${exists})`;
-          });
-      }));
-    applyNonCodingIssueReviewJobFilter(
-      query,
-      'coding_job',
-      'assignedVariableCoverageReviewJobType'
+    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
+    const peerKeySet = new Set(
+      peerKeys.map(peerKey => serializeAggregationPeerKey(peerKey))
     );
-    this.applyManualProgressStatusFilter(query, 'andWhere');
-    this.applyVariableReferenceFilter(query, variables, {
-      unitNameExpression: 'cju.unit_name',
-      variableIdExpression: 'cju.variable_id',
-      parameterPrefix: 'assignedVariableCoverage'
+    const exactValueMatching =
+      !matchingFlags.includes('IGNORE_CASE') &&
+      !matchingFlags.includes('IGNORE_WHITESPACE');
+    const completedV2Status = statusStringToNumber('CODING_COMPLETE');
+    const createCompletedPeerQuery = (): SelectQueryBuilder<ResponseEntity> => (
+      this.responseRepository
+        .createQueryBuilder('response')
+        .leftJoin('response.unit', 'unit')
+        .leftJoin('unit.booklet', 'booklet')
+        .leftJoin('booklet.bookletinfo', 'bookletinfo')
+        .leftJoin('booklet.person', 'person')
+        .where('person.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('person.consider = :consider', { consider: true })
+        .andWhere('response.status_v1 IN (:...statuses)', {
+          statuses: [
+            statusStringToNumber('CODING_INCOMPLETE'),
+            statusStringToNumber('INTENDED_INCOMPLETE')
+          ]
+        })
+        .andWhere('response.status_v2 = :completedV2Status', {
+          completedV2Status
+        })
+        .andWhere(
+          '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+          { aggregatedCode: -111, defaultMirCode }
+        )
+        .andWhere(new Brackets(qb => {
+          qb.where('response.code_v2 IS NULL')
+            .orWhere(subQuery => {
+              const exists = subQuery
+                .subQuery()
+                .select('1')
+                .from('coding_job_unit', 'manual_cju')
+                .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
+                .where('manual_cju.response_id = response.id')
+                .andWhere('manual_cj.training_id IS NULL')
+                .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
+                .getQuery();
+              return `EXISTS (${exists})`;
+            });
+        }))
+    );
+
+    const peerVariableIds = Array.from(new Set(
+      peerKeys.map(peerKey => peerKey.variableId)
+    ));
+    const peerUnitQuery = createCompletedPeerQuery()
+      .select('DISTINCT unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .andWhere('response.variableid IN (:...peerVariableIds)', {
+        peerVariableIds
+      });
+    applyResolvedExclusionsToQuery(peerUnitQuery, exclusions, {
+      parameterPrefix: 'completedVariableCoveragePeerUnits'
     });
+    const peerUnitKeys = buildAggregationPeerUnitKeys(
+      peerKeys,
+      await peerUnitQuery.getRawMany()
+    );
+    if (peerUnitKeys.length === 0) {
+      return [];
+    }
+
+    const peerValueQuery = createCompletedPeerQuery()
+      .select('DISTINCT unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('response.value', 'value')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerUnits AS jsonb))
+            AS aggregation_peer_unit("unitName" text, "variableId" text)
+          WHERE aggregation_peer_unit."unitName" = unit.name
+            AND aggregation_peer_unit."variableId" = response.variableid
+        )`,
+        { aggregationPeerUnits: JSON.stringify(peerUnitKeys) }
+      );
+    applyResolvedExclusionsToQuery(peerValueQuery, exclusions, {
+      parameterPrefix: 'completedVariableCoveragePeerValues'
+    });
+    if (exactValueMatching) {
+      peerValueQuery.andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerValues AS jsonb))
+            AS aggregation_peer_value("variableId" text, "normalizedValue" text)
+          WHERE aggregation_peer_value."variableId" = response.variableid
+            AND aggregation_peer_value."normalizedValue" = response.value
+        )`,
+        { aggregationPeerValues: JSON.stringify(peerKeys) }
+      );
+    }
+    const peerLookupKeys = buildAggregationPeerLookupKeys(
+      peerKeys,
+      await peerValueQuery.getRawMany(),
+      matchingFlags
+    );
+    if (peerLookupKeys.length === 0) {
+      return [];
+    }
+
+    const query = createCompletedPeerQuery()
+      .select('response.id', 'responseId')
+      .addSelect('response.value', 'value')
+      .addSelect('response.code_v2', 'codeV2')
+      .addSelect('response.status_v2', 'statusV2')
+      .addSelect('response.status_v1', 'statusV1')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('unit.name', 'unitName')
+      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
+      .addSelect("COALESCE(person.login, '')", 'personLogin')
+      .addSelect("COALESCE(person.code, '')", 'personCode')
+      .addSelect("COALESCE(person.group, '')", 'personGroup')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerKeys AS jsonb))
+            AS aggregation_peer("unitName" text, "variableId" text, "value" text)
+          WHERE aggregation_peer."unitName" = unit.name
+            AND aggregation_peer."variableId" = response.variableid
+            AND aggregation_peer."value" = response.value
+        )`,
+        { aggregationPeerKeys: JSON.stringify(peerLookupKeys) }
+      )
+      .orderBy('response.id', 'ASC');
     applyResolvedExclusionsToQuery(query, exclusions, {
-      unitNameExpression: 'cju.unit_name',
-      bookletNameExpression: 'cju.booklet_name',
-      parameterPrefix: 'assignedVariableCoverage'
+      parameterPrefix: 'completedVariableCoveragePeers'
     });
     const raw = await query.getRawMany();
 
-    return new Set(raw.map(row => Number(row.responseId)));
+    return raw.map(row => ({
+      responseId: Number(row.responseId),
+      value: row.value ?? null,
+      codeV2: row.codeV2 === null || row.codeV2 === undefined ? null : Number(row.codeV2),
+      statusV2: row.statusV2 === null || row.statusV2 === undefined ? null : Number(row.statusV2),
+      statusV1: row.statusV1 === null || row.statusV1 === undefined ? null : Number(row.statusV1),
+      variableId: row.variableId,
+      unitName: row.unitName,
+      bookletName: row.bookletName ?? '',
+      personLogin: row.personLogin ?? '',
+      personCode: row.personCode ?? '',
+      personGroup: row.personGroup ?? ''
+    })).filter(response => (
+      isAggregatableValue(response.value) &&
+      peerKeySet.has(serializeAggregationPeerKey(getAggregationPeerKey(
+        response.unitName,
+        response.variableId,
+        response.value,
+        matchingFlags
+      )))
+    ));
+  }
+
+  private async getAssignedVariableCoverageResponseIds(
+    workspaceId: number,
+    responseIds: number[]
+  ): Promise<Set<number>> {
+    const assignedResponseIds = new Set<number>();
+    const uniqueResponseIds = Array.from(new Set(responseIds));
+    const chunkSize = 5000;
+
+    for (let offset = 0; offset < uniqueResponseIds.length; offset += chunkSize) {
+      const responseIdChunk = uniqueResponseIds.slice(offset, offset + chunkSize);
+      const query = this.codingJobUnitRepository
+        .createQueryBuilder('cju')
+        .select('DISTINCT cju.response_id', 'responseId')
+        .leftJoin('cju.coding_job', 'coding_job')
+        .where('coding_job.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('coding_job.training_id IS NULL')
+        .andWhere('cju.response_id IN (:...responseIds)', {
+          responseIds: responseIdChunk
+        });
+      applyNonCodingIssueReviewJobFilter(
+        query,
+        'coding_job',
+        `assignedVariableCoverageReviewJobType${offset}`
+      );
+      const raw = await query.getRawMany();
+      raw.forEach(row => assignedResponseIds.add(Number(row.responseId)));
+    }
+
+    return assignedResponseIds;
   }
 
   private applyVariableReferenceFilter(
@@ -1566,8 +1791,11 @@ export class CodingProgressService {
         return;
       }
 
-      const variableKey = `${row.unitName}:${row.variableId}`;
-      const caseKey = `${row.unitName}::${row.variableId}::${responseId}`;
+      const variableKey = getCoverageVariableKey(row.unitName, row.variableId);
+      const caseKey = `${getAggregationVariableKey(
+        row.unitName,
+        row.variableId
+      )}::${responseId}`;
       const caseDefinitions = definitionsByCaseKey.get(caseKey) || new Map<number, VariableDefinitionReference>();
 
       caseDefinitions.set(definitionId, {

--- a/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
@@ -41,9 +41,11 @@ describe('CodingResultsService', () => {
     leftJoinAndSelect: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
-    getMany: jest.fn().mockResolvedValue(rows)
+    getMany: jest.fn().mockResolvedValue(rows),
+    getRawMany: jest.fn().mockResolvedValue(rows)
   });
 
   beforeEach(() => {
@@ -739,6 +741,33 @@ describe('CodingResultsService', () => {
       fromJobSnapshot: true
     });
 
+    const unitNameQuery = createQueryBuilderMock([
+      { unitName: 'UNIT', variableId: 'VAR' },
+      { unitName: 'unit', variableId: 'VAR' }
+    ]);
+    const candidateQuery = createQueryBuilderMock([
+      {
+        id: 99,
+        value: ' A ',
+        variableid: 'VAR',
+        status_v2: 3,
+        unit: { id: 1, name: 'UNIT' }
+      },
+      {
+        id: 100,
+        value: 'a',
+        variableid: 'VAR',
+        status_v2: null,
+        unit: { id: 2, name: 'unit' }
+      },
+      {
+        id: 101,
+        value: 'A',
+        variableid: 'VAR',
+        status_v2: 5,
+        unit: { id: 3, name: 'UNIT' }
+      }
+    ]);
     (responseRepository.createQueryBuilder as jest.Mock)
       .mockReturnValueOnce(createQueryBuilderMock([
         {
@@ -749,29 +778,8 @@ describe('CodingResultsService', () => {
           unit: { id: 1, name: 'UNIT' }
         }
       ]))
-      .mockReturnValueOnce(createQueryBuilderMock([
-        {
-          id: 99,
-          value: ' A ',
-          variableid: 'VAR',
-          status_v2: 3,
-          unit: { id: 1, name: 'UNIT' }
-        },
-        {
-          id: 100,
-          value: 'a',
-          variableid: 'VAR',
-          status_v2: null,
-          unit: { id: 2, name: 'UNIT' }
-        },
-        {
-          id: 101,
-          value: 'A',
-          variableid: 'VAR',
-          status_v2: 5,
-          unit: { id: 3, name: 'UNIT' }
-        }
-      ]));
+      .mockReturnValueOnce(unitNameQuery)
+      .mockReturnValueOnce(candidateQuery);
 
     const result = await service.applyCodingResults(17, 10);
 
@@ -779,6 +787,10 @@ describe('CodingResultsService', () => {
     expect(result.updatedResponsesCount).toBe(2);
     expect(result.skippedAlreadyCodedCount).toBe(1);
     expect(result.overwrittenExistingCount).toBe(0);
+    expect(candidateQuery.andWhere).toHaveBeenCalledWith(
+      'unit.name IN (:...unitNames)',
+      { unitNames: ['UNIT', 'unit'] }
+    );
     expect(queryRunner.manager.update).toHaveBeenCalledWith(
       ResponseEntity,
       100,
@@ -846,6 +858,9 @@ describe('CodingResultsService', () => {
         }
       ]))
       .mockReturnValueOnce(createQueryBuilderMock([
+        { unitName: 'UNIT', variableId: 'VAR' }
+      ]))
+      .mockReturnValueOnce(createQueryBuilderMock([
         {
           id: 99,
           value: ' A ',
@@ -908,6 +923,9 @@ describe('CodingResultsService', () => {
         }
       ]))
       .mockReturnValueOnce(createQueryBuilderMock([
+        { unitName: 'UNIT', variableId: 'VAR' }
+      ]))
+      .mockReturnValueOnce(createQueryBuilderMock([
         {
           id: 99,
           value: ' A ',
@@ -964,6 +982,9 @@ describe('CodingResultsService', () => {
         }
       ]))
       .mockReturnValueOnce(createQueryBuilderMock([
+        { unitName: 'UNIT', variableId: 'VAR' }
+      ]))
+      .mockReturnValueOnce(createQueryBuilderMock([
         {
           id: 99,
           value: ' A ',
@@ -1016,6 +1037,9 @@ describe('CodingResultsService', () => {
           status_v2: 3,
           unit: { id: 1, name: 'UNIT' }
         }
+      ]))
+      .mockReturnValueOnce(createQueryBuilderMock([
+        { unitName: 'UNIT', variableId: 'VAR' }
       ]))
       .mockReturnValueOnce(createQueryBuilderMock([
         {

--- a/apps/backend/src/app/database/services/coding/coding-results.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.ts
@@ -6,7 +6,10 @@ import { ResponseEntity } from '../../entities/response.entity';
 import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { CodingStatisticsService } from './coding-statistics.service';
 import { CodingAnalysisService } from './coding-analysis.service';
-import { buildAggregationGroups } from './aggregation-metrics.util';
+import {
+  buildAggregationGroups,
+  getAggregationVariableKey
+} from './aggregation-metrics.util';
 import {
   formatCodingTestPerson,
   generateCodingProgressKey
@@ -272,6 +275,58 @@ export class CodingResultsService {
               .where('response.id IN (:...ids)', { ids: codedResponseIds })
               .getMany();
 
+            const codedVariableIds = Array.from(new Set(
+              codedResponses
+                .map(response => response.variableid)
+                .filter((variableId): variableId is string => Boolean(variableId))
+            ));
+            const unitNamesByVariable = new Map<string, Set<string>>();
+            codedResponses.forEach(response => {
+              if (!response.unit?.name || !response.variableid) {
+                return;
+              }
+              const variableKey = getAggregationVariableKey(
+                response.unit.name,
+                response.variableid
+              );
+              const unitNames = unitNamesByVariable.get(variableKey) || new Set<string>();
+              unitNames.add(response.unit.name);
+              unitNamesByVariable.set(variableKey, unitNames);
+            });
+
+            if (codedVariableIds.length > 0) {
+              const unitNameRows: Array<{ unitName: string; variableId: string }> =
+                await this.responseRepository
+                  .createQueryBuilder('response')
+                  .select('DISTINCT unit.name', 'unitName')
+                  .addSelect('response.variableid', 'variableId')
+                  .leftJoin('response.unit', 'unit')
+                  .leftJoin('unit.booklet', 'booklet')
+                  .leftJoin('booklet.person', 'person')
+                  .where('person.workspace_id = :workspaceId', { workspaceId })
+                  .andWhere('person.consider = :consider', { consider: true })
+                  .andWhere('response.status_v1 IN (:...statuses)', {
+                    statuses: [
+                      statusStringToNumber('CODING_INCOMPLETE'),
+                      statusStringToNumber('INTENDED_INCOMPLETE')
+                    ]
+                  })
+                  .andWhere('response.variableid IN (:...codedVariableIds)', {
+                    codedVariableIds
+                  })
+                  .getRawMany();
+              unitNameRows.forEach(row => {
+                const variableKey = getAggregationVariableKey(
+                  row.unitName,
+                  row.variableId
+                );
+                if (!unitNamesByVariable.has(variableKey)) {
+                  return;
+                }
+                unitNamesByVariable.get(variableKey)?.add(row.unitName);
+              });
+            }
+
             for (const codedResponse of codedResponses) {
               const update = completedUpdates.find(u => u.responseId === codedResponse.id);
               if (!update) continue;
@@ -280,6 +335,13 @@ export class CodingResultsService {
               const variableId = codedResponse.variableid;
 
               if (!unitName || !variableId) continue;
+
+              const unitNames = Array.from(
+                unitNamesByVariable.get(getAggregationVariableKey(
+                  unitName,
+                  variableId
+                )) || [unitName]
+              );
 
               // Find all sibling responses for the same workspace + unit + variable.
               // Existing v2 codings are either reported as skipped or overwritten only when explicitly requested.
@@ -304,7 +366,7 @@ export class CodingResultsService {
                     statusStringToNumber('INTENDED_INCOMPLETE')
                   ]
                 })
-                .andWhere('unit.name = :unitName', { unitName })
+                .andWhere('unit.name IN (:...unitNames)', { unitNames })
                 .andWhere('response.variableid = :variableId', { variableId })
                 .getMany();
 

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
@@ -344,10 +344,10 @@ describe('CodingStatisticsService', () => {
         'coding_incomplete_variables_version:1'
       );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1'
+        'coding_incomplete_variables_v9:1'
       );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_scope_v1:1'
+        'coding_incomplete_variables_scope_v2:1'
       );
     });
 

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -9,7 +9,7 @@ import { CacheService } from '../../../cache/cache.service';
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import { WorkspacePlayerService } from '../workspace/workspace-player.service';
 import { WorkspaceExclusionService } from '../workspace/workspace-exclusion.service';
-import { CodingJobService } from './coding-job.service';
+import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { getManualCodingScopeKey } from '../../utils/manual-coding-scope.util';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 
@@ -151,8 +151,14 @@ describe('CodingValidationService', () => {
       getResponseMatchingMode: jest.fn().mockResolvedValue([]),
       getAggregationThreshold: jest.fn().mockResolvedValue(2),
       getSlimResponsesForVariables: jest.fn().mockResolvedValue([]),
+      getSlimResponsesForVariableCoverage: jest.fn(),
       aggregateResponsesByValue: jest.fn().mockReturnValue([])
     } as unknown as jest.Mocked<CodingJobService>;
+    mockCodingJobService.getSlimResponsesForVariableCoverage.mockImplementation(
+      async (workspaceId, variables) => (
+        mockCodingJobService.getSlimResponsesForVariables(workspaceId, variables)
+      )
+    );
     mockQueryBuilder.getRawMany.mockResolvedValue([]);
     mockQueryBuilder.getCount.mockResolvedValue(0);
     mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(new Map());
@@ -543,7 +549,91 @@ describe('CodingValidationService', () => {
 
       expect(result).toEqual(cachedVariables);
       expect(mockCacheService.get).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1'
+        'coding_incomplete_variables_v9:1'
+      );
+    });
+
+    it('should filter cached variables by unit name without case sensitivity', async () => {
+      const cachedVariables = [{
+        unitName: 'Unit1',
+        variableId: 'var1',
+        responseCount: 5,
+        deriveErrorResponseCount: 0,
+        casesInJobs: 0,
+        availableCases: 5,
+        uniqueCasesAfterAggregation: 5,
+        isDerived: false,
+        coderTrainingRequired: false
+      }];
+      mockCacheService.get.mockResolvedValue(cachedVariables);
+
+      await expect(
+        service.getCodingIncompleteVariables(1, 'UNIT1')
+      ).resolves.toEqual(cachedVariables);
+    });
+
+    it('should include all unit-name case aliases in a scoped database query', async () => {
+      const unitAliasesQb = createQueryBuilderMock([
+        { unitName: 'UNIT1' },
+        { unitName: 'unit1' },
+        { unitName: 'OTHER' }
+      ]);
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'UNIT1', variableId: 'var1', responseCount: '2' },
+        { unitName: 'unit1', variableId: 'var1', responseCount: '3' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([]);
+      const assignedResponsesQb = createQueryBuilderMock([]);
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(unitAliasesQb)
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(assignedResponsesQb);
+      mockCacheService.get.mockResolvedValue(null);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        ...createSlimResponses('UNIT1', 'var1', 2),
+        ...createSlimResponses('unit1', 'var1', 3).map((response, index) => ({
+          ...response,
+          id: index + 3,
+          value: `lower-value-${index + 1}`,
+          personLogin: `lower-person-${index + 1}`,
+          personCode: `lower-${index + 1}`
+        }))
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(1, 'Unit1');
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'UNIT1',
+          variableId: 'var1',
+          responseCount: 5,
+          uniqueCasesAfterAggregation: 5
+        })
+      ]);
+      [codingIncompleteQb, intendedIncompleteQb, deriveErrorQb]
+        .forEach(query => {
+          expect(query.andWhere).toHaveBeenCalledWith(
+            'unit.name IN (:...scopedUnitNames)',
+            { scopedUnitNames: ['UNIT1', 'unit1'] }
+          );
+        });
+      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
+        1,
+        [
+          { unitName: 'UNIT1', variableId: 'var1' },
+          { unitName: 'unit1', variableId: 'var1' }
+        ]
       );
     });
 
@@ -563,7 +653,7 @@ describe('CodingValidationService', () => {
 
       mockCacheService.getNumber.mockResolvedValue(2);
       mockCacheService.get.mockImplementation(async key => (
-        key === 'coding_incomplete_variables_v8:1' ?
+        key === 'coding_incomplete_variables_v9:1' ?
           {
             invalidationVersion: 1,
             data: [
@@ -605,7 +695,7 @@ describe('CodingValidationService', () => {
         })
       ]);
       expect(mockCacheService.set).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1',
+        'coding_incomplete_variables_v9:1',
         {
           invalidationVersion: 2,
           data: result
@@ -670,7 +760,7 @@ describe('CodingValidationService', () => {
         })
       ]);
       expect(mockCacheService.set).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1',
+        'coding_incomplete_variables_v9:1',
         {
           invalidationVersion: 0,
           data: result
@@ -678,7 +768,7 @@ describe('CodingValidationService', () => {
         300
       );
       expect(mockCacheService.set).toHaveBeenCalledWith(
-        'coding_incomplete_variables_scope_v1:1',
+        'coding_incomplete_variables_scope_v2:1',
         expect.objectContaining({
           invalidationVersion: 0,
           data: expect.objectContaining({
@@ -942,7 +1032,7 @@ describe('CodingValidationService', () => {
 
     it('should return manual coding scope summary from cache without querying responses', async () => {
       mockCacheService.get.mockImplementation(async key => (
-        key === 'coding_incomplete_variables_scope_v1:1' ?
+        key === 'coding_incomplete_variables_scope_v2:1' ?
           {
             variables: [
               {
@@ -1168,6 +1258,71 @@ describe('CodingValidationService', () => {
           uniqueCasesAfterAggregation: 3
         })
       ]);
+    });
+
+    it('should keep an open sibling unavailable when its completed aggregation peer is assigned', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '1' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([]);
+      const assignedResponsesQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseId: '1' }
+      ]);
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(assignedResponsesQb);
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([
+        ResponseMatchingFlag.IGNORE_CASE,
+        ResponseMatchingFlag.IGNORE_WHITESPACE
+      ]);
+      mockCodingJobService.getSlimResponsesForVariableCoverage.mockResolvedValue([
+        {
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'Same answer',
+          statusV2: null,
+          personLogin: 'person-2'
+        },
+        {
+          id: 1,
+          unitName: 'UNIT1',
+          variableid: 'var1',
+          value: ' sameanswer ',
+          statusV2: statusStringToNumber('CODING_COMPLETE'),
+          personLogin: 'person-1'
+        }
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(1);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'unit1',
+          variableId: 'var1',
+          casesInJobs: 1,
+          availableCases: 0,
+          uniqueCasesAfterAggregation: 1
+        })
+      ]);
+      expect(assignedResponsesQb.andWhere).toHaveBeenCalledWith(
+        'cju.response_id IN (:...responseIds)',
+        { responseIds: [2, 1] }
+      );
     });
 
     it('should treat assigned duplicate responses as assigned after deduplication and aggregation', async () => {
@@ -1795,7 +1950,7 @@ describe('CodingValidationService', () => {
 
     it('should reuse an in-flight validation for identical manual code availability requests', async () => {
       mockCacheService.get.mockImplementation(async key => (
-        key === 'coding_incomplete_variables_v8:1' ?
+        key === 'coding_incomplete_variables_v9:1' ?
           [
             {
               unitName: 'unit1',
@@ -1878,7 +2033,7 @@ describe('CodingValidationService', () => {
     it('should generate correct cache key', () => {
       const cacheKey = service.generateIncompleteVariablesCacheKey(123);
 
-      expect(cacheKey).toBe('coding_incomplete_variables_v8:123');
+      expect(cacheKey).toBe('coding_incomplete_variables_v9:123');
     });
   });
 
@@ -1892,10 +2047,10 @@ describe('CodingValidationService', () => {
         'coding_incomplete_variables_version:1'
       );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1'
+        'coding_incomplete_variables_v9:1'
       );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_scope_v1:1'
+        'coding_incomplete_variables_scope_v2:1'
       );
     });
   });

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -22,12 +22,15 @@ import { VariableDetailDto } from '../../../models/unit-variable-details.dto';
 import { WorkspacePlayerService } from '../workspace/workspace-player.service';
 import {
   applyResolvedExclusionsToQuery,
+  ResolvedWorkspaceExclusions,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
-import { CodingJobService } from './coding-job.service';
+import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import {
   countEffectiveManualCodingCases,
-  ManualCodingDeduplicationResponse
+  getAggregationVariableKey,
+  ManualCodingDeduplicationResponse,
+  partitionResponsesByAggregationVariable
 } from './aggregation-metrics.util';
 import {
   getCodingIncompleteVariablesCacheKey,
@@ -65,6 +68,7 @@ interface NormalizedExpectedCombination {
 
 type ManualCodingVariableCaseCounts = {
   unitName: string;
+  unitNameAliases?: string[];
   variableId: string;
   responseCount: number;
   deriveErrorResponseCount: number;
@@ -78,6 +82,7 @@ type SlimCodingResponse = {
   variableid: string;
   value: string | null;
   statusV1?: number | null;
+  statusV2?: number | null;
   personLogin?: string | null;
   personCode?: string | null;
   personGroup?: string | null;
@@ -948,8 +953,9 @@ export class CodingValidationService {
     unitName?: string,
     trainingRequired?: boolean
   ): T[] {
+    const normalizedUnitName = unitName ? String(unitName).toUpperCase() : undefined;
     return variables.filter(variable => (
-      (!unitName || variable.unitName === unitName) &&
+      (!normalizedUnitName || variable.unitName.toUpperCase() === normalizedUnitName) &&
       (
         trainingRequired === undefined ||
         variable.coderTrainingRequired === trainingRequired
@@ -1060,7 +1066,10 @@ export class CodingValidationService {
     );
 
     return variables.map(variable => {
-      const key = `${variable.unitName}::${variable.variableId}`;
+      const key = getAggregationVariableKey(
+        variable.unitName,
+        variable.variableId
+      );
       const caseInfo = caseInfoMap.get(key) || {
         casesInJobs: 0,
         availableCases: variable.responseCount,
@@ -1068,7 +1077,12 @@ export class CodingValidationService {
       };
 
       return {
-        ...variable,
+        unitName: variable.unitName,
+        variableId: variable.variableId,
+        responseCount: variable.responseCount,
+        deriveErrorResponseCount: variable.deriveErrorResponseCount,
+        isDerived: variable.isDerived,
+        coderTrainingRequired: variable.coderTrainingRequired,
         ...caseInfo
       };
     });
@@ -1094,25 +1108,26 @@ export class CodingValidationService {
     const aggregationThreshold = await this.codingJobService.getAggregationThreshold(workspaceId);
 
     const matchingFlags = await this.codingJobService.getResponseMatchingMode(workspaceId);
-    const variableReferences = variables.map(v => ({
-      unitName: v.unitName,
-      variableId: v.variableId,
-      ...(includeDeriveErrorInCaseInfo && v.deriveErrorResponseCount > 0 ?
-        { includeDeriveError: true } :
-        {})
-    }));
-    const [slimResponses, assignedResponseIdsByVariable] = await Promise.all([
-      this.codingJobService.getSlimResponsesForVariables(
-        workspaceId,
-        variableReferences
-      ) as Promise<SlimCodingResponse[]>,
-      this.getAssignedResponseIdsByVariable(
-        workspaceId,
-        variableReferences,
-        excludeJobDefinitionId
-      )
-    ]);
-
+    const variableReferences = Array.from(variables.reduce((references, variable) => {
+      const unitNames = variable.unitNameAliases?.length ?
+        variable.unitNameAliases :
+        [variable.unitName];
+      unitNames.forEach(unitName => {
+        const key = `${unitName}::${variable.variableId}`;
+        references.set(key, {
+          unitName,
+          variableId: variable.variableId,
+          ...(includeDeriveErrorInCaseInfo && variable.deriveErrorResponseCount > 0 ?
+            { includeDeriveError: true } :
+            {})
+        });
+      });
+      return references;
+    }, new Map<string, {
+      unitName: string;
+      variableId: string;
+      includeDeriveError?: boolean;
+    }>()).values());
     const derivedVariableMap = new Map<string, Set<string>>();
     variables
       .filter(variable => variable.isDerived)
@@ -1122,13 +1137,50 @@ export class CodingValidationService {
         derivedVariables.add(variable.variableId);
         derivedVariableMap.set(unitKey, derivedVariables);
       });
+    const aggregationActive = aggregationThreshold !== null &&
+      !matchingFlags.includes(ResponseMatchingFlag.NO_AGGREGATION);
+    const slimResponses = aggregationActive ?
+      await this.codingJobService.getSlimResponsesForVariableCoverage(
+        workspaceId,
+        variableReferences,
+        matchingFlags,
+        aggregationThreshold,
+        derivedVariableMap
+      ) as SlimCodingResponse[] :
+      await this.codingJobService.getSlimResponsesForVariables(
+        workspaceId,
+        variableReferences
+      ) as SlimCodingResponse[];
+    const activeResponseIds = new Set(
+      slimResponses
+        .filter(response => (
+          response.statusV2 !== statusStringToNumber('CODING_COMPLETE')
+        ))
+        .map(response => response.id)
+    );
+    const assignedResponseIds =
+      await this.getAssignedResponseIds(
+        workspaceId,
+        slimResponses.map(response => response.id),
+        excludeJobDefinitionId
+      );
+
+    const responsesByVariable = partitionResponsesByAggregationVariable(
+      slimResponses,
+      variables,
+      response => ({
+        unitName: response.unitName,
+        variableId: response.variableid
+      })
+    );
 
     for (const variable of variables) {
-      const key = `${variable.unitName}::${variable.variableId}`;
-
-      const varResponsesWithRequestedStatuses = slimResponses.filter(
-        r => r.unitName === variable.unitName && r.variableid === variable.variableId
+      const key = getAggregationVariableKey(
+        variable.unitName,
+        variable.variableId
       );
+      const varResponsesWithRequestedStatuses =
+        responsesByVariable.get(key) || [];
 
       const countAggregatedCases = (responses: SlimCodingResponse[]) => {
         const responsesWithCaseFields: ManualCodingDeduplicationResponse[] =
@@ -1137,14 +1189,13 @@ export class CodingValidationService {
             responseId: response.id,
             variableId: response.variableid
           }));
-        const assignedResponseIds = assignedResponseIdsByVariable.get(key) || new Set<number>();
-
         return countEffectiveManualCodingCases(
           responsesWithCaseFields,
           assignedResponseIds,
           matchingFlags,
           aggregationThreshold,
-          derivedVariableMap
+          derivedVariableMap,
+          activeResponseIds
         );
       };
 
@@ -1242,73 +1293,65 @@ export class CodingValidationService {
     return `${String(unitName || '').trim().toUpperCase()}::${String(variableId || '').trim()}`;
   }
 
-  private async getAssignedResponseIdsByVariable(
+  private async getAssignedResponseIds(
     workspaceId: number,
-    variables: { unitName: string; variableId: string }[],
+    responseIds: number[],
     excludeJobDefinitionId?: number
-  ): Promise<Map<string, Set<number>>> {
-    const result = new Map<string, Set<number>>();
+  ): Promise<Set<number>> {
+    const result = new Set<number>();
 
-    if (variables.length === 0) {
+    const uniqueResponseIds = Array.from(new Set(responseIds));
+    if (uniqueResponseIds.length === 0) {
       return result;
     }
 
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-    const query = this.codingJobUnitRepository
-      .createQueryBuilder('cju')
-      .select('cju.unit_name', 'unitName')
-      .addSelect('cju.variable_id', 'variableId')
-      .addSelect('cju.response_id', 'responseId')
-      .leftJoin('cju.coding_job', 'coding_job')
-      .where('coding_job.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('coding_job.training_id IS NULL');
+    const chunkSize = 5000;
 
-    if (
-      excludeJobDefinitionId !== undefined &&
-      excludeJobDefinitionId !== null
-    ) {
-      query.andWhere(
-        '(coding_job.job_definition_id IS NULL OR coding_job.job_definition_id != :excludeJobDefinitionId)',
-        { excludeJobDefinitionId }
-      );
-    }
+    for (let offset = 0; offset < uniqueResponseIds.length; offset += chunkSize) {
+      const responseIdChunk = uniqueResponseIds.slice(offset, offset + chunkSize);
+      const query = this.codingJobUnitRepository
+        .createQueryBuilder('cju')
+        .select('DISTINCT cju.response_id', 'responseId')
+        .leftJoin('cju.coding_job', 'coding_job')
+        .where('coding_job.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('coding_job.training_id IS NULL')
+        .andWhere('cju.response_id IN (:...responseIds)', {
+          responseIds: responseIdChunk
+        });
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `assignedUnitName${index}`;
-      const variableParam = `assignedVariableId${index}`;
-      conditions.push(`(cju.unit_name = :${unitParam} AND cju.variable_id = :${variableParam})`);
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    query.andWhere(`(${conditions.join(' OR ')})`, parameters);
-    applyNonCodingIssueReviewJobFilter(
-      query,
-      'coding_job',
-      'codingValidationAssignedResponsesReviewJobType'
-    );
-    applyResolvedExclusionsToQuery(query, exclusions, {
-      unitNameExpression: 'cju.unit_name',
-      bookletNameExpression: 'cju.booklet_name',
-      parameterPrefix: 'codingValidationAssignedResponses'
-    });
-
-    const rawResults = await query.getRawMany();
-
-    rawResults.forEach(row => {
-      const responseId = Number(row.responseId);
-      if (!Number.isFinite(responseId)) {
-        return;
+      if (
+        excludeJobDefinitionId !== undefined &&
+        excludeJobDefinitionId !== null
+      ) {
+        query.andWhere(
+          '(coding_job.job_definition_id IS NULL OR coding_job.job_definition_id != :excludeJobDefinitionId)',
+          { excludeJobDefinitionId }
+        );
       }
 
-      const key = `${row.unitName}::${row.variableId}`;
-      const responseIds = result.get(key) || new Set<number>();
-      responseIds.add(responseId);
-      result.set(key, responseIds);
-    });
+      applyNonCodingIssueReviewJobFilter(
+        query,
+        'coding_job',
+        'codingValidationAssignedResponsesReviewJobType'
+      );
+      applyResolvedExclusionsToQuery(query, exclusions, {
+        unitNameExpression: 'cju.unit_name',
+        bookletNameExpression: 'cju.booklet_name',
+        parameterPrefix: `codingValidationAssignedResponses${offset}`
+      });
+
+      const rawResults = await query.getRawMany();
+
+      rawResults.forEach(row => {
+        const responseId = Number(row.responseId);
+        if (!Number.isFinite(responseId)) {
+          return;
+        }
+
+        result.add(responseId);
+      });
+    }
 
     return result;
   }
@@ -1318,9 +1361,7 @@ export class CodingValidationService {
     unitName?: string,
     trainingRequired?: boolean,
     includeDeriveErrorOnly = false
-  ): Promise<
-    { unitName: string; variableId: string; responseCount: number; deriveErrorResponseCount: number; isDerived: boolean; coderTrainingRequired: boolean }[]
-    > {
+  ): Promise<ManualCodingVariableCaseCounts[]> {
     const scope = await this.fetchManualCodingScopeFromDb(
       workspaceId,
       unitName,
@@ -1337,6 +1378,13 @@ export class CodingValidationService {
     includeDeriveErrorOnly = false
   ): Promise<ManualCodingScopeFromDb> {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const scopedUnitNames = unitName ?
+      await this.resolveUnitNameCaseAliases(
+        workspaceId,
+        unitName,
+        exclusions
+      ) :
+      [];
     // Helper to build the base query for a given status
     const buildQuery = (status: number) => {
       const qb = this.responseRepository
@@ -1356,8 +1404,10 @@ export class CodingValidationService {
         .groupBy('unit.name')
         .addGroupBy('response.variableid');
 
-      if (unitName) {
-        qb.andWhere('unit.name = :unitName', { unitName });
+      if (scopedUnitNames.length > 0) {
+        qb.andWhere('unit.name IN (:...scopedUnitNames)', {
+          scopedUnitNames
+        });
       }
       applyResolvedExclusionsToQuery(qb, exclusions);
       return qb;
@@ -1367,7 +1417,10 @@ export class CodingValidationService {
     const [codingIncompleteRaw, intendedIncompleteRaw, deriveErrorCountsByKey] = await Promise.all([
       buildQuery(statusStringToNumber('CODING_INCOMPLETE')).getRawMany(),
       buildQuery(statusStringToNumber('INTENDED_INCOMPLETE')).getRawMany(),
-      this.getDeriveErrorResponseCountsByVariable(workspaceId, unitName)
+      this.getDeriveErrorResponseCountsByVariable(
+        workspaceId,
+        scopedUnitNames
+      )
     ]);
 
     this.logger.debug(
@@ -1474,6 +1527,21 @@ export class CodingValidationService {
         derivedVariablesBySourceMap
       ) :
       new Set<string>();
+    const normalizedDeriveErrorCounts = new Map<string, number>();
+    const deriveErrorUnitNames = new Map<string, string[]>();
+    deriveErrorCountsByKey.forEach((count, exactKey) => {
+      const [deriveUnitName, variableId] = exactKey.split('::');
+      const key = getAggregationVariableKey(deriveUnitName, variableId);
+      normalizedDeriveErrorCounts.set(
+        key,
+        (normalizedDeriveErrorCounts.get(key) || 0) + count
+      );
+      const aliases = deriveErrorUnitNames.get(key) || [];
+      if (!aliases.includes(deriveUnitName)) {
+        aliases.push(deriveUnitName);
+      }
+      deriveErrorUnitNames.set(key, aliases);
+    });
     const getScopedDeriveErrorResponseCount = (
       responseUnitName: string,
       variableId: string
@@ -1484,12 +1552,15 @@ export class CodingValidationService {
         deriveErrorCoveredSourceKeys
       ) ?
         0 :
-        deriveErrorCountsByKey.get(`${responseUnitName}::${variableId}`) || 0
+        normalizedDeriveErrorCounts.get(
+          getAggregationVariableKey(responseUnitName, variableId)
+        ) || 0
     );
 
     // Merge results, summing response counts for variables that appear in both
     const mergedMap = new Map<string, {
       unitName: string;
+      unitNameAliases: string[];
       variableId: string;
       responseCount: number;
       deriveErrorResponseCount: number;
@@ -1498,7 +1569,7 @@ export class CodingValidationService {
     }>();
 
     for (const row of [...filteredCodingIncomplete, ...filteredIntendedIncomplete]) {
-      const key = `${row.unitName}::${row.variableId}`;
+      const key = getAggregationVariableKey(row.unitName, row.variableId);
       const existing = mergedMap.get(key);
       const count = parseInt(row.responseCount, 10);
       const deriveErrorResponseCount =
@@ -1508,9 +1579,13 @@ export class CodingValidationService {
 
       if (existing) {
         existing.responseCount += count;
+        if (!existing.unitNameAliases.includes(row.unitName)) {
+          existing.unitNameAliases.push(row.unitName);
+        }
       } else {
         mergedMap.set(key, {
           unitName: row.unitName,
+          unitNameAliases: [row.unitName],
           variableId: row.variableId,
           responseCount: count,
           deriveErrorResponseCount,
@@ -1521,12 +1596,23 @@ export class CodingValidationService {
     }
 
     if (includeDeriveErrorOnly) {
-      deriveErrorCountsByKey.forEach((deriveErrorResponseCount, key) => {
-        if (mergedMap.has(key)) {
+      normalizedDeriveErrorCounts.forEach((deriveErrorResponseCount, key) => {
+        const existing = mergedMap.get(key);
+        const aliases = deriveErrorUnitNames.get(key) || [];
+        if (existing) {
+          aliases.forEach(alias => {
+            if (!existing.unitNameAliases.includes(alias)) {
+              existing.unitNameAliases.push(alias);
+            }
+          });
           return;
         }
 
-        const [deriveUnitName, variableId] = key.split('::');
+        const [, variableId] = key.split('::');
+        const deriveUnitName = aliases[0];
+        if (!deriveUnitName) {
+          return;
+        }
         if (
           isCoveredSourceVariable(
             { unitName: deriveUnitName, variableId },
@@ -1545,6 +1631,7 @@ export class CodingValidationService {
 
         mergedMap.set(key, {
           unitName: deriveUnitName,
+          unitNameAliases: aliases,
           variableId,
           responseCount: 0,
           deriveErrorResponseCount,
@@ -1569,7 +1656,7 @@ export class CodingValidationService {
 
   private async getDeriveErrorResponseCountsByVariable(
     workspaceId: number,
-    unitName?: string
+    scopedUnitNames: string[] = []
   ): Promise<Map<string, number>> {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     const query = this.responseRepository
@@ -1590,8 +1677,10 @@ export class CodingValidationService {
       .groupBy('unit.name')
       .addGroupBy('response.variableid');
 
-    if (unitName) {
-      query.andWhere('unit.name = :unitName', { unitName });
+    if (scopedUnitNames.length > 0) {
+      query.andWhere('unit.name IN (:...scopedUnitNames)', {
+        scopedUnitNames
+      });
     }
 
     applyResolvedExclusionsToQuery(query, exclusions, {
@@ -1610,6 +1699,31 @@ export class CodingValidationService {
       }
       return counts;
     }, new Map<string, number>());
+  }
+
+  private async resolveUnitNameCaseAliases(
+    workspaceId: number,
+    unitName: string,
+    exclusions: ResolvedWorkspaceExclusions
+  ): Promise<string[]> {
+    const query = this.responseRepository
+      .createQueryBuilder('response')
+      .select('DISTINCT unit.name', 'unitName')
+      .leftJoin('response.unit', 'unit')
+      .leftJoin('unit.booklet', 'booklet')
+      .leftJoin('booklet.bookletinfo', 'bookletinfo')
+      .leftJoin('booklet.person', 'person')
+      .where('person.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('person.consider = :consider', { consider: true });
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      parameterPrefix: 'unitNameCaseAliases'
+    });
+    const normalizedUnitName = String(unitName).toUpperCase();
+    const aliases = (await query.getRawMany<{ unitName: string }>())
+      .map(row => row.unitName)
+      .filter(candidate => candidate?.toUpperCase() === normalizedUnitName);
+
+    return aliases.length > 0 ? Array.from(new Set(aliases)) : [unitName];
   }
 
   generateIncompleteVariablesCacheKey(workspaceId: number): string {

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -106,8 +106,8 @@ describe('ExternalCodingImportService', () => {
     expect(queryRunner.rollbackTransaction).not.toHaveBeenCalled();
     expect(queryRunner.release).toHaveBeenCalled();
     expect(cacheService.incr).toHaveBeenCalledWith('coding_incomplete_variables_version:17');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v8:17');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v1:17');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v9:17');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v2:17');
   });
 
   it('imports DERIVE_ERROR without turning it into completed false coding', async () => {

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
@@ -130,8 +130,8 @@ describe('WorkspaceCoreService', () => {
     expect(cacheService.delete).toHaveBeenCalledWith('coding-statistics:schema-v4:1:v2');
     expect(cacheService.delete).toHaveBeenCalledWith('coding-statistics:schema-v4:1:v3');
     expect(cacheService.incr).toHaveBeenCalledWith('coding_incomplete_variables_version:1');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v8:1');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v1:1');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v9:1');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v2:1');
     expect(cacheService.delete).toHaveBeenCalledWith('flat_response_filter_options:version:1');
     expect(cacheService.deleteByPattern).toHaveBeenCalledWith('response-analysis:1_*');
     expect(cacheService.deleteByPattern).toHaveBeenCalledWith('responses:1:*');


### PR DESCRIPTION
## Was wurde geändert?

- Abgeschlossene, manuell kodierte Aggregationsgeschwister werden bei der effektiven Fall- und Variablenabdeckung berücksichtigt.
- Unit-Namen mit unterschiedlicher Groß-/Kleinschreibung werden in Validierung und Coverage gemeinsam ausgewertet.
- Die Suche nach abgeschlossenen Peers wird auf passende Unit-/Variablen-Aliase und Werte begrenzt.
- Neu angewendete Aggregationsergebnisse werden über Unit-Schreibvarianten hinweg auf passende offene Geschwister übertragen.
- Die betroffenen Redis-Cache-Versionen wurden angehoben und Regressionstests ergänzt.

## Ursache und Wirkung

Nach Abschluss eines Aggregationsgeschwisters wurde dieses aus dem offenen Scope entfernt. Ein verbleibender Zwilling konnte dadurch unter den Aggregationsschwellwert fallen und in der Variablenabdeckung fälschlich als partiell bzw. unzugeordnet erscheinen. Zusätzlich wurden Unit-Schreibvarianten in den beteiligten Auswertungen nicht einheitlich behandelt.

Die Änderung führt abgeschlossene manuelle Peers gezielt wieder für die Aggregationsberechnung zu, zählt dabei aber weiterhin nur aktive Fälle als offene Arbeit. Damit nähern sich Variablenabdeckung, offene Fälle und Job-Verfügbarkeit wieder derselben effektiven Fallebene an.

Bezug: #795

## Validierung

- `npx nx lint backend --skip-nx-cache`
- `npx nx test backend --runInBand --skip-nx-cache`
- 138 Testsuiten und 2.081 Tests bestanden
- `git diff --check`

## Offene Review-Punkte

- Die eigentliche Job-Verteilung verwendet für Unit-Referenzen weiterhin exakte Schreibweisen; der neue Alias-Scope muss dort noch konsistent übernommen werden.
- Die erweiterte Ergebnis-Propagation muss Workspace-Ausschlüsse für Units, Booklets und Testlets berücksichtigen.
