### PR TITLE
Fix response-analysis freshness scope

### DIFF
--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -1426,6 +1426,11 @@ export class WorkspaceCodingStatisticsController {
           description:
             'Raw status total before covered source variables are excluded'
         },
+        responseAnalysisRawCases: {
+          type: 'number',
+          description:
+            'Raw response count covered by response analysis statuses'
+        },
         coveredSourceVariableCount: {
           type: 'number',
           description:
@@ -1478,6 +1483,7 @@ export class WorkspaceCodingStatisticsController {
   ): Promise<{
         totalCasesToCode: number;
         statusTotalCasesToCode: number;
+        responseAnalysisRawCases: number;
         coveredSourceVariableCount: number;
         coveredSourceResponseCount: number;
         completedCases: number;
@@ -1510,6 +1516,11 @@ export class WorkspaceCodingStatisticsController {
           type: 'number',
           description:
             'Raw status total before covered source variables are excluded'
+        },
+        responseAnalysisRawCases: {
+          type: 'number',
+          description:
+            'Raw response count covered by response analysis statuses'
         },
         coveredSourceVariableCount: {
           type: 'number',
@@ -1586,6 +1597,7 @@ export class WorkspaceCodingStatisticsController {
   ): Promise<{
         totalIncompleteResponses: number;
         statusTotalIncompleteResponses: number;
+        responseAnalysisRawCases: number;
         coveredSourceVariableCount: number;
         coveredSourceResponseCount: number;
         appliedResponses: number;
@@ -1623,6 +1635,11 @@ export class WorkspaceCodingStatisticsController {
           type: 'number',
           description:
             'Raw status total before covered source variables are excluded'
+        },
+        responseAnalysisRawCases: {
+          type: 'number',
+          description:
+            'Raw response count covered by response analysis statuses'
         },
         coveredSourceVariableCount: {
           type: 'number',
@@ -1689,6 +1706,7 @@ export class WorkspaceCodingStatisticsController {
   async getCaseCoverageOverview(@WorkspaceId() workspace_id: number): Promise<{
     totalCasesToCode: number;
     statusTotalCasesToCode: number;
+    responseAnalysisRawCases: number;
     coveredSourceVariableCount: number;
     coveredSourceResponseCount: number;
     effectiveTotalCasesToCode: number;

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.spec.ts
@@ -334,6 +334,8 @@ describe('CodingProgressService variable coverage conflicts', () => {
       totalIncompleteResponses: 2,
       appliedResponses: 1,
       remainingResponses: 1,
+      statusTotalIncompleteResponses: 2,
+      responseAnalysisRawCases: 1,
       deriveErrorRawTotalResponses: 1,
       deriveErrorRawAppliedResponses: 1,
       deriveErrorTotalResponses: 1,
@@ -341,12 +343,13 @@ describe('CodingProgressService variable coverage conflicts', () => {
       deriveErrorRemainingResponses: 0
     });
     expect(cacheService.set).toHaveBeenCalledWith(
-      'coding-progress:applied-results-overview:v1:5',
+      'coding-progress:applied-results-overview:v2:5',
       expect.objectContaining({
         cacheVersion: 0,
         data: expect.objectContaining({
           rawTotalIncompleteResponses: 2,
           rawAppliedResponses: 1,
+          responseAnalysisRawCases: 1,
           deriveErrorRawTotalResponses: 1,
           deriveErrorRawAppliedResponses: 1
         })
@@ -389,7 +392,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
       0
     );
     expect(cacheService.get).toHaveBeenCalledWith(
-      'coding-progress:applied-results-overview:v1:5'
+      'coding-progress:applied-results-overview:v2:5'
     );
     expect(responseRepository.createQueryBuilder).not.toHaveBeenCalled();
     expect(cacheService.set).not.toHaveBeenCalled();
@@ -399,7 +402,7 @@ describe('CodingProgressService variable coverage conflicts', () => {
     await service.invalidateAppliedResultsOverviewCache(5);
 
     expect(cacheService.delete).toHaveBeenCalledWith(
-      'coding-progress:applied-results-overview:v1:5'
+      'coding-progress:applied-results-overview:v2:5'
     );
   });
 

--- a/apps/backend/src/app/database/services/coding/coding-progress.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-progress.service.ts
@@ -37,6 +37,7 @@ import {
 } from './coding-job-type.util';
 import { getCodingIncompleteVariablesCacheVersionKey } from './coding-incomplete-variables-cache-key.util';
 import { CodingAggregationPeerService } from './coding-aggregation-peer.service';
+import { MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES } from '../../utils/manual-coding-candidate.util';
 
 type ResponseMatchingFlag =
   | 'NO_AGGREGATION'
@@ -60,6 +61,7 @@ interface CoverageResponse {
 interface CoverageResponseScope {
   allResponses: CoverageResponse[];
   manualResponses: CoverageResponse[];
+  responseAnalysisRawCases: number;
   excludedSourceSummary: ManualCodingExcludedSourceSummary;
 }
 
@@ -105,6 +107,7 @@ interface AppliedResultsOverview {
   aggregationThreshold: number | null;
   aggregatedDuplicateCases: number;
   statusTotalIncompleteResponses: number;
+  responseAnalysisRawCases: number;
   coveredSourceVariableCount: number;
   coveredSourceResponseCount: number;
   deriveErrorTotalResponses: number;
@@ -232,6 +235,7 @@ export class CodingProgressService {
     aggregationThreshold: number | null;
     aggregatedDuplicateCases: number;
     statusTotalCasesToCode: number;
+    responseAnalysisRawCases: number;
     coveredSourceVariableCount: number;
     coveredSourceResponseCount: number;
   }> {
@@ -268,6 +272,7 @@ export class CodingProgressService {
       aggregationThreshold: effectiveProgress.aggregationThreshold,
       aggregatedDuplicateCases: effectiveProgress.aggregatedDuplicateCases,
       statusTotalCasesToCode: responseScope.allResponses.length,
+      responseAnalysisRawCases: responseScope.responseAnalysisRawCases,
       coveredSourceVariableCount:
         responseScope.excludedSourceSummary.coveredSourceVariableCount,
       coveredSourceResponseCount:
@@ -310,7 +315,7 @@ export class CodingProgressService {
   }
 
   private getAppliedResultsOverviewCacheKey(workspaceId: number): string {
-    return `coding-progress:applied-results-overview:v1:${workspaceId}`;
+    return `coding-progress:applied-results-overview:v2:${workspaceId}`;
   }
 
   private async getAppliedResultsOverviewCacheVersion(workspaceId: number): Promise<number> {
@@ -371,6 +376,7 @@ export class CodingProgressService {
       aggregationThreshold: effectiveProgress.aggregationThreshold,
       aggregatedDuplicateCases: effectiveProgress.aggregatedDuplicateCases,
       statusTotalIncompleteResponses: responseScope.allResponses.length,
+      responseAnalysisRawCases: responseScope.responseAnalysisRawCases,
       coveredSourceVariableCount:
         responseScope.excludedSourceSummary.coveredSourceVariableCount,
       coveredSourceResponseCount:
@@ -394,6 +400,7 @@ export class CodingProgressService {
     aggregationThreshold: number | null;
     aggregatedDuplicateCases: number;
     statusTotalCasesToCode: number;
+    responseAnalysisRawCases: number;
     coveredSourceVariableCount: number;
     coveredSourceResponseCount: number;
   }> {
@@ -439,6 +446,7 @@ export class CodingProgressService {
       aggregationThreshold: effectiveCoverage.aggregationThreshold,
       aggregatedDuplicateCases: effectiveCoverage.aggregatedDuplicateCases,
       statusTotalCasesToCode: responseScope.allResponses.length,
+      responseAnalysisRawCases: responseScope.responseAnalysisRawCases,
       coveredSourceVariableCount:
         responseScope.excludedSourceSummary.coveredSourceVariableCount,
       coveredSourceResponseCount:
@@ -523,6 +531,10 @@ export class CodingProgressService {
     return {
       allResponses,
       manualResponses,
+      responseAnalysisRawCases: allResponses.filter(response => (
+        response.statusV1 !== null &&
+        MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES.includes(response.statusV1)
+      )).length,
       excludedSourceSummary
     };
   }
@@ -564,10 +576,7 @@ export class CodingProgressService {
     const deriveErrorStatus = statusStringToNumber('DERIVE_ERROR');
     query[method](new Brackets(qb => {
       qb.where('response.status_v1 IN (:...statuses)', {
-        statuses: [
-          statusStringToNumber('CODING_INCOMPLETE'),
-          statusStringToNumber('INTENDED_INCOMPLETE')
-        ]
+        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
       }).orWhere(
         `response.status_v1 = :deriveErrorStatus
           AND EXISTS (

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
@@ -11,7 +11,7 @@ import {
   DuplicateValueGroupDto
 } from '../../../../../../api-dto/coding/response-analysis.dto';
 import { CacheService } from '../../cache/cache.service';
-import { statusStringToNumber } from '../../database/utils/response-status-converter';
+import { MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES } from '../../database/utils/manual-coding-candidate.util';
 import { CodingAnalysisJobData } from '../job-queue.service';
 import {
   applyResolvedExclusionsToQuery,
@@ -94,8 +94,6 @@ export class CodingAnalysisProcessor {
     threshold: number,
     job?: Job<CodingAnalysisJobData>
   ): Promise<ResponseAnalysisDto> {
-    const codingIncompleteStatus = statusStringToNumber('CODING_INCOMPLETE');
-    const intendedIncompleteStatus = statusStringToNumber('INTENDED_INCOMPLETE');
     const exclusions = await this.workspaceExclusionService.resolveExclusionsForQueries(workspaceId);
     const defaultMirCode = await this.getDefaultMirCode(workspaceId);
     const derivedVariableMap = await this.getDerivedVariableMap(workspaceId);
@@ -113,7 +111,9 @@ export class CodingAnalysisProcessor {
       .innerJoin('booklet.person', 'person')
       .where('person.workspace_id = :workspaceId', { workspaceId })
       .andWhere('person.consider = :consider', { consider: true })
-      .andWhere('response.status_v1 IN (:...statuses)', { statuses: [codingIncompleteStatus, intendedIncompleteStatus] });
+      .andWhere('response.status_v1 IN (:...statuses)', {
+        statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+      });
     applyResolvedExclusionsToQuery(relevantVariablesQuery, exclusions);
     const relevantVariables = await relevantVariablesQuery
       .getRawMany();
@@ -155,7 +155,9 @@ export class CodingAnalysisProcessor {
         .leftJoinAndSelect('booklet.person', 'person')
         .where('person.workspace_id = :workspaceId', { workspaceId })
         .andWhere('person.consider = :consider', { consider: true })
-        .andWhere('response.status_v1 IN (:...statuses)', { statuses: [codingIncompleteStatus, intendedIncompleteStatus] })
+        .andWhere('response.status_v1 IN (:...statuses)', {
+          statuses: MANUAL_CODING_DEFAULT_CANDIDATE_STATUSES
+        })
         // Exclude already-aggregated responses (non-master duplicates) so they don't reappear after aggregation
         .andWhere(
           '(response.code_v2 IS NULL OR (response.code_v2 != :aggregatedCode AND response.code_v2 != :emptyCode))',

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -747,7 +747,7 @@ describe('CodingManagementManualComponent', () => {
     expect(component.isPreparationReady()).toBe(true);
   });
 
-  it('should flag response analysis as outdated when the status pool count changed', () => {
+  it('should flag response analysis as outdated when the analysis candidate count changed', () => {
     component.responseAnalysis = {
       emptyResponses: { total: 0, totalUncoded: 0, items: [] },
       duplicateValues: {
@@ -772,6 +772,7 @@ describe('CodingManagementManualComponent', () => {
     component.appliedResultsOverview!.rawTotalIncompleteResponses = 973;
     setCodingProgress(973, 8);
     component.codingProgressOverview!.statusTotalCasesToCode = 973;
+    component.codingProgressOverview!.responseAnalysisRawCases = 973;
 
     expect(component.getCurrentRawManualResponses()).toBe(973);
     expect(component.getResponseAnalysisReferenceRawCases()).toBe(973);
@@ -801,10 +802,12 @@ describe('CodingManagementManualComponent', () => {
     };
     setCodingProgress(16606, 12000);
     component.codingProgressOverview!.rawTotalCasesToCode = 17705;
-    component.codingProgressOverview!.statusTotalCasesToCode = 21606;
+    component.codingProgressOverview!.statusTotalCasesToCode = 21948;
+    component.codingProgressOverview!.responseAnalysisRawCases = 21606;
     setAppliedResults(17705, 3901, 13804);
 
     expect(component.getCurrentRawManualResponses()).toBe(17705);
+    expect(component.getManualStatusPoolCount()).toBe(21948);
     expect(component.getResponseAnalysisReferenceRawCases()).toBe(21606);
     expect(component.isResponseAnalysisOutdated()).toBe(false);
     expect(component.hasResponseAnalysisRestScopeDifference()).toBe(true);

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -2165,7 +2165,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   getResponseAnalysisReferenceRawCases(): number {
-    return this.getManualStatusPoolCount();
+    return this.codingProgressOverview?.responseAnalysisRawCases ??
+      this.caseCoverageOverview?.responseAnalysisRawCases ??
+      this.appliedResultsOverview?.responseAnalysisRawCases ??
+      this.getManualStatusPoolCount();
   }
 
   getManualStatusPoolCount(): number {

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -201,6 +201,7 @@ export interface CaseCoverageOverview {
   aggregationThreshold: number | null;
   aggregatedDuplicateCases: number;
   statusTotalCasesToCode?: number;
+  responseAnalysisRawCases?: number;
   coveredSourceVariableCount?: number;
   coveredSourceResponseCount?: number;
 }
@@ -216,6 +217,7 @@ export interface CodingProgressOverview {
   aggregationThreshold: number | null;
   aggregatedDuplicateCases: number;
   statusTotalCasesToCode?: number;
+  responseAnalysisRawCases?: number;
   coveredSourceVariableCount?: number;
   coveredSourceResponseCount?: number;
 }
@@ -232,6 +234,7 @@ export interface AppliedResultsOverview {
   aggregationThreshold: number | null;
   aggregatedDuplicateCases: number;
   statusTotalIncompleteResponses?: number;
+  responseAnalysisRawCases?: number;
   coveredSourceVariableCount?: number;
   coveredSourceResponseCount?: number;
   deriveErrorTotalResponses?: number;


### PR DESCRIPTION
## Summary

- expose a dedicated raw response count for the response-analysis scope
- keep job-bound `DERIVE_ERROR` responses in manual coding progress without treating them as response-analysis candidates
- share the canonical candidate statuses between progress calculation and the analysis processor
- use the analysis-specific count for the frontend freshness check, with a compatibility fallback
- version the applied-results cache so existing cached payloads cannot omit the new field

## Root cause

The freshness check compared the response analysis with the complete manual status pool. In VERA_3, that pool contained 21,948 responses because it also included 342 job-bound `DERIVE_ERROR` responses. The response analysis intentionally processes only `CODING_INCOMPLETE` and `INTENDED_INCOMPLETE`, resulting in 21,606 analyzed responses. The permanent 342-response difference therefore incorrectly marked a freshly calculated analysis as outdated.

## User impact

After recalculating the preparation, the warning is no longer shown merely because productive manual jobs contain `DERIVE_ERROR` responses. A real change to the response-analysis candidate set still marks the analysis as outdated.

## Validation

- `npx nx lint backend`
- `npx nx test backend --runInBand` — 2,400 passed, 10 skipped
- `npx nx build backend`
- `npx nx lint frontend`
- `npx nx test frontend --runInBand` — 2,005 passed
- `npx nx build frontend`
- targeted backend and frontend regression tests

Refs #794
