### PR TITLE
Align aggregation coverage with completed response siblings

### DIFF
--- a/apps/backend/src/app/coding/coding.module.spec.ts
+++ b/apps/backend/src/app/coding/coding.module.spec.ts
@@ -1,0 +1,14 @@
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { CodingAggregationPeerService } from '../database/services/coding/coding-aggregation-peer.service';
+import { CodingModule } from './coding.module';
+
+describe('CodingModule', () => {
+  it('exports CodingAggregationPeerService for importing modules', () => {
+    const exportedProviders = Reflect.getMetadata(
+      MODULE_METADATA.EXPORTS,
+      CodingModule
+    ) as unknown[];
+
+    expect(exportedProviders).toContain(CodingAggregationPeerService);
+  });
+});

--- a/apps/backend/src/app/coding/coding.module.ts
+++ b/apps/backend/src/app/coding/coding.module.ts
@@ -133,6 +133,7 @@ import { UserModule } from '../user/user.module';
     }
   ],
   exports: [
+    CodingAggregationPeerService,
     CodingJobService,
     JobDefinitionService,
     CodingStatisticsService,

--- a/apps/backend/src/app/coding/coding.module.ts
+++ b/apps/backend/src/app/coding/coding.module.ts
@@ -22,6 +22,7 @@ import { Unit } from '../database/entities/unit.entity';
 import { Booklet } from '../database/entities/booklet.entity';
 import { ChunkEntity } from '../database/entities/chunk.entity';
 import { CodingUnitFreshness } from '../database/entities/coding-unit-freshness.entity';
+import { CodingAggregationPeerService } from '../database/services/coding/coding-aggregation-peer.service';
 
 import {
   CodingJobService,
@@ -94,6 +95,7 @@ import { UserModule } from '../user/user.module';
     UserModule
   ],
   providers: [
+    CodingAggregationPeerService,
     CodingJobService,
     JobDefinitionService,
     CodingStatisticsService,

--- a/apps/backend/src/app/database/services/coding/aggregation-metrics.util.spec.ts
+++ b/apps/backend/src/app/database/services/coding/aggregation-metrics.util.spec.ts
@@ -1,5 +1,10 @@
 import {
+  buildAggregationPeerLookupKeys,
+  buildAggregationPeerKeys,
+  buildAggregationPeerUnitKeys,
   buildAggregationGroups,
+  countEffectiveManualCodingCases,
+  partitionResponsesByAggregationVariable,
   summarizeAggregationGroups
 } from './aggregation-metrics.util';
 
@@ -94,5 +99,222 @@ describe('aggregation metrics', () => {
       effectiveCases: 2,
       aggregationActive: false
     });
+  });
+
+  it('normalizes unit names in completed peer lookup keys like aggregation groups', () => {
+    const peerKeys = buildAggregationPeerKeys(
+      [
+        {
+          responseId: 1,
+          unitName: 'unit_base',
+          variableId: 'answer',
+          value: 'Same\u00a0answer'
+        }
+      ],
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE'],
+      derivedVariables
+    );
+
+    expect(peerKeys).toEqual([
+      {
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        normalizedValue: 'sameanswer'
+      }
+    ]);
+  });
+
+  it('builds exact raw-value lookups only for normalized peer matches', () => {
+    const peerKeys = buildAggregationPeerKeys(
+      [{
+        responseId: 1,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'Same answer'
+      }],
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE'],
+      derivedVariables
+    );
+
+    expect(buildAggregationPeerLookupKeys(
+      peerKeys,
+      [
+        {
+          unitName: 'unit_base',
+          variableId: 'answer',
+          value: ' sameanswer '
+        },
+        {
+          unitName: 'UNIT_BASE',
+          variableId: 'answer',
+          value: 'different'
+        },
+        {
+          unitName: 'OTHER_UNIT',
+          variableId: 'answer',
+          value: 'Same answer'
+        }
+      ],
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE']
+    )).toEqual([{
+      unitName: 'unit_base',
+      variableId: 'answer',
+      value: ' sameanswer '
+    }]);
+  });
+
+  it('keeps only exact unit aliases for requested canonical peer variables', () => {
+    expect(buildAggregationPeerUnitKeys(
+      [{
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        normalizedValue: 'same'
+      }],
+      [
+        { unitName: 'unit_base', variableId: 'answer' },
+        { unitName: 'UNIT_BASE', variableId: 'answer' },
+        { unitName: 'OTHER_UNIT', variableId: 'answer' },
+        { unitName: 'UNIT_BASE', variableId: 'other' }
+      ]
+    )).toEqual([
+      { unitName: 'unit_base', variableId: 'answer' },
+      { unitName: 'UNIT_BASE', variableId: 'answer' }
+    ]);
+  });
+
+  it('assigns all unit-name case variants to one canonical variable partition', () => {
+    const responses = [
+      { unitName: 'unit_base', variableId: 'answer', responseId: 1 },
+      { unitName: 'UNIT_BASE', variableId: 'answer', responseId: 2 },
+      { unitName: 'Unit_Base', variableId: 'answer', responseId: 3 }
+    ];
+    const partitions = partitionResponsesByAggregationVariable(
+      responses,
+      [
+        { unitName: 'unit_base', variableId: 'answer' },
+        { unitName: 'UNIT_BASE', variableId: 'answer' }
+      ],
+      response => response
+    );
+
+    expect(partitions.get('UNIT_BASE::answer')?.map(r => r.responseId)).toEqual([
+      1,
+      2,
+      3
+    ]);
+    expect(partitions.size).toBe(1);
+  });
+
+  it('assigns a differently cased peer when there is one unambiguous variable', () => {
+    const responses = [
+      { unitName: 'UNIT_BASE', variableId: 'answer', responseId: 1 }
+    ];
+    const partitions = partitionResponsesByAggregationVariable(
+      responses,
+      [{ unitName: 'unit_base', variableId: 'answer' }],
+      response => response
+    );
+
+    expect(partitions.get('UNIT_BASE::answer')?.map(r => r.responseId)).toEqual([1]);
+  });
+
+  it('keeps an open sibling covered by an assigned completed aggregation group', () => {
+    const responses = [
+      {
+        responseId: 1,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'Same answer',
+        personLogin: 'person-1'
+      },
+      {
+        responseId: 2,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: ' sameanswer ',
+        personLogin: 'person-2'
+      }
+    ];
+
+    const counts = countEffectiveManualCodingCases(
+      responses,
+      new Set([1]),
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE'],
+      2,
+      derivedVariables,
+      new Set([2])
+    );
+
+    expect(counts).toEqual({ uniqueCases: 1, casesInJobs: 1 });
+  });
+
+  it('does not transfer coverage when the full group stays below the threshold', () => {
+    const responses = [
+      {
+        responseId: 1,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'Same answer',
+        personLogin: 'person-1'
+      },
+      {
+        responseId: 2,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'sameanswer',
+        personLogin: 'person-2'
+      }
+    ];
+
+    const counts = countEffectiveManualCodingCases(
+      responses,
+      new Set([1]),
+      ['IGNORE_CASE', 'IGNORE_WHITESPACE'],
+      3,
+      derivedVariables,
+      new Set([2])
+    );
+
+    expect(counts).toEqual({ uniqueCases: 1, casesInJobs: 0 });
+  });
+
+  it('deduplicates same-person responses across unit-name case variants', () => {
+    const responses = [
+      {
+        responseId: 1,
+        unitName: 'unit_base',
+        variableId: 'answer',
+        value: 'same',
+        bookletName: 'booklet',
+        personLogin: 'person-1'
+      },
+      {
+        responseId: 2,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'same',
+        bookletName: 'booklet',
+        personLogin: 'person-1'
+      },
+      {
+        responseId: 3,
+        unitName: 'UNIT_BASE',
+        variableId: 'answer',
+        value: 'same',
+        bookletName: 'booklet',
+        personLogin: 'person-2'
+      }
+    ];
+
+    const counts = countEffectiveManualCodingCases(
+      responses,
+      new Set([3]),
+      [],
+      3,
+      derivedVariables,
+      new Set([2])
+    );
+
+    expect(counts).toEqual({ uniqueCases: 1, casesInJobs: 0 });
   });
 });

--- a/apps/backend/src/app/database/services/coding/aggregation-metrics.util.spec.ts
+++ b/apps/backend/src/app/database/services/coding/aggregation-metrics.util.spec.ts
@@ -1,7 +1,6 @@
 import {
   buildAggregationPeerLookupKeys,
   buildAggregationPeerKeys,
-  buildAggregationPeerUnitKeys,
   buildAggregationGroups,
   countEffectiveManualCodingCases,
   partitionResponsesByAggregationVariable,
@@ -161,25 +160,6 @@ describe('aggregation metrics', () => {
       variableId: 'answer',
       value: ' sameanswer '
     }]);
-  });
-
-  it('keeps only exact unit aliases for requested canonical peer variables', () => {
-    expect(buildAggregationPeerUnitKeys(
-      [{
-        unitName: 'UNIT_BASE',
-        variableId: 'answer',
-        normalizedValue: 'same'
-      }],
-      [
-        { unitName: 'unit_base', variableId: 'answer' },
-        { unitName: 'UNIT_BASE', variableId: 'answer' },
-        { unitName: 'OTHER_UNIT', variableId: 'answer' },
-        { unitName: 'UNIT_BASE', variableId: 'other' }
-      ]
-    )).toEqual([
-      { unitName: 'unit_base', variableId: 'answer' },
-      { unitName: 'UNIT_BASE', variableId: 'answer' }
-    ]);
   });
 
   it('assigns all unit-name case variants to one canonical variable partition', () => {

--- a/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
+++ b/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
@@ -43,41 +43,10 @@ export interface AggregationPeerValueCandidate {
   value: string | null;
 }
 
-export interface AggregationPeerUnitKey {
-  unitName: string;
-  variableId: string;
-}
-
 export interface AggregationPeerLookupKey {
   unitName: string;
   variableId: string;
   value: string;
-}
-
-export function buildAggregationPeerUnitKeys(
-  peerKeys: readonly AggregationPeerKey[],
-  candidates: readonly AggregationPeerUnitKey[]
-): AggregationPeerUnitKey[] {
-  const peerVariableKeys = new Set(peerKeys.map(peerKey => (
-    getAggregationVariableKey(peerKey.unitName, peerKey.variableId)
-  )));
-  const unitKeys = new Map<string, AggregationPeerUnitKey>();
-
-  candidates.forEach(candidate => {
-    if (!peerVariableKeys.has(getAggregationVariableKey(
-      candidate.unitName,
-      candidate.variableId
-    ))) {
-      return;
-    }
-
-    unitKeys.set(
-      JSON.stringify([candidate.unitName, candidate.variableId]),
-      candidate
-    );
-  });
-
-  return Array.from(unitKeys.values());
 }
 
 export function buildAggregationPeerLookupKeys(

--- a/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
+++ b/apps/backend/src/app/database/services/coding/aggregation-metrics.util.ts
@@ -31,6 +31,116 @@ export interface EffectiveManualCodingCaseCounts {
   casesInJobs: number;
 }
 
+export interface AggregationPeerKey {
+  unitName: string;
+  variableId: string;
+  normalizedValue: string;
+}
+
+export interface AggregationPeerValueCandidate {
+  unitName: string;
+  variableId: string;
+  value: string | null;
+}
+
+export interface AggregationPeerUnitKey {
+  unitName: string;
+  variableId: string;
+}
+
+export interface AggregationPeerLookupKey {
+  unitName: string;
+  variableId: string;
+  value: string;
+}
+
+export function buildAggregationPeerUnitKeys(
+  peerKeys: readonly AggregationPeerKey[],
+  candidates: readonly AggregationPeerUnitKey[]
+): AggregationPeerUnitKey[] {
+  const peerVariableKeys = new Set(peerKeys.map(peerKey => (
+    getAggregationVariableKey(peerKey.unitName, peerKey.variableId)
+  )));
+  const unitKeys = new Map<string, AggregationPeerUnitKey>();
+
+  candidates.forEach(candidate => {
+    if (!peerVariableKeys.has(getAggregationVariableKey(
+      candidate.unitName,
+      candidate.variableId
+    ))) {
+      return;
+    }
+
+    unitKeys.set(
+      JSON.stringify([candidate.unitName, candidate.variableId]),
+      candidate
+    );
+  });
+
+  return Array.from(unitKeys.values());
+}
+
+export function buildAggregationPeerLookupKeys(
+  peerKeys: readonly AggregationPeerKey[],
+  candidates: readonly AggregationPeerValueCandidate[],
+  matchingFlags: readonly AggregationMatchingFlag[]
+): AggregationPeerLookupKey[] {
+  const peerKeySet = new Set(peerKeys.map(serializeAggregationPeerKey));
+  const lookupKeys = new Map<string, AggregationPeerLookupKey>();
+
+  candidates.forEach(candidate => {
+    if (!isAggregatableValue(candidate.value)) {
+      return;
+    }
+
+    const peerKey = getAggregationPeerKey(
+      candidate.unitName,
+      candidate.variableId,
+      candidate.value,
+      matchingFlags
+    );
+    if (!peerKeySet.has(serializeAggregationPeerKey(peerKey))) {
+      return;
+    }
+
+    const lookupKey = {
+      unitName: candidate.unitName,
+      variableId: candidate.variableId,
+      value: candidate.value as string
+    };
+    lookupKeys.set(JSON.stringify([
+      lookupKey.unitName,
+      lookupKey.variableId,
+      lookupKey.value
+    ]), lookupKey);
+  });
+
+  return Array.from(lookupKeys.values());
+}
+
+export function serializeAggregationPeerKey(
+  peerKey: AggregationPeerKey
+): string {
+  return JSON.stringify([
+    peerKey.unitName,
+    peerKey.variableId,
+    peerKey.normalizedValue
+  ]);
+}
+
+export function getAggregationPeerKey(
+  unitName: string,
+  variableId: string,
+  value: string | null,
+  matchingFlags: readonly AggregationMatchingFlag[]
+): AggregationPeerKey {
+  return {
+    unitName: unitName.toUpperCase(),
+    variableId,
+    normalizedValue: normalizeAggregationValue(value, matchingFlags)
+  };
+}
+
 export function normalizeAggregationValue(
   value: string | null,
   flags: readonly AggregationMatchingFlag[]
@@ -65,6 +175,78 @@ export function isDerivedAggregationVariable(
   return derivedVariableMap.get(unitName.toUpperCase())?.has(variableId) ?? false;
 }
 
+export function getAggregationVariableKey(
+  unitName: string,
+  variableId: string
+): string {
+  return `${unitName.toUpperCase()}::${variableId}`;
+}
+
+export function partitionResponsesByAggregationVariable<T>(
+  responses: readonly T[],
+  variables: readonly { unitName: string; variableId: string }[],
+  getVariableReference: (response: T) => {
+    unitName: string;
+    variableId: string;
+  }
+): Map<string, T[]> {
+  const variableKeys = new Set(
+    variables.map(variable => getAggregationVariableKey(
+      variable.unitName,
+      variable.variableId
+    ))
+  );
+
+  const partitionedResponses = new Map<string, T[]>();
+  responses.forEach(response => {
+    const reference = getVariableReference(response);
+    const variableKey = getAggregationVariableKey(
+      reference.unitName,
+      reference.variableId
+    );
+    if (!variableKeys.has(variableKey)) {
+      return;
+    }
+
+    const variableResponses = partitionedResponses.get(variableKey) || [];
+    variableResponses.push(response);
+    partitionedResponses.set(variableKey, variableResponses);
+  });
+
+  return partitionedResponses;
+}
+
+export function buildAggregationPeerKeys<T extends AggregationSourceResponse>(
+  responses: T[],
+  matchingFlags: readonly AggregationMatchingFlag[],
+  derivedVariableMap: Map<string, Set<string>>
+): AggregationPeerKey[] {
+  const keys = new Map<string, AggregationPeerKey>();
+
+  responses.forEach(response => {
+    if (
+      !isAggregatableValue(response.value) ||
+      isDerivedAggregationVariable(
+        derivedVariableMap,
+        response.unitName,
+        response.variableId
+      )
+    ) {
+      return;
+    }
+
+    const peerKey = getAggregationPeerKey(
+      response.unitName,
+      response.variableId,
+      response.value,
+      matchingFlags
+    );
+    keys.set(serializeAggregationPeerKey(peerKey), peerKey);
+  });
+
+  return Array.from(keys.values());
+}
+
 export function getManualCodingDeduplicationKey(
   response: ManualCodingDeduplicationResponse
 ): string {
@@ -74,7 +256,7 @@ export function getManualCodingDeduplicationKey(
     response.personCode || '',
     response.personGroup || '',
     response.bookletName || '',
-    response.unitName,
+    response.unitName.toUpperCase(),
     response.variableId,
     valueHash
   ].join('::');
@@ -101,7 +283,8 @@ export function countEffectiveManualCodingCases<T extends ManualCodingDeduplicat
   assignedResponseIds: ReadonlySet<number>,
   matchingFlags: readonly AggregationMatchingFlag[],
   threshold: number | null,
-  derivedVariableMap: Map<string, Set<string>>
+  derivedVariableMap: Map<string, Set<string>>,
+  activeResponseIds?: ReadonlySet<number>
 ): EffectiveManualCodingCaseCounts {
   const assignedDeduplicationKeys = new Set(
     responses
@@ -117,6 +300,19 @@ export function countEffectiveManualCodingCases<T extends ManualCodingDeduplicat
       ))
       .map(response => response.responseId)
   );
+  const activeDeduplicationKeys = activeResponseIds ? new Set(
+    responses
+      .filter(response => activeResponseIds.has(response.responseId))
+      .map(response => getManualCodingDeduplicationKey(response))
+  ) : null;
+  const activeDedupedResponseIds = activeResponseIds ? new Set(
+    dedupedResponses
+      .filter(response => (
+        activeResponseIds.has(response.responseId) ||
+        activeDeduplicationKeys?.has(getManualCodingDeduplicationKey(response))
+      ))
+      .map(response => response.responseId)
+  ) : null;
   const aggregatedGroups = buildAggregationGroups(
     dedupedResponses,
     matchingFlags,
@@ -127,6 +323,14 @@ export function countEffectiveManualCodingCases<T extends ManualCodingDeduplicat
   let casesInJobs = 0;
 
   for (const group of aggregatedGroups) {
+    const activeResponses = activeDedupedResponseIds ?
+      group.responses.filter(response => activeDedupedResponseIds.has(response.responseId)) :
+      group.responses;
+
+    if (activeResponses.length === 0) {
+      continue;
+    }
+
     if (threshold !== null && group.responses.length >= threshold) {
       uniqueCases += 1;
       if (group.responses.some(response => assignedDedupedResponseIds.has(response.responseId))) {
@@ -135,8 +339,8 @@ export function countEffectiveManualCodingCases<T extends ManualCodingDeduplicat
       continue;
     }
 
-    uniqueCases += group.responses.length;
-    casesInJobs += group.responses
+    uniqueCases += activeResponses.length;
+    casesInJobs += activeResponses
       .filter(response => assignedDedupedResponseIds.has(response.responseId))
       .length;
   }
@@ -156,7 +360,10 @@ export function buildAggregationGroups<T extends AggregationSourceResponse>(
   const groupedResponses = new Map<string, T[]>();
 
   for (const response of responses) {
-    const variableKey = `${response.unitName.toUpperCase()}::${response.variableId}`;
+    const variableKey = getAggregationVariableKey(
+      response.unitName,
+      response.variableId
+    );
     const keepSeparate =
       !aggregationActive ||
       !isAggregatableValue(response.value) ||

--- a/apps/backend/src/app/database/services/coding/coding-aggregation-peer.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-aggregation-peer.service.spec.ts
@@ -1,0 +1,123 @@
+import { CodingAggregationPeerService } from './coding-aggregation-peer.service';
+
+const createQueryBuilder = (rows: unknown[]) => {
+  const queryBuilder: Record<string, jest.Mock> = {};
+  [
+    'select',
+    'addSelect',
+    'innerJoin',
+    'leftJoin',
+    'where',
+    'andWhere',
+    'orderBy'
+  ].forEach(method => {
+    queryBuilder[method] = jest.fn().mockReturnValue(queryBuilder);
+  });
+  queryBuilder.getRawMany = jest.fn().mockResolvedValue(rows);
+  return queryBuilder;
+};
+
+describe('CodingAggregationPeerService', () => {
+  it('loads normalized completed peers in two exclusion-safe queries', async () => {
+    const peerValueQuery = createQueryBuilder([
+      {
+        unitName: 'unit',
+        variableId: 'VAR',
+        value: ' sameanswer '
+      }
+    ]);
+    const completedPeersQuery = createQueryBuilder([
+      {
+        responseId: '7',
+        unitName: 'unit',
+        unitAlias: null,
+        variableId: 'VAR',
+        value: ' sameanswer ',
+        statusV1: '2',
+        statusV2: '5',
+        codeV2: '1',
+        bookletName: 'Booklet',
+        personLogin: 'login',
+        personCode: 'code',
+        personGroup: 'group'
+      }
+    ]);
+    const responseRepository = {
+      createQueryBuilder: jest.fn()
+        .mockReturnValueOnce(peerValueQuery)
+        .mockReturnValueOnce(completedPeersQuery)
+    };
+    const loadQueryContext = jest.fn().mockResolvedValue({
+      defaultMirCode: -98,
+      exclusions: {
+        globalIgnoredUnits: [],
+        ignoredBooklets: ['blocked'],
+        testletIgnoredUnits: [{ bookletId: 'Booklet', unitId: 'UNIT.XML' }]
+      }
+    });
+    const service = new CodingAggregationPeerService(responseRepository as never);
+
+    const result = await service.findCompletedPeers({
+      workspaceId: 5,
+      sourceResponses: [{
+        responseId: 1,
+        unitName: 'UNIT',
+        variableId: 'VAR',
+        value: 'Same\u00a0answer'
+      }],
+      matchingFlags: ['IGNORE_CASE', 'IGNORE_WHITESPACE'],
+      derivedVariableMap: new Map(),
+      loadQueryContext
+    });
+
+    expect(result).toEqual([expect.objectContaining({
+      responseId: 7,
+      unitName: 'unit',
+      variableId: 'VAR',
+      codeV2: 1
+    })]);
+    expect(responseRepository.createQueryBuilder).toHaveBeenCalledTimes(2);
+    expect(peerValueQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('aggregation_peer_variable'),
+      {
+        aggregationPeerVariables: JSON.stringify([
+          { unitName: 'UNIT', variableId: 'VAR' }
+        ])
+      }
+    );
+    expect(peerValueQuery.andWhere).toHaveBeenCalledWith(
+      'UPPER(bookletinfo.name) NOT IN (:...completedAggregationPeersValuesIgnoredBooklets)',
+      { completedAggregationPeersValuesIgnoredBooklets: ['BLOCKED'] }
+    );
+    expect(completedPeersQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('completedAggregationPeersPeersBooklet0'),
+      {
+        completedAggregationPeersPeersBooklet0: 'BOOKLET',
+        completedAggregationPeersPeersUnit0: 'UNIT'
+      }
+    );
+    expect(loadQueryContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not load query context when no source response can form a peer key', async () => {
+    const responseRepository = { createQueryBuilder: jest.fn() };
+    const loadQueryContext = jest.fn();
+    const service = new CodingAggregationPeerService(responseRepository as never);
+
+    await expect(service.findCompletedPeers({
+      workspaceId: 5,
+      sourceResponses: [{
+        responseId: 1,
+        unitName: 'UNIT',
+        variableId: 'VAR',
+        value: null
+      }],
+      matchingFlags: ['IGNORE_CASE'],
+      derivedVariableMap: new Map(),
+      loadQueryContext
+    })).resolves.toEqual([]);
+
+    expect(loadQueryContext).not.toHaveBeenCalled();
+    expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/app/database/services/coding/coding-aggregation-peer.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-aggregation-peer.service.ts
@@ -1,0 +1,265 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  Brackets,
+  EntityManager,
+  Repository,
+  SelectQueryBuilder
+} from 'typeorm';
+import { ResponseEntity } from '../../entities/response.entity';
+import { statusStringToNumber } from '../../utils/response-status-converter';
+import {
+  DERIVE_ERROR_STATUS,
+  getDeriveErrorManualCodingPairKeys,
+  ManualCodingVariableReference,
+  MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+} from '../../utils/manual-coding-candidate.util';
+import {
+  applyResolvedExclusionsToQuery,
+  ResolvedWorkspaceExclusions
+} from '../workspace/workspace-exclusion-query.util';
+import {
+  AggregationMatchingFlag,
+  AggregationSourceResponse,
+  buildAggregationPeerKeys,
+  buildAggregationPeerLookupKeys,
+  getAggregationPeerKey,
+  isAggregatableValue,
+  serializeAggregationPeerKey
+} from './aggregation-metrics.util';
+import { getNonCodingIssueReviewJobSqlCondition } from './coding-job-type.util';
+
+export interface CompletedAggregationPeer {
+  responseId: number;
+  variableId: string;
+  value: string | null;
+  statusV1: number | null;
+  statusV2: number | null;
+  codeV2: number | null;
+  unitName: string;
+  unitAlias: string | null;
+  bookletName: string;
+  personLogin: string;
+  personCode: string;
+  personGroup: string;
+}
+
+export interface FindCompletedAggregationPeersOptions {
+  workspaceId: number;
+  sourceResponses: readonly AggregationSourceResponse[];
+  matchingFlags: readonly AggregationMatchingFlag[];
+  derivedVariableMap: Map<string, Set<string>>;
+  variables?: ManualCodingVariableReference[];
+  manager?: EntityManager;
+  loadQueryContext: () => Promise<{
+    defaultMirCode: number;
+    exclusions: ResolvedWorkspaceExclusions;
+  }>;
+}
+
+@Injectable()
+export class CodingAggregationPeerService {
+  constructor(
+    @InjectRepository(ResponseEntity)
+    private readonly responseRepository: Repository<ResponseEntity>
+  ) {}
+
+  async findCompletedPeers(
+    options: FindCompletedAggregationPeersOptions
+  ): Promise<CompletedAggregationPeer[]> {
+    const peerKeys = buildAggregationPeerKeys(
+      [...options.sourceResponses],
+      options.matchingFlags,
+      options.derivedVariableMap
+    );
+    if (peerKeys.length === 0) {
+      return [];
+    }
+
+    const { defaultMirCode, exclusions } = await options.loadQueryContext();
+    const peerKeySet = new Set(
+      peerKeys.map(peerKey => serializeAggregationPeerKey(peerKey))
+    );
+    const exactValueMatching =
+      !options.matchingFlags.includes('IGNORE_CASE') &&
+      !options.matchingFlags.includes('IGNORE_WHITESPACE');
+    const responseRepository = options.manager ?
+      options.manager.getRepository(ResponseEntity) :
+      this.responseRepository;
+    const createCompletedPeerQuery = (
+      parameterSuffix: string
+    ): SelectQueryBuilder<ResponseEntity> => {
+      const query = responseRepository
+        .createQueryBuilder('response')
+        .innerJoin('response.unit', 'unit')
+        .innerJoin('unit.booklet', 'booklet')
+        .leftJoin('booklet.bookletinfo', 'bookletinfo')
+        .innerJoin('booklet.person', 'person')
+        .where('person.workspace_id = :workspaceId', {
+          workspaceId: options.workspaceId
+        })
+        .andWhere('person.consider = :consider', { consider: true })
+        .andWhere('response.status_v2 = :completedV2Status', {
+          completedV2Status: statusStringToNumber('CODING_COMPLETE')
+        })
+        .andWhere(
+          '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+          { aggregatedCode: -111, defaultMirCode }
+        )
+        .andWhere(new Brackets(qb => {
+          qb.where('response.code_v2 IS NULL')
+            .orWhere(subQuery => {
+              const exists = subQuery
+                .subQuery()
+                .select('1')
+                .from('coding_job_unit', 'manual_cju')
+                .innerJoin(
+                  'coding_job',
+                  'manual_cj',
+                  'manual_cj.id = manual_cju.coding_job_id'
+                )
+                .where('manual_cju.response_id = response.id')
+                .andWhere('manual_cj.training_id IS NULL')
+                .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
+                .getQuery();
+              return `EXISTS (${exists})`;
+            });
+        }));
+      this.applyManualCodingCandidateStatusFilter(
+        query,
+        options.variables || []
+      );
+      applyResolvedExclusionsToQuery(query, exclusions, {
+        parameterPrefix: `completedAggregationPeers${parameterSuffix}`
+      });
+      return query;
+    };
+
+    const peerVariables = Array.from(new Map(
+      peerKeys.map(peerKey => [
+        JSON.stringify([peerKey.unitName, peerKey.variableId]),
+        {
+          unitName: peerKey.unitName,
+          variableId: peerKey.variableId
+        }
+      ])
+    ).values());
+
+    const peerValueQuery = createCompletedPeerQuery('Values')
+      .select('DISTINCT unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('response.value', 'value')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerVariables AS jsonb))
+            AS aggregation_peer_variable("unitName" text, "variableId" text)
+          WHERE aggregation_peer_variable."unitName" = UPPER(unit.name)
+            AND aggregation_peer_variable."variableId" = response.variableid
+        )`,
+        { aggregationPeerVariables: JSON.stringify(peerVariables) }
+      );
+    if (exactValueMatching) {
+      peerValueQuery.andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerValues AS jsonb))
+            AS aggregation_peer_value("variableId" text, "normalizedValue" text)
+          WHERE aggregation_peer_value."variableId" = response.variableid
+            AND aggregation_peer_value."normalizedValue" = response.value
+        )`,
+        { aggregationPeerValues: JSON.stringify(peerKeys) }
+      );
+    }
+    const peerLookupKeys = buildAggregationPeerLookupKeys(
+      peerKeys,
+      await peerValueQuery.getRawMany(),
+      options.matchingFlags
+    );
+    if (peerLookupKeys.length === 0) {
+      return [];
+    }
+
+    const query = createCompletedPeerQuery('Peers')
+      .select('response.id', 'responseId')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('response.value', 'value')
+      .addSelect('response.status_v1', 'statusV1')
+      .addSelect('response.status_v2', 'statusV2')
+      .addSelect('response.code_v2', 'codeV2')
+      .addSelect('unit.name', 'unitName')
+      .addSelect('unit.alias', 'unitAlias')
+      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
+      .addSelect("COALESCE(person.login, '')", 'personLogin')
+      .addSelect("COALESCE(person.code, '')", 'personCode')
+      .addSelect("COALESCE(person.group, '')", 'personGroup')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerKeys AS jsonb))
+            AS aggregation_peer("unitName" text, "variableId" text, "value" text)
+          WHERE aggregation_peer."unitName" = unit.name
+            AND aggregation_peer."variableId" = response.variableid
+            AND aggregation_peer."value" = response.value
+        )`,
+        { aggregationPeerKeys: JSON.stringify(peerLookupKeys) }
+      )
+      .orderBy('response.id', 'ASC');
+    const raw = await query.getRawMany();
+
+    return raw.map(row => ({
+      responseId: Number(row.responseId ?? row.id),
+      variableId: row.variableId ?? row.variableid,
+      value: row.value ?? null,
+      statusV1: this.toNullableNumber(row.statusV1),
+      statusV2: this.toNullableNumber(row.statusV2),
+      codeV2: this.toNullableNumber(row.codeV2),
+      unitName: row.unitName ?? '',
+      unitAlias: row.unitAlias ?? null,
+      bookletName: row.bookletName ?? '',
+      personLogin: row.personLogin ?? '',
+      personCode: row.personCode ?? '',
+      personGroup: row.personGroup ?? ''
+    })).filter(response => (
+      isAggregatableValue(response.value) &&
+      peerKeySet.has(serializeAggregationPeerKey(getAggregationPeerKey(
+        response.unitName,
+        response.variableId,
+        response.value,
+        options.matchingFlags
+      )))
+    ));
+  }
+
+  private applyManualCodingCandidateStatusFilter(
+    queryBuilder: SelectQueryBuilder<ResponseEntity>,
+    variables: ManualCodingVariableReference[]
+  ): void {
+    const deriveErrorManualCodingPairKeys =
+      getDeriveErrorManualCodingPairKeys(variables);
+
+    if (deriveErrorManualCodingPairKeys.length === 0) {
+      queryBuilder.andWhere('response.status_v1 IN (:...statuses)', {
+        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+      });
+      return;
+    }
+
+    queryBuilder.andWhere(new Brackets(qb => {
+      qb.where('response.status_v1 IN (:...statuses)', {
+        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+      }).orWhere(
+        `response.status_v1 = :deriveErrorStatus
+        AND CONCAT(UPPER(unit.name), CHR(31), response.variableid) IN (:...deriveErrorManualCodingPairKeys)`,
+        {
+          deriveErrorStatus: DERIVE_ERROR_STATUS,
+          deriveErrorManualCodingPairKeys
+        }
+      );
+    }));
+  }
+
+  private toNullableNumber(value: unknown): number | null {
+    return value === null || value === undefined ? null : Number(value);
+  }
+}

--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.spec.ts
@@ -1004,7 +1004,15 @@ describe('CodingFreshnessService', () => {
       [1, [10], 'stale_source', 'RESULT_ADDED']
     );
     expect(connection.query).toHaveBeenCalledWith(
-      expect.stringContaining('variable_bundle.variables @>'),
+      expect.stringContaining(
+        'UPPER(coding_job_variable.unit_name) = UPPER(added_responses.unit_name)'
+      ),
+      [1, [10], 'stale_source', 'RESULT_ADDED']
+    );
+    expect(connection.query).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'FROM jsonb_array_elements(variable_bundle.variables) bundle_variable'
+      ),
       [1, [10], 'stale_source', 'RESULT_ADDED']
     );
   });
@@ -1062,6 +1070,18 @@ describe('CodingFreshnessService', () => {
     expect((freshnessRepository.upsert as jest.Mock).mock.calls[0][0]).toHaveLength(4);
     expect(connection.query).toHaveBeenCalledWith(
       expect.stringContaining('response.id = ANY($2::int[])'),
+      [1, [100, 101, 102], 'stale_source', 'RESULT_ADDED']
+    );
+    expect(connection.query).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'UPPER(coding_job_variable.unit_name) = UPPER(added_responses.unit_name)'
+      ),
+      [1, [100, 101, 102], 'stale_source', 'RESULT_ADDED']
+    );
+    expect(connection.query).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "UPPER(bundle_variable ->> 'unitName') = UPPER(added_responses.unit_name)"
+      ),
       [1, [100, 101, 102], 'stale_source', 'RESULT_ADDED']
     );
   });

--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
@@ -1434,7 +1434,7 @@ export class CodingFreshnessService {
             added_responses.response_id
           FROM added_responses
           INNER JOIN coding_job_variable
-            ON coding_job_variable.unit_name = added_responses.unit_name
+            ON UPPER(coding_job_variable.unit_name) = UPPER(added_responses.unit_name)
             AND coding_job_variable.variable_id = added_responses.variable_id
           INNER JOIN coding_job
             ON coding_job.id = coding_job_variable.coding_job_id
@@ -1449,12 +1449,12 @@ export class CodingFreshnessService {
           FROM added_responses
           INNER JOIN variable_bundle
             ON variable_bundle.workspace_id = $1
-            AND variable_bundle.variables @> jsonb_build_array(
-              jsonb_build_object(
-                'unitName', added_responses.unit_name,
-                'variableId', added_responses.variable_id
+            AND EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(variable_bundle.variables) bundle_variable
+              WHERE UPPER(bundle_variable ->> 'unitName') = UPPER(added_responses.unit_name)
+                AND bundle_variable ->> 'variableId' = added_responses.variable_id
               )
-            )
           INNER JOIN coding_job_variable_bundle
             ON coding_job_variable_bundle.variable_bundle_id = variable_bundle.id
           INNER JOIN coding_job
@@ -1533,7 +1533,7 @@ export class CodingFreshnessService {
             added_responses.response_id
           FROM added_responses
           INNER JOIN coding_job_variable
-            ON coding_job_variable.unit_name = added_responses.unit_name
+            ON UPPER(coding_job_variable.unit_name) = UPPER(added_responses.unit_name)
             AND coding_job_variable.variable_id = added_responses.variable_id
           INNER JOIN coding_job
             ON coding_job.id = coding_job_variable.coding_job_id
@@ -1548,12 +1548,12 @@ export class CodingFreshnessService {
           FROM added_responses
           INNER JOIN variable_bundle
             ON variable_bundle.workspace_id = $1
-            AND variable_bundle.variables @> jsonb_build_array(
-              jsonb_build_object(
-                'unitName', added_responses.unit_name,
-                'variableId', added_responses.variable_id
+            AND EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(variable_bundle.variables) bundle_variable
+              WHERE UPPER(bundle_variable ->> 'unitName') = UPPER(added_responses.unit_name)
+                AND bundle_variable ->> 'variableId' = added_responses.variable_id
               )
-            )
           INNER JOIN coding_job_variable_bundle
             ON coding_job_variable_bundle.variable_bundle_id = variable_bundle.id
           INNER JOIN coding_job

--- a/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-incomplete-variables-cache-key.util.ts
@@ -1,9 +1,9 @@
 export function getCodingIncompleteVariablesCacheKey(workspaceId: number): string {
-  return `coding_incomplete_variables_v8:${workspaceId}`;
+  return `coding_incomplete_variables_v9:${workspaceId}`;
 }
 
 export function getCodingIncompleteVariablesScopeCacheKey(workspaceId: number): string {
-  return `coding_incomplete_variables_scope_v1:${workspaceId}`;
+  return `coding_incomplete_variables_scope_v2:${workspaceId}`;
 }
 
 export function getCodingIncompleteVariablesCacheVersionKey(workspaceId: number): string {

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -3,6 +3,8 @@ import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { CodingJob } from '../../entities/coding-job.entity';
 import { JobDefinition } from '../../entities/job-definition.entity';
 import { DERIVE_ERROR_STATUS } from '../../utils/manual-coding-candidate.util';
+import { CodingAggregationPeerService } from './coding-aggregation-peer.service';
+import { statusStringToNumber } from '../../utils/response-status-converter';
 
 jest.mock('../workspace/workspace-files.service', () => ({
   WorkspaceFilesService: class {}
@@ -13,6 +15,7 @@ type SlimResponseForTest = {
   variableid: string;
   value: string | null;
   statusV1?: number | null;
+  statusV2?: number | null;
   unitName: string;
   unitAlias: string | null;
   bookletName: string;
@@ -155,7 +158,8 @@ describe('CodingJobService distribution from job definitions', () => {
       cacheService as never,
       workspaceFilesService as never,
       workspaceExclusionService as never,
-      usersService as never
+      usersService as never,
+      new CodingAggregationPeerService(responseRepository as never)
     );
 
     jest.spyOn(
@@ -173,10 +177,20 @@ describe('CodingJobService distribution from job definitions', () => {
   });
 
   function mockResponses(responses: SlimResponseForTest[]): void {
-    jest.spyOn(service, 'getSlimResponsesForVariables').mockImplementation(async (_workspaceId, variables) => responses.filter(response => variables.some(variable => variable.unitName === response.unitName &&
+    const responsesForVariables = (
+      variables: Array<{ unitName: string; variableId: string }>
+    ) => responses.filter(response => variables.some(variable => (
+      variable.unitName.toUpperCase() === response.unitName.toUpperCase() &&
       variable.variableId === response.variableid
-    ))
-    );
+    )));
+    jest.spyOn(service, 'getSlimResponsesForVariables')
+      .mockImplementation(async (_workspaceId, variables) => (
+        responsesForVariables(variables)
+      ));
+    jest.spyOn(service, 'getSlimResponsesForVariableCoverage')
+      .mockImplementation(async (_workspaceId, variables) => (
+        responsesForVariables(variables)
+      ));
     jest.spyOn(
       service as unknown as { getVariableCasesInJobs: () => Promise<Map<string, number>> },
       'getVariableCasesInJobs'
@@ -325,6 +339,86 @@ describe('CodingJobService distribution from job definitions', () => {
     });
     expect([...assignedResponseCounts.values()].filter(count => count === 2)).toHaveLength(2);
     expect(Math.max(...assignedResponseCounts.values())).toBe(2);
+  });
+
+  it('uses all unit-name case variants in preview, usage and created jobs', async () => {
+    const responses = [
+      makeResponse(1, 'Unit A', 'Var 1'),
+      makeResponse(2, 'Unit A', 'Var 1'),
+      makeResponse(3, 'UNIT A', 'Var 1'),
+      makeResponse(4, 'UNIT A', 'Var 1')
+    ];
+    const createdSubsets: SlimResponseForTest[][] = [];
+
+    mockResponses(responses);
+    jest.spyOn(service, 'getResponseMatchingMode')
+      .mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
+    jest.spyOn(
+      service as unknown as {
+        createCodingJobWithUnitSubsetInManager: (
+          workspaceId: number,
+          dto: unknown,
+          subset: SlimResponseForTest[]
+        ) => Promise<CodingJob>
+      },
+      'createCodingJobWithUnitSubsetInManager'
+    ).mockImplementation(async (_workspaceId, _dto, subset) => {
+      createdSubsets.push(subset as SlimResponseForTest[]);
+      return { id: 900 + createdSubsets.length } as CodingJob;
+    });
+
+    const request = {
+      selectedVariables: [{ unitName: 'Unit A', variableId: 'Var 1' }],
+      selectedCoders: [{ id: 1, name: 'Ada', username: 'ada' }],
+      caseOrderingMode: 'continuous' as const,
+      distributionSeed: 'unit-case-variants'
+    };
+    const preview = await service.calculateDistribution(5, request);
+    const usage = await service.calculateDistributionVariableUsage(5, request);
+    const result = await service.createDistributedCodingJobs(5, {
+      ...request,
+      jobDefinitionId: 91
+    });
+
+    expect(preview.distribution['Unit A::Var 1']).toEqual({ Ada: 4 });
+    expect(Object.fromEntries(usage)).toEqual({ 'Unit A::Var 1': 4 });
+    expect(result.distribution).toEqual(preview.distribution);
+    expect(createdSubsets.flat().map(response => response.id).sort())
+      .toEqual([1, 2, 3, 4]);
+  });
+
+  it('does not redistribute an open sibling covered by a completed aggregation peer', async () => {
+    const completedResponse = {
+      ...makeResponse(1, 'Unit A', 'Var 1', 'same answer'),
+      statusV2: statusStringToNumber('CODING_COMPLETE')
+    };
+    const activeResponse = {
+      ...makeResponse(2, 'UNIT A', 'Var 1', 'same answer'),
+      statusV2: null
+    };
+    mockResponses([completedResponse, activeResponse]);
+    jest.spyOn(service, 'getResponseMatchingMode').mockResolvedValue([]);
+    jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(2);
+
+    const request = {
+      selectedVariables: [{ unitName: 'Unit A', variableId: 'Var 1' }],
+      selectedCoders: [{ id: 1, name: 'Ada', username: 'ada' }],
+      distributionSeed: 'completed-peer-coverage'
+    };
+
+    const preview = await service.calculateDistribution(5, request);
+    const usage = await service.calculateDistributionVariableUsage(5, request);
+    const result = await service.createDistributedCodingJobs(5, request);
+
+    expect(preview.distribution['Unit A::Var 1']).toEqual({ Ada: 0 });
+    expect(preview.aggregationInfo['Unit A::Var 1']).toEqual({
+      uniqueCases: 0,
+      totalResponses: 0
+    });
+    expect(usage).toEqual(new Map());
+    expect(result.jobsCreated).toBe(0);
+    expect(result.jobs).toEqual([]);
   });
 
   it('skips cases already assigned by an earlier definition when creating later jobs', async () => {
@@ -1357,7 +1451,7 @@ describe('CodingJobService distribution from job definitions', () => {
     const matchingSpy = jest.spyOn(service, 'getResponseMatchingMode')
       .mockResolvedValue([ResponseMatchingFlag.NO_AGGREGATION]);
     const thresholdSpy = jest.spyOn(service, 'getAggregationThreshold').mockResolvedValue(null);
-    const slimResponsesSpy = service.getSlimResponsesForVariables as jest.Mock;
+    const slimResponsesSpy = service.getSlimResponsesForVariableCoverage as jest.Mock;
     const assignedResponseIdsSpy = (
       service as unknown as { getAssignedResponseIdsForVariables: jest.Mock }
     ).getAssignedResponseIdsForVariables;
@@ -1393,7 +1487,7 @@ describe('CodingJobService distribution from job definitions', () => {
     expect(slimResponsesSpy).toHaveBeenCalledWith(5, [
       { unitName: 'Unit 1', variableId: 'Var 1' },
       { unitName: 'Unit 2', variableId: 'Var 2' }
-    ]);
+    ], [ResponseMatchingFlag.NO_AGGREGATION], null, expect.any(Map));
   });
 
   it('calculates batched variable usage split by regular and DERIVE_ERROR cases', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job-distribution.spec.ts
@@ -286,8 +286,8 @@ describe('CodingJobService distribution from job definitions', () => {
 
     expect(result.success).toBe(true);
     expect(cacheService.incr).toHaveBeenCalledWith('coding_incomplete_variables_version:5');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v8:5');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v1:5');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v9:5');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v2:5');
     expect(result.distribution).toEqual(preview.distribution);
     expect(result.doubleCodingInfo).toEqual(preview.doubleCodingInfo);
     expect(result.jobsCreated).toBe(createdJobCalls.length);

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -14,6 +14,7 @@ import { JobDefinition } from '../../entities/job-definition.entity';
 import { VariableBundle } from '../../entities/variable-bundle.entity';
 import { ResponseEntity } from '../../entities/response.entity';
 import { statusStringToNumber } from '../../utils/response-status-converter';
+import { CodingAggregationPeerService } from './coding-aggregation-peer.service';
 
 jest.mock('../workspace/workspace-files.service', () => ({
   WorkspaceFilesService: class {}
@@ -259,6 +260,7 @@ describe('CodingJobService', () => {
       workspaceFilesService as never,
       workspaceExclusionService as never,
       usersService as never,
+      new CodingAggregationPeerService(responseRepository as never),
       codingFreshnessService as never,
       codingFileCacheService as never,
       missingsProfilesService as never,
@@ -528,7 +530,7 @@ describe('CodingJobService', () => {
         {
           id: 123,
           variableid: 'VAR',
-          unitName: 'UNIT',
+          unitName: 'unit',
           unitAlias: 'ALIAS',
           bookletName: 'BOOKLET',
           personLogin: 'coder-login',
@@ -2280,6 +2282,38 @@ describe('CodingJobService', () => {
       'response.status_v2',
       'statusV2'
     );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      '((UPPER(unit.name) = UPPER(:slimUnitName0) AND response.variableid = :slimVariableId0))',
+      {
+        slimUnitName0: 'UNIT',
+        slimVariableId0: 'VAR'
+      }
+    );
+  });
+
+  it('matches assigned responses across unit-name case variants', async () => {
+    const qb = createQueryBuilder([{ responseId: '42' }]);
+    codingJobUnitRepository.createQueryBuilder.mockReturnValue(qb);
+
+    const result = await (
+      service as unknown as {
+        getAssignedResponseIdsForVariables: (
+          workspaceId: number,
+          variables: Array<{ unitName: string; variableId: string }>
+        ) => Promise<Set<number>>;
+      }
+    ).getAssignedResponseIdsForVariables(3, [
+      { unitName: 'Unit', variableId: 'VAR' }
+    ]);
+
+    expect(result).toEqual(new Set([42]));
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      '((UPPER(cju.unit_name) = UPPER(:assignedUnitName0) AND cju.variable_id = :assignedVariableId0))',
+      {
+        assignedUnitName0: 'Unit',
+        assignedVariableId0: 'VAR'
+      }
+    );
   });
 
   it('loads completed aggregation peers only for normalized active response values', async () => {
@@ -2330,14 +2364,8 @@ describe('CodingJobService', () => {
       { unitName: 'UNIT', variableId: 'VAR', value: ' sameanswer ' },
       { unitName: 'Unit', variableId: 'VAR', value: 'Same answer' }
     ]);
-    const peerUnitQuery = createQueryBuilder([
-      { unitName: 'UNIT', variableId: 'VAR' },
-      { unitName: 'Unit', variableId: 'VAR' },
-      { unitName: 'OTHER_UNIT', variableId: 'VAR' }
-    ]);
     responseRepository.createQueryBuilder
       .mockReturnValueOnce(activeQuery)
-      .mockReturnValueOnce(peerUnitQuery)
       .mockReturnValueOnce(peerValueQuery)
       .mockReturnValueOnce(peerQuery);
 
@@ -2357,17 +2385,16 @@ describe('CodingJobService', () => {
       })
     );
     expect(peerValueQuery.andWhere).toHaveBeenCalledWith(
-      expect.stringContaining('aggregation_peer_unit'),
+      expect.stringContaining('aggregation_peer_variable'),
       {
-        aggregationPeerUnits: JSON.stringify([
-          { unitName: 'UNIT', variableId: 'VAR' },
-          { unitName: 'Unit', variableId: 'VAR' }
+        aggregationPeerVariables: JSON.stringify([
+          { unitName: 'UNIT', variableId: 'VAR' }
         ])
       }
     );
     expect(peerQuery.andWhere).toHaveBeenCalledWith(
-      'response.status_v2 = :completedStatus',
-      { completedStatus: statusStringToNumber('CODING_COMPLETE') }
+      'response.status_v2 = :completedV2Status',
+      { completedV2Status: statusStringToNumber('CODING_COMPLETE') }
     );
     expect(peerQuery.andWhere).toHaveBeenCalledWith(
       '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
@@ -2409,13 +2436,9 @@ describe('CodingJobService', () => {
     const peerValueQuery = createQueryBuilder([
       { unitName: 'UNIT', variableId: 'VAR', value: 'exact answer' }
     ]);
-    const peerUnitQuery = createQueryBuilder([
-      { unitName: 'UNIT', variableId: 'VAR' }
-    ]);
     const peerQuery = createQueryBuilder([]);
     responseRepository.createQueryBuilder
       .mockReturnValueOnce(activeQuery)
-      .mockReturnValueOnce(peerUnitQuery)
       .mockReturnValueOnce(peerValueQuery)
       .mockReturnValueOnce(peerQuery);
 
@@ -2450,7 +2473,7 @@ describe('CodingJobService', () => {
     await expect(
       service.getResponsesForVariables(3, [
         {
-          unitName: 'UNIT',
+          unitName: 'Unit',
           variableId: 'VAR',
           includeDeriveError: true
         }
@@ -2478,7 +2501,7 @@ describe('CodingJobService', () => {
       }
     );
     expect(bracketBuilder.orWhere).toHaveBeenCalledWith(
-      expect.stringContaining('response.status_v1 = :deriveErrorStatus'),
+      expect.stringContaining('CONCAT(UPPER(unit.name), CHR(31), response.variableid)'),
       {
         deriveErrorStatus: statusStringToNumber('DERIVE_ERROR'),
         deriveErrorManualCodingPairKeys: ['UNIT\u001FVAR']
@@ -4917,6 +4940,25 @@ describe('CodingJobService', () => {
             person: { login: 'login', code: 'code', group: 'group' }
           }
         }
+      },
+      {
+        id: 101,
+        variableid: 'VAR_A',
+        is_autocoder_generated: false,
+        status_v1: null,
+        code_v1: null,
+        score_v1: null,
+        code_v2: null,
+        score_v2: null,
+        code_v3: null,
+        score_v3: null,
+        unit: {
+          name: 'unit_a',
+          booklet: {
+            bookletinfo: { name: 'BOOKLET' },
+            person: { login: 'login', code: 'code', group: 'group' }
+          }
+        }
       }
     ]);
 
@@ -4940,7 +4982,7 @@ describe('CodingJobService', () => {
         workspace_id: 3,
         name: 'Bundle',
         variables: [
-          { unitName: 'UNIT_A', variableId: 'VAR_A' },
+          { unitName: 'unit_a', variableId: 'VAR_A' },
           { unitName: 'UNIT_B', variableId: 'VAR_B' }
         ]
       }

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -1761,10 +1761,10 @@ describe('CodingJobService', () => {
       'coding_incomplete_variables_version:7'
     );
     expect(cacheService.delete).toHaveBeenCalledWith(
-      'coding_incomplete_variables_v8:7'
+      'coding_incomplete_variables_v9:7'
     );
     expect(cacheService.delete).toHaveBeenCalledWith(
-      'coding_incomplete_variables_scope_v1:7'
+      'coding_incomplete_variables_scope_v2:7'
     );
   });
 
@@ -2276,6 +2276,171 @@ describe('CodingJobService', () => {
     ).resolves.toEqual([]);
 
     expectManualCodingCandidateStatusFilter(qb);
+    expect(qb.addSelect).toHaveBeenCalledWith(
+      'response.status_v2',
+      'statusV2'
+    );
+  });
+
+  it('loads completed aggregation peers only for normalized active response values', async () => {
+    const activeQuery = createQueryBuilder([
+      {
+        id: '2',
+        variableid: 'VAR',
+        value: 'Same\u00a0answer',
+        statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+        statusV2: null,
+        unitName: 'UNIT',
+        unitAlias: null,
+        bookletName: 'BOOKLET',
+        personLogin: 'person-2',
+        personCode: 'code-2',
+        personGroup: 'group'
+      }
+    ]);
+    const peerQuery = createQueryBuilder([
+      {
+        id: '1',
+        variableid: 'VAR',
+        value: ' sameanswer ',
+        statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+        statusV2: statusStringToNumber('CODING_COMPLETE'),
+        unitName: 'UNIT',
+        unitAlias: null,
+        bookletName: 'BOOKLET',
+        personLogin: 'person-1',
+        personCode: 'code-1',
+        personGroup: 'group'
+      },
+      {
+        id: '3',
+        variableid: 'VAR',
+        value: 'Different answer',
+        statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+        statusV2: statusStringToNumber('CODING_COMPLETE'),
+        unitName: 'UNIT',
+        unitAlias: null,
+        bookletName: 'BOOKLET',
+        personLogin: 'person-3',
+        personCode: 'code-3',
+        personGroup: 'group'
+      }
+    ]);
+    const peerValueQuery = createQueryBuilder([
+      { unitName: 'UNIT', variableId: 'VAR', value: ' sameanswer ' },
+      { unitName: 'Unit', variableId: 'VAR', value: 'Same answer' }
+    ]);
+    const peerUnitQuery = createQueryBuilder([
+      { unitName: 'UNIT', variableId: 'VAR' },
+      { unitName: 'Unit', variableId: 'VAR' },
+      { unitName: 'OTHER_UNIT', variableId: 'VAR' }
+    ]);
+    responseRepository.createQueryBuilder
+      .mockReturnValueOnce(activeQuery)
+      .mockReturnValueOnce(peerUnitQuery)
+      .mockReturnValueOnce(peerValueQuery)
+      .mockReturnValueOnce(peerQuery);
+
+    const result = await service.getSlimResponsesForVariableCoverage(
+      3,
+      [{ unitName: 'UNIT', variableId: 'VAR' }],
+      [ResponseMatchingFlag.IGNORE_CASE, ResponseMatchingFlag.IGNORE_WHITESPACE],
+      2,
+      new Map()
+    );
+
+    expect(result.map(response => response.id)).toEqual([2, 1]);
+    expect(peerQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('jsonb_to_recordset'),
+      expect.objectContaining({
+        aggregationPeerKeys: expect.stringContaining('sameanswer')
+      })
+    );
+    expect(peerValueQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('aggregation_peer_unit'),
+      {
+        aggregationPeerUnits: JSON.stringify([
+          { unitName: 'UNIT', variableId: 'VAR' },
+          { unitName: 'Unit', variableId: 'VAR' }
+        ])
+      }
+    );
+    expect(peerQuery.andWhere).toHaveBeenCalledWith(
+      'response.status_v2 = :completedStatus',
+      { completedStatus: statusStringToNumber('CODING_COMPLETE') }
+    );
+    expect(peerQuery.andWhere).toHaveBeenCalledWith(
+      '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+      { aggregatedCode: -111, defaultMirCode: 99 }
+    );
+    const peerLookupCondition = peerQuery.andWhere.mock.calls.find(
+      ([condition]) => typeof condition === 'string' &&
+        condition.includes('jsonb_to_recordset')
+    )?.[0] as string;
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."value" = response.value'
+    );
+    expect(peerLookupCondition).not.toContain('UPPER(unit.name)');
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."unitName" = unit.name'
+    );
+    expect(peerQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('jsonb_to_recordset'),
+      expect.objectContaining({
+        aggregationPeerKeys: expect.stringContaining('"unitName":"Unit"')
+      })
+    );
+  });
+
+  it('filters completed aggregation peers by value in SQL for exact matching', async () => {
+    const activeQuery = createQueryBuilder([{
+      id: '2',
+      variableid: 'VAR',
+      value: 'exact answer',
+      statusV1: statusStringToNumber('CODING_INCOMPLETE'),
+      statusV2: null,
+      unitName: 'UNIT',
+      unitAlias: null,
+      bookletName: 'BOOKLET',
+      personLogin: 'person-2',
+      personCode: 'code-2',
+      personGroup: 'group'
+    }]);
+    const peerValueQuery = createQueryBuilder([
+      { unitName: 'UNIT', variableId: 'VAR', value: 'exact answer' }
+    ]);
+    const peerUnitQuery = createQueryBuilder([
+      { unitName: 'UNIT', variableId: 'VAR' }
+    ]);
+    const peerQuery = createQueryBuilder([]);
+    responseRepository.createQueryBuilder
+      .mockReturnValueOnce(activeQuery)
+      .mockReturnValueOnce(peerUnitQuery)
+      .mockReturnValueOnce(peerValueQuery)
+      .mockReturnValueOnce(peerQuery);
+
+    await service.getSlimResponsesForVariableCoverage(
+      3,
+      [{ unitName: 'UNIT', variableId: 'VAR' }],
+      [],
+      2,
+      new Map()
+    );
+
+    const peerLookupCondition = peerQuery.andWhere.mock.calls.find(
+      ([condition]) => typeof condition === 'string' &&
+        condition.includes('jsonb_to_recordset')
+    )?.[0] as string;
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."value" = response.value'
+    );
+    const peerValueCondition = peerValueQuery.andWhere.mock.calls.find(
+      ([condition]) => typeof condition === 'string' &&
+        condition.includes('aggregation_peer_value')
+    )?.[0] as string;
+    expect(peerValueCondition).toContain(
+      'aggregation_peer_value."normalizedValue" = response.value'
+    );
   });
 
   it('includes DERIVE_ERROR responses for job-definition variables that opt into manual coding', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -50,16 +50,11 @@ import {
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
 import {
-  buildAggregationPeerLookupKeys,
-  buildAggregationPeerKeys,
-  buildAggregationPeerUnitKeys,
   buildAggregationGroups,
   deduplicateManualCodingResponses,
-  getAggregationPeerKey,
+  getAggregationVariableKey,
   getManualCodingDeduplicationKey,
-  isAggregatableValue,
-  ManualCodingDeduplicationResponse,
-  serializeAggregationPeerKey
+  ManualCodingDeduplicationResponse
 } from './aggregation-metrics.util';
 import {
   formatCodingTestPersonFromUnit,
@@ -93,7 +88,6 @@ import {
 import {
   applyNonCodingIssueReviewJobFilter,
   CODING_JOB_TYPE_CODING_ISSUE_REVIEW,
-  getNonCodingIssueReviewJobSqlCondition,
   isCodingIssueReviewJobType
 } from './coding-job-type.util';
 import { statusStringToNumber } from '../../utils/response-status-converter';
@@ -102,6 +96,7 @@ import {
   CodingJobDistributionPlanner,
   DistributionCoderLoad
 } from './coding-job-distribution-planner';
+import { CodingAggregationPeerService } from './coding-aggregation-peer.service';
 
 function isSafeKey(key: string): boolean {
   return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
@@ -484,6 +479,7 @@ export class CodingJobService {
     private workspaceFilesService: WorkspaceFilesService,
     private workspaceExclusionService: WorkspaceExclusionService,
     private usersService: UsersService,
+    private codingAggregationPeerService: CodingAggregationPeerService,
     @Optional()
     private codingFreshnessService?: CodingFreshnessService,
     @Optional()
@@ -624,7 +620,7 @@ export class CodingJobService {
           statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
         }).orWhere(
           `response.status_v1 = :deriveErrorStatus
-          AND CONCAT(unit.name, CHR(31), response.variableid) IN (:...deriveErrorManualCodingPairKeys)`,
+          AND CONCAT(UPPER(unit.name), CHR(31), response.variableid) IN (:...deriveErrorManualCodingPairKeys)`,
           {
             deriveErrorStatus: DERIVE_ERROR_STATUS,
             deriveErrorManualCodingPairKeys
@@ -639,8 +635,8 @@ export class CodingJobService {
     variable: VariableReference
   ): boolean {
     if (
-      response.unitName !== variable.unitName ||
-      response.variableid !== variable.variableId
+      getAggregationVariableKey(response.unitName, response.variableid) !==
+        getAggregationVariableKey(variable.unitName, variable.variableId)
     ) {
       return false;
     }
@@ -3296,7 +3292,7 @@ export class CodingJobService {
       const unitParam = `unitName${index}`;
       const variableParam = `variableId${index}`;
       conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
+        `(UPPER(unit.name) = UPPER(:${unitParam}) AND response.variableid = :${variableParam})`
       );
       parameters[unitParam] = variable.unit_name;
       parameters[variableParam] = variable.variable_id;
@@ -4680,6 +4676,9 @@ export class CodingJobService {
     const personCodes = Array.from(new Set(bundledUnits.map(unit => unit.person_code)));
     const personGroups = Array.from(new Set(bundledUnits.map(unit => unit.person_group)));
     const bookletNames = Array.from(new Set(bundledUnits.map(unit => unit.booklet_name)));
+    const manualUnitByResponseId = new Map(
+      contextBundledUnits.map(unit => [unit.response_id, unit])
+    );
     const responses = await this.responseRepository
       .createQueryBuilder('response')
       .leftJoinAndSelect('response.unit', 'unit')
@@ -4688,7 +4687,9 @@ export class CodingJobService {
       .leftJoinAndSelect('booklet.bookletinfo', 'bookletinfo')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('response.variableid IN (:...variableIds)', { variableIds })
-      .andWhere('unit.name IN (:...unitNames)', { unitNames })
+      .andWhere('UPPER(unit.name) IN (:...unitNames)', {
+        unitNames: unitNames.map(unitName => unitName.toUpperCase())
+      })
       .andWhere('person.login IN (:...personLogins)', { personLogins })
       .andWhere('person.code IN (:...personCodes)', { personCodes })
       .andWhere('person.group IN (:...personGroups)', { personGroups })
@@ -4704,15 +4705,24 @@ export class CodingJobService {
         return;
       }
 
-      responseByCaseAndVariable.set(
-        `${caseKey}\u0000${response.unit?.name || ''}::${response.variableid}`,
-        response
-      );
+      const responseKey = `${caseKey}\u0000${getAggregationVariableKey(
+        response.unit?.name || '',
+        response.variableid
+      )}`;
+      const existing = responseByCaseAndVariable.get(responseKey);
+      const responseIsManual = manualUnitByResponseId.has(response.id);
+      const existingIsManual = existing ?
+        manualUnitByResponseId.has(existing.id) :
+        false;
+      if (
+        !existing ||
+        (responseIsManual && !existingIsManual) ||
+        (responseIsManual === existingIsManual && response.id < existing.id)
+      ) {
+        responseByCaseAndVariable.set(responseKey, response);
+      }
     });
 
-    const manualUnitByResponseId = new Map(
-      contextBundledUnits.map(unit => [unit.response_id, unit])
-    );
     const bundleContextByResponseId = new Map<number, CodingJobBundleContext>();
     const configuredBundleIds = new Set(
       codingJobBundles.map(bundle => bundle.variable_bundle_id)
@@ -4733,11 +4743,15 @@ export class CodingJobService {
       const contextVariables = (variableBundle.variables || [])
         .map(variable => {
           const response = responseByCaseAndVariable.get(
-            `${caseKey}\u0000${variable.unitName}::${variable.variableId}`
+            `${caseKey}\u0000${getAggregationVariableKey(
+              variable.unitName,
+              variable.variableId
+            )}`
           );
           const manualUnit = response ?
             manualUnitByResponseId.get(response.id) :
             undefined;
+          const resolvedUnitName = response?.unit?.name || variable.unitName;
           const status = this.getCodingJobBundleVariableStatus(
             response,
             manualUnit
@@ -4745,13 +4759,13 @@ export class CodingJobService {
 
           return {
             responseId: response?.id ?? null,
-            unitName: variable.unitName,
+            unitName: resolvedUnitName,
             variableId: variable.variableId,
             variableAnchor:
-              variableAnchorMaps.get(variable.unitName)?.get(variable.variableId) ||
+              variableAnchorMaps.get(resolvedUnitName)?.get(variable.variableId) ||
               variable.variableId,
             variablePage:
-              variablePageMaps.get(variable.unitName)?.get(variable.variableId) ||
+              variablePageMaps.get(resolvedUnitName)?.get(variable.variableId) ||
               '0',
             ...status
           };
@@ -4902,7 +4916,7 @@ export class CodingJobService {
             variable_id: variable.variableId
           });
           variableBundleMap.set(
-            `${variable.unitName}::${variable.variableId}`,
+            getAggregationVariableKey(variable.unitName, variable.variableId),
             bundle.variable_bundle_id
           );
         });
@@ -4943,7 +4957,7 @@ export class CodingJobService {
       const unitParam = `cjUnitName${index}`;
       const variableParam = `cjVariableId${index}`;
       conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
+        `(UPPER(unit.name) = UPPER(:${unitParam}) AND response.variableid = :${variableParam})`
       );
       parameters[unitParam] = variable.unit_name;
       parameters[variableParam] = variable.variable_id;
@@ -4986,7 +5000,9 @@ export class CodingJobService {
         personLogin: r.personLogin ?? '',
         personCode: r.personCode ?? '',
         personGroup: r.personGroup ?? '',
-        variableBundleId: variableBundleMap.get(`${unitName}::${variableid}`)
+        variableBundleId: variableBundleMap.get(
+          getAggregationVariableKey(unitName, variableid)
+        )
       };
     });
   }
@@ -5315,7 +5331,7 @@ export class CodingJobService {
       }
 
       const variableBundleId = variableBundleIdByVariable.get(
-        `${response.unitName}::${response.variableid}`
+        getAggregationVariableKey(response.unitName, response.variableid)
       );
       return variableBundleId ? { ...response, variableBundleId } : response;
     });
@@ -5365,7 +5381,7 @@ export class CodingJobService {
     bundleVariablesById.forEach((variables, bundleId) => {
       variables.forEach(variable => {
         variableBundleIdByVariable.set(
-          `${variable.unitName}::${variable.variableId}`,
+          getAggregationVariableKey(variable.unitName, variable.variableId),
           bundleId
         );
       });
@@ -5730,7 +5746,7 @@ export class CodingJobService {
       const unitParam = `unitName${index}`;
       const variableParam = `variableId${index}`;
       conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
+        `(UPPER(unit.name) = UPPER(:${unitParam}) AND response.variableid = :${variableParam})`
       );
       parameters[unitParam] = variable.unitName;
       parameters[variableParam] = variable.variableId;
@@ -5798,7 +5814,7 @@ export class CodingJobService {
       const unitParam = `slimUnitName${index}`;
       const variableParam = `slimVariableId${index}`;
       conditions.push(
-        `(unit.name = :${unitParam} AND response.variableid = :${variableParam})`
+        `(UPPER(unit.name) = UPPER(:${unitParam}) AND response.variableid = :${variableParam})`
       );
       parameters[unitParam] = variable.unitName;
       parameters[variableParam] = variable.variableId;
@@ -5836,11 +5852,13 @@ export class CodingJobService {
     variables: VariableReference[],
     matchingFlags: ResponseMatchingFlag[],
     aggregationThreshold: number | null,
-    derivedVariableMap: Map<string, Set<string>>
+    derivedVariableMap: Map<string, Set<string>>,
+    manager?: EntityManager
   ): Promise<SlimResponse[]> {
     const activeResponses = await this.getSlimResponsesForVariables(
       workspaceId,
-      variables
+      variables,
+      manager
     );
     const aggregationActive = aggregationThreshold !== null &&
       !matchingFlags.includes(ResponseMatchingFlag.NO_AGGREGATION);
@@ -5849,172 +5867,46 @@ export class CodingJobService {
       return activeResponses;
     }
 
-    const peerKeys = buildAggregationPeerKeys(
-      activeResponses.map(response => ({
-        responseId: response.id,
-        unitName: response.unitName,
-        variableId: response.variableid,
-        value: response.value
-      })),
-      matchingFlags,
-      derivedVariableMap
-    );
-
-    if (peerKeys.length === 0) {
-      return activeResponses;
-    }
-
-    const completedStatus = statusStringToNumber('CODING_COMPLETE');
-    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
-    const exclusions =
-      await this.workspaceExclusionService.resolveExclusionsForQueries(
-        workspaceId
-      );
-    const peerKeySet = new Set(
-      peerKeys.map(peerKey => serializeAggregationPeerKey(peerKey))
-    );
-    const exactValueMatching =
-      !matchingFlags.includes(ResponseMatchingFlag.IGNORE_CASE) &&
-      !matchingFlags.includes(ResponseMatchingFlag.IGNORE_WHITESPACE);
-    const createCompletedPeerQuery = (): SelectQueryBuilder<ResponseEntity> => {
-      const query = this.responseRepository
-        .createQueryBuilder('response')
-        .innerJoin('response.unit', 'unit')
-        .innerJoin('unit.booklet', 'booklet')
-        .leftJoin('booklet.bookletinfo', 'bookletinfo')
-        .innerJoin('booklet.person', 'person')
-        .where('person.workspace_id = :workspaceId', { workspaceId })
-        .andWhere('person.consider = :consider', { consider: true })
-        .andWhere('response.status_v2 = :completedStatus', { completedStatus })
-        .andWhere(
-          '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
-          { aggregatedCode: -111, defaultMirCode }
-        )
-        .andWhere(new Brackets(qb => {
-          qb.where('response.code_v2 IS NULL')
-            .orWhere(subQuery => {
-              const exists = subQuery
-                .subQuery()
-                .select('1')
-                .from('coding_job_unit', 'manual_cju')
-                .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
-                .where('manual_cju.response_id = response.id')
-                .andWhere('manual_cj.training_id IS NULL')
-                .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
-                .getQuery();
-              return `EXISTS (${exists})`;
-            });
-        }));
-      this.applyManualCodingCandidateStatusFilter(query, variables);
-      applyResolvedExclusionsToQuery(query, exclusions);
-      return query;
-    };
-
-    const peerVariableIds = Array.from(new Set(
-      peerKeys.map(peerKey => peerKey.variableId)
-    ));
-    const peerUnitQuery = createCompletedPeerQuery()
-      .select('DISTINCT unit.name', 'unitName')
-      .addSelect('response.variableid', 'variableId')
-      .andWhere('response.variableid IN (:...peerVariableIds)', {
-        peerVariableIds
+    const completedPeers = await this.codingAggregationPeerService
+      .findCompletedPeers({
+        workspaceId,
+        sourceResponses: activeResponses.map(response => ({
+          responseId: response.id,
+          unitName: response.unitName,
+          variableId: response.variableid,
+          value: response.value
+        })),
+        matchingFlags,
+        derivedVariableMap,
+        variables,
+        manager,
+        loadQueryContext: async () => {
+          const [defaultMirCode, exclusions] = await Promise.all([
+            this.getDefaultMirCode(workspaceId),
+            this.workspaceExclusionService.resolveExclusionsForQueries(
+              workspaceId
+            )
+          ]);
+          return { defaultMirCode, exclusions };
+        }
       });
-    const peerUnitKeys = buildAggregationPeerUnitKeys(
-      peerKeys,
-      await peerUnitQuery.getRawMany()
-    );
-    if (peerUnitKeys.length === 0) {
-      return activeResponses;
-    }
 
-    const peerValueQuery = createCompletedPeerQuery()
-      .select('DISTINCT unit.name', 'unitName')
-      .addSelect('response.variableid', 'variableId')
-      .addSelect('response.value', 'value')
-      .andWhere(
-        `EXISTS (
-          SELECT 1
-          FROM jsonb_to_recordset(CAST(:aggregationPeerUnits AS jsonb))
-            AS aggregation_peer_unit("unitName" text, "variableId" text)
-          WHERE aggregation_peer_unit."unitName" = unit.name
-            AND aggregation_peer_unit."variableId" = response.variableid
-        )`,
-        { aggregationPeerUnits: JSON.stringify(peerUnitKeys) }
-      );
-    if (exactValueMatching) {
-      peerValueQuery.andWhere(
-        `EXISTS (
-          SELECT 1
-          FROM jsonb_to_recordset(CAST(:aggregationPeerValues AS jsonb))
-            AS aggregation_peer_value("variableId" text, "normalizedValue" text)
-          WHERE aggregation_peer_value."variableId" = response.variableid
-            AND aggregation_peer_value."normalizedValue" = response.value
-        )`,
-        { aggregationPeerValues: JSON.stringify(peerKeys) }
-      );
-    }
-    const peerLookupKeys = buildAggregationPeerLookupKeys(
-      peerKeys,
-      await peerValueQuery.getRawMany(),
-      matchingFlags
-    );
-    if (peerLookupKeys.length === 0) {
-      return activeResponses;
-    }
-
-    const queryBuilder = createCompletedPeerQuery()
-      .select('response.id', 'id')
-      .addSelect('response.variableid', 'variableid')
-      .addSelect('response.value', 'value')
-      .addSelect('response.status_v1', 'statusV1')
-      .addSelect('response.status_v2', 'statusV2')
-      .addSelect('unit.name', 'unitName')
-      .addSelect('unit.alias', 'unitAlias')
-      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
-      .addSelect("COALESCE(person.login, '')", 'personLogin')
-      .addSelect("COALESCE(person.code, '')", 'personCode')
-      .addSelect("COALESCE(person.group, '')", 'personGroup')
-      .andWhere(
-        `EXISTS (
-          SELECT 1
-          FROM jsonb_to_recordset(CAST(:aggregationPeerKeys AS jsonb))
-            AS aggregation_peer("unitName" text, "variableId" text, "value" text)
-          WHERE aggregation_peer."unitName" = unit.name
-            AND aggregation_peer."variableId" = response.variableid
-            AND aggregation_peer."value" = response.value
-        )`,
-        { aggregationPeerKeys: JSON.stringify(peerLookupKeys) }
-      );
-    const raw = await queryBuilder.orderBy('response.id', 'ASC').getRawMany();
-    const completedPeers: SlimResponse[] = raw.map(r => ({
-      id: Number(r.id),
-      variableid: r.variableid,
-      value: r.value ?? null,
-      statusV1:
-        r.statusV1 !== undefined && r.statusV1 !== null ?
-          Number(r.statusV1) :
-          null,
-      statusV2:
-        r.statusV2 !== undefined && r.statusV2 !== null ?
-          Number(r.statusV2) :
-          null,
-      unitName: r.unitName ?? '',
-      unitAlias: r.unitAlias ?? null,
-      bookletName: r.bookletName ?? '',
-      personLogin: r.personLogin ?? '',
-      personCode: r.personCode ?? '',
-      personGroup: r.personGroup ?? ''
-    })).filter(response => (
-      isAggregatableValue(response.value) &&
-      peerKeySet.has(serializeAggregationPeerKey(getAggregationPeerKey(
-        response.unitName,
-        response.variableid,
-        response.value,
-        matchingFlags
-      )))
-    ));
-
-    return [...activeResponses, ...completedPeers];
+    return [
+      ...activeResponses,
+      ...completedPeers.map(response => ({
+        id: response.responseId,
+        variableid: response.variableId,
+        value: response.value,
+        statusV1: response.statusV1,
+        statusV2: response.statusV2,
+        unitName: response.unitName,
+        unitAlias: response.unitAlias,
+        bookletName: response.bookletName,
+        personLogin: response.personLogin,
+        personCode: response.personCode,
+        personGroup: response.personGroup
+      }))
+    ];
   }
 
   private async getAssignedResponseIdsForVariables(
@@ -6059,7 +5951,7 @@ export class CodingJobService {
       const unitParam = `assignedUnitName${index}`;
       const variableParam = `assignedVariableId${index}`;
       conditions.push(
-        `(cju.unit_name = :${unitParam} AND cju.variable_id = :${variableParam})`
+        `(UPPER(cju.unit_name) = UPPER(:${unitParam}) AND cju.variable_id = :${variableParam})`
       );
       parameters[unitParam] = variable.unitName;
       parameters[variableParam] = variable.variableId;
@@ -6163,6 +6055,20 @@ export class CodingJobService {
       totalResponses: unassignedResponses.length,
       caseStatusesByResponseId
     };
+  }
+
+  private addCompletedResponsesToAssignedSets(
+    responses: SlimResponse[],
+    assignedResponseIdSets: Set<number>[]
+  ): void {
+    const completedStatus = statusStringToNumber('CODING_COMPLETE');
+    responses
+      .filter(response => response.statusV2 === completedStatus)
+      .forEach(response => {
+        assignedResponseIdSets.forEach(assignedResponseIds => {
+          assignedResponseIds.add(response.id);
+        });
+      });
   }
 
   private getAggregatedCaseUsageStatus(
@@ -6606,7 +6512,10 @@ export class CodingJobService {
     const uniqueVariables = new Map<string, VariableReference>();
 
     variables.forEach(variable => {
-      const key = `${variable.unitName}::${variable.variableId}`;
+      const key = getAggregationVariableKey(
+        variable.unitName,
+        variable.variableId
+      );
       const existing = uniqueVariables.get(key);
       uniqueVariables.set(key, {
         ...variable,
@@ -6824,9 +6733,12 @@ export class CodingJobService {
           .itemVariables
       )
     );
-    const allResponses = await this.getSlimResponsesForVariables(
+    const allResponses = await this.getSlimResponsesForVariableCoverage(
       workspaceId,
       allVariables,
+      matchingFlags,
+      aggregationThreshold,
+      derivedVariableMap,
       manager
     );
     const assignedResponseIds = await this.getAssignedResponseIdsForVariables(
@@ -6835,6 +6747,9 @@ export class CodingJobService {
       request.jobDefinitionId,
       manager
     );
+    this.addCompletedResponsesToAssignedSets(allResponses, [
+      assignedResponseIds
+    ]);
     const warnings: JobCreationWarning[] = [];
     const warnedVariables = new Set<string>();
 
@@ -7359,15 +7274,24 @@ export class CodingJobService {
     const [
       matchingFlags,
       aggregationThreshold,
-      derivedVariableMap,
+      derivedVariableMap
+    ] = await Promise.all([
+      this.getResponseMatchingMode(workspaceId),
+      this.getAggregationThreshold(workspaceId),
+      this.workspaceFilesService.getDerivedVariableMap(workspaceId)
+    ]);
+    const [
       allResponses,
       assignedResponseIds,
       assignedResponseIdsByExcludedJobDefinitionIdEntries
     ] = await Promise.all([
-      this.getResponseMatchingMode(workspaceId),
-      this.getAggregationThreshold(workspaceId),
-      this.workspaceFilesService.getDerivedVariableMap(workspaceId),
-      this.getSlimResponsesForVariables(workspaceId, allVariables),
+      this.getSlimResponsesForVariableCoverage(
+        workspaceId,
+        allVariables,
+        matchingFlags,
+        aggregationThreshold,
+        derivedVariableMap
+      ),
       this.getAssignedResponseIdsForVariables(workspaceId, allVariables),
       Promise.all(
         excludedJobDefinitionIds.map(async jobDefinitionId => [
@@ -7379,6 +7303,10 @@ export class CodingJobService {
           )
         ] as const)
       )
+    ]);
+    this.addCompletedResponsesToAssignedSets(allResponses, [
+      assignedResponseIds,
+      ...assignedResponseIdsByExcludedJobDefinitionIdEntries.map(([, ids]) => ids)
     ]);
 
     return {
@@ -7477,11 +7405,15 @@ export class CodingJobService {
 
     selectedCases.forEach(({ item, caseGroup }) => {
       caseGroup.responses.forEach(response => {
+        const selectedVariable = item.itemVariables.find(variable => (
+          this.responseMatchesVariableReference(response, variable)
+        ));
         this.addResponseToVariableUsageByStatus(
           usageByVariable,
           response,
           item.caseStatusesByResponseId.get(response.id) ||
-            this.getResponseUsageStatus(response)
+            this.getResponseUsageStatus(response),
+          selectedVariable
         );
       });
     });
@@ -7492,9 +7424,12 @@ export class CodingJobService {
   private addResponseToVariableUsageByStatus(
     usageByVariable: Map<string, DistributionVariableUsageByStatus>,
     response: SlimResponse,
-    caseStatus: DistributionVariableUsageCaseStatus
+    caseStatus: DistributionVariableUsageCaseStatus,
+    selectedVariable?: VariableReference
   ): void {
-    const variableKey = `${response.unitName}::${response.variableid}`;
+    const variableKey = selectedVariable ?
+      `${selectedVariable.unitName}::${selectedVariable.variableId}` :
+      `${response.unitName}::${response.variableid}`;
     const usage = usageByVariable.get(variableKey) || {
       regular: 0,
       deriveError: 0,

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -50,10 +50,16 @@ import {
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
 import {
+  buildAggregationPeerLookupKeys,
+  buildAggregationPeerKeys,
+  buildAggregationPeerUnitKeys,
   buildAggregationGroups,
   deduplicateManualCodingResponses,
+  getAggregationPeerKey,
   getManualCodingDeduplicationKey,
-  ManualCodingDeduplicationResponse
+  isAggregatableValue,
+  ManualCodingDeduplicationResponse,
+  serializeAggregationPeerKey
 } from './aggregation-metrics.util';
 import {
   formatCodingTestPersonFromUnit,
@@ -87,6 +93,7 @@ import {
 import {
   applyNonCodingIssueReviewJobFilter,
   CODING_JOB_TYPE_CODING_ISSUE_REVIEW,
+  getNonCodingIssueReviewJobSqlCondition,
   isCodingIssueReviewJobType
 } from './coding-job-type.util';
 import { statusStringToNumber } from '../../utils/response-status-converter';
@@ -399,6 +406,7 @@ interface SlimResponse {
   variableid: string;
   value: string | null;
   statusV1?: number | null;
+  statusV2?: number | null;
   unitName: string;
   unitAlias: string | null;
   bookletName: string;
@@ -5753,6 +5761,7 @@ export class CodingJobService {
       .addSelect('response.variableid', 'variableid')
       .addSelect('response.value', 'value')
       .addSelect('response.status_v1', 'statusV1')
+      .addSelect('response.status_v2', 'statusV2')
       .addSelect('unit.name', 'unitName')
       .addSelect('unit.alias', 'unitAlias')
       .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
@@ -5809,6 +5818,10 @@ export class CodingJobService {
         r.statusV1 !== undefined && r.statusV1 !== null ?
           Number(r.statusV1) :
           null,
+      statusV2:
+        r.statusV2 !== undefined && r.statusV2 !== null ?
+          Number(r.statusV2) :
+          null,
       unitName: r.unitName ?? '',
       unitAlias: r.unitAlias ?? null,
       bookletName: r.bookletName ?? '',
@@ -5816,6 +5829,192 @@ export class CodingJobService {
       personCode: r.personCode ?? '',
       personGroup: r.personGroup ?? ''
     }));
+  }
+
+  async getSlimResponsesForVariableCoverage(
+    workspaceId: number,
+    variables: VariableReference[],
+    matchingFlags: ResponseMatchingFlag[],
+    aggregationThreshold: number | null,
+    derivedVariableMap: Map<string, Set<string>>
+  ): Promise<SlimResponse[]> {
+    const activeResponses = await this.getSlimResponsesForVariables(
+      workspaceId,
+      variables
+    );
+    const aggregationActive = aggregationThreshold !== null &&
+      !matchingFlags.includes(ResponseMatchingFlag.NO_AGGREGATION);
+
+    if (!aggregationActive || activeResponses.length === 0) {
+      return activeResponses;
+    }
+
+    const peerKeys = buildAggregationPeerKeys(
+      activeResponses.map(response => ({
+        responseId: response.id,
+        unitName: response.unitName,
+        variableId: response.variableid,
+        value: response.value
+      })),
+      matchingFlags,
+      derivedVariableMap
+    );
+
+    if (peerKeys.length === 0) {
+      return activeResponses;
+    }
+
+    const completedStatus = statusStringToNumber('CODING_COMPLETE');
+    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
+    const exclusions =
+      await this.workspaceExclusionService.resolveExclusionsForQueries(
+        workspaceId
+      );
+    const peerKeySet = new Set(
+      peerKeys.map(peerKey => serializeAggregationPeerKey(peerKey))
+    );
+    const exactValueMatching =
+      !matchingFlags.includes(ResponseMatchingFlag.IGNORE_CASE) &&
+      !matchingFlags.includes(ResponseMatchingFlag.IGNORE_WHITESPACE);
+    const createCompletedPeerQuery = (): SelectQueryBuilder<ResponseEntity> => {
+      const query = this.responseRepository
+        .createQueryBuilder('response')
+        .innerJoin('response.unit', 'unit')
+        .innerJoin('unit.booklet', 'booklet')
+        .leftJoin('booklet.bookletinfo', 'bookletinfo')
+        .innerJoin('booklet.person', 'person')
+        .where('person.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('person.consider = :consider', { consider: true })
+        .andWhere('response.status_v2 = :completedStatus', { completedStatus })
+        .andWhere(
+          '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+          { aggregatedCode: -111, defaultMirCode }
+        )
+        .andWhere(new Brackets(qb => {
+          qb.where('response.code_v2 IS NULL')
+            .orWhere(subQuery => {
+              const exists = subQuery
+                .subQuery()
+                .select('1')
+                .from('coding_job_unit', 'manual_cju')
+                .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
+                .where('manual_cju.response_id = response.id')
+                .andWhere('manual_cj.training_id IS NULL')
+                .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
+                .getQuery();
+              return `EXISTS (${exists})`;
+            });
+        }));
+      this.applyManualCodingCandidateStatusFilter(query, variables);
+      applyResolvedExclusionsToQuery(query, exclusions);
+      return query;
+    };
+
+    const peerVariableIds = Array.from(new Set(
+      peerKeys.map(peerKey => peerKey.variableId)
+    ));
+    const peerUnitQuery = createCompletedPeerQuery()
+      .select('DISTINCT unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .andWhere('response.variableid IN (:...peerVariableIds)', {
+        peerVariableIds
+      });
+    const peerUnitKeys = buildAggregationPeerUnitKeys(
+      peerKeys,
+      await peerUnitQuery.getRawMany()
+    );
+    if (peerUnitKeys.length === 0) {
+      return activeResponses;
+    }
+
+    const peerValueQuery = createCompletedPeerQuery()
+      .select('DISTINCT unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('response.value', 'value')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerUnits AS jsonb))
+            AS aggregation_peer_unit("unitName" text, "variableId" text)
+          WHERE aggregation_peer_unit."unitName" = unit.name
+            AND aggregation_peer_unit."variableId" = response.variableid
+        )`,
+        { aggregationPeerUnits: JSON.stringify(peerUnitKeys) }
+      );
+    if (exactValueMatching) {
+      peerValueQuery.andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerValues AS jsonb))
+            AS aggregation_peer_value("variableId" text, "normalizedValue" text)
+          WHERE aggregation_peer_value."variableId" = response.variableid
+            AND aggregation_peer_value."normalizedValue" = response.value
+        )`,
+        { aggregationPeerValues: JSON.stringify(peerKeys) }
+      );
+    }
+    const peerLookupKeys = buildAggregationPeerLookupKeys(
+      peerKeys,
+      await peerValueQuery.getRawMany(),
+      matchingFlags
+    );
+    if (peerLookupKeys.length === 0) {
+      return activeResponses;
+    }
+
+    const queryBuilder = createCompletedPeerQuery()
+      .select('response.id', 'id')
+      .addSelect('response.variableid', 'variableid')
+      .addSelect('response.value', 'value')
+      .addSelect('response.status_v1', 'statusV1')
+      .addSelect('response.status_v2', 'statusV2')
+      .addSelect('unit.name', 'unitName')
+      .addSelect('unit.alias', 'unitAlias')
+      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
+      .addSelect("COALESCE(person.login, '')", 'personLogin')
+      .addSelect("COALESCE(person.code, '')", 'personCode')
+      .addSelect("COALESCE(person.group, '')", 'personGroup')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerKeys AS jsonb))
+            AS aggregation_peer("unitName" text, "variableId" text, "value" text)
+          WHERE aggregation_peer."unitName" = unit.name
+            AND aggregation_peer."variableId" = response.variableid
+            AND aggregation_peer."value" = response.value
+        )`,
+        { aggregationPeerKeys: JSON.stringify(peerLookupKeys) }
+      );
+    const raw = await queryBuilder.orderBy('response.id', 'ASC').getRawMany();
+    const completedPeers: SlimResponse[] = raw.map(r => ({
+      id: Number(r.id),
+      variableid: r.variableid,
+      value: r.value ?? null,
+      statusV1:
+        r.statusV1 !== undefined && r.statusV1 !== null ?
+          Number(r.statusV1) :
+          null,
+      statusV2:
+        r.statusV2 !== undefined && r.statusV2 !== null ?
+          Number(r.statusV2) :
+          null,
+      unitName: r.unitName ?? '',
+      unitAlias: r.unitAlias ?? null,
+      bookletName: r.bookletName ?? '',
+      personLogin: r.personLogin ?? '',
+      personCode: r.personCode ?? '',
+      personGroup: r.personGroup ?? ''
+    })).filter(response => (
+      isAggregatableValue(response.value) &&
+      peerKeySet.has(serializeAggregationPeerKey(getAggregationPeerKey(
+        response.unitName,
+        response.variableid,
+        response.value,
+        matchingFlags
+      )))
+    ));
+
+    return [...activeResponses, ...completedPeers];
   }
 
   private async getAssignedResponseIdsForVariables(

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -594,6 +594,60 @@ describe('CodingProgressService variable coverage conflicts', () => {
     ]);
   });
 
+  it('merges unit-name case variants into one covered variable', async () => {
+    const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+    responseRepository.createQueryBuilder.mockReturnValue(createQueryBuilder([
+      {
+        unitName: 'UnitA',
+        variableId: 'manual-var',
+        statusV1: String(codingIncompleteStatus),
+        caseCount: '2'
+      },
+      {
+        unitName: 'UNITA',
+        variableId: 'manual-var',
+        statusV1: String(codingIncompleteStatus),
+        caseCount: '1'
+      }
+    ]));
+    workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
+      ['UNITA', new Set(['manual-var'])]
+    ]));
+    jobDefinitionRepository.find.mockResolvedValue([{
+      id: 10,
+      status: 'approved',
+      assigned_variables: [{ unitName: 'unita', variableId: 'manual-var' }]
+    }]);
+    const casesInJobsQuery = createQueryBuilder([
+      { unitName: 'UnitA', variableId: 'manual-var', casesInJobs: '2' },
+      { unitName: 'UNITA', variableId: 'manual-var', casesInJobs: '1' }
+    ]);
+    codingJobUnitRepository.createQueryBuilder
+      .mockReturnValueOnce(casesInJobsQuery)
+      .mockReturnValueOnce(createQueryBuilder([]));
+
+    const result = await service.getVariableCoverageOverview(5);
+
+    expect(result).toMatchObject({
+      totalVariables: 1,
+      coveredVariables: 1,
+      fullyAbgedeckteVariablen: 1,
+      statusTotalVariables: 1
+    });
+    expect(result.variableCaseCounts).toEqual([{
+      unitName: 'UnitA',
+      variableId: 'manual-var',
+      caseCount: 3
+    }]);
+    expect(casesInJobsQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('variableCasesInJobsUnitName1'),
+      expect.objectContaining({
+        variableCasesInJobsUnitName0: 'UnitA',
+        variableCasesInJobsUnitName1: 'UNITA'
+      })
+    );
+  });
+
   it('excludes intended-incomplete variables without manual instructions from case coverage', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
@@ -779,9 +833,8 @@ describe('CodingProgressService variable coverage conflicts', () => {
     expect(result.coverageByStatus.conflicted).toEqual([]);
   });
 
-  it('classifies duplicate-aggregated variable coverage on effective cases', async () => {
+  it('classifies active duplicate-aggregated variable coverage on effective cases', async () => {
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
-    const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
 
     settingRepository.findOne.mockImplementation(async ({ where }: { where: { key: string } }) => {
       if (where.key === 'workspace-5-duplicate-aggregation-threshold') {
@@ -802,7 +855,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
         caseCount: '3'
       }
     ]);
-    const variableResponsesQuery = createQueryBuilder([
+    const activeResponsesQuery = createQueryBuilder([
       {
         responseId: '100',
         unitName: 'AGG_UNIT',
@@ -841,24 +894,17 @@ describe('CodingProgressService variable coverage conflicts', () => {
         personLogin: 'login-3',
         personCode: 'code-3',
         personGroup: 'group-1'
-      },
-      {
-        responseId: '103',
-        unitName: 'AGG_UNIT',
-        variableId: '01',
-        value: 'already applied answer',
-        codeV2: null,
-        statusV2: String(codingCompleteStatus),
-        statusV1: String(codingIncompleteStatus),
-        bookletName: 'BookletA',
-        personLogin: 'login-4',
-        personCode: 'code-4',
-        personGroup: 'group-1'
       }
     ]);
+    const unitNamesQuery = createQueryBuilder([
+      { unitName: 'AGG_UNIT', variableId: '01' }
+    ]);
+    const completedPeersQuery = createQueryBuilder([]);
     responseRepository.createQueryBuilder
       .mockReturnValueOnce(incompleteVariablesQuery)
-      .mockReturnValueOnce(variableResponsesQuery);
+      .mockReturnValueOnce(activeResponsesQuery)
+      .mockReturnValueOnce(unitNamesQuery)
+      .mockReturnValueOnce(completedPeersQuery);
     workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
       ['AGG_UNIT', new Set(['01'])]
     ]));
@@ -883,6 +929,104 @@ describe('CodingProgressService variable coverage conflicts', () => {
     expect(result.variableCaseCounts).toEqual([
       { unitName: 'AGG_UNIT', variableId: '01', caseCount: 3 }
     ]);
+    expect(assignedResponseIdsQuery.andWhere).toHaveBeenCalledWith(
+      'cju.response_id IN (:...responseIds)',
+      { responseIds: [100, 101, 102] }
+    );
+  });
+
+  it('keeps an open response covered after its assigned aggregation sibling completed', async () => {
+    const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
+    const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
+
+    settingRepository.findOne.mockImplementation(async ({ where }: { where: { key: string } }) => {
+      if (where.key === 'workspace-5-duplicate-aggregation-threshold') {
+        return { content: '2' };
+      }
+
+      if (where.key === 'workspace-5-response-matching-mode') {
+        return { content: JSON.stringify({ flags: ['IGNORE_CASE', 'IGNORE_WHITESPACE'] }) };
+      }
+
+      return null;
+    });
+    const incompleteVariablesQuery = createQueryBuilder([
+      {
+        unitName: 'AGG_UNIT',
+        variableId: '01',
+        statusV1: String(codingIncompleteStatus),
+        caseCount: '1'
+      }
+    ]);
+    const variableResponsesQuery = createQueryBuilder([
+      {
+        responseId: '100',
+        unitName: 'AGG_UNIT',
+        variableId: '01',
+        value: 'Same answer',
+        codeV2: null,
+        statusV2: null,
+        statusV1: String(codingIncompleteStatus),
+        bookletName: 'BookletA',
+        personLogin: 'login-1',
+        personCode: 'code-1',
+        personGroup: 'group-1'
+      }
+    ]);
+    const completedPeersQuery = createQueryBuilder([
+      {
+        responseId: '103',
+        unitName: 'agg_unit',
+        variableId: '01',
+        value: ' sameanswer ',
+        codeV2: '1',
+        statusV2: String(codingCompleteStatus),
+        statusV1: String(codingIncompleteStatus),
+        bookletName: 'BookletA',
+        personLogin: 'login-4',
+        personCode: 'code-4',
+        personGroup: 'group-1'
+      }
+    ]);
+    const peerValueQuery = createQueryBuilder([
+      { unitName: 'AGG_UNIT', variableId: '01', value: 'Same answer' },
+      { unitName: 'agg_unit', variableId: '01', value: ' sameanswer ' }
+    ]);
+    const peerUnitQuery = createQueryBuilder([
+      { unitName: 'AGG_UNIT', variableId: '01' },
+      { unitName: 'agg_unit', variableId: '01' },
+      { unitName: 'OTHER_UNIT', variableId: '01' }
+    ]);
+    responseRepository.createQueryBuilder
+      .mockReturnValueOnce(incompleteVariablesQuery)
+      .mockReturnValueOnce(variableResponsesQuery)
+      .mockReturnValueOnce(peerUnitQuery)
+      .mockReturnValueOnce(peerValueQuery)
+      .mockReturnValueOnce(completedPeersQuery);
+    workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
+      ['AGG_UNIT', new Set(['01'])]
+    ]));
+    jobDefinitionRepository.find.mockResolvedValue([
+      {
+        id: 40,
+        status: 'approved',
+        assigned_variables: [{ unitName: 'AGG_UNIT', variableId: '01' }]
+      }
+    ]);
+    const assignedResponseIdsQuery = createQueryBuilder([{ responseId: '103' }]);
+    codingJobUnitRepository.createQueryBuilder
+      .mockReturnValueOnce(assignedResponseIdsQuery)
+      .mockReturnValueOnce(createQueryBuilder([]));
+
+    const result = await service.getVariableCoverageOverview(5);
+
+    expect(result.totalVariables).toBe(1);
+    expect(result.coveredVariables).toBe(1);
+    expect(result.fullyAbgedeckteVariablen).toBe(1);
+    expect(result.partiallyAbgedeckteVariablen).toBe(0);
+    expect(result.variableCaseCounts).toEqual([
+      { unitName: 'AGG_UNIT', variableId: '01', caseCount: 1 }
+    ]);
     expect(variableResponsesQuery.andWhere).toHaveBeenCalledWith(
       expect.stringContaining('unit.name = :variableCoverageResponsesUnitName0'),
       expect.objectContaining({
@@ -890,12 +1034,44 @@ describe('CodingProgressService variable coverage conflicts', () => {
         variableCoverageResponsesVariableId0: '01'
       })
     );
+    expect(variableResponsesQuery.andWhere).toHaveBeenCalledWith(
+      '(response.status_v2 IS NULL OR response.status_v2 != :completedV2Status)',
+      { completedV2Status: codingCompleteStatus }
+    );
+    expect(completedPeersQuery.andWhere).toHaveBeenCalledWith(
+      'response.status_v2 = :completedV2Status',
+      { completedV2Status: codingCompleteStatus }
+    );
+    expect(completedPeersQuery.andWhere).toHaveBeenCalledWith(
+      '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+      {
+        aggregatedCode: -111,
+        defaultMirCode: expect.any(Number)
+      }
+    );
+    const peerLookupCondition = completedPeersQuery.andWhere.mock.calls.find(
+      ([condition]) => typeof condition === 'string' &&
+        condition.includes('jsonb_to_recordset')
+    )?.[0] as string;
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."value" = response.value'
+    );
+    expect(peerLookupCondition).not.toContain('UPPER(unit.name)');
+    expect(peerLookupCondition).toContain(
+      'aggregation_peer."unitName" = unit.name'
+    );
+    expect(peerValueQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('aggregation_peer_unit'),
+      {
+        aggregationPeerUnits: JSON.stringify([
+          { unitName: 'AGG_UNIT', variableId: '01' },
+          { unitName: 'agg_unit', variableId: '01' }
+        ])
+      }
+    );
     expect(assignedResponseIdsQuery.andWhere).toHaveBeenCalledWith(
-      expect.stringContaining('cju.unit_name = :assignedVariableCoverageUnitName0'),
-      expect.objectContaining({
-        assignedVariableCoverageUnitName0: 'AGG_UNIT',
-        assignedVariableCoverageVariableId0: '01'
-      })
+      'cju.response_id IN (:...responseIds)',
+      { responseIds: [100, 103] }
     );
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -1,5 +1,6 @@
 import { Brackets } from 'typeorm';
 import { CodingProgressService } from './coding-progress.service';
+import { CodingAggregationPeerService } from './coding-aggregation-peer.service';
 import { getManualCodingScopeKey } from '../../utils/manual-coding-scope.util';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 
@@ -145,7 +146,8 @@ describe('CodingProgressService variable coverage conflicts', () => {
       settingRepository as never,
       workspaceFilesService as never,
       workspaceExclusionService as never,
-      cacheService as never
+      cacheService as never,
+      new CodingAggregationPeerService(responseRepository as never)
     );
   });
 
@@ -992,15 +994,9 @@ describe('CodingProgressService variable coverage conflicts', () => {
       { unitName: 'AGG_UNIT', variableId: '01', value: 'Same answer' },
       { unitName: 'agg_unit', variableId: '01', value: ' sameanswer ' }
     ]);
-    const peerUnitQuery = createQueryBuilder([
-      { unitName: 'AGG_UNIT', variableId: '01' },
-      { unitName: 'agg_unit', variableId: '01' },
-      { unitName: 'OTHER_UNIT', variableId: '01' }
-    ]);
     responseRepository.createQueryBuilder
       .mockReturnValueOnce(incompleteVariablesQuery)
       .mockReturnValueOnce(variableResponsesQuery)
-      .mockReturnValueOnce(peerUnitQuery)
       .mockReturnValueOnce(peerValueQuery)
       .mockReturnValueOnce(completedPeersQuery);
     workspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([
@@ -1061,11 +1057,10 @@ describe('CodingProgressService variable coverage conflicts', () => {
       'aggregation_peer."unitName" = unit.name'
     );
     expect(peerValueQuery.andWhere).toHaveBeenCalledWith(
-      expect.stringContaining('aggregation_peer_unit'),
+      expect.stringContaining('aggregation_peer_variable'),
       {
-        aggregationPeerUnits: JSON.stringify([
-          { unitName: 'AGG_UNIT', variableId: '01' },
-          { unitName: 'agg_unit', variableId: '01' }
+        aggregationPeerVariables: JSON.stringify([
+          { unitName: 'AGG_UNIT', variableId: '01' }
         ])
       }
     );

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
-  Brackets, In, Repository, SelectQueryBuilder
+  Brackets, In, Repository
 } from 'typeorm';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { ResponseEntity } from '../../entities/response.entity';
@@ -16,17 +16,11 @@ import {
 } from '../workspace/workspace-exclusion.service';
 import { CacheService } from '../../../cache/cache.service';
 import {
-  buildAggregationPeerLookupKeys,
-  buildAggregationPeerKeys,
-  buildAggregationPeerUnitKeys,
   buildAggregationGroups,
   countEffectiveManualCodingCases,
-  getAggregationPeerKey,
   getAggregationVariableKey,
-  isAggregatableValue,
   ManualCodingDeduplicationResponse,
   partitionResponsesByAggregationVariable,
-  serializeAggregationPeerKey,
   summarizeAggregationGroups
 } from './aggregation-metrics.util';
 import { IQB_STANDARD_MISSING_CODES, MissingsProfilesService } from './missings-profiles.service';
@@ -42,6 +36,7 @@ import {
   getNonCodingIssueReviewJobSqlCondition
 } from './coding-job-type.util';
 import { getCodingIncompleteVariablesCacheVersionKey } from './coding-incomplete-variables-cache-key.util';
+import { CodingAggregationPeerService } from './coding-aggregation-peer.service';
 
 type ResponseMatchingFlag =
   | 'NO_AGGREGATION'
@@ -206,6 +201,7 @@ export class CodingProgressService {
     private workspaceFilesService: WorkspaceFilesService,
     private workspaceExclusionService: WorkspaceExclusionService,
     private cacheService: CacheService,
+    private codingAggregationPeerService: CodingAggregationPeerService,
     @Optional()
     private missingsProfilesService?: MissingsProfilesService
   ) { }
@@ -1518,172 +1514,36 @@ export class CodingProgressService {
     matchingFlags: ResponseMatchingFlag[],
     derivedVariableMap: Map<string, Set<string>>
   ): Promise<CoverageResponse[]> {
-    const peerKeys = buildAggregationPeerKeys(
-      activeResponses,
-      matchingFlags,
-      derivedVariableMap
-    );
-
-    if (peerKeys.length === 0) {
-      return [];
-    }
-
-    const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
-    const peerKeySet = new Set(
-      peerKeys.map(peerKey => serializeAggregationPeerKey(peerKey))
-    );
-    const exactValueMatching =
-      !matchingFlags.includes('IGNORE_CASE') &&
-      !matchingFlags.includes('IGNORE_WHITESPACE');
-    const completedV2Status = statusStringToNumber('CODING_COMPLETE');
-    const createCompletedPeerQuery = (): SelectQueryBuilder<ResponseEntity> => (
-      this.responseRepository
-        .createQueryBuilder('response')
-        .leftJoin('response.unit', 'unit')
-        .leftJoin('unit.booklet', 'booklet')
-        .leftJoin('booklet.bookletinfo', 'bookletinfo')
-        .leftJoin('booklet.person', 'person')
-        .where('person.workspace_id = :workspaceId', { workspaceId })
-        .andWhere('person.consider = :consider', { consider: true })
-        .andWhere('response.status_v1 IN (:...statuses)', {
-          statuses: [
-            statusStringToNumber('CODING_INCOMPLETE'),
-            statusStringToNumber('INTENDED_INCOMPLETE')
-          ]
-        })
-        .andWhere('response.status_v2 = :completedV2Status', {
-          completedV2Status
-        })
-        .andWhere(
-          '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
-          { aggregatedCode: -111, defaultMirCode }
-        )
-        .andWhere(new Brackets(qb => {
-          qb.where('response.code_v2 IS NULL')
-            .orWhere(subQuery => {
-              const exists = subQuery
-                .subQuery()
-                .select('1')
-                .from('coding_job_unit', 'manual_cju')
-                .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
-                .where('manual_cju.response_id = response.id')
-                .andWhere('manual_cj.training_id IS NULL')
-                .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
-                .getQuery();
-              return `EXISTS (${exists})`;
-            });
-        }))
-    );
-
-    const peerVariableIds = Array.from(new Set(
-      peerKeys.map(peerKey => peerKey.variableId)
-    ));
-    const peerUnitQuery = createCompletedPeerQuery()
-      .select('DISTINCT unit.name', 'unitName')
-      .addSelect('response.variableid', 'variableId')
-      .andWhere('response.variableid IN (:...peerVariableIds)', {
-        peerVariableIds
+    const completedPeers = await this.codingAggregationPeerService
+      .findCompletedPeers({
+        workspaceId,
+        sourceResponses: activeResponses,
+        matchingFlags,
+        derivedVariableMap,
+        loadQueryContext: async () => {
+          const [defaultMirCode, exclusions] = await Promise.all([
+            this.getDefaultMirCode(workspaceId),
+            this.workspaceExclusionService.resolveExclusionsForQueries(
+              workspaceId
+            )
+          ]);
+          return { defaultMirCode, exclusions };
+        }
       });
-    applyResolvedExclusionsToQuery(peerUnitQuery, exclusions, {
-      parameterPrefix: 'completedVariableCoveragePeerUnits'
-    });
-    const peerUnitKeys = buildAggregationPeerUnitKeys(
-      peerKeys,
-      await peerUnitQuery.getRawMany()
-    );
-    if (peerUnitKeys.length === 0) {
-      return [];
-    }
 
-    const peerValueQuery = createCompletedPeerQuery()
-      .select('DISTINCT unit.name', 'unitName')
-      .addSelect('response.variableid', 'variableId')
-      .addSelect('response.value', 'value')
-      .andWhere(
-        `EXISTS (
-          SELECT 1
-          FROM jsonb_to_recordset(CAST(:aggregationPeerUnits AS jsonb))
-            AS aggregation_peer_unit("unitName" text, "variableId" text)
-          WHERE aggregation_peer_unit."unitName" = unit.name
-            AND aggregation_peer_unit."variableId" = response.variableid
-        )`,
-        { aggregationPeerUnits: JSON.stringify(peerUnitKeys) }
-      );
-    applyResolvedExclusionsToQuery(peerValueQuery, exclusions, {
-      parameterPrefix: 'completedVariableCoveragePeerValues'
-    });
-    if (exactValueMatching) {
-      peerValueQuery.andWhere(
-        `EXISTS (
-          SELECT 1
-          FROM jsonb_to_recordset(CAST(:aggregationPeerValues AS jsonb))
-            AS aggregation_peer_value("variableId" text, "normalizedValue" text)
-          WHERE aggregation_peer_value."variableId" = response.variableid
-            AND aggregation_peer_value."normalizedValue" = response.value
-        )`,
-        { aggregationPeerValues: JSON.stringify(peerKeys) }
-      );
-    }
-    const peerLookupKeys = buildAggregationPeerLookupKeys(
-      peerKeys,
-      await peerValueQuery.getRawMany(),
-      matchingFlags
-    );
-    if (peerLookupKeys.length === 0) {
-      return [];
-    }
-
-    const query = createCompletedPeerQuery()
-      .select('response.id', 'responseId')
-      .addSelect('response.value', 'value')
-      .addSelect('response.code_v2', 'codeV2')
-      .addSelect('response.status_v2', 'statusV2')
-      .addSelect('response.status_v1', 'statusV1')
-      .addSelect('response.variableid', 'variableId')
-      .addSelect('unit.name', 'unitName')
-      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
-      .addSelect("COALESCE(person.login, '')", 'personLogin')
-      .addSelect("COALESCE(person.code, '')", 'personCode')
-      .addSelect("COALESCE(person.group, '')", 'personGroup')
-      .andWhere(
-        `EXISTS (
-          SELECT 1
-          FROM jsonb_to_recordset(CAST(:aggregationPeerKeys AS jsonb))
-            AS aggregation_peer("unitName" text, "variableId" text, "value" text)
-          WHERE aggregation_peer."unitName" = unit.name
-            AND aggregation_peer."variableId" = response.variableid
-            AND aggregation_peer."value" = response.value
-        )`,
-        { aggregationPeerKeys: JSON.stringify(peerLookupKeys) }
-      )
-      .orderBy('response.id', 'ASC');
-    applyResolvedExclusionsToQuery(query, exclusions, {
-      parameterPrefix: 'completedVariableCoveragePeers'
-    });
-    const raw = await query.getRawMany();
-
-    return raw.map(row => ({
-      responseId: Number(row.responseId),
-      value: row.value ?? null,
-      codeV2: row.codeV2 === null || row.codeV2 === undefined ? null : Number(row.codeV2),
-      statusV2: row.statusV2 === null || row.statusV2 === undefined ? null : Number(row.statusV2),
-      statusV1: row.statusV1 === null || row.statusV1 === undefined ? null : Number(row.statusV1),
-      variableId: row.variableId,
-      unitName: row.unitName,
-      bookletName: row.bookletName ?? '',
-      personLogin: row.personLogin ?? '',
-      personCode: row.personCode ?? '',
-      personGroup: row.personGroup ?? ''
-    })).filter(response => (
-      isAggregatableValue(response.value) &&
-      peerKeySet.has(serializeAggregationPeerKey(getAggregationPeerKey(
-        response.unitName,
-        response.variableId,
-        response.value,
-        matchingFlags
-      )))
-    ));
+    return completedPeers.map(response => ({
+      responseId: response.responseId,
+      value: response.value,
+      codeV2: response.codeV2,
+      statusV2: response.statusV2,
+      statusV1: response.statusV1,
+      variableId: response.variableId,
+      unitName: response.unitName,
+      bookletName: response.bookletName,
+      personLogin: response.personLogin,
+      personCode: response.personCode,
+      personGroup: response.personGroup
+    }));
   }
 
   private async getAssignedVariableCoverageResponseIds(

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
-  Brackets, In, Repository
+  Brackets, In, Repository, SelectQueryBuilder
 } from 'typeorm';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { ResponseEntity } from '../../entities/response.entity';
@@ -16,9 +16,17 @@ import {
 } from '../workspace/workspace-exclusion.service';
 import { CacheService } from '../../../cache/cache.service';
 import {
+  buildAggregationPeerLookupKeys,
+  buildAggregationPeerKeys,
+  buildAggregationPeerUnitKeys,
   buildAggregationGroups,
   countEffectiveManualCodingCases,
+  getAggregationPeerKey,
+  getAggregationVariableKey,
+  isAggregatableValue,
   ManualCodingDeduplicationResponse,
+  partitionResponsesByAggregationVariable,
+  serializeAggregationPeerKey,
   summarizeAggregationGroups
 } from './aggregation-metrics.util';
 import { IQB_STANDARD_MISSING_CODES, MissingsProfilesService } from './missings-profiles.service';
@@ -132,6 +140,36 @@ interface VariableDefinitionReference {
 
 interface VariableCaseCount extends UnitVariableReference {
   caseCount: number;
+  unitNameAliases: string[];
+}
+
+type UnitVariableReferenceWithAliases = UnitVariableReference & {
+  unitNameAliases?: string[];
+};
+
+function getCoverageVariableKey(
+  unitName: string,
+  variableId: string
+): string {
+  return `${unitName.toUpperCase()}:${variableId}`;
+}
+
+function expandUnitNameAliases(
+  variables: UnitVariableReferenceWithAliases[]
+): UnitVariableReference[] {
+  const references = new Map<string, UnitVariableReference>();
+
+  variables.forEach(variable => {
+    const unitNames = variable.unitNameAliases?.length ?
+      variable.unitNameAliases :
+      [variable.unitName];
+    unitNames.forEach(unitName => {
+      const key = `${unitName}::${variable.variableId}`;
+      references.set(key, { unitName, variableId: variable.variableId });
+    });
+  });
+
+  return Array.from(references.values());
 }
 
 interface CrossDefinitionCaseRow {
@@ -1028,21 +1066,25 @@ export class CodingProgressService {
       const variableCaseCountMap = new Map<string, VariableCaseCount>();
 
       filteredIncompleteVariablesResult.forEach(row => {
-        const variableKey = `${row.unitName}:${row.variableId}`;
+        const variableKey = getCoverageVariableKey(row.unitName, row.variableId);
         const existing = variableCaseCountMap.get(variableKey);
         if (existing) {
           existing.caseCount += parseInt(row.caseCount, 10);
+          if (!existing.unitNameAliases.includes(row.unitName)) {
+            existing.unitNameAliases.push(row.unitName);
+          }
           return;
         }
         variableCaseCountMap.set(variableKey, {
           unitName: row.unitName,
           variableId: row.variableId,
-          caseCount: parseInt(row.caseCount, 10)
+          caseCount: parseInt(row.caseCount, 10),
+          unitNameAliases: [row.unitName]
         });
       });
 
       variableCaseCountMap.forEach(row => {
-        const variableKey = `${row.unitName}:${row.variableId}`;
+        const variableKey = getCoverageVariableKey(row.unitName, row.variableId);
         variablesNeedingCoding.add(variableKey);
         variableCaseCounts.push(row);
       });
@@ -1068,7 +1110,10 @@ export class CodingProgressService {
 
         if (definition.assigned_variables) {
           definition.assigned_variables.forEach(variable => {
-            const variableKey = `${variable.unitName}:${variable.variableId}`;
+            const variableKey = getCoverageVariableKey(
+              variable.unitName,
+              variable.variableId
+            );
             if (variablesNeedingCoding.has(variableKey)) {
               definitionVariables.add(variableKey);
             }
@@ -1086,7 +1131,10 @@ export class CodingProgressService {
           variableBundles.forEach(bundle => {
             if (bundle.variables) {
               bundle.variables.forEach(variable => {
-                const variableKey = `${variable.unitName}:${variable.variableId}`;
+                const variableKey = getCoverageVariableKey(
+                  variable.unitName,
+                  variable.variableId
+                );
                 if (variablesNeedingCoding.has(variableKey)) {
                   definitionVariables.add(variableKey);
                 }
@@ -1110,7 +1158,10 @@ export class CodingProgressService {
       }
 
       const coveredVariableCaseCounts = variableCaseCounts.filter(
-        variable => coveredVariables.has(`${variable.unitName}:${variable.variableId}`)
+        variable => coveredVariables.has(getCoverageVariableKey(
+          variable.unitName,
+          variable.variableId
+        ))
       );
       const effectiveVariableCaseCoverageMap =
         await this.getEffectiveVariableCasesInJobs(workspaceId, coveredVariableCaseCounts);
@@ -1140,12 +1191,15 @@ export class CodingProgressService {
 
         // Check if variable is fully or partially covered on the effective case level.
         const variableCaseInfo = variableCaseCounts.find(
-          v => `${v.unitName}:${v.variableId}` === variableKey
+          v => getCoverageVariableKey(v.unitName, v.variableId) === variableKey
         );
 
         if (variableCaseInfo) {
           const effectiveCoverage = effectiveVariableCaseCoverageMap.get(
-            `${variableCaseInfo.unitName}::${variableCaseInfo.variableId}`
+            getAggregationVariableKey(
+              variableCaseInfo.unitName,
+              variableCaseInfo.variableId
+            )
           ) || {
             effectiveTotalCasesToCode: variableCaseInfo.caseCount,
             effectiveCasesInJobs: 0
@@ -1191,7 +1245,11 @@ export class CodingProgressService {
         partiallyAbgedeckteVariablen: partiallyAbgedeckteCount,
         fullyAbgedeckteVariablen: fullyAbgedeckteCount,
         coveragePercentage,
-        variableCaseCounts,
+        variableCaseCounts: variableCaseCounts.map(({
+          unitName,
+          variableId,
+          caseCount
+        }) => ({ unitName, variableId, caseCount })),
         coverageByStatus: {
           draft: Array.from(coverageByStatus.draft),
           pending_review: Array.from(coverageByStatus.pending_review),
@@ -1204,7 +1262,10 @@ export class CodingProgressService {
           )
         },
         statusTotalVariables: new Set(
-          incompleteVariablesResult.map(row => `${row.unitName}:${row.variableId}`)
+          incompleteVariablesResult.map(row => getCoverageVariableKey(
+            row.unitName,
+            row.variableId
+          ))
         ).size,
         coveredSourceVariableCount:
           excludedSourceSummary.coveredSourceVariableCount,
@@ -1224,7 +1285,7 @@ export class CodingProgressService {
 
   private async getVariableCasesInJobs(
     workspaceId: number,
-    variables: UnitVariableReference[]
+    variables: UnitVariableReferenceWithAliases[]
   ): Promise<Map<string, number>> {
     if (variables.length === 0) {
       return new Map<string, number>();
@@ -1245,7 +1306,7 @@ export class CodingProgressService {
       })
       .groupBy('cju.unit_name')
       .addGroupBy('cju.variable_id');
-    this.applyVariableReferenceFilter(query, variables, {
+    this.applyVariableReferenceFilter(query, expandUnitNameAliases(variables), {
       unitNameExpression: 'cju.unit_name',
       variableIdExpression: 'cju.variable_id',
       parameterPrefix: 'variableCasesInJobs'
@@ -1265,8 +1326,11 @@ export class CodingProgressService {
     const casesInJobsMap = new Map<string, number>();
 
     rawResults.forEach(row => {
-      const key = `${row.unitName}::${row.variableId}`;
-      casesInJobsMap.set(key, parseInt(row.casesInJobs, 10));
+      const key = getAggregationVariableKey(row.unitName, row.variableId);
+      casesInJobsMap.set(
+        key,
+        (casesInJobsMap.get(key) || 0) + parseInt(row.casesInJobs, 10)
+      );
     });
 
     return casesInJobsMap;
@@ -1290,7 +1354,10 @@ export class CodingProgressService {
     if (!aggregationActive) {
       const casesInJobsMap = await this.getVariableCasesInJobs(workspaceId, variables);
       variables.forEach(variable => {
-        const key = `${variable.unitName}::${variable.variableId}`;
+        const key = getAggregationVariableKey(
+          variable.unitName,
+          variable.variableId
+        );
         result.set(key, {
           effectiveTotalCasesToCode: variable.caseCount,
           effectiveCasesInJobs: casesInJobsMap.get(key) || 0
@@ -1301,34 +1368,43 @@ export class CodingProgressService {
 
     const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
     const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
-    const codingCompleteStatus = statusStringToNumber('CODING_COMPLETE');
-    const variableKeys = new Set(
-      variables.map(variable => `${variable.unitName}:${variable.variableId}`)
-    );
-    const [responses, assignedResponseIds, derivedVariableMap] = await Promise.all([
+    const [activeResponses, derivedVariableMap] = await Promise.all([
       this.getCoverageResponsesForVariables(workspaceId, variables),
-      this.getAssignedCoverageResponseIdsForVariables(workspaceId, variables),
       this.getDerivedVariableMap(workspaceId)
     ]);
-    const responsesByVariable = new Map<string, CoverageResponse[]>();
-
-    responses
-      .filter(response => (
-        response.statusV1 === codingIncompleteStatus ||
-        response.statusV1 === intendedIncompleteStatus
-      ))
-      .filter(response => response.statusV2 !== codingCompleteStatus)
-      .filter(response => variableKeys.has(`${response.unitName}:${response.variableId}`))
-      .forEach(response => {
-        const key = `${response.unitName}::${response.variableId}`;
-        const variableResponses = responsesByVariable.get(key) || [];
-        variableResponses.push(response);
-        responsesByVariable.set(key, variableResponses);
-      });
+    const completedPeers = await this.getCompletedCoveragePeersForResponses(
+      workspaceId,
+      activeResponses,
+      matchingFlags,
+      derivedVariableMap
+    );
+    const responses = [...activeResponses, ...completedPeers];
+    const assignedResponseIds = await this.getAssignedVariableCoverageResponseIds(
+      workspaceId,
+      responses.map(response => response.responseId)
+    );
+    const activeResponseIds = new Set(
+      activeResponses.map(response => response.responseId)
+    );
+    const responsesByVariable = partitionResponsesByAggregationVariable(
+      responses
+        .filter(response => (
+          response.statusV1 === codingIncompleteStatus ||
+          response.statusV1 === intendedIncompleteStatus
+        )),
+      variables,
+      response => ({
+        unitName: response.unitName,
+        variableId: response.variableId
+      })
+    );
 
     variables.forEach(variable => {
-      const key = `${variable.unitName}::${variable.variableId}`;
-      const variableResponses = responsesByVariable.get(key) || [];
+      const resultKey = getAggregationVariableKey(
+        variable.unitName,
+        variable.variableId
+      );
+      const variableResponses = responsesByVariable.get(resultKey) || [];
       const responsesWithCaseFields: ManualCodingDeduplicationResponse[] =
         variableResponses.map(response => ({
           responseId: response.responseId,
@@ -1345,10 +1421,11 @@ export class CodingProgressService {
         assignedResponseIds,
         matchingFlags,
         aggregationThreshold,
-        derivedVariableMap
+        derivedVariableMap,
+        activeResponseIds
       );
 
-      result.set(key, {
+      result.set(resultKey, {
         effectiveTotalCasesToCode: effectiveCaseCounts.uniqueCases,
         effectiveCasesInJobs: effectiveCaseCounts.casesInJobs
       });
@@ -1359,7 +1436,7 @@ export class CodingProgressService {
 
   private async getCoverageResponsesForVariables(
     workspaceId: number,
-    variables: UnitVariableReference[]
+    variables: UnitVariableReferenceWithAliases[]
   ): Promise<CoverageResponse[]> {
     if (variables.length === 0) {
       return [];
@@ -1410,7 +1487,7 @@ export class CodingProgressService {
           });
       }))
       .orderBy('response.id', 'ASC');
-    this.applyVariableReferenceFilter(query, variables, {
+    this.applyVariableReferenceFilter(query, expandUnitNameAliases(variables), {
       unitNameExpression: 'unit.name',
       variableIdExpression: 'response.variableid',
       parameterPrefix: 'variableCoverageResponses'
@@ -1435,61 +1512,209 @@ export class CodingProgressService {
     }));
   }
 
-  private async getAssignedCoverageResponseIdsForVariables(
+  private async getCompletedCoveragePeersForResponses(
     workspaceId: number,
-    variables: UnitVariableReference[]
-  ): Promise<Set<number>> {
-    if (variables.length === 0) {
-      return new Set<number>();
+    activeResponses: CoverageResponse[],
+    matchingFlags: ResponseMatchingFlag[],
+    derivedVariableMap: Map<string, Set<string>>
+  ): Promise<CoverageResponse[]> {
+    const peerKeys = buildAggregationPeerKeys(
+      activeResponses,
+      matchingFlags,
+      derivedVariableMap
+    );
+
+    if (peerKeys.length === 0) {
+      return [];
     }
 
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-    const query = this.codingJobUnitRepository
-      .createQueryBuilder('cju')
-      .select('DISTINCT cju.response_id', 'responseId')
-      .innerJoin('cju.response', 'response')
-      .leftJoin('cju.coding_job', 'coding_job')
-      .leftJoin('response.unit', 'unit')
-      .leftJoin('unit.booklet', 'booklet')
-      .leftJoin('booklet.bookletinfo', 'bookletinfo')
-      .leftJoin('booklet.person', 'person')
-      .where('person.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('coding_job.training_id IS NULL')
-      .andWhere('(response.status_v2 IS NULL OR response.status_v2 != :completedV2Status)', {
-        completedV2Status: statusStringToNumber('CODING_COMPLETE')
-      })
-      .andWhere(new Brackets(qb => {
-        qb.where('response.code_v2 IS NULL')
-          .orWhere(subQuery => {
-            const exists = subQuery
-              .subQuery()
-              .select('1')
-              .from('coding_job_unit', 'assigned_cju')
-              .where('assigned_cju.response_id = response.id')
-              .getQuery();
-            return `EXISTS (${exists})`;
-          });
-      }));
-    applyNonCodingIssueReviewJobFilter(
-      query,
-      'coding_job',
-      'assignedVariableCoverageReviewJobType'
+    const defaultMirCode = await this.getDefaultMirCode(workspaceId);
+    const peerKeySet = new Set(
+      peerKeys.map(peerKey => serializeAggregationPeerKey(peerKey))
     );
-    this.applyManualProgressStatusFilter(query, 'andWhere');
-    this.applyVariableReferenceFilter(query, variables, {
-      unitNameExpression: 'cju.unit_name',
-      variableIdExpression: 'cju.variable_id',
-      parameterPrefix: 'assignedVariableCoverage'
+    const exactValueMatching =
+      !matchingFlags.includes('IGNORE_CASE') &&
+      !matchingFlags.includes('IGNORE_WHITESPACE');
+    const completedV2Status = statusStringToNumber('CODING_COMPLETE');
+    const createCompletedPeerQuery = (): SelectQueryBuilder<ResponseEntity> => (
+      this.responseRepository
+        .createQueryBuilder('response')
+        .leftJoin('response.unit', 'unit')
+        .leftJoin('unit.booklet', 'booklet')
+        .leftJoin('booklet.bookletinfo', 'bookletinfo')
+        .leftJoin('booklet.person', 'person')
+        .where('person.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('person.consider = :consider', { consider: true })
+        .andWhere('response.status_v1 IN (:...statuses)', {
+          statuses: [
+            statusStringToNumber('CODING_INCOMPLETE'),
+            statusStringToNumber('INTENDED_INCOMPLETE')
+          ]
+        })
+        .andWhere('response.status_v2 = :completedV2Status', {
+          completedV2Status
+        })
+        .andWhere(
+          '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :defaultMirCode))',
+          { aggregatedCode: -111, defaultMirCode }
+        )
+        .andWhere(new Brackets(qb => {
+          qb.where('response.code_v2 IS NULL')
+            .orWhere(subQuery => {
+              const exists = subQuery
+                .subQuery()
+                .select('1')
+                .from('coding_job_unit', 'manual_cju')
+                .innerJoin('coding_job', 'manual_cj', 'manual_cj.id = manual_cju.coding_job_id')
+                .where('manual_cju.response_id = response.id')
+                .andWhere('manual_cj.training_id IS NULL')
+                .andWhere(getNonCodingIssueReviewJobSqlCondition('manual_cj'))
+                .getQuery();
+              return `EXISTS (${exists})`;
+            });
+        }))
+    );
+
+    const peerVariableIds = Array.from(new Set(
+      peerKeys.map(peerKey => peerKey.variableId)
+    ));
+    const peerUnitQuery = createCompletedPeerQuery()
+      .select('DISTINCT unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .andWhere('response.variableid IN (:...peerVariableIds)', {
+        peerVariableIds
+      });
+    applyResolvedExclusionsToQuery(peerUnitQuery, exclusions, {
+      parameterPrefix: 'completedVariableCoveragePeerUnits'
     });
+    const peerUnitKeys = buildAggregationPeerUnitKeys(
+      peerKeys,
+      await peerUnitQuery.getRawMany()
+    );
+    if (peerUnitKeys.length === 0) {
+      return [];
+    }
+
+    const peerValueQuery = createCompletedPeerQuery()
+      .select('DISTINCT unit.name', 'unitName')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('response.value', 'value')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerUnits AS jsonb))
+            AS aggregation_peer_unit("unitName" text, "variableId" text)
+          WHERE aggregation_peer_unit."unitName" = unit.name
+            AND aggregation_peer_unit."variableId" = response.variableid
+        )`,
+        { aggregationPeerUnits: JSON.stringify(peerUnitKeys) }
+      );
+    applyResolvedExclusionsToQuery(peerValueQuery, exclusions, {
+      parameterPrefix: 'completedVariableCoveragePeerValues'
+    });
+    if (exactValueMatching) {
+      peerValueQuery.andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerValues AS jsonb))
+            AS aggregation_peer_value("variableId" text, "normalizedValue" text)
+          WHERE aggregation_peer_value."variableId" = response.variableid
+            AND aggregation_peer_value."normalizedValue" = response.value
+        )`,
+        { aggregationPeerValues: JSON.stringify(peerKeys) }
+      );
+    }
+    const peerLookupKeys = buildAggregationPeerLookupKeys(
+      peerKeys,
+      await peerValueQuery.getRawMany(),
+      matchingFlags
+    );
+    if (peerLookupKeys.length === 0) {
+      return [];
+    }
+
+    const query = createCompletedPeerQuery()
+      .select('response.id', 'responseId')
+      .addSelect('response.value', 'value')
+      .addSelect('response.code_v2', 'codeV2')
+      .addSelect('response.status_v2', 'statusV2')
+      .addSelect('response.status_v1', 'statusV1')
+      .addSelect('response.variableid', 'variableId')
+      .addSelect('unit.name', 'unitName')
+      .addSelect("COALESCE(bookletinfo.name, '')", 'bookletName')
+      .addSelect("COALESCE(person.login, '')", 'personLogin')
+      .addSelect("COALESCE(person.code, '')", 'personCode')
+      .addSelect("COALESCE(person.group, '')", 'personGroup')
+      .andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(CAST(:aggregationPeerKeys AS jsonb))
+            AS aggregation_peer("unitName" text, "variableId" text, "value" text)
+          WHERE aggregation_peer."unitName" = unit.name
+            AND aggregation_peer."variableId" = response.variableid
+            AND aggregation_peer."value" = response.value
+        )`,
+        { aggregationPeerKeys: JSON.stringify(peerLookupKeys) }
+      )
+      .orderBy('response.id', 'ASC');
     applyResolvedExclusionsToQuery(query, exclusions, {
-      unitNameExpression: 'cju.unit_name',
-      bookletNameExpression: 'cju.booklet_name',
-      parameterPrefix: 'assignedVariableCoverage'
+      parameterPrefix: 'completedVariableCoveragePeers'
     });
     const raw = await query.getRawMany();
 
-    return new Set(raw.map(row => Number(row.responseId)));
+    return raw.map(row => ({
+      responseId: Number(row.responseId),
+      value: row.value ?? null,
+      codeV2: row.codeV2 === null || row.codeV2 === undefined ? null : Number(row.codeV2),
+      statusV2: row.statusV2 === null || row.statusV2 === undefined ? null : Number(row.statusV2),
+      statusV1: row.statusV1 === null || row.statusV1 === undefined ? null : Number(row.statusV1),
+      variableId: row.variableId,
+      unitName: row.unitName,
+      bookletName: row.bookletName ?? '',
+      personLogin: row.personLogin ?? '',
+      personCode: row.personCode ?? '',
+      personGroup: row.personGroup ?? ''
+    })).filter(response => (
+      isAggregatableValue(response.value) &&
+      peerKeySet.has(serializeAggregationPeerKey(getAggregationPeerKey(
+        response.unitName,
+        response.variableId,
+        response.value,
+        matchingFlags
+      )))
+    ));
+  }
+
+  private async getAssignedVariableCoverageResponseIds(
+    workspaceId: number,
+    responseIds: number[]
+  ): Promise<Set<number>> {
+    const assignedResponseIds = new Set<number>();
+    const uniqueResponseIds = Array.from(new Set(responseIds));
+    const chunkSize = 5000;
+
+    for (let offset = 0; offset < uniqueResponseIds.length; offset += chunkSize) {
+      const responseIdChunk = uniqueResponseIds.slice(offset, offset + chunkSize);
+      const query = this.codingJobUnitRepository
+        .createQueryBuilder('cju')
+        .select('DISTINCT cju.response_id', 'responseId')
+        .leftJoin('cju.coding_job', 'coding_job')
+        .where('coding_job.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('coding_job.training_id IS NULL')
+        .andWhere('cju.response_id IN (:...responseIds)', {
+          responseIds: responseIdChunk
+        });
+      applyNonCodingIssueReviewJobFilter(
+        query,
+        'coding_job',
+        `assignedVariableCoverageReviewJobType${offset}`
+      );
+      const raw = await query.getRawMany();
+      raw.forEach(row => assignedResponseIds.add(Number(row.responseId)));
+    }
+
+    return assignedResponseIds;
   }
 
   private applyVariableReferenceFilter(
@@ -1566,8 +1791,11 @@ export class CodingProgressService {
         return;
       }
 
-      const variableKey = `${row.unitName}:${row.variableId}`;
-      const caseKey = `${row.unitName}::${row.variableId}::${responseId}`;
+      const variableKey = getCoverageVariableKey(row.unitName, row.variableId);
+      const caseKey = `${getAggregationVariableKey(
+        row.unitName,
+        row.variableId
+      )}::${responseId}`;
       const caseDefinitions = definitionsByCaseKey.get(caseKey) || new Map<number, VariableDefinitionReference>();
 
       caseDefinitions.set(definitionId, {

--- a/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
@@ -8,6 +8,7 @@ import { CodingFreshnessService } from './coding-freshness.service';
 import { CodingValidationService } from './coding-validation.service';
 import { MissingsProfilesService } from './missings-profiles.service';
 import { statusStringToNumber } from '../../utils/response-status-converter';
+import { WorkspaceExclusionService } from '../workspace/workspace-exclusion.service';
 
 jest.mock('../workspace/workspace-files.service', () => ({
   WorkspaceFilesService: jest.fn()
@@ -36,6 +37,10 @@ describe('CodingResultsService', () => {
   'getMissingByIdForProfileOrDefault' | 'getMissingByCodeForProfileOrDefault'
   >>;
   let codingFreshnessService: jest.Mocked<Pick<CodingFreshnessService, 'markManualCodingCurrent'>>;
+  let workspaceExclusionService: jest.Mocked<Pick<
+  WorkspaceExclusionService,
+  'resolveExclusionsForQueries'
+  >>;
 
   const createQueryBuilderMock = (rows: unknown[]) => ({
     leftJoinAndSelect: jest.fn().mockReturnThis(),
@@ -140,6 +145,14 @@ describe('CodingResultsService', () => {
       markManualCodingCurrent: jest.fn().mockResolvedValue(undefined)
     };
 
+    workspaceExclusionService = {
+      resolveExclusionsForQueries: jest.fn().mockResolvedValue({
+        globalIgnoredUnits: [],
+        ignoredBooklets: [],
+        testletIgnoredUnits: []
+      })
+    };
+
     service = new CodingResultsService(
       responseRepository,
       codingStatisticsService,
@@ -147,6 +160,7 @@ describe('CodingResultsService', () => {
       codingValidationService as unknown as CodingValidationService,
       codingAnalysisService as unknown as CodingAnalysisService,
       missingsProfilesService as unknown as MissingsProfilesService,
+      workspaceExclusionService as unknown as WorkspaceExclusionService,
       codingFreshnessService as unknown as CodingFreshnessService
     );
   });
@@ -793,7 +807,12 @@ describe('CodingResultsService', () => {
     );
     expect(queryRunner.manager.update).toHaveBeenCalledWith(
       ResponseEntity,
-      100,
+      expect.objectContaining({
+        id: 100,
+        status_v2: expect.anything(),
+        code_v2: expect.anything(),
+        score_v2: expect.anything()
+      }),
       {
         code_v2: 0,
         score_v2: 0,
@@ -804,6 +823,195 @@ describe('CodingResultsService', () => {
       ResponseEntity,
       101,
       expect.any(Object)
+    );
+  });
+
+  it('does not propagate over a sibling with partial existing v2 data', async () => {
+    codingJobService.getAggregationSettingsForCodingJob.mockResolvedValue({
+      aggregationEnabled: true,
+      aggregationThreshold: 2,
+      responseMatchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
+      aggregationSettingsVersion: 1,
+      fromJobSnapshot: true
+    });
+
+    (responseRepository.createQueryBuilder as jest.Mock)
+      .mockReturnValueOnce(createQueryBuilderMock([{
+        id: 99,
+        value: 'A',
+        variableid: 'VAR',
+        status_v2: 3,
+        unit: { id: 1, name: 'UNIT' }
+      }]))
+      .mockReturnValueOnce(createQueryBuilderMock([{
+        unitName: 'UNIT', variableId: 'VAR'
+      }]))
+      .mockReturnValueOnce(createQueryBuilderMock([
+        {
+          id: 99,
+          value: 'A',
+          variableid: 'VAR',
+          status_v2: 3,
+          code_v2: null,
+          score_v2: null,
+          unit: { id: 1, name: 'UNIT' }
+        },
+        {
+          id: 100,
+          value: 'a',
+          variableid: 'VAR',
+          status_v2: null,
+          code_v2: 7,
+          score_v2: null,
+          unit: { id: 2, name: 'UNIT' }
+        }
+      ]));
+
+    const result = await service.applyCodingResults(17, 10);
+
+    expect(result.updatedResponsesCount).toBe(1);
+    expect(result.skippedAlreadyCodedCount).toBe(1);
+    expect(queryRunner.manager.update).not.toHaveBeenCalledWith(
+      ResponseEntity,
+      expect.objectContaining({ id: 100 }),
+      expect.any(Object)
+    );
+  });
+
+  it('atomically skips a sibling coded after candidate discovery', async () => {
+    codingJobService.getAggregationSettingsForCodingJob.mockResolvedValue({
+      aggregationEnabled: true,
+      aggregationThreshold: 2,
+      responseMatchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
+      aggregationSettingsVersion: 1,
+      fromJobSnapshot: true
+    });
+
+    (responseRepository.createQueryBuilder as jest.Mock)
+      .mockReturnValueOnce(createQueryBuilderMock([{
+        id: 99,
+        value: 'A',
+        variableid: 'VAR',
+        status_v2: 3,
+        unit: { id: 1, name: 'UNIT' }
+      }]))
+      .mockReturnValueOnce(createQueryBuilderMock([{
+        unitName: 'UNIT', variableId: 'VAR'
+      }]))
+      .mockReturnValueOnce(createQueryBuilderMock([
+        {
+          id: 99,
+          value: 'A',
+          variableid: 'VAR',
+          status_v2: 3,
+          unit: { id: 1, name: 'UNIT' }
+        },
+        {
+          id: 100,
+          value: 'a',
+          variableid: 'VAR',
+          status_v2: null,
+          code_v2: null,
+          score_v2: null,
+          unit: { id: 2, name: 'UNIT' }
+        }
+      ]));
+    queryRunner.manager.update.mockImplementation(
+      async (_entity, criteria) => ({
+        affected: typeof criteria === 'object' && criteria.id === 100 ? 0 : 1
+      })
+    );
+
+    const result = await service.applyCodingResults(17, 10);
+
+    expect(result.updatedResponsesCount).toBe(1);
+    expect(result.skippedAlreadyCodedCount).toBe(1);
+    expect(queryRunner.manager.update).toHaveBeenCalledWith(
+      ResponseEntity,
+      expect.objectContaining({
+        id: 100,
+        status_v2: expect.anything(),
+        code_v2: expect.anything(),
+        score_v2: expect.anything()
+      }),
+      {
+        code_v2: 0,
+        score_v2: 0,
+        status_v2: 5
+      }
+    );
+  });
+
+  it('applies workspace exclusions to aggregation sibling discovery and candidates', async () => {
+    codingJobService.getAggregationSettingsForCodingJob.mockResolvedValue({
+      aggregationEnabled: true,
+      aggregationThreshold: 2,
+      responseMatchingFlags: [ResponseMatchingFlag.IGNORE_CASE],
+      aggregationSettingsVersion: 1,
+      fromJobSnapshot: true
+    });
+    workspaceExclusionService.resolveExclusionsForQueries.mockResolvedValue({
+      globalIgnoredUnits: [],
+      ignoredBooklets: ['blocked_booklet'],
+      testletIgnoredUnits: [{ bookletId: 'booklet_a', unitId: 'unit.xml' }]
+    });
+
+    const unitNameQuery = createQueryBuilderMock([
+      { unitName: 'UNIT', variableId: 'VAR' }
+    ]);
+    const candidateQuery = createQueryBuilderMock([
+      {
+        id: 99,
+        value: 'A',
+        variableid: 'VAR',
+        status_v2: 3,
+        unit: { id: 1, name: 'UNIT' }
+      }
+    ]);
+    (responseRepository.createQueryBuilder as jest.Mock)
+      .mockReturnValueOnce(createQueryBuilderMock([
+        {
+          id: 99,
+          value: 'A',
+          variableid: 'VAR',
+          status_v2: 3,
+          unit: { id: 1, name: 'UNIT' }
+        }
+      ]))
+      .mockReturnValueOnce(unitNameQuery)
+      .mockReturnValueOnce(candidateQuery);
+
+    await service.applyCodingResults(17, 10);
+
+    expect(workspaceExclusionService.resolveExclusionsForQueries)
+      .toHaveBeenCalledWith(17);
+    [unitNameQuery, candidateQuery].forEach(query => {
+      expect(query.leftJoin).toHaveBeenCalledWith(
+        'booklet.bookletinfo',
+        'bookletinfo'
+      );
+    });
+    expect(unitNameQuery.andWhere).toHaveBeenCalledWith(
+      'UPPER(bookletinfo.name) NOT IN (:...aggregationSiblingUnitsIgnoredBooklets)',
+      { aggregationSiblingUnitsIgnoredBooklets: ['BLOCKED_BOOKLET'] }
+    );
+    expect(unitNameQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('aggregationSiblingUnitsBooklet0'),
+      {
+        aggregationSiblingUnitsBooklet0: 'BOOKLET_A',
+        aggregationSiblingUnitsUnit0: 'UNIT'
+      }
+    );
+    expect(candidateQuery.andWhere).toHaveBeenCalledWith(
+      'UPPER(bookletinfo.name) NOT IN (:...aggregationSiblingCandidatesIgnoredBooklets)',
+      { aggregationSiblingCandidatesIgnoredBooklets: ['BLOCKED_BOOKLET'] }
+    );
+    expect(candidateQuery.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('aggregationSiblingCandidatesBooklet0'),
+      {
+        aggregationSiblingCandidatesBooklet0: 'BOOKLET_A',
+        aggregationSiblingCandidatesUnit0: 'UNIT'
+      }
     );
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
@@ -41,9 +41,11 @@ describe('CodingResultsService', () => {
     leftJoinAndSelect: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
-    getMany: jest.fn().mockResolvedValue(rows)
+    getMany: jest.fn().mockResolvedValue(rows),
+    getRawMany: jest.fn().mockResolvedValue(rows)
   });
 
   beforeEach(() => {
@@ -739,6 +741,33 @@ describe('CodingResultsService', () => {
       fromJobSnapshot: true
     });
 
+    const unitNameQuery = createQueryBuilderMock([
+      { unitName: 'UNIT', variableId: 'VAR' },
+      { unitName: 'unit', variableId: 'VAR' }
+    ]);
+    const candidateQuery = createQueryBuilderMock([
+      {
+        id: 99,
+        value: ' A ',
+        variableid: 'VAR',
+        status_v2: 3,
+        unit: { id: 1, name: 'UNIT' }
+      },
+      {
+        id: 100,
+        value: 'a',
+        variableid: 'VAR',
+        status_v2: null,
+        unit: { id: 2, name: 'unit' }
+      },
+      {
+        id: 101,
+        value: 'A',
+        variableid: 'VAR',
+        status_v2: 5,
+        unit: { id: 3, name: 'UNIT' }
+      }
+    ]);
     (responseRepository.createQueryBuilder as jest.Mock)
       .mockReturnValueOnce(createQueryBuilderMock([
         {
@@ -749,29 +778,8 @@ describe('CodingResultsService', () => {
           unit: { id: 1, name: 'UNIT' }
         }
       ]))
-      .mockReturnValueOnce(createQueryBuilderMock([
-        {
-          id: 99,
-          value: ' A ',
-          variableid: 'VAR',
-          status_v2: 3,
-          unit: { id: 1, name: 'UNIT' }
-        },
-        {
-          id: 100,
-          value: 'a',
-          variableid: 'VAR',
-          status_v2: null,
-          unit: { id: 2, name: 'UNIT' }
-        },
-        {
-          id: 101,
-          value: 'A',
-          variableid: 'VAR',
-          status_v2: 5,
-          unit: { id: 3, name: 'UNIT' }
-        }
-      ]));
+      .mockReturnValueOnce(unitNameQuery)
+      .mockReturnValueOnce(candidateQuery);
 
     const result = await service.applyCodingResults(17, 10);
 
@@ -779,6 +787,10 @@ describe('CodingResultsService', () => {
     expect(result.updatedResponsesCount).toBe(2);
     expect(result.skippedAlreadyCodedCount).toBe(1);
     expect(result.overwrittenExistingCount).toBe(0);
+    expect(candidateQuery.andWhere).toHaveBeenCalledWith(
+      'unit.name IN (:...unitNames)',
+      { unitNames: ['UNIT', 'unit'] }
+    );
     expect(queryRunner.manager.update).toHaveBeenCalledWith(
       ResponseEntity,
       100,
@@ -846,6 +858,9 @@ describe('CodingResultsService', () => {
         }
       ]))
       .mockReturnValueOnce(createQueryBuilderMock([
+        { unitName: 'UNIT', variableId: 'VAR' }
+      ]))
+      .mockReturnValueOnce(createQueryBuilderMock([
         {
           id: 99,
           value: ' A ',
@@ -908,6 +923,9 @@ describe('CodingResultsService', () => {
         }
       ]))
       .mockReturnValueOnce(createQueryBuilderMock([
+        { unitName: 'UNIT', variableId: 'VAR' }
+      ]))
+      .mockReturnValueOnce(createQueryBuilderMock([
         {
           id: 99,
           value: ' A ',
@@ -964,6 +982,9 @@ describe('CodingResultsService', () => {
         }
       ]))
       .mockReturnValueOnce(createQueryBuilderMock([
+        { unitName: 'UNIT', variableId: 'VAR' }
+      ]))
+      .mockReturnValueOnce(createQueryBuilderMock([
         {
           id: 99,
           value: ' A ',
@@ -1016,6 +1037,9 @@ describe('CodingResultsService', () => {
           status_v2: 3,
           unit: { id: 1, name: 'UNIT' }
         }
+      ]))
+      .mockReturnValueOnce(createQueryBuilderMock([
+        { unitName: 'UNIT', variableId: 'VAR' }
       ]))
       .mockReturnValueOnce(createQueryBuilderMock([
         {

--- a/apps/backend/src/app/database/services/coding/coding-results.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager, IsNull, Repository } from 'typeorm';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { ResponseEntity } from '../../entities/response.entity';
 import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
@@ -19,6 +19,10 @@ import { lockWorkspaceTestResultsMutationInTransaction } from '../shared/workspa
 import { CodingValidationService } from './coding-validation.service';
 import { MissingsProfilesService } from './missings-profiles.service';
 import { getNonCodingIssueReviewJobSqlCondition } from './coding-job-type.util';
+import {
+  applyResolvedExclusionsToQuery,
+  WorkspaceExclusionService
+} from '../workspace/workspace-exclusion.service';
 
 export interface ApplyCodingResultsOptions {
   overwriteExisting?: boolean;
@@ -40,6 +44,14 @@ interface ExistingV2State {
   score: number | null;
 }
 
+interface PendingResponseUpdate {
+  responseId: number;
+  code_v2: number | null;
+  score_v2: number | null;
+  status_v2: number;
+  protectExistingV2?: boolean;
+}
+
 @Injectable()
 export class CodingResultsService {
   private readonly logger = new Logger(CodingResultsService.name);
@@ -56,6 +68,7 @@ export class CodingResultsService {
     private codingValidationService: CodingValidationService,
     private codingAnalysisService: CodingAnalysisService,
     private missingsProfilesService: MissingsProfilesService,
+    private workspaceExclusionService: WorkspaceExclusionService,
     @Optional()
     private codingFreshnessService?: CodingFreshnessService
   ) { }
@@ -100,12 +113,7 @@ export class CodingResultsService {
       };
     }
 
-    const responsesToUpdate: {
-      responseId: number;
-      code_v2: number | null;
-      score_v2: number | null;
-      status_v2: number;
-    }[] = [];
+    const responsesToUpdate: PendingResponseUpdate[] = [];
 
     try {
       const codingJobUnits = await this.codingJobService.getCodingJobUnits(codingJobId);
@@ -294,27 +302,35 @@ export class CodingResultsService {
               unitNamesByVariable.set(variableKey, unitNames);
             });
 
+            const exclusions = await this.workspaceExclusionService
+              .resolveExclusionsForQueries(workspaceId);
             if (codedVariableIds.length > 0) {
-              const unitNameRows: Array<{ unitName: string; variableId: string }> =
-                await this.responseRepository
-                  .createQueryBuilder('response')
-                  .select('DISTINCT unit.name', 'unitName')
-                  .addSelect('response.variableid', 'variableId')
-                  .leftJoin('response.unit', 'unit')
-                  .leftJoin('unit.booklet', 'booklet')
-                  .leftJoin('booklet.person', 'person')
-                  .where('person.workspace_id = :workspaceId', { workspaceId })
-                  .andWhere('person.consider = :consider', { consider: true })
-                  .andWhere('response.status_v1 IN (:...statuses)', {
-                    statuses: [
-                      statusStringToNumber('CODING_INCOMPLETE'),
-                      statusStringToNumber('INTENDED_INCOMPLETE')
-                    ]
-                  })
-                  .andWhere('response.variableid IN (:...codedVariableIds)', {
-                    codedVariableIds
-                  })
-                  .getRawMany();
+              const unitNameQuery = this.responseRepository
+                .createQueryBuilder('response')
+                .select('DISTINCT unit.name', 'unitName')
+                .addSelect('response.variableid', 'variableId')
+                .leftJoin('response.unit', 'unit')
+                .leftJoin('unit.booklet', 'booklet')
+                .leftJoin('booklet.bookletinfo', 'bookletinfo')
+                .leftJoin('booklet.person', 'person')
+                .where('person.workspace_id = :workspaceId', { workspaceId })
+                .andWhere('person.consider = :consider', { consider: true })
+                .andWhere('response.status_v1 IN (:...statuses)', {
+                  statuses: [
+                    statusStringToNumber('CODING_INCOMPLETE'),
+                    statusStringToNumber('INTENDED_INCOMPLETE')
+                  ]
+                })
+                .andWhere('response.variableid IN (:...codedVariableIds)', {
+                  codedVariableIds
+                });
+              applyResolvedExclusionsToQuery(unitNameQuery, exclusions, {
+                parameterPrefix: 'aggregationSiblingUnits'
+              });
+              const unitNameRows: Array<{
+                unitName: string;
+                variableId: string;
+              }> = await unitNameQuery.getRawMany();
               unitNameRows.forEach(row => {
                 const variableKey = getAggregationVariableKey(
                   row.unitName,
@@ -345,16 +361,19 @@ export class CodingResultsService {
 
               // Find all sibling responses for the same workspace + unit + variable.
               // Existing v2 codings are either reported as skipped or overwritten only when explicitly requested.
-              const candidates = await this.responseRepository
+              const candidateQuery = this.responseRepository
                 .createQueryBuilder('response')
                 .leftJoinAndSelect('response.unit', 'unit')
                 .leftJoin('unit.booklet', 'booklet')
+                .leftJoin('booklet.bookletinfo', 'bookletinfo')
                 .leftJoin('booklet.person', 'person')
                 .select([
                   'response.id',
                   'response.value',
                   'response.variableid',
                   'response.status_v2',
+                  'response.code_v2',
+                  'response.score_v2',
                   'unit.id',
                   'unit.name'
                 ])
@@ -367,8 +386,11 @@ export class CodingResultsService {
                   ]
                 })
                 .andWhere('unit.name IN (:...unitNames)', { unitNames })
-                .andWhere('response.variableid = :variableId', { variableId })
-                .getMany();
+                .andWhere('response.variableid = :variableId', { variableId });
+              applyResolvedExclusionsToQuery(candidateQuery, exclusions, {
+                parameterPrefix: 'aggregationSiblingCandidates'
+              });
+              const candidates = await candidateQuery.getMany();
 
               const groups = buildAggregationGroups(
                 candidates.map(candidate => ({
@@ -376,7 +398,9 @@ export class CodingResultsService {
                   unitName: candidate.unit?.name || unitName,
                   variableId: candidate.variableid,
                   value: candidate.value,
-                  statusV2: candidate.status_v2
+                  statusV2: candidate.status_v2,
+                  codeV2: candidate.code_v2,
+                  scoreV2: candidate.score_v2
                 })),
                 matchingFlags,
                 aggregationThreshold,
@@ -393,7 +417,11 @@ export class CodingResultsService {
               for (const candidate of aggregationGroup.responses) {
                 if (candidate.responseId === codedResponse.id || alreadyUpdatedIds.has(candidate.responseId)) continue;
 
-                if (candidate.statusV2 !== null && candidate.statusV2 !== undefined) {
+                if (this.hasExistingV2Value({
+                  status: candidate.statusV2 ?? null,
+                  code: candidate.codeV2 ?? null,
+                  score: candidate.scoreV2 ?? null
+                })) {
                   if (!overwriteExisting) {
                     skippedAlreadyCodedCount += 1;
                     alreadyUpdatedIds.add(candidate.responseId);
@@ -406,7 +434,8 @@ export class CodingResultsService {
                   responseId: candidate.responseId,
                   code_v2: update.code_v2,
                   score_v2: update.score_v2,
-                  status_v2: update.status_v2
+                  status_v2: update.status_v2,
+                  protectExistingV2: !overwriteExisting
                 });
                 alreadyUpdatedIds.add(candidate.responseId);
               }
@@ -486,28 +515,47 @@ export class CodingResultsService {
 
         const batchSize = 500;
         let totalUpdated = 0;
+        const updatedResponseIds: number[] = [];
 
         for (let i = 0; i < responsesToUpdate.length; i += batchSize) {
           const batch = responsesToUpdate.slice(i, i + batchSize);
 
-          const updatePromises = batch.map(responseUpdate => queryRunner.manager.update(
-            ResponseEntity,
-            responseUpdate.responseId,
-            {
-              code_v2: responseUpdate.code_v2,
-              score_v2: responseUpdate.score_v2,
-              status_v2: responseUpdate.status_v2
-            }
-          )
-          );
+          const updateResults = await Promise.all(batch.map(async responseUpdate => ({
+            responseUpdate,
+            result: await queryRunner.manager.update(
+              ResponseEntity,
+              responseUpdate.protectExistingV2 ?
+                {
+                  id: responseUpdate.responseId,
+                  status_v2: IsNull(),
+                  code_v2: IsNull(),
+                  score_v2: IsNull()
+                } :
+                responseUpdate.responseId,
+              {
+                code_v2: responseUpdate.code_v2,
+                score_v2: responseUpdate.score_v2,
+                status_v2: responseUpdate.status_v2
+              }
+            )
+          })));
 
-          await Promise.all(updatePromises);
-          totalUpdated += batch.length;
+          const protectedUpdatesSkipped = updateResults.filter(({ responseUpdate, result }) => (
+            responseUpdate.protectExistingV2 && result.affected === 0
+          )).length;
+          skippedAlreadyCodedCount += protectedUpdatesSkipped;
 
-          this.logger.log(`Updated batch of ${batch.length} responses (${totalUpdated}/${responsesToUpdate.length})`);
+          const updatedBatch = updateResults.filter(({ responseUpdate, result }) => (
+            !responseUpdate.protectExistingV2 || result.affected !== 0
+          ));
+          updatedResponseIds.push(...updatedBatch.map(({ responseUpdate }) => (
+            responseUpdate.responseId
+          )));
+          totalUpdated += updatedBatch.length;
+
+          this.logger.log(`Updated batch of ${updatedBatch.length} responses (${totalUpdated}/${responsesToUpdate.length})`);
         }
 
-        const updatedResponseIds = responsesToUpdate.map(response => response.responseId);
         const freshnessResponseIds = skippedReviewCount === 0 ?
           Array.from(new Set([
             ...directResponseIds,
@@ -538,13 +586,13 @@ export class CodingResultsService {
 
         return {
           success: true,
-          updatedResponsesCount: responsesToUpdate.length,
+          updatedResponsesCount: totalUpdated,
           skippedReviewCount,
           skippedAlreadyCodedCount,
           overwrittenExistingCount,
           messageKey: 'coding-results.apply.success.bulk',
           messageParams: {
-            count: responsesToUpdate.length,
+            count: totalUpdated,
             skipped: skippedReviewCount,
             skippedAlreadyCoded: skippedAlreadyCodedCount,
             overwrittenExisting: overwrittenExistingCount

--- a/apps/backend/src/app/database/services/coding/coding-results.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.ts
@@ -6,7 +6,10 @@ import { ResponseEntity } from '../../entities/response.entity';
 import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { CodingStatisticsService } from './coding-statistics.service';
 import { CodingAnalysisService } from './coding-analysis.service';
-import { buildAggregationGroups } from './aggregation-metrics.util';
+import {
+  buildAggregationGroups,
+  getAggregationVariableKey
+} from './aggregation-metrics.util';
 import {
   formatCodingTestPerson,
   generateCodingProgressKey
@@ -272,6 +275,58 @@ export class CodingResultsService {
               .where('response.id IN (:...ids)', { ids: codedResponseIds })
               .getMany();
 
+            const codedVariableIds = Array.from(new Set(
+              codedResponses
+                .map(response => response.variableid)
+                .filter((variableId): variableId is string => Boolean(variableId))
+            ));
+            const unitNamesByVariable = new Map<string, Set<string>>();
+            codedResponses.forEach(response => {
+              if (!response.unit?.name || !response.variableid) {
+                return;
+              }
+              const variableKey = getAggregationVariableKey(
+                response.unit.name,
+                response.variableid
+              );
+              const unitNames = unitNamesByVariable.get(variableKey) || new Set<string>();
+              unitNames.add(response.unit.name);
+              unitNamesByVariable.set(variableKey, unitNames);
+            });
+
+            if (codedVariableIds.length > 0) {
+              const unitNameRows: Array<{ unitName: string; variableId: string }> =
+                await this.responseRepository
+                  .createQueryBuilder('response')
+                  .select('DISTINCT unit.name', 'unitName')
+                  .addSelect('response.variableid', 'variableId')
+                  .leftJoin('response.unit', 'unit')
+                  .leftJoin('unit.booklet', 'booklet')
+                  .leftJoin('booklet.person', 'person')
+                  .where('person.workspace_id = :workspaceId', { workspaceId })
+                  .andWhere('person.consider = :consider', { consider: true })
+                  .andWhere('response.status_v1 IN (:...statuses)', {
+                    statuses: [
+                      statusStringToNumber('CODING_INCOMPLETE'),
+                      statusStringToNumber('INTENDED_INCOMPLETE')
+                    ]
+                  })
+                  .andWhere('response.variableid IN (:...codedVariableIds)', {
+                    codedVariableIds
+                  })
+                  .getRawMany();
+              unitNameRows.forEach(row => {
+                const variableKey = getAggregationVariableKey(
+                  row.unitName,
+                  row.variableId
+                );
+                if (!unitNamesByVariable.has(variableKey)) {
+                  return;
+                }
+                unitNamesByVariable.get(variableKey)?.add(row.unitName);
+              });
+            }
+
             for (const codedResponse of codedResponses) {
               const update = completedUpdates.find(u => u.responseId === codedResponse.id);
               if (!update) continue;
@@ -280,6 +335,13 @@ export class CodingResultsService {
               const variableId = codedResponse.variableid;
 
               if (!unitName || !variableId) continue;
+
+              const unitNames = Array.from(
+                unitNamesByVariable.get(getAggregationVariableKey(
+                  unitName,
+                  variableId
+                )) || [unitName]
+              );
 
               // Find all sibling responses for the same workspace + unit + variable.
               // Existing v2 codings are either reported as skipped or overwritten only when explicitly requested.
@@ -304,7 +366,7 @@ export class CodingResultsService {
                     statusStringToNumber('INTENDED_INCOMPLETE')
                   ]
                 })
-                .andWhere('unit.name = :unitName', { unitName })
+                .andWhere('unit.name IN (:...unitNames)', { unitNames })
                 .andWhere('response.variableid = :variableId', { variableId })
                 .getMany();
 

--- a/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-statistics.service.spec.ts
@@ -344,10 +344,10 @@ describe('CodingStatisticsService', () => {
         'coding_incomplete_variables_version:1'
       );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1'
+        'coding_incomplete_variables_v9:1'
       );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_scope_v1:1'
+        'coding_incomplete_variables_scope_v2:1'
       );
     });
 

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -9,7 +9,7 @@ import { CacheService } from '../../../cache/cache.service';
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import { WorkspacePlayerService } from '../workspace/workspace-player.service';
 import { WorkspaceExclusionService } from '../workspace/workspace-exclusion.service';
-import { CodingJobService } from './coding-job.service';
+import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import { getManualCodingScopeKey } from '../../utils/manual-coding-scope.util';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 
@@ -151,8 +151,14 @@ describe('CodingValidationService', () => {
       getResponseMatchingMode: jest.fn().mockResolvedValue([]),
       getAggregationThreshold: jest.fn().mockResolvedValue(2),
       getSlimResponsesForVariables: jest.fn().mockResolvedValue([]),
+      getSlimResponsesForVariableCoverage: jest.fn(),
       aggregateResponsesByValue: jest.fn().mockReturnValue([])
     } as unknown as jest.Mocked<CodingJobService>;
+    mockCodingJobService.getSlimResponsesForVariableCoverage.mockImplementation(
+      async (workspaceId, variables) => (
+        mockCodingJobService.getSlimResponsesForVariables(workspaceId, variables)
+      )
+    );
     mockQueryBuilder.getRawMany.mockResolvedValue([]);
     mockQueryBuilder.getCount.mockResolvedValue(0);
     mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(new Map());
@@ -543,7 +549,91 @@ describe('CodingValidationService', () => {
 
       expect(result).toEqual(cachedVariables);
       expect(mockCacheService.get).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1'
+        'coding_incomplete_variables_v9:1'
+      );
+    });
+
+    it('should filter cached variables by unit name without case sensitivity', async () => {
+      const cachedVariables = [{
+        unitName: 'Unit1',
+        variableId: 'var1',
+        responseCount: 5,
+        deriveErrorResponseCount: 0,
+        casesInJobs: 0,
+        availableCases: 5,
+        uniqueCasesAfterAggregation: 5,
+        isDerived: false,
+        coderTrainingRequired: false
+      }];
+      mockCacheService.get.mockResolvedValue(cachedVariables);
+
+      await expect(
+        service.getCodingIncompleteVariables(1, 'UNIT1')
+      ).resolves.toEqual(cachedVariables);
+    });
+
+    it('should include all unit-name case aliases in a scoped database query', async () => {
+      const unitAliasesQb = createQueryBuilderMock([
+        { unitName: 'UNIT1' },
+        { unitName: 'unit1' },
+        { unitName: 'OTHER' }
+      ]);
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'UNIT1', variableId: 'var1', responseCount: '2' },
+        { unitName: 'unit1', variableId: 'var1', responseCount: '3' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([]);
+      const assignedResponsesQb = createQueryBuilderMock([]);
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(unitAliasesQb)
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(assignedResponsesQb);
+      mockCacheService.get.mockResolvedValue(null);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(null);
+      mockCodingJobService.getSlimResponsesForVariables.mockResolvedValue([
+        ...createSlimResponses('UNIT1', 'var1', 2),
+        ...createSlimResponses('unit1', 'var1', 3).map((response, index) => ({
+          ...response,
+          id: index + 3,
+          value: `lower-value-${index + 1}`,
+          personLogin: `lower-person-${index + 1}`,
+          personCode: `lower-${index + 1}`
+        }))
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(1, 'Unit1');
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'UNIT1',
+          variableId: 'var1',
+          responseCount: 5,
+          uniqueCasesAfterAggregation: 5
+        })
+      ]);
+      [codingIncompleteQb, intendedIncompleteQb, deriveErrorQb]
+        .forEach(query => {
+          expect(query.andWhere).toHaveBeenCalledWith(
+            'unit.name IN (:...scopedUnitNames)',
+            { scopedUnitNames: ['UNIT1', 'unit1'] }
+          );
+        });
+      expect(mockCodingJobService.getSlimResponsesForVariables).toHaveBeenCalledWith(
+        1,
+        [
+          { unitName: 'UNIT1', variableId: 'var1' },
+          { unitName: 'unit1', variableId: 'var1' }
+        ]
       );
     });
 
@@ -563,7 +653,7 @@ describe('CodingValidationService', () => {
 
       mockCacheService.getNumber.mockResolvedValue(2);
       mockCacheService.get.mockImplementation(async key => (
-        key === 'coding_incomplete_variables_v8:1' ?
+        key === 'coding_incomplete_variables_v9:1' ?
           {
             invalidationVersion: 1,
             data: [
@@ -605,7 +695,7 @@ describe('CodingValidationService', () => {
         })
       ]);
       expect(mockCacheService.set).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1',
+        'coding_incomplete_variables_v9:1',
         {
           invalidationVersion: 2,
           data: result
@@ -670,7 +760,7 @@ describe('CodingValidationService', () => {
         })
       ]);
       expect(mockCacheService.set).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1',
+        'coding_incomplete_variables_v9:1',
         {
           invalidationVersion: 0,
           data: result
@@ -678,7 +768,7 @@ describe('CodingValidationService', () => {
         300
       );
       expect(mockCacheService.set).toHaveBeenCalledWith(
-        'coding_incomplete_variables_scope_v1:1',
+        'coding_incomplete_variables_scope_v2:1',
         expect.objectContaining({
           invalidationVersion: 0,
           data: expect.objectContaining({
@@ -942,7 +1032,7 @@ describe('CodingValidationService', () => {
 
     it('should return manual coding scope summary from cache without querying responses', async () => {
       mockCacheService.get.mockImplementation(async key => (
-        key === 'coding_incomplete_variables_scope_v1:1' ?
+        key === 'coding_incomplete_variables_scope_v2:1' ?
           {
             variables: [
               {
@@ -1168,6 +1258,71 @@ describe('CodingValidationService', () => {
           uniqueCasesAfterAggregation: 3
         })
       ]);
+    });
+
+    it('should keep an open sibling unavailable when its completed aggregation peer is assigned', async () => {
+      const codingIncompleteQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseCount: '1' }
+      ]);
+      const intendedIncompleteQb = createQueryBuilderMock([]);
+      const deriveErrorQb = createQueryBuilderMock([]);
+      const assignedResponsesQb = createQueryBuilderMock([
+        { unitName: 'unit1', variableId: 'var1', responseId: '1' }
+      ]);
+
+      mockResponseRepository.createQueryBuilder = jest.fn()
+        .mockReturnValueOnce(codingIncompleteQb)
+        .mockReturnValueOnce(intendedIncompleteQb)
+        .mockReturnValueOnce(deriveErrorQb);
+      (mockCodingJobUnitRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(assignedResponsesQb);
+      mockCacheService.get.mockResolvedValue(null);
+      mockCacheService.set.mockResolvedValue(true);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['var1'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getCoderTrainingRequiredVariableMap.mockResolvedValue(new Map());
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(new Map());
+      mockCodingJobService.getAggregationThreshold.mockResolvedValue(2);
+      mockCodingJobService.getResponseMatchingMode.mockResolvedValue([
+        ResponseMatchingFlag.IGNORE_CASE,
+        ResponseMatchingFlag.IGNORE_WHITESPACE
+      ]);
+      mockCodingJobService.getSlimResponsesForVariableCoverage.mockResolvedValue([
+        {
+          id: 2,
+          unitName: 'unit1',
+          variableid: 'var1',
+          value: 'Same answer',
+          statusV2: null,
+          personLogin: 'person-2'
+        },
+        {
+          id: 1,
+          unitName: 'UNIT1',
+          variableid: 'var1',
+          value: ' sameanswer ',
+          statusV2: statusStringToNumber('CODING_COMPLETE'),
+          personLogin: 'person-1'
+        }
+      ] as never);
+
+      const result = await service.getCodingIncompleteVariables(1);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          unitName: 'unit1',
+          variableId: 'var1',
+          casesInJobs: 1,
+          availableCases: 0,
+          uniqueCasesAfterAggregation: 1
+        })
+      ]);
+      expect(assignedResponsesQb.andWhere).toHaveBeenCalledWith(
+        'cju.response_id IN (:...responseIds)',
+        { responseIds: [2, 1] }
+      );
     });
 
     it('should treat assigned duplicate responses as assigned after deduplication and aggregation', async () => {
@@ -1795,7 +1950,7 @@ describe('CodingValidationService', () => {
 
     it('should reuse an in-flight validation for identical manual code availability requests', async () => {
       mockCacheService.get.mockImplementation(async key => (
-        key === 'coding_incomplete_variables_v8:1' ?
+        key === 'coding_incomplete_variables_v9:1' ?
           [
             {
               unitName: 'unit1',
@@ -1878,7 +2033,7 @@ describe('CodingValidationService', () => {
     it('should generate correct cache key', () => {
       const cacheKey = service.generateIncompleteVariablesCacheKey(123);
 
-      expect(cacheKey).toBe('coding_incomplete_variables_v8:123');
+      expect(cacheKey).toBe('coding_incomplete_variables_v9:123');
     });
   });
 
@@ -1892,10 +2047,10 @@ describe('CodingValidationService', () => {
         'coding_incomplete_variables_version:1'
       );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_v8:1'
+        'coding_incomplete_variables_v9:1'
       );
       expect(mockCacheService.delete).toHaveBeenCalledWith(
-        'coding_incomplete_variables_scope_v1:1'
+        'coding_incomplete_variables_scope_v2:1'
       );
     });
   });

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository, SelectQueryBuilder } from 'typeorm';
+import { Brackets, Repository, SelectQueryBuilder } from 'typeorm';
 import { ExpectedCombinationDto } from '../../../../../../../api-dto/coding/expected-combination.dto';
 import { CodingValidationService } from './coding-validation.service';
 import { ResponseEntity } from '../../entities/response.entity';
@@ -575,8 +575,7 @@ describe('CodingValidationService', () => {
     it('should include all unit-name case aliases in a scoped database query', async () => {
       const unitAliasesQb = createQueryBuilderMock([
         { unitName: 'UNIT1' },
-        { unitName: 'unit1' },
-        { unitName: 'OTHER' }
+        { unitName: 'unit1' }
       ]);
       const codingIncompleteQb = createQueryBuilderMock([
         { unitName: 'UNIT1', variableId: 'var1', responseCount: '2' },
@@ -621,6 +620,10 @@ describe('CodingValidationService', () => {
           uniqueCasesAfterAggregation: 5
         })
       ]);
+      expect(unitAliasesQb.andWhere).toHaveBeenCalledWith(
+        'UPPER(unit.name) = UPPER(:unitName)',
+        { unitName: 'Unit1' }
+      );
       [codingIncompleteQb, intendedIncompleteQb, deriveErrorQb]
         .forEach(query => {
           expect(query.andWhere).toHaveBeenCalledWith(
@@ -2080,6 +2083,31 @@ describe('CodingValidationService', () => {
         'response'
       );
       expect(mockQueryBuilder.getCount).toHaveBeenCalled();
+    });
+
+    it('should match applied-result unit names case-insensitively', async () => {
+      mockQueryBuilder.getCount.mockResolvedValueOnce(1);
+
+      await service.getAppliedResultsCount(1, [
+        { unitName: 'UNIT_A', variableId: 'VAR' }
+      ]);
+
+      const bracketCalls = mockQueryBuilder.andWhere.mock.calls
+        .filter(([condition]) => condition instanceof Brackets);
+      const variableFilter = bracketCalls[bracketCalls.length - 1]?.[0] as Brackets;
+      const bracketBuilder = {
+        where: jest.fn().mockReturnThis(),
+        orWhere: jest.fn().mockReturnThis()
+      };
+      variableFilter.whereFactory(bracketBuilder as never);
+
+      expect(bracketBuilder.where).toHaveBeenCalledWith(
+        '(UPPER(unit.name) = UPPER(:appliedUnitName0) AND response.variableid = :appliedVariableId0)',
+        {
+          appliedUnitName0: 'UNIT_A',
+          appliedVariableId0: 'VAR'
+        }
+      );
     });
 
     it('should count applied DERIVE_ERROR job variables even without incomplete variables', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -1714,14 +1714,13 @@ export class CodingValidationService {
       .leftJoin('booklet.bookletinfo', 'bookletinfo')
       .leftJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('person.consider = :consider', { consider: true });
+      .andWhere('person.consider = :consider', { consider: true })
+      .andWhere('UPPER(unit.name) = UPPER(:unitName)', { unitName });
     applyResolvedExclusionsToQuery(query, exclusions, {
       parameterPrefix: 'unitNameCaseAliases'
     });
-    const normalizedUnitName = String(unitName).toUpperCase();
     const aliases = (await query.getRawMany<{ unitName: string }>())
-      .map(row => row.unitName)
-      .filter(candidate => candidate?.toUpperCase() === normalizedUnitName);
+      .map(row => row.unitName);
 
     return aliases.length > 0 ? Array.from(new Set(aliases)) : [unitName];
   }
@@ -1926,7 +1925,7 @@ export class CodingValidationService {
                 [`appliedUnitName${index}`]: variable.unitName,
                 [`appliedVariableId${index}`]: variable.variableId
               };
-              const condition = `(unit.name = :appliedUnitName${index} AND response.variableid = :appliedVariableId${index})`;
+              const condition = `(UPPER(unit.name) = UPPER(:appliedUnitName${index}) AND response.variableid = :appliedVariableId${index})`;
               if (index === 0) {
                 qb.where(condition, parameters);
               } else {

--- a/apps/backend/src/app/database/services/coding/coding-validation.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-validation.service.ts
@@ -22,12 +22,15 @@ import { VariableDetailDto } from '../../../models/unit-variable-details.dto';
 import { WorkspacePlayerService } from '../workspace/workspace-player.service';
 import {
   applyResolvedExclusionsToQuery,
+  ResolvedWorkspaceExclusions,
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
-import { CodingJobService } from './coding-job.service';
+import { CodingJobService, ResponseMatchingFlag } from './coding-job.service';
 import {
   countEffectiveManualCodingCases,
-  ManualCodingDeduplicationResponse
+  getAggregationVariableKey,
+  ManualCodingDeduplicationResponse,
+  partitionResponsesByAggregationVariable
 } from './aggregation-metrics.util';
 import {
   getCodingIncompleteVariablesCacheKey,
@@ -65,6 +68,7 @@ interface NormalizedExpectedCombination {
 
 type ManualCodingVariableCaseCounts = {
   unitName: string;
+  unitNameAliases?: string[];
   variableId: string;
   responseCount: number;
   deriveErrorResponseCount: number;
@@ -78,6 +82,7 @@ type SlimCodingResponse = {
   variableid: string;
   value: string | null;
   statusV1?: number | null;
+  statusV2?: number | null;
   personLogin?: string | null;
   personCode?: string | null;
   personGroup?: string | null;
@@ -948,8 +953,9 @@ export class CodingValidationService {
     unitName?: string,
     trainingRequired?: boolean
   ): T[] {
+    const normalizedUnitName = unitName ? String(unitName).toUpperCase() : undefined;
     return variables.filter(variable => (
-      (!unitName || variable.unitName === unitName) &&
+      (!normalizedUnitName || variable.unitName.toUpperCase() === normalizedUnitName) &&
       (
         trainingRequired === undefined ||
         variable.coderTrainingRequired === trainingRequired
@@ -1060,7 +1066,10 @@ export class CodingValidationService {
     );
 
     return variables.map(variable => {
-      const key = `${variable.unitName}::${variable.variableId}`;
+      const key = getAggregationVariableKey(
+        variable.unitName,
+        variable.variableId
+      );
       const caseInfo = caseInfoMap.get(key) || {
         casesInJobs: 0,
         availableCases: variable.responseCount,
@@ -1068,7 +1077,12 @@ export class CodingValidationService {
       };
 
       return {
-        ...variable,
+        unitName: variable.unitName,
+        variableId: variable.variableId,
+        responseCount: variable.responseCount,
+        deriveErrorResponseCount: variable.deriveErrorResponseCount,
+        isDerived: variable.isDerived,
+        coderTrainingRequired: variable.coderTrainingRequired,
         ...caseInfo
       };
     });
@@ -1094,25 +1108,26 @@ export class CodingValidationService {
     const aggregationThreshold = await this.codingJobService.getAggregationThreshold(workspaceId);
 
     const matchingFlags = await this.codingJobService.getResponseMatchingMode(workspaceId);
-    const variableReferences = variables.map(v => ({
-      unitName: v.unitName,
-      variableId: v.variableId,
-      ...(includeDeriveErrorInCaseInfo && v.deriveErrorResponseCount > 0 ?
-        { includeDeriveError: true } :
-        {})
-    }));
-    const [slimResponses, assignedResponseIdsByVariable] = await Promise.all([
-      this.codingJobService.getSlimResponsesForVariables(
-        workspaceId,
-        variableReferences
-      ) as Promise<SlimCodingResponse[]>,
-      this.getAssignedResponseIdsByVariable(
-        workspaceId,
-        variableReferences,
-        excludeJobDefinitionId
-      )
-    ]);
-
+    const variableReferences = Array.from(variables.reduce((references, variable) => {
+      const unitNames = variable.unitNameAliases?.length ?
+        variable.unitNameAliases :
+        [variable.unitName];
+      unitNames.forEach(unitName => {
+        const key = `${unitName}::${variable.variableId}`;
+        references.set(key, {
+          unitName,
+          variableId: variable.variableId,
+          ...(includeDeriveErrorInCaseInfo && variable.deriveErrorResponseCount > 0 ?
+            { includeDeriveError: true } :
+            {})
+        });
+      });
+      return references;
+    }, new Map<string, {
+      unitName: string;
+      variableId: string;
+      includeDeriveError?: boolean;
+    }>()).values());
     const derivedVariableMap = new Map<string, Set<string>>();
     variables
       .filter(variable => variable.isDerived)
@@ -1122,13 +1137,50 @@ export class CodingValidationService {
         derivedVariables.add(variable.variableId);
         derivedVariableMap.set(unitKey, derivedVariables);
       });
+    const aggregationActive = aggregationThreshold !== null &&
+      !matchingFlags.includes(ResponseMatchingFlag.NO_AGGREGATION);
+    const slimResponses = aggregationActive ?
+      await this.codingJobService.getSlimResponsesForVariableCoverage(
+        workspaceId,
+        variableReferences,
+        matchingFlags,
+        aggregationThreshold,
+        derivedVariableMap
+      ) as SlimCodingResponse[] :
+      await this.codingJobService.getSlimResponsesForVariables(
+        workspaceId,
+        variableReferences
+      ) as SlimCodingResponse[];
+    const activeResponseIds = new Set(
+      slimResponses
+        .filter(response => (
+          response.statusV2 !== statusStringToNumber('CODING_COMPLETE')
+        ))
+        .map(response => response.id)
+    );
+    const assignedResponseIds =
+      await this.getAssignedResponseIds(
+        workspaceId,
+        slimResponses.map(response => response.id),
+        excludeJobDefinitionId
+      );
+
+    const responsesByVariable = partitionResponsesByAggregationVariable(
+      slimResponses,
+      variables,
+      response => ({
+        unitName: response.unitName,
+        variableId: response.variableid
+      })
+    );
 
     for (const variable of variables) {
-      const key = `${variable.unitName}::${variable.variableId}`;
-
-      const varResponsesWithRequestedStatuses = slimResponses.filter(
-        r => r.unitName === variable.unitName && r.variableid === variable.variableId
+      const key = getAggregationVariableKey(
+        variable.unitName,
+        variable.variableId
       );
+      const varResponsesWithRequestedStatuses =
+        responsesByVariable.get(key) || [];
 
       const countAggregatedCases = (responses: SlimCodingResponse[]) => {
         const responsesWithCaseFields: ManualCodingDeduplicationResponse[] =
@@ -1137,14 +1189,13 @@ export class CodingValidationService {
             responseId: response.id,
             variableId: response.variableid
           }));
-        const assignedResponseIds = assignedResponseIdsByVariable.get(key) || new Set<number>();
-
         return countEffectiveManualCodingCases(
           responsesWithCaseFields,
           assignedResponseIds,
           matchingFlags,
           aggregationThreshold,
-          derivedVariableMap
+          derivedVariableMap,
+          activeResponseIds
         );
       };
 
@@ -1242,73 +1293,65 @@ export class CodingValidationService {
     return `${String(unitName || '').trim().toUpperCase()}::${String(variableId || '').trim()}`;
   }
 
-  private async getAssignedResponseIdsByVariable(
+  private async getAssignedResponseIds(
     workspaceId: number,
-    variables: { unitName: string; variableId: string }[],
+    responseIds: number[],
     excludeJobDefinitionId?: number
-  ): Promise<Map<string, Set<number>>> {
-    const result = new Map<string, Set<number>>();
+  ): Promise<Set<number>> {
+    const result = new Set<number>();
 
-    if (variables.length === 0) {
+    const uniqueResponseIds = Array.from(new Set(responseIds));
+    if (uniqueResponseIds.length === 0) {
       return result;
     }
 
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
-    const query = this.codingJobUnitRepository
-      .createQueryBuilder('cju')
-      .select('cju.unit_name', 'unitName')
-      .addSelect('cju.variable_id', 'variableId')
-      .addSelect('cju.response_id', 'responseId')
-      .leftJoin('cju.coding_job', 'coding_job')
-      .where('coding_job.workspace_id = :workspaceId', { workspaceId })
-      .andWhere('coding_job.training_id IS NULL');
+    const chunkSize = 5000;
 
-    if (
-      excludeJobDefinitionId !== undefined &&
-      excludeJobDefinitionId !== null
-    ) {
-      query.andWhere(
-        '(coding_job.job_definition_id IS NULL OR coding_job.job_definition_id != :excludeJobDefinitionId)',
-        { excludeJobDefinitionId }
-      );
-    }
+    for (let offset = 0; offset < uniqueResponseIds.length; offset += chunkSize) {
+      const responseIdChunk = uniqueResponseIds.slice(offset, offset + chunkSize);
+      const query = this.codingJobUnitRepository
+        .createQueryBuilder('cju')
+        .select('DISTINCT cju.response_id', 'responseId')
+        .leftJoin('cju.coding_job', 'coding_job')
+        .where('coding_job.workspace_id = :workspaceId', { workspaceId })
+        .andWhere('coding_job.training_id IS NULL')
+        .andWhere('cju.response_id IN (:...responseIds)', {
+          responseIds: responseIdChunk
+        });
 
-    const conditions: string[] = [];
-    const parameters: Record<string, string> = {};
-
-    variables.forEach((variable, index) => {
-      const unitParam = `assignedUnitName${index}`;
-      const variableParam = `assignedVariableId${index}`;
-      conditions.push(`(cju.unit_name = :${unitParam} AND cju.variable_id = :${variableParam})`);
-      parameters[unitParam] = variable.unitName;
-      parameters[variableParam] = variable.variableId;
-    });
-
-    query.andWhere(`(${conditions.join(' OR ')})`, parameters);
-    applyNonCodingIssueReviewJobFilter(
-      query,
-      'coding_job',
-      'codingValidationAssignedResponsesReviewJobType'
-    );
-    applyResolvedExclusionsToQuery(query, exclusions, {
-      unitNameExpression: 'cju.unit_name',
-      bookletNameExpression: 'cju.booklet_name',
-      parameterPrefix: 'codingValidationAssignedResponses'
-    });
-
-    const rawResults = await query.getRawMany();
-
-    rawResults.forEach(row => {
-      const responseId = Number(row.responseId);
-      if (!Number.isFinite(responseId)) {
-        return;
+      if (
+        excludeJobDefinitionId !== undefined &&
+        excludeJobDefinitionId !== null
+      ) {
+        query.andWhere(
+          '(coding_job.job_definition_id IS NULL OR coding_job.job_definition_id != :excludeJobDefinitionId)',
+          { excludeJobDefinitionId }
+        );
       }
 
-      const key = `${row.unitName}::${row.variableId}`;
-      const responseIds = result.get(key) || new Set<number>();
-      responseIds.add(responseId);
-      result.set(key, responseIds);
-    });
+      applyNonCodingIssueReviewJobFilter(
+        query,
+        'coding_job',
+        'codingValidationAssignedResponsesReviewJobType'
+      );
+      applyResolvedExclusionsToQuery(query, exclusions, {
+        unitNameExpression: 'cju.unit_name',
+        bookletNameExpression: 'cju.booklet_name',
+        parameterPrefix: `codingValidationAssignedResponses${offset}`
+      });
+
+      const rawResults = await query.getRawMany();
+
+      rawResults.forEach(row => {
+        const responseId = Number(row.responseId);
+        if (!Number.isFinite(responseId)) {
+          return;
+        }
+
+        result.add(responseId);
+      });
+    }
 
     return result;
   }
@@ -1318,9 +1361,7 @@ export class CodingValidationService {
     unitName?: string,
     trainingRequired?: boolean,
     includeDeriveErrorOnly = false
-  ): Promise<
-    { unitName: string; variableId: string; responseCount: number; deriveErrorResponseCount: number; isDerived: boolean; coderTrainingRequired: boolean }[]
-    > {
+  ): Promise<ManualCodingVariableCaseCounts[]> {
     const scope = await this.fetchManualCodingScopeFromDb(
       workspaceId,
       unitName,
@@ -1337,6 +1378,13 @@ export class CodingValidationService {
     includeDeriveErrorOnly = false
   ): Promise<ManualCodingScopeFromDb> {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
+    const scopedUnitNames = unitName ?
+      await this.resolveUnitNameCaseAliases(
+        workspaceId,
+        unitName,
+        exclusions
+      ) :
+      [];
     // Helper to build the base query for a given status
     const buildQuery = (status: number) => {
       const qb = this.responseRepository
@@ -1356,8 +1404,10 @@ export class CodingValidationService {
         .groupBy('unit.name')
         .addGroupBy('response.variableid');
 
-      if (unitName) {
-        qb.andWhere('unit.name = :unitName', { unitName });
+      if (scopedUnitNames.length > 0) {
+        qb.andWhere('unit.name IN (:...scopedUnitNames)', {
+          scopedUnitNames
+        });
       }
       applyResolvedExclusionsToQuery(qb, exclusions);
       return qb;
@@ -1367,7 +1417,10 @@ export class CodingValidationService {
     const [codingIncompleteRaw, intendedIncompleteRaw, deriveErrorCountsByKey] = await Promise.all([
       buildQuery(statusStringToNumber('CODING_INCOMPLETE')).getRawMany(),
       buildQuery(statusStringToNumber('INTENDED_INCOMPLETE')).getRawMany(),
-      this.getDeriveErrorResponseCountsByVariable(workspaceId, unitName)
+      this.getDeriveErrorResponseCountsByVariable(
+        workspaceId,
+        scopedUnitNames
+      )
     ]);
 
     this.logger.debug(
@@ -1474,6 +1527,21 @@ export class CodingValidationService {
         derivedVariablesBySourceMap
       ) :
       new Set<string>();
+    const normalizedDeriveErrorCounts = new Map<string, number>();
+    const deriveErrorUnitNames = new Map<string, string[]>();
+    deriveErrorCountsByKey.forEach((count, exactKey) => {
+      const [deriveUnitName, variableId] = exactKey.split('::');
+      const key = getAggregationVariableKey(deriveUnitName, variableId);
+      normalizedDeriveErrorCounts.set(
+        key,
+        (normalizedDeriveErrorCounts.get(key) || 0) + count
+      );
+      const aliases = deriveErrorUnitNames.get(key) || [];
+      if (!aliases.includes(deriveUnitName)) {
+        aliases.push(deriveUnitName);
+      }
+      deriveErrorUnitNames.set(key, aliases);
+    });
     const getScopedDeriveErrorResponseCount = (
       responseUnitName: string,
       variableId: string
@@ -1484,12 +1552,15 @@ export class CodingValidationService {
         deriveErrorCoveredSourceKeys
       ) ?
         0 :
-        deriveErrorCountsByKey.get(`${responseUnitName}::${variableId}`) || 0
+        normalizedDeriveErrorCounts.get(
+          getAggregationVariableKey(responseUnitName, variableId)
+        ) || 0
     );
 
     // Merge results, summing response counts for variables that appear in both
     const mergedMap = new Map<string, {
       unitName: string;
+      unitNameAliases: string[];
       variableId: string;
       responseCount: number;
       deriveErrorResponseCount: number;
@@ -1498,7 +1569,7 @@ export class CodingValidationService {
     }>();
 
     for (const row of [...filteredCodingIncomplete, ...filteredIntendedIncomplete]) {
-      const key = `${row.unitName}::${row.variableId}`;
+      const key = getAggregationVariableKey(row.unitName, row.variableId);
       const existing = mergedMap.get(key);
       const count = parseInt(row.responseCount, 10);
       const deriveErrorResponseCount =
@@ -1508,9 +1579,13 @@ export class CodingValidationService {
 
       if (existing) {
         existing.responseCount += count;
+        if (!existing.unitNameAliases.includes(row.unitName)) {
+          existing.unitNameAliases.push(row.unitName);
+        }
       } else {
         mergedMap.set(key, {
           unitName: row.unitName,
+          unitNameAliases: [row.unitName],
           variableId: row.variableId,
           responseCount: count,
           deriveErrorResponseCount,
@@ -1521,12 +1596,23 @@ export class CodingValidationService {
     }
 
     if (includeDeriveErrorOnly) {
-      deriveErrorCountsByKey.forEach((deriveErrorResponseCount, key) => {
-        if (mergedMap.has(key)) {
+      normalizedDeriveErrorCounts.forEach((deriveErrorResponseCount, key) => {
+        const existing = mergedMap.get(key);
+        const aliases = deriveErrorUnitNames.get(key) || [];
+        if (existing) {
+          aliases.forEach(alias => {
+            if (!existing.unitNameAliases.includes(alias)) {
+              existing.unitNameAliases.push(alias);
+            }
+          });
           return;
         }
 
-        const [deriveUnitName, variableId] = key.split('::');
+        const [, variableId] = key.split('::');
+        const deriveUnitName = aliases[0];
+        if (!deriveUnitName) {
+          return;
+        }
         if (
           isCoveredSourceVariable(
             { unitName: deriveUnitName, variableId },
@@ -1545,6 +1631,7 @@ export class CodingValidationService {
 
         mergedMap.set(key, {
           unitName: deriveUnitName,
+          unitNameAliases: aliases,
           variableId,
           responseCount: 0,
           deriveErrorResponseCount,
@@ -1569,7 +1656,7 @@ export class CodingValidationService {
 
   private async getDeriveErrorResponseCountsByVariable(
     workspaceId: number,
-    unitName?: string
+    scopedUnitNames: string[] = []
   ): Promise<Map<string, number>> {
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     const query = this.responseRepository
@@ -1590,8 +1677,10 @@ export class CodingValidationService {
       .groupBy('unit.name')
       .addGroupBy('response.variableid');
 
-    if (unitName) {
-      query.andWhere('unit.name = :unitName', { unitName });
+    if (scopedUnitNames.length > 0) {
+      query.andWhere('unit.name IN (:...scopedUnitNames)', {
+        scopedUnitNames
+      });
     }
 
     applyResolvedExclusionsToQuery(query, exclusions, {
@@ -1610,6 +1699,31 @@ export class CodingValidationService {
       }
       return counts;
     }, new Map<string, number>());
+  }
+
+  private async resolveUnitNameCaseAliases(
+    workspaceId: number,
+    unitName: string,
+    exclusions: ResolvedWorkspaceExclusions
+  ): Promise<string[]> {
+    const query = this.responseRepository
+      .createQueryBuilder('response')
+      .select('DISTINCT unit.name', 'unitName')
+      .leftJoin('response.unit', 'unit')
+      .leftJoin('unit.booklet', 'booklet')
+      .leftJoin('booklet.bookletinfo', 'bookletinfo')
+      .leftJoin('booklet.person', 'person')
+      .where('person.workspace_id = :workspaceId', { workspaceId })
+      .andWhere('person.consider = :consider', { consider: true });
+    applyResolvedExclusionsToQuery(query, exclusions, {
+      parameterPrefix: 'unitNameCaseAliases'
+    });
+    const normalizedUnitName = String(unitName).toUpperCase();
+    const aliases = (await query.getRawMany<{ unitName: string }>())
+      .map(row => row.unitName)
+      .filter(candidate => candidate?.toUpperCase() === normalizedUnitName);
+
+    return aliases.length > 0 ? Array.from(new Set(aliases)) : [unitName];
   }
 
   generateIncompleteVariablesCacheKey(workspaceId: number): string {

--- a/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/external-coding-import.service.spec.ts
@@ -106,8 +106,8 @@ describe('ExternalCodingImportService', () => {
     expect(queryRunner.rollbackTransaction).not.toHaveBeenCalled();
     expect(queryRunner.release).toHaveBeenCalled();
     expect(cacheService.incr).toHaveBeenCalledWith('coding_incomplete_variables_version:17');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v8:17');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v1:17');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v9:17');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v2:17');
   });
 
   it('imports DERIVE_ERROR without turning it into completed false coding', async () => {

--- a/apps/backend/src/app/database/services/jobs/job-definition-realistic-scenarios.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition-realistic-scenarios.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { CodingJobService } from '../coding/coding-job.service';
+import { CodingAggregationPeerService } from '../coding/coding-aggregation-peer.service';
 import {
   JobDefinition,
   JobDefinitionVariable
@@ -161,10 +162,17 @@ describe('JobDefinitionService realistic manual-coding edit scenarios', () => {
       cacheService as never,
       workspaceFilesService as never,
       workspaceExclusionService as never,
-      usersService as never
+      usersService as never,
+      new CodingAggregationPeerService(responseRepository as never)
     );
 
     jest.spyOn(codingJobService, 'getSlimResponsesForVariables').mockImplementation(
+      async (_workspaceId, variables) => scenarioResponses.filter(response => variables.some(
+        variable => variable.unitName === response.unitName &&
+          variable.variableId === response.variableid
+      )) as never
+    );
+    jest.spyOn(codingJobService, 'getSlimResponsesForVariableCoverage').mockImplementation(
       async (_workspaceId, variables) => scenarioResponses.filter(response => variables.some(
         variable => variable.unitName === response.unitName &&
           variable.variableId === response.variableid

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -332,18 +332,22 @@ export class JobDefinitionService {
       workspaceId,
       usageRequests
     );
-    const requestedUsage =
+    const requestedUsage = this.normalizeVariableUsageByKey(
       usageByRequestKey.get(requestedUsageKey) ||
-      new Map<string, DistributionVariableUsageByStatus>();
+        new Map<string, DistributionVariableUsageByStatus>()
+    );
     const plannerAvailableUsage = availableUsageRequest ?
-      usageByRequestKey.get(availableUsageKey) ||
-        new Map<string, DistributionVariableUsageByStatus>() :
+      this.normalizeVariableUsageByKey(
+        usageByRequestKey.get(availableUsageKey) ||
+          new Map<string, DistributionVariableUsageByStatus>()
+      ) :
       requestedUsage;
 
     existingUsageRequests.forEach(usageRequest => {
-      const usage =
+      const usage = this.normalizeVariableUsageByKey(
         usageByRequestKey.get(usageRequest.key) ||
-        new Map<string, DistributionVariableUsageByStatus>();
+          new Map<string, DistributionVariableUsageByStatus>()
+      );
       usage.forEach((usageCount, variableKey) => {
         this.addVariableUsageByStatus(reservedCasesByVariable, variableKey, usageCount);
       });
@@ -438,6 +442,28 @@ export class JobDefinitionService {
     usageByVariable.set(variableKey, currentUsage);
   }
 
+  private normalizeVariableUsageByKey(
+    usageByVariable: Map<string, DistributionVariableUsageByStatus>
+  ): Map<string, DistributionVariableUsageByStatus> {
+    const normalizedUsage = new Map<
+    string,
+    DistributionVariableUsageByStatus
+    >();
+
+    usageByVariable.forEach((usage, variableKey) => {
+      const separatorIndex = variableKey.indexOf('::');
+      const normalizedKey = separatorIndex < 0 ?
+        variableKey :
+        this.makeVariableKey(
+          variableKey.slice(0, separatorIndex),
+          variableKey.slice(separatorIndex + 2)
+        );
+      this.addVariableUsageByStatus(normalizedUsage, normalizedKey, usage);
+    });
+
+    return normalizedUsage;
+  }
+
   private getVariableUsageCountForConflict(
     usage: DistributionVariableUsageByStatus | undefined,
     includeDeriveError: boolean
@@ -450,7 +476,7 @@ export class JobDefinitionService {
   }
 
   private makeVariableKey(unitName: string, variableId: string): string {
-    return `${unitName}::${variableId}`;
+    return `${unitName.toUpperCase()}::${variableId}`;
   }
 
   private buildDistributionVariableSelection(

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
@@ -130,8 +130,8 @@ describe('WorkspaceCoreService', () => {
     expect(cacheService.delete).toHaveBeenCalledWith('coding-statistics:schema-v4:1:v2');
     expect(cacheService.delete).toHaveBeenCalledWith('coding-statistics:schema-v4:1:v3');
     expect(cacheService.incr).toHaveBeenCalledWith('coding_incomplete_variables_version:1');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v8:1');
-    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v1:1');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_v9:1');
+    expect(cacheService.delete).toHaveBeenCalledWith('coding_incomplete_variables_scope_v2:1');
     expect(cacheService.delete).toHaveBeenCalledWith('flat_response_filter_options:version:1');
     expect(cacheService.deleteByPattern).toHaveBeenCalledWith('response-analysis:1_*');
     expect(cacheService.deleteByPattern).toHaveBeenCalledWith('responses:1:*');

--- a/apps/backend/src/app/database/services/workspace/workspace-exclusion-query.util.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-exclusion-query.util.ts
@@ -1,0 +1,124 @@
+import { SelectQueryBuilder } from 'typeorm';
+
+export type ResolvedWorkspaceExclusions = {
+  globalIgnoredUnits: string[];
+  ignoredBooklets: string[];
+  testletIgnoredUnits: { bookletId: string; unitId: string }[];
+};
+
+export type ExclusionQueryOptions = {
+  unitAlias?: string | null;
+  bookletInfoAlias?: string | null;
+  unitNameExpression?: string | null;
+  bookletNameExpression?: string | null;
+  parameterPrefix?: string;
+};
+
+export const normalizeExclusionUnitId = (
+  value: string | null | undefined
+): string => String(value || '').trim().toUpperCase().replace(/\.XML$/i, '');
+
+export const normalizeExclusionBookletId = (
+  value: string | null | undefined
+): string => String(value || '').trim().toUpperCase();
+
+const normalizedUnitSql = (expression: string): string => (
+  `REGEXP_REPLACE(UPPER(${expression}), '\\.XML$', '', 'i')`
+);
+
+export function isExcludedByResolvedExclusions(
+  exclusions: ResolvedWorkspaceExclusions,
+  bookletName: string | null | undefined,
+  unitName: string | null | undefined
+): boolean {
+  const normalizedUnit = normalizeExclusionUnitId(unitName);
+  const normalizedBooklet = normalizeExclusionBookletId(bookletName);
+
+  if (
+    normalizedUnit &&
+    exclusions.globalIgnoredUnits.map(normalizeExclusionUnitId)
+      .includes(normalizedUnit)
+  ) {
+    return true;
+  }
+
+  if (
+    normalizedBooklet &&
+    exclusions.ignoredBooklets.map(normalizeExclusionBookletId)
+      .includes(normalizedBooklet)
+  ) {
+    return true;
+  }
+
+  if (normalizedBooklet && normalizedUnit) {
+    return exclusions.testletIgnoredUnits.some(t => (
+      normalizeExclusionBookletId(t.bookletId) === normalizedBooklet &&
+      normalizeExclusionUnitId(t.unitId) === normalizedUnit
+    ));
+  }
+
+  return false;
+}
+
+export function applyResolvedExclusionsToQuery<T>(
+  qb: SelectQueryBuilder<T>,
+  exclusions: ResolvedWorkspaceExclusions,
+  options: ExclusionQueryOptions = {}
+): void {
+  let unitExpression: string | null | undefined;
+  if (options.unitNameExpression !== undefined) {
+    unitExpression = options.unitNameExpression;
+  } else {
+    unitExpression = options.unitAlias === null ?
+      null :
+      `${options.unitAlias || 'unit'}.name`;
+  }
+
+  let bookletExpression: string | null | undefined;
+  if (options.bookletNameExpression !== undefined) {
+    bookletExpression = options.bookletNameExpression;
+  } else {
+    bookletExpression = options.bookletInfoAlias === null ?
+      null :
+      `${options.bookletInfoAlias || 'bookletinfo'}.name`;
+  }
+  const prefix = options.parameterPrefix || 'workspaceExclusion';
+
+  if (unitExpression && exclusions.globalIgnoredUnits.length > 0) {
+    qb.andWhere(
+      `${normalizedUnitSql(unitExpression)} NOT IN (:...${prefix}IgnoredUnits)`,
+      {
+        [`${prefix}IgnoredUnits`]: exclusions.globalIgnoredUnits
+          .map(normalizeExclusionUnitId)
+      }
+    );
+  }
+
+  if (bookletExpression && exclusions.ignoredBooklets.length > 0) {
+    qb.andWhere(
+      `UPPER(${bookletExpression}) NOT IN (:...${prefix}IgnoredBooklets)`,
+      {
+        [`${prefix}IgnoredBooklets`]: exclusions.ignoredBooklets
+          .map(normalizeExclusionBookletId)
+      }
+    );
+  }
+
+  if (
+    unitExpression &&
+    bookletExpression &&
+    exclusions.testletIgnoredUnits.length > 0
+  ) {
+    const condition = exclusions.testletIgnoredUnits
+      .map((_, i: number) => (
+        `(UPPER(${bookletExpression}) = :${prefix}Booklet${i} AND ${normalizedUnitSql(unitExpression)} = :${prefix}Unit${i})`
+      ))
+      .join(' OR ');
+    const params: Record<string, string> = {};
+    exclusions.testletIgnoredUnits.forEach((t, i: number) => {
+      params[`${prefix}Booklet${i}`] = normalizeExclusionBookletId(t.bookletId);
+      params[`${prefix}Unit${i}`] = normalizeExclusionUnitId(t.unitId);
+    });
+    qb.andWhere(`NOT (${condition})`, params);
+  }
+}

--- a/apps/backend/src/app/database/services/workspace/workspace-exclusion.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-exclusion.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, SelectQueryBuilder } from 'typeorm';
+import { Repository } from 'typeorm';
 import * as cheerio from 'cheerio';
 // eslint-disable-next-line import/no-cycle
 import { WorkspaceCoreService } from './workspace-core.service';
@@ -8,117 +8,28 @@ import { WorkspaceSettingsDto } from '../../../../../../../api-dto/workspaces/wo
 import FileUpload from '../../entities/file_upload.entity';
 import { CacheService } from '../../../cache/cache.service';
 import { EXCLUSION_CACHE_PREFIX } from './workspace-constants';
+import {
+  normalizeExclusionBookletId,
+  normalizeExclusionUnitId,
+  ResolvedWorkspaceExclusions
+} from './workspace-exclusion-query.util';
+
+export {
+  applyResolvedExclusionsToQuery,
+  isExcludedByResolvedExclusions,
+  normalizeExclusionBookletId,
+  normalizeExclusionUnitId
+} from './workspace-exclusion-query.util';
+export type {
+  ExclusionQueryOptions,
+  ResolvedWorkspaceExclusions
+} from './workspace-exclusion-query.util';
 
 export type ExclusionContext = {
   unitId?: string;
   bookletId?: string;
   testletId?: string;
 };
-
-export type ResolvedWorkspaceExclusions = {
-  globalIgnoredUnits: string[];
-  ignoredBooklets: string[];
-  testletIgnoredUnits: { bookletId: string; unitId: string }[];
-};
-
-export type ExclusionQueryOptions = {
-  unitAlias?: string | null;
-  bookletInfoAlias?: string | null;
-  unitNameExpression?: string | null;
-  bookletNameExpression?: string | null;
-  parameterPrefix?: string;
-};
-
-export const normalizeExclusionUnitId = (value: string | null | undefined): string => (
-  String(value || '').trim().toUpperCase().replace(/\.XML$/i, '')
-);
-
-export const normalizeExclusionBookletId = (value: string | null | undefined): string => (
-  String(value || '').trim().toUpperCase()
-);
-
-const normalizedUnitSql = (expression: string): string => (
-  `REGEXP_REPLACE(UPPER(${expression}), '\\.XML$', '', 'i')`
-);
-
-export function isExcludedByResolvedExclusions(
-  exclusions: ResolvedWorkspaceExclusions,
-  bookletName: string | null | undefined,
-  unitName: string | null | undefined
-): boolean {
-  const normalizedUnit = normalizeExclusionUnitId(unitName);
-  const normalizedBooklet = normalizeExclusionBookletId(bookletName);
-
-  if (normalizedUnit && exclusions.globalIgnoredUnits.map(normalizeExclusionUnitId).includes(normalizedUnit)) {
-    return true;
-  }
-
-  if (normalizedBooklet && exclusions.ignoredBooklets.map(normalizeExclusionBookletId).includes(normalizedBooklet)) {
-    return true;
-  }
-
-  if (normalizedBooklet && normalizedUnit) {
-    return exclusions.testletIgnoredUnits.some(t => (
-      normalizeExclusionBookletId(t.bookletId) === normalizedBooklet &&
-      normalizeExclusionUnitId(t.unitId) === normalizedUnit
-    ));
-  }
-
-  return false;
-}
-
-export function applyResolvedExclusionsToQuery<T>(
-  qb: SelectQueryBuilder<T>,
-  exclusions: ResolvedWorkspaceExclusions,
-  options: ExclusionQueryOptions = {}
-): void {
-  let unitExpression: string | null | undefined;
-  if (options.unitNameExpression !== undefined) {
-    unitExpression = options.unitNameExpression;
-  } else {
-    unitExpression = options.unitAlias === null ? null : `${options.unitAlias || 'unit'}.name`;
-  }
-
-  let bookletExpression: string | null | undefined;
-  if (options.bookletNameExpression !== undefined) {
-    bookletExpression = options.bookletNameExpression;
-  } else {
-    bookletExpression = options.bookletInfoAlias === null ? null : `${options.bookletInfoAlias || 'bookletinfo'}.name`;
-  }
-  const prefix = options.parameterPrefix || 'workspaceExclusion';
-
-  if (unitExpression && exclusions.globalIgnoredUnits.length > 0) {
-    qb.andWhere(
-      `${normalizedUnitSql(unitExpression)} NOT IN (:...${prefix}IgnoredUnits)`,
-      {
-        [`${prefix}IgnoredUnits`]: exclusions.globalIgnoredUnits.map(normalizeExclusionUnitId)
-      }
-    );
-  }
-
-  if (bookletExpression && exclusions.ignoredBooklets.length > 0) {
-    qb.andWhere(
-      `UPPER(${bookletExpression}) NOT IN (:...${prefix}IgnoredBooklets)`,
-      {
-        [`${prefix}IgnoredBooklets`]: exclusions.ignoredBooklets.map(normalizeExclusionBookletId)
-      }
-    );
-  }
-
-  if (unitExpression && bookletExpression && exclusions.testletIgnoredUnits.length > 0) {
-    const condition = exclusions.testletIgnoredUnits
-      .map((_, i: number) => (
-        `(UPPER(${bookletExpression}) = :${prefix}Booklet${i} AND ${normalizedUnitSql(unitExpression)} = :${prefix}Unit${i})`
-      ))
-      .join(' OR ');
-    const params: Record<string, string> = {};
-    exclusions.testletIgnoredUnits.forEach((t, i: number) => {
-      params[`${prefix}Booklet${i}`] = normalizeExclusionBookletId(t.bookletId);
-      params[`${prefix}Unit${i}`] = normalizeExclusionUnitId(t.unitId);
-    });
-    qb.andWhere(`NOT (${condition})`, params);
-  }
-}
 
 @Injectable()
 export class WorkspaceExclusionService {

--- a/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
+++ b/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
@@ -70,7 +70,7 @@ export function getDeriveErrorManualCodingPairKeys(
     variables
       .filter(variable => variable.includeDeriveError === true)
       .map(variable => toManualCodingVariablePairKey(
-        variable.unitName,
+        variable.unitName.toUpperCase(),
         variable.variableId
       ))
   ));

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -894,6 +894,69 @@ describe('CodeSelectorComponent', () => {
     expect(fixture.nativeElement.querySelector('.variable-trigger-btn')).toBeNull();
   });
 
+  it('resolves bundle variables by response id across unit-name case variants', () => {
+    const bundleContext = {
+      bundleId: 9,
+      bundleName: 'Bundle',
+      caseKey: 'case-1',
+      caseOrderingMode: 'alternating' as const,
+      variables: [
+        {
+          responseId: 1,
+          unitName: 'Unit_A',
+          variableId: 'VAR1',
+          variableAnchor: 'VAR1',
+          variablePage: '0',
+          status: 'manual-open' as const,
+          code: null,
+          score: null,
+          source: 'manual' as const
+        },
+        {
+          responseId: 2,
+          unitName: 'unit_a',
+          variableId: 'VAR2',
+          variableAnchor: 'VAR2',
+          variablePage: '0',
+          status: 'manual-open' as const,
+          code: null,
+          score: null,
+          source: 'manual' as const
+        }
+      ]
+    };
+    component.unitsData = {
+      id: 1,
+      name: 'Job',
+      currentUnitIndex: 0,
+      units: [
+        {
+          id: 1,
+          name: 'UNIT_A',
+          alias: 'UNIT_A',
+          bookletId: 0,
+          variableId: 'VAR1',
+          variableBundleId: 9,
+          bundleContext
+        },
+        {
+          id: 2,
+          name: 'UNIT_A',
+          alias: 'UNIT_A',
+          bookletId: 0,
+          variableId: 'VAR2',
+          variableBundleId: 9,
+          bundleContext
+        }
+      ]
+    };
+
+    const secondVariable = component.bundleVariableNavigationItems[1];
+
+    expect(secondVariable.targetUnit?.id).toBe(2);
+    expect(secondVariable.disabled).toBe(false);
+  });
+
   it('keeps the navigation dropdown visible for bundle jobs and lists one entry per bundle', () => {
     component.showProgress = true;
     component.codingService = {

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -829,12 +829,16 @@ export class CodeSelectorComponent implements OnChanges {
     if (!this.unitsData?.units) return undefined;
     const currentUnit = this.unitsData.units[this.unitsData.currentUnitIndex];
 
-    return this.unitsData.units.find(unit => (
-      this.isUnitInBundle(unit, context.bundleId) &&
-      unit.variableId === variable.variableId &&
-      unit.name === variable.unitName &&
-      this.isUnitInCurrentBundleCase(unit, currentUnit, context)
-    ));
+    return this.unitsData.units.find(unit => {
+      const matchesVariable = variable.responseId !== null ?
+        unit.id === variable.responseId :
+        unit.variableId === variable.variableId &&
+          unit.name.toUpperCase() === variable.unitName.toUpperCase();
+
+      return this.isUnitInBundle(unit, context.bundleId) &&
+        matchesVariable &&
+        this.isUnitInCurrentBundleCase(unit, currentUnit, context);
+    });
   }
 
   private isUnitInBundle(unit: UnitsReplayUnit, bundleId: number): boolean {


### PR DESCRIPTION
## Was wurde geändert?

- Abgeschlossene, manuell kodierte Aggregationsgeschwister werden bei der effektiven Fall- und Variablenabdeckung berücksichtigt.
- Unit-Namen mit unterschiedlicher Groß-/Kleinschreibung werden in Validierung und Coverage gemeinsam ausgewertet.
- Die Suche nach abgeschlossenen Peers wird auf passende Unit-/Variablen-Aliase und Werte begrenzt.
- Neu angewendete Aggregationsergebnisse werden über Unit-Schreibvarianten hinweg auf passende offene Geschwister übertragen.
- Die betroffenen Redis-Cache-Versionen wurden angehoben und Regressionstests ergänzt.

## Ursache und Wirkung

Nach Abschluss eines Aggregationsgeschwisters wurde dieses aus dem offenen Scope entfernt. Ein verbleibender Zwilling konnte dadurch unter den Aggregationsschwellwert fallen und in der Variablenabdeckung fälschlich als partiell bzw. unzugeordnet erscheinen. Zusätzlich wurden Unit-Schreibvarianten in den beteiligten Auswertungen nicht einheitlich behandelt.

Die Änderung führt abgeschlossene manuelle Peers gezielt wieder für die Aggregationsberechnung zu, zählt dabei aber weiterhin nur aktive Fälle als offene Arbeit. Damit nähern sich Variablenabdeckung, offene Fälle und Job-Verfügbarkeit wieder derselben effektiven Fallebene an.

Bezug: #795

## Validierung

- `npx nx lint backend --skip-nx-cache`
- `npx nx test backend --runInBand --skip-nx-cache`
- 138 Testsuiten und 2.081 Tests bestanden
- `git diff --check`

## Offene Review-Punkte

- Die eigentliche Job-Verteilung verwendet für Unit-Referenzen weiterhin exakte Schreibweisen; der neue Alias-Scope muss dort noch konsistent übernommen werden.
- Die erweiterte Ergebnis-Propagation muss Workspace-Ausschlüsse für Units, Booklets und Testlets berücksichtigen.
