### PR TITLE
Patch release database image vulnerabilities

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -19,6 +19,9 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt update && \
     apt install -y --no-install-recommends tini
 
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g --no-fund npm@11.18.0
+
 USER node
 
 WORKDIR /usr/src/coding-box-${PROJECT}

--- a/database/Liquibase.Dockerfile
+++ b/database/Liquibase.Dockerfile
@@ -3,7 +3,13 @@
 ARG REGISTRY_PATH=""
 
 
-FROM ${REGISTRY_PATH}liquibase/liquibase:4.28 AS base
+FROM ${REGISTRY_PATH}liquibase/liquibase:4.28@sha256:7c813a2cb861f8b4718a09375c5265909127f4cb99f56bb95c956175c9b91525 AS base
+
+# The application only uses the Liquibase CLI. The bundled LPM binary is not
+# needed at runtime and is built with a Go version affected by CVE-2025-68121.
+USER root
+RUN rm /liquibase/bin/lpm
+USER liquibase:liquibase
 
 FROM base AS prod
 

--- a/database/Postgres.Dockerfile
+++ b/database/Postgres.Dockerfile
@@ -2,11 +2,29 @@
 
 ARG REGISTRY_PATH=""
 
+FROM ${REGISTRY_PATH}golang:1.24.13-alpine3.23@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS gosu-builder
 
-FROM ${REGISTRY_PATH}postgres:14.12-alpine3.19
+ARG GOSU_COMMIT=6456aaa0f3c854d199d0f037f068eb97515b7513
+ARG GOSU_SOURCE_SHA256=33d7537d588ea49458b9509bcf4554bdf5ceacc66da71e5caa1058ea3b689c3b
+
+WORKDIR /src/gosu
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    wget --output-document=gosu.tar.gz \
+        "https://github.com/tianon/gosu/archive/${GOSU_COMMIT}.tar.gz" \
+    && echo "${GOSU_SOURCE_SHA256}  gosu.tar.gz" | sha256sum -c \
+    && tar --extract --gzip --file=gosu.tar.gz --strip-components=1 \
+    && CGO_ENABLED=0 go build -trimpath -ldflags '-d -w' -o /out/gosu . \
+    && /out/gosu --version | grep -F '1.19 (go1.24.13 '
+
+FROM ${REGISTRY_PATH}postgres:14.23-alpine3.24@sha256:f1341c01408dc7278e9d365ed4f860cd3f87dd16b4464ac326fc0f422083a579
+
+COPY --from=gosu-builder --chmod=0755 /out/gosu /usr/local/bin/gosu
 
 RUN --mount=type=cache,target=/var/cache/apk \
-    apk add --update musl musl-utils musl-locales tzdata
+    apk add --update musl musl-utils musl-locales tzdata \
+    && gosu --version | grep -F '1.19 (go1.24.13 '
 
 # Localization
 ENV LANG=de_DE.utf8
@@ -24,6 +42,4 @@ HEALTHCHECK \
     CMD ["postgres-healthcheck"]
 
 EXPOSE 5432
-
-
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35995,9 +35995,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "form-data": "4.0.4",
     "@nestjs/terminus": "^11.0.0",
     "lodash": "4.18.1",
-    "tar": "7.5.11",
+    "tar": "7.5.19",
     "qs": "6.14.2",
     "hono": "4.12.12",
     "@tootallnate/once": "3.0.1",


### PR DESCRIPTION
## Zweck

Isolierter Infrastrukturfix für die in der 1.16.6-rc1-Pipeline gefundenen Critical-CVEs. Dieser Draft enthält keine Hotfix-Runtime-, Versions- oder Release-Pipeline-Änderungen und wird nicht automatisch gemergt.

## Scope

- PostgreSQL bleibt Major 14 und wird auf das offizielle, digest-gepinnte `14.23-alpine3.24` aktualisiert; `PGDATA=/var/lib/postgresql/data` bleibt unverändert.
- gosu bleibt 1.19 und wird architekturgerecht aus dem gepinnten offiziellen Commit mit Go 1.24.13 neu gebaut; die Quellarchiv-Checksumme wird geprüft.
- Liquibase bleibt 4.28/JRE 17; ausschließlich das ungenutzte, von CVE-2025-68121 betroffene `lpm`-Binary wird entfernt. Der Runtime-User bleibt `liquibase:liquibase`.

## Validierung

- ARM64- und AMD64-Builds für DB und Liquibase: bestanden
- Trivy `--ignore-unfixed --severity CRITICAL --exit-code 1`: beide Architekturen, beide Images, 0 Criticals
- PostgreSQL-Wegwerfstart und gosu-Userwechsel: bestanden
- Liquibase `status`, `validate` und `updateSQL` gegen Wegwerf-PostgreSQL: bestanden
- Dockerfile Build-Checks und Diff-Check: bestanden
- Backend vollständig: 2022 bestanden, 7 übersprungen; Lint und Build bestanden

Nicht mergen, solange Review und CI ausstehen. Auto-Merge ist nicht aktiviert.