### PR TITLE
Prepare hotfix 1.16.6 for autocoder alias collisions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ stages:
   - scan-dependencies
   - build-images
   - scan-images
+  - publish-images
 
 image: ${DOCKER_HUB_PROXY}${BASE_IMAGE}
 

--- a/.gitlab-ci/Branch&PreRelease-Pipelines.gitlab-ci.yml
+++ b/.gitlab-ci/Branch&PreRelease-Pipelines.gitlab-ci.yml
@@ -965,9 +965,18 @@ scan-develop-commit-traefik-image:
 
 
 build-pre-release:
-  stage: build-images
+  stage: publish-images
   rules:
     - !reference [ .pre-release_rules, rules ]
+  needs:
+    - job: scan-main-commit-db-image
+      artifacts: false
+    - job: scan-main-commit-liquibase-image
+      artifacts: false
+    - job: scan-main-commit-backend-image
+      artifacts: false
+    - job: scan-main-commit-frontend-image
+      artifacts: false
   image: ${DOCKER_IMAGE}
   services:
     - name: ${DOCKER_SERVICE}

--- a/.gitlab-ci/Release-Pipelines.gitlab-ci.yml
+++ b/.gitlab-ci/Release-Pipelines.gitlab-ci.yml
@@ -23,6 +23,29 @@
     - if: $CI_COMMIT_TAG
       when: never
 
+.production_image_rules:
+  rules:
+    - if: "$CI_COMMIT_TAG =~ $PRERELEASE_RULES_REGEX"
+    - if: "$CI_COMMIT_TAG =~ $RELEASE_RULES_REGEX"
+    - if: $CI_COMMIT_BRANCH &&
+        $CI_COMMIT_BRANCH == "main" &&
+        $CI_PIPELINE_SOURCE != "external_pull_request_event"
+    - if: $CI_COMMIT_TAG
+      when: never
+
+.production_image_scan_rules:
+  rules:
+    - if: "$CI_COMMIT_TAG =~ $PRERELEASE_RULES_REGEX"
+      allow_failure: false
+    - if: "$CI_COMMIT_TAG =~ $RELEASE_RULES_REGEX"
+      allow_failure: false
+    - if: $CI_COMMIT_BRANCH &&
+        $CI_COMMIT_BRANCH == "main" &&
+        $CI_PIPELINE_SOURCE != "external_pull_request_event"
+      allow_failure: true
+    - if: $CI_COMMIT_TAG
+      when: never
+
 .release_rules:
   rules:
     - if: "$CI_COMMIT_TAG =~ $RELEASE_RULES_REGEX"
@@ -102,6 +125,20 @@ check-release-rules:
     - if [[ ${CI_COMMIT_TAG} =~ ${RELEASE_SCRIPT_REGEX} ]];
       then echo "${CI_COMMIT_TAG} is a valid release tag.";
       else echo "${CI_COMMIT_TAG} is not a valid release tag!"; fi
+
+check-release-version:
+  stage: .pre
+  rules:
+    - if: "$CI_COMMIT_TAG =~ $PRERELEASE_RULES_REGEX"
+    - if: "$CI_COMMIT_TAG =~ $RELEASE_RULES_REGEX"
+  script:
+    - RELEASE_VERSION="${CI_COMMIT_TAG%%-*}"
+    - PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+    - LOCK_VERSION="$(node -p "require('./package-lock.json').version")"
+    - LOCK_ROOT_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
+    - test "${RELEASE_VERSION}" = "${PACKAGE_VERSION}"
+    - test "${RELEASE_VERSION}" = "${LOCK_VERSION}"
+    - test "${RELEASE_VERSION}" = "${LOCK_ROOT_VERSION}"
 
 build-main-pr-base-image:
   stage: build
@@ -659,7 +696,7 @@ audit-main-pr-frontend:
 build-main-commit-db-image:
   stage: build-images
   rules:
-    - !reference [ .main_commit_rules, rules ]
+    - !reference [ .production_image_rules, rules ]
   image: ${DOCKER_IMAGE}
   services:
     - name: ${DOCKER_SERVICE}
@@ -694,7 +731,7 @@ build-main-commit-db-image:
 build-main-commit-liquibase-image:
   stage: build-images
   rules:
-    - !reference [ .main_commit_rules, rules ]
+    - !reference [ .production_image_rules, rules ]
   image: ${DOCKER_IMAGE}
   services:
     - name: ${DOCKER_SERVICE}
@@ -729,7 +766,7 @@ build-main-commit-liquibase-image:
 build-main-commit-base-image:
   stage: build-images
   rules:
-    - !reference [ .main_commit_rules, rules ]
+    - !reference [ .production_image_rules, rules ]
   image: ${DOCKER_IMAGE}
   services:
     - name: ${DOCKER_SERVICE}
@@ -764,7 +801,7 @@ build-main-commit-base-image:
 build-main-commit-backend-image:
   stage: build-images
   rules:
