### PR TITLE
Antwortwerthäufigkeiten korrekt skalieren

### DIFF
--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -1755,6 +1755,40 @@ describe('WorkspaceTestResultsService', () => {
     });
   });
 
+  describe('findFlatResponseFrequencies', () => {
+    it('should return response-value frequencies as proportions', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getRawMany
+        .mockResolvedValueOnce([{
+          unitKey: 'Unit A',
+          variableId: 'variable-1',
+          total: '10'
+        }])
+        .mockResolvedValueOnce([{
+          unitKey: 'Unit A',
+          variableId: 'variable-1',
+          value: 'answer-a',
+          count: '2'
+        }]);
+
+      const result = await service.findFlatResponseFrequencies(1, [{
+        unitKey: 'Unit A',
+        variableId: 'variable-1',
+        values: ['answer-a']
+      }]);
+
+      expect(result['Unit%20A:variable-1']).toEqual({
+        total: 10,
+        values: [{
+          value: 'answer-a',
+          count: 2,
+          p: 0.2
+        }]
+      });
+    });
+  });
+
   describe('findLogAnomaliesForBooklets', () => {
     const thresholds = {
       longLoadingThresholdMs: 5000,

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -3580,7 +3580,7 @@ export class WorkspaceTestResultsService {
         return {
           value: v,
           count,
-          p: total > 0 ? (count / total) * 100 : 0
+          p: total > 0 ? count / total : 0
         };
       });
       result[key] = { total, values: rows };

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.html
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.html
@@ -294,7 +294,13 @@
           </ng-container>
 
           <ng-container matColumnDef="frequencies">
-            <th mat-header-cell *matHeaderCellDef>Lösungshäufigkeiten</th>
+            <th
+              mat-header-cell
+              *matHeaderCellDef
+              [matTooltip]="'test-results-page.flat-table.response-frequency-tooltip' | translate"
+            >
+              {{ 'test-results-page.flat-table.response-frequency-column' | translate }}
+            </th>
             <td mat-cell *matCellDef="let row" [matTooltip]="getFrequencySummary(row)">
               {{ getFrequencySummary(row) }}
             </td>

--- a/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.spec.ts
+++ b/apps/frontend/src/app/ws-admin/components/test-results/test-results-flat-table.component.spec.ts
@@ -109,6 +109,31 @@ describe('TestResultsFlatTableComponent', () => {
     fixture.destroy();
   });
 
+  it('should display response-value frequencies as proportions', () => {
+    const frequencyState = component as unknown as {
+      frequenciesByComboKey: Map<string, {
+        total: number;
+        values: Array<{ value: string; count: number; p: number }>;
+      }>;
+    };
+    frequencyState.frequenciesByComboKey.set('Unit%20A:variable-1', {
+      total: 10,
+      values: [{
+        value: 'answer-a',
+        count: 2,
+        p: 0.2
+      }]
+    });
+
+    const summary = component.getFrequencySummary({
+      unit: 'Unit A',
+      response: 'variable-1',
+      responseValue: 'answer-a'
+    } as Parameters<TestResultsFlatTableComponent['getFrequencySummary']>[0]);
+
+    expect(summary).toBe('p=.200 (n=2)');
+  });
+
   it('should not include row log anomalies when the dashboard force is disabled by workspace setting', () => {
     component.forceShowLogAnomalies = true;
     component.ngOnChanges({

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -2225,6 +2225,10 @@
       "manual-title": "Kodierstatus wird manuell aktualisiert",
       "manual-text": "Automatische Statusprüfungen sind für diesen Arbeitsbereich deaktiviert. Aktualisieren Sie den Kodierstatus in der Kodierungsverwaltung bei Bedarf manuell.",
       "refresh": "Kodierstatus aktualisieren"
+    },
+    "flat-table": {
+      "response-frequency-column": "Antwortwerthäufigkeit",
+      "response-frequency-tooltip": "Aggregierte Häufigkeit dieses Antwortwerts über alle berücksichtigten Fälle. Der Wert wird in jeder passenden Fallzeile wiederholt."
     }
   },
   "coding-variables-dialog": {


### PR DESCRIPTION
## Änderung

- Relative Antwortwerthäufigkeiten werden im Backend als Anteil zwischen 0 und 1 zurückgegeben.
- Die Spalte in der fallweisen Testergebnistabelle heißt nun „Antwortwerthäufigkeit“.
- Ein Tooltip erläutert, dass der Wert über alle berücksichtigten Fälle aggregiert und in passenden Fallzeilen wiederholt wird.
- Backend- und Frontend-Regressionstests decken die Skalierung ab.

## Ursache

Das Backend multiplizierte `count / total` mit 100, während das Frontend einen Anteil zwischen 0 und 1 erwartete und größere Werte auf 1 begrenzte. Dadurch wurde bereits ab einem Anteil von einem Prozent häufig `p=1.000` angezeigt.

## Auswirkung

Beispielsweise wird eine Häufigkeit von 2 aus 10 Fällen nun korrekt als `p=.200 (n=2)` dargestellt.

## Validierung

- `npx nx lint backend`
- `npx nx test backend --runInBand` — 2.070 Tests bestanden
- `npx nx lint frontend`
- `npx nx test frontend --runInBand` — 1.866 Tests bestanden
- `git diff --check`

Related to #184
