### PR TITLE
Missing-Werte für Kappa-Statistiken profilgerecht normalisieren

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.spec.ts
@@ -1232,7 +1232,9 @@ describe('CodingReviewService', () => {
     expect(queryBuilder.leftJoin).toHaveBeenCalledWith('cj.training', 'training');
     expect(queryBuilder.select).toHaveBeenCalledWith('cju.response_id', 'responseId');
     expect(queryBuilder.addSelect).toHaveBeenCalledWith('cju.variable_anchor', 'variableAnchor');
-    expect(queryBuilder.andWhere).toHaveBeenCalledWith('cju.code IS NOT NULL');
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      '(cju.code IS NOT NULL OR cju.coding_issue_option IN (-3, -4))'
+    );
     expect(queryBuilder.andWhere).toHaveBeenCalledWith('cj.training_id IS NULL');
     expect(queryBuilder.addOrderBy).toHaveBeenCalledWith('cju.id', 'ASC');
     expect(queryBuilder.addOrderBy).toHaveBeenCalledWith('cjc.id', 'ASC');
@@ -1288,17 +1290,223 @@ describe('CodingReviewService', () => {
 
     await service.getCodedVariablesForKappa(workspaceId, false);
 
-    expect(queryBuilder.andWhere).toHaveBeenCalledWith('cju.code IS NOT NULL');
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      '(cju.code IS NOT NULL OR cju.coding_issue_option IN (-3, -4))'
+    );
     expect(queryBuilder.andWhere).not.toHaveBeenCalledWith('cj.training_id IS NULL');
   });
 
