### PR TITLE
Optimize replay session start for large coding jobs

### DIFF
--- a/api-dto/coding/replay-coding-session.dto.ts
+++ b/api-dto/coding/replay-coding-session.dto.ts
@@ -1,0 +1,68 @@
+export type ReplayCodingBundleVariableStatus =
+  | 'manual-open'
+  | 'manual-coded'
+  | 'auto-coded'
+  | 'not-coded'
+  | 'not-available';
+
+export interface ReplayCodingBundleVariableContextDto {
+  responseId: number | null;
+  unitName: string;
+  variableId: string;
+  variableAnchor: string;
+  variablePage: string;
+  status: ReplayCodingBundleVariableStatus;
+  code: number | null;
+  score: number | null;
+  source: 'manual' | 'auto' | 'none';
+}
+
+export interface ReplayCodingBundleContextDto {
+  bundleId: number;
+  bundleName: string;
+  caseKey: string;
+  caseOrderingMode: 'continuous' | 'alternating';
+  variables: ReplayCodingBundleVariableContextDto[];
+}
+
+export interface ReplayCodingSessionUnitDto {
+  responseId: number;
+  unitName: string;
+  unitAlias: string | null;
+  variableId: string;
+  variableAnchor: string;
+  variablePage: string;
+  bookletName: string;
+  personLogin: string;
+  personCode: string;
+  personGroup: string;
+  variableBundleId: number | null;
+  bundleContext: ReplayCodingBundleContextDto | null;
+}
+
+export interface ReplayCodingProgressEntryDto {
+  id: number;
+  code?: string;
+  label?: string;
+  score?: number;
+  codingIssueOption?: number;
+}
+
+export interface ReplayCodingSessionJobDto {
+  status: string;
+  comment: string | null;
+  showScore: boolean;
+  allowComments: boolean;
+  suppressGeneralInstructions: boolean;
+}
+
+export type ReplayCodingSessionServerTimingsDto =
+  Record<string, number | null>;
+
+export interface ReplayCodingSessionDto {
+  units: ReplayCodingSessionUnitDto[];
+  progress: Record<string, ReplayCodingProgressEntryDto | null>;
+  notes: Record<string, string>;
+  job: ReplayCodingSessionJobDto;
+  serverTimings: ReplayCodingSessionServerTimingsDto;
+}

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -4750,6 +4750,93 @@ describe('CodingJobService', () => {
     }
   });
 