-    - !reference [ .main_commit_rules, rules ]
+    - !reference [ .production_image_rules, rules ]
   needs:
     - build-main-commit-base-image
   image: ${DOCKER_IMAGE}
@@ -805,7 +842,7 @@ build-main-commit-backend-image:
 build-main-commit-frontend-image:
   stage: build-images
   rules:
-    - !reference [ .main_commit_rules, rules ]
+    - !reference [ .production_image_rules, rules ]
   needs:
     - build-main-commit-base-image
   image: ${DOCKER_IMAGE}
@@ -834,7 +871,7 @@ build-main-commit-frontend-image:
           --build-arg REGISTRY_PATH=${DOCKER_HUB_PROXY}
           --build-arg BASE_IMAGE_NAME=${BASE_IMAGE_NAME}:${CI_COMMIT_SHA}
           --build-arg BUILDKIT_INLINE_CACHE=1
-          --cache-from ${BACKEND_IMAGE_NAME}:main
+          --cache-from ${FRONTEND_IMAGE_NAME}:main
           --file apps/frontend/Dockerfile
           --tag ${FRONTEND_IMAGE_NAME}:${CI_COMMIT_SHA}
         .
@@ -847,7 +884,7 @@ scan-main-commit-db-image:
   stage: scan-images
   allow_failure: true
   rules:
-    - !reference [ .main_commit_rules, rules ]
+    - !reference [ .production_image_scan_rules, rules ]
   needs:
     - build-main-commit-db-image
   image:
@@ -905,7 +942,7 @@ scan-main-commit-liquibase-image:
   stage: scan-images
   allow_failure: true
   rules:
-    - !reference [ .main_commit_rules, rules ]
+    - !reference [ .production_image_scan_rules, rules ]
   needs:
     - build-main-commit-liquibase-image
   image:
@@ -963,7 +1000,7 @@ scan-main-commit-backend-image:
   stage: scan-images
   allow_failure: true
   rules:
-    - !reference [ .main_commit_rules, rules ]
+    - !reference [ .production_image_scan_rules, rules ]
   needs:
     - build-main-commit-backend-image
   image:
@@ -1021,7 +1058,7 @@ scan-main-commit-frontend-image:
   stage: scan-images
   allow_failure: true
   rules:
-    - !reference [ .main_commit_rules, rules ]
+    - !reference [ .production_image_scan_rules, rules ]
   needs:
     - build-main-commit-frontend-image
   image:
@@ -1133,9 +1170,18 @@ scan-main-commit-traefik-image:
       container_scanning: gl-container-scanning-report.json
 
 build-release:
-  stage: build-images
+  stage: publish-images
   rules:
     - !reference [ .release_rules, rules ]
+  needs:
+    - job: scan-main-commit-db-image
+      artifacts: false
+    - job: scan-main-commit-liquibase-image
+      artifacts: false
+    - job: scan-main-commit-backend-image
+      artifacts: false
+    - job: scan-main-commit-frontend-image
+      artifacts: false
   image: ${DOCKER_IMAGE}
   services:
     - name: ${DOCKER_SERVICE}
@@ -1168,10 +1214,14 @@ build-release:
     - docker tag ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA} iqbberlin/coding-box-backend:latest
     - docker tag ${FRONTEND_IMAGE_NAME}:${CI_COMMIT_SHA} iqbberlin/coding-box-frontend:${CI_COMMIT_TAG}
     - docker tag ${FRONTEND_IMAGE_NAME}:${CI_COMMIT_SHA} iqbberlin/coding-box-frontend:latest
-    - docker push -a -q iqbberlin/coding-box-db
-    - docker push -a -q iqbberlin/coding-box-liquibase
-    - docker push -a -q iqbberlin/coding-box-backend
-    - docker push -a -q iqbberlin/coding-box-frontend
+    - docker push --quiet iqbberlin/coding-box-db:${CI_COMMIT_TAG}
+    - docker push --quiet iqbberlin/coding-box-liquibase:${CI_COMMIT_TAG}
+    - docker push --quiet iqbberlin/coding-box-backend:${CI_COMMIT_TAG}
+    - docker push --quiet iqbberlin/coding-box-frontend:${CI_COMMIT_TAG}
+    - docker push --quiet iqbberlin/coding-box-db:latest
+    - docker push --quiet iqbberlin/coding-box-liquibase:latest
+    - docker push --quiet iqbberlin/coding-box-backend:latest
+    - docker push --quiet iqbberlin/coding-box-frontend:latest
   after_script:
     - docker logout ${CI_REGISTRY}
     - docker logout

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -19,6 +19,9 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt update && \
     apt install -y --no-install-recommends tini
 
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g --no-fund npm@11.18.0
+
 USER node
 
 WORKDIR /usr/src/coding-box-${PROJECT}

