### PR TITLE
Use Content Pool capabilities for connection tests

### DIFF
--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.spec.ts
@@ -44,6 +44,23 @@ function createAxiosError(status: number, message: string): unknown {
   };
 }
 
+function createCapabilitiesResponse(
+  scopes: string[] = ['acp.read', 'files.read', 'files.write']
+): { data: unknown } {
+  return {
+    data: {
+      clientId: 'coding-box',
+      scopes,
+      capabilities: {
+        'acp.read': scopes.includes('acp.read'),
+        'files.read': scopes.includes('files.read'),
+        'files.write': scopes.includes('files.write')
+      },
+      allowedAcpIds: null
+    }
+  };
+}
+
 function createWorkspaceFilesServiceMock(): WorkspaceFilesServiceMock {
   return {
     uploadTestFiles: jest.fn()
@@ -181,16 +198,13 @@ describe('ContentPoolIntegrationService settings', () => {
     const settingRepository = createEnabledSettings();
     const service = createService(httpService, undefined, settingRepository);
     httpService.axiosRef.get
+      .mockResolvedValueOnce(createCapabilitiesResponse())
       .mockResolvedValueOnce({
         data: [
           { id: 'acp-1', name: 'ACP 1' },
           { id: 'acp-2', name: 'ACP 2' }
         ]
-      })
-      .mockResolvedValueOnce({ data: [] });
-    httpService.axiosRef.post.mockRejectedValueOnce(
-      createAxiosError(400, 'At least one file is required')
-    );
+      });
 
     await expect(service.testConnection({
       baseUrl: 'http://content-pool.test',
@@ -204,19 +218,16 @@ describe('ContentPoolIntegrationService settings', () => {
     });
     expect(httpService.axiosRef.get).toHaveBeenNthCalledWith(
       1,
-      'http://content-pool.test/api/server/acp',
+      'http://content-pool.test/api/server/capabilities',
       { headers: { 'X-Server-Token': 'cp_unsaved_token' } }
     );
     expect(httpService.axiosRef.get).toHaveBeenNthCalledWith(
       2,
-      'http://content-pool.test/api/server/acp/acp-1/files',
+      'http://content-pool.test/api/server/acp',
       { headers: { 'X-Server-Token': 'cp_unsaved_token' } }
     );
-    expect(httpService.axiosRef.post).toHaveBeenCalledWith(
-      'http://content-pool.test/api/server/acp/acp-1/files/upload?conflictStrategy=reject',
-      null,
-      { headers: { 'X-Server-Token': 'cp_unsaved_token' } }
-    );
+    expect(httpService.axiosRef.get).toHaveBeenCalledTimes(2);
+    expect(httpService.axiosRef.post).not.toHaveBeenCalled();
     expect(settingRepository.getContent('system-content-pool-application-token'))
       .toBe('cp_test_token');
   });
@@ -241,25 +252,70 @@ describe('ContentPoolIntegrationService settings', () => {
     const httpService = createHttpServiceMock();
     const settingRepository = createEnabledSettings();
     const service = createService(httpService, undefined, settingRepository);
-    httpService.axiosRef.get
-      .mockResolvedValueOnce({
-        data: [{ id: 'acp-1', name: 'ACP 1' }]
-      })
-      .mockRejectedValueOnce(
-        createAxiosError(403, 'Missing required scopes: files.read')
-      );
+    httpService.axiosRef.get.mockResolvedValueOnce(
+      createCapabilitiesResponse(['acp.read', 'files.write'])
+    );
 
     await expect(service.testConnection({
       baseUrl: 'http://content-pool.test'
     })).rejects.toThrow(ForbiddenException);
+    expect(httpService.axiosRef.get).toHaveBeenCalledTimes(1);
     expect(httpService.axiosRef.post).not.toHaveBeenCalled();
   });
+
+  it('should reject an invalid capabilities response without using the fallback', async () => {
+    const httpService = createHttpServiceMock();
+    const settingRepository = createEnabledSettings();
+    const service = createService(httpService, undefined, settingRepository);
+    httpService.axiosRef.get.mockResolvedValueOnce({
+      data: {
+        scopes: ['acp.read', 'files.read', 'files.write'],
+        capabilities: {
+          'acp.read': true,
+          'files.read': true
+        }
+      }
+    });
+
+    await expect(service.testConnection({
+      baseUrl: 'http://content-pool.test'
+    })).rejects.toThrow(
+      'Content Pool hat eine ungültige Capabilities-Antwort geliefert.'
+    );
+    expect(httpService.axiosRef.get).toHaveBeenCalledTimes(1);
+    expect(httpService.axiosRef.post).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [401, 'Invalid token'],
+    [403, 'Token is not allowed'],
+    [500, 'Internal server error']
+  ])(
+    'should not use the legacy fallback for a capabilities error with status %i',
+    async (status, message) => {
+      const httpService = createHttpServiceMock();
+      const settingRepository = createEnabledSettings();
+      const service = createService(httpService, undefined, settingRepository);
+      httpService.axiosRef.get.mockRejectedValueOnce(
+        createAxiosError(status, message)
+      );
+
+      await expect(service.testConnection({
+        baseUrl: 'http://content-pool.test'
+      })).rejects.toThrow();
+      expect(httpService.axiosRef.get).toHaveBeenCalledTimes(1);
+      expect(httpService.axiosRef.post).not.toHaveBeenCalled();
+    }
+  );
 
   it('should not treat a real ACP file route 404 as a successful scope probe', async () => {
     const httpService = createHttpServiceMock();
     const settingRepository = createEnabledSettings();
     const service = createService(httpService, undefined, settingRepository);
     httpService.axiosRef.get
+      .mockRejectedValueOnce(
+        createAxiosError(404, 'Cannot GET /api/server/capabilities')
+      )
       .mockResolvedValueOnce({
         data: [{ id: 'acp-1', name: 'ACP 1' }]
       })
@@ -278,6 +334,9 @@ describe('ContentPoolIntegrationService settings', () => {
     const settingRepository = createEnabledSettings();
     const service = createService(httpService, undefined, settingRepository);
     httpService.axiosRef.get
+      .mockRejectedValueOnce(
+        createAxiosError(404, 'Cannot GET /api/server/capabilities')
+      )
       .mockResolvedValueOnce({
         data: [{ id: 'acp-1', name: 'ACP 1' }]
       })
@@ -296,6 +355,9 @@ describe('ContentPoolIntegrationService settings', () => {
     const settingRepository = createEnabledSettings();
     const service = createService(httpService, undefined, settingRepository);
     httpService.axiosRef.get
+      .mockRejectedValueOnce(
+        createAxiosError(404, 'Cannot GET /api/server/capabilities')
+      )
       .mockResolvedValueOnce({ data: [] })
       .mockRejectedValueOnce(createAxiosError(500, 'Internal server error'));
 
@@ -314,6 +376,9 @@ describe('ContentPoolIntegrationService settings', () => {
     const settingRepository = createEnabledSettings();
     const service = createService(httpService, undefined, settingRepository);
     httpService.axiosRef.get
+      .mockRejectedValueOnce(
+        createAxiosError(404, 'Cannot GET /api/server/capabilities')
+      )
       .mockResolvedValueOnce({ data: [] })
       .mockRejectedValueOnce(createAxiosError(404, 'ACP not found'));
     httpService.axiosRef.post.mockRejectedValueOnce(
@@ -330,7 +395,7 @@ describe('ContentPoolIntegrationService settings', () => {
         'Verbindung erfolgreich. 0 ACPs erreichbar. Benötigte Scopes geprüft.'
     });
     expect(httpService.axiosRef.get).toHaveBeenNthCalledWith(
-      2,
+      3,
       'http://content-pool.test/api/server/acp/00000000-0000-4000-8000-000000000000/files',
       { headers: { 'X-Server-Token': 'cp_test_token' } }
     );

--- a/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
+++ b/apps/backend/src/app/admin/content-pool/content-pool-integration.service.ts
@@ -51,6 +51,11 @@ interface ScopeProbeOptions {
   acceptsFallbackAcpNotFound?: boolean;
 }
 
+interface ContentPoolCapabilities {
+  scopes: unknown;
+  capabilities: unknown;
+}
+
 interface ContentPoolRuntimeSettings extends ContentPoolSettings {
   applicationToken: string;
 }
@@ -295,15 +300,22 @@ export class ContentPoolIntegrationService {
 
     try {
       const apiBaseUrl = this.normalizeApiBaseUrl(baseUrl);
+      const capabilitiesAvailable =
+        await this.validateRequiredScopesFromCapabilities(
+          apiBaseUrl,
+          applicationToken
+        );
       const acps = await this.fetchAcps(
         apiBaseUrl,
         applicationToken
       );
-      await this.validateRequiredCodingBoxScopes(
-        apiBaseUrl,
-        applicationToken,
-        acps
-      );
+      if (!capabilitiesAvailable) {
+        await this.validateRequiredScopesWithLegacyProbe(
+          apiBaseUrl,
+          applicationToken,
+          acps
+        );
+      }
 
       return {
         success: true,
@@ -977,7 +989,68 @@ export class ContentPoolIntegrationService {
     return { 'X-Server-Token': token };
   }
 
-  private async validateRequiredCodingBoxScopes(
+  private async validateRequiredScopesFromCapabilities(
+    apiBaseUrl: string,
+    token: string
+  ): Promise<boolean> {
+    let response: { data?: unknown };
+
+    try {
+      response = await this.httpService.axiosRef.get(
+        `${apiBaseUrl}/server/capabilities`,
+        {
+          headers: this.getApplicationTokenHeaders(token)
+        }
+      );
+    } catch (error) {
+      if (this.getErrorHttpStatus(error) === 404) {
+        return false;
+      }
+
+      return this.throwHttpError(
+        error,
+        'Content-Pool-Capabilities konnten nicht geladen werden.'
+      );
+    }
+
+    const payload = response.data as Partial<ContentPoolCapabilities> | null;
+    if (
+      !payload ||
+      !Array.isArray(payload.scopes) ||
+      !this.isCapabilitiesMap(payload.capabilities)
+    ) {
+      throw new InternalServerErrorException(
+        'Content Pool hat eine ungültige Capabilities-Antwort geliefert.'
+      );
+    }
+
+    const grantedScopes = new Set(
+      payload.scopes.filter((scope): scope is string => typeof scope === 'string')
+    );
+    const missingScopes = this.requiredCodingBoxScopes.filter(
+      scope => !grantedScopes.has(scope) ||
+        payload.capabilities[scope] !== true
+    );
+    if (missingScopes.length > 0) {
+      throw new ForbiddenException(
+        `Content-Pool-Token fehlen benötigte Scopes: ${missingScopes.join(', ')}.`
+      );
+    }
+
+    return true;
+  }
+
+  private isCapabilitiesMap(value: unknown): value is Record<string, boolean> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return false;
+    }
+
+    return this.requiredCodingBoxScopes.every(
+      scope => typeof (value as Record<string, unknown>)[scope] === 'boolean'
+    );
+  }
+
+  private async validateRequiredScopesWithLegacyProbe(
     apiBaseUrl: string,
     token: string,
     acps: ContentPoolAcpSummary[]


### PR DESCRIPTION
## Summary

- query `GET /api/server/capabilities` before accessing ACP resources during connection tests
- validate `acp.read`, `files.read`, and `files.write` from both the granted scopes and capability map
- keep the existing ACP/file probe only when the capabilities endpoint returns `404`
- surface authentication, authorization, server, and malformed-response errors without hiding them behind the legacy fallback
- continue fetching accessible ACPs and reporting `acpCount`

## Why

The connection test previously had to infer file scopes by addressing a real or synthetic ACP and issuing an empty upload request. The Content Pool now exposes an ACP-independent capabilities endpoint through iqb-berlin/content-pool-next#77, so current installations can validate the token without resource probes while older Content Pool versions remain supported.

## Impact

Modern Content Pool installations no longer receive synthetic ACP/file requests from connection tests. Existing installations without the endpoint continue to use the established UUID-based compatibility path.

## Validation

- `npx nx test backend --testFile=content-pool-integration.service.spec.ts --runInBand --skipNxCache --silent` (22 tests)
- `npx nx lint backend --skipNxCache`
- `npx nx test backend --runInBand --skipNxCache --silent` (138 suites, 2069 tests passed; 2 suites/10 tests skipped)
- `npx nx build backend --skipNxCache`

Closes #921