-  it('uses score values as the database filter for score-level kappa data', async () => {
+  it('loads raw missing values for profile-aware score-level kappa normalization', async () => {
     queryBuilder.getRawMany.mockResolvedValueOnce([]);
 
     await service.getCodedVariablesForKappa(workspaceId, true, [], [], [], 'score');
 
-    expect(queryBuilder.andWhere).toHaveBeenCalledWith('cju.score IS NOT NULL');
-    expect(queryBuilder.andWhere).not.toHaveBeenCalledWith('cju.code IS NOT NULL');
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      '(cju.score IS NOT NULL OR cju.code < 0 OR cju.coding_issue_option IN (-3, -4))'
+    );
+  });
+
+  it('normalizes general missing codes before filtering score-level kappa data', async () => {
+    const missingsProfilesService = {
+      getMissingByIdForProfileOrDefault: jest.fn()
+        .mockImplementation(async (_workspaceId: number, _profileId: number | null, missingId: string) => (
+          missingId === 'mir' ?
+            {
+              id: 'mir', label: 'Missing invalid response', code: -98, score: 0
+            } :
+            {
+              id: 'mci', label: 'Missing coding impossible', code: -97, score: null
+            }
+        )),
+      getMissingByCodeForProfileOrDefault: jest.fn()
+        .mockResolvedValue({
+          id: 'mbi_mbo', label: 'Missing by omission', code: -99, score: 0
+        })
+    };
+    service = new CodingReviewService(
+      {} as never,
+      codingJobUnitRepository as never,
+      jobDefinitionRepository as never,
+      variableBundleRepository as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {
+        resolveExclusionsForQueries: jest.fn().mockResolvedValue(emptyExclusions)
+      } as never,
+      codingJobService as never,
+      missingsProfilesService as never
+    );
+    queryBuilder.getRawMany.mockResolvedValueOnce([
+      {
+        responseId: 10,
+        unitName: 'UNIT_1',
+        variableId: 'VAR_1',
+        variableAnchor: 'ANCHOR_1',
+        personLogin: 'person-1',
+        personCode: 'P001',
+        personGroup: 'GROUP_1',
+        bookletName: 'BOOKLET_1',
+        coderId: 1,
+        coderName: 'Coder 1',
+        jobId: 100,
+        jobName: 'Training job 1',
+        jobDefinitionId: null,
+        trainingId: 60,
+        trainingLabel: 'Training A',
+        missingsProfileId: 77,
+        code: -3,
+        codingIssueOption: -3,
+        score: null,
+        notes: null,
+        supervisorComment: null,
+        codedAt: new Date('2026-05-18T00:00:00.000Z')
+      },
+      {
+        responseId: 10,
+        unitName: 'UNIT_1',
+        variableId: 'VAR_1',
+        variableAnchor: 'ANCHOR_1',
+        personLogin: 'person-1',
+        personCode: 'P001',
+        personGroup: 'GROUP_1',
+        bookletName: 'BOOKLET_1',
+        coderId: 2,
+        coderName: 'Coder 2',
+        jobId: 101,
+        jobName: 'Training job 2',
+        jobDefinitionId: null,
+        trainingId: 60,
+        trainingLabel: 'Training A',
+        missingsProfileId: 77,
+        code: -99,
+        codingIssueOption: null,
+        score: null,
+        notes: null,
+        supervisorComment: null,
+        codedAt: new Date('2026-05-18T00:00:00.000Z')
+      },
+      {
+        responseId: 11,
+        unitName: 'UNIT_1',
+        variableId: 'VAR_1',
+        variableAnchor: 'ANCHOR_1',
+        personLogin: 'person-2',
+        personCode: 'P002',
+        personGroup: 'GROUP_1',
+        bookletName: 'BOOKLET_1',
+        coderId: 1,
+        coderName: 'Coder 1',
+        jobId: 100,
+        jobName: 'Training job 1',
+        jobDefinitionId: null,
+        trainingId: 60,
+        trainingLabel: 'Training A',
+        missingsProfileId: 77,
+        code: -4,
+        codingIssueOption: -4,
+        score: null,
+        notes: null,
+        supervisorComment: null,
+        codedAt: new Date('2026-05-18T00:00:00.000Z')
+      }
+    ]);
+
+    const result = await service.getCodedVariablesForKappa(
+      workspaceId,
+      false,
+      [],
+      [60],
+      [],
+      'score'
+    );
+
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault)
+      .toHaveBeenCalledWith(workspaceId, 77, 'mir');
+    expect(missingsProfilesService.getMissingByIdForProfileOrDefault)
+      .toHaveBeenCalledWith(workspaceId, 77, 'mci');
+    expect(missingsProfilesService.getMissingByCodeForProfileOrDefault)
+      .toHaveBeenCalledWith(workspaceId, 77, -99);
+    expect(result).toEqual([
+      expect.objectContaining({
+        responseId: 10,
+        coderResults: [
+          expect.objectContaining({ coderId: 1, code: -98, score: 0 }),
+          expect.objectContaining({ coderId: 2, code: -99, score: 0 })
+        ]
+      })
+    ]);
+  });
+
+  it('excludes internal issue marker codes from code-level kappa data', async () => {
+    queryBuilder.getRawMany.mockResolvedValueOnce([
+      {
+        responseId: 10,
+        unitName: 'UNIT_1',
+        variableId: 'VAR_1',
+        variableAnchor: 'ANCHOR_1',
+        personLogin: 'person-1',
+        personCode: 'P001',
+        personGroup: 'GROUP_1',
+        bookletName: 'BOOKLET_1',
+        coderId: 1,
+        coderName: 'Coder 1',
+        jobId: 100,
+        jobName: 'Issue marker job',
+        jobDefinitionId: null,
+        trainingId: 60,
+        trainingLabel: 'Training A',
+        missingsProfileId: 77,
+        code: -1,
+        codingIssueOption: -1,
+        score: null,
+        notes: null,
+        supervisorComment: null,
+        codedAt: new Date('2026-05-18T00:00:00.000Z')
+      },
+      {
+        responseId: 11,
+        unitName: 'UNIT_1',
+        variableId: 'VAR_1',
+        variableAnchor: 'ANCHOR_1',
+        personLogin: 'person-2',
+        personCode: 'P002',
+        personGroup: 'GROUP_1',
+        bookletName: 'BOOKLET_1',
+        coderId: 1,
+        coderName: 'Coder 1',
+        jobId: 100,
+        jobName: 'Provisional regular code',
+        jobDefinitionId: null,
+        trainingId: 60,
+        trainingLabel: 'Training A',
+        missingsProfileId: 77,
+        code: 1,
+        codingIssueOption: -1,
+        score: 1,
+        notes: null,
+        supervisorComment: null,
+        codedAt: new Date('2026-05-18T00:00:00.000Z')
+      }
+    ]);
+
+    const result = await service.getCodedVariablesForKappa(
+      workspaceId,
+      false,
+      [],
+      [60],
+      [],
+      'code'
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        responseId: 11,
+        coderResults: [
+          expect.objectContaining({ coderId: 1, code: 1, score: 1 })
+        ]
+      })
+    ]);
   });
 
   it('deduplicates kappa rows by score availability when score-level kappa data is loaded', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-review.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-review.service.ts
@@ -82,7 +82,9 @@ type KappaCodedVariableRow = {
   jobDefinitionId: number | string | null;
   trainingId: number | string | null;
   trainingLabel: string | null;
+  missingsProfileId: number | string | null;
   code: number | string | null;
+  codingIssueOption: number | string | null;
   score: number | string | null;
   notes: string | null;
   supervisorComment: string | null;
@@ -146,6 +148,57 @@ export class CodingReviewService {
       code: missing.code,
       score: missing.score
     };
+  }
+
+  private async resolveKappaCodeAndScore(
+    workspaceId: number,
+    code: number | null,
+    score: number | null,
+    codingIssueOption: number | null,
+    missingsProfileId: number | null,
+    cache: Map<string, ResolvedMissingValue>
+  ): Promise<{ code: number | null; score: number | null }> {
+    if (code === -1 || code === -2) {
+      return { code: null, score: null };
+    }
+
+    const missingId = this.manualMissingIdsByIssueOptionId.get(code ?? 0) ??
+      this.manualMissingIdsByIssueOptionId.get(codingIssueOption ?? 0);
+    if (missingId && this.missingsProfilesService) {
+      const cacheKey = `${missingsProfileId ?? 'default'}:id:${missingId}`;
+      let missing = cache.get(cacheKey);
+      if (!missing) {
+        missing = await this.missingsProfilesService.getMissingByIdForProfileOrDefault(
+          workspaceId,
+          missingsProfileId,
+          missingId
+        );
+        cache.set(cacheKey, missing);
+      }
+      return {
+        code: missing.code,
+        score: missing.score
+      };
+    }
+
+    if (code !== null && code < 0 && this.missingsProfilesService) {
+      const cacheKey = `${missingsProfileId ?? 'default'}:code:${code}`;
+      let missing = cache.get(cacheKey);
+      if (!missing) {
+        missing = await this.missingsProfilesService.getMissingByCodeForProfileOrDefault(
+          workspaceId,
+          missingsProfileId,
+          code
+        );
+        cache.set(cacheKey, missing);
+      }
+      return {
+        code: missing.code,
+        score: missing.score
+      };
+    }
+
+    return { code, score };
   }
 
   async getDoubleCodedVariablesForReview(
@@ -677,7 +730,9 @@ export class CodingReviewService {
       .addSelect('cj.job_definition_id', 'jobDefinitionId')
       .addSelect('cj.training_id', 'trainingId')
       .addSelect('training.label', 'trainingLabel')
+      .addSelect('cj.missings_profile_id', 'missingsProfileId')
       .addSelect('cju.code', 'code')
+      .addSelect('cju.coding_issue_option', 'codingIssueOption')
       .addSelect('cju.score', 'score')
       .addSelect('cju.notes', 'notes')
       .addSelect('cju.supervisor_comment', 'supervisorComment')
@@ -685,8 +740,8 @@ export class CodingReviewService {
       .where('cj.workspace_id = :workspaceId', { workspaceId })
       .andWhere(
         calculationLevel === 'score' ?
-          'cju.score IS NOT NULL' :
-          'cju.code IS NOT NULL'
+          '(cju.score IS NOT NULL OR cju.code < 0 OR cju.coding_issue_option IN (-3, -4))' :
+          '(cju.code IS NOT NULL OR cju.coding_issue_option IN (-3, -4))'
       )
       .orderBy('cju.unit_name', 'ASC')
       .addOrderBy('cju.variable_id', 'ASC')
@@ -752,6 +807,7 @@ export class CodingReviewService {
       coderResults: ReviewCoderResult[];
     }>();
     const coderResultIndexByItemKey = new Map<string, Map<number, number>>();
+    const missingValueCache = new Map<string, ResolvedMissingValue>();
     let offset = 0;
     let hasMoreRows = true;
 
@@ -761,9 +817,24 @@ export class CodingReviewService {
         .limit(batchSize)
         .getRawMany<KappaCodedVariableRow>();
 
-      rows.forEach(row => {
+      for (const row of rows) {
         const responseId = Number(row.responseId);
         const coderId = Number(row.coderId);
+        const codeAndScore = await this.resolveKappaCodeAndScore(
+          workspaceId,
+          this.toNullableNumber(row.code),
+          this.toNullableNumber(row.score),
+          this.toNullableNumber(row.codingIssueOption),
+          this.toNullableNumber(row.missingsProfileId),
+          missingValueCache
+        );
+        const hasCalculationLevelValue = calculationLevel === 'score' ?
+          codeAndScore.score !== null :
+          codeAndScore.code !== null;
+        if (!hasCalculationLevelValue) {
+          continue;
+        }
+
         const itemKey = JSON.stringify([responseId, row.unitName, row.variableId]);
         if (!groups.has(itemKey)) {
           groups.set(itemKey, {
@@ -788,8 +859,8 @@ export class CodingReviewService {
           jobDefinitionId: row.jobDefinitionId === null ? null : Number(row.jobDefinitionId),
           trainingId: row.trainingId === null ? null : Number(row.trainingId),
           trainingLabel: row.trainingLabel,
-          code: row.code === null ? null : Number(row.code),
-          score: row.score === null ? null : Number(row.score),
+          code: codeAndScore.code,
+          score: codeAndScore.score,
           notes: row.notes,
           supervisorComment: row.supervisorComment || null,
           codedAt: new Date(row.codedAt)
@@ -810,7 +881,7 @@ export class CodingReviewService {
         )) {
           group.coderResults[existingResultIndex] = coderResult;
         }
-      });
+      }
 
       offset += batchSize;
       hasMoreRows = rows.length === batchSize;


### PR DESCRIPTION
## Änderung

- Missing-Codes werden vor der Kappa-Berechnung anhand des Missing-Profils in Code und Score aufgelöst.
- Score-basierte Auswertungen laden dafür auch negative Codes und die allgemeinen Missing-Optionen MIR/MCI.
- Interne Marker `-1` und `-2` werden nicht als gültige Kodierergebnisse gezählt.
- Regressionstests decken profilabhängige MIR/MCI-Werte, direkte Missing-Codes und interne Marker ab.

## Fehlerursache

Die Datenbankabfrage filterte bei score-basierter Berechnung bereits auf `cju.score IS NOT NULL`. Allgemeine manuelle Missing-Werte werden jedoch zunächst mit einem technischen Code und `score = NULL` gespeichert; ihr fachlicher Score entsteht erst aus dem Missing-Profil. Dadurch wurden diese Ergebnisse vor der Profilauflösung verworfen und die Anzahl doppelt kodierter Fälle zu niedrig ausgewiesen.

## Auswirkung

Kappa-Statistiken berücksichtigen Missing-Werte jetzt konsistent mit dem ausgewählten Missing-Profil. Missing-Werte ohne fachlichen Score bleiben bei score-basierter Berechnung ausgeschlossen.

## Validierung

- `npx nx lint backend`
- `npx nx test backend --runInBand`
- `git diff --check`

Bezug: #920. Das Issue bleibt bis zur fachlichen Prüfung offen.