--- a/apps/backend/src/app/database/services/coding/autocoder-persistence-target-collision.error.ts
+++ b/apps/backend/src/app/database/services/coding/autocoder-persistence-target-collision.error.ts
@@ -1,0 +1,13 @@
+export class AutocoderPersistenceTargetCollisionError extends Error {
+  constructor(
+    target: string,
+    firstResultIndex: number,
+    secondResultIndex: number
+  ) {
+    super(
+      `Autocoder produced multiple updates for ${target} ` +
+      `(results ${firstResultIndex + 1} and ${secondResultIndex + 1}).`
+    );
+    this.name = AutocoderPersistenceTargetCollisionError.name;
+  }
+}

--- a/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
@@ -978,6 +978,252 @@ describe('CodingProcessService', () => {
         );
     });
 
+    it('prefers exact DHB003 aliases over colliding technical variable IDs', () => {
+      const response02 = createMockResponse(10, 1, '02');
+      const response04 = createMockResponse(20, 1, '04');
+      const response03 = createMockResponse(30, 1, '03');
+      const response05 = createMockResponse(40, 1, '05');
+      const generatedTechnical04 = createMockResponse(50, 1, '04');
+      generatedTechnical04.is_autocoder_generated = true;
+      const generatedTechnical05 = createMockResponse(60, 1, '05');
+      generatedTechnical05.is_autocoder_generated = true;
+      const technicalIdFallbackByAlias = new Map([
+        ['02', '04'],
+        ['04', '07'],
+        ['03', '05'],
+        ['05', '09']
+      ]);
+      const resolveResponse = (
+        service as unknown as {
+          findExistingResponseForAutocoderResult: (
+            responses: ResponseEntity[],
+            codedResultId: string,
+            codedSubform: string,
+            technicalIdFallbackByAlias: Map<string, string>
+          ) => ResponseEntity | undefined;
+        }
+      ).findExistingResponseForAutocoderResult.bind(service);
+      const responses = [
+        response02,
+        response04,
+        response03,
+        response05,
+        generatedTechnical04,
+        generatedTechnical05
+      ];
+
+      expect(resolveResponse(responses, '02', '', technicalIdFallbackByAlias))
+        .toBe(response02);
+      expect(resolveResponse(responses, '04', '', technicalIdFallbackByAlias))
+        .toBe(response04);
+      expect(resolveResponse(responses, '03', '', technicalIdFallbackByAlias))
+        .toBe(response03);
+      expect(resolveResponse(responses, '05', '', technicalIdFallbackByAlias))
+        .toBe(response05);
+    });
+
+    it('limits the technical-ID fallback to legacy generated responses', () => {
+      const importedTechnicalIdCollision = createMockResponse(
+        20,
+        1,
+        'TECHNICAL_04'
+      );
+      const legacyGeneratedResponse = createMockResponse(
+        30,
+        1,
+        'TECHNICAL_04'
+      );
+      legacyGeneratedResponse.is_autocoder_generated = true;
+      const technicalIdFallbackByAlias = new Map([
+        ['02', 'TECHNICAL_04']
+      ]);
+      const resolveResponse = (
+        service as unknown as {
+          findExistingResponseForAutocoderResult: (
+            responses: ResponseEntity[],
+            codedResultId: string,
+            codedSubform: string,
+            technicalIdFallbackByAlias: Map<string, string>
+          ) => ResponseEntity | undefined;
+        }
+      ).findExistingResponseForAutocoderResult.bind(service);
+
+      expect(resolveResponse(
+        [importedTechnicalIdCollision],
+        '02',
+        '',
+        technicalIdFallbackByAlias
+      )).toBeUndefined();
+      expect(resolveResponse(
+        [importedTechnicalIdCollision, legacyGeneratedResponse],
+        '02',
+        '',
+        technicalIdFallbackByAlias
+      )).toBe(legacyGeneratedResponse);
+    });
+
+    it('excludes technical IDs that are also another output alias', () => {
+      const serviceInternals = service as unknown as {
+        createUnambiguousTechnicalIdFallbacks: (
+          variableCodings: Array<{ id: string; alias?: string }>
+        ) => Map<string, string>;
+        findExistingResponseForAutocoderResult: (
+          responses: ResponseEntity[],
+          codedResultId: string,
+          codedSubform: string,
+          technicalIdFallbackByAlias: Map<string, string>
+        ) => ResponseEntity | undefined;
+      };
+      const technicalIdFallbackByAlias =
+        serviceInternals.createUnambiguousTechnicalIdFallbacks([
+          { id: '04', alias: '02' },
+          { id: '07', alias: '04' },
+          { id: '05', alias: '03' },
+          { id: '09', alias: '05' }
+        ]);
+      const generated04 = createMockResponse(50, 1, '04');
+      generated04.is_autocoder_generated = true;
+
+      expect(Array.from(technicalIdFallbackByAlias.entries())).toEqual([
+        ['04', '07'],
+        ['05', '09']
+      ]);
+      expect(serviceInternals.findExistingResponseForAutocoderResult(
+        [generated04],
+        '02',
+        '',
+        technicalIdFallbackByAlias
+      )).toBeUndefined();
+    });
+
+    it('routes all DHB003 aliases correctly through response processing', async () => {
+      const dhbResponses = [
+        createMockResponse(10, 1, '02'),
+        createMockResponse(20, 1, '04'),
+        createMockResponse(40, 1, '05')
+      ];
+      const dhbVariableCodings = [
+        { id: '04', alias: '02' },
+        { id: '07', alias: '04' },
+        { id: '05', alias: '03' },
+        { id: '09', alias: '05' }
+      ];
+      (Autocoder.CodingSchemeFactory.code as jest.Mock).mockReturnValueOnce([
+        {
+          id: '02',
+          value: 'response 02',
+          status: 'CODING_COMPLETE',
+          code: 102,
+          score: 1,
+          subform: ''
+        },
+        {
+          id: '04',
+          value: 'response 04',
+          status: 'CODING_COMPLETE',
+          code: 104,
+          score: 1,
+          subform: ''
+        },
+        {
+          id: '03',
+          value: 'derived 03',
+          status: 'CODING_COMPLETE',
+          code: 103,
+          score: 1,
+          subform: ''
+        },
+        {
+          id: '05',
+          value: 'response 05',
+          status: 'CODING_COMPLETE',
+          code: 105,
+          score: 1,
+          subform: ''
+        }
+      ]);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([
+          ['TEST_UNIT_1', new Set(['02', '04', '05'])]
+        ])
+      );
+      mockQueryBuilder.getMany
+        .mockResolvedValueOnce([mockUnits[0]])
+        .mockResolvedValueOnce(dhbResponses);
+      (fileUploadRepository.find as jest.Mock)
+        .mockReset()
+        .mockResolvedValueOnce([
+          createMockFileUpload(
+            'ALIAS_1',
+            '<xml><codingSchemeRef>TEST-SCHEME-REF</codingSchemeRef></xml>'
+          )
+        ])
+        .mockResolvedValueOnce([
+          createMockFileUpload(
+            'TEST-SCHEME-REF',
+            JSON.stringify({
+              version: '3.4',
+              variableCodings: dhbVariableCodings
+            })
+          )
+        ]);
+
+      await service.processTestPersonsBatch(workspaceId, ['1'], 1);
+
+      const codedResponses =
+        mockResponseManagementService.updateResponsesInDatabase
+          .mock.calls[0][1];
+      expect(codedResponses).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: 10, code_v1: 102 }),
+        expect.objectContaining({ id: 20, code_v1: 104 }),
+        expect.objectContaining({
+          id: -1,
+          isNew: true,
+          variableid: '03',
+          code_v1: 103
+        }),
+        expect.objectContaining({ id: 40, code_v1: 105 })
+      ]));
+      expect(codedResponses).toHaveLength(4);
+    });
+
+    it('rejects multiple autocoder results for the same persistence target', () => {
+      const assertUniqueTargets = (
+        service as unknown as {
+          assertUniqueAutocoderPersistenceTargets: (
+            responses: Array<{
+              id: number;
+              isNew?: boolean;
+              unitid?: number;
+              variableid?: string;
+              subform?: string;
+            }>
+          ) => void;
+        }
+      ).assertUniqueAutocoderPersistenceTargets.bind(service);
+
+      expect(() => assertUniqueTargets([
+        { id: 10 },
+        { id: 10 }
+      ])).toThrow('Autocoder produced multiple updates for response:10');
+      expect(() => assertUniqueTargets([
+        {
+          id: -1,
+          isNew: true,
+          unitid: 1,
+          variableid: '03',
+          subform: ''
+        },
+        {
+          id: -1,
+          isNew: true,
+          unitid: 1,
+          variableid: '03',
+          subform: ''
+        }
+      ])).toThrow('Autocoder produced multiple updates for generated:1:03:');
+    });
+
     it('should call progress callback at appropriate intervals', async () => {
       mockQueryBuilder.getMany
         .mockResolvedValueOnce(mockUnits)

--- a/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.spec.ts
@@ -16,6 +16,7 @@ import Persons from '../../entities/persons.entity';
 import { Unit } from '../../entities/unit.entity';
 import { Booklet } from '../../entities/booklet.entity';
 import { ResponseEntity } from '../../entities/response.entity';
+import { AutocoderPersistenceTargetCollisionError } from './autocoder-persistence-target-collision.error';
 
 jest.mock('@iqb/responses', () => ({
   CodingSchemeFactory: {
@@ -1205,7 +1206,7 @@ describe('CodingProcessService', () => {
       expect(() => assertUniqueTargets([
         { id: 10 },
         { id: 10 }
-      ])).toThrow('Autocoder produced multiple updates for response:10');
+      ])).toThrow(AutocoderPersistenceTargetCollisionError);
       expect(() => assertUniqueTargets([
         {
           id: -1,
@@ -1222,6 +1223,64 @@ describe('CodingProcessService', () => {
           subform: ''
         }
       ])).toThrow('Autocoder produced multiple updates for generated:1:03:');
+    });
+
+    it('rolls back and rejects persistence target collisions', async () => {
+      const response02 = createMockResponse(10, 1, '02');
+      (Autocoder.CodingSchemeFactory.code as jest.Mock).mockReturnValueOnce([
+        {
+          id: '02',
+          value: 'first result',
+          status: 'CODING_COMPLETE',
+          code: 1,
+          score: 1,
+          subform: ''
+        },
+        {
+          id: '02',
+          value: 'second result',
+          status: 'CODING_COMPLETE',
+          code: 2,
+          score: 1,
+          subform: ''
+        }
+      ]);
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(
+        new Map([
+          ['TEST_UNIT_1', new Set(['02'])]
+        ])
+      );
+      mockQueryBuilder.getMany
+        .mockResolvedValueOnce([mockUnits[0]])
+        .mockResolvedValueOnce([response02]);
+      (fileUploadRepository.find as jest.Mock)
+        .mockReset()
+        .mockResolvedValueOnce([
+          createMockFileUpload(
+            'ALIAS_1',
+            '<xml><codingSchemeRef>TEST-SCHEME-REF</codingSchemeRef></xml>'
+          )
+        ])
+        .mockResolvedValueOnce([
+          createMockFileUpload(
+            'TEST-SCHEME-REF',
+            JSON.stringify({
+              version: '3.4',
+              variableCodings: [{ id: '04', alias: '02' }]
+            })
+          )
+        ]);
+
+      await expect(
+        service.processTestPersonsBatch(workspaceId, ['1'], 1)
+      ).rejects.toBeInstanceOf(AutocoderPersistenceTargetCollisionError);
+
+      const createQueryRunner = responseRepository.manager.connection
+        .createQueryRunner as jest.Mock;
+      const queryRunner = createQueryRunner.mock.results[0].value;
+      expect(queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
+      expect(mockResponseManagementService.updateResponsesInDatabase)
+        .not.toHaveBeenCalled();
     });
 
     it('should call progress callback at appropriate intervals', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-process.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.ts
@@ -956,16 +956,10 @@ export class CodingProcessService {
           fileIdToCodingSchemeMap.get(codingSchemeRef) || emptyScheme :
           emptyScheme;
 
-        const variableAliasToIdMap = new Map<string, string>();
-        if (Array.isArray(scheme.variableCodings)) {
-          scheme.variableCodings.forEach((vc: VariableCodingData) => {
-            const key = (vc.alias ?? vc.id) as string | undefined;
-            const value = vc.id as string | undefined;
-            if (key && value) {
-              variableAliasToIdMap.set(key, value);
-            }
-          });
-        }
+        const technicalIdFallbackByAlias =
+          this.createUnambiguousTechnicalIdFallbacks(
+            scheme.variableCodings || []
+          );
 
         const inputResponses = responses.map(response => {
           let inputStatus = response.status;
@@ -1008,27 +1002,13 @@ export class CodingProcessService {
           }
           statistics.statusCounts[codedStatus] += 1;
 
-          const mappedIdFromAlias = variableAliasToIdMap.get(codedResult.id);
-          const possibleVariableIds = new Set<string>([codedResult.id]);
-          if (mappedIdFromAlias) {
-            possibleVariableIds.add(mappedIdFromAlias);
-          }
-          const possibleVariableIdsNormalized = new Set(
-            Array.from(possibleVariableIds).map(v => String(v).toUpperCase())
-          );
           const codedSubform = codedResult.subform || '';
-
-          // Prefer updates for the same variable + subform to avoid generating
-          // duplicates on repeated autocoder runs (especially for derived vars).
-          const matchingResponses = responses
-            .filter(
-              r => possibleVariableIdsNormalized.has(
-                String(r.variableid).toUpperCase()
-              ) &&
-                String(r.subform || '') === codedSubform
-            )
-            .sort((a, b) => b.id - a.id);
-          const existingResponse = matchingResponses[0];
+          const existingResponse = this.findExistingResponseForAutocoderResult(
+            responses,
+            codedResult.id,
+            codedSubform,
+            technicalIdFallbackByAlias
+          );
 
           const codedResponse: CodedResponse = {
             id: existingResponse ? existingResponse.id : -1
@@ -1084,12 +1064,130 @@ export class CodingProcessService {
     }
 
     allCodedResponses.length = responseIndex;
+    this.assertUniqueAutocoderPersistenceTargets(allCodedResponses);
 
     if (progressCallback) {
       progressCallback(95);
     }
 
     return { allCodedResponses, statistics };
+  }
+
+  private createUnambiguousTechnicalIdFallbacks(
+    variableCodings: VariableCodingData[]
+  ): Map<string, string> {
+    const outputVariableIds = new Set(
+      variableCodings
+        .map(coding => this.normalizeVariableId(coding.alias || coding.id))
+        .filter(Boolean)
+    );
+    const technicalIdFallbackByAlias = new Map<string, string>();
+
+    variableCodings.forEach(coding => {
+      const alias = coding.alias || coding.id;
+      const technicalId = coding.id;
+      if (!alias || !technicalId) {
+        return;
+      }
+
+      const normalizedAlias = this.normalizeVariableId(alias);
+      const normalizedTechnicalId = this.normalizeVariableId(technicalId);
+
+      // A technical ID that is also another coding's output alias is
+      // ambiguous and must never be used as a compatibility fallback.
+      if (
+        normalizedAlias === normalizedTechnicalId ||
+        outputVariableIds.has(normalizedTechnicalId)
+      ) {
+        return;
+      }
+
+      technicalIdFallbackByAlias.set(normalizedAlias, technicalId);
+    });
+
+    return technicalIdFallbackByAlias;
+  }
+
+  private findExistingResponseForAutocoderResult(
+    responses: ResponseEntity[],
+    codedResultId: string,
+    codedSubform: string,
+    technicalIdFallbackByAlias: Map<string, string>
+  ): ResponseEntity | undefined {
+    const normalizedResultId = this.normalizeVariableId(codedResultId);
+    const hasMatchingSubform = (response: ResponseEntity) => (
+      String(response.subform || '') === codedSubform
+    );
+    const newestResponse = (matchingResponses: ResponseEntity[]) => (
+      matchingResponses.sort((a, b) => b.id - a.id)[0]
+    );
+
+    // Test-result response IDs use the variable alias. An exact alias match
+    // must win even when that alias is also another variable's technical ID.
+    const exactAliasMatch = responses
+      .filter(response => (
+        this.normalizeVariableId(response.variableid) === normalizedResultId &&
+        hasMatchingSubform(response)
+      ))
+      .sort((a, b) => (
+        Number(a.is_autocoder_generated) -
+          Number(b.is_autocoder_generated) ||
+        b.id - a.id
+      ))[0];
+    if (exactAliasMatch) {
+      return exactAliasMatch;
+    }
+
+    const mappedTechnicalId = technicalIdFallbackByAlias.get(
+      normalizedResultId
+    );
+    if (
+      !mappedTechnicalId ||
+      this.normalizeVariableId(mappedTechnicalId) === normalizedResultId
+    ) {
+      return undefined;
+    }
+
+    // Older runs may have persisted generated derived responses under the
+    // technical ID. Keep that compatibility fallback strictly limited to
+    // generated rows so an imported response with a colliding alias can never
+    // receive another variable's result.
+    return newestResponse(
+      responses.filter(response => (
+        response.is_autocoder_generated === true &&
+        this.normalizeVariableId(response.variableid) ===
+          this.normalizeVariableId(mappedTechnicalId) &&
+        hasMatchingSubform(response)
+      ))
+    );
+  }
+
+  private assertUniqueAutocoderPersistenceTargets(
+    codedResponses: CodedResponse[]
+  ): void {
+    const targetIndexes = new Map<string, number>();
+
+    codedResponses.forEach((response, index) => {
+      const target = response.isNew ?
+        `generated:${response.unitid}:${this.normalizeVariableId(
+          response.variableid
+        )}:${String(response.subform || '')}` :
+        `response:${response.id}`;
+      const previousIndex = targetIndexes.get(target);
+
+      if (previousIndex !== undefined) {
+        throw new Error(
+          `Autocoder produced multiple updates for ${target} ` +
+          `(results ${previousIndex + 1} and ${index + 1}).`
+        );
+      }
+
+      targetIndexes.set(target, index);
+    });
+  }
+
+  private normalizeVariableId(variableId: unknown): string {
+    return String(variableId ?? '').toUpperCase();
   }
 
   private async getCodingSchemeFiles(

--- a/apps/backend/src/app/database/services/coding/coding-process.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-process.service.ts
@@ -30,6 +30,7 @@ import {
   WorkspaceExclusionService
 } from '../workspace/workspace-exclusion.service';
 import { CodingReadinessService } from './coding-readiness.service';
+import { AutocoderPersistenceTargetCollisionError } from './autocoder-persistence-target-collision.error';
 
 type UnitCodingJobMetadata = {
   source?: 'manual-selection' | 'coding-freshness';
@@ -644,6 +645,9 @@ export class CodingProcessService {
         `Error while processing test persons in batch: ${error.message} \n ${error.stack}`
       );
       await queryRunner.rollbackTransaction();
+      if (error instanceof AutocoderPersistenceTargetCollisionError) {
+        throw error;
+      }
       return statistics;
     } finally {
       if (!queryRunner.isReleased) {
@@ -1176,9 +1180,10 @@ export class CodingProcessService {
       const previousIndex = targetIndexes.get(target);
 
       if (previousIndex !== undefined) {
-        throw new Error(
-          `Autocoder produced multiple updates for ${target} ` +
-          `(results ${previousIndex + 1} and ${index + 1}).`
+        throw new AutocoderPersistenceTargetCollisionError(
+          target,
+          previousIndex,
+          index
         );
       }
 

--- a/apps/backend/src/app/job-queue/processors/test-person-coding.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/test-person-coding.processor.spec.ts
@@ -3,6 +3,7 @@ import { Logger } from '@nestjs/common';
 import { WorkspaceCodingService } from '../../database/services/workspace';
 import { TestPersonCodingJobData } from '../job-queue.service';
 import { TestPersonCodingProcessor } from './test-person-coding.processor';
+import { AutocoderPersistenceTargetCollisionError } from '../../database/services/coding/autocoder-persistence-target-collision.error';
 
 describe('TestPersonCodingProcessor', () => {
   afterEach(() => {
@@ -88,5 +89,33 @@ describe('TestPersonCodingProcessor', () => {
       totalResponses: 10,
       statusCounts: { CODED: 10 }
     });
+  });
+
+  it('fails collision jobs without reporting 100 percent or success', async () => {
+    const collisionError = new AutocoderPersistenceTargetCollisionError(
+      'response:10',
+      0,
+      1
+    );
+    const workspaceCodingService = {
+      processTestPersonsBatch: jest.fn().mockRejectedValue(collisionError)
+    };
+    const getLatestJob = jest.fn().mockResolvedValue({
+      data: { isPaused: false }
+    });
+    const job = createJob(getLatestJob);
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    const processor = new TestPersonCodingProcessor(
+      workspaceCodingService as unknown as WorkspaceCodingService
+    );
+
+    await expect(processor.process(job)).rejects.toBe(collisionError);
+
+    expect(job.progress).toHaveBeenCalledWith(0);
+    expect(job.progress).not.toHaveBeenCalledWith(100);
+    expect(logSpy).not.toHaveBeenCalledWith(
+      `Job ${job.id} completed successfully`
+    );
   });
 });

--- a/apps/frontend/src/app/components/home/home.component.html
+++ b/apps/frontend/src/app/components/home/home.component.html
@@ -11,7 +11,7 @@
     [appTitle]="'Web application for coding'"
     [introHtml]="'appService.appConfig.introHtml'"
     [appName]="'IQB-Kodierbox'"
-    [appVersion]="'1.16.5'"
+    [appVersion]="'1.16.6'"
     [userName]="authData.userName"
     [userLongName]="appService.userProfile.firstName + ' ' + appService.userProfile.lastName"
     [isUserLoggedIn]="Number(authData.userId) > 0"

--- a/database/Liquibase.Dockerfile
+++ b/database/Liquibase.Dockerfile
@@ -3,7 +3,13 @@
 ARG REGISTRY_PATH=""
 
 
-FROM ${REGISTRY_PATH}liquibase/liquibase:4.28 AS base
+FROM ${REGISTRY_PATH}liquibase/liquibase:4.28@sha256:7c813a2cb861f8b4718a09375c5265909127f4cb99f56bb95c956175c9b91525 AS base
+
+# The application only uses the Liquibase CLI. The bundled LPM binary is not
+# needed at runtime and is built with a Go version affected by CVE-2025-68121.
+USER root
+RUN rm /liquibase/bin/lpm
+USER liquibase:liquibase
 
 FROM base AS prod
 

--- a/database/Postgres.Dockerfile
+++ b/database/Postgres.Dockerfile
@@ -2,11 +2,29 @@
 
 ARG REGISTRY_PATH=""
 
+FROM ${REGISTRY_PATH}golang:1.24.13-alpine3.23@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS gosu-builder
 
-FROM ${REGISTRY_PATH}postgres:14.12-alpine3.19
+ARG GOSU_COMMIT=6456aaa0f3c854d199d0f037f068eb97515b7513
+ARG GOSU_SOURCE_SHA256=33d7537d588ea49458b9509bcf4554bdf5ceacc66da71e5caa1058ea3b689c3b
+
+WORKDIR /src/gosu
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    wget --output-document=gosu.tar.gz \
+        "https://github.com/tianon/gosu/archive/${GOSU_COMMIT}.tar.gz" \
+    && echo "${GOSU_SOURCE_SHA256}  gosu.tar.gz" | sha256sum -c \
+    && tar --extract --gzip --file=gosu.tar.gz --strip-components=1 \
+    && CGO_ENABLED=0 go build -trimpath -ldflags '-d -w' -o /out/gosu . \
+    && /out/gosu --version | grep -F '1.19 (go1.24.13 '
+
+FROM ${REGISTRY_PATH}postgres:14.23-alpine3.24@sha256:f1341c01408dc7278e9d365ed4f860cd3f87dd16b4464ac326fc0f422083a579
+
+COPY --from=gosu-builder --chmod=0755 /out/gosu /usr/local/bin/gosu
 
 RUN --mount=type=cache,target=/var/cache/apk \
-    apk add --update musl musl-utils musl-locales tzdata
+    apk add --update musl musl-utils musl-locales tzdata \
+    && gosu --version | grep -F '1.19 (go1.24.13 '
 
 # Localization
 ENV LANG=de_DE.utf8
@@ -24,6 +42,4 @@ HEALTHCHECK \
     CMD ["postgres-healthcheck"]
 
 EXPOSE 5432
-
-
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coding-box",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coding-box",
-      "version": "1.16.5",
+      "version": "1.16.6",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "20.3.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35995,9 +35995,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "form-data": "4.0.4",
     "@nestjs/terminus": "^11.0.0",
     "lodash": "4.18.1",
-    "tar": "7.5.11",
+    "tar": "7.5.19",
     "qs": "6.14.2",
     "hono": "4.12.12",
     "@tootallnate/once": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-box",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Zweck

Audit-PR für Hotfix 1.16.6, exakt auf Tag `1.16.5` aufgebaut. **Nicht mergen:** `main` muss unverändert bleiben; der spätere Release soll direkt vom freigegebenen Hotfix-Commit erfolgen.

## Enthalten

- Backport von `105955b6` / PR #941 für Autocoder-Alias-Kollisionen
- Version `1.16.6` in `package.json`, `package-lock.json` und Home-Komponente
- tag-native GitLab-Pipeline: vier Produktionsimages werden für RC- und Stable-Tags aus dem getaggten Commit gebaut und gescannt
- separater Publish-Stage; RC veröffentlicht ausschließlich den RC-Tag, Stable veröffentlicht Version und `latest`
- Versionskonsistenzprüfung zwischen Tag, Manifest und Lockfile
- minimaler Queue-Lifecycle-Fix: spezifische Persistenzziel-Kollisionen werden nach Rollback weitergeworfen und lassen den Bull-Job sichtbar fehlschlagen

## Queue-Lifecycle-Nachweis

`AutocoderPersistenceTargetCollisionError` wird ausschließlich vom Duplicate-Guard erzeugt und ausschließlich nach dem vorhandenen Rollback erneut geworfen. Ein gezielter Service-Test prüft Reject, Rollback und ausbleibende Persistenz; ein Processor-Test prüft Reject sowie ausbleibendes `progress(100)` und ausbleibende Erfolgsmeldung.

PR #941 benötigt keinen äquivalenten Zusatz: Sein Head `105955b6` wirft Verarbeitungsfehler bereits weiter und rollt aktive Transaktionen im `finally` zurück.

## Lokale Validierung

- CodingProcessService: 31/31
- TestPersonCodingProcessor: 3/3
- Backend vollständig: 2022 bestanden, 7 übersprungen
- Backend Lint und Build: bestanden
- Frontend vollständig: 1825/1825
- Frontend Lint und Build: bestanden
- GitLab-YAML syntaktisch geparst; Diff-Check sauber
- statische CI-Invarianten: RC pusht kein Docker-Hub-`latest`; Stable pusht vier Versionstags und vier `latest`; fünf Tag-Builder und vier blockierende Tag-Scans

## RC-Prüfung

`1.16.6-rc1` zeigt auf `60dca368`. GitLab-Pipeline #97103 hat den Publish korrekt blockiert:

- DB-Scan fehlgeschlagen: `libxml2` CVE-2024-56171 und Criticals im eingebetteten alten `gosu`-Go-Binary
- Liquibase-Scan fehlgeschlagen: Go-stdlib CVE-2025-68121
- `build-pre-release` wurde nicht ausgeführt
- alle vier Docker-Hub-Tags `1.16.6-rc1` fehlen weiterhin
- alle vier Docker-Hub-`latest`-Digests entsprechen weiterhin exakt `1.16.5`

Deshalb wurden kein Stable-Tag, kein GitHub Release und kein Deployment erzeugt.

Dieser Draft dient ausschließlich Audit und CI. Er darf nicht nach `main` gemergt werden; Auto-Merge ist nicht aktiviert.

## RC1-Image-Härtung

Separater Infrastrukturcommit `9c5ec9bb`:

- PostgreSQL bleibt Major 14 und wird auf das offizielle, digest-gepinnte `14.23-alpine3.24` aktualisiert; `PGDATA=/var/lib/postgresql/data` bleibt unverändert.
- gosu bleibt 1.19 und wird architekturgerecht aus dem gepinnten offiziellen Commit mit Go 1.24.13 neu gebaut; die Quellarchiv-Checksumme wird beim Build geprüft.
- Liquibase bleibt 4.28/JRE 17; ausschließlich das ungenutzte, von CVE-2025-68121 betroffene `lpm`-Binary wird entfernt, der Runtime-User bleibt `liquibase:liquibase`.
- Lokale ARM64- und AMD64-Builds sowie blockierende Critical-Scans: bestanden (0 Criticals).
- Wegwerf-PostgreSQL-Start, Liquibase status/validate/updateSQL: bestanden.

Nächster Freigabepunkt ist die grüne Branch-Pipeline; erst danach wird der unveränderliche Tag `1.16.6-rc2` erzeugt.