### PR TITLE
Fix autocoder alias collisions

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
@@ -1120,6 +1120,252 @@ describe('CodingProcessService', () => {
         );
     });
 
+    it('prefers exact DHB003 aliases over colliding technical variable IDs', () => {
+      const response02 = createMockResponse(10, 1, '02');
+      const response04 = createMockResponse(20, 1, '04');
+      const response03 = createMockResponse(30, 1, '03');
+      const response05 = createMockResponse(40, 1, '05');
+      const generatedTechnical04 = createMockResponse(50, 1, '04');
+      generatedTechnical04.is_autocoder_generated = true;
+      const generatedTechnical05 = createMockResponse(60, 1, '05');
+      generatedTechnical05.is_autocoder_generated = true;
+      const technicalIdFallbackByAlias = new Map([
+        ['02', '04'],
+        ['04', '07'],
+        ['03', '05'],
+        ['05', '09']
+      ]);
+      const resolveResponse = (
+        service as unknown as {
+          findExistingResponseForAutocoderResult: (
+            responses: ResponseEntity[],
+            codedResultId: string,
+            codedSubform: string,
+            technicalIdFallbackByAlias: Map<string, string>
+          ) => ResponseEntity | undefined;
+        }
+      ).findExistingResponseForAutocoderResult.bind(service);
+      const responses = [
+        response02,
+        response04,
+        response03,
+        response05,
+        generatedTechnical04,
+        generatedTechnical05
+      ];
+
+      expect(resolveResponse(responses, '02', '', technicalIdFallbackByAlias))
+        .toBe(response02);
+      expect(resolveResponse(responses, '04', '', technicalIdFallbackByAlias))
+        .toBe(response04);
+      expect(resolveResponse(responses, '03', '', technicalIdFallbackByAlias))
+        .toBe(response03);
+      expect(resolveResponse(responses, '05', '', technicalIdFallbackByAlias))
+        .toBe(response05);
+    });
+
+    it('limits the technical-ID fallback to legacy generated responses', () => {
+      const importedTechnicalIdCollision = createMockResponse(
+        20,
+        1,
+        'TECHNICAL_04'
+      );
+      const legacyGeneratedResponse = createMockResponse(
+        30,
+        1,
+        'TECHNICAL_04'
+      );
+      legacyGeneratedResponse.is_autocoder_generated = true;
+      const technicalIdFallbackByAlias = new Map([
+        ['02', 'TECHNICAL_04']
+      ]);
+      const resolveResponse = (
+        service as unknown as {
+          findExistingResponseForAutocoderResult: (
+            responses: ResponseEntity[],
+            codedResultId: string,
+            codedSubform: string,
+            technicalIdFallbackByAlias: Map<string, string>
+          ) => ResponseEntity | undefined;
+        }
+      ).findExistingResponseForAutocoderResult.bind(service);
+
+      expect(resolveResponse(
+        [importedTechnicalIdCollision],
+        '02',
+        '',
+        technicalIdFallbackByAlias
+      )).toBeUndefined();
+      expect(resolveResponse(
+        [importedTechnicalIdCollision, legacyGeneratedResponse],
+        '02',
+        '',
+        technicalIdFallbackByAlias
+      )).toBe(legacyGeneratedResponse);
+    });
+
+    it('excludes technical IDs that are also another output alias', () => {
+      const serviceInternals = service as unknown as {
+        createUnambiguousTechnicalIdFallbacks: (
+          variableCodings: Array<{ id: string; alias?: string }>
+        ) => Map<string, string>;
+        findExistingResponseForAutocoderResult: (
+          responses: ResponseEntity[],
+          codedResultId: string,
+          codedSubform: string,
+          technicalIdFallbackByAlias: Map<string, string>
+        ) => ResponseEntity | undefined;
+      };
+      const technicalIdFallbackByAlias =
+        serviceInternals.createUnambiguousTechnicalIdFallbacks([
+          { id: '04', alias: '02' },
+          { id: '07', alias: '04' },
+          { id: '05', alias: '03' },
+          { id: '09', alias: '05' }
+        ]);
+      const generated04 = createMockResponse(50, 1, '04');
+      generated04.is_autocoder_generated = true;
+
+      expect(Array.from(technicalIdFallbackByAlias.entries())).toEqual([
+        ['04', '07'],
+        ['05', '09']
+      ]);
+      expect(serviceInternals.findExistingResponseForAutocoderResult(
+        [generated04],
+        '02',
+        '',
+        technicalIdFallbackByAlias
+      )).toBeUndefined();
+    });
+
+    it('routes all DHB003 aliases correctly through response processing', async () => {
+      const dhbResponses = [
+        createMockResponse(10, 1, '02'),
+        createMockResponse(20, 1, '04'),
+        createMockResponse(40, 1, '05')
+      ];
+      const dhbVariableCodings = [
+        { id: '04', alias: '02' },
+        { id: '07', alias: '04' },
+        { id: '05', alias: '03' },
+        { id: '09', alias: '05' }
+      ];
+      (Autocoder.CodingSchemeFactory.code as jest.Mock).mockReturnValueOnce([
+        {
+          id: '02',
+          value: 'response 02',
+          status: 'CODING_COMPLETE',
+          code: 102,
+          score: 1,
+          subform: ''
+        },
+        {
+          id: '04',
+          value: 'response 04',
+          status: 'CODING_COMPLETE',
+          code: 104,
+          score: 1,
+          subform: ''
+        },
+        {
+          id: '03',
+          value: 'derived 03',
+          status: 'CODING_COMPLETE',
+          code: 103,
+          score: 1,
+          subform: ''
+        },
+        {
+          id: '05',
+          value: 'response 05',
+          status: 'CODING_COMPLETE',
+          code: 105,
+          score: 1,
+          subform: ''
+        }
+      ]);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([
+          ['TEST_UNIT_1', new Set(['02', '04', '05'])]
+        ])
+      );
+      mockQueryBuilder.getMany
+        .mockResolvedValueOnce([mockUnits[0]])
+        .mockResolvedValueOnce(dhbResponses);
+      (fileUploadRepository.find as jest.Mock)
+        .mockReset()
+        .mockResolvedValueOnce([
+          createMockFileUpload(
+            'ALIAS_1',
+            '<xml><codingSchemeRef>TEST-SCHEME-REF</codingSchemeRef></xml>'
+          )
+        ])
+        .mockResolvedValueOnce([
+          createMockFileUpload(
+            'TEST-SCHEME-REF',
+            JSON.stringify({
+              version: '3.4',
+              variableCodings: dhbVariableCodings
+            })
+          )
+        ]);
+
+      await service.processTestPersonsBatch(workspaceId, ['1'], 1);
+
+      const codedResponses =
+        mockResponseManagementService.updateResponsesInDatabase
+          .mock.calls[0][1];
+      expect(codedResponses).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: 10, code_v1: 102 }),
+        expect.objectContaining({ id: 20, code_v1: 104 }),
+        expect.objectContaining({
+          id: -1,
+          isNew: true,
+          variableid: '03',
+          code_v1: 103
+        }),
+        expect.objectContaining({ id: 40, code_v1: 105 })
+      ]));
+      expect(codedResponses).toHaveLength(4);
+    });
+
+    it('rejects multiple autocoder results for the same persistence target', () => {
+      const assertUniqueTargets = (
+        service as unknown as {
+          assertUniqueAutocoderPersistenceTargets: (
+            responses: Array<{
+              id: number;
+              isNew?: boolean;
+              unitid?: number;
+              variableid?: string;
+              subform?: string;
+            }>
+          ) => void;
+        }
+      ).assertUniqueAutocoderPersistenceTargets.bind(service);
+
+      expect(() => assertUniqueTargets([
+        { id: 10 },
+        { id: 10 }
+      ])).toThrow('Autocoder produced multiple updates for response:10');
+      expect(() => assertUniqueTargets([
+        {
+          id: -1,
+          isNew: true,
+          unitid: 1,
+          variableid: '03',
+          subform: ''
+        },
+        {
+          id: -1,
+          isNew: true,
+          unitid: 1,
+          variableid: '03',
+          subform: ''
+        }
+      ])).toThrow('Autocoder produced multiple updates for generated:1:03:');
+    });
+
     it('should call progress callback at appropriate intervals', async () => {
       mockQueryBuilder.getMany
         .mockResolvedValueOnce(mockUnits)

--- a/apps/backend/src/app/database/services/coding/coding-process.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.ts
@@ -942,16 +942,10 @@ export class CodingProcessService {
           fileIdToCodingSchemeMap.get(codingSchemeRef) || emptyScheme :
           emptyScheme;
 
-        const variableAliasToIdMap = new Map<string, string>();
-        if (Array.isArray(scheme.variableCodings)) {
-          scheme.variableCodings.forEach((vc: VariableCodingData) => {
-            const key = (vc.alias ?? vc.id) as string | undefined;
-            const value = vc.id as string | undefined;
-            if (key && value) {
-              variableAliasToIdMap.set(key, value);
-            }
-          });
-        }
+        const technicalIdFallbackByAlias =
+          this.createUnambiguousTechnicalIdFallbacks(
+            scheme.variableCodings || []
+          );
 
         const inputResponses = responses.map(response => {
           let inputStatus = response.status;
@@ -994,27 +988,13 @@ export class CodingProcessService {
           }
           statistics.statusCounts[codedStatus] += 1;
 
-          const mappedIdFromAlias = variableAliasToIdMap.get(codedResult.id);
-          const possibleVariableIds = new Set<string>([codedResult.id]);
-          if (mappedIdFromAlias) {
-            possibleVariableIds.add(mappedIdFromAlias);
-          }
-          const possibleVariableIdsNormalized = new Set(
-            Array.from(possibleVariableIds).map(v => String(v).toUpperCase())
-          );
           const codedSubform = codedResult.subform || '';
-
-          // Prefer updates for the same variable + subform to avoid generating
-          // duplicates on repeated autocoder runs (especially for derived vars).
-          const matchingResponses = responses
-            .filter(
-              r => possibleVariableIdsNormalized.has(
-                String(r.variableid).toUpperCase()
-              ) &&
-                String(r.subform || '') === codedSubform
-            )
-            .sort((a, b) => b.id - a.id);
-          const existingResponse = matchingResponses[0];
+          const existingResponse = this.findExistingResponseForAutocoderResult(
+            responses,
+            codedResult.id,
+            codedSubform,
+            technicalIdFallbackByAlias
+          );
 
           const codedResponse: CodedResponse = {
             id: existingResponse ? existingResponse.id : -1
@@ -1067,12 +1047,130 @@ export class CodingProcessService {
     }
 
     allCodedResponses.length = responseIndex;
+    this.assertUniqueAutocoderPersistenceTargets(allCodedResponses);
 
     if (progressCallback) {
       progressCallback(95);
     }
 
     return { allCodedResponses, statistics };
+  }
+
+  private createUnambiguousTechnicalIdFallbacks(
+    variableCodings: VariableCodingData[]
+  ): Map<string, string> {
+    const outputVariableIds = new Set(
+      variableCodings
+        .map(coding => this.normalizeVariableId(coding.alias || coding.id))
+        .filter(Boolean)
+    );
+    const technicalIdFallbackByAlias = new Map<string, string>();
+
+    variableCodings.forEach(coding => {
+      const alias = coding.alias || coding.id;
+      const technicalId = coding.id;
+      if (!alias || !technicalId) {
+        return;
+      }
+
+      const normalizedAlias = this.normalizeVariableId(alias);
+      const normalizedTechnicalId = this.normalizeVariableId(technicalId);
+
+      // A technical ID that is also another coding's output alias is
+      // ambiguous and must never be used as a compatibility fallback.
+      if (
+        normalizedAlias === normalizedTechnicalId ||
+        outputVariableIds.has(normalizedTechnicalId)
+      ) {
+        return;
+      }
+
+      technicalIdFallbackByAlias.set(normalizedAlias, technicalId);
+    });
+
+    return technicalIdFallbackByAlias;
+  }
+
+  private findExistingResponseForAutocoderResult(
+    responses: ResponseEntity[],
+    codedResultId: string,
+    codedSubform: string,
+    technicalIdFallbackByAlias: Map<string, string>
+  ): ResponseEntity | undefined {
+    const normalizedResultId = this.normalizeVariableId(codedResultId);
+    const hasMatchingSubform = (response: ResponseEntity) => (
+      String(response.subform || '') === codedSubform
+    );
+    const newestResponse = (matchingResponses: ResponseEntity[]) => (
+      matchingResponses.sort((a, b) => b.id - a.id)[0]
+    );
+
+    // Test-result response IDs use the variable alias. An exact alias match
+    // must win even when that alias is also another variable's technical ID.
+    const exactAliasMatch = responses
+      .filter(response => (
+        this.normalizeVariableId(response.variableid) === normalizedResultId &&
+        hasMatchingSubform(response)
+      ))
+      .sort((a, b) => (
+        Number(a.is_autocoder_generated) -
+          Number(b.is_autocoder_generated) ||
+        b.id - a.id
+      ))[0];
+    if (exactAliasMatch) {
+      return exactAliasMatch;
+    }
+
+    const mappedTechnicalId = technicalIdFallbackByAlias.get(
+      normalizedResultId
+    );
+    if (
+      !mappedTechnicalId ||
+      this.normalizeVariableId(mappedTechnicalId) === normalizedResultId
+    ) {
+      return undefined;
+    }
+
+    // Older runs may have persisted generated derived responses under the
+    // technical ID. Keep that compatibility fallback strictly limited to
+    // generated rows so an imported response with a colliding alias can never
+    // receive another variable's result.
+    return newestResponse(
+      responses.filter(response => (
+        response.is_autocoder_generated === true &&
+        this.normalizeVariableId(response.variableid) ===
+          this.normalizeVariableId(mappedTechnicalId) &&
+        hasMatchingSubform(response)
+      ))
+    );
+  }
+
+  private assertUniqueAutocoderPersistenceTargets(
+    codedResponses: CodedResponse[]
+  ): void {
+    const targetIndexes = new Map<string, number>();
+
+    codedResponses.forEach((response, index) => {
+      const target = response.isNew ?
+        `generated:${response.unitid}:${this.normalizeVariableId(
+          response.variableid
+        )}:${String(response.subform || '')}` :
+        `response:${response.id}`;
+      const previousIndex = targetIndexes.get(target);
+
+      if (previousIndex !== undefined) {
+        throw new Error(
+          `Autocoder produced multiple updates for ${target} ` +
+          `(results ${previousIndex + 1} and ${index + 1}).`
+        );
+      }
+
+      targetIndexes.set(target, index);
+    });
+  }
+
+  private normalizeVariableId(variableId: unknown): string {
+    return String(variableId ?? '').toUpperCase();
   }
 
   private async getCodingSchemeFiles(


### PR DESCRIPTION
## Summary

- prioritize exact variable aliases when autocoder output IDs overlap technical IDs
- restrict technical-ID compatibility fallbacks to unambiguous generated legacy responses
- reject duplicate persistence targets before database updates
- add DHB003 regression coverage for variables 02–05

## Root cause

Autocoder output aliases and technical variable IDs were combined into one candidate set and the newest matching response row won. For DHB003, overlapping IDs caused results for variables 02 and 03 to be written to variables 04 and 05.

## Impact

Autocoder results are now persisted to the exact aliased response. Derived outputs remain separate, while unambiguous legacy generated rows continue to be supported.

## Validation

- Targeted backend service tests: 36 passed
- Full backend tests: 152 suites and 2242 tests passed
- Backend lint passed
- Backend build passed

Fixes #803