### PR TITLE
Include eligible DERIVE_ERROR responses in coding lists

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-aggregation-peer.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-aggregation-peer.service.spec.ts
@@ -9,6 +9,7 @@ const createQueryBuilder = (rows: unknown[]) => {
     'leftJoin',
     'where',
     'andWhere',
+    'distinct',
     'orderBy'
   ].forEach(method => {
     queryBuilder[method] = jest.fn().mockReturnValue(queryBuilder);
@@ -77,6 +78,11 @@ describe('CodingAggregationPeerService', () => {
       codeV2: 1
     })]);
     expect(responseRepository.createQueryBuilder).toHaveBeenCalledTimes(2);
+    expect(peerValueQuery.select).toHaveBeenCalledWith(
+      'unit.name',
+      'unitName'
+    );
+    expect(peerValueQuery.distinct).toHaveBeenCalledWith(true);
     expect(peerValueQuery.andWhere).toHaveBeenCalledWith(
       expect.stringContaining('aggregation_peer_variable'),
       {

--- a/apps/backend/src/app/database/services/coding/coding-aggregation-peer.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-aggregation-peer.service.ts
@@ -146,9 +146,10 @@ export class CodingAggregationPeerService {
     ).values());
 
     const peerValueQuery = createCompletedPeerQuery('Values')
-      .select('DISTINCT unit.name', 'unitName')
+      .select('unit.name', 'unitName')
       .addSelect('response.variableid', 'variableId')
       .addSelect('response.value', 'value')
+      .distinct(true)
       .andWhere(
         `EXISTS (
           SELECT 1

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -43,6 +43,7 @@ const createQueryBuilder = (result: unknown = []) => {
     'innerJoinAndSelect',
     'where',
     'andWhere',
+    'distinct',
     'groupBy',
     'addGroupBy',
     'orderBy',

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -85,6 +85,7 @@ import {
   ManualCodingVariableReference,
   MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
 } from '../../utils/manual-coding-candidate.util';
+import { isDeriveErrorInManualCodingEnabled } from '../../utils/manual-coding-setting.util';
 import {
   applyNonCodingIssueReviewJobFilter,
   CODING_JOB_TYPE_CODING_ISSUE_REVIEW,
@@ -446,9 +447,6 @@ export interface CodingJobAggregationSettings {
   fromJobSnapshot: boolean;
 }
 
-const INCLUDE_DERIVE_ERROR_IN_MANUAL_CODING_SETTING_KEY =
-  'include-derive-error-in-manual-coding';
-
 @Injectable()
 export class CodingJobService {
   private readonly logger = new Logger(CodingJobService.name);
@@ -668,22 +666,7 @@ export class CodingJobService {
     const repository = manager ?
       manager.getRepository(Setting) :
       this.settingRepository;
-    const setting = await repository.findOne({
-      where: {
-        key: `workspace-${workspaceId}-${INCLUDE_DERIVE_ERROR_IN_MANUAL_CODING_SETTING_KEY}`
-      }
-    });
-
-    if (!setting) {
-      return false;
-    }
-
-    try {
-      const parsed = JSON.parse(setting.content);
-      return parsed.enabled === true;
-    } catch {
-      return false;
-    }
+    return isDeriveErrorInManualCodingEnabled(repository, workspaceId);
   }
 
   async assertDeriveErrorManualCodingEnabled(

--- a/apps/backend/src/app/database/services/coding/coding-list-query.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-query.service.spec.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm';
 import FileUpload from '../../entities/file_upload.entity';
 import { ResponseEntity } from '../../entities/response.entity';
+import { Setting } from '../../entities/setting.entity';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { WorkspaceFilesService, WorkspaceCoreService } from '../workspace';
 import { WorkspaceExclusionService } from '../workspace/workspace-exclusion.service';
@@ -35,6 +36,8 @@ type CreateServiceOptions = {
   derivedVariablesBySourceMap?: Map<string, Set<string>>;
   manualInstructionMap?: Map<string, Set<string>>;
   replayAnchorMap?: Map<string, string>;
+  includeDeriveErrorInManualCoding?: boolean;
+  onQueryBuilderCreated?: (queryBuilder: QueryBuilderMock) => void;
 };
 
 describe('CodingListQueryService', () => {
@@ -95,6 +98,7 @@ describe('CodingListQueryService', () => {
       responses.length,
       options.rawVariableRows
     );
+    options.onQueryBuilderCreated?.(queryBuilder);
     const responseRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(queryBuilder)
     } as unknown as Repository<ResponseEntity>;
@@ -132,6 +136,16 @@ describe('CodingListQueryService', () => {
         )
       )
     } as unknown as CodingReplayAnchorService;
+    const settingRepository = {
+      findOne: jest.fn().mockResolvedValue(
+        options.includeDeriveErrorInManualCoding ?
+          {
+            key: 'workspace-1-include-derive-error-in-manual-coding',
+            content: JSON.stringify({ enabled: true })
+          } :
+          null
+      )
+    } as unknown as Repository<Setting>;
 
     return new CodingListQueryService(
       responseRepository,
@@ -139,7 +153,8 @@ describe('CodingListQueryService', () => {
       workspaceFilesService,
       {} as unknown as WorkspaceCoreService,
       workspaceExclusionService,
-      replayAnchorService
+      replayAnchorService,
+      settingRepository
     );
   }
 
@@ -349,6 +364,70 @@ describe('CodingListQueryService', () => {
     expect(result.items.map(item => item.variable_id)).toEqual(['INCOMPLETE_VAR']);
   });
 
+  it('includes scoped DERIVE_ERROR responses when manual coding is enabled', async () => {
+    const unitVariableMap = new Map([[
+      'UNIT',
+      new Set(['SOURCE_VAR', 'DERIVED_VAR'])
+    ]]);
+    const derivedVariablesBySourceMap = new Map([
+      [getManualCodingScopeKey('UNIT', 'SOURCE_VAR'), new Set(['DERIVED_VAR'])]
+    ]);
+    const manualInstructionMap = new Map([[
+      'UNIT',
+      new Set(['DERIVED_VAR'])
+    ]]);
+    const createResponse = (
+      id: number,
+      variableId: string
+    ): ResponseEntity => ({
+      id,
+      variableid: variableId,
+      value: 'O',
+      status_v1: statusStringToNumber('DERIVE_ERROR'),
+      unit: {
+        name: 'UNIT',
+        alias: 'Unit Alias',
+        booklet: {
+          person: {
+            login: 'login',
+            code: 'code',
+            group: 'group'
+          },
+          bookletinfo: {
+            name: 'BOOKLET'
+          }
+        }
+      }
+    }) as unknown as ResponseEntity;
+    const service = createService(
+      [
+        createResponse(1, 'SOURCE_VAR'),
+        createResponse(2, 'DERIVED_VAR')
+      ],
+      createFileRepository({}),
+      {
+        unitVariableMap,
+        derivedVariablesBySourceMap,
+        manualInstructionMap,
+        includeDeriveErrorInManualCoding: true
+      }
+    );
+
+    const result = await service.getCodingList(
+      1,
+      'token',
+      'https://iqb-kodierbox.de'
+    );
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        variable_id: 'DERIVED_VAR',
+        status_v1: 'DERIVE_ERROR'
+      })
+    ]);
+    expect(result.total).toBe(1);
+  });
+
   it('excludes intended incomplete coding-list responses without manual instruction', async () => {
     const unitVariableMap = new Map([[
       'UNIT',
@@ -490,5 +569,57 @@ describe('CodingListQueryService', () => {
     await expect(service.getCodingListVariables(1)).resolves.toEqual([
       { unitName: 'UNIT', variableId: 'INCOMPLETE_VAR' }
     ]);
+  });
+
+  it('includes DERIVE_ERROR variables when manual coding is enabled', async () => {
+    const unitVariableMap = new Map([[
+      'UNIT',
+      new Set(['DERIVE_VAR', 'INCOMPLETE_VAR'])
+    ]]);
+    const rawVariableRows = [
+      {
+        unitName: 'UNIT',
+        variableId: 'DERIVE_VAR',
+        statusV1: statusStringToNumber('DERIVE_ERROR')
+      },
+      {
+        unitName: 'UNIT',
+        variableId: 'INCOMPLETE_VAR',
+        statusV1: statusStringToNumber('CODING_INCOMPLETE')
+      }
+    ];
+    const service = createService([], createFileRepository({}), {
+      rawVariableRows,
+      unitVariableMap,
+      includeDeriveErrorInManualCoding: true
+    });
+
+    await expect(service.getCodingListVariables(1)).resolves.toEqual([
+      { unitName: 'UNIT', variableId: 'DERIVE_VAR' },
+      { unitName: 'UNIT', variableId: 'INCOMPLETE_VAR' }
+    ]);
+  });
+
+  it('uses the shared response candidate filters for coding-list variables', async () => {
+    let queryBuilder: QueryBuilderMock | undefined;
+    const service = createService([], createFileRepository({}), {
+      rawVariableRows: [],
+      unitVariableMap: new Map(),
+      onQueryBuilderCreated: createdQueryBuilder => {
+        queryBuilder = createdQueryBuilder;
+      }
+    });
+
+    await service.getCodingListVariables(1);
+
+    const conditions = queryBuilder?.andWhere.mock.calls
+      .map(([condition]) => String(condition)) ?? [];
+    expect(conditions).toContain(
+      "response.value IS NOT NULL AND response.value ~ '[^[:space:]]'"
+    );
+    expect(conditions).toEqual(expect.arrayContaining([
+      expect.stringContaining("response.variableid NOT ILIKE '%image%'"),
+      expect.stringContaining("response.variableid NOT ILIKE '%\\_0%'")
+    ]));
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-list-query.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-query.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ResponseEntity } from '../../entities/response.entity';
+import { Setting } from '../../entities/setting.entity';
 import { statusNumberToString } from '../../utils/response-status-converter';
 // eslint-disable-next-line import/no-cycle
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
@@ -18,11 +19,19 @@ import {
 } from '../../utils/manual-coding-scope.util';
 import {
   CODING_INCOMPLETE_STATUS,
+  DERIVE_ERROR_STATUS,
+  getDeriveErrorCodingListPairKeys,
   INTENDED_INCOMPLETE_STATUS,
-  MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+  MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES,
+  toManualCodingVariablePairKey
 } from '../../utils/manual-coding-candidate.util';
+import { isDeriveErrorInManualCodingEnabled } from '../../utils/manual-coding-setting.util';
 import { generateReplayUrl } from '../../../utils/replay-url.util';
 import { CodingReplayAnchorService } from './coding-replay-anchor.service';
+import {
+  getCodingResponseValueCandidateSql,
+  getCodingVariableIdCandidateSql
+} from './coding-response-candidate.util';
 
 const PAGE_MAP_LOOKUP_BATCH_SIZE = 8;
 
@@ -45,7 +54,10 @@ export class CodingListQueryService {
     private readonly workspaceFilesService: WorkspaceFilesService,
     private readonly workspaceCoreService: WorkspaceCoreService,
     private readonly workspaceExclusionService: WorkspaceExclusionService,
-    @Optional() private readonly replayAnchorService?: CodingReplayAnchorService
+    @Optional() private readonly replayAnchorService?: CodingReplayAnchorService,
+    @Optional()
+    @InjectRepository(Setting)
+    private readonly settingRepository?: Repository<Setting>
   ) { }
 
   async getValidVariablePairKeys(workspaceId: number): Promise<string[]> {
@@ -70,6 +82,14 @@ export class CodingListQueryService {
     }> {
     try {
       const server = serverUrl;
+      const includeDeriveError =
+        await isDeriveErrorInManualCodingEnabled(
+          this.settingRepository,
+          workspace_id
+        );
+      const candidateStatuses = includeDeriveError ?
+        [...MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES, DERIVE_ERROR_STATUS] :
+        MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES;
 
       // 1) Query explicitly selected manual-coding candidate responses.
       const queryBuilder = this.responseRepository
@@ -81,7 +101,7 @@ export class CodingListQueryService {
         .where('person.workspace_id = :workspace_id', { workspace_id })
         .andWhere('person.consider = :consider', { consider: true })
         .andWhere('response.status_v1 IN (:...statuses)', {
-          statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+          statuses: candidateStatuses
         })
         .orderBy('response.id', 'ASC');
 
@@ -119,6 +139,15 @@ export class CodingListQueryService {
       manualInstructionMap.forEach((variables: Set<string>, unitNameKey: string) => {
         manualInstructionSets.set(unitNameKey.toUpperCase(), variables);
       });
+      const deriveErrorPairKeys = new Set(
+        includeDeriveError ?
+          getDeriveErrorCodingListPairKeys(
+            unitVariableMap,
+            manualInstructionMap,
+            derivedVariablesBySourceMap
+          ) :
+          []
+      );
 
       // 3) Filter responses:
       //    - Variable must exist in unitVariableMap (valid, non-BASE/BASE_NO_VALUE)
@@ -129,8 +158,18 @@ export class CodingListQueryService {
         const unitKey = r.unit?.name || '';
         const variableId = r.variableid || '';
         const hasValue = r.value != null && r.value.trim() !== '';
+        const responseStatus = Number(r.status_v1);
+        const isIncludedDeriveError =
+          responseStatus === DERIVE_ERROR_STATUS &&
+          deriveErrorPairKeys.has(toManualCodingVariablePairKey(
+            unitKey.toUpperCase(),
+            variableId
+          ));
 
-        if (!MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES.includes(Number(r.status_v1))) return false;
+        if (
+          !MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES.includes(responseStatus) &&
+          !isIncludedDeriveError
+        ) return false;
         if (!hasValue) return false;
 
         const hasExcludedSubstring = /image|text|audio|frame|video|_0/i.test(variableId);
@@ -249,7 +288,7 @@ export class CodingListQueryService {
       this.logger.log(
         `Found ${sortedResult.length} coding items after manual-coding candidate filtering, total raw ${total}`
       );
-      return { items: sortedResult, total };
+      return { items: sortedResult, total: sortedResult.length };
     } catch (error) {
       this.logger.error(`Error fetching coding list: ${error.message}`);
       return { items: [], total: 0 };
@@ -318,6 +357,13 @@ export class CodingListQueryService {
     workspaceId: number,
     trainingRequired?: boolean
   ): Promise<Array<{ unitName: string; variableId: string }>> {
+    const includeDeriveError = await isDeriveErrorInManualCodingEnabled(
+      this.settingRepository,
+      workspaceId
+    );
+    const candidateStatuses = includeDeriveError ?
+      [...MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES, DERIVE_ERROR_STATUS] :
+      MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES;
     const queryBuilder = this.responseRepository
       .createQueryBuilder('response')
       .innerJoin('response.unit', 'unit')
@@ -329,20 +375,12 @@ export class CodingListQueryService {
       .addSelect('response.status_v1', 'statusV1')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
-      .andWhere("(response.value IS NOT NULL AND response.value != '')")
+      .andWhere(getCodingResponseValueCandidateSql('response'))
       .andWhere('response.status_v1 IN (:...statuses)', {
-        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+        statuses: candidateStatuses
       });
 
-    // Exclude media variables
-    queryBuilder.andWhere(
-      `response.variableid NOT LIKE 'image%'
-       AND response.variableid NOT LIKE 'text%'
-       AND response.variableid NOT LIKE 'audio%'
-       AND response.variableid NOT LIKE 'frame%'
-       AND response.variableid NOT LIKE 'video%'
-       AND response.variableid NOT LIKE '%_0' ESCAPE '\\'`
-    );
+    queryBuilder.andWhere(getCodingVariableIdCandidateSql('response'));
 
     const { globalIgnoredUnits, ignoredBooklets, testletIgnoredUnits } = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     applyResolvedExclusionsToQuery(queryBuilder, { globalIgnoredUnits, ignoredBooklets, testletIgnoredUnits });
@@ -378,12 +416,31 @@ export class CodingListQueryService {
     manualInstructionMap.forEach((variables: Set<string>, unitName: string) => {
       manualInstructionSets.set(unitName.toUpperCase(), variables);
     });
+    const deriveErrorPairKeys = new Set(
+      includeDeriveError ?
+        getDeriveErrorCodingListPairKeys(
+          unitVariableMap,
+          manualInstructionMap,
+          derivedVariablesBySourceMap
+        ) :
+        []
+    );
 
     const baseFilteredResults = rawResults.filter(row => {
-      const unitNameUpper = row.unitName?.toUpperCase();
+      const unitNameUpper = row.unitName?.toUpperCase() || '';
       const variableId: string = row.variableId;
+      const responseStatus = Number(row.statusV1);
+      const isIncludedDeriveError =
+        responseStatus === DERIVE_ERROR_STATUS &&
+        deriveErrorPairKeys.has(toManualCodingVariablePairKey(
+          unitNameUpper,
+          variableId
+        ));
 
-      if (!MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES.includes(Number(row.statusV1))) return false;
+      if (
+        !MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES.includes(responseStatus) &&
+        !isIncludedDeriveError
+      ) return false;
 
       const validVars = validVariableSets.get(unitNameUpper);
       if (!validVars?.has(variableId)) return false;

--- a/apps/backend/src/app/database/services/coding/coding-list-stream.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-stream.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import * as ExcelJS from 'exceljs';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -11,7 +12,9 @@ import { CodingItemBuilderService, CodingItemVersionRow } from './coding-item-bu
 import { CodingFileCacheService } from './coding-file-cache.service';
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
 import { ResponseEntity } from '../../entities/response.entity';
+import { Setting } from '../../entities/setting.entity';
 import { CodingReplayAnchorService } from './coding-replay-anchor.service';
+import { getManualCodingScopeKey } from '../../utils/manual-coding-scope.util';
 import type {
   MissingsProfilesService,
   ResolvedMissingsProfile
@@ -26,6 +29,8 @@ describe('CodingListStreamService', () => {
   let mockFileCacheService: jest.Mocked<CodingFileCacheService>;
   let mockConfigService: jest.Mocked<ConfigService>;
   let mockReplayAnchorService: jest.Mocked<CodingReplayAnchorService>;
+  let mockWorkspaceFilesService: jest.Mocked<WorkspaceFilesService>;
+  let mockSettingRepository: { findOne: jest.Mock };
 
   const createMockResponse = (id: number): ResponseEntity => ({
     id,
@@ -137,6 +142,15 @@ describe('CodingListStreamService', () => {
     mockReplayAnchorService = {
       getVariableAnchorMaps: jest.fn().mockResolvedValue(new Map())
     } as unknown as jest.Mocked<CodingReplayAnchorService>;
+    mockWorkspaceFilesService = {
+      getCoderTrainingRequiredVariableMap: jest.fn().mockResolvedValue(new Map()),
+      getUnitVariableMap: jest.fn().mockResolvedValue(new Map()),
+      getManualInstructionVariableMap: jest.fn().mockResolvedValue(new Map()),
+      getDerivedVariablesBySourceMap: jest.fn().mockResolvedValue(new Map())
+    } as unknown as jest.Mocked<WorkspaceFilesService>;
+    mockSettingRepository = {
+      findOne: jest.fn().mockResolvedValue(null)
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -151,10 +165,9 @@ describe('CodingListStreamService', () => {
         { provide: CodingReplayAnchorService, useValue: mockReplayAnchorService },
         {
           provide: WorkspaceFilesService,
-          useValue: {
-            getCoderTrainingRequiredVariableMap: jest.fn().mockResolvedValue(new Map())
-          }
-        }
+          useValue: mockWorkspaceFilesService
+        },
+        { provide: getRepositoryToken(Setting), useValue: mockSettingRepository }
       ]
     }).compile();
 
@@ -169,6 +182,66 @@ describe('CodingListStreamService', () => {
   });
 
   describe('Stream creation', () => {
+    it('forwards the workspace DERIVE_ERROR scope through CSV, Excel and JSON exports', async () => {
+      mockSettingRepository.findOne.mockResolvedValue({
+        key: 'workspace-1-include-derive-error-in-manual-coding',
+        content: JSON.stringify({ enabled: true })
+      });
+      mockWorkspaceFilesService.getUnitVariableMap.mockResolvedValue(new Map([[
+        'UNIT1',
+        new Set(['SOURCE_VAR', 'DERIVED_VAR'])
+      ]]));
+      mockWorkspaceFilesService.getManualInstructionVariableMap.mockResolvedValue(
+        new Map([['UNIT1', new Set(['DERIVED_VAR'])]])
+      );
+      mockWorkspaceFilesService.getDerivedVariablesBySourceMap.mockResolvedValue(
+        new Map([[
+          getManualCodingScopeKey('UNIT1', 'SOURCE_VAR'),
+          new Set(['DERIVED_VAR'])
+        ]])
+      );
+
+      const expectedFilterOptions = {
+        manualCodingCandidatesOnly: true,
+        deriveErrorManualCodingPairKeys: ['UNIT1\u001FDERIVED_VAR']
+      };
+      mockResponseFilterService.getResponsesBatch
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const csvStream = await service.getCodingListCsvStream(
+        1,
+        'token',
+        'http://server'
+      );
+      csvStream.on('data', () => {});
+      await new Promise<void>(resolve => {
+        csvStream.on('end', resolve);
+      });
+
+      await service.getCodingListAsExcel(1, 'token', 'http://server');
+
+      const jsonStream = service.getCodingListJsonStream(
+        1,
+        'token',
+        'http://server'
+      );
+      await new Promise<void>(resolve => {
+        jsonStream.on('end', resolve);
+        jsonStream.on('data', () => {});
+      });
+
+      expect(mockResponseFilterService.countResponses).toHaveBeenCalledTimes(3);
+      expect(mockResponseFilterService.getResponsesBatch).toHaveBeenCalledTimes(3);
+      mockResponseFilterService.countResponses.mock.calls.forEach(call => {
+        expect(call).toEqual([1, expectedFilterOptions]);
+      });
+      mockResponseFilterService.getResponsesBatch.mock.calls.forEach(call => {
+        expect(call).toEqual([1, 0, 500, expectedFilterOptions]);
+      });
+    });
+
     it('should create CSV stream', async () => {
       mockResponseFilterService.getResponsesBatch.mockResolvedValueOnce([]);
 

--- a/apps/backend/src/app/database/services/coding/coding-list-stream.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-list-stream.service.ts
@@ -2,11 +2,13 @@ import {
   BadRequestException, Injectable, Logger, Optional
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
 import * as fastCsv from 'fast-csv';
 import * as ExcelJS from 'exceljs';
 import * as fs from 'fs';
 import archiver = require('archiver');
 import { PassThrough, Writable } from 'stream';
+import { Repository } from 'typeorm';
 // eslint-disable-next-line import/no-cycle
 import {
   CodingResponseFilterService,
@@ -26,12 +28,15 @@ import {
   decodeGeoGebraValue
 } from './geogebra-export.util';
 import { ResponseEntity } from '../../entities/response.entity';
+import { Setting } from '../../entities/setting.entity';
 import { CodingReplayAnchorService } from './coding-replay-anchor.service';
 import {
   MissingsProfilesService,
   ResolvedMissingsProfile
 } from './missings-profiles.service';
 import { resolveV1ExportValue } from './versioned-results-missing-resolver';
+import { getDeriveErrorCodingListPairKeys } from '../../utils/manual-coding-candidate.util';
+import { isDeriveErrorInManualCodingEnabled } from '../../utils/manual-coding-setting.util';
 
 interface JsonStream {
   on(event: 'data', listener: (item: CodingItem) => void): void;
@@ -81,7 +86,10 @@ export class CodingListStreamService {
     private readonly workspaceFilesService: WorkspaceFilesService,
     @Optional() private readonly configService?: ConfigService,
     @Optional() private readonly replayAnchorService?: CodingReplayAnchorService,
-    @Optional() private readonly missingsProfilesService?: MissingsProfilesService
+    @Optional() private readonly missingsProfilesService?: MissingsProfilesService,
+    @Optional()
+    @InjectRepository(Setting)
+    private readonly settingRepository?: Repository<Setting>
   ) { }
 
   private async loadV1ExportProfile(
@@ -273,16 +281,44 @@ export class CodingListStreamService {
       trainingRequiredMap: Map<string, Set<string>> | null;
     }> {
     await checkCancellation?.();
-    const trainingRequiredMap = await (
+    const includeDeriveError = await isDeriveErrorInManualCodingEnabled(
+      this.settingRepository,
+      workspaceId
+    );
+    const [
+      trainingRequiredMap,
+      unitVariableMap,
+      manualInstructionMap,
+      derivedVariablesBySourceMap
+    ] = await Promise.all([
       trainingRequired !== undefined ?
         this.workspaceFilesService.getCoderTrainingRequiredVariableMap(workspaceId) :
-        Promise.resolve(null)
-    );
+        Promise.resolve(null),
+      includeDeriveError ?
+        this.workspaceFilesService.getUnitVariableMap(workspaceId) :
+        Promise.resolve(new Map<string, Set<string>>()),
+      includeDeriveError ?
+        this.workspaceFilesService.getManualInstructionVariableMap(workspaceId) :
+        Promise.resolve(new Map<string, Set<string>>()),
+      includeDeriveError ?
+        this.workspaceFilesService.getDerivedVariablesBySourceMap(workspaceId) :
+        Promise.resolve(new Map<string, Set<string>>())
+    ]);
     await checkCancellation?.();
+    const deriveErrorManualCodingPairKeys = includeDeriveError ?
+      getDeriveErrorCodingListPairKeys(
+        unitVariableMap,
+        manualInstructionMap,
+        derivedVariablesBySourceMap
+      ) :
+      [];
 
     return {
       filterOptions: {
-        manualCodingCandidatesOnly: true
+        manualCodingCandidatesOnly: true,
+        ...(deriveErrorManualCodingPairKeys.length > 0 ?
+          { deriveErrorManualCodingPairKeys } :
+          {})
       },
       trainingRequiredMap
     };

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -63,6 +63,7 @@ const createQueryBuilder = (rawResults: unknown[] = []) => {
     'leftJoin',
     'where',
     'andWhere',
+    'distinct',
     'groupBy',
     'addGroupBy',
     'orderBy'

--- a/apps/backend/src/app/database/services/coding/coding-response-candidate.util.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-candidate.util.spec.ts
@@ -1,5 +1,6 @@
 import {
   excludedCodingVariableFragments,
+  getCodingResponseValueCandidateSql,
   getCodingVariableIdCandidateSql,
   isCodingResponseCandidateByPattern,
   isCodingVariableIdCandidate
@@ -24,6 +25,13 @@ describe('coding response candidate utils', () => {
   it('keeps the stricter response-candidate helper value-aware', () => {
     expect(isCodingResponseCandidateByPattern('var1', 'answer')).toBe(true);
     expect(isCodingResponseCandidateByPattern('var1', '   ')).toBe(false);
+    expect(isCodingResponseCandidateByPattern('var1', '\t\n')).toBe(false);
     expect(isCodingResponseCandidateByPattern('image_1', 'answer')).toBe(false);
+  });
+
+  it('uses a SQL value filter that rejects every whitespace-only value', () => {
+    expect(getCodingResponseValueCandidateSql('response')).toBe(
+      "response.value IS NOT NULL AND response.value ~ '[^[:space:]]'"
+    );
   });
 });

--- a/apps/backend/src/app/database/services/coding/coding-response-candidate.util.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-candidate.util.ts
@@ -27,6 +27,10 @@ export function isCodingResponseCandidateByPattern(
   return hasCodingResponseValue(value) && isCodingVariableIdCandidate(variableId);
 }
 
+export function getCodingResponseValueCandidateSql(alias: string): string {
+  return `${alias}.value IS NOT NULL AND ${alias}.value ~ '[^[:space:]]'`;
+}
+
 export function getCodingVariableIdCandidateSql(alias: string): string {
   return excludedCodingVariableFragments
     .map(fragment => {

--- a/apps/backend/src/app/database/services/coding/coding-response-filter.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-filter.service.spec.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { Brackets, Repository } from 'typeorm';
 import { CodingResponseFilterService } from './coding-response-filter.service';
 import { ResponseEntity } from '../../entities/response.entity';
 import { CodingFileCacheService } from './coding-file-cache.service';
@@ -13,6 +13,7 @@ function createQueryBuilderMock() {
   queryBuilder.select = jest.fn(() => queryBuilder);
   queryBuilder.addSelect = jest.fn(() => queryBuilder);
   queryBuilder.where = jest.fn(() => queryBuilder);
+  queryBuilder.orWhere = jest.fn(() => queryBuilder);
   queryBuilder.andWhere = jest.fn(() => queryBuilder);
   queryBuilder.orderBy = jest.fn(() => queryBuilder);
   queryBuilder.take = jest.fn(() => queryBuilder);
@@ -162,6 +163,43 @@ describe('CodingResponseFilterService', () => {
           12
         ]
       }
+    );
+  });
+
+  it('includes DERIVE_ERROR only for explicitly scoped coding-list variables', async () => {
+    const { service, queryBuilder } = createService();
+    const deriveErrorManualCodingPairKeys = ['UNIT1\u001Fvar1'];
+
+    await service.countResponses(1, {
+      manualCodingCandidatesOnly: true,
+      deriveErrorManualCodingPairKeys
+    });
+
+    const statusFilter = queryBuilder.where.mock.calls[0][0] as Brackets;
+    expect(statusFilter).toBeInstanceOf(Brackets);
+    statusFilter.whereFactory(queryBuilder as never);
+    expect(queryBuilder.where).toHaveBeenCalledWith(
+      'response.status_v1 IN (:...statuses)',
+      { statuses: [8, 12] }
+    );
+    expect(queryBuilder.orWhere).toHaveBeenCalledWith(
+      expect.stringContaining('response.status_v1 = :deriveErrorStatus'),
+      {
+        deriveErrorStatus: 4,
+        deriveErrorManualCodingPairKeys
+      }
+    );
+    const deriveErrorCondition =
+      queryBuilder.orWhere.mock.calls[0][0] as string;
+    expect(deriveErrorCondition).toContain('response.value IS NOT NULL');
+    expect(deriveErrorCondition).toContain(
+      "response.value ~ '[^[:space:]]'"
+    );
+    expect(deriveErrorCondition).toContain(
+      "response.variableid NOT ILIKE '%image%'"
+    );
+    expect(deriveErrorCondition).toContain(
+      "response.variableid NOT ILIKE '%\\_0%' ESCAPE '\\'"
     );
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-response-filter.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-response-filter.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Brackets, Repository } from 'typeorm';
 import { ResponseEntity } from '../../entities/response.entity';
 import {
   statusStringToNumber,
@@ -16,8 +16,15 @@ import {
 } from '../workspace/workspace-exclusion.service';
 // eslint-disable-next-line import/no-cycle
 import { WorkspaceFilesService } from '../workspace/workspace-files.service';
-import { MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES } from '../../utils/manual-coding-candidate.util';
-import { isCodingResponseCandidateByPattern } from './coding-response-candidate.util';
+import {
+  DERIVE_ERROR_STATUS,
+  MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+} from '../../utils/manual-coding-candidate.util';
+import {
+  getCodingResponseValueCandidateSql,
+  getCodingVariableIdCandidateSql,
+  isCodingResponseCandidateByPattern
+} from './coding-response-candidate.util';
 import type { CodingItemVersionRow } from './coding-item-builder.service';
 
 type RawNumericValue = number | string | null;
@@ -53,6 +60,7 @@ export interface ResponseFilterOptions {
   validCodingVariablesOnly?: boolean;
   givenResponsesOnly?: boolean;
   manualCodingCandidatesOnly?: boolean;
+  deriveErrorManualCodingPairKeys?: string[];
 }
 
 /**
@@ -155,9 +163,29 @@ export class CodingResponseFilterService {
         { statisticsIgnoredStatuses: ignoredStatuses }
       );
     } else if (options.manualCodingCandidatesOnly) {
-      queryBuilder.where('response.status_v1 IN (:...statuses)', {
-        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
-      });
+      const deriveErrorManualCodingPairKeys =
+        options.deriveErrorManualCodingPairKeys || [];
+      if (deriveErrorManualCodingPairKeys.length === 0) {
+        queryBuilder.where('response.status_v1 IN (:...statuses)', {
+          statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+        });
+      } else {
+        queryBuilder.where(new Brackets(qb => {
+          qb.where('response.status_v1 IN (:...statuses)', {
+            statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+          }).orWhere(
+            `response.status_v1 = :deriveErrorStatus
+              AND ${getCodingResponseValueCandidateSql('response')}
+              AND ${getCodingVariableIdCandidateSql('response')}
+              AND CONCAT(UPPER(unit.name), CHR(31), response.variableid)
+                IN (:...deriveErrorManualCodingPairKeys)`,
+            {
+              deriveErrorStatus: DERIVE_ERROR_STATUS,
+              deriveErrorManualCodingPairKeys
+            }
+          );
+        }));
+      }
     } else if (options.statuses?.length) {
       queryBuilder.where('response.status_v1 IN (:...statuses)', {
         statuses: options.statuses

--- a/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
+++ b/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
@@ -1,4 +1,8 @@
 import { statusStringToNumber } from './response-status-converter';
+import {
+  getCoveredSourceKeysForManualDerivedVariables,
+  getManualCodingScopeKey
+} from './manual-coding-scope.util';
 
 function requireStatusNumber(status: string): number {
   const statusNumber = statusStringToNumber(status);
@@ -74,4 +78,31 @@ export function getDeriveErrorManualCodingPairKeys(
         variable.variableId
       ))
   ));
+}
+
+export function getDeriveErrorCodingListPairKeys(
+  unitVariableMap: Map<string, Set<string>>,
+  manualInstructionMap: Map<string, Set<string>>,
+  derivedVariablesBySourceMap: Map<string, Set<string>>
+): string[] {
+  const manualInstructionVariables = Array.from(
+    manualInstructionMap.entries()
+  ).flatMap(([unitName, variableIds]) => (
+    Array.from(variableIds).map(variableId => ({ unitName, variableId }))
+  ));
+  const coveredSourceKeys = getCoveredSourceKeysForManualDerivedVariables(
+    manualInstructionVariables,
+    derivedVariablesBySourceMap
+  );
+
+  return Array.from(unitVariableMap.entries()).flatMap(
+    ([unitName, variableIds]) => Array.from(variableIds)
+      .filter(variableId => !coveredSourceKeys.has(
+        getManualCodingScopeKey(unitName, variableId)
+      ))
+      .map(variableId => toManualCodingVariablePairKey(
+        unitName.toUpperCase(),
+        variableId
+      ))
+  );
 }

--- a/apps/backend/src/app/database/utils/manual-coding-setting.util.ts
+++ b/apps/backend/src/app/database/utils/manual-coding-setting.util.ts
@@ -1,0 +1,33 @@
+import { Repository } from 'typeorm';
+import { Setting } from '../entities/setting.entity';
+
+export const INCLUDE_DERIVE_ERROR_IN_MANUAL_CODING_SETTING_KEY =
+  'include-derive-error-in-manual-coding';
+
+type SettingReader = Pick<Repository<Setting>, 'findOne'>;
+
+export async function isDeriveErrorInManualCodingEnabled(
+  settingRepository: SettingReader | undefined,
+  workspaceId: number
+): Promise<boolean> {
+  if (!settingRepository) {
+    return false;
+  }
+
+  const setting = await settingRepository.findOne({
+    where: {
+      key: `workspace-${workspaceId}-${INCLUDE_DERIVE_ERROR_IN_MANUAL_CODING_SETTING_KEY}`
+    }
+  });
+
+  if (!setting) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(setting.content);
+    return parsed.enabled === true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/backend/src/app/workspace/workspace-settings.controller.spec.ts
+++ b/apps/backend/src/app/workspace/workspace-settings.controller.spec.ts
@@ -129,7 +129,7 @@ describe('WorkspaceSettingsController', () => {
       key: 'workspace-5-include-derive-error-in-manual-coding',
       value: JSON.stringify({ enabled: false }),
       description:
-        'Controls whether DERIVE_ERROR responses can be included in manual coding jobs'
+        'Controls whether DERIVE_ERROR responses are included in coding lists and can be selected for manual coding jobs'
     });
   });
 

--- a/apps/backend/src/app/workspace/workspace-settings.controller.ts
+++ b/apps/backend/src/app/workspace/workspace-settings.controller.ts
@@ -69,7 +69,7 @@ const DEFAULT_WORKSPACE_SETTINGS: Record<string, {
   'include-derive-error-in-manual-coding': {
     value: { enabled: false },
     description:
-      'Controls whether DERIVE_ERROR responses can be included in manual coding jobs'
+      'Controls whether DERIVE_ERROR responses are included in coding lists and can be selected for manual coding jobs'
   },
   'enable-regex-search': {
     value: { enabled: false },

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.spec.ts
@@ -467,7 +467,7 @@ describe('WorkspaceSettingsService', () => {
       expect(req.request.body).toEqual({
         key: 'include-derive-error-in-manual-coding',
         value: '{"enabled":true}',
-        description: 'Controls whether DERIVE_ERROR responses can be included in manual coding jobs'
+        description: 'Controls whether DERIVE_ERROR responses are included in coding lists and can be selected for manual coding jobs'
       });
       req.flush({});
     });

--- a/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
+++ b/apps/frontend/src/app/ws-admin/services/workspace-settings.service.ts
@@ -376,7 +376,7 @@ export class WorkspaceSettingsService {
       workspaceId,
       'include-derive-error-in-manual-coding',
       value,
-      'Controls whether DERIVE_ERROR responses can be included in manual coding jobs'
+      'Controls whether DERIVE_ERROR responses are included in coding lists and can be selected for manual coding jobs'
     );
   }
 

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1348,7 +1348,7 @@
     "auto-refresh-manual-coding-jobs": "Kodierübersichten und Kodierjob-Tabellen automatisch aktualisieren",
     "auto-refresh-manual-coding-jobs-description": "Wenn aktiviert, werden Kodierübersicht, Manuelle Kodierung und Kodierjob-Tabellen automatisch bei relevanten Änderungen aktualisiert. Wenn deaktiviert, laden Sie teure Übersichten und Listen gezielt per Aktualisieren-Button.",
     "include-derive-error-in-manual-coding": "DERIVE_ERROR in manueller Kodierung zulassen",
-    "include-derive-error-in-manual-coding-description": "Wenn aktiviert, können DERIVE_ERROR-Fälle bei Kodierjobdefinitionen gezielt in die manuelle Kodierung aufgenommen werden. Standardmäßig ist diese Funktion deaktiviert.",
+    "include-derive-error-in-manual-coding-description": "Wenn aktiviert, werden DERIVE_ERROR-Fälle in Kodierlisten aufgenommen und können bei Kodierjobdefinitionen gezielt in die manuelle Kodierung einbezogen werden. Standardmäßig ist diese Funktion deaktiviert.",
     "include-derive-error-in-manual-coding-enabled": "DERIVE_ERROR-Fälle können in die manuelle Kodierung aufgenommen werden",
     "include-derive-error-in-manual-coding-disabled": "DERIVE_ERROR-Fälle werden nicht in die manuelle Kodierung aufgenommen",
     "enable-regex-search": "Reguläre Ausdrücke in Suchfeldern",


### PR DESCRIPTION
## Summary

- include eligible `DERIVE_ERROR` responses in direct coding lists when the workspace setting is enabled
- apply the same scoped Unit/Variable eligibility rules to CSV, Excel, and JSON exports
- preserve the original `DERIVE_ERROR` status in exported results
- clarify the workspace-setting descriptions in the backend and frontend

## Motivation

The workspace setting previously allowed `DERIVE_ERROR` responses to be selected for manual coding jobs, but the same responses were missing from coding lists and their exports. This made the behavior inconsistent across the manual-coding workflow.

The implementation centralizes setting lookup and candidate checks, restricts derived-error responses to eligible Unit/Variable pairs, and uses the same context for direct lists and streamed exports.

## Validation

- `npx nx lint backend`
- `npx nx test backend` — 152 suites, 2243 passed, 10 skipped
- `git diff --check`

Relates to #546