+  it('builds a replay session from one visible-unit scan without peer lookup', async () => {
+    const createUnit = (
+      responseId: number,
+      personLogin: string,
+      isOpen: boolean,
+      code: number | null,
+      notes: string | null
+    ) => ({
+      response_id: responseId,
+      coding_job_id: 10,
+      unit_name: 'UNIT',
+      unit_alias: 'ALIAS',
+      variable_id: 'VAR',
+      variable_anchor: 'VAR',
+      booklet_name: 'BOOKLET',
+      person_login: personLogin,
+      person_code: 'code',
+      person_group: 'group',
+      notes,
+      variable_bundle_id: null,
+      code,
+      score: code === null ? null : 2,
+      is_open: isOpen,
+      coding_issue_option: null
+    });
+    codingJobRepository.findOne.mockResolvedValue({
+      id: 10,
+      workspace_id: 3,
+      status: 'active',
+      comment: 'Training',
+      showScore: true,
+      allowComments: false,
+      suppressGeneralInstructions: true,
+      job_type: 'regular',
+      case_ordering_mode: 'continuous'
+    });
+    codingJobVariableBundleRepository.find.mockResolvedValue([]);
+    codingJobUnitRepository.find.mockResolvedValue([
+      createUnit(1, 'open', true, null, null),
+      createUnit(2, 'coded-a', false, 7, 'First note'),
+      createUnit(3, 'coded-b', false, 7, 'Second note')
+    ]);
+    codingFileCacheService.getVariablePageMap.mockResolvedValue(
+      new Map([['VAR', '0']])
+    );
+    mockCodingScheme();
+    const extractCodingSchemeRefSpy = jest.spyOn(
+      service as unknown as {
+        extractCodingSchemeRef: (
+          unitFile: { file_id: string; data: unknown }
+        ) => string | null;
+      },
+      'extractCodingSchemeRef'
+    );
+
+    const result = await service.getCodingJobReplaySession(10, 3, true);
+
+    expect(codingJobUnitRepository.find).toHaveBeenCalledTimes(1);
+    expect(codingJobUnitRepository.find).toHaveBeenCalledWith({
+      where: { coding_job_id: 10 }
+    });
+    expect(result.units).toHaveLength(1);
+    expect(result.units[0]).toMatchObject({
+      responseId: 1,
+      personLogin: 'open',
+      variablePage: '0'
+    });
+    expect(result.units[0]).not.toHaveProperty('otherCoders');
+    expect(result.units[0]).not.toHaveProperty('isDoubleCoded');
+    expect(Object.values(result.progress).filter(entry => entry?.id === 7))
+      .toHaveLength(2);
+    expect(Object.values(result.notes)).toEqual([
+      'First note',
+      'Second note'
+    ]);
+    expect(result.job).toEqual({
+      status: 'active',
+      comment: 'Training',
+      showScore: true,
+      allowComments: false,
+      suppressGeneralInstructions: true
+    });
+    expect(extractCodingSchemeRefSpy).toHaveBeenCalledTimes(1);
+    expect(fileUploadRepository.find).toHaveBeenCalledTimes(2);
+    expect(result.serverTimings.totalMs).toEqual(expect.any(Number));
+  });
+
   it('filters current coder and unrelated scopes from double-coding markers', async () => {
     codingJobRepository.findOne.mockResolvedValue({
       id: 10,
@@ -5098,7 +5185,6 @@ describe('CodingJobService', () => {
       }
     ]);
     codingJobUnitRepository.find
-      .mockResolvedValueOnce([openUnit])
       .mockResolvedValueOnce([
         openUnit,
         closedBundleUnit,
@@ -5118,13 +5204,12 @@ describe('CodingJobService', () => {
 
     const result = await service.getCodingJobUnits(10, true);
 
-    expect(result).toHaveLength(1);
-    expect(codingJobUnitRepository.find).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        where: { coding_job_id: 10 }
-      })
-    );
+    expect(result).toHaveLength(2);
+    expect(codingJobUnitRepository.find).toHaveBeenCalledTimes(2);
+    expect(codingJobUnitRepository.find).toHaveBeenNthCalledWith(1, {
+      where: { coding_job_id: 10 },
+      select: expect.any(Array)
+    });
     expect(result[0].bundleContext?.caseKey).toBe('login\u0000code\u0000group\u0000BOOKLET');
     expect(result[0].bundleContext?.variables).toEqual([
       expect.objectContaining({

--- a/apps/backend/src/app/database/services/coding/coding-job.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.ts
@@ -98,6 +98,13 @@ import {
   DistributionCoderLoad
 } from './coding-job-distribution-planner';
 import { CodingAggregationPeerService } from './coding-aggregation-peer.service';
+import {
+  ReplayCodingBundleContextDto,
+  ReplayCodingBundleVariableStatus,
+  ReplayCodingProgressEntryDto,
+  ReplayCodingSessionDto,
+  ReplayCodingSessionUnitDto
+} from '../../../../../../../api-dto/coding/replay-coding-session.dto';
 
 function isSafeKey(key: string): boolean {
   return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
@@ -305,31 +312,12 @@ type DistributionCreatedJob = {
   caseCount: number;
 };
 
-type CodingJobBundleVariableStatus =
-  | 'manual-open'
-  | 'manual-coded'
-  | 'auto-coded'
-  | 'not-coded'
-  | 'not-available';
-
-type CodingJobBundleVariableContext = {
-  responseId: number | null;
-  unitName: string;
-  variableId: string;
-  variableAnchor: string;
-  variablePage: string;
-  status: CodingJobBundleVariableStatus;
-  code: number | null;
-  score: number | null;
-  source: 'manual' | 'auto' | 'none';
-};
-
-type CodingJobBundleContext = {
-  bundleId: number;
-  bundleName: string;
-  caseKey: string;
-  caseOrderingMode: 'continuous' | 'alternating';
-  variables: CodingJobBundleVariableContext[];
+type CodingJobBundleVariableStatus = ReplayCodingBundleVariableStatus;
+type CodingJobBundleContext = ReplayCodingBundleContextDto;
+type CodingJobNavigationUnit = ReplayCodingSessionUnitDto & {
+  notes: string | null;
+  isDoubleCoded: boolean;
+  otherCoders: string[];
 };
 
 type DistributedCodingJobsResult = {
@@ -3925,6 +3913,7 @@ export class CodingJobService {
       select: ['file_id', 'data']
     });
     const unitFileById = new Map(unitFiles.map(file => [file.file_id, file]));
+    const codingSchemeRefsByUnitFileId = new Map<string, string[]>();
     const codingSchemeRefsByUnit = new Map<CodingJobUnit, string[]>();
     const codingSchemeRefs = new Set<string>();
 
@@ -3937,12 +3926,18 @@ export class CodingJobService {
         return;
       }
 
-      const codingSchemeRef = this.extractCodingSchemeRef(unitFile);
-      if (!codingSchemeRef) {
-        return;
+      let refs = codingSchemeRefsByUnitFileId.get(unitFile.file_id);
+      if (!refs) {
+        const codingSchemeRef = this.extractCodingSchemeRef(unitFile);
+        refs = codingSchemeRef ?
+          this.getCodingSchemeFileIdCandidates(codingSchemeRef) :
+          [];
+        codingSchemeRefsByUnitFileId.set(unitFile.file_id, refs);
       }
 
-      const refs = this.getCodingSchemeFileIdCandidates(codingSchemeRef);
+      if (refs.length === 0) {
+        return;
+      }
       codingSchemeRefsByUnit.set(unit, refs);
       refs.forEach(ref => codingSchemeRefs.add(ref));
     });
@@ -4185,20 +4180,22 @@ export class CodingJobService {
       codingJob
     );
 
-    if (codingJobUnits.length === 0) {
-      return {};
-    }
+    return this.buildCodingProgress(codingJobUnits, codingJob.workspace_id);
+  }
 
+  private async buildCodingProgress(
+    codingJobUnits: CodingJobUnit[],
+    workspaceId: number
+  ): Promise<Record<string, ReplayCodingProgressEntryDto>> {
     const codedUnits = codingJobUnits.filter(
       unit => unit.code !== null && unit.code >= 0
     );
     const codingSchemesByUnit = await this.getCodingSchemesForUnits(
       codedUnits,
-      codingJob.workspace_id
+      workspaceId
     );
 
-    const progressMap: Record<string, SaveCodingProgressDto['selectedCode']> =
-      {};
+    const progressMap: Record<string, ReplayCodingProgressEntryDto> = {};
 
     const setProgressEntry = (unit: CodingJobUnit, compositeKey: string) => {
       const progressCode = unit.code ?? unit.coding_issue_option;
@@ -4279,10 +4276,12 @@ export class CodingJobService {
       codingJob
     );
 
-    if (codingJobUnits.length === 0) {
-      return {};
-    }
+    return this.buildCodingNotes(codingJobUnits);
+  }
 
+  private buildCodingNotes(
+    codingJobUnits: CodingJobUnit[]
+  ): Record<string, string> {
     const notesMap: Record<string, string> = {};
 
     codingJobUnits.forEach(unit => {
@@ -4298,33 +4297,7 @@ export class CodingJobService {
   async getCodingJobUnits(
     codingJobId: number,
     onlyOpen: boolean = false
-  ): Promise<
-    {
-      responseId: number;
-      unitName: string;
-      unitAlias: string | null;
-      variableId: string;
-      variableAnchor: string;
-      variablePage: string;
-      bookletName: string;
-      personLogin: string;
-      personCode: string;
-      personGroup: string;
-      notes: string | null;
-      variableBundleId: number | null;
-      bundleContext: CodingJobBundleContext | null;
-      isDoubleCoded: boolean;
-      otherCoders: string[];
-    }[]
-    > {
-    const whereClause: { coding_job_id: number; is_open?: boolean } = {
-      coding_job_id: codingJobId
-    };
-
-    if (onlyOpen) {
-      whereClause.is_open = true;
-    }
-
+  ): Promise<CodingJobNavigationUnit[]> {
     const codingJob = await this.codingJobRepository.findOne({
       where: { id: codingJobId },
       relations: ['codingJobCoders', 'codingJobCoders.user']
@@ -4333,17 +4306,10 @@ export class CodingJobService {
       return [];
     }
 
-    const globalMode = codingJob.case_ordering_mode || 'continuous';
-
     const bundles = await this.codingJobVariableBundleRepository.find({
       where: { coding_job_id: codingJobId },
       order: { id: 'ASC' }
     });
-
-    const bundleModes = new Map<number, string>();
-    for (const b of bundles) {
-      bundleModes.set(b.variable_bundle_id, b.case_ordering_mode || globalMode);
-    }
 
     const codingJobUnitSelect: (keyof CodingJobUnit)[] = [
       'response_id',
@@ -4363,7 +4329,7 @@ export class CodingJobService {
     ];
 
     const codingJobUnits = await this.codingJobUnitRepository.find({
-      where: whereClause,
+      where: { coding_job_id: codingJobId },
       select: codingJobUnitSelect
     });
     const exclusions =
@@ -4377,18 +4343,132 @@ export class CodingJobService {
         unit.unit_name
       )
     );
-    const visibleCodingJobUnitsForContext = onlyOpen ?
-      (await this.codingJobUnitRepository.find({
+
+    return this.buildCodingJobNavigationUnits(
+      codingJob,
+      bundles,
+      visibleCodingJobUnits,
+      onlyOpen,
+      true
+    );
+  }
+
+  async getCodingJobReplaySession(
+    codingJobId: number,
+    workspaceId: number,
+    onlyOpen: boolean = false
+  ): Promise<ReplayCodingSessionDto> {
+    const startedAt = Date.now();
+    const codingJob = await this.codingJobRepository.findOne({
+      where: { id: codingJobId, workspace_id: workspaceId }
+    });
+    const jobLoadedAt = Date.now();
+
+    if (!codingJob) {
+      throw new NotFoundException(
+        `Coding job with ID ${codingJobId} not found`
+      );
+    }
+
+    const [bundles, codingJobUnits, exclusions] = await Promise.all([
+      this.codingJobVariableBundleRepository.find({
         where: { coding_job_id: codingJobId },
-        select: codingJobUnitSelect
-      })).filter(
-        unit => !isExcludedByResolvedExclusions(
-          exclusions,
-          unit.booklet_name,
-          unit.unit_name
-        )
-      ) :
-      visibleCodingJobUnits;
+        order: { id: 'ASC' }
+      }),
+      this.codingJobUnitRepository.find({
+        where: { coding_job_id: codingJobId }
+      }),
+      this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId)
+    ]);
+    const contextLoadedAt = Date.now();
+    const visibleCodingJobUnits = codingJobUnits.filter(
+      unit => !isExcludedByResolvedExclusions(
+        exclusions,
+        unit.booklet_name,
+        unit.unit_name
+      )
+    );
+    const effectiveCodingJobUnits =
+      await this.applyCodingIssueReviewOverlays(
+        codingJob,
+        visibleCodingJobUnits
+      );
+    const reviewOverlaysAppliedAt = Date.now();
+
+    const navigationUnits = await this.buildCodingJobNavigationUnits(
+      codingJob,
+      bundles,
+      visibleCodingJobUnits,
+      onlyOpen,
+      false
+    );
+    const units: ReplayCodingSessionUnitDto[] = navigationUnits.map(unit => ({
+      responseId: unit.responseId,
+      unitName: unit.unitName,
+      unitAlias: unit.unitAlias,
+      variableId: unit.variableId,
+      variableAnchor: unit.variableAnchor,
+      variablePage: unit.variablePage,
+      bookletName: unit.bookletName,
+      personLogin: unit.personLogin,
+      personCode: unit.personCode,
+      personGroup: unit.personGroup,
+      variableBundleId: unit.variableBundleId,
+      bundleContext: unit.bundleContext
+    }));
+    const unitsBuiltAt = Date.now();
+    const progress = await this.buildCodingProgress(
+      effectiveCodingJobUnits,
+      workspaceId
+    );
+    const progressBuiltAt = Date.now();
+    const notes = this.buildCodingNotes(effectiveCodingJobUnits);
+    const notesBuiltAt = Date.now();
+    const job = {
+      status: codingJob.status,
+      comment: codingJob.comment ?? null,
+      showScore: codingJob.showScore,
+      allowComments: codingJob.allowComments,
+      suppressGeneralInstructions: codingJob.suppressGeneralInstructions
+    };
+    const responsePreparedAt = Date.now();
+
+    return {
+      units,
+      progress,
+      notes,
+      job,
+      serverTimings: {
+        loadJobMs: jobLoadedAt - startedAt,
+        loadContextMs: contextLoadedAt - jobLoadedAt,
+        reviewOverlaysMs: reviewOverlaysAppliedAt - contextLoadedAt,
+        buildUnitsMs: unitsBuiltAt - reviewOverlaysAppliedAt,
+        buildProgressMs: progressBuiltAt - unitsBuiltAt,
+        buildNotesMs: notesBuiltAt - progressBuiltAt,
+        finalizeResponseMs: responsePreparedAt - notesBuiltAt,
+        totalMs: responsePreparedAt - startedAt
+      }
+    };
+  }
+
+  private async buildCodingJobNavigationUnits(
+    codingJob: CodingJob,
+    bundles: CodingJobVariableBundle[],
+    visibleCodingJobUnitsForContext: CodingJobUnit[],
+    onlyOpen: boolean,
+    includePeerCoders: boolean
+  ): Promise<CodingJobNavigationUnit[]> {
+    const globalMode = codingJob.case_ordering_mode || 'continuous';
+    const bundleModes = new Map<number, string>();
+    for (const bundle of bundles) {
+      bundleModes.set(
+        bundle.variable_bundle_id,
+        bundle.case_ordering_mode || globalMode
+      );
+    }
+    const visibleCodingJobUnits = onlyOpen ?
+      visibleCodingJobUnitsForContext.filter(unit => unit.is_open) :
+      visibleCodingJobUnitsForContext;
 
     // Detect double coding and other coders in the same logical coding scope.
     const responseIds = visibleCodingJobUnits.map(unit => unit.response_id);
@@ -4397,11 +4477,11 @@ export class CodingJobService {
       (codingJob.codingJobCoders || []).map(cjc => cjc.user_id)
     );
 
-    if (responseIds.length > 0) {
+    if (includePeerCoders && responseIds.length > 0) {
       const otherUnits = await this.codingJobUnitRepository.find({
         where: {
           response_id: In(responseIds),
-          coding_job_id: Not(codingJobId)
+          coding_job_id: Not(codingJob.id)
         },
         relations: [
           'coding_job',

--- a/apps/backend/src/app/database/services/test-results/replay-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/replay-statistics.service.spec.ts
@@ -61,7 +61,9 @@ describe('ReplayStatisticsService', () => {
         unitId: 'UNIT-1',
         durationMilliseconds: 1234,
         clientTimings: {
-          codingSessionMs: 100.123
+          codingSessionMs: 100.123,
+          routeToCodingSessionRequestMs: 12.345,
+          codingSessionResponseToPayloadRequestMs: 23.456
         },
         serverTimings: {
           codingSessionLoadJobMs: 1,
@@ -77,7 +79,9 @@ describe('ReplayStatisticsService', () => {
 
       expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({
         client_timings: {
-          codingSessionMs: 100.12
+          codingSessionMs: 100.12,
+          routeToCodingSessionRequestMs: 12.35,
+          codingSessionResponseToPayloadRequestMs: 23.46
         },
         server_timings: {
           codingSessionLoadJobMs: 1,

--- a/apps/backend/src/app/database/services/test-results/replay-statistics.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/replay-statistics.service.spec.ts
@@ -55,6 +55,43 @@ describe('ReplayStatisticsService', () => {
       }));
     });
 
+    it('should store coding session timings', async () => {
+      await service.storeReplayStatistics({
+        workspaceId: 1,
+        unitId: 'UNIT-1',
+        durationMilliseconds: 1234,
+        clientTimings: {
+          codingSessionMs: 100.123
+        },
+        serverTimings: {
+          codingSessionLoadJobMs: 1,
+          codingSessionLoadContextMs: 2,
+          codingSessionReviewOverlaysMs: 3,
+          codingSessionBuildUnitsMs: 4,
+          codingSessionBuildProgressMs: 5,
+          codingSessionBuildNotesMs: 6,
+          codingSessionFinalizeResponseMs: 7,
+          codingSessionTotalMs: 28.456
+        }
+      });
+
+      expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({
+        client_timings: {
+          codingSessionMs: 100.12
+        },
+        server_timings: {
+          codingSessionLoadJobMs: 1,
+          codingSessionLoadContextMs: 2,
+          codingSessionReviewOverlaysMs: 3,
+          codingSessionBuildUnitsMs: 4,
+          codingSessionBuildProgressMs: 5,
+          codingSessionBuildNotesMs: 6,
+          codingSessionFinalizeResponseMs: 7,
+          codingSessionTotalMs: 28.46
+        }
+      }));
+    });
+
     it('should store external replay source when provided', async () => {
       await service.storeReplayStatistics({
         workspaceId: 1,

--- a/apps/backend/src/app/database/services/test-results/replay-statistics.service.ts
+++ b/apps/backend/src/app/database/services/test-results/replay-statistics.service.ts
@@ -35,7 +35,8 @@ export class ReplayStatisticsService {
     'payloadMs',
     'payloadToVisibleMs',
     'payloadToPlayerReadyMs',
-    'playerReadyToVisibleMs'
+    'playerReadyToVisibleMs',
+    'codingSessionMs'
   ]);
 
   private static readonly SERVER_TIMING_KEYS = new Set([
@@ -53,7 +54,15 @@ export class ReplayStatisticsService {
     'payloadExtractPlayerIdMs',
     'payloadFindPlayerMs',
     'payloadFindUnitResponseMs',
-    'payloadTotalMs'
+    'payloadTotalMs',
+    'codingSessionLoadJobMs',
+    'codingSessionLoadContextMs',
+    'codingSessionReviewOverlaysMs',
+    'codingSessionBuildUnitsMs',
+    'codingSessionBuildProgressMs',
+    'codingSessionBuildNotesMs',
+    'codingSessionFinalizeResponseMs',
+    'codingSessionTotalMs'
   ]);
 
   private applyTimeFilters(

--- a/apps/backend/src/app/database/services/test-results/replay-statistics.service.ts
+++ b/apps/backend/src/app/database/services/test-results/replay-statistics.service.ts
@@ -36,7 +36,9 @@ export class ReplayStatisticsService {
     'payloadToVisibleMs',
     'payloadToPlayerReadyMs',
     'playerReadyToVisibleMs',
-    'codingSessionMs'
+    'codingSessionMs',
+    'routeToCodingSessionRequestMs',
+    'codingSessionResponseToPayloadRequestMs'
   ]);
 
   private static readonly SERVER_TIMING_KEYS = new Set([

--- a/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.spec.ts
+++ b/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.spec.ts
@@ -17,6 +17,7 @@ describe('WsgCodingJobController', () => {
     getCodingJobs: jest.Mock;
     getCodingJob: jest.Mock;
     getCodingJobUnits: jest.Mock;
+    getCodingJobReplaySession: jest.Mock;
     getBulkCodingProgress: jest.Mock;
     createCodingJob: jest.Mock;
     updateCodingJob: jest.Mock;
@@ -54,6 +55,19 @@ describe('WsgCodingJobController', () => {
       }),
       getCodingJob: jest.fn().mockResolvedValue({ codingJob: { id: 123 } }),
       getCodingJobUnits: jest.fn().mockResolvedValue([]),
+      getCodingJobReplaySession: jest.fn().mockResolvedValue({
+        units: [],
+        progress: {},
+        notes: {},
+        job: {
+          status: 'active',
+          comment: null,
+          showScore: false,
+          allowComments: true,
+          suppressGeneralInstructions: false
+        },
+        serverTimings: {}
+      }),
       getBulkCodingProgress: jest.fn().mockResolvedValue({}),
       createCodingJob: jest.fn().mockResolvedValue({ id: 124 }),
       updateCodingJob: jest.fn(),
@@ -104,7 +118,8 @@ describe('WsgCodingJobController', () => {
   it.each([
     'pauseCodingJob',
     'resumeCodingJob',
-    'submitCodingJob'
+    'submitCodingJob',
+    'getCodingJobReplaySession'
   ] as const)('uses coder access guards for %s', methodName => {
     const handler = WsgCodingJobController.prototype[methodName];
 
@@ -131,6 +146,55 @@ describe('WsgCodingJobController', () => {
     await controller.getCodingJobUnits(47, 123, req);
 
     expect(codingJobService.getCodingJobUnits).toHaveBeenCalledWith(123, false);
+  });
+
+  it('starts a replay session after one coding-job access check', async () => {
+    const result = await controller.getCodingJobReplaySession(
+      47,
+      123,
+      req,
+      'true'
+    );
+
+    expect(codingJobService.assertUserCanAccessCodingJob).toHaveBeenCalledWith(
+      123,
+      47,
+      5
+    );
+    expect(codingJobService.getCodingJobReplaySession).toHaveBeenCalledWith(
+      123,
+      47,
+      true
+    );
+    expect(codingJobService.getCodingJob).not.toHaveBeenCalled();
+    expect(result.job.status).toBe('active');
+  });
+
+  it('documents the replay-session response body in OpenAPI', () => {
+    const handler = WsgCodingJobController.prototype.getCodingJobReplaySession;
+    const responses = Reflect.getMetadata(
+      'swagger/apiResponse',
+      handler
+    ) as Record<string, { schema?: Record<string, unknown> }>;
+    const schema = responses['200']?.schema as {
+      required?: string[];
+      properties?: Record<string, unknown>;
+    };
+
+    expect(schema.required).toEqual([
+      'units',
+      'progress',
+      'notes',
+      'job',
+      'serverTimings'
+    ]);
+    expect(schema.properties).toEqual(expect.objectContaining({
+      units: expect.any(Object),
+      progress: expect.any(Object),
+      notes: expect.any(Object),
+      job: expect.any(Object),
+      serverTimings: expect.any(Object)
+    }));
   });
 
   it('changes completed jobs back to active when starting them again', async () => {

--- a/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
+++ b/apps/backend/src/app/wsg-admin/coding-job/coding-job.controller.ts
@@ -56,6 +56,7 @@ import { SaveCodingProgressDto } from '../../admin/coding-job/dto/save-coding-pr
 import { SaveCodingNotesDto } from '../../admin/coding-job/dto/save-coding-notes.dto';
 import { TransferCodingCasesDto } from '../../admin/coding-job/dto/transfer-coding-cases.dto';
 import { TransferCodingCasesResultDto } from '../../admin/coding-job/dto/transfer-coding-cases-result.dto';
+import type { ReplayCodingSessionDto } from '../../../../../../api-dto/coding/replay-coding-session.dto';
 
 @ApiTags('WSG Admin Coding Jobs')
 @Controller('wsg-admin/workspace/:workspace_id/coding-job')
@@ -1131,6 +1132,192 @@ export class WsgCodingJobController {
     );
 
     return this.codingJobService.getBulkCodingProgress(jobIds, workspaceId);
+  }
+
+  @Get(':id/replay-session')
+  @AllowWorkspaceTokenScopes(WORKSPACE_TOKEN_SCOPE_CODING_JOB_OPERATE)
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Start a coding-job replay session',
+    description:
+      'Returns navigation units, progress, notes, and replay metadata from one shared coding-job context'
+  })
+  @ApiParam({
+    name: 'workspace_id',
+    type: Number,
+    required: true,
+    description: 'The ID of the workspace'
+  })
+  @ApiParam({
+    name: 'id',
+    type: Number,
+    required: true,
+    description: 'The ID of the coding job'
+  })
+  @ApiQuery({
+    name: 'onlyOpen',
+    required: false,
+    type: Boolean,
+    description: 'When true, only open units are returned for navigation'
+  })
+  @ApiOkResponse({
+    description: 'Replay session initialized successfully',
+    schema: {
+      type: 'object',
+      required: ['units', 'progress', 'notes', 'job', 'serverTimings'],
+      properties: {
+        units: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: [
+              'responseId',
+              'unitName',
+              'unitAlias',
+              'variableId',
+              'variableAnchor',
+              'variablePage',
+              'bookletName',
+              'personLogin',
+              'personCode',
+              'personGroup',
+              'variableBundleId',
+              'bundleContext'
+            ],
+            properties: {
+              responseId: { type: 'number' },
+              unitName: { type: 'string' },
+              unitAlias: { type: 'string', nullable: true },
+              variableId: { type: 'string' },
+              variableAnchor: { type: 'string' },
+              variablePage: { type: 'string' },
+              bookletName: { type: 'string' },
+              personLogin: { type: 'string' },
+              personCode: { type: 'string' },
+              personGroup: { type: 'string' },
+              variableBundleId: { type: 'number', nullable: true },
+              bundleContext: {
+                type: 'object',
+                nullable: true,
+                required: [
+                  'bundleId',
+                  'bundleName',
+                  'caseKey',
+                  'caseOrderingMode',
+                  'variables'
+                ],
+                properties: {
+                  bundleId: { type: 'number' },
+                  bundleName: { type: 'string' },
+                  caseKey: { type: 'string' },
+                  caseOrderingMode: {
+                    type: 'string',
+                    enum: ['continuous', 'alternating']
+                  },
+                  variables: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      required: [
+                        'responseId',
+                        'unitName',
+                        'variableId',
+                        'variableAnchor',
+                        'variablePage',
+                        'status',
+                        'code',
+                        'score',
+                        'source'
+                      ],
+                      properties: {
+                        responseId: { type: 'number', nullable: true },
+                        unitName: { type: 'string' },
+                        variableId: { type: 'string' },
+                        variableAnchor: { type: 'string' },
+                        variablePage: { type: 'string' },
+                        status: {
+                          type: 'string',
+                          enum: [
+                            'manual-open',
+                            'manual-coded',
+                            'auto-coded',
+                            'not-coded',
+                            'not-available'
+                          ]
+                        },
+                        code: { type: 'number', nullable: true },
+                        score: { type: 'number', nullable: true },
+                        source: {
+                          type: 'string',
+                          enum: ['manual', 'auto', 'none']
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        progress: {
+          type: 'object',
+          additionalProperties: {
+            type: 'object',
+            nullable: true,
+            required: ['id'],
+            properties: {
+              id: { type: 'number' },
+              code: { type: 'string' },
+              label: { type: 'string' },
+              score: { type: 'number' },
+              codingIssueOption: { type: 'number' }
+            }
+          }
+        },
+        notes: {
+          type: 'object',
+          additionalProperties: { type: 'string' }
+        },
+        job: {
+          type: 'object',
+          required: [
+            'status',
+            'comment',
+            'showScore',
+            'allowComments',
+            'suppressGeneralInstructions'
+          ],
+          properties: {
+            status: { type: 'string' },
+            comment: { type: 'string', nullable: true },
+            showScore: { type: 'boolean' },
+            allowComments: { type: 'boolean' },
+            suppressGeneralInstructions: { type: 'boolean' }
+          }
+        },
+        serverTimings: {
+          type: 'object',
+          additionalProperties: { type: 'number', nullable: true }
+        }
+      }
+    }
+  })
+  @ApiNotFoundResponse({
+    description: 'Coding job not found.'
+  })
+  async getCodingJobReplaySession(
+    @WorkspaceId() workspaceId: number,
+      @Param('id', ParseIntPipe) id: number,
+      @Req() req: Request,
+      @Query('onlyOpen') onlyOpen?: string
+  ): Promise<ReplayCodingSessionDto> {
+    await this.assertCodingJobAccess(workspaceId, id, req);
+    return this.codingJobService.getCodingJobReplaySession(
+      id,
+      workspaceId,
+      onlyOpen === 'true'
+    );
   }
 
   @Get(':id/units')

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -612,6 +612,29 @@ describe('CodingJobBackendService', () => {
       req.flush([]);
     });
 
+    it('should load a replay session with the supplied token and onlyOpen flag', () => {
+      service.getReplayCodingSession(47, 123, 'url-token', true).subscribe();
+
+      const req = httpMock.expectOne(
+        `${mockServerUrl}wsg-admin/workspace/47/coding-job/123/replay-session?onlyOpen=true`
+      );
+      expect(req.request.method).toBe('GET');
+      expect(req.request.headers.get('Authorization')).toBe('Bearer url-token');
+      req.flush({
+        units: [],
+        progress: {},
+        notes: {},
+        job: {
+          status: 'active',
+          comment: null,
+          showScore: false,
+          allowComments: true,
+          suppressGeneralInstructions: false
+        },
+        serverTimings: {}
+      });
+    });
+
     it('should prepare coding job reviews through the read-only endpoint', () => {
       service.prepareCodingJobReview(47, 123).subscribe();
 

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../../../../../api-dto/coding/job-refresh.dto';
 import type { ManualCodeAvailabilityValidationDto } from '../../../../../../api-dto/coding/manual-code-availability.dto';
 import type { PsychometricDomainCandidatesDto } from '../../../../../../api-dto/coding/psychometric-discrimination.dto';
+import type { ReplayCodingSessionDto } from '../../../../../../api-dto/coding/replay-coding-session.dto';
 import type {
   BackgroundExportRequest,
   ItemDatasetOptionsDto
@@ -28,6 +29,7 @@ import {
   VariableBundle
 } from '../models/coding-job.model';
 import type { BundleContext } from '../../replay/services/units-replay.service';
+import { suppressGlobalHttpErrorContext } from '../../core/interceptors/http-error-context';
 
 export interface CodingJobUnitDto {
   responseId: number;
@@ -860,6 +862,21 @@ export class CodingJobBackendService {
     return this.http.get<CodingJobUnitDto[]>(url, {
       headers: this.getAuthHeader(authToken),
       params
+    });
+  }
+
+  getReplayCodingSession(
+    workspaceId: number,
+    codingJobId: number,
+    authToken?: string,
+    onlyOpen: boolean = false
+  ): Observable<ReplayCodingSessionDto> {
+    const url = `${this.serverUrl}wsg-admin/workspace/${workspaceId}/coding-job/${codingJobId}/replay-session`;
+    const params = new HttpParams().set('onlyOpen', String(onlyOpen));
+    return this.http.get<ReplayCodingSessionDto>(url, {
+      headers: this.getAuthHeader(authToken),
+      params,
+      context: suppressGlobalHttpErrorContext()
     });
   }
 

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -398,6 +398,8 @@ describe('ReplayComponent', () => {
     const privateComponent = component as unknown as {
       routeStartTime: number;
       loadStartTime: number;
+      codingSessionRequestStartTime: number;
+      codingSessionResponseTime: number;
       payloadRequestStartTime: number;
       payloadResponseTime: number;
       playerReadyTime: number;
@@ -406,12 +408,16 @@ describe('ReplayComponent', () => {
 
     privateComponent.routeStartTime = 100;
     privateComponent.loadStartTime = 300;
+    privateComponent.codingSessionRequestStartTime = 150;
+    privateComponent.codingSessionResponseTime = 250;
     privateComponent.payloadRequestStartTime = 300;
     privateComponent.payloadResponseTime = 500;
     privateComponent.playerReadyTime = 650;
 
     expect(privateComponent.getClientTimings(900)).toEqual({
-      codingSessionMs: null,
+      codingSessionMs: 100,
+      routeToCodingSessionRequestMs: 50,
+      codingSessionResponseToPayloadRequestMs: 50,
       routeToVisibleMs: 800,
       loadToVisibleMs: 600,
       routeToPayloadRequestMs: 200,
@@ -478,6 +484,8 @@ describe('ReplayComponent', () => {
         success: true,
         clientTimings: {
           codingSessionMs: null,
+          routeToCodingSessionRequestMs: null,
+          codingSessionResponseToPayloadRequestMs: null,
           routeToVisibleMs: 800,
           loadToVisibleMs: 600,
           routeToPayloadRequestMs: 200,

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -1277,12 +1277,9 @@ describe('ReplayComponent', () => {
       setTimeout(resolve, 0);
     });
 
-    const sessionRequests = (
-      component as unknown as {
-        replayCodingSessionRequests: Map<string, unknown>;
-      }
-    ).replayCodingSessionRequests;
-    expect([...sessionRequests.keys()]).toEqual(['47:88:false']);
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledTimes(2);
 
     firstSessionResponse.next({
       units: [{
@@ -1313,7 +1310,6 @@ describe('ReplayComponent', () => {
     firstSessionResponse.complete();
     await Promise.resolve();
 
-    expect([...sessionRequests.keys()]).toEqual(['47:88:false']);
     expect(component.unitId).not.toBe('unit-1');
 
     secondSessionResponse.next({
@@ -1348,7 +1344,9 @@ describe('ReplayComponent', () => {
       setTimeout(resolve, 0);
     });
 
-    expect(sessionRequests.size).toBe(0);
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledTimes(2);
     expect(component.unitId).toBe('unit-2');
     expect(component.codingService.currentVariableId).toBe('VAR2');
   });

--- a/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.spec.ts
@@ -2,7 +2,7 @@
 import { ActivatedRoute } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import {
-  BehaviorSubject, finalize, of, Subject
+  BehaviorSubject, finalize, of, Subject, throwError
 } from 'rxjs';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -25,6 +25,11 @@ import { utf8ToBase64 } from '../../../shared/utils/common-utils';
 import { CodingScheme } from '../../../models/coding-interfaces';
 import { SessionRecoveryService } from '../../../core/services/session-recovery.service';
 import { UnitPlayerComponent } from '../unit-player/unit-player.component';
+import {
+  CODING_JOB_WORKSPACE_TOKEN_SCOPES,
+  REPLAY_WORKSPACE_TOKEN_SCOPES
+} from '../../../core/services/auth-session.config';
+import type { ReplayCodingSessionDto } from '../../../../../../../api-dto/coding/replay-coding-session.dto';
 
 function createUnsignedJwt(payload: Record<string, unknown>): string {
   const encode = (value: Record<string, unknown>) => btoa(JSON.stringify(value))
@@ -118,12 +123,13 @@ let routeParams: {
   page: 'page-1', testPerson: 'valid@test@person', unitId: 'unit-123', anchor: undefined
 };
 let routeQueryParams: Record<string, string> = { auth: 'valid-token' };
+let routeParamsSubject: Subject<typeof routeParams> | null = null;
 
 // Konfiguration der Aktivierten Route, inklusive Parameter und Query Params
 const fakeActivatedRoute = {
   snapshot: { data: {}, url: [{ path: '' }] },
   get params() {
-    return of(routeParams);
+    return routeParamsSubject?.asObservable() ?? of(routeParams);
   },
   get queryParams() {
     return of(routeQueryParams);
@@ -137,6 +143,7 @@ describe('ReplayComponent', () => {
   let replayBackendService: ReplayBackendServiceMock;
   let codingJobBackendServiceMock: {
     getCodingJobUnits: jest.Mock;
+    getReplayCodingSession: jest.Mock;
     updateCodingJob: jest.Mock;
     pauseCodingJob: jest.Mock;
     resumeCodingJob: jest.Mock;
@@ -152,6 +159,7 @@ describe('ReplayComponent', () => {
 
   beforeEach(async () => {
     sessionStorage.clear();
+    routeParamsSubject = null;
     routeParams = {
       page: 'page-1', testPerson: 'valid@test@person', unitId: 'unit-123', anchor: undefined
     };
@@ -168,6 +176,9 @@ describe('ReplayComponent', () => {
 
     codingJobBackendServiceMock = {
       getCodingJobUnits: jest.fn().mockReturnValue(of([])),
+      getReplayCodingSession: jest.fn().mockReturnValue(throwError(() => (
+        new HttpErrorResponse({ status: 404 })
+      ))),
       updateCodingJob: jest.fn().mockReturnValue(of({})),
       pauseCodingJob: jest.fn().mockReturnValue(of({})),
       resumeCodingJob: jest.fn().mockReturnValue(of({})),
@@ -206,6 +217,7 @@ describe('ReplayComponent', () => {
   });
 
   afterEach(() => {
+    routeParamsSubject = null;
     jest.useRealTimers();
     jest.restoreAllMocks();
     sessionStorage.clear();
@@ -399,6 +411,7 @@ describe('ReplayComponent', () => {
     privateComponent.playerReadyTime = 650;
 
     expect(privateComponent.getClientTimings(900)).toEqual({
+      codingSessionMs: null,
       routeToVisibleMs: 800,
       loadToVisibleMs: 600,
       routeToPayloadRequestMs: 200,
@@ -407,6 +420,26 @@ describe('ReplayComponent', () => {
       payloadToPlayerReadyMs: 150,
       playerReadyToVisibleMs: 250
     });
+  });
+
+  it('should clear coding session timings when resetting the replay context', () => {
+    const privateComponent = component as unknown as {
+      codingSessionRequestStartTime: number;
+      codingSessionResponseTime: number;
+      codingSessionServerTimings: Record<string, number> | null;
+      resetUnitData: (preserveCodingData?: boolean) => void;
+      getClientTimings: (visibleTime: number) => Record<string, number | null>;
+    };
+    privateComponent.codingSessionRequestStartTime = 100;
+    privateComponent.codingSessionResponseTime = 250;
+    privateComponent.codingSessionServerTimings = {
+      codingSessionTotalMs: 75
+    };
+
+    privateComponent.resetUnitData();
+
+    expect(privateComponent.getClientTimings(300).codingSessionMs).toBeNull();
+    expect(privateComponent.codingSessionServerTimings).toBeNull();
   });
 
   it('should store client and server timings with replay statistics', () => {
@@ -444,6 +477,7 @@ describe('ReplayComponent', () => {
         durationMilliseconds: 800,
         success: true,
         clientTimings: {
+          codingSessionMs: null,
           routeToVisibleMs: 800,
           loadToVisibleMs: 600,
           routeToPayloadRequestMs: 200,
@@ -959,6 +993,9 @@ describe('ReplayComponent', () => {
       workspaceId: '47',
       onlyOpen: 'true'
     };
+    codingJobBackendServiceMock.getReplayCodingSession.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 405 }))
+    );
     codingJobBackendServiceMock.getCodingJobUnits.mockReturnValue(of([{
       responseId: 1,
       unitName: 'unit-123',
@@ -982,7 +1019,735 @@ describe('ReplayComponent', () => {
       setTimeout(resolve, 0);
     });
 
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledWith(47, 77, 'valid-token', true);
     expect(codingJobBackendServiceMock.getCodingJobUnits).toHaveBeenCalledWith(47, 77, 'valid-token', true);
+  });
+
+  it('should initialize coding replay from one session request', async () => {
+    routeParams = {
+      page: '0',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-123',
+      anchor: 'VAR1'
+    };
+    routeQueryParams = {
+      auth: 'valid-token',
+      mode: 'coding',
+      codingJobId: '77',
+      workspaceId: '47',
+      onlyOpen: 'true'
+    };
+    codingJobBackendServiceMock.getReplayCodingSession.mockReturnValue(of({
+      units: [{
+        responseId: 1,
+        unitName: 'unit-123',
+        unitAlias: 'Unit 123',
+        variableId: 'VAR1',
+        variableAnchor: 'VAR1',
+        variablePage: '0',
+        bookletName: 'Booklet 1',
+        personLogin: 'valid',
+        personCode: 'test',
+        personGroup: '',
+        variableBundleId: null,
+        bundleContext: null
+      }],
+      progress: {
+        saved: {
+          id: 7,
+          code: '7',
+          label: 'Code 7',
+          score: 1
+        }
+      },
+      notes: {
+        saved: 'Session note'
+      },
+      job: {
+        status: 'active',
+        comment: 'Session comment',
+        showScore: true,
+        allowComments: false,
+        suppressGeneralInstructions: true
+      },
+      serverTimings: {
+        totalMs: 15
+      }
+    }));
+    codingJobBackendServiceMock.getCodingJobUnits.mockClear();
+    codingJobBackendServiceMock.getCodingProgress.mockClear();
+    codingJobBackendServiceMock.getCodingNotes.mockClear();
+    codingJobBackendServiceMock.getCodingJob.mockClear();
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(ReplayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledWith(47, 77, 'valid-token', true);
+    expect(codingJobBackendServiceMock.getCodingJobUnits).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.getCodingProgress).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.getCodingNotes).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.getCodingJob).not.toHaveBeenCalled();
+    expect(component.codingService.selectedCodes.get('saved')).toEqual({
+      id: 7,
+      code: '7',
+      label: 'Code 7',
+      score: 1
+    });
+    expect(component.codingService.notes.get('saved')).toBe('Session note');
+    expect(component.codingService.codingJobComment).toBe('Session comment');
+    expect(component.codingService.showScore).toBe(true);
+    expect(component.codingService.allowComments).toBe(false);
+  });
+
+  it('should share an in-flight session request and only apply the latest route', async () => {
+    routeQueryParams = {
+      auth: 'valid-token',
+      mode: 'coding',
+      codingJobId: '77',
+      workspaceId: '47'
+    };
+    routeParamsSubject = new Subject<typeof routeParams>();
+    const sessionResponse = new Subject<ReplayCodingSessionDto>();
+    codingJobBackendServiceMock.getReplayCodingSession.mockReturnValue(
+      sessionResponse.asObservable()
+    );
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(ReplayComponent);
+    component = fixture.componentInstance;
+    let releaseSecondRouterRun: (() => void) | undefined;
+    const secondRouterRunPending = new Promise<void>(resolve => {
+      releaseSecondRouterRun = resolve;
+    });
+    const refreshAuthTokenSpy = jest.spyOn(
+      component as unknown as {
+        refreshExpiredReplayAuthToken: (
+          workspaceId: number,
+          routerRunId?: number
+        ) => Promise<void>;
+      },
+      'refreshExpiredReplayAuthToken'
+    );
+    refreshAuthTokenSpy
+      .mockResolvedValueOnce()
+      .mockReturnValueOnce(secondRouterRunPending);
+    fixture.detectChanges();
+
+    routeParamsSubject.next({
+      page: '0',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-1',
+      anchor: 'VAR1'
+    });
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    routeParamsSubject.next({
+      page: '1',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-2',
+      anchor: 'VAR2'
+    });
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledTimes(1);
+
+    sessionResponse.next({
+      units: [
+        {
+          responseId: 1,
+          unitName: 'unit-1',
+          unitAlias: 'Unit 1',
+          variableId: 'VAR1',
+          variableAnchor: 'VAR1',
+          variablePage: '0',
+          bookletName: 'Booklet 1',
+          personLogin: 'valid',
+          personCode: 'test',
+          personGroup: '',
+          variableBundleId: null,
+          bundleContext: null
+        },
+        {
+          responseId: 2,
+          unitName: 'unit-2',
+          unitAlias: 'Unit 2',
+          variableId: 'VAR2',
+          variableAnchor: 'VAR2',
+          variablePage: '1',
+          bookletName: 'Booklet 1',
+          personLogin: 'valid',
+          personCode: 'test',
+          personGroup: '',
+          variableBundleId: null,
+          bundleContext: null
+        }
+      ],
+      progress: {},
+      notes: {},
+      job: {
+        status: 'active',
+        comment: null,
+        showScore: false,
+        allowComments: true,
+        suppressGeneralInstructions: false
+      },
+      serverTimings: {
+        totalMs: 15
+      }
+    });
+    sessionResponse.complete();
+    await Promise.resolve();
+
+    releaseSecondRouterRun?.();
+    await fixture.whenStable();
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledTimes(1);
+    expect(component.unitId).toBe('unit-2');
+    expect(component.page).toBe('1');
+    expect(component.codingService.currentVariableId).toBe('VAR2');
+  });
+
+  it('should discard an abandoned session request after switching coding jobs', async () => {
+    routeQueryParams = {
+      auth: 'valid-token',
+      mode: 'coding',
+      codingJobId: '77',
+      workspaceId: '47'
+    };
+    routeParamsSubject = new Subject<typeof routeParams>();
+    const firstSessionResponse = new Subject<ReplayCodingSessionDto>();
+    const secondSessionResponse = new Subject<ReplayCodingSessionDto>();
+    codingJobBackendServiceMock.getReplayCodingSession.mockImplementation(
+      (_workspaceId: number, jobId: number) => (
+        jobId === 77 ?
+          firstSessionResponse.asObservable() :
+          secondSessionResponse.asObservable()
+      )
+    );
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(ReplayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    routeParamsSubject.next({
+      page: '0',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-1',
+      anchor: 'VAR1'
+    });
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    routeQueryParams = {
+      auth: 'valid-token',
+      mode: 'coding',
+      codingJobId: '88',
+      workspaceId: '47'
+    };
+    routeParamsSubject.next({
+      page: '1',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-2',
+      anchor: 'VAR2'
+    });
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    const sessionRequests = (
+      component as unknown as {
+        replayCodingSessionRequests: Map<string, unknown>;
+      }
+    ).replayCodingSessionRequests;
+    expect([...sessionRequests.keys()]).toEqual(['47:88:false']);
+
+    firstSessionResponse.next({
+      units: [{
+        responseId: 1,
+        unitName: 'unit-1',
+        unitAlias: 'Unit 1',
+        variableId: 'VAR1',
+        variableAnchor: 'VAR1',
+        variablePage: '0',
+        bookletName: 'Booklet 1',
+        personLogin: 'valid',
+        personCode: 'test',
+        personGroup: '',
+        variableBundleId: null,
+        bundleContext: null
+      }],
+      progress: {},
+      notes: {},
+      job: {
+        status: 'active',
+        comment: null,
+        showScore: false,
+        allowComments: true,
+        suppressGeneralInstructions: false
+      },
+      serverTimings: {}
+    });
+    firstSessionResponse.complete();
+    await Promise.resolve();
+
+    expect([...sessionRequests.keys()]).toEqual(['47:88:false']);
+    expect(component.unitId).not.toBe('unit-1');
+
+    secondSessionResponse.next({
+      units: [{
+        responseId: 2,
+        unitName: 'unit-2',
+        unitAlias: 'Unit 2',
+        variableId: 'VAR2',
+        variableAnchor: 'VAR2',
+        variablePage: '1',
+        bookletName: 'Booklet 1',
+        personLogin: 'valid',
+        personCode: 'test',
+        personGroup: '',
+        variableBundleId: null,
+        bundleContext: null
+      }],
+      progress: {},
+      notes: {},
+      job: {
+        status: 'active',
+        comment: null,
+        showScore: false,
+        allowComments: true,
+        suppressGeneralInstructions: false
+      },
+      serverTimings: {}
+    });
+    secondSessionResponse.complete();
+    await fixture.whenStable();
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(sessionRequests.size).toBe(0);
+    expect(component.unitId).toBe('unit-2');
+    expect(component.codingService.currentVariableId).toBe('VAR2');
+  });
+
+  it('should await one shared token refresh before starting the latest replay session', async () => {
+    const appService = TestBed.inject(AppService) as unknown as AppServiceMock;
+    const expiredToken = createUnsignedJwt({
+      workspace: '47',
+      exp: Math.floor(Date.now() / 1000) - 60
+    });
+    const tokenSubject = new Subject<string>();
+    routeQueryParams = {
+      auth: expiredToken,
+      mode: 'coding',
+      codingJobId: '77',
+      workspaceId: '47'
+    };
+    routeParamsSubject = new Subject<typeof routeParams>();
+    (tokenUtils.validateToken as jest.Mock).mockImplementation((token: string) => {
+      if (token === expiredToken) {
+        return { isValid: false, errorType: 'token_expired' };
+      }
+      return { isValid: true };
+    });
+    (jwtDecodeModule.jwtDecode as jest.Mock).mockReturnValue({
+      workspace: '47'
+    });
+    appService.createOwnToken.mockClear();
+    appService.createOwnToken.mockReturnValue(tokenSubject.asObservable());
+    codingJobBackendServiceMock.getReplayCodingSession.mockReturnValue(of({
+      units: [{
+        responseId: 2,
+        unitName: 'unit-2',
+        unitAlias: 'Unit 2',
+        variableId: 'VAR2',
+        variableAnchor: 'VAR2',
+        variablePage: '1',
+        bookletName: 'Booklet 1',
+        personLogin: 'valid',
+        personCode: 'test',
+        personGroup: '',
+        variableBundleId: null,
+        bundleContext: null
+      }],
+      progress: {},
+      notes: {},
+      job: {
+        status: 'active',
+        comment: null,
+        showScore: false,
+        allowComments: true,
+        suppressGeneralInstructions: false
+      },
+      serverTimings: {}
+    }));
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(ReplayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    routeParamsSubject.next({
+      page: '0',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-1',
+      anchor: 'VAR1'
+    });
+    await Promise.resolve();
+    routeParamsSubject.next({
+      page: '1',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-2',
+      anchor: 'VAR2'
+    });
+    await Promise.resolve();
+
+    expect(appService.createOwnToken).toHaveBeenCalledTimes(1);
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).not.toHaveBeenCalled();
+
+    tokenSubject.next('fresh-token');
+    tokenSubject.complete();
+    await fixture.whenStable();
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(appService.createOwnToken).toHaveBeenCalledTimes(1);
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledWith(47, 77, 'fresh-token', false);
+    expect(component.unitId).toBe('unit-2');
+    expect(component.page).toBe('1');
+    expect(component.codingService.currentVariableId).toBe('VAR2');
+  });
+
+  it('should not share a replay-only token refresh with a coding route', async () => {
+    const appService = TestBed.inject(AppService) as unknown as AppServiceMock;
+    const expiredToken = createUnsignedJwt({
+      workspace: '47',
+      exp: Math.floor(Date.now() / 1000) - 60
+    });
+    const replayTokenSubject = new Subject<string>();
+    const codingTokenSubject = new Subject<string>();
+    routeQueryParams = {
+      auth: expiredToken,
+      mode: 'booklet-view',
+      workspaceId: '47'
+    };
+    routeParamsSubject = new Subject<typeof routeParams>();
+    (tokenUtils.validateToken as jest.Mock).mockImplementation((token: string) => {
+      if (token === expiredToken) {
+        return { isValid: false, errorType: 'token_expired' };
+      }
+      return { isValid: true };
+    });
+    (jwtDecodeModule.jwtDecode as jest.Mock).mockReturnValue({
+      workspace: '47'
+    });
+    appService.createOwnToken.mockClear();
+    appService.createOwnToken.mockImplementation(
+      (
+        _workspaceId: number,
+        _duration: number,
+        scopes: string[]
+      ) => (
+        scopes.includes('coding-job:operate') ?
+          codingTokenSubject.asObservable() :
+          replayTokenSubject.asObservable()
+      )
+    );
+    codingJobBackendServiceMock.getReplayCodingSession.mockReturnValue(of({
+      units: [{
+        responseId: 2,
+        unitName: 'unit-2',
+        unitAlias: 'Unit 2',
+        variableId: 'VAR2',
+        variableAnchor: 'VAR2',
+        variablePage: '1',
+        bookletName: 'Booklet 1',
+        personLogin: 'valid',
+        personCode: 'test',
+        personGroup: '',
+        variableBundleId: null,
+        bundleContext: null
+      }],
+      progress: {},
+      notes: {},
+      job: {
+        status: 'active',
+        comment: null,
+        showScore: false,
+        allowComments: true,
+        suppressGeneralInstructions: false
+      },
+      serverTimings: {}
+    }));
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(ReplayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    routeParamsSubject.next({
+      page: '0',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-1',
+      anchor: 'VAR1'
+    });
+    await Promise.resolve();
+
+    routeQueryParams = {
+      auth: expiredToken,
+      mode: 'coding',
+      codingJobId: '77',
+      workspaceId: '47'
+    };
+    routeParamsSubject.next({
+      page: '1',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-2',
+      anchor: 'VAR2'
+    });
+    await Promise.resolve();
+
+    expect(appService.createOwnToken).toHaveBeenCalledTimes(2);
+    expect(appService.createOwnToken).toHaveBeenNthCalledWith(
+      1,
+      47,
+      1,
+      REPLAY_WORKSPACE_TOKEN_SCOPES
+    );
+    expect(appService.createOwnToken).toHaveBeenNthCalledWith(
+      2,
+      47,
+      1,
+      CODING_JOB_WORKSPACE_TOKEN_SCOPES
+    );
+
+    replayTokenSubject.next('replay-token');
+    replayTokenSubject.complete();
+    await Promise.resolve();
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).not.toHaveBeenCalled();
+
+    codingTokenSubject.next('coding-token');
+    codingTokenSubject.complete();
+    await fixture.whenStable();
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledWith(47, 77, 'coding-token', false);
+    expect(component.unitId).toBe('unit-2');
+    expect(component.codingService.currentVariableId).toBe('VAR2');
+  });
+
+  it('should retry an abandoned failed token refresh for the same scopes', async () => {
+    const appService = TestBed.inject(AppService) as unknown as AppServiceMock;
+    const expiredToken = createUnsignedJwt({
+      workspace: '47',
+      exp: Math.floor(Date.now() / 1000) - 60
+    });
+    const firstReplayTokenSubject = new Subject<string>();
+    const codingTokenSubject = new Subject<string>();
+    const retryReplayTokenSubject = new Subject<string>();
+    const privateComponent = component as unknown as {
+      authToken: string;
+      routerRunId: number;
+      replayTokenRefreshRequests: Map<string, unknown>;
+      refreshExpiredReplayAuthToken: (
+        workspaceId: number,
+        routerRunId: number,
+        scopes: string[]
+      ) => Promise<void>;
+    };
+    (tokenUtils.validateToken as jest.Mock).mockImplementation((token: string) => (
+      token === expiredToken ?
+        { isValid: false, errorType: 'token_expired' } :
+        { isValid: true }
+    ));
+    (jwtDecodeModule.jwtDecode as jest.Mock).mockReturnValue({
+      workspace: '47'
+    });
+    appService.createOwnToken.mockClear();
+    appService.createOwnToken
+      .mockReturnValueOnce(firstReplayTokenSubject.asObservable())
+      .mockReturnValueOnce(codingTokenSubject.asObservable())
+      .mockReturnValueOnce(retryReplayTokenSubject.asObservable());
+    privateComponent.authToken = expiredToken;
+
+    privateComponent.routerRunId = 1;
+    const firstRefresh = privateComponent.refreshExpiredReplayAuthToken(
+      47,
+      1,
+      REPLAY_WORKSPACE_TOKEN_SCOPES
+    );
+    await Promise.resolve();
+
+    privateComponent.routerRunId = 2;
+    const codingRefresh = privateComponent.refreshExpiredReplayAuthToken(
+      47,
+      2,
+      CODING_JOB_WORKSPACE_TOKEN_SCOPES
+    );
+    await Promise.resolve();
+
+    expect(appService.createOwnToken).toHaveBeenCalledTimes(2);
+    expect([...privateComponent.replayTokenRefreshRequests.keys()]).toEqual([
+      '47:coding-job:operate,replay-statistics:write,replay:read'
+    ]);
+
+    firstReplayTokenSubject.error(new Error('temporary refresh failure'));
+    await firstRefresh;
+
+    privateComponent.routerRunId = 3;
+    const retryRefresh = privateComponent.refreshExpiredReplayAuthToken(
+      47,
+      3,
+      REPLAY_WORKSPACE_TOKEN_SCOPES
+    );
+    await Promise.resolve();
+
+    expect(appService.createOwnToken).toHaveBeenCalledTimes(3);
+    expect(appService.createOwnToken).toHaveBeenLastCalledWith(
+      47,
+      1,
+      REPLAY_WORKSPACE_TOKEN_SCOPES
+    );
+
+    retryReplayTokenSubject.next('fresh-replay-token');
+    retryReplayTokenSubject.complete();
+    await retryRefresh;
+    codingTokenSubject.error(new Error('abandoned coding refresh'));
+    await codingRefresh;
+
+    expect(privateComponent.authToken).toBe('fresh-replay-token');
+    expect(privateComponent.replayTokenRefreshRequests.size).toBe(0);
+  });
+
+  it('should not apply an abandoned reauthentication token after a newer scoped refresh', async () => {
+    const appService = TestBed.inject(AppService) as unknown as AppServiceMock;
+    const expiredToken = createUnsignedJwt({
+      workspace: '47',
+      exp: Math.floor(Date.now() / 1000) - 60
+    });
+    const replayTokenSubject = new Subject<string>();
+    const codingTokenSubject = new Subject<string>();
+    const privateComponent = component as unknown as {
+      authToken: string;
+      routerRunId: number;
+      refreshReplayAuthTokenForWorkspace: (
+        workspaceId: number,
+        canApply: (() => boolean) | undefined,
+        scopes: string[]
+      ) => Promise<boolean>;
+      refreshExpiredReplayAuthToken: (
+        workspaceId: number,
+        routerRunId: number,
+        scopes: string[]
+      ) => Promise<void>;
+    };
+    (tokenUtils.validateToken as jest.Mock).mockImplementation((token: string) => (
+      token === expiredToken ?
+        { isValid: false, errorType: 'token_expired' } :
+        { isValid: true }
+    ));
+    (jwtDecodeModule.jwtDecode as jest.Mock).mockReturnValue({
+      workspace: '47'
+    });
+    appService.createOwnToken.mockClear();
+    appService.createOwnToken
+      .mockReturnValueOnce(replayTokenSubject.asObservable())
+      .mockReturnValueOnce(codingTokenSubject.asObservable());
+    privateComponent.authToken = expiredToken;
+
+    const abandonedReplayRefresh =
+      privateComponent.refreshReplayAuthTokenForWorkspace(
+        47,
+        undefined,
+        REPLAY_WORKSPACE_TOKEN_SCOPES
+      );
+    await Promise.resolve();
+
+    privateComponent.routerRunId = 1;
+    const codingRefresh = privateComponent.refreshExpiredReplayAuthToken(
+      47,
+      1,
+      CODING_JOB_WORKSPACE_TOKEN_SCOPES
+    );
+    await Promise.resolve();
+
+    codingTokenSubject.next('fresh-coding-token');
+    codingTokenSubject.complete();
+    await codingRefresh;
+    expect(privateComponent.authToken).toBe('fresh-coding-token');
+
+    replayTokenSubject.next('stale-replay-token');
+    replayTokenSubject.complete();
+
+    await expect(abandonedReplayRefresh).resolves.toBe(false);
+    expect(privateComponent.authToken).toBe('fresh-coding-token');
+  });
+
+  it('should not mask replay-session server errors with legacy requests', async () => {
+    routeParams = {
+      page: '0',
+      testPerson: 'valid@test@person',
+      unitId: 'unit-123',
+      anchor: 'VAR1'
+    };
+    routeQueryParams = {
+      auth: 'valid-token',
+      mode: 'coding',
+      codingJobId: '77',
+      workspaceId: '47'
+    };
+    codingJobBackendServiceMock.getReplayCodingSession.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 }))
+    );
+    codingJobBackendServiceMock.getCodingJobUnits.mockClear();
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(ReplayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(codingJobBackendServiceMock.getCodingJobUnits).not.toHaveBeenCalled();
   });
 
   it('should load the recovered coding unit instead of stale route params after session recovery', async () => {
@@ -1782,20 +2547,41 @@ describe('ReplayComponent', () => {
       workspaceId: '47',
       onlyOpen: 'true'
     };
-    codingJobBackendServiceMock.getCodingJobUnits.mockReturnValue(of([{
-      responseId: 1,
-      unitName: 'unit-123',
-      unitAlias: 'Unit 123',
-      variableId: 'VAR1',
-      variableAnchor: 'VAR1',
-      variablePage: '0',
-      bookletName: 'Booklet 1',
-      personLogin: 'valid',
-      personCode: 'test',
-      personGroup: '',
-      isDoubleCoded: false,
-      otherCoders: []
-    }]));
+    codingJobBackendServiceMock.getReplayCodingSession.mockReturnValue(of({
+      units: [{
+        responseId: 1,
+        unitName: 'unit-123',
+        unitAlias: 'Unit 123',
+        variableId: 'VAR1',
+        variableAnchor: 'VAR1',
+        variablePage: '0',
+        bookletName: 'Booklet 1',
+        personLogin: 'valid',
+        personCode: 'test',
+        personGroup: '',
+        variableBundleId: null,
+        bundleContext: null
+      }],
+      progress: {
+        saved: {
+          id: 7,
+          code: '7',
+          label: 'Code 7',
+          score: 1
+        }
+      },
+      notes: {
+        saved: 'Cached session note'
+      },
+      job: {
+        status: 'review',
+        comment: 'Cached session comment',
+        showScore: true,
+        allowComments: false,
+        suppressGeneralInstructions: true
+      },
+      serverTimings: {}
+    }));
 
     fixture.destroy();
     fixture = TestBed.createComponent(ReplayComponent);
@@ -1806,16 +2592,49 @@ describe('ReplayComponent', () => {
       setTimeout(resolve, 0);
     });
 
-    expect(codingJobBackendServiceMock.getCodingJobUnits).toHaveBeenCalledTimes(1);
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).toHaveBeenCalledTimes(1);
+    expect(codingJobBackendServiceMock.getCodingJobUnits).not.toHaveBeenCalled();
+    expect(component.codingService.selectedCodes.get('saved')).toEqual({
+      id: 7,
+      code: '7',
+      label: 'Code 7',
+      score: 1
+    });
+    expect(component.codingService.notes.get('saved')).toBe('Cached session note');
+    expect(component.codingService.isCompletedJobReview).toBe(true);
 
-    codingJobBackendServiceMock.getCodingJobUnits.mockClear();
+    codingJobBackendServiceMock.getReplayCodingSession.mockClear();
+    codingJobBackendServiceMock.getCodingProgress.mockClear();
+    codingJobBackendServiceMock.getCodingNotes.mockClear();
+    codingJobBackendServiceMock.getCodingJob.mockClear();
+    codingJobBackendServiceMock.resumeCodingJob.mockClear();
     component.subscribeRouter();
     await fixture.whenStable();
     await new Promise<void>(resolve => {
       setTimeout(resolve, 0);
     });
 
-    expect(codingJobBackendServiceMock.getCodingJobUnits).not.toHaveBeenCalled();
+    expect(
+      codingJobBackendServiceMock.getReplayCodingSession
+    ).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.getCodingProgress).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.getCodingNotes).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.getCodingJob).not.toHaveBeenCalled();
+    expect(codingJobBackendServiceMock.resumeCodingJob).not.toHaveBeenCalled();
+    expect(component.codingService.selectedCodes.get('saved')).toEqual({
+      id: 7,
+      code: '7',
+      label: 'Code 7',
+      score: 1
+    });
+    expect(component.codingService.notes.get('saved')).toBe('Cached session note');
+    expect(component.codingService.codingJobComment).toBe('Cached session comment');
+    expect(component.codingService.showScore).toBe(true);
+    expect(component.codingService.allowComments).toBe(false);
+    expect(component.codingService.suppressGeneralInstructions).toBe(true);
+    expect(component.codingService.isCompletedJobReview).toBe(true);
   });
 
   it('should normalize player ID correctly', () => {

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -1110,6 +1110,24 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
           this.codingSessionResponseTime
         ) :
         null,
+      routeToCodingSessionRequestMs: (
+        this.routeStartTime &&
+        this.codingSessionRequestStartTime
+      ) ?
+        this.getElapsedMs(
+          this.routeStartTime,
+          this.codingSessionRequestStartTime
+        ) :
+        null,
+      codingSessionResponseToPayloadRequestMs: (
+        this.codingSessionResponseTime &&
+        this.payloadRequestStartTime
+      ) ?
+        this.getElapsedMs(
+          this.codingSessionResponseTime,
+          this.payloadRequestStartTime
+        ) :
+        null,
       routeToVisibleMs: this.routeStartTime ? this.getElapsedMs(this.routeStartTime, visibleTime) : null,
       loadToVisibleMs: this.loadStartTime ? this.getElapsedMs(this.loadStartTime, visibleTime) : null,
       routeToPayloadRequestMs: (this.routeStartTime && this.payloadRequestStartTime) ?

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -41,7 +41,6 @@ import { CodingJobCommentDialogComponent } from '../../../coding/components/codi
 import { NavigateCodingCasesDialogComponent, NavigateCodingCasesDialogData } from '../navigate-coding-cases-dialog/navigate-coding-cases-dialog.component';
 import { ReplayCodingRecoverySnapshot, ReplayCodingService, SavedCode } from '../../services/replay-coding.service';
 import { base64ToUtf8 } from '../../../shared/utils/common-utils';
-import { CodingJobBackendService } from '../../../coding/services/coding-job-backend.service';
 import { hasManualInstruction } from '../../../coding/utils/manual-coding.util';
 import { findVariableCodingByPublicId } from '../../../coding/utils/coding-scheme.util';
 import {
@@ -51,10 +50,11 @@ import {
 } from '../../../core/services/auth-session.config';
 import { SessionRecoveryService } from '../../../core/services/session-recovery.service';
 import { CodingScheme } from '../../../models/coding-interfaces';
-import type {
-  ReplayCodingSessionDto,
-  ReplayCodingSessionUnitDto
-} from '../../../../../../../api-dto/coding/replay-coding-session.dto';
+import {
+  ReplaySessionLoadError,
+  ReplaySessionLoadRequest,
+  ReplaySessionLoaderService
+} from '../../services/replay-session-loader.service';
 
 interface ReplayUnitPayload {
   unitDef: FilesDto[];
@@ -73,11 +73,6 @@ interface ReplayUnitPayload {
 interface PendingReplayNotesCommit {
   variableId: string;
   notes: string;
-}
-
-interface PendingReplayCodingSession {
-  request: Promise<ReplayCodingSessionDto>;
-  startedAt: number;
 }
 
 interface PendingReplayTokenRefresh {
@@ -100,7 +95,7 @@ interface ReplayRecoveryDraft {
 }
 
 @Component({
-  providers: [ReplayCodingService],
+  providers: [ReplayCodingService, ReplaySessionLoaderService],
   selector: 'coding-box-replay',
   imports: [
     MatFormFieldModule,
@@ -131,7 +126,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
   codingService = inject(ReplayCodingService);
-  private codingJobBackendService = inject(CodingJobBackendService);
+  private replaySessionLoader = inject(ReplaySessionLoaderService);
   private sessionRecoveryService = inject(SessionRecoveryService);
 
   player: string = '';
@@ -157,9 +152,6 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private pageErrorSnackbarRef: MatSnackBarRef<TextOnlySnackBar> | null = null;
   private routerSubscription: Subscription | null = null;
   private routerRunId = 0;
-
-  private readonly replayCodingSessionRequests =
-    new Map<string, PendingReplayCodingSession>();
 
   private readonly replayTokenRefreshRequests =
     new Map<string, PendingReplayTokenRefresh>();
@@ -507,75 +499,6 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  private createCodingJobUnitsReplay(
-    jobId: number,
-    apiUnits: ReplayCodingSessionUnitDto[]
-  ): UnitsReplay {
-    return {
-      id: jobId,
-      name: `Coding-Job: ${jobId}`,
-      units: apiUnits.map((item, idx) => ({
-        id: idx,
-        name: item.unitName,
-        alias: item.unitAlias,
-        bookletId: 0,
-        testPerson: item.personGroup ?
-          `${item.personLogin}@${item.personCode}@${item.personGroup}@${item.bookletName}` :
-          `${item.personLogin}@${item.personCode}@${item.bookletName}`,
-        variableId: item.variableId,
-        variableAnchor: item.variableAnchor,
-        variablePage: item.variablePage,
-        variableBundleId: item.variableBundleId,
-        bundleContext: item.bundleContext
-      })),
-      currentUnitIndex: 0
-    };
-  }
-
-  private getReplayCodingSessionRequest(
-    cacheKey: string,
-    workspaceId: number,
-    jobId: number,
-    authToken: string,
-    onlyOpen: boolean
-  ): PendingReplayCodingSession {
-    const pendingRequest = this.replayCodingSessionRequests.get(cacheKey);
-    if (pendingRequest) {
-      return pendingRequest;
-    }
-
-    const requestEntry: PendingReplayCodingSession = {
-      startedAt: performance.now(),
-      request: firstValueFrom(
-        this.codingJobBackendService.getReplayCodingSession(
-          workspaceId,
-          jobId,
-          authToken,
-          onlyOpen
-        )
-      )
-    };
-    this.replayCodingSessionRequests.set(cacheKey, requestEntry);
-    return requestEntry;
-  }
-
-  private clearReplayCodingSessionRequest(
-    cacheKey: string,
-    requestEntry: PendingReplayCodingSession
-  ): void {
-    if (this.replayCodingSessionRequests.get(cacheKey) === requestEntry) {
-      this.replayCodingSessionRequests.delete(cacheKey);
-    }
-  }
-
-  private pruneReplayCodingSessionRequests(cacheKey: string | null): void {
-    this.replayCodingSessionRequests.forEach((_requestEntry, requestCacheKey) => {
-      if (requestCacheKey !== cacheKey) {
-        this.replayCodingSessionRequests.delete(requestCacheKey);
-      }
-    });
-  }
-
   private isCurrentRouterRun(runId: number): boolean {
     return runId === this.routerRunId;
   }
@@ -652,12 +575,19 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
         const cachedJobId = Number(queryParams.codingJobId);
         const cachedWorkspaceId = Number(queryParams.workspaceId);
         const cachedOnlyOpen = queryParams.onlyOpen === 'true';
-        const incomingUnitsCacheKey = queryParams.codingJobId &&
+        const incomingSessionRequest: ReplaySessionLoadRequest | null =
+          queryParams.codingJobId &&
           queryParams.workspaceId &&
           !queryParams.unitsData ?
-          `${cachedWorkspaceId}:${cachedJobId}:${cachedOnlyOpen}` :
-          null;
-        this.pruneReplayCodingSessionRequests(incomingUnitsCacheKey);
+            {
+              workspaceId: cachedWorkspaceId,
+              codingJobId: cachedJobId,
+              authToken: this.authToken,
+              onlyOpen: cachedOnlyOpen
+            } :
+            null;
+        const incomingUnitsCacheKey =
+          this.replaySessionLoader.retainOnly(incomingSessionRequest);
         const preserveCodingData = incomingUnitsCacheKey !== null &&
           this.unitsData?.id === cachedJobId &&
           this.loadedCodingJobUnitsKey === incomingUnitsCacheKey;
@@ -705,78 +635,66 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
             const jobId = Number(queryParams.codingJobId);
             const wsId = Number(queryParams.workspaceId);
             const onlyOpen = queryParams.onlyOpen === 'true';
-            const unitsCacheKey = `${wsId}:${jobId}:${onlyOpen}`;
+            const sessionRequest: ReplaySessionLoadRequest = {
+              workspaceId: wsId,
+              codingJobId: jobId,
+              authToken: this.authToken,
+              onlyOpen
+            };
+            const unitsCacheKey =
+              this.replaySessionLoader.getRequestKey(sessionRequest);
             if (this.unitsData?.id === jobId && this.loadedCodingJobUnitsKey === unitsCacheKey) {
               deserializedUnits = this.unitsData;
             } else {
-              this.codingSessionResponseTime = 0;
-              this.codingSessionServerTimings = null;
-              const sessionRequest = this.getReplayCodingSessionRequest(
-                unitsCacheKey,
-                wsId,
-                jobId,
-                this.authToken,
-                onlyOpen
-              );
-              this.codingSessionRequestStartTime = sessionRequest.startedAt;
+              const sessionLoad =
+                this.replaySessionLoader.load(sessionRequest);
               try {
-                const session = await sessionRequest.request;
+                const result = await sessionLoad;
                 if (!this.isCurrentRouterRun(routerRunId)) {
                   return;
                 }
-                this.codingSessionResponseTime = performance.now();
-                this.codingSessionServerTimings = Object.fromEntries(
-                  Object.entries(session.serverTimings).map(([key, value]) => [
-                    `codingSession${key.charAt(0).toUpperCase()}${key.slice(1)}`,
-                    value
-                  ])
+                this.replaySessionLoader.discard(
+                  sessionRequest,
+                  sessionLoad
                 );
-                this.codingService.applyReplayCodingSession(session);
-                this.codingProgressLoadedForJobKey = `${wsId}:${jobId}`;
-                deserializedUnits = this.createCodingJobUnitsReplay(
-                  jobId,
-                  session.units
-                );
-                this.loadedCodingJobUnitsKey = unitsCacheKey;
-                this.clearReplayCodingSessionRequest(
-                  unitsCacheKey,
-                  sessionRequest
-                );
+                this.codingSessionRequestStartTime =
+                  result.timings.requestStartedAt;
+                this.codingSessionResponseTime =
+                  result.timings.responseReceivedAt;
+                this.codingSessionServerTimings =
+                  result.timings.serverTimings;
+                if (result.source === 'session') {
+                  this.codingService.applyReplayCodingSession(result.session);
+                  this.codingProgressLoadedForJobKey = `${wsId}:${jobId}`;
+                }
+                deserializedUnits = result.unitsData;
+                if (deserializedUnits) {
+                  this.loadedCodingJobUnitsKey = unitsCacheKey;
+                }
               } catch (error) {
                 if (!this.isCurrentRouterRun(routerRunId)) {
                   return;
                 }
-                this.clearReplayCodingSessionRequest(
-                  unitsCacheKey,
-                  sessionRequest
+                this.replaySessionLoader.discard(
+                  sessionRequest,
+                  sessionLoad
                 );
-                this.codingSessionResponseTime = performance.now();
-                const httpError = error as HttpErrorResponse;
-                if (httpError.status !== 404 && httpError.status !== 405) {
-                  this.setIsLoaded();
-                  this.catchError(httpError);
-                  return;
+                const loadError = error instanceof ReplaySessionLoadError ?
+                  error :
+                  null;
+                if (loadError) {
+                  this.codingSessionRequestStartTime =
+                    loadError.timings.requestStartedAt;
+                  this.codingSessionResponseTime =
+                    loadError.timings.responseReceivedAt;
+                  this.codingSessionServerTimings =
+                    loadError.timings.serverTimings;
                 }
-
-                try {
-                  const apiUnits = await firstValueFrom(
-                    this.codingJobBackendService.getCodingJobUnits(wsId, jobId, this.authToken, onlyOpen)
-                  );
-                  if (!this.isCurrentRouterRun(routerRunId)) {
-                    return;
-                  }
-                  if (apiUnits && apiUnits.length > 0) {
-                    deserializedUnits = this.createCodingJobUnitsReplay(jobId, apiUnits);
-                    this.loadedCodingJobUnitsKey = unitsCacheKey;
-                  }
-                } catch (legacyError) {
-                  if (!this.isCurrentRouterRun(routerRunId)) {
-                    return;
-                  }
-                  this.setIsLoaded();
-                  this.catchError(legacyError as HttpErrorResponse);
-                  return;
-                }
+                this.setIsLoaded();
+                this.catchError(
+                  (loadError?.requestError ?? error) as HttpErrorResponse
+                );
+                return;
               }
             }
           } else if (queryParams.bookletKey) {
@@ -1604,7 +1522,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnDestroy(): void {
     this.routerRunId += 1;
-    this.replayCodingSessionRequests.clear();
+    this.replaySessionLoader.clear();
     this.replayTokenRefreshRequests.clear();
     this.invalidateUnitPayloadRequests();
     this.unitPayloadCancellation?.complete();

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -51,6 +51,10 @@ import {
 } from '../../../core/services/auth-session.config';
 import { SessionRecoveryService } from '../../../core/services/session-recovery.service';
 import { CodingScheme } from '../../../models/coding-interfaces';
+import type {
+  ReplayCodingSessionDto,
+  ReplayCodingSessionUnitDto
+} from '../../../../../../../api-dto/coding/replay-coding-session.dto';
 
 interface ReplayUnitPayload {
   unitDef: FilesDto[];
@@ -69,6 +73,15 @@ interface ReplayUnitPayload {
 interface PendingReplayNotesCommit {
   variableId: string;
   notes: string;
+}
+
+interface PendingReplayCodingSession {
+  request: Promise<ReplayCodingSessionDto>;
+  startedAt: number;
+}
+
+interface PendingReplayTokenRefresh {
+  request: Promise<string | null>;
 }
 
 type ReplayRecoveryMode = 'coding' | 'coding-decision';
@@ -143,6 +156,14 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private errorSnackbarRef: MatSnackBarRef<TextOnlySnackBar> | null = null;
   private pageErrorSnackbarRef: MatSnackBarRef<TextOnlySnackBar> | null = null;
   private routerSubscription: Subscription | null = null;
+  private routerRunId = 0;
+
+  private readonly replayCodingSessionRequests =
+    new Map<string, PendingReplayCodingSession>();
+
+  private readonly replayTokenRefreshRequests =
+    new Map<string, PendingReplayTokenRefresh>();
+
   readonly testPersonInput = input<string>();
   readonly unitIdInput = input<string>();
   protected unitsData: UnitsReplay | null = null;
@@ -155,7 +176,6 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private unregisterRecoveryProvider: (() => void) | null = null;
   private readonly replayNotesCommitSubject = new Subject<PendingReplayNotesCommit>();
   private replayReAuthenticationPending = false;
-  private replayTokenRefreshRunning = false;
   private replayRecoveryRestorePromise: Promise<void> | null = null;
   @ViewChild(UnitPlayerComponent) unitPlayerComponent: UnitPlayerComponent | undefined;
   @ViewChild(CodeSelectorComponent) codeSelectorComponent: CodeSelectorComponent | undefined;
@@ -172,6 +192,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   private payloadResponseTime: number = 0;
   private playerReadyTime: number = 0;
   private serverTimings: ReplayServerTimings | null = null;
+  private codingSessionRequestStartTime: number = 0;
+  private codingSessionResponseTime: number = 0;
+  private codingSessionServerTimings: ReplayServerTimings | null = null;
   private successStoredForCurrentReplay: boolean = false;
   protected reloadKey: number = 0;
   workspaceId: number = 0;
@@ -242,12 +265,6 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  private async getAuthToken(): Promise<string> {
-    const queryParams = await firstValueFrom(this.route.queryParams);
-    const { auth } = queryParams;
-    return auth;
-  }
-
   private getWorkspaceIdFromAuthToken(authToken?: string): number {
     if (!authToken) {
       return 0;
@@ -293,19 +310,36 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     return tokenWorkspaceId === workspaceId;
   }
 
-  private async refreshExpiredReplayAuthToken(workspaceId: number): Promise<void> {
+  private async refreshExpiredReplayAuthToken(
+    workspaceId: number,
+    routerRunId?: number,
+    scopes: WorkspaceTokenScope[] = this.getReplayTokenScopes()
+  ): Promise<void> {
     const tokenValidation: ReturnType<typeof validateToken> = this.authToken ?
       validateToken(this.authToken) :
       { isValid: false, errorType: 'token_invalid' };
-    if (tokenValidation.isValid || tokenValidation.errorType !== 'token_expired') {
+    const shouldRefresh = !tokenValidation.isValid &&
+      tokenValidation.errorType === 'token_expired' &&
+      this.canRefreshReplayAuthTokenForWorkspace(
+        workspaceId,
+        tokenValidation
+      );
+    this.pruneReplayTokenRefreshRequests(
+      shouldRefresh ?
+        this.getReplayTokenRefreshCacheKey(workspaceId, scopes) :
+        null
+    );
+    if (!shouldRefresh) {
       return;
     }
 
-    if (!this.canRefreshReplayAuthTokenForWorkspace(workspaceId, tokenValidation)) {
-      return;
-    }
-
-    await this.refreshReplayAuthTokenForWorkspace(workspaceId);
+    await this.refreshReplayAuthTokenForWorkspace(
+      workspaceId,
+      routerRunId === undefined ?
+        undefined :
+        () => this.isCurrentRouterRun(routerRunId),
+      scopes
+    );
   }
 
   private async refreshReplayAuthTokenAfterReAuthentication(): Promise<void> {
@@ -335,32 +369,91 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  private async refreshReplayAuthTokenForWorkspace(workspaceId: number): Promise<boolean> {
-    if (this.replayTokenRefreshRunning || !this.appService.hasStoredAuthToken()) {
-      return false;
+  private getReplayTokenRefreshRequest(
+    workspaceId: number,
+    scopes: WorkspaceTokenScope[]
+  ): PendingReplayTokenRefresh {
+    const cacheKey = this.getReplayTokenRefreshCacheKey(workspaceId, scopes);
+    const pendingRequest = this.replayTokenRefreshRequests.get(cacheKey);
+    if (pendingRequest) {
+      return pendingRequest;
     }
 
-    this.replayTokenRefreshRunning = true;
-    try {
-      const token = await firstValueFrom(this.appService.createOwnToken(
+    const requestEntry: PendingReplayTokenRefresh = {
+      request: firstValueFrom(this.appService.createOwnToken(
         workspaceId,
         1,
-        this.getReplayTokenScopes()
-      ));
-      if (!token) {
-        return false;
-      }
+        scopes
+      ))
+        .then(token => token || null)
+        .catch(() => null)
+    };
+    this.replayTokenRefreshRequests.set(cacheKey, requestEntry);
+    return requestEntry;
+  }
 
-      this.authToken = token;
-      this.workspaceId = workspaceId;
-      this.codingService.setAuthToken(token);
-      this.removeReplayAuthTokenFromUrl(token);
-      return true;
-    } catch (error) {
-      return false;
-    } finally {
-      this.replayTokenRefreshRunning = false;
+  private clearReplayTokenRefreshRequest(
+    workspaceId: number,
+    scopes: WorkspaceTokenScope[],
+    requestEntry: PendingReplayTokenRefresh
+  ): void {
+    const cacheKey = this.getReplayTokenRefreshCacheKey(workspaceId, scopes);
+    if (this.replayTokenRefreshRequests.get(cacheKey) === requestEntry) {
+      this.replayTokenRefreshRequests.delete(cacheKey);
     }
+  }
+
+  private async refreshReplayAuthTokenForWorkspace(
+    workspaceId: number,
+    canApply: (() => boolean) | undefined = undefined,
+    scopes: WorkspaceTokenScope[] = this.getReplayTokenScopes()
+  ): Promise<boolean> {
+    if (!this.appService.hasStoredAuthToken()) {
+      return false;
+    }
+
+    const requestEntry = this.getReplayTokenRefreshRequest(workspaceId, scopes);
+    const token = await requestEntry.request;
+    const cacheKey = this.getReplayTokenRefreshCacheKey(workspaceId, scopes);
+    if (
+      this.replayTokenRefreshRequests.get(cacheKey) !== requestEntry ||
+      (canApply && !canApply())
+    ) {
+      return false;
+    }
+    this.clearReplayTokenRefreshRequest(workspaceId, scopes, requestEntry);
+    if (!token) {
+      return false;
+    }
+
+    this.authToken = token;
+    this.workspaceId = workspaceId;
+    this.codingService.setAuthToken(token);
+    this.removeReplayAuthTokenFromUrl(token);
+    return true;
+  }
+
+  private getReplayTokenRefreshCacheKey(
+    workspaceId: number,
+    scopes: WorkspaceTokenScope[]
+  ): string {
+    const normalizedScopes = [...new Set(scopes)].sort();
+    return `${workspaceId}:${normalizedScopes.join(',')}`;
+  }
+
+  private pruneReplayTokenRefreshRequests(cacheKey: string | null): void {
+    this.replayTokenRefreshRequests.forEach((_requestEntry, requestCacheKey) => {
+      if (requestCacheKey !== cacheKey) {
+        this.replayTokenRefreshRequests.delete(requestCacheKey);
+      }
+    });
+  }
+
+  private getReplayTokenScopesForQueryParams(queryParams: Params): WorkspaceTokenScope[] {
+    const mode = String(queryParams.mode || '');
+    return queryParams.codingJobId || mode.startsWith('coding') ?
+      CODING_JOB_WORKSPACE_TOKEN_SCOPES :
+      REPLAY_WORKSPACE_TOKEN_SCOPES;
   }
 
   private getReplayTokenScopes(): WorkspaceTokenScope[] {
@@ -412,6 +505,79 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     } catch (error) {
       return null;
     }
+  }
+
+  private createCodingJobUnitsReplay(
+    jobId: number,
+    apiUnits: ReplayCodingSessionUnitDto[]
+  ): UnitsReplay {
+    return {
+      id: jobId,
+      name: `Coding-Job: ${jobId}`,
+      units: apiUnits.map((item, idx) => ({
+        id: idx,
+        name: item.unitName,
+        alias: item.unitAlias,
+        bookletId: 0,
+        testPerson: item.personGroup ?
+          `${item.personLogin}@${item.personCode}@${item.personGroup}@${item.bookletName}` :
+          `${item.personLogin}@${item.personCode}@${item.bookletName}`,
+        variableId: item.variableId,
+        variableAnchor: item.variableAnchor,
+        variablePage: item.variablePage,
+        variableBundleId: item.variableBundleId,
+        bundleContext: item.bundleContext
+      })),
+      currentUnitIndex: 0
+    };
+  }
+
+  private getReplayCodingSessionRequest(
+    cacheKey: string,
+    workspaceId: number,
+    jobId: number,
+    authToken: string,
+    onlyOpen: boolean
+  ): PendingReplayCodingSession {
+    const pendingRequest = this.replayCodingSessionRequests.get(cacheKey);
+    if (pendingRequest) {
+      return pendingRequest;
+    }
+
+    const requestEntry: PendingReplayCodingSession = {
+      startedAt: performance.now(),
+      request: firstValueFrom(
+        this.codingJobBackendService.getReplayCodingSession(
+          workspaceId,
+          jobId,
+          authToken,
+          onlyOpen
+        )
+      )
+    };
+    this.replayCodingSessionRequests.set(cacheKey, requestEntry);
+    return requestEntry;
+  }
+
+  private clearReplayCodingSessionRequest(
+    cacheKey: string,
+    requestEntry: PendingReplayCodingSession
+  ): void {
+    if (this.replayCodingSessionRequests.get(cacheKey) === requestEntry) {
+      this.replayCodingSessionRequests.delete(cacheKey);
+    }
+  }
+
+  private pruneReplayCodingSessionRequests(cacheKey: string | null): void {
+    this.replayCodingSessionRequests.forEach((_requestEntry, requestCacheKey) => {
+      if (requestCacheKey !== cacheKey) {
+        this.replayCodingSessionRequests.delete(requestCacheKey);
+      }
+    });
+  }
+
+  private isCurrentRouterRun(runId: number): boolean {
+    return runId === this.routerRunId;
   }
 
   private deserializeReviewCodeSelections(value: unknown): ReviewCodeSelection[] {
@@ -469,20 +635,47 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   subscribeRouter(): void {
+    this.routerSubscription?.unsubscribe();
     this.routerSubscription = this.route.params
       ?.subscribe(async params => {
+        this.routerRunId += 1;
+        const routerRunId = this.routerRunId;
         this.routeStartTime = performance.now();
         this.resetSnackBars();
-        this.resetUnitData();
-        this.authToken = await this.getAuthToken();
+        this.invalidateUnitPayloadRequests();
+        this.cancelPendingAnchorHighlight();
         const queryParams = await firstValueFrom(this.route.queryParams);
+        if (!this.isCurrentRouterRun(routerRunId)) {
+          return;
+        }
+        this.authToken = queryParams.auth;
+        const cachedJobId = Number(queryParams.codingJobId);
+        const cachedWorkspaceId = Number(queryParams.workspaceId);
+        const cachedOnlyOpen = queryParams.onlyOpen === 'true';
+        const incomingUnitsCacheKey = queryParams.codingJobId &&
+          queryParams.workspaceId &&
+          !queryParams.unitsData ?
+          `${cachedWorkspaceId}:${cachedJobId}:${cachedOnlyOpen}` :
+          null;
+        this.pruneReplayCodingSessionRequests(incomingUnitsCacheKey);
+        const preserveCodingData = incomingUnitsCacheKey !== null &&
+          this.unitsData?.id === cachedJobId &&
+          this.loadedCodingJobUnitsKey === incomingUnitsCacheKey;
+        this.resetUnitData(preserveCodingData);
         let restoredReplayRecovery = false;
         this.workspaceId = this.getWorkspaceIdFromQueryParams(queryParams) ||
           this.getWorkspaceIdFromAuthToken(this.authToken);
         if (this.workspaceId > 0) {
           this.appService.selectedWorkspaceId = this.workspaceId;
         }
-        await this.refreshExpiredReplayAuthToken(this.workspaceId);
+        await this.refreshExpiredReplayAuthToken(
+          this.workspaceId,
+          routerRunId,
+          this.getReplayTokenScopesForQueryParams(queryParams)
+        );
+        if (!this.isCurrentRouterRun(routerRunId)) {
+          return;
+        }
         this.codingService.setAuthToken(this.authToken);
         const workspace = this.workspaceId ? String(this.workspaceId) : undefined;
         this.isReviewMode = queryParams.mode === 'coding-review';
@@ -504,46 +697,92 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
           let deserializedUnits = null as UnitsReplay | null;
 
           if (queryParams.unitsData) {
+            this.codingSessionRequestStartTime = 0;
+            this.codingSessionResponseTime = 0;
+            this.codingSessionServerTimings = null;
             deserializedUnits = this.deserializeUnitsData(queryParams.unitsData);
           } else if (queryParams.codingJobId && queryParams.workspaceId) {
             const jobId = Number(queryParams.codingJobId);
             const wsId = Number(queryParams.workspaceId);
             const onlyOpen = queryParams.onlyOpen === 'true';
             const unitsCacheKey = `${wsId}:${jobId}:${onlyOpen}`;
-            try {
-              if (this.unitsData?.id === jobId && this.loadedCodingJobUnitsKey === unitsCacheKey) {
-                deserializedUnits = this.unitsData;
-              } else {
-                const apiUnits = await firstValueFrom(
-                  this.codingJobBackendService.getCodingJobUnits(wsId, jobId, this.authToken, onlyOpen)
+            if (this.unitsData?.id === jobId && this.loadedCodingJobUnitsKey === unitsCacheKey) {
+              deserializedUnits = this.unitsData;
+            } else {
+              this.codingSessionResponseTime = 0;
+              this.codingSessionServerTimings = null;
+              const sessionRequest = this.getReplayCodingSessionRequest(
+                unitsCacheKey,
+                wsId,
+                jobId,
+                this.authToken,
+                onlyOpen
+              );
+              this.codingSessionRequestStartTime = sessionRequest.startedAt;
+              try {
+                const session = await sessionRequest.request;
+                if (!this.isCurrentRouterRun(routerRunId)) {
+                  return;
+                }
+                this.codingSessionResponseTime = performance.now();
+                this.codingSessionServerTimings = Object.fromEntries(
+                  Object.entries(session.serverTimings).map(([key, value]) => [
+                    `codingSession${key.charAt(0).toUpperCase()}${key.slice(1)}`,
+                    value
+                  ])
                 );
-                if (apiUnits && apiUnits.length > 0) {
-                  deserializedUnits = {
-                    id: jobId,
-                    name: `Coding-Job: ${jobId}`,
-                    units: apiUnits.map((item, idx) => ({
-                      id: idx,
-                      name: item.unitName,
-                      alias: item.unitAlias,
-                      bookletId: 0,
-                      testPerson: item.personGroup ?
-                        `${item.personLogin}@${item.personCode}@${item.personGroup}@${item.bookletName}` :
-                        `${item.personLogin}@${item.personCode}@${item.bookletName}`,
-                      variableId: item.variableId,
-                      variableAnchor: item.variableAnchor,
-                      variablePage: item.variablePage,
-                      variableBundleId: item.variableBundleId,
-                      bundleContext: item.bundleContext
-                    })),
-                    currentUnitIndex: 0
-                  };
-                  this.loadedCodingJobUnitsKey = unitsCacheKey;
+                this.codingService.applyReplayCodingSession(session);
+                this.codingProgressLoadedForJobKey = `${wsId}:${jobId}`;
+                deserializedUnits = this.createCodingJobUnitsReplay(
+                  jobId,
+                  session.units
+                );
+                this.loadedCodingJobUnitsKey = unitsCacheKey;
+                this.clearReplayCodingSessionRequest(
+                  unitsCacheKey,
+                  sessionRequest
+                );
+              } catch (error) {
+                if (!this.isCurrentRouterRun(routerRunId)) {
+                  return;
+                }
+                this.clearReplayCodingSessionRequest(
+                  unitsCacheKey,
+                  sessionRequest
+                );
+                this.codingSessionResponseTime = performance.now();
+                const httpError = error as HttpErrorResponse;
+                if (httpError.status !== 404 && httpError.status !== 405) {
+                  this.setIsLoaded();
+                  this.catchError(httpError);
+                  return;
+                }
+
+                try {
+                  const apiUnits = await firstValueFrom(
+                    this.codingJobBackendService.getCodingJobUnits(wsId, jobId, this.authToken, onlyOpen)
+                  );
+                  if (!this.isCurrentRouterRun(routerRunId)) {
+                    return;
+                  }
+                  if (apiUnits && apiUnits.length > 0) {
+                    deserializedUnits = this.createCodingJobUnitsReplay(jobId, apiUnits);
+                    this.loadedCodingJobUnitsKey = unitsCacheKey;
+                  }
+                } catch (legacyError) {
+                  if (!this.isCurrentRouterRun(routerRunId)) {
+                    return;
+                  }
+                  this.setIsLoaded();
+                  this.catchError(legacyError as HttpErrorResponse);
+                  return;
                 }
               }
-            } catch (e) {
-              // ignore fetch errors — unitsData stays null
             }
           } else if (queryParams.bookletKey) {
+            this.codingSessionRequestStartTime = 0;
+            this.codingSessionResponseTime = 0;
+            this.codingSessionServerTimings = null;
             const key = queryParams.bookletKey as string;
             try {
               const stored = localStorage.getItem(key);
@@ -587,9 +826,15 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
                 const jobKey = `${this.workspaceId}:${jobId}`;
                 if (this.codingProgressLoadedForJobKey !== jobKey) {
                   await this.codingService.loadSavedCodingProgress(this.workspaceId, jobId);
+                  if (!this.isCurrentRouterRun(routerRunId)) {
+                    return;
+                  }
                   this.codingProgressLoadedForJobKey = jobKey;
                 }
                 restoredReplayRecovery = await this.restoreReplayRecoveryDraft();
+                if (!this.isCurrentRouterRun(routerRunId)) {
+                  return;
+                }
                 if (!this.isReviewMode &&
                   !this.isCodingIssueReviewMode &&
                   !this.codingService.isCompletedJobReview &&
@@ -672,6 +917,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
             ReplayComponent.throwError('ParamsError');
           }
         } catch (error) {
+          if (!this.isCurrentRouterRun(routerRunId)) {
+            return;
+          }
           this.setIsLoaded();
           this.catchError(error as HttpErrorResponse);
         }
@@ -935,6 +1183,15 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
 
   private getClientTimings(visibleTime: number = performance.now()): ReplayClientTimings {
     return {
+      codingSessionMs: (
+        this.codingSessionRequestStartTime &&
+        this.codingSessionResponseTime
+      ) ?
+        this.getElapsedMs(
+          this.codingSessionRequestStartTime,
+          this.codingSessionResponseTime
+        ) :
+        null,
       routeToVisibleMs: this.routeStartTime ? this.getElapsedMs(this.routeStartTime, visibleTime) : null,
       loadToVisibleMs: this.loadStartTime ? this.getElapsedMs(this.loadStartTime, visibleTime) : null,
       routeToPayloadRequestMs: (this.routeStartTime && this.payloadRequestStartTime) ?
@@ -974,6 +1231,10 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       bookletId
     } = this.parseTestPersonData();
     const replayUrl = this.getReplayStatisticsUrl();
+    const serverTimings = {
+      ...(this.codingSessionServerTimings ?? {}),
+      ...(this.serverTimings ?? {})
+    };
 
     this.replayBackendService.storeReplayStatistics(workspaceId, {
       unitId: this.unitId || 'unknown',
@@ -985,7 +1246,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
       success,
       errorMessage,
       clientTimings: this.getClientTimings(visibleTime),
-      serverTimings: this.serverTimings ?? undefined
+      serverTimings: Object.keys(serverTimings).length > 0 ?
+        serverTimings :
+        undefined
     }, this.getReplayRequestAuthToken()).subscribe({
       error: () => undefined
     });
@@ -1135,7 +1398,7 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     if (this.pageErrorSnackbarRef) this.pageErrorSnackBar.dismiss();
   }
 
-  private resetUnitData() {
+  private resetUnitData(preserveCodingData = false) {
     this.invalidateUnitPayloadRequests();
     this.cancelPendingAnchorHighlight();
     this.unitId = '';
@@ -1145,7 +1408,12 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     this.responses = undefined;
     this.serverTimings = null;
     this.reviewCodeSelections = [];
-    this.codingService.resetCodingData();
+    if (!preserveCodingData) {
+      this.codingSessionRequestStartTime = 0;
+      this.codingSessionResponseTime = 0;
+      this.codingSessionServerTimings = null;
+      this.codingService.resetCodingData();
+    }
   }
 
   private createReplayRecoveryDraft(): ReplayRecoveryDraft | null {
@@ -1335,6 +1603,9 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy(): void {
+    this.routerRunId += 1;
+    this.replayCodingSessionRequests.clear();
+    this.replayTokenRefreshRequests.clear();
     this.invalidateUnitPayloadRequests();
     this.unitPayloadCancellation?.complete();
     this.unitPayloadCancellation = undefined;

--- a/apps/frontend/src/app/replay/services/replay-backend.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-backend.service.spec.ts
@@ -66,6 +66,7 @@ describe('ReplayBackendService', () => {
         unitId: 'u1',
         durationMilliseconds: 1000,
         clientTimings: {
+          codingSessionMs: null,
           payloadMs: 100,
           routeToVisibleMs: null,
           loadToVisibleMs: 200,

--- a/apps/frontend/src/app/replay/services/replay-backend.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-backend.service.spec.ts
@@ -67,6 +67,8 @@ describe('ReplayBackendService', () => {
         durationMilliseconds: 1000,
         clientTimings: {
           codingSessionMs: null,
+          routeToCodingSessionRequestMs: null,
+          codingSessionResponseToPayloadRequestMs: null,
           payloadMs: 100,
           routeToVisibleMs: null,
           loadToVisibleMs: 200,

--- a/apps/frontend/src/app/replay/services/replay-backend.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-backend.service.ts
@@ -21,6 +21,7 @@ export type ReplayUnitResponse = {
 export type ReplayTimingMap = Record<string, number | null>;
 export type ReplayStatisticsSource = 'internal' | 'external';
 export type ReplayClientTimings = {
+  codingSessionMs: number | null;
   routeToVisibleMs: number | null;
   loadToVisibleMs: number | null;
   routeToPayloadRequestMs: number | null;

--- a/apps/frontend/src/app/replay/services/replay-backend.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-backend.service.ts
@@ -22,6 +22,8 @@ export type ReplayTimingMap = Record<string, number | null>;
 export type ReplayStatisticsSource = 'internal' | 'external';
 export type ReplayClientTimings = {
   codingSessionMs: number | null;
+  routeToCodingSessionRequestMs: number | null;
+  codingSessionResponseToPayloadRequestMs: number | null;
   routeToVisibleMs: number | null;
   loadToVisibleMs: number | null;
   routeToPayloadRequestMs: number | null;

--- a/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
@@ -203,6 +203,56 @@ describe('ReplayCodingService', () => {
     });
   });
 
+  describe('applyReplayCodingSession', () => {
+    it('applies progress, open markers, notes, and slim job metadata', () => {
+      service.applyReplayCodingSession({
+        units: [],
+        progress: {
+          coded: {
+            id: 7,
+            code: '7',
+            label: 'Code 7',
+            score: 2,
+            codingIssueOption: -1
+          },
+          'open-key:open': {
+            id: -1,
+            code: '',
+            label: 'OPEN'
+          }
+        },
+        notes: {
+          coded: 'Check this response'
+        },
+        job: {
+          status: 'review',
+          comment: 'Training hint',
+          showScore: true,
+          allowComments: false,
+          suppressGeneralInstructions: true
+        },
+        serverTimings: {
+          totalMs: 12
+        }
+      });
+
+      expect(service.selectedCodes.get('coded')).toEqual({
+        id: 7,
+        code: '7',
+        label: 'Code 7',
+        score: 2,
+        codingIssueOption: -1
+      });
+      expect(service.openUnitKeys).toContain('open-key');
+      expect(service.notes.get('coded')).toBe('Check this response');
+      expect(service.codingJobComment).toBe('Training hint');
+      expect(service.showScore).toBe(true);
+      expect(service.allowComments).toBe(false);
+      expect(service.suppressGeneralInstructions).toBe(true);
+      expect(service.isCompletedJobReview).toBe(true);
+    });
+  });
+
   describe('saveCodingProgress', () => {
     it('should save progress via backend', async () => {
       codingJobBackendServiceMock.saveCodingProgress.mockReturnValue(of({} as CodingJob));

--- a/apps/frontend/src/app/replay/services/replay-coding.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.ts
@@ -8,6 +8,7 @@ import {
 } from '../../models/coding-interfaces';
 import { findVariableCodingByPublicId } from '../../coding/utils/coding-scheme.util';
 import { UnitsReplay, UnitsReplayUnit } from './units-replay.service';
+import type { ReplayCodingSessionDto } from '../../../../../../api-dto/coding/replay-coding-session.dto';
 
 export interface SavedCode {
   id: number;
@@ -300,41 +301,18 @@ export class ReplayCodingService {
   async loadSavedCodingProgress(workspaceId: number, jobId: number): Promise<void> {
     if (!jobId || !workspaceId) return;
 
-    this.selectedCodes.clear();
-    this.openUnitKeys.clear();
-    this.notes.clear();
-    this.latestRequestedSelectionByKey.clear();
+    this.resetLoadedCodingState();
 
     try {
       const savedProgress = await firstValueFrom(
         this.codingJobBackendService.getCodingProgress(workspaceId, jobId, ...this.authTokenArg)
       ) as { [key: string]: SavedCode };
-
-      Object.keys(savedProgress).forEach(compositeKey => {
-        const partialCode = savedProgress[compositeKey];
-        if (compositeKey.endsWith(':open')) {
-          this.openUnitKeys.add(compositeKey.slice(0, -':open'.length));
-          return;
-        }
-        if (partialCode?.id !== null && partialCode?.id !== undefined) {
-          const fullCode = this.findCodeById(partialCode.id);
-          const toStore: SavedCode = fullCode ? this.convertCodeToSavedCode(fullCode) : partialCode;
-          if (partialCode.codingIssueOption !== undefined && partialCode.codingIssueOption !== null) {
-            toStore.codingIssueOption = partialCode.codingIssueOption;
-          }
-          this.selectedCodes.set(compositeKey, toStore);
-          this.openUnitKeys.delete(compositeKey);
-        }
-      });
+      this.applySavedProgress(savedProgress);
 
       const savedNotes = await firstValueFrom(
         this.codingJobBackendService.getCodingNotes(workspaceId, jobId, ...this.authTokenArg)
       );
-      if (savedNotes) {
-        Object.keys(savedNotes).forEach(key => {
-          this.notes.set(key, savedNotes[key]);
-        });
-      }
+      this.applySavedNotes(savedNotes ?? {});
 
       const codingJob = await firstValueFrom(
         this.codingJobBackendService.getCodingJob(workspaceId, jobId, ...this.authTokenArg)
@@ -343,6 +321,56 @@ export class ReplayCodingService {
     } catch (error) {
       // Ignore errors when loading saved coding progress
     }
+  }
+
+  applyReplayCodingSession(session: ReplayCodingSessionDto): void {
+    this.resetLoadedCodingState();
+    const progress = Object.fromEntries(
+      Object.entries(session.progress)
+        .filter((entry): entry is [string, NonNullable<typeof entry[1]>] => entry[1] !== null)
+        .map(([key, entry]) => [
+          key,
+          {
+            ...entry,
+            label: entry.label ?? ''
+          } satisfies SavedCode
+        ])
+    );
+    this.applySavedProgress(progress);
+    this.applySavedNotes(session.notes);
+    this.setCodingJobMetadata(session.job);
+  }
+
+  private resetLoadedCodingState(): void {
+    this.selectedCodes.clear();
+    this.openUnitKeys.clear();
+    this.notes.clear();
+    this.latestRequestedSelectionByKey.clear();
+  }
+
+  private applySavedProgress(savedProgress: Record<string, SavedCode>): void {
+    Object.keys(savedProgress).forEach(compositeKey => {
+      const partialCode = savedProgress[compositeKey];
+      if (compositeKey.endsWith(':open')) {
+        this.openUnitKeys.add(compositeKey.slice(0, -':open'.length));
+        return;
+      }
+      if (partialCode?.id !== null && partialCode?.id !== undefined) {
+        const fullCode = this.findCodeById(partialCode.id);
+        const toStore: SavedCode = fullCode ? this.convertCodeToSavedCode(fullCode) : partialCode;
+        if (partialCode.codingIssueOption !== undefined && partialCode.codingIssueOption !== null) {
+          toStore.codingIssueOption = partialCode.codingIssueOption;
+        }
+        this.selectedCodes.set(compositeKey, toStore);
+        this.openUnitKeys.delete(compositeKey);
+      }
+    });
+  }
+
+  private applySavedNotes(savedNotes: Record<string, string>): void {
+    Object.keys(savedNotes).forEach(key => {
+      this.notes.set(key, savedNotes[key]);
+    });
   }
 
   findCodeById(codeId: number): Code | null {

--- a/apps/frontend/src/app/replay/services/replay-session-load.error.ts
+++ b/apps/frontend/src/app/replay/services/replay-session-load.error.ts
@@ -1,0 +1,16 @@
+import { ReplayServerTimings } from './replay-backend.service';
+
+export interface ReplaySessionLoadTimings {
+  requestStartedAt: number;
+  responseReceivedAt: number;
+  serverTimings: ReplayServerTimings | null;
+}
+
+export class ReplaySessionLoadError extends Error {
+  constructor(
+    readonly requestError: unknown,
+    readonly timings: ReplaySessionLoadTimings
+  ) {
+    super('Replay session load failed');
+  }
+}

--- a/apps/frontend/src/app/replay/services/replay-session-loader.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-session-loader.service.spec.ts
@@ -1,0 +1,233 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import {
+  Observable, Subject, of, throwError
+} from 'rxjs';
+import { CodingJobBackendService } from '../../coding/services/coding-job-backend.service';
+import type { ReplayCodingSessionDto } from '../../../../../../api-dto/coding/replay-coding-session.dto';
+import {
+  ReplaySessionLoadRequest,
+  ReplaySessionLoadError,
+  ReplaySessionLoaderService
+} from './replay-session-loader.service';
+
+describe('ReplaySessionLoaderService', () => {
+  let service: ReplaySessionLoaderService;
+  let codingJobBackendService: {
+    getReplayCodingSession: jest.Mock;
+    getCodingJobUnits: jest.Mock;
+  };
+
+  const request: ReplaySessionLoadRequest = {
+    workspaceId: 47,
+    codingJobId: 77,
+    authToken: 'replay-token',
+    onlyOpen: true
+  };
+
+  const session: ReplayCodingSessionDto = {
+    units: [{
+      responseId: 1,
+      unitName: 'unit-1',
+      unitAlias: 'Unit 1',
+      variableId: 'VAR1',
+      variableAnchor: 'VAR1',
+      variablePage: '2',
+      bookletName: 'Booklet 1',
+      personLogin: 'person',
+      personCode: 'code',
+      personGroup: 'group',
+      variableBundleId: null,
+      bundleContext: null
+    }],
+    progress: {},
+    notes: {},
+    job: {
+      status: 'active',
+      comment: null,
+      showScore: false,
+      allowComments: true,
+      suppressGeneralInstructions: false
+    },
+    serverTimings: {
+      totalMs: 15
+    }
+  };
+
+  beforeEach(() => {
+    codingJobBackendService = {
+      getReplayCodingSession: jest.fn().mockReturnValue(of(session)),
+      getCodingJobUnits: jest.fn().mockReturnValue(of([]))
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        ReplaySessionLoaderService,
+        {
+          provide: CodingJobBackendService,
+          useValue: codingJobBackendService
+        }
+      ]
+    });
+
+    service = TestBed.inject(ReplaySessionLoaderService);
+  });
+
+  it('loads and maps a replay session', async () => {
+    const result = await service.load(request);
+
+    expect(codingJobBackendService.getReplayCodingSession)
+      .toHaveBeenCalledWith(47, 77, 'replay-token', true);
+    expect(codingJobBackendService.getCodingJobUnits).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      session,
+      source: 'session',
+      unitsData: {
+        id: 77,
+        name: 'Coding-Job: 77',
+        currentUnitIndex: 0,
+        units: [{
+          id: 0,
+          name: 'unit-1',
+          alias: 'Unit 1',
+          bookletId: 0,
+          testPerson: 'person@code@group@Booklet 1',
+          variableId: 'VAR1',
+          variableAnchor: 'VAR1',
+          variablePage: '2',
+          variableBundleId: null,
+          bundleContext: null
+        }]
+      },
+      timings: {
+        serverTimings: {
+          codingSessionTotalMs: 15
+        }
+      }
+    });
+    expect(result.timings.responseReceivedAt)
+      .toBeGreaterThanOrEqual(result.timings.requestStartedAt);
+  });
+
+  it.each([404, 405])(
+    'falls back to legacy units for a %i response',
+    async status => {
+      codingJobBackendService.getReplayCodingSession.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status }))
+      );
+      codingJobBackendService.getCodingJobUnits.mockReturnValue(of(session.units));
+
+      const result = await service.load(request);
+
+      expect(codingJobBackendService.getCodingJobUnits)
+        .toHaveBeenCalledWith(47, 77, 'replay-token', true);
+      expect(result.source).toBe('legacy');
+      expect(result.session).toBeNull();
+      expect(result.unitsData?.units).toHaveLength(1);
+      expect(result.timings.serverTimings).toBeNull();
+    }
+  );
+
+  it('does not hide replay-session server errors with a legacy request', async () => {
+    const error = new HttpErrorResponse({ status: 500 });
+    codingJobBackendService.getReplayCodingSession.mockReturnValue(
+      throwError(() => error)
+    );
+
+    await expect(service.load(request)).rejects.toMatchObject({
+      requestError: error,
+      timings: {
+        serverTimings: null
+      }
+    });
+    expect(codingJobBackendService.getCodingJobUnits).not.toHaveBeenCalled();
+  });
+
+  it('exposes a legacy fallback error with the session request timings', async () => {
+    const legacyError = new HttpErrorResponse({ status: 503 });
+    codingJobBackendService.getReplayCodingSession.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 404 }))
+    );
+    codingJobBackendService.getCodingJobUnits.mockReturnValue(
+      throwError(() => legacyError)
+    );
+
+    await expect(service.load(request)).rejects.toMatchObject({
+      requestError: legacyError,
+      timings: {
+        serverTimings: null
+      }
+    });
+  });
+
+  it('shares an in-flight request for the same replay session', async () => {
+    const response = new Subject<ReplayCodingSessionDto>();
+    codingJobBackendService.getReplayCodingSession.mockReturnValue(
+      response.asObservable() as Observable<ReplayCodingSessionDto>
+    );
+
+    const firstLoad = service.load(request);
+    const secondLoad = service.load(request);
+    response.next(session);
+    response.complete();
+
+    await expect(firstLoad).resolves.toEqual(await secondLoad);
+    expect(codingJobBackendService.getReplayCodingSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts an abandoned request when the requested coding job changes', async () => {
+    const firstResponse = new Subject<ReplayCodingSessionDto>();
+    const secondResponse = new Subject<ReplayCodingSessionDto>();
+    const repeatedFirstResponse = new Subject<ReplayCodingSessionDto>();
+    const otherRequest: ReplaySessionLoadRequest = {
+      ...request,
+      codingJobId: 88
+    };
+    codingJobBackendService.getReplayCodingSession
+      .mockReturnValueOnce(firstResponse.asObservable())
+      .mockReturnValueOnce(secondResponse.asObservable())
+      .mockReturnValueOnce(repeatedFirstResponse.asObservable());
+
+    const firstLoad = service.load(request);
+    const secondLoad = service.load(otherRequest);
+    const repeatedFirstLoad = service.load(request);
+
+    expect(codingJobBackendService.getReplayCodingSession).toHaveBeenCalledTimes(3);
+
+    firstResponse.next(session);
+    firstResponse.complete();
+    await firstLoad;
+    service.discard(request, firstLoad);
+
+    const sharedRepeatedFirstLoad = service.load(request);
+
+    expect(sharedRepeatedFirstLoad).toBe(repeatedFirstLoad);
+    expect(codingJobBackendService.getReplayCodingSession).toHaveBeenCalledTimes(3);
+
+    secondResponse.next(session);
+    secondResponse.complete();
+    repeatedFirstResponse.next(session);
+    repeatedFirstResponse.complete();
+
+    await Promise.all([
+      secondLoad,
+      repeatedFirstLoad,
+      sharedRepeatedFirstLoad
+    ]);
+  });
+
+  it('can discard a failed request before retrying it', async () => {
+    codingJobBackendService.getReplayCodingSession.mockReturnValueOnce(
+      throwError(() => new HttpErrorResponse({ status: 500 }))
+    );
+
+    const failedLoad = service.load(request);
+    await expect(failedLoad).rejects.toBeInstanceOf(ReplaySessionLoadError);
+    service.discard(request, failedLoad);
+    await expect(service.load(request)).resolves.toMatchObject({
+      source: 'session'
+    });
+
+    expect(codingJobBackendService.getReplayCodingSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/frontend/src/app/replay/services/replay-session-loader.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-session-loader.service.ts
@@ -1,0 +1,202 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import {
+  CodingJobBackendService,
+  CodingJobUnitDto
+} from '../../coding/services/coding-job-backend.service';
+import type {
+  ReplayCodingSessionDto,
+  ReplayCodingSessionUnitDto
+} from '../../../../../../api-dto/coding/replay-coding-session.dto';
+import { ReplayServerTimings } from './replay-backend.service';
+import {
+  ReplaySessionLoadError,
+  ReplaySessionLoadTimings
+} from './replay-session-load.error';
+import { UnitsReplay } from './units-replay.service';
+
+export {
+  ReplaySessionLoadError,
+  ReplaySessionLoadTimings
+} from './replay-session-load.error';
+
+export interface ReplaySessionLoadRequest {
+  workspaceId: number;
+  codingJobId: number;
+  authToken?: string;
+  onlyOpen: boolean;
+}
+
+export type ReplaySessionLoadSource = 'session' | 'legacy';
+
+interface ReplaySessionLoadResultBase {
+  timings: ReplaySessionLoadTimings;
+}
+
+export type ReplaySessionLoadResult = ReplaySessionLoadResultBase & (
+  {
+    unitsData: UnitsReplay;
+    session: ReplayCodingSessionDto;
+    source: 'session';
+  } |
+  {
+    unitsData: UnitsReplay | null;
+    session: null;
+    source: 'legacy';
+  }
+);
+
+@Injectable()
+export class ReplaySessionLoaderService {
+  private codingJobBackendService = inject(CodingJobBackendService);
+  private readonly requests = new Map<string, Promise<ReplaySessionLoadResult>>();
+
+  getRequestKey(request: ReplaySessionLoadRequest): string {
+    return `${request.workspaceId}:${request.codingJobId}:${request.onlyOpen}`;
+  }
+
+  retainOnly(request: ReplaySessionLoadRequest): string;
+  retainOnly(request: null): null;
+  retainOnly(request: ReplaySessionLoadRequest | null): string | null;
+  retainOnly(request: ReplaySessionLoadRequest | null): string | null {
+    const requestKey = request ? this.getRequestKey(request) : null;
+    this.requests.forEach((_request, key) => {
+      if (key !== requestKey) {
+        this.requests.delete(key);
+      }
+    });
+    return requestKey;
+  }
+
+  load(request: ReplaySessionLoadRequest): Promise<ReplaySessionLoadResult> {
+    const requestKey = this.retainOnly(request);
+    const pendingRequest = this.requests.get(requestKey);
+    if (pendingRequest) {
+      return pendingRequest;
+    }
+
+    const loadRequest = this.loadSession(request);
+    this.requests.set(requestKey, loadRequest);
+    return loadRequest;
+  }
+
+  discard(
+    request: ReplaySessionLoadRequest,
+    loadRequest: Promise<ReplaySessionLoadResult>
+  ): void {
+    const requestKey = this.getRequestKey(request);
+    if (this.requests.get(requestKey) === loadRequest) {
+      this.requests.delete(requestKey);
+    }
+  }
+
+  clear(): void {
+    this.requests.clear();
+  }
+
+  private async loadSession(
+    request: ReplaySessionLoadRequest
+  ): Promise<ReplaySessionLoadResult> {
+    const requestStartedAt = performance.now();
+
+    try {
+      const session = await firstValueFrom(
+        this.codingJobBackendService.getReplayCodingSession(
+          request.workspaceId,
+          request.codingJobId,
+          request.authToken,
+          request.onlyOpen
+        )
+      );
+      const responseReceivedAt = performance.now();
+
+      return {
+        unitsData: this.createUnitsData(request.codingJobId, session.units),
+        session,
+        source: 'session',
+        timings: {
+          requestStartedAt,
+          responseReceivedAt,
+          serverTimings: this.prefixServerTimings(session.serverTimings)
+        }
+      };
+    } catch (error) {
+      const responseReceivedAt = performance.now();
+      const httpError = error as HttpErrorResponse;
+      if (httpError.status !== 404 && httpError.status !== 405) {
+        throw new ReplaySessionLoadError(error, {
+          requestStartedAt,
+          responseReceivedAt,
+          serverTimings: null
+        });
+      }
+
+      try {
+        const units = await firstValueFrom(
+          this.codingJobBackendService.getCodingJobUnits(
+            request.workspaceId,
+            request.codingJobId,
+            request.authToken,
+            request.onlyOpen
+          )
+        );
+
+        return {
+          unitsData: units.length > 0 ?
+            this.createUnitsData(request.codingJobId, units) :
+            null,
+          session: null,
+          source: 'legacy',
+          timings: {
+            requestStartedAt,
+            responseReceivedAt,
+            serverTimings: null
+          }
+        };
+      } catch (legacyError) {
+        throw new ReplaySessionLoadError(legacyError, {
+          requestStartedAt,
+          responseReceivedAt,
+          serverTimings: null
+        });
+      }
+    }
+  }
+
+  private createUnitsData(
+    codingJobId: number,
+    units: Array<ReplayCodingSessionUnitDto | CodingJobUnitDto>
+  ): UnitsReplay {
+    return {
+      id: codingJobId,
+      name: `Coding-Job: ${codingJobId}`,
+      units: units.map((unit, index) => ({
+        id: index,
+        name: unit.unitName,
+        alias: unit.unitAlias,
+        bookletId: 0,
+        testPerson: unit.personGroup ?
+          `${unit.personLogin}@${unit.personCode}@${unit.personGroup}@${unit.bookletName}` :
+          `${unit.personLogin}@${unit.personCode}@${unit.bookletName}`,
+        variableId: unit.variableId,
+        variableAnchor: unit.variableAnchor,
+        variablePage: unit.variablePage,
+        variableBundleId: unit.variableBundleId,
+        bundleContext: unit.bundleContext
+      })),
+      currentUnitIndex: 0
+    };
+  }
+
+  private prefixServerTimings(
+    serverTimings: ReplayCodingSessionDto['serverTimings']
+  ): ReplayServerTimings {
+    return Object.fromEntries(
+      Object.entries(serverTimings).map(([key, value]) => [
+        `codingSession${key.charAt(0).toUpperCase()}${key.slice(1)}`,
+        value
+      ])
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- add a combined replay-session endpoint that returns navigation units, progress, notes, job metadata, and server timings from one shared backend context
- avoid peer-coder lookup in the replay start path and reuse Unit XML/coding-scheme resolution per unique Unit file
- load coding-job replay through one session request in the frontend while preserving existing booklet, serialized-units, and single-review flows
- fall back to the legacy request sequence only for mixed-deployment `404`/`405` responses
- reuse session and token-refresh requests safely across router reevaluations, including protection against stale token responses
- expose session timing data through the existing replay statistics

## Motivation

Large training coding jobs previously required four sequential start requests and repeated backend preparation. The new additive endpoint reduces the startup request chain and constructs the replay state from one shared scan without changing navigation semantics or introducing paging.

Addresses #917.

## Compatibility

Existing endpoints remain unchanged. Mixed frontend/backend deployments fall back to the legacy flow on `404` or `405`; authentication and server errors remain visible instead of triggering additional load.

## Performance validation

The optimized endpoint and the real legacy fallback were measured in Docker with 5 warm-up runs and 30 measured runs per path for coding jobs 571 and 788 (`onlyOpen=false`).

| Job | Legacy API median | Session API median | Change | Requests | Response bytes |
| --- | ---: | ---: | ---: | ---: | ---: |
| 571 | 87.39 ms | 34.68 ms | -60.3% | 4 to 1 | -22.8% |
| 788 | 99.78 ms | 29.08 ms | -70.9% | 4 to 1 | -15.2% |

The API improvement is statistically supported for both jobs, and API p95 also improved. A general improvement in navigation-to-visible UI time was not confirmed: job 788 had a lower median, while job 571 was effectively unchanged and its p95 regressed. The performance claim for this PR is therefore limited to fewer requests, reduced transfer size, and faster API startup rather than a guaranteed end-to-end rendering improvement.

## Validation

- `npx nx lint frontend`
- `npx nx test frontend --runInBand` (197 suites, 1943 tests passed)
- `npx nx build frontend`
- `npx nx lint backend`
- `npx nx test backend --runInBand` (152 suites, 2248 tests passed; 2 suites skipped)
- `npx nx build backend`
- Docker runtime verification for the optimized and legacy replay paths
- `git diff --check`
