### PR TITLE
Add names and descriptions to job definitions

### DIFF
--- a/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.spec.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.spec.ts
@@ -3,8 +3,47 @@ import { validate } from 'class-validator';
 import { CreateJobDefinitionDto } from './create-job-definition.dto';
 
 describe('CreateJobDefinitionDto', () => {
+  it('trims and accepts a required name with an optional description', async () => {
+    const dto = plainToInstance(CreateJobDefinitionDto, {
+      name: '  Lesen Klasse 4  ',
+      description: '  Erste Kodierwelle  '
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some(error => error.property === 'name')).toBe(false);
+    expect(errors.some(error => error.property === 'description')).toBe(false);
+    expect(dto.name).toBe('Lesen Klasse 4');
+    expect(dto.description).toBe('Erste Kodierwelle');
+  });
+
+  it.each([
+    {},
+    { name: '   ' },
+    { name: 'x'.repeat(256) }
+  ])('rejects a missing, blank, or oversized name', async input => {
+    const dto = plainToInstance(CreateJobDefinitionDto, input);
+
+    const errors = await validate(dto);
+
+    expect(errors.some(error => error.property === 'name')).toBe(true);
+  });
+
+  it('normalizes an empty description to null', async () => {
+    const dto = plainToInstance(CreateJobDefinitionDto, {
+      name: 'Lesen Klasse 4',
+      description: '   '
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some(error => error.property === 'description')).toBe(false);
+    expect(dto.description).toBeNull();
+  });
+
   it('accepts a bounded distribution seed', async () => {
     const dto = plainToInstance(CreateJobDefinitionDto, {
+      name: 'Lesen Klasse 4',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       distributionSeed: `job-definition:7:${'a'.repeat(32)}`
@@ -17,6 +56,7 @@ describe('CreateJobDefinitionDto', () => {
 
   it('rejects oversized distribution seeds', async () => {
     const dto = plainToInstance(CreateJobDefinitionDto, {
+      name: 'Lesen Klasse 4',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       distributionSeed: 'x'.repeat(129)

--- a/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/create-job-definition.dto.ts
@@ -6,12 +6,13 @@ import {
   IsBoolean,
   IsNumber,
   IsString,
+  IsNotEmpty,
   MaxLength,
   Max,
   Min,
   ValidateNested
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { JobDefinitionStatus, CaseOrderingMode } from '../../../database/entities/job-definition.entity';
 import {
   JobDefinitionVariableDto,
@@ -23,6 +24,36 @@ import { JobDefinitionCoderConfigDto } from './job-definition-coder-config.dto';
  * DTO for creating a job definition
  */
 export class CreateJobDefinitionDto {
+  @ApiProperty({
+    description: 'User-facing name of the job definition',
+    example: 'Lesen Klasse 4',
+    maxLength: 255
+  })
+  @Transform(({ value }) => (
+    typeof value === 'string' ? value.trim() : value
+  ))
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+    name: string;
+
+  @ApiProperty({
+    description: 'Optional user-facing description of the job definition',
+    example: 'Variablen für die erste Kodierwelle',
+    required: false,
+    nullable: true
+  })
+  @Transform(({ value }) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    const trimmedValue = value.trim();
+    return trimmedValue.length > 0 ? trimmedValue : null;
+  })
+  @IsString()
+  @IsOptional()
+    description?: string | null;
+
   @ApiProperty({
     description: 'Status of the job definition',
     enum: ['draft', 'pending_review', 'approved'],

--- a/apps/backend/src/app/admin/coding-job/dto/update-job-definition.dto.spec.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/update-job-definition.dto.spec.ts
@@ -3,6 +3,29 @@ import { validate } from 'class-validator';
 import { UpdateJobDefinitionDto } from './update-job-definition.dto';
 
 describe('UpdateJobDefinitionDto', () => {
+  it('accepts a partial metadata update and normalizes an empty description', async () => {
+    const dto = plainToInstance(UpdateJobDefinitionDto, {
+      name: '  Lesen Klasse 4  ',
+      description: '   '
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.name).toBe('Lesen Klasse 4');
+    expect(dto.description).toBeNull();
+  });
+
+  it('rejects null as a job definition name', async () => {
+    const dto = plainToInstance(UpdateJobDefinitionDto, {
+      name: null
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some(error => error.property === 'name')).toBe(true);
+  });
+
   it('does not expose distributionSeed as an updatable field', async () => {
     const dto = plainToInstance(UpdateJobDefinitionDto, {
       maxCodingCases: 10,

--- a/apps/backend/src/app/admin/coding-job/dto/update-job-definition.dto.ts
+++ b/apps/backend/src/app/admin/coding-job/dto/update-job-definition.dto.ts
@@ -5,5 +5,6 @@ import { CreateJobDefinitionDto } from './create-job-definition.dto';
  * DTO for updating a job definition
  */
 export class UpdateJobDefinitionDto extends PartialType(
-  OmitType(CreateJobDefinitionDto, ['distributionSeed'] as const)
+  OmitType(CreateJobDefinitionDto, ['distributionSeed'] as const),
+  { skipNullProperties: false }
 ) {}

--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
@@ -215,6 +215,8 @@ export class WorkspaceCodingJobDefinitionController {
         type: 'object',
         properties: {
           id: { type: 'number' },
+          name: { type: 'string', maxLength: 255 },
+          description: { type: 'string', nullable: true },
           status: { type: 'string' },
           assigned_variables: { type: 'array' },
           assigned_variable_bundles: { type: 'array' },
@@ -271,6 +273,8 @@ export class WorkspaceCodingJobDefinitionController {
         type: 'object',
         properties: {
           id: { type: 'number' },
+          name: { type: 'string', maxLength: 255 },
+          description: { type: 'string', nullable: true },
           assigned_variables: { type: 'array' },
           assigned_variable_bundles: { type: 'array' },
           assigned_coders: { type: 'array' },

--- a/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-job-definition.controller.ts
@@ -13,6 +13,7 @@ import {
   Query
 } from '@nestjs/common';
 import {
+  ApiCreatedResponse,
   ApiOkResponse,
   ApiParam,
   ApiTags,
@@ -421,7 +422,7 @@ export class WorkspaceCodingJobDefinitionController {
   @ApiTags('coding')
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiParam({ name: 'id', type: Number, description: 'Job definition ID' })
-  @ApiOkResponse({
+  @ApiCreatedResponse({
     description: 'Distributed coding jobs created successfully from job definition.'
   })
   async createCodingJobFromDefinition(

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -1824,6 +1824,10 @@ export class WorkspaceCodingStatisticsController {
                           type: 'number',
                           description: 'Job definition ID'
                         },
+                        name: {
+                          type: 'string',
+                          description: 'User-facing job definition name'
+                        },
                         status: {
                           type: 'string',
                           description: 'Job definition status'
@@ -1871,6 +1875,7 @@ export class WorkspaceCodingStatisticsController {
             variableKey: string;
             conflictingDefinitions: Array<{
               id: number;
+              name?: string;
               status: string;
             }>;
           }>;

--- a/apps/backend/src/app/database/entities/job-definition.entity.ts
+++ b/apps/backend/src/app/database/entities/job-definition.entity.ts
@@ -99,6 +99,12 @@ export class JobDefinition {
   @Index()
     workspace_id: number;
 
+  @Column({ type: 'varchar', length: 255 })
+    name: string;
+
+  @Column({ type: 'text', nullable: true })
+    description: string | null;
+
   @ManyToOne(() => Workspace, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'workspace_id' })
     workspace: Workspace;

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -130,6 +130,7 @@ interface VariableReferenceFilterQuery {
 
 interface VariableDefinitionReference {
   id: number;
+  name?: string;
   status: string;
 }
 
@@ -172,6 +173,7 @@ interface CrossDefinitionCaseRow {
   variableId: string;
   responseId: number | string;
   definitionId: number | string;
+  definitionName?: string;
   definitionStatus: string;
 }
 
@@ -955,6 +957,7 @@ export class CodingProgressService {
         variableKey: string;
         conflictingDefinitions: Array<{
           id: number;
+          name?: string;
           status: string;
         }>;
       }>;
@@ -1098,7 +1101,7 @@ export class CodingProgressService {
 
       const variableToDefinitions = new Map<
       string,
-      Array<{ id: number; status: string }>
+      Array<{ id: number; name?: string; status: string }>
       >();
 
       for (const definition of jobDefinitions) {
@@ -1148,6 +1151,7 @@ export class CodingProgressService {
           }
           variableToDefinitions.get(variableKey)!.push({
             id: definition.id,
+            ...(definition.name ? { name: definition.name } : {}),
             status: definition.status
           });
         });
@@ -1612,6 +1616,7 @@ export class CodingProgressService {
       .addSelect('cju.variable_id', 'variableId')
       .addSelect('cju.response_id', 'responseId')
       .addSelect('job_definition.id', 'definitionId')
+      .addSelect('job_definition.name', 'definitionName')
       .addSelect('job_definition.status', 'definitionStatus')
       .innerJoin('cju.coding_job', 'coding_job')
       .innerJoin('coding_job.jobDefinition', 'job_definition')
@@ -1660,6 +1665,7 @@ export class CodingProgressService {
 
       caseDefinitions.set(definitionId, {
         id: definitionId,
+        ...(row.definitionName ? { name: row.definitionName } : {}),
         status: row.definitionStatus
       });
       definitionsByCaseKey.set(caseKey, caseDefinitions);

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.spec.ts
@@ -263,11 +263,13 @@ describe('JobDefinitionService', () => {
 
   it('rejects definitions without coders or assigned variables/bundles', async () => {
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: []
     }, 7)).rejects.toBeInstanceOf(BadRequestException);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [],
       assignedVariableBundles: [],
       assignedCoders: [1]
@@ -276,6 +278,7 @@ describe('JobDefinitionService', () => {
 
   it('rejects invalid double coding settings', async () => {
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       doubleCodingAbsolute: 2,
@@ -283,6 +286,7 @@ describe('JobDefinitionService', () => {
     }, 7)).rejects.toBeInstanceOf(BadRequestException);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       doubleCodingPercentage: 101
@@ -291,6 +295,7 @@ describe('JobDefinitionService', () => {
 
   it('rejects double coding with fewer than two coders', async () => {
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       doubleCodingAbsolute: 1
@@ -299,6 +304,7 @@ describe('JobDefinitionService', () => {
 
   it('uses the persisted distribution seed when checking and saving new definitions', async () => {
     const result = await service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 2
@@ -321,8 +327,28 @@ describe('JobDefinitionService', () => {
     ]));
   });
 
+  it('persists the user-facing name and optional description', async () => {
+    await expect(service.createJobDefinition({
+      name: 'Lesen Klasse 4',
+      description: 'Erste Kodierwelle',
+      assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assignedCoders: [1]
+    }, 7)).resolves.toMatchObject({
+      name: 'Lesen Klasse 4',
+      description: 'Erste Kodierwelle'
+    });
+
+    expect(jobDefinitionRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Lesen Klasse 4',
+        description: 'Erste Kodierwelle'
+      })
+    );
+  });
+
   it('uses a provided distribution seed when creating a definition', async () => {
     const result = await service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 2,
@@ -353,6 +379,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }],
       assignedVariableBundles: [{ id: 9, name: 'Bundle' }],
       assignedCoders: [1],
@@ -384,6 +411,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [
         { unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true },
         { unitName: 'Unit 1', variableId: 'Var 1' }
@@ -407,6 +435,7 @@ describe('JobDefinitionService', () => {
 
   it('deduplicates duplicate unbundled variables when planning usage', async () => {
     await service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [
         { unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true },
         { unitName: 'Unit 1', variableId: 'Var 1' }
@@ -442,6 +471,7 @@ describe('JobDefinitionService', () => {
     );
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1', includeDeriveError: true }],
       assignedCoders: [1],
       maxCodingCases: 3
@@ -470,6 +500,7 @@ describe('JobDefinitionService', () => {
     );
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'MMB022', variableId: '01b' }],
       assignedCoders: [1],
       maxCodingCases: null
@@ -491,6 +522,7 @@ describe('JobDefinitionService', () => {
     );
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'MMB022', variableId: '01b' }],
       assignedCoders: [1],
       maxCodingCases: 7
@@ -526,6 +558,7 @@ describe('JobDefinitionService', () => {
     );
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'MMB022', variableId: '01b' }],
       assignedCoders: [1],
       maxCodingCases: 7
@@ -557,6 +590,7 @@ describe('JobDefinitionService', () => {
     );
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 5
@@ -597,6 +631,7 @@ describe('JobDefinitionService', () => {
     );
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 5
@@ -627,6 +662,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 1
@@ -678,6 +714,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 1
@@ -705,6 +742,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariableBundles: [{ id: 9, name: 'Bundle' }],
       assignedCoders: [1],
       maxCodingCases: 5
@@ -728,6 +766,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariableBundles: [{ id: 9, name: 'Bundle' }],
       assignedCoders: [1],
       maxCodingCases: 17
@@ -762,6 +801,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 6
@@ -796,6 +836,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 8
@@ -827,6 +868,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 75
@@ -868,6 +910,7 @@ describe('JobDefinitionService', () => {
     ]));
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 6
@@ -903,6 +946,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 3
@@ -1035,6 +1079,7 @@ describe('JobDefinitionService', () => {
     codingJobService.calculateDistributionVariableUsageByStatusBatch.mockClear();
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       maxCodingCases: 5
@@ -1068,6 +1113,7 @@ describe('JobDefinitionService', () => {
     ]);
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 2', variableId: 'Var 2' }],
       assignedCoders: [1],
       maxCodingCases: 60
@@ -1076,6 +1122,7 @@ describe('JobDefinitionService', () => {
 
   it('persists coding display options on job definitions', async () => {
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       showScore: true,
@@ -1091,6 +1138,7 @@ describe('JobDefinitionService', () => {
 
   it('normalizes missing profiles on job definitions', async () => {
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1]
     }, 7)).resolves.toMatchObject({
@@ -1098,6 +1146,7 @@ describe('JobDefinitionService', () => {
     });
 
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [1],
       missingsProfileId: 77
@@ -1131,6 +1180,7 @@ describe('JobDefinitionService', () => {
     jobDefinitionRepository.findOne.mockResolvedValue({
       id: 42,
       workspace_id: 7,
+      name: '=Lesen Klasse 4',
       assigned_variable_bundles: [],
       distribution_snapshots: [
         {
@@ -1217,8 +1267,8 @@ describe('JobDefinitionService', () => {
       }
     });
     expect(usersRepository.find).toHaveBeenCalledWith({ where: { id: In([1, 2]) } });
-    expect(csv).toContain('Job-Definition-ID;Snapshot-Zeitpunkt;Quelle;Typ;Variable/Buendel;Coder-ID;Coder;Fallzahl');
-    expect(csv).toContain("Neuverteilung;Variable;'=UNIT -> +VAR;1;'=Ada;2;2;1;1;1");
+    expect(csv).toContain('Job-Definition-ID;Job-Definition-Name;Snapshot-Zeitpunkt;Quelle;Typ;Variable/Buendel;Coder-ID;Coder;Fallzahl');
+    expect(csv).toContain("42;'=Lesen Klasse 4;2026-01-02T00:00:00.000Z;Neuverteilung;Variable;'=UNIT -> +VAR;1;'=Ada;2;2;1;1;1");
     expect(csv).toContain("Neuverteilung;Variable;Legacy -> Var;1;'=Ada;2;2;1;1;1");
     expect(csv).toContain("Neuverteilung;Buendel;'@Bundle;2;Bob;3;3;0;3;0");
     expect(csv).not.toContain('Old::Var');
@@ -1238,6 +1288,7 @@ describe('JobDefinitionService', () => {
 
   it('persists coder capacity configs and derives assigned coder ids from them', async () => {
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoders: [99],
       assignedCoderConfigs: [
@@ -1285,6 +1336,46 @@ describe('JobDefinitionService', () => {
       ]
     });
     expect(codingJobService.assertCodersCanCodeInWorkspace).toHaveBeenCalledWith([2, 3], 7);
+  });
+
+  it('updates metadata directly even when coding jobs already exist', async () => {
+    const existingDefinition = {
+      id: 2,
+      workspace_id: 7,
+      name: 'Alter Name',
+      description: 'Alt',
+      status: 'approved',
+      assigned_variables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
+      assigned_variable_bundles: [],
+      assigned_coders: [1],
+      duration_seconds: 1,
+      max_coding_cases: 5,
+      case_ordering_mode: 'continuous',
+      distribution_seed: 'seed-2'
+    };
+
+    jobDefinitionRepository.findOne.mockResolvedValue(existingDefinition);
+    jobDefinitionRepository.find.mockResolvedValue([existingDefinition]);
+    codingJobService.getCodingJobCountsByDefinitionIds.mockResolvedValue(
+      new Map([[2, 3]])
+    );
+
+    await expect(service.updateJobDefinition(2, 7, {
+      name: 'Neuer Name',
+      description: null
+    })).resolves.toMatchObject({
+      id: 2,
+      name: 'Neuer Name',
+      description: null
+    });
+
+    expect(jobDefinitionRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Neuer Name',
+        description: null
+      })
+    );
+    expect(codingJobService.refreshDistributedCodingJobs).not.toHaveBeenCalled();
   });
 
   it('preserves DERIVE_ERROR bundle variable options when updating the same bundle selection', async () => {
@@ -1418,6 +1509,7 @@ describe('JobDefinitionService', () => {
 
   it('rejects invalid coder capacity configs', async () => {
     await expect(service.createJobDefinition({
+      name: 'Definition',
       assignedVariables: [{ unitName: 'Unit 1', variableId: 'Var 1' }],
       assignedCoderConfigs: [{ coderId: 1, capacityPercent: 0 }]
     }, 7)).rejects.toBeInstanceOf(BadRequestException);

--- a/apps/backend/src/app/database/services/jobs/job-definition.service.ts
+++ b/apps/backend/src/app/database/services/jobs/job-definition.service.ts
@@ -211,6 +211,7 @@ const MIN_CODER_CAPACITY_PERCENT = 10;
 const MAX_CODER_CAPACITY_PERCENT = 300;
 const JOB_DEFINITION_DISTRIBUTION_CSV_HEADERS = [
   'Job-Definition-ID',
+  'Job-Definition-Name',
   'Snapshot-Zeitpunkt',
   'Quelle',
   'Typ',
@@ -1064,6 +1065,8 @@ export class JobDefinitionService {
 
     const jobDefinition = this.jobDefinitionRepository.create({
       workspace_id: workspaceId,
+      name: createDto.name,
+      description: createDto.description ?? null,
       status: createDto.status ?? 'draft',
       assigned_variables: createDto.assignedVariables,
       assigned_variable_bundles: this.toStoredAssignedVariableBundles(
@@ -1123,6 +1126,7 @@ export class JobDefinitionService {
     const coderNamesById = await this.getCoderNamesById(coderIds);
     const rows = this.createDistributionCsvRows(
       jobDefinition.id,
+      jobDefinition.name,
       snapshot,
       coderIds,
       coderNamesById
@@ -1166,6 +1170,7 @@ export class JobDefinitionService {
 
   private createDistributionCsvRows(
     jobDefinitionId: number,
+    jobDefinitionName: string,
     snapshot: JobDefinitionDistributionSnapshot,
     coderIds: number[],
     coderNamesById: Map<number, string>
@@ -1186,6 +1191,7 @@ export class JobDefinitionService {
 
         return coderIds.map(coderId => ({
           'Job-Definition-ID': jobDefinitionId,
+          'Job-Definition-Name': sanitizeCsvText(jobDefinitionName),
           'Snapshot-Zeitpunkt': sanitizeCsvText(snapshot.createdAt),
           Quelle: sanitizeCsvText(this.getSnapshotSourceLabel(snapshot.source)),
           Typ: sanitizeCsvText(this.getSnapshotItemType(itemKey)),
@@ -1694,6 +1700,13 @@ export class JobDefinitionService {
         nextState.assignedVariableBundles
       )
     } as JobDefinition;
+
+    if (updateDto.name !== undefined) {
+      updatedDefinition.name = updateDto.name;
+    }
+    if (updateDto.description !== undefined) {
+      updatedDefinition.description = updateDto.description;
+    }
 
     if (updateDto.status !== undefined) {
       updatedDefinition.status = updateDto.status;

--- a/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-coding.service.ts
@@ -577,6 +577,7 @@ export class WorkspaceCodingService {
         variableKey: string;
         conflictingDefinitions: Array<{
           id: number;
+          name?: string;
           status: string;
         }>;
       }>;

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.html
@@ -31,6 +31,27 @@
       <div class="form-section">
         <h3>{{ 'coding-job-definition-dialog.sections.general-info' | translate }}</h3>
 
+        @if (data.mode === 'definition') {
+        <mat-form-field appearance="fill" class="full-width">
+          <mat-label>{{ 'coding-job-definition-dialog.form-fields.name-label' | translate }}</mat-label>
+          <input matInput formControlName="name" maxlength="255"
+            [placeholder]="'coding-job-definition-dialog.form-fields.name-placeholder' | translate">
+          @if ((codingJobForm.get('name')?.hasError('required') || codingJobForm.get('name')?.hasError('pattern')) &&
+          codingJobForm.get('name')?.touched) {
+          <mat-error>{{ 'coding-job-definition-dialog.form-fields.name-required' | translate }}</mat-error>
+          }
+          @if (codingJobForm.get('name')?.hasError('maxlength') && codingJobForm.get('name')?.touched) {
+          <mat-error>{{ 'coding-job-definition-dialog.form-fields.name-maxlength' | translate }}</mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="fill" class="full-width">
+          <mat-label>{{ 'coding-job-definition-dialog.form-fields.description-label' | translate }}</mat-label>
+          <textarea matInput formControlName="description" rows="3"
+            [placeholder]="'coding-job-definition-dialog.form-fields.description-placeholder' | translate"></textarea>
+        </mat-form-field>
+        }
+
         <mat-form-field appearance="fill" class="full-width">
           <mat-label>{{ 'coding-job-definition-dialog.form-fields.duration-label' | translate }}</mat-label>
           <input matInput type="number" formControlName="durationSeconds"

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
@@ -205,7 +205,8 @@ describe('CodingJobDefinitionDialogComponent', () => {
 
   const createComponent = (
     dataOverride?: Partial<CodingJobDefinitionDialogData>,
-    includeDeriveErrorInManualCoding = false
+    includeDeriveErrorInManualCoding = false,
+    provideValidDefinitionName = true
   ) => {
     (mockWorkspaceSettingsService.getIncludeDeriveErrorInManualCoding as jest.Mock)
       .mockReturnValue(of(includeDeriveErrorInManualCoding));
@@ -213,6 +214,13 @@ describe('CodingJobDefinitionDialogComponent', () => {
     fixture = TestBed.createComponent(CodingJobDefinitionDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    if (
+      provideValidDefinitionName &&
+      component.data.mode === 'definition' &&
+      !component.codingJobForm.get('name')?.value
+    ) {
+      component.codingJobForm.get('name')?.setValue('Testdefinition', { emitEvent: false });
+    }
   };
 
   afterEach(() => {
@@ -259,13 +267,27 @@ describe('CodingJobDefinitionDialogComponent', () => {
   });
 
   it('should initialize form with default values', () => {
-    createComponent();
+    createComponent(undefined, false, false);
     expect(component.codingJobForm).toBeDefined();
+    expect(component.codingJobForm.get('name')?.value).toBe('');
+    expect(component.codingJobForm.get('description')?.value).toBe('');
+    expect(component.codingJobForm.get('name')?.hasError('required')).toBe(true);
     expect(component.codingJobForm.get('durationSeconds')?.value).toBe(1);
     expect(component.codingJobForm.get('caseOrderingMode')?.value).toBe('continuous');
     expect(component.codingJobForm.get('missingsProfileId')?.value).toBe(7);
     expect(component.codingJobForm.get('showScore')?.value).toBe(false);
     expect(component.codingJobForm.get('allowComments')?.value).toBe(true);
+  });
+
+  it('validates the definition name length', () => {
+    createComponent(undefined, false, false);
+
+    component.codingJobForm.get('name')?.setValue('   ');
+    expect(component.codingJobForm.get('name')?.hasError('pattern')).toBe(true);
+
+    component.codingJobForm.get('name')?.setValue('A'.repeat(256));
+
+    expect(component.codingJobForm.get('name')?.hasError('maxlength')).toBe(true);
   });
 
   it('should initialize an edited definition with its camel-case missings profile id', () => {
@@ -644,7 +666,11 @@ describe('CodingJobDefinitionDialogComponent', () => {
     });
     (mockCodingJobBackendService.updateJobDefinition as jest.Mock).mockReturnValue(of({ id: 55 }));
 
-    component.codingJobForm.patchValue({ showScore: true });
+    component.codingJobForm.patchValue({
+      name: '  Neuer Anzeigename  ',
+      description: '   ',
+      showScore: true
+    });
     component.onSubmit();
     tick();
 
@@ -652,6 +678,8 @@ describe('CodingJobDefinitionDialogComponent', () => {
       1,
       55,
       expect.objectContaining({
+        name: 'Neuer Anzeigename',
+        description: null,
         showScore: true
       })
     );
@@ -920,11 +948,17 @@ describe('CodingJobDefinitionDialogComponent', () => {
 
     component.selectedCoders.select(mockCoders[0]);
     component.selectedVariables.select(mockVariables[0]);
-    component.codingJobForm.patchValue({ missingsProfileId: 9 });
+    component.codingJobForm.patchValue({
+      name: '  Lesen Klasse 4  ',
+      description: '  Erste Erhebung  ',
+      missingsProfileId: 9
+    });
 
     await component.onSubmit();
 
     expect(mockCodingJobBackendService.createJobDefinition).toHaveBeenCalledWith(1, expect.objectContaining({
+      name: 'Lesen Klasse 4',
+      description: 'Erste Erhebung',
       missingsProfileId: 9
     }));
   });
@@ -1616,6 +1650,8 @@ describe('CodingJobDefinitionDialogComponent', () => {
     const selectedBundle = component.variableBundles[0];
 
     component.codingJobForm.patchValue({
+      name: 'Lesen Klasse 4',
+      description: 'Erste Erhebung',
       durationSeconds: 90,
       maxCodingCases: 4,
       doubleCodingAbsolute: 2,
@@ -1641,6 +1677,10 @@ describe('CodingJobDefinitionDialogComponent', () => {
       workspaceId: 1,
       mode: 'definition',
       isEdit: false,
+      formValue: expect.objectContaining({
+        name: 'Lesen Klasse 4',
+        description: 'Erste Erhebung'
+      }),
       selectedCoderConfigs: [{ coderId: 1, capacityPercent: 150 }],
       unitNameFilter: 'Unit',
       variableIdFilter: 'Var',
@@ -1655,6 +1695,8 @@ describe('CodingJobDefinitionDialogComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
 
+    expect(component.codingJobForm.get('name')?.value).toBe('Lesen Klasse 4');
+    expect(component.codingJobForm.get('description')?.value).toBe('Erste Erhebung');
     expect(component.codingJobForm.get('durationSeconds')?.value).toBe(90);
     expect(component.codingJobForm.get('maxCodingCases')?.value).toBe(4);
     expect(component.codingJobForm.get('doubleCodingAbsolute')?.value).toBe(2);

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
@@ -56,6 +56,7 @@ import { CodingJobBulkCreationDialogComponent, BulkCreationData, BulkCreationRes
 import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
 import { JobDefinitionRefreshDialogComponent } from '../coding-job-definitions/job-definition-refresh-dialog.component';
 import { SessionRecoveryService } from '../../../core/services/session-recovery.service';
+import { getJobDefinitionDisplayLabel } from '../../utils/job-definition-display.util';
 
 export interface CodingJobDefinitionDialogData {
   codingJob?: CodingJob;
@@ -69,6 +70,8 @@ export interface CodingJobDefinitionDialogData {
 
 export interface JobDefinition {
   id?: number;
+  name?: string;
+  description?: string | null;
   status?: 'draft' | 'pending_review' | 'approved';
   assignedVariables?: Variable[];
   assignedVariableBundles?: VariableBundle[];
@@ -419,6 +422,8 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
 
     const formValue = this.codingJobForm.getRawValue();
     const hasFormChanges = this.codingJobForm.dirty && (
+      ((formValue.name as string | undefined)?.trim().length ?? 0) > 0 ||
+      ((formValue.description as string | undefined)?.trim().length ?? 0) > 0 ||
       formValue.durationSeconds !== 1 ||
       formValue.maxCodingCases !== null ||
       (formValue.doubleCodingAbsolute ?? 0) !== 0 ||
@@ -870,6 +875,11 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     };
 
     if (this.data.mode === 'definition') {
+      formFields.name = [
+        this.data.codingJob?.name || '',
+        [Validators.required, Validators.pattern(/\S/), Validators.maxLength(255)]
+      ];
+      formFields.description = [this.data.codingJob?.description || '', []];
       formFields.missingsProfileId = [
         this.data.codingJob?.missingsProfileId ?? this.data.codingJob?.missings_profile_id ?? 0,
         [Validators.min(0)]
@@ -2372,6 +2382,8 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     const selectedCoderConfigs = this.getSelectedCoderConfigs();
 
     const jobDefinition: JobDefinition = {
+      name: this.codingJobForm.value.name.trim(),
+      description: this.sanitizeDescription(this.codingJobForm.value.description),
       status: 'draft',
       assignedVariables: this.getSelectedDefinitionVariables(),
       assignedVariableBundles: this.getSelectedDefinitionVariableBundles(),
@@ -2409,6 +2421,8 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     const selectedCoderConfigs = this.getSelectedCoderConfigs();
 
     const jobDefinition: Partial<JobDefinition> = {
+      name: this.codingJobForm.value.name.trim(),
+      description: this.sanitizeDescription(this.codingJobForm.value.description),
       assignedVariables: this.getSelectedDefinitionVariables(),
       assignedVariableBundles: this.getSelectedDefinitionVariableBundles(),
       assignedCoders: selectedCoderIds,
@@ -2436,6 +2450,8 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     jobDefinition: Partial<JobDefinition>
   ): Partial<JobDefinition> {
     return {
+      name: jobDefinition.name,
+      description: jobDefinition.description,
       durationSeconds: jobDefinition.durationSeconds,
       showScore: jobDefinition.showScore,
       allowComments: jobDefinition.allowComments,
@@ -2583,6 +2599,10 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
         maxWidth: '95vw',
         data: {
           definitionId: jobDefinitionId,
+          definitionLabel: getJobDefinitionDisplayLabel({
+            id: jobDefinitionId,
+            name: jobDefinition.name
+          }),
           preview,
           mode: 'update'
         },
@@ -2728,6 +2748,8 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     const selectedCoderConfigs = this.getSelectedCoderConfigs();
 
     const jobDefinition: JobDefinition = {
+      name: this.codingJobForm.value.name.trim(),
+      description: this.sanitizeDescription(this.codingJobForm.value.description),
       status: 'pending_review', // Submit for review
       assignedVariables: this.getSelectedDefinitionVariables(),
       assignedVariableBundles: this.getSelectedDefinitionVariableBundles(),
@@ -2775,6 +2797,15 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     }
     const num = Number(value);
     return Number.isNaN(num) ? undefined : num;
+  }
+
+  private sanitizeDescription(value: unknown): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    const description = value.trim();
+    return description.length > 0 ? description : null;
   }
 
   private getErrorMessage(error: unknown): string {

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.html
@@ -200,6 +200,17 @@
         </td>
       </ng-container>
 
+      <!-- Name and Description Column -->
+      <ng-container matColumnDef="identity">
+        <th mat-header-cell *matHeaderCellDef>{{ 'coding-job-definitions.table-headers.name' | translate }}</th>
+        <td mat-cell *matCellDef="let definition" class="identity-cell">
+          <strong class="definition-name">{{ getDefinitionDisplayLabel(definition) }}</strong>
+          <span *ngIf="definition.description" class="definition-description" [matTooltip]="definition.description">
+            {{ definition.description }}
+          </span>
+        </td>
+      </ng-container>
+
       <!-- Status Column -->
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef>{{ 'coding-job-definitions.table-headers.status' | translate }}</th>

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.scss
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.scss
@@ -103,6 +103,32 @@
     margin-bottom: 12px;
   }
 
+  .identity-cell {
+    min-width: 220px;
+    max-width: 320px;
+  }
+
+  .definition-name,
+  .definition-description {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .definition-name {
+    white-space: nowrap;
+  }
+
+  .definition-description {
+    margin-top: 4px;
+    color: rgba(0, 0, 0, 0.64);
+    font-size: 12px;
+    line-height: 1.35;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
   .summary-item {
     display: flex;
     align-items: center;

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.spec.ts
@@ -144,6 +144,25 @@ describe('CodingJobDefinitionsComponent', () => {
     expect(fixture.nativeElement.querySelector('.job-definitions-table-wrapper')).toBeTruthy();
   });
 
+  it('renders a definition name with its id and description', () => {
+    component.isLoading = false;
+    component.jobDefinitions = [{
+      id: 42,
+      name: 'Lesen Klasse 4',
+      description: 'Erste Erhebung',
+      status: 'draft',
+      assignedVariables: [],
+      assignedVariableBundles: [],
+      assignedCoders: []
+    }];
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.definition-name').textContent.trim())
+      .toBe('Lesen Klasse 4 (#42)');
+    expect(fixture.nativeElement.querySelector('.definition-description').textContent.trim())
+      .toBe('Erste Erhebung');
+  });
+
   it('keeps the create action only in the empty state when no definitions exist', () => {
     component.isLoading = false;
     component.jobDefinitions = [];
@@ -361,6 +380,7 @@ describe('CodingJobDefinitionsComponent', () => {
       expect.objectContaining({
         data: expect.objectContaining({
           definitionId: 42,
+          definitionLabel: 'Definition #42',
           snapshot: latestSnapshot,
           coders: component.coders,
           createdJobsCount: 2
@@ -513,6 +533,7 @@ describe('CodingJobDefinitionsComponent', () => {
       expect.objectContaining({
         data: {
           definitionId: 42,
+          definitionLabel: 'Definition #42',
           preview
         }
       })
@@ -558,6 +579,7 @@ describe('CodingJobDefinitionsComponent', () => {
       expect.objectContaining({
         data: {
           definitionId: 42,
+          definitionLabel: 'Definition #42',
           preview
         }
       })
@@ -753,6 +775,8 @@ describe('CodingJobDefinitionsComponent', () => {
 
     component.editDefinition({
       id: 24,
+      name: 'Lesen Klasse 4',
+      description: 'Erste Erhebung',
       status: 'draft',
       assignedVariables: [{ unitName: 'Unit', variableId: 'Var' }],
       assignedCoders: [1],
@@ -767,6 +791,8 @@ describe('CodingJobDefinitionsComponent', () => {
     expect(matDialog.open).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({
       data: expect.objectContaining({
         codingJob: expect.objectContaining({
+          name: 'Lesen Klasse 4',
+          description: 'Erste Erhebung',
           showScore: false,
           allowComments: false,
           suppressGeneralInstructions: true,

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/coding-job-definitions.component.ts
@@ -49,9 +49,12 @@ import {
   JobDefinitionDistributionSummaryDialogComponent
 } from './job-definition-distribution-summary-dialog.component';
 import { SessionRecoveryService } from '../../../core/services/session-recovery.service';
+import { getJobDefinitionDisplayLabel } from '../../utils/job-definition-display.util';
 
 interface JobDefinition {
   id?: number;
+  name?: string;
+  description?: string | null;
   status?: 'draft' | 'pending_review' | 'approved';
   assignedVariables?: Variable[];
   assignedVariableBundles?: VariableBundle[];
@@ -124,6 +127,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
 
   displayedColumns: string[] = [
     'actions',
+    'identity',
     'status',
     'variables',
     'codersCount',
@@ -337,6 +341,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
 
   getDefinitionWorkflowLabel(definition: JobDefinition): string {
     const createdJobsCount = this.getCreatedJobsCount(definition);
+    const label = this.getDefinitionDisplayLabel(definition);
 
     if (!definition.id) {
       return this.translateService.instant(
@@ -347,27 +352,27 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
     if (createdJobsCount === undefined) {
       return this.translateService.instant(
         'coding-job-definitions.workflow.jobs-count-unavailable',
-        { id: definition.id }
+        { label }
       );
     }
 
     if (createdJobsCount === 0) {
       return this.translateService.instant(
         'coding-job-definitions.workflow.no-jobs',
-        { id: definition.id }
+        { label }
       );
     }
 
     if (createdJobsCount === 1) {
       return this.translateService.instant(
         'coding-job-definitions.workflow.one-job',
-        { id: definition.id }
+        { label }
       );
     }
 
     return this.translateService.instant(
       'coding-job-definitions.workflow.many-jobs',
-      { id: definition.id, count: createdJobsCount }
+      { label, count: createdJobsCount }
     );
   }
 
@@ -388,7 +393,11 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       return actionLabel;
     }
 
-    return `${actionLabel}: Definition ${definition.id}`;
+    return `${actionLabel}: ${this.getDefinitionDisplayLabel(definition)}`;
+  }
+
+  getDefinitionDisplayLabel(definition: JobDefinition): string {
+    return getJobDefinitionDisplayLabel(definition);
   }
 
   getCreatedJobsCount(definition: JobDefinition): number | undefined {
@@ -559,7 +568,8 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       codingJob: {
         id: definition.id!,
         workspace_id: workspaceId,
-        name: `Definition ${definition.id!}`,
+        name: definition.name || `Definition #${definition.id!}`,
+        description: definition.description || undefined,
         status: definition.status!,
         assignedVariables: definition.assignedVariables,
         assignedVariableBundles: definition.assignedVariableBundles,
@@ -816,6 +826,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
         maxWidth: '95vw',
         data: {
           definitionId: definition.id,
+          definitionLabel: this.getDefinitionDisplayLabel(definition),
           preview
         },
         autoFocus: false
@@ -847,6 +858,7 @@ export class CodingJobDefinitionsComponent implements OnInit, OnDestroy {
       maxWidth: '95vw',
       data: {
         definitionId: definition.id,
+        definitionLabel: this.getDefinitionDisplayLabel(definition),
         snapshot: this.getLatestDistributionSnapshot(definition),
         snapshots: definition.distributionSnapshots || [],
         coders: this.coders,

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.html
@@ -5,7 +5,7 @@
 
 <mat-dialog-content class="distribution-content">
   <div class="definition-meta">
-    <span>{{ 'coding-job-definitions.distribution-summary.definition-label' | translate:{id: data.definitionId} }}</span>
+    <span>{{ data.definitionLabel || ('coding-job-definitions.distribution-summary.definition-label' | translate:{id: data.definitionId}) }}</span>
     @if (snapshot) {
       <span>{{ getSourceLabelKey() | translate }}</span>
       <span>{{ getSnapshotDate() }}</span>

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-distribution-summary-dialog.component.ts
@@ -30,6 +30,7 @@ interface DistributionSummaryRow {
 
 export interface JobDefinitionDistributionSummaryDialogData {
   definitionId: number;
+  definitionLabel?: string;
   snapshot?: JobDefinitionDistributionSnapshot;
   snapshots?: JobDefinitionDistributionSnapshot[];
   coders: DialogCoder[];

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.html
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.html
@@ -8,7 +8,7 @@
         {{ getApplyTitleKey() | translate }}
       </h2>
       <p class="definition-label">
-        {{ 'coding-job-definitions.refresh-dialog.definition-label' | translate: { id: data.definitionId } }}
+        {{ data.definitionLabel || ('coding-job-definitions.refresh-dialog.definition-label' | translate: { id: data.definitionId }) }}
       </p>
     </div>
   </div>

--- a/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definitions/job-definition-refresh-dialog.component.ts
@@ -16,6 +16,7 @@ import {
 
 export interface JobDefinitionRefreshDialogData {
   definitionId: number;
+  definitionLabel?: string;
   preview: JobDefinitionRefreshPreviewDto;
   mode?: 'refresh' | 'update';
 }

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.html
@@ -1392,7 +1392,7 @@
                       "
                       class="conflict-definition"
                     >
-                      Definition #{{ def.id }} ({{
+                      {{ getJobDefinitionIdentityLabel(def) }} ({{
                         getStatusLabel(def.status)
                       }}){{ !last ? ', ' : '' }}
                     </span>

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -36,6 +36,7 @@ import {
   VariableConfig
 } from '../coder-training/coder-training.component';
 import { CoderTrainingsListComponent } from '../coder-trainings-list/coder-trainings-list.component';
+import { getJobDefinitionDisplayLabel } from '../../utils/job-definition-display.util';
 import { CoderTraining } from '../../models/coder-training.model';
 import {
   ImportComparisonDialogComponent,
@@ -388,6 +389,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         variableKey: string;
         conflictingDefinitions: Array<{
           id: number;
+          name?: string;
           status: string;
         }>;
       }>;
@@ -1598,7 +1600,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         const status = jobDefinition.status ? ` (${jobDefinition.status})` : '';
         return {
           id: jobDefinition.id as number,
-          label: `Definition #${jobDefinition.id}${status}: ${variableCount} Variablen, ${bundleCount} Bündel`
+          label: `${getJobDefinitionDisplayLabel(jobDefinition)}${status}: ${variableCount} Variablen, ${bundleCount} Bündel`
         };
       });
   }
@@ -3894,6 +3896,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
               variableKey: string;
               conflictingDefinitions: Array<{
                 id: number;
+                name?: string;
                 status: string;
               }>;
             }>;
@@ -4480,6 +4483,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       default:
         return status;
     }
+  }
+
+  getJobDefinitionIdentityLabel(definition: { id: number; name?: string }): string {
+    return getJobDefinitionDisplayLabel(definition);
   }
 
   private loadResponseMatchingMode(): void {

--- a/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
+++ b/apps/frontend/src/app/coding/components/double-coded-review/double-coded-review.component.ts
@@ -39,6 +39,7 @@ import {
   normalizeReplayUrlToCurrentOrigin
 } from '../../utils/replay-url.util';
 import { ReviewCodeSelection } from '../../../replay/services/units-replay.service';
+import { getJobDefinitionDisplayLabel } from '../../utils/job-definition-display.util';
 
 interface CoderResult {
   coderId: number;
@@ -324,11 +325,10 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
   }
 
   private getJobDefinitionLabel(definition: JobDefinition): string {
-    const definitionId = definition.id ?? 0;
     const statusLabel = this.getJobDefinitionStatusLabel(definition.status);
     const status = statusLabel ? ` (${statusLabel})` : '';
     const jobsCount = definition.createdJobsCount ?? 0;
-    return `Definition #${definitionId}${status}, ${jobsCount} ${this.getJobCountLabel(jobsCount)}`;
+    return `${getJobDefinitionDisplayLabel(definition)}${status}, ${jobsCount} ${this.getJobCountLabel(jobsCount)}`;
   }
 
   private getCoderTrainingLabel(training: CoderTraining): string {
@@ -387,7 +387,8 @@ export class DoubleCodedReviewComponent implements OnInit, OnDestroy {
   private getScopeLabel(scope: string): string {
     if (scope.startsWith('job_')) {
       const scopeId = parseInt(scope.replace('job_', ''), 10);
-      return this.availableJobDefinitions.find(definition => definition.id === scopeId)?.label || `Definition #${scopeId}`;
+      return this.availableJobDefinitions.find(definition => definition.id === scopeId)?.label ||
+        getJobDefinitionDisplayLabel({ id: scopeId });
     }
 
     if (scope.startsWith('training_')) {

--- a/apps/frontend/src/app/coding/components/export-coding-book/export-coding-book.component.ts
+++ b/apps/frontend/src/app/coding/components/export-coding-book/export-coding-book.component.ts
@@ -38,6 +38,7 @@ import { MissingsProfileService } from '../../services/missings-profile.service'
 import { FileService } from '../../../shared/services/file/file.service';
 import { AppService } from '../../../core/services/app.service';
 import { ValidationStateService, ValidationProgress } from '../../services/validation-state.service';
+import { getJobDefinitionDisplayLabel } from '../../utils/job-definition-display.util';
 import { ValidateCodingCompletenessResponseDto } from '../../../../../../../api-dto/coding/validate-coding-completeness-response.dto';
 import {
   CodebookJobDefinitionOption,
@@ -298,7 +299,7 @@ export class ExportCodingBookComponent implements OnInit, OnDestroy {
   }
 
   private getJobDefinitionLabel(jobDefinition: JobDefinition): string {
-    return `${this.translateService.instant('coding.job-definition-label', { id: jobDefinition.id })} · ${this.getJobDefinitionStatusLabel(jobDefinition)}`;
+    return `${getJobDefinitionDisplayLabel(jobDefinition)} · ${this.getJobDefinitionStatusLabel(jobDefinition)}`;
   }
 
   private getJobDefinitionMeta(jobDefinition: JobDefinition): string {

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -261,6 +261,8 @@ describe('CodingJobBackendService', () => {
         expect(definitions).toEqual([
           expect.objectContaining({
             id: 7,
+            name: 'Lesen Klasse 4',
+            description: 'Erste Erhebung',
             createdJobsCount: 3,
             blockingCreatedJobsCount: 1,
             showScore: true,
@@ -295,6 +297,8 @@ describe('CodingJobBackendService', () => {
       req.flush([
         {
           id: 7,
+          name: 'Lesen Klasse 4',
+          description: 'Erste Erhebung',
           status: 'approved',
           created_jobs_count: 3,
           blocking_created_jobs_count: 1,

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -99,6 +99,8 @@ export function getDownloadFileName(
 
 interface JobDefinitionApiResponse {
   id?: number;
+  name?: string;
+  description?: string | null;
   status?: 'draft' | 'pending_review' | 'approved';
   assigned_variables?: import('../models/coding-job.model').Variable[];
   assigned_variable_bundles?: import('../models/coding-job.model').VariableBundle[];
@@ -194,6 +196,8 @@ export interface JobDefinitionDistributionSnapshot {
 
 export interface JobDefinition {
   id?: number;
+  name?: string;
+  description?: string | null;
   status?: 'draft' | 'pending_review' | 'approved';
   assignedVariables?: import('../models/coding-job.model').Variable[];
   assignedVariableBundles?: import('../models/coding-job.model').VariableBundle[];
@@ -1024,6 +1028,8 @@ export class CodingJobBackendService {
       .pipe(
         map((definitions: JobDefinitionApiResponse[]) => definitions.map(def => ({
           id: def.id,
+          name: def.name,
+          description: def.description,
           status: def.status,
           assignedVariables: def.assigned_variables,
           assignedVariableBundles: def.assigned_variable_bundles,

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -1176,6 +1176,7 @@ export class TestPersonCodingService {
         variableKey: string;
         conflictingDefinitions: Array<{
           id: number;
+          name?: string;
           status: string;
         }>;
       }>;
@@ -1205,6 +1206,7 @@ export class TestPersonCodingService {
           variableKey: string;
           conflictingDefinitions: Array<{
             id: number;
+            name?: string;
             status: string;
           }>;
         }>;

--- a/apps/frontend/src/app/coding/utils/job-definition-display.util.spec.ts
+++ b/apps/frontend/src/app/coding/utils/job-definition-display.util.spec.ts
@@ -6,6 +6,16 @@ describe('getJobDefinitionDisplayLabel', () => {
       .toBe('Lesen Klasse 4 (#42)');
   });
 
+  it('does not duplicate the id for an exact migrated legacy name', () => {
+    expect(getJobDefinitionDisplayLabel({ id: 42, name: '  Definition #42  ' }))
+      .toBe('Definition #42');
+  });
+
+  it('keeps the id visible when a legacy-looking name refers to another id', () => {
+    expect(getJobDefinitionDisplayLabel({ id: 42, name: 'Definition #41' }))
+      .toBe('Definition #41 (#42)');
+  });
+
   it('falls back to the legacy id label when the name is missing', () => {
     expect(getJobDefinitionDisplayLabel({ id: 42, name: '   ' }))
       .toBe('Definition #42');

--- a/apps/frontend/src/app/coding/utils/job-definition-display.util.spec.ts
+++ b/apps/frontend/src/app/coding/utils/job-definition-display.util.spec.ts
@@ -1,0 +1,18 @@
+import { getJobDefinitionDisplayLabel } from './job-definition-display.util';
+
+describe('getJobDefinitionDisplayLabel', () => {
+  it('shows the user-facing name together with the stable id', () => {
+    expect(getJobDefinitionDisplayLabel({ id: 42, name: 'Lesen Klasse 4' }))
+      .toBe('Lesen Klasse 4 (#42)');
+  });
+
+  it('falls back to the legacy id label when the name is missing', () => {
+    expect(getJobDefinitionDisplayLabel({ id: 42, name: '   ' }))
+      .toBe('Definition #42');
+  });
+
+  it('supports unsaved definitions without an id', () => {
+    expect(getJobDefinitionDisplayLabel({ name: 'Lesen Klasse 4' }))
+      .toBe('Lesen Klasse 4');
+  });
+});

--- a/apps/frontend/src/app/coding/utils/job-definition-display.util.ts
+++ b/apps/frontend/src/app/coding/utils/job-definition-display.util.ts
@@ -1,0 +1,25 @@
+export interface JobDefinitionIdentity {
+  id?: number | null;
+  name?: string | null;
+}
+
+export function getJobDefinitionDisplayLabel(
+  definition: JobDefinitionIdentity
+): string {
+  const name = definition.name?.trim();
+  const hasId = typeof definition.id === 'number' && Number.isFinite(definition.id);
+
+  if (name && hasId) {
+    return `${name} (#${definition.id})`;
+  }
+
+  if (name) {
+    return name;
+  }
+
+  if (hasId) {
+    return `Definition #${definition.id}`;
+  }
+
+  return 'Jobdefinition';
+}

--- a/apps/frontend/src/app/coding/utils/job-definition-display.util.ts
+++ b/apps/frontend/src/app/coding/utils/job-definition-display.util.ts
@@ -10,6 +10,9 @@ export function getJobDefinitionDisplayLabel(
   const hasId = typeof definition.id === 'number' && Number.isFinite(definition.id);
 
   if (name && hasId) {
+    if (name === `Definition #${definition.id}`) {
+      return name;
+    }
     return `${name} (#${definition.id})`;
   }
 

--- a/apps/frontend/src/app/ws-admin/components/export/export-selection-dialog.component.ts
+++ b/apps/frontend/src/app/ws-admin/components/export/export-selection-dialog.component.ts
@@ -10,6 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { JobDefinition } from '../../../coding/services/coding-job-backend.service';
 import { CoderTraining } from '../../../coding/models/coder-training.model';
 import { Coder } from '../../../coding/models/coder.model';
+import { getJobDefinitionDisplayLabel } from '../../../coding/utils/job-definition-display.util';
 
 export interface ExportSelectionDialogData {
   jobDefinitions: JobDefinition[];
@@ -50,7 +51,7 @@ export interface ExportSelectionDialogResult {
                       [checked]="isSelected(jobValue(def))"
                       (click)="$event.stopPropagation()"
                       (change)="toggle(jobValue(def))">
-                      Definition #{{ def.id }} {{ def.status ? '(' + def.status + ')' : '' }}
+                      {{ getDefinitionLabel(def) }} {{ def.status ? '(' + def.status + ')' : '' }}
                     </mat-checkbox>
                   </mat-panel-title>
                   <mat-panel-description>
@@ -181,6 +182,10 @@ export class ExportSelectionDialogComponent {
 
   jobValue(def: JobDefinition): string {
     return `job_${def.id}`;
+  }
+
+  getDefinitionLabel(definition: JobDefinition): string {
+    return getJobDefinitionDisplayLabel(definition);
   }
 
   trainingValue(training: CoderTraining): string {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -1141,7 +1141,7 @@
     "job-definition-none": "Keine Jobdefinitionen verfügbar",
     "job-definition-picker-title": "Jobdefinition auswählen",
     "job-definition-picker-search": "Jobdefinitionen suchen",
-    "job-definition-picker-search-placeholder": "ID, Status, Gruppe oder Umfang",
+    "job-definition-picker-search-placeholder": "Name, ID, Status, Gruppe oder Umfang",
     "job-definition-picker-clear-search": "Suche leeren",
     "job-definition-picker-clear": "Jobdefinition-Filter entfernen",
     "job-definition-picker-apply": "Auswahl übernehmen",
@@ -2421,6 +2421,12 @@
       }
     },
     "form-fields": {
+      "name-label": "Name",
+      "name-placeholder": "z.B. Lesen Klasse 4",
+      "name-required": "Ein Name für die Jobdefinition ist erforderlich",
+      "name-maxlength": "Der Name darf höchstens 255 Zeichen lang sein",
+      "description-label": "Beschreibung",
+      "description-placeholder": "Optionale Beschreibung der Jobdefinition",
       "status-label": "Status",
       "duration-label": "Dauer für eine Kodieraufgabe (Sekunden)",
       "duration-placeholder": "z.B. 300 (5 Minuten)",
@@ -2595,6 +2601,7 @@
     "bulk-creation-in-progress": "Kodier-Jobs werden erstellt...",
     "table-headers": {
       "id": "ID",
+      "name": "Jobdefinition",
       "status": "Status",
       "variables": "Variablen",
       "coders": "Kodierer",
@@ -2627,10 +2634,10 @@
     },
     "workflow": {
       "definition": "Definition",
-      "jobs-count-unavailable": "Definition #{{id}} · Jobstatus nicht geladen",
-      "no-jobs": "Definition #{{id}} · Noch keine Kodierjobs erstellt",
-      "one-job": "Definition #{{id}} · 1 Kodierjob erstellt",
-      "many-jobs": "Definition #{{id}} · {{count}} Kodierjobs erstellt"
+      "jobs-count-unavailable": "{{label}} · Jobstatus nicht geladen",
+      "no-jobs": "{{label}} · Noch keine Kodierjobs erstellt",
+      "one-job": "{{label}} · 1 Kodierjob erstellt",
+      "many-jobs": "{{label}} · {{count}} Kodierjobs erstellt"
     },
     "refresh-dialog": {
       "title": {

--- a/database/changelog/coding-box.changelog-1.17.0.sql
+++ b/database/changelog/coding-box.changelog-1.17.0.sql
@@ -59,7 +59,7 @@ CREATE INDEX "replay_statistics_attempt_idx"
 -- rollback ALTER TABLE "public"."replay_statistics" DROP COLUMN IF EXISTS "request_id";
 -- rollback ALTER TABLE "public"."replay_statistics" DROP COLUMN IF EXISTS "replay_attempt_id";
 
--- changeset iqb:839-job-definition-name-description
+-- changeset jurei733:839-job-definition-name-description
 -- comment: Add user-facing names and descriptions to job definitions
 ALTER TABLE "public"."job_definitions"
   ADD COLUMN "name" VARCHAR(255),

--- a/database/changelog/coding-box.changelog-1.17.0.sql
+++ b/database/changelog/coding-box.changelog-1.17.0.sql
@@ -58,3 +58,18 @@ CREATE INDEX "replay_statistics_attempt_idx"
 -- rollback DROP INDEX IF EXISTS "public"."replay_statistics_attempt_idx";
 -- rollback ALTER TABLE "public"."replay_statistics" DROP COLUMN IF EXISTS "request_id";
 -- rollback ALTER TABLE "public"."replay_statistics" DROP COLUMN IF EXISTS "replay_attempt_id";
+
+-- changeset iqb:839-job-definition-name-description
+-- comment: Add user-facing names and descriptions to job definitions
+ALTER TABLE "public"."job_definitions"
+  ADD COLUMN "name" VARCHAR(255),
+  ADD COLUMN "description" TEXT;
+
+UPDATE "public"."job_definitions"
+SET "name" = 'Definition #' || "id";
+
+ALTER TABLE "public"."job_definitions"
+  ALTER COLUMN "name" SET NOT NULL;
+
+-- rollback ALTER TABLE "public"."job_definitions" DROP COLUMN IF EXISTS "description";
+-- rollback ALTER TABLE "public"."job_definitions" DROP COLUMN IF EXISTS "name";


### PR DESCRIPTION
Refs #839

## Zusammenfassung

- ergänzt Jobdefinitionen um einen verpflichtenden Namen und eine optionale Beschreibung
- migriert bestehende Definitionen mit `Definition #<ID>` als initialem Namen
- validiert und persistiert die Metadaten bei Create und Update, auch bei bereits erzeugten Kodierjobs ohne Neuverteilung
- ergänzt den Verteilungs-CSV-Export um den Namen der Jobdefinition
- zeigt `Name (#ID)` einheitlich in Übersicht, Filtern, Auswahl- und Verteilungsdialogen an
- ergänzt Formular-Recovery, API-Mapping und Request-Payloads um Name und Beschreibung

## Auswirkungen

Jobdefinitionen lassen sich fachlich benennen und beschreiben. Die technische ID bleibt sichtbar; bei alten oder unvollständigen API-Daten wird weiterhin `Definition #ID` angezeigt. Die Namen der daraus erzeugten einzelnen Kodierjobs bleiben unverändert.

## Validierung

- `npx nx lint backend`
- `npx nx test backend --runInBand` — 157 Suites, 2.307 Tests bestanden
- `npx nx build backend`
- `npx nx lint frontend`
- `npx nx test frontend` — 200 Suites, 1.968 Tests bestanden
- `npx nx build frontend`
- `git diff --check`

Die Liquibase-Changelog-Validierung wurde zweimal angestoßen, erreichte Liquibase aber nicht: Der Docker-Build scheitert beim Abruf der gepinnten PostgreSQL-/Go-Basis-Images am IQB-Dependency-Proxy mit Digest-/Größenabweichungen.
