### PR TITLE
Cache replay assets and cancel stale requests

### DIFF
--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -2,7 +2,7 @@
 import { ActivatedRoute } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import {
-  BehaviorSubject, of, Subject
+  BehaviorSubject, finalize, of, Subject
 } from 'rxjs';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -245,6 +245,78 @@ describe('ReplayComponent', () => {
 
     const replacementPlayer = fixture.debugElement.query(By.directive(UnitPlayerComponent)).componentInstance;
     expect(replacementPlayer).not.toBe(initialPlayer);
+  });
+
+  it('should cancel the previous payload request and only apply the latest result', async () => {
+    const firstRequest = new Subject<{
+      unitDef: { data: string; file_id: string }[];
+      response: { responses: { id: string; content: string }[] };
+      vocs: { data: string; file_id: string }[];
+      player: { data: string; file_id: string }[];
+    }>();
+    const secondRequest = new Subject<{
+      unitDef: { data: string; file_id: string }[];
+      response: { responses: { id: string; content: string }[] };
+      vocs: { data: string; file_id: string }[];
+      player: { data: string; file_id: string }[];
+    }>();
+    const firstRequestFinalized = jest.fn();
+    replayBackendService.getReplayPayload
+      .mockReset()
+      .mockReturnValueOnce(firstRequest.pipe(finalize(firstRequestFinalized)))
+      .mockReturnValueOnce(secondRequest);
+    const replayComponent = component as unknown as {
+      loadAndApplyUnitData: (workspace: number, authToken?: string) => Promise<boolean>;
+    };
+    component.testPerson = 'person-1@code@booklet';
+    component.unitId = 'unit-1';
+
+    const firstLoad = replayComponent.loadAndApplyUnitData(47, 'token');
+    component.testPerson = 'person-2@code@booklet';
+    const secondLoad = replayComponent.loadAndApplyUnitData(47, 'token');
+
+    expect(firstRequestFinalized).toHaveBeenCalledTimes(1);
+    secondRequest.next({
+      unitDef: [{ data: 'latest unitDef', file_id: 'UNIT-1.VOUD' }],
+      response: { responses: [{ id: 'chunk', content: 'latest response' }] },
+      vocs: [],
+      player: [{ data: 'latest player', file_id: 'PLAYER-1.0' }]
+    });
+    secondRequest.complete();
+
+    await expect(firstLoad).resolves.toBe(false);
+    await expect(secondLoad).resolves.toBe(true);
+    expect(component.unitDef).toBe('latest unitDef');
+    expect(component.responses).toEqual({
+      responses: [{ id: 'chunk', content: 'latest response' }]
+    });
+  });
+
+  it('should apply the coding scheme already parsed by the asset cache', async () => {
+    const parsedCodingScheme: CodingScheme = {
+      version: '1.0',
+      variableCodings: []
+    };
+    replayBackendService.getReplayPayload.mockReset().mockReturnValue(of({
+      unitDef: [{ data: 'unitDef data', file_id: 'UNIT-1.VOUD' }],
+      response: { responses: [{ id: 'chunk', content: 'response' }] },
+      vocs: [{
+        data: '{"version":"1.0","variableCodings":[]}',
+        file_id: 'UNIT-1.VOCS'
+      }],
+      player: [{ data: 'player data', file_id: 'PLAYER-1.0' }],
+      codingScheme: parsedCodingScheme
+    }));
+    const replayComponent = component as unknown as {
+      loadAndApplyUnitData: (workspace: number, authToken?: string) => Promise<boolean>;
+    };
+    component.isCodingMode = true;
+    component.testPerson = 'person-1@code@booklet';
+    component.unitId = 'unit-1';
+
+    await expect(replayComponent.loadAndApplyUnitData(47, 'token')).resolves.toBe(true);
+
+    expect(component.codingService.codingScheme).toBe(parsedCodingScheme);
   });
 
   it('should apply display options from query params', async () => {
@@ -992,13 +1064,15 @@ describe('ReplayComponent', () => {
       47,
       'valid@test@person',
       'unit-new',
-      'valid-token'
+      'valid-token',
+      true
     );
     expect(replayBackendService.getReplayPayload).not.toHaveBeenCalledWith(
       47,
       'valid@test@person',
       'unit-old',
-      'valid-token'
+      'valid-token',
+      true
     );
     expect(component.unitId).toBe('unit-new');
     expect(component.codingService.currentVariableId).toBe('NEW_VAR');

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -12,7 +12,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import {
-  firstValueFrom, of, Subject, Subscription, catchError, debounceTime
+  firstValueFrom, of, Subject, Subscription, catchError, debounceTime, takeUntil
 } from 'rxjs';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
 import { MatSnackBar, MatSnackBarRef, TextOnlySnackBar } from '@angular/material/snack-bar';
@@ -50,6 +50,7 @@ import {
   WorkspaceTokenScope
 } from '../../../core/services/auth-session.config';
 import { SessionRecoveryService } from '../../../core/services/session-recovery.service';
+import { CodingScheme } from '../../../models/coding-interfaces';
 
 interface ReplayUnitPayload {
   unitDef: FilesDto[];
@@ -61,6 +62,7 @@ interface ReplayUnitPayload {
   };
   player: FilesDto[];
   vocs: FilesDto[];
+  codingScheme?: CodingScheme | null;
   serverTimings?: ReplayServerTimings;
 }
 
@@ -181,6 +183,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private anchorHighlightTimeout: ReturnType<typeof setTimeout> | null = null;
   private anchorHighlightRunId = 0;
   private unitPayloadRunId = 0;
+  private unitPayloadCancellation: Subject<void> | undefined = new Subject<void>();
   private readonly ANCHOR_HIGHLIGHT_RETRY_DELAY_MS = 100;
   private readonly ANCHOR_HIGHLIGHT_MAX_ATTEMPTS = 40;
   private readonly REPLAY_NOTES_COMMIT_DEBOUNCE_MS = 750;
@@ -764,20 +767,34 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     this.responses = unitData.response;
     this.serverTimings = unitData.serverTimings ?? null;
 
-    if (this.isCodingMode && unitData.vocs && unitData.vocs[0] && unitData.vocs[0].data) {
-      this.codingService.setCodingSchemeFromVocsData(unitData.vocs[0].data);
+    const vocsData = unitData.vocs[0]?.data;
+    if (this.isCodingMode && unitData.codingScheme !== undefined) {
+      this.codingService.setParsedCodingScheme(unitData.codingScheme, vocsData);
+    } else if (this.isCodingMode && vocsData) {
+      this.codingService.setCodingSchemeFromVocsData(vocsData);
     } else if (this.isCodingMode && !this.codingService.codingScheme) {
       this.loadCodingSchemeForCodingJob(unitPayloadRunId);
     }
   }
 
   private nextUnitPayloadRunId(): number {
+    this.cancelActiveUnitPayloadRequest();
     this.unitPayloadRunId += 1;
     return this.unitPayloadRunId;
   }
 
   private invalidateUnitPayloadRequests(): void {
+    this.cancelActiveUnitPayloadRequest();
     this.unitPayloadRunId += 1;
+  }
+
+  private cancelActiveUnitPayloadRequest(): void {
+    this.unitPayloadCancellation?.next();
+  }
+
+  private getUnitPayloadCancellation(): Subject<void> {
+    this.unitPayloadCancellation ??= new Subject<void>();
+    return this.unitPayloadCancellation;
   }
 
   private isCurrentUnitPayloadRun(runId: number): boolean {
@@ -789,7 +806,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
     try {
       const unitData = await this.getUnitData(workspace, authToken, runId);
-      if (!this.isCurrentUnitPayloadRun(runId)) {
+      if (!unitData || !this.isCurrentUnitPayloadRun(runId)) {
         return false;
       }
 
@@ -823,7 +840,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     workspace: number,
     authToken?: string,
     unitPayloadRunId?: number
-  ): Promise<ReplayUnitPayload> {
+  ): Promise<ReplayUnitPayload | null> {
     this.replayStartTime = performance.now();
     this.loadStartTime = this.replayStartTime;
     this.payloadRequestStartTime = this.replayStartTime;
@@ -837,9 +854,14 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         workspace,
         this.testPerson,
         this.unitId,
-        authToken
-      )
+        authToken,
+        this.isCodingMode
+      ).pipe(takeUntil(this.getUnitPayloadCancellation())),
+      { defaultValue: null }
     );
+    if (!unitData) {
+      return null;
+    }
     if (!unitPayloadRunId || this.isCurrentUnitPayloadRun(unitPayloadRunId)) {
       this.payloadResponseTime = performance.now();
       this.setIsLoaded();
@@ -849,6 +871,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       response: unitData.response,
       vocs: unitData.vocs,
       player: unitData.player,
+      codingScheme: unitData.codingScheme,
       serverTimings: unitData.serverTimings
     };
   }
@@ -1312,6 +1335,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy(): void {
+    this.invalidateUnitPayloadRequests();
+    this.unitPayloadCancellation?.complete();
+    this.unitPayloadCancellation = undefined;
     this.routerSubscription?.unsubscribe();
     this.authBootstrapSubscription?.unsubscribe();
     this.sessionRecoverySubscription?.unsubscribe();

--- a/apps/frontend/src/app/replay/services/replay-backend.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-backend.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import Keycloak from 'keycloak-js';
 import { ReplayBackendService } from './replay-backend.service';
 import { SERVER_URL } from '../../injection-tokens';
 import {
@@ -13,8 +14,21 @@ describe('ReplayBackendService', () => {
   let httpMock: HttpTestingController;
 
   const mockServerUrl = 'http://localhost/api/';
+  const replayAssets = {
+    unitDef: [{ data: 'unchanged unitDef data', file_id: 'UNIT-1.VOUD' }],
+    player: [{ data: 'player data', file_id: 'PLAYER-1.0' }],
+    vocs: [{ data: 'vocs data', file_id: 'UNIT-1.VOCS' }]
+  };
+  const keycloakMock: {
+    tokenParsed?: { sub?: string };
+    idTokenParsed?: { sub?: string };
+  } = {
+    tokenParsed: { sub: 'internal-user' }
+  };
 
   beforeEach(() => {
+    keycloakMock.tokenParsed = { sub: 'internal-user' };
+    keycloakMock.idTokenParsed = undefined;
     Object.defineProperty(window, 'localStorage', {
       value: {
         getItem: jest.fn().mockReturnValue('mock-token')
@@ -27,6 +41,7 @@ describe('ReplayBackendService', () => {
         ReplayBackendService,
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
+        { provide: Keycloak, useValue: keycloakMock },
         { provide: SERVER_URL, useValue: mockServerUrl }
       ]
     });
@@ -36,6 +51,8 @@ describe('ReplayBackendService', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
     httpMock.verify();
   });
 
@@ -90,6 +107,7 @@ describe('ReplayBackendService', () => {
 
   describe('getReplayPayload', () => {
     it('should fetch split replay assets and response and merge them', done => {
+      const parseSpy = jest.spyOn(JSON, 'parse');
       service.getReplayPayload(1, 'person@code@booklet', 'unit 1', 'url-token')
         .subscribe(result => {
           expect(result).toEqual({
@@ -102,6 +120,7 @@ describe('ReplayBackendService', () => {
               responseTotalMs: 4
             }
           });
+          expect(parseSpy).not.toHaveBeenCalled();
           done();
         });
 
@@ -118,6 +137,8 @@ describe('ReplayBackendService', () => {
         unitDef: [{ data: 'unitDef data', file_id: 'UNIT-1.VOUD' }],
         player: [{ data: 'player data', file_id: 'PLAYER-1.0' }],
         vocs: [{ data: 'vocs data', file_id: 'UNIT-1.VOCS' }]
+      }, {
+        headers: { 'Cache-Control': 'private, max-age=300' }
       });
 
       const responseReq = httpMock.expectOne(req => {
@@ -137,6 +158,77 @@ describe('ReplayBackendService', () => {
         }
       });
     });
+
+    it('should reuse assets while fetching each test person response', () => {
+      const firstResult = jest.fn();
+      const secondResult = jest.fn();
+      const assetsWithCodingScheme = {
+        ...replayAssets,
+        vocs: [{
+          data: JSON.stringify({
+            id: 'scheme-1',
+            label: 'Scheme',
+            variableCodings: []
+          }),
+          file_id: 'UNIT-1.VOCS'
+        }]
+      };
+
+      service.getReplayPayload(1, 'person-1@code@booklet', 'unit-1', 'url-token', true)
+        .subscribe(firstResult);
+      const firstAssetsRequest = httpMock.expectOne(request => (
+        request.url === `${mockServerUrl}admin/workspace/1/replay-assets/unit-1`
+      ));
+      const firstResponseRequest = httpMock.expectOne(request => (
+        request.url.includes('/replay-response/person-1%40code%40booklet/unit-1')
+      ));
+      firstAssetsRequest.flush(assetsWithCodingScheme, {
+        headers: { 'Cache-Control': 'private, max-age=300' }
+      });
+      firstResponseRequest.flush({
+        response: { responses: [{ id: 'chunk', content: 'first response' }] }
+      });
+
+      service.getReplayPayload(1, 'person-2@code@booklet', 'unit-1', 'url-token', true)
+        .subscribe(secondResult);
+      httpMock.expectNone(request => request.url.includes('/replay-assets/'));
+      const secondResponseRequest = httpMock.expectOne(request => (
+        request.url.includes('/replay-response/person-2%40code%40booklet/unit-1')
+      ));
+      secondResponseRequest.flush({
+        response: { responses: [{ id: 'chunk', content: 'second response' }] }
+      });
+
+      expect(firstResult).toHaveBeenCalledWith(expect.objectContaining({
+        unitDef: assetsWithCodingScheme.unitDef,
+        response: { responses: [{ id: 'chunk', content: 'first response' }] }
+      }));
+      expect(secondResult).toHaveBeenCalledWith(expect.objectContaining({
+        unitDef: assetsWithCodingScheme.unitDef,
+        response: { responses: [{ id: 'chunk', content: 'second response' }] }
+      }));
+      const firstCodingScheme = firstResult.mock.calls[0][0].codingScheme;
+      expect(firstCodingScheme).toEqual(expect.objectContaining({ id: 'scheme-1' }));
+      expect(secondResult.mock.calls[0][0].codingScheme).toBe(firstCodingScheme);
+    });
+
+    it('should cancel only the response request when a combined payload is unsubscribed', () => {
+      const subscription = service
+        .getReplayPayload(1, 'person-1@code@booklet', 'unit-1', 'url-token')
+        .subscribe();
+      const assetsRequest = httpMock.expectOne(request => request.url.includes('/replay-assets/unit-1'));
+      const responseRequest = httpMock.expectOne(
+        request => request.url.includes('/replay-response/person-1%40code%40booklet/unit-1')
+      );
+
+      subscription.unsubscribe();
+
+      expect(responseRequest.cancelled).toBe(true);
+      expect(assetsRequest.cancelled).toBe(false);
+      assetsRequest.flush(replayAssets, {
+        headers: { 'Cache-Control': 'no-store' }
+      });
+    });
   });
 
   describe('getReplayAssets', () => {
@@ -153,6 +245,129 @@ describe('ReplayBackendService', () => {
       );
       expect(req.request.headers.get('Authorization')).toBeNull();
       req.flush({ unitDef: [], player: [], vocs: [] });
+    });
+
+    it('should share an in-flight asset request and preserve the raw payload', () => {
+      const firstResult = jest.fn();
+      const secondResult = jest.fn();
+
+      service.getReplayAssets(1, 'unit-1', 'url-token').subscribe(firstResult);
+      service.getReplayAssets(1, 'unit-1', 'url-token').subscribe(secondResult);
+
+      const requests = httpMock.match(request => request.url.includes('/replay-assets/unit-1'));
+      expect(requests).toHaveLength(1);
+      requests[0].flush(replayAssets, {
+        headers: { 'Cache-Control': 'private, max-age=300' }
+      });
+
+      expect(firstResult).toHaveBeenCalledWith(replayAssets);
+      expect(secondResult).toHaveBeenCalledWith(replayAssets);
+      expect(firstResult.mock.calls[0][0].unitDef[0].data).toBe('unchanged unitDef data');
+    });
+
+    it('should keep cache entries separate by workspace, unit, and auth context', () => {
+      service.getReplayAssets(1, 'unit-1', 'token-a').subscribe();
+      service.getReplayAssets(1, 'unit-1', 'token-b').subscribe();
+      service.getReplayAssets(1, 'unit-2', 'token-a').subscribe();
+      service.getReplayAssets(2, 'unit-1', 'token-a').subscribe();
+
+      const requests = httpMock.match(request => request.url.includes('/replay-assets/'));
+      expect(requests).toHaveLength(4);
+      expect(requests.map(request => [
+        request.request.url,
+        request.request.headers.get('Authorization')
+      ])).toEqual(expect.arrayContaining([
+        [`${mockServerUrl}admin/workspace/1/replay-assets/unit-1`, 'Bearer token-a'],
+        [`${mockServerUrl}admin/workspace/1/replay-assets/unit-1`, 'Bearer token-b'],
+        [`${mockServerUrl}admin/workspace/1/replay-assets/unit-2`, 'Bearer token-a'],
+        [`${mockServerUrl}admin/workspace/2/replay-assets/unit-1`, 'Bearer token-a']
+      ]));
+      requests.forEach(request => request.flush(replayAssets, {
+        headers: { 'Cache-Control': 'private, max-age=300' }
+      }));
+    });
+
+    it('should keep cache entries separate when the signed-in user changes', () => {
+      service.getReplayAssets(1, 'unit-1').subscribe();
+      const firstRequest = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/1/replay-assets/unit-1?replayPart=assets`
+      );
+      firstRequest.flush(replayAssets, {
+        headers: { 'Cache-Control': 'private, max-age=300' }
+      });
+
+      keycloakMock.tokenParsed = { sub: 'different-internal-user' };
+      service.getReplayAssets(1, 'unit-1').subscribe();
+      const secondRequest = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/1/replay-assets/unit-1?replayPart=assets`
+      );
+      secondRequest.flush(replayAssets, {
+        headers: { 'Cache-Control': 'private, max-age=300' }
+      });
+    });
+
+    it('should reload assets after the server max-age expires', () => {
+      jest.useFakeTimers();
+
+      service.getReplayAssets(1, 'unit-1').subscribe();
+      httpMock.expectOne(request => request.url.includes('/replay-assets/unit-1'))
+        .flush(replayAssets, {
+          headers: { 'Cache-Control': 'private, max-age=1' }
+        });
+
+      jest.advanceTimersByTime(1000);
+      service.getReplayAssets(1, 'unit-1').subscribe();
+      httpMock.expectOne(request => request.url.includes('/replay-assets/unit-1'))
+        .flush(replayAssets, {
+          headers: { 'Cache-Control': 'private, max-age=1' }
+        });
+    });
+
+    it('should not retain assets when browser caching is disabled', () => {
+      service.getReplayAssets(1, 'unit-1').subscribe();
+      httpMock.expectOne(request => request.url.includes('/replay-assets/unit-1'))
+        .flush(replayAssets, {
+          headers: { 'Cache-Control': 'no-store' }
+        });
+
+      service.getReplayAssets(1, 'unit-1').subscribe();
+      httpMock.expectOne(request => request.url.includes('/replay-assets/unit-1'))
+        .flush(replayAssets, {
+          headers: { 'Cache-Control': 'private, max-age=0' }
+        });
+    });
+
+    it('should evict failed asset requests', () => {
+      service.getReplayAssets(1, 'unit-1').subscribe({ error: () => undefined });
+      httpMock.expectOne(request => request.url.includes('/replay-assets/unit-1'))
+        .flush('failed', { status: 500, statusText: 'Server Error' });
+
+      service.getReplayAssets(1, 'unit-1').subscribe();
+      httpMock.expectOne(request => request.url.includes('/replay-assets/unit-1'))
+        .flush(replayAssets, {
+          headers: { 'Cache-Control': 'private, max-age=300' }
+        });
+    });
+
+    it('should abort and evict an asset request that exceeds the in-flight timeout', () => {
+      jest.useFakeTimers();
+      const errorHandler = jest.fn();
+
+      service.getReplayAssets(1, 'unit-1').subscribe({ error: errorHandler });
+      const timedOutRequest = httpMock.expectOne(
+        request => request.url.includes('/replay-assets/unit-1')
+      );
+
+      jest.advanceTimersByTime(120_001);
+
+      expect(timedOutRequest.cancelled).toBe(true);
+      expect(errorHandler).toHaveBeenCalledTimes(1);
+
+      service.getReplayAssets(1, 'unit-1').subscribe();
+      httpMock.expectOne(request => request.url.includes('/replay-assets/unit-1'))
+        .flush(replayAssets, {
+          headers: { 'Cache-Control': 'no-store' }
+        });
     });
   });
 

--- a/apps/frontend/src/app/replay/services/replay-backend.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-backend.service.ts
@@ -1,9 +1,15 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable, forkJoin, map } from 'rxjs';
+import {
+  Observable, catchError, forkJoin, map, shareReplay, throwError, timeout
+} from 'rxjs';
+import Keycloak from 'keycloak-js';
 import { SERVER_URL } from '../../injection-tokens';
 import { FilesDto } from '../../../../../../api-dto/files/files.dto';
 import { suppressGlobalAndAuthRedirectHttpErrorContext } from '../../core/interceptors/http-error-context';
+import { CodingScheme } from '../../models/coding-interfaces';
+
+const REPLAY_ASSETS_REQUEST_TIMEOUT_MS = 120_000;
 
 export type ReplayUnitResponse = {
   responses: {
@@ -37,6 +43,7 @@ export type ReplayResponsePayload = {
 };
 
 export type ReplayPayload = ReplayAssetsPayload & ReplayResponsePayload & {
+  codingScheme?: CodingScheme | null;
   serverTimings?: ReplayServerTimings;
 };
 
@@ -63,12 +70,26 @@ export type ReplaySourceSummaryResponse = {
   total: number;
 };
 
+type ReplayAssetsCacheEntry = {
+  identity: object;
+  request$: Observable<ReplayAssetsCacheValue>;
+  expiresAt: number | null;
+  expirationTimer: ReturnType<typeof setTimeout> | null;
+};
+
+type ReplayAssetsCacheValue = {
+  assets: ReplayAssetsPayload;
+  getCodingScheme: () => CodingScheme | null | undefined;
+};
+
 @Injectable({
   providedIn: 'root'
 })
 export class ReplayBackendService {
   private readonly serverUrl = inject(SERVER_URL);
   private http = inject(HttpClient);
+  private readonly keycloak = inject(Keycloak, { optional: true });
+  private readonly replayAssetsCache = new Map<string, ReplayAssetsCacheEntry>();
 
   private get authHeader() {
     return {};
@@ -104,14 +125,18 @@ export class ReplayBackendService {
     workspaceId: number,
     testPerson: string,
     unitId: string,
-    authToken?: string
+    authToken?: string,
+    includeCodingScheme = false
   ): Observable<ReplayPayload> {
     return forkJoin({
-      assets: this.getReplayAssets(workspaceId, unitId, authToken),
+      assetsEntry: this.getReplayAssetsCacheValue(workspaceId, unitId, authToken),
       responsePayload: this.getReplayResponse(workspaceId, testPerson, unitId, authToken)
     }).pipe(
-      map(({ assets, responsePayload }) => ({
-        ...assets,
+      map(({ assetsEntry, responsePayload }) => ({
+        ...assetsEntry.assets,
+        ...(includeCodingScheme ?
+          { codingScheme: assetsEntry.getCodingScheme() } :
+          {}),
         response: responsePayload.response,
         serverTimings: this.prefixServerTimings(
           'response',
@@ -142,12 +167,127 @@ export class ReplayBackendService {
     unitId: string,
     authToken?: string
   ): Observable<ReplayAssetsPayload> {
+    return this.getReplayAssetsCacheValue(workspaceId, unitId, authToken)
+      .pipe(map(entry => entry.assets));
+  }
+
+  private getReplayAssetsCacheValue(
+    workspaceId: number,
+    unitId: string,
+    authToken?: string
+  ): Observable<ReplayAssetsCacheValue> {
+    const now = Date.now();
+    this.removeExpiredReplayAssets(now);
+    const authContext = authToken ??
+      this.keycloak?.tokenParsed?.sub ??
+      this.keycloak?.idTokenParsed?.sub ??
+      null;
+    const cacheKey = JSON.stringify([workspaceId, unitId, authContext]);
+    const cached = this.replayAssetsCache.get(cacheKey);
+    if (cached && (cached.expiresAt === null || cached.expiresAt > now)) {
+      return cached.request$;
+    }
+
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/replay-assets/${encodeURIComponent(unitId)}`;
     const headers = authToken ?
       { Authorization: `Bearer ${authToken}` } :
       this.authHeader;
     const params = new HttpParams().set('replayPart', 'assets');
-    return this.http.get<ReplayAssetsPayload>(url, { headers, params });
+    const identity = {};
+    const request$ = this.http.get<ReplayAssetsPayload>(url, {
+      headers,
+      params,
+      observe: 'response'
+    }).pipe(
+      timeout({ first: REPLAY_ASSETS_REQUEST_TIMEOUT_MS }),
+      map(response => {
+        const maxAgeSeconds = ReplayBackendService.getCacheMaxAgeSeconds(
+          response.headers.get('Cache-Control')
+        );
+        const current = this.replayAssetsCache.get(cacheKey);
+        if (current?.identity === identity) {
+          if (maxAgeSeconds > 0) {
+            current.expiresAt = Date.now() + maxAgeSeconds * 1000;
+            current.expirationTimer = setTimeout(() => {
+              this.deleteReplayAssetsCacheEntry(cacheKey, identity);
+            }, maxAgeSeconds * 1000);
+          } else {
+            this.deleteReplayAssetsCacheEntry(cacheKey, identity);
+          }
+        }
+        if (!response.body) {
+          throw new Error('Replay assets response body is empty.');
+        }
+        return ReplayBackendService.createAssetsCacheValue(response.body);
+      }),
+      catchError(error => {
+        this.deleteReplayAssetsCacheEntry(cacheKey, identity);
+        return throwError(() => error);
+      }),
+      shareReplay({ bufferSize: 1, refCount: false })
+    );
+
+    this.replayAssetsCache.set(cacheKey, {
+      identity,
+      request$,
+      expiresAt: null,
+      expirationTimer: null
+    });
+    return request$;
+  }
+
+  private removeExpiredReplayAssets(now: number): void {
+    this.replayAssetsCache.forEach((entry, key) => {
+      if (entry.expiresAt !== null && entry.expiresAt <= now) {
+        this.deleteReplayAssetsCacheEntry(key, entry.identity);
+      }
+    });
+  }
+
+  private deleteReplayAssetsCacheEntry(key: string, identity: object): void {
+    const entry = this.replayAssetsCache.get(key);
+    if (entry?.identity !== identity) {
+      return;
+    }
+    if (entry.expirationTimer !== null) {
+      clearTimeout(entry.expirationTimer);
+    }
+    this.replayAssetsCache.delete(key);
+  }
+
+  private static getCacheMaxAgeSeconds(cacheControl: string | null): number {
+    if (!cacheControl || /(?:^|,)\s*(?:no-store|no-cache)\s*(?:,|$)/i.test(cacheControl)) {
+      return 0;
+    }
+    const maxAgeMatch = cacheControl.match(/(?:^|,)\s*max-age\s*=\s*(\d+)\s*(?:,|$)/i);
+    return maxAgeMatch ? Number(maxAgeMatch[1]) : 0;
+  }
+
+  private static parseCodingScheme(vocs: FilesDto[]): CodingScheme | null | undefined {
+    const vocsData = vocs[0]?.data;
+    if (!vocsData) {
+      return undefined;
+    }
+    try {
+      return JSON.parse(vocsData) as CodingScheme;
+    } catch {
+      return null;
+    }
+  }
+
+  private static createAssetsCacheValue(assets: ReplayAssetsPayload): ReplayAssetsCacheValue {
+    let codingSchemeParsed = false;
+    let codingScheme: CodingScheme | null | undefined;
+    return {
+      assets,
+      getCodingScheme: () => {
+        if (!codingSchemeParsed) {
+          codingScheme = ReplayBackendService.parseCodingScheme(assets.vocs);
+          codingSchemeParsed = true;
+        }
+        return codingScheme;
+      }
+    };
   }
 
   getReplayResponse(

--- a/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
@@ -5,6 +5,7 @@ import { of, Subject, throwError } from 'rxjs';
 import { CodingJobBackendService } from '../../coding/services/coding-job-backend.service';
 import { ReplayCodingService } from './replay-coding.service';
 import { CodingJob } from '../../coding/models/coding-job.model';
+import { CodingScheme } from '../../models/coding-interfaces';
 
 describe('ReplayCodingService', () => {
   let service: ReplayCodingService;
@@ -49,6 +50,40 @@ describe('ReplayCodingService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should reuse consecutively parsed standalone VOCS data', () => {
+    const vocsData = JSON.stringify({
+      id: 'scheme-1',
+      label: 'Scheme',
+      variableCodings: []
+    });
+
+    service.setCodingSchemeFromVocsData(vocsData);
+    const parsedCodingScheme = service.codingScheme;
+    service.setCodingSchemeFromVocsData(vocsData);
+
+    expect(service.codingScheme).toBe(parsedCodingScheme);
+
+    service.resetCodingData();
+    service.setCodingSchemeFromVocsData(vocsData);
+    expect(service.codingScheme).not.toBe(parsedCodingScheme);
+  });
+
+  it('should accept an asset-cache coding scheme without parsing its raw source', () => {
+    const parsedCodingScheme: CodingScheme = {
+      version: '1.0',
+      variableCodings: []
+    };
+    const parseSpy = jest.spyOn(JSON, 'parse');
+
+    service.setParsedCodingScheme(
+      parsedCodingScheme,
+      '{"version":"1.0","variableCodings":[]}'
+    );
+
+    expect(service.codingScheme).toBe(parsedCodingScheme);
+    expect(parseSpy).not.toHaveBeenCalled();
   });
 
   describe('updateCodingJobStatus', () => {

--- a/apps/frontend/src/app/replay/services/replay-coding.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.ts
@@ -71,6 +71,7 @@ export class ReplayCodingService {
   private latestRequestedSelectionByKey = new Map<string, SavedCode | null>();
   private selectionRevision = 0;
   private codingDataRunId = 0;
+  private codingSchemeSource: string | null = null;
   currentCodingJobStatus: string | null = null;
   showScore = false;
   allowComments = true;
@@ -82,6 +83,7 @@ export class ReplayCodingService {
   resetCodingData() {
     this.codingDataRunId += 1;
     this.codingScheme = null;
+    this.codingSchemeSource = null;
     this.currentVariableId = '';
     this.codingJobId = null;
     this.authToken = undefined;
@@ -262,11 +264,20 @@ export class ReplayCodingService {
   }
 
   setCodingSchemeFromVocsData(vocsData: string) {
+    if (this.codingSchemeSource === vocsData) {
+      return;
+    }
+    this.codingSchemeSource = vocsData;
     try {
       this.codingScheme = JSON.parse(vocsData);
     } catch (error) {
       this.codingScheme = null;
     }
+  }
+
+  setParsedCodingScheme(codingScheme: CodingScheme | null, source?: string): void {
+    this.codingScheme = codingScheme;
+    this.codingSchemeSource = source ?? null;
   }
 
   setCodingJobMetadata(codingJob: {


### PR DESCRIPTION
## Summary

- cache replay assets per workspace, unit, and authentication context
- coalesce parallel asset requests and honor `Cache-Control: max-age`
- avoid caching failed requests and responses with disabled caching
- cancel stale replay response requests during rapid case changes while keeping the latest-result guard
- parse unchanged VOCS at most once per asset-cache entry without changing raw assets

## Root cause

Replay assets were fetched again for every coding case, including repeated cases using the same unit. Rapid case changes left obsolete response requests running, while repeated VOCS parsing added avoidable client-side work.

## Impact

After the first case of a unit, subsequent people using the same unit request only `/replay-response` while the asset cache entry is valid. Obsolete response requests are aborted, and cached assets remain byte-for-byte unchanged when passed to the player.

## Validation

- `npx nx lint frontend`
- `npx nx test frontend --runInBand` — 194 suites, 1,875 tests
- `npx nx build frontend`
- `git diff --check`

## Relationship

Built on #916.

Related to #917. The issue intentionally remains open for deployment and browser verification.

