### PR TITLE
Detaillierten Exportkommentar erhalten

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.spec.ts
@@ -44,13 +44,14 @@ function createServiceWithDetailedMocks(
     discussionResults?: Record<string, unknown>[],
     users?: Record<string, unknown>[],
     totalCount?: number,
+    notes?: string,
     missingsProfilesService?: { getMissingByIdForProfileOrDefault: jest.Mock }
   } = {}
 ) {
   const defaultUnit = {
     code: 7,
     coding_issue_option: codingIssueOption,
-    notes: '',
+    notes: overrides.notes ?? '',
     updated_at: new Date('2026-04-14T10:00:00.000Z'),
     response_id: 123,
     unit_name: 'U1',
@@ -356,14 +357,20 @@ describe('CodingExportService (WS-Admin export smoke)', () => {
     expect(manualJobVariablesQuery.andWhere).not.toHaveBeenCalledWith('cj.training_id IS NULL');
   });
 
-  it('keeps code value and writes code hint when coding_issue_option is set', async () => {
-    const { service, totalCountQueryBuilder, unitsBatchQueryBuilder } = createServiceWithDetailedMocks(1);
+  it('keeps comment and code value and writes code hint when coding_issue_option is set', async () => {
+    const { service, totalCountQueryBuilder, unitsBatchQueryBuilder } = createServiceWithDetailedMocks(
+      1,
+      { notes: 'Coder comment' }
+    );
 
     const buffer = await service.exportCodingResultsDetailed(1, false, false, false, false);
     const csv = buffer.toString('utf-8');
+    const rowFields = csv.trim().split('\n')[1].split(';');
 
     expect(csv).toContain('"Code";"Code-Hinweis"');
     expect(csv).toContain('"7";"Code-Vergabe unsicher"');
+    expect(rowFields[6]).toBe('"Coder comment"');
+    expect(rowFields[9]).toBe('"Code-Vergabe unsicher"');
     expect(totalCountQueryBuilder.leftJoin).toHaveBeenCalledWith('cju.response', 'countResp');
     expect(totalCountQueryBuilder.andWhere).toHaveBeenCalledWith(
       '(countResp.status_v1 IS NULL OR countResp.status_v1 NOT IN (:...excludedStatuses))',

--- a/apps/backend/src/app/database/services/coding/coding-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-export.service.ts
@@ -3987,11 +3987,8 @@ export class CodingExportService {
           );
           const codeValue = mapped.code === null ? '' : mapped.code.toString();
 
-          let commentValue = unit.notes || '';
+          const commentValue = unit.notes || '';
           const codingIssueOption = this.toIntegerOrNull(unit.codingIssueOption);
-          if (!outputCommentsInsteadOfCodes && codingIssueOption) {
-            commentValue = this.getCodingIssueText(codingIssueOption) || commentValue;
-          }
           const codeIssueValue = this.getCodingIssueText(codingIssueOption);
 
           const rowFields = [

--- a/apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results-export.service.spec.ts
@@ -369,9 +369,12 @@ describe('CodingResultsExportService', () => {
     });
 
     const csv = (await service.exportCodingResultsDetailed(1)).toString('utf-8');
+    const firstRowFields = csv.trim().split('\n')[1].split(';');
 
     expect(csv).toContain('"Code";"Code-Hinweis"');
     expect(csv).toContain('"7";"Code-Vergabe unsicher"');
+    expect(firstRowFields[6]).toBe('"needs review"');
+    expect(firstRowFields[9]).toBe('"Code-Vergabe unsicher"');
     expect(csv).toContain('"0";""');
     expect(csv).toContain('"zero-code note"');
     expect(csv).not.toContain('skipped');

--- a/apps/backend/src/app/database/services/coding/coding-results-export.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results-export.service.ts
@@ -2078,10 +2078,7 @@ export class CodingResultsExportService {
           const timestamp = unit.updated_at ?
             new Date(unit.updated_at).toLocaleString('de-DE').replace(',', '') : '';
 
-          let commentValue = unit.notes || '';
-          if (!outputCommentsInsteadOfCodes && unit.coding_issue_option) {
-            commentValue = this.getCodingIssueText(unit.coding_issue_option) || commentValue;
-          }
+          const commentValue = unit.notes || '';
 
           const mapped = await this.mapCodeAndScoreForExport(
             workspaceId,


### PR DESCRIPTION
## Änderung

- Der detaillierte Kodierexport übernimmt die Kommentare der Kodierenden unverändert aus `unit.notes`.
- Code-Hinweise werden ausschließlich in der separaten Spalte `Code-Hinweis` ausgegeben.
- Beide Export-Implementierungen erhalten Regressionstests für gleichzeitig vorhandenen Kommentar und Code-Hinweis.

## Ursache

Bei vorhandenem `coding_issue_option` wurde der bereits gesetzte Kommentar durch den Text des Code-Hinweises überschrieben, obwohl dieser zusätzlich in seine eigene CSV-Spalte geschrieben wurde.

## Auswirkung

Die Spalte `Kommentar` enthält wieder den tatsächlichen Kommentar der kodierenden Person. Die Spalte `Code-Hinweis` bleibt unverändert erhalten.

## Validierung

- `npx nx lint backend`
- `npx nx test backend --runInBand` (138 Testsuiten, 2.068 Tests bestanden)

Related to #919 — das Issue soll mit diesem PR noch nicht geschlossen werden.
