### PR TITLE
Fix coding navigation save race

### DIFF
--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts
@@ -580,6 +580,27 @@ describe('CodeSelectorComponent', () => {
     });
   });
 
+  it('clears the local selection when the coding case changes', () => {
+    component.codingScheme = mixedCodingScheme;
+    component.variableId = 'VAR1';
+    component.codingCaseKey = 'case-1';
+    component.ngOnChanges({
+      codingScheme: new SimpleChange(null, mixedCodingScheme, false),
+      variableId: new SimpleChange(null, 'VAR1', false),
+      codingCaseKey: new SimpleChange('', 'case-1', true)
+    });
+    component.onSelect(1);
+
+    component.codingCaseKey = 'case-2';
+    component.ngOnChanges({
+      codingCaseKey: new SimpleChange('case-1', 'case-2', false)
+    });
+
+    expect(component.selectedCode).toBeNull();
+    expect(component.selectedCodingIssueOption).toBeNull();
+    expect(component.legacySelectedCode).toBeNull();
+  });
+
   it('nextUnit should navigate to immediate next case for interleaved variables', () => {
     component.unitsData = {
       ...interleavedUnitsData,
@@ -590,6 +611,51 @@ describe('CodeSelectorComponent', () => {
 
     component.nextUnit();
 
+    expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[1]);
+  });
+
+  it('blocks nextUnit until the current selection has been saved', () => {
+    const isUnitCoded = jest.fn().mockReturnValue(false);
+    component.codingService = { isUnitCoded } as never;
+    component.unitsData = {
+      ...interleavedUnitsData,
+      currentUnitIndex: 0
+    };
+    component.selectedCode = 1;
+    const emitSpy = jest.spyOn(component.unitChanged, 'emit');
+
+    expect(component.hasNextUnit()).toBe(false);
+    component.nextUnit();
+    expect(emitSpy).not.toHaveBeenCalled();
+
+    isUnitCoded.mockReturnValue(true);
+
+    expect(component.hasNextUnit()).toBe(true);
+    component.nextUnit();
+    expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[1]);
+  });
+
+  it('blocks nextUnit while an updated selection is still being saved', () => {
+    const isUnitSavePending = jest.fn().mockReturnValue(true);
+    component.codingService = {
+      isUnitCoded: jest.fn().mockReturnValue(true),
+      isUnitSavePending
+    } as never;
+    component.unitsData = {
+      ...interleavedUnitsData,
+      currentUnitIndex: 0
+    };
+    component.selectedCode = 1;
+    const emitSpy = jest.spyOn(component.unitChanged, 'emit');
+
+    expect(component.hasNextUnit()).toBe(false);
+    component.nextUnit();
+    expect(emitSpy).not.toHaveBeenCalled();
+
+    isUnitSavePending.mockReturnValue(false);
+
+    expect(component.hasNextUnit()).toBe(true);
+    component.nextUnit();
     expect(emitSpy).toHaveBeenCalledWith(component.unitsData.units[1]);
   });
 

--- a/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
+++ b/apps/frontend/src/app/coding/components/code-selector/code-selector.component.ts
@@ -70,6 +70,7 @@ interface IndexedReplayUnit {
 export class CodeSelectorComponent implements OnChanges {
   @Input() codingScheme!: string | CodingScheme;
   @Input() variableId!: string;
+  @Input() codingCaseKey: string = '';
   @Input() preSelectedCodeId: number | null = null;
   @Input() preSelectedCodingIssueOptionId: number | null = null;
   @Input() coderNotes: string = '';
@@ -156,7 +157,12 @@ export class CodeSelectorComponent implements OnChanges {
     if (changes.codingScheme || changes.variableId || changes.missings) {
       this.loadCodes();
     }
-    if (changes.preSelectedCodeId || changes.preSelectedCodingIssueOptionId || changes.allowComments) {
+    if (
+      changes.codingCaseKey ||
+      changes.preSelectedCodeId ||
+      changes.preSelectedCodingIssueOptionId ||
+      changes.allowComments
+    ) {
       this.selectPreSelectedCode();
     }
   }
@@ -432,6 +438,17 @@ export class CodeSelectorComponent implements OnChanges {
       this.legacySelectedCode !== null;
   }
 
+  private hasSavedCurrentSelection(): boolean {
+    const data = this.unitsData;
+    const currentUnit = data?.units[data.currentUnitIndex];
+    if (!currentUnit || !this.codingService) {
+      return this.hasCurrentSelection();
+    }
+
+    return this.codingService.isUnitCoded(currentUnit) &&
+      !this.codingService.isUnitSavePending?.(currentUnit);
+  }
+
   deselectAll(): void {
     if (this.isReadOnly) return;
     this.selectedCode = null;
@@ -509,7 +526,7 @@ export class CodeSelectorComponent implements OnChanges {
 
     if (this.isNavigationDisabled) return;
     if (this.hasSaveError) return;
-    if (!this.isReadOnly && !this.hasCurrentSelection()) return;
+    if (!this.isReadOnly && !this.hasSavedCurrentSelection()) return;
     if (!this.isReadOnly && !this.canLeaveCurrentUnit()) return;
 
     const currentIndex = data.currentUnitIndex;
@@ -540,7 +557,7 @@ export class CodeSelectorComponent implements OnChanges {
     const nextIndex = currentIndex + 1;
     const hasNext = nextIndex < data.units.length;
     if (this.isReadOnly) return hasNext;
-    return hasNext && this.hasCurrentSelection() && !this.hasSaveError;
+    return hasNext && this.hasSavedCurrentSelection() && !this.hasSaveError;
   }
 
   hasPreviousUnit(): boolean {

--- a/apps/frontend/src/app/replay/components/replay/replay.component.html
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.html
@@ -38,6 +38,7 @@
     <div class="code-selector-container" [style.width.px]="codePanelWidth" [style.min-width.px]="codePanelWidth">
       @if (codingService.codingScheme && codingService.currentVariableId) {
       <app-code-selector [codingScheme]="codingService.codingScheme" [variableId]="codingService.currentVariableId"
+        [codingCaseKey]="getCurrentCodingCaseKey()"
         [preSelectedCodeId]="getPreSelectedCodeId(codingService.currentVariableId)"
         [preSelectedCodingIssueOptionId]="getPreSelectedCodingIssueOptionId(codingService.currentVariableId)"
         [coderNotes]="getCoderNotes()" [showProgress]="!!codingService.codingJobId"

--- a/apps/frontend/src/app/replay/components/replay/replay.component.ts
+++ b/apps/frontend/src/app/replay/components/replay/replay.component.ts
@@ -1858,6 +1858,15 @@ export class ReplayComponent implements OnInit, OnDestroy, OnChanges {
     return this.codingService.getPreSelectedCodeId(this.testPerson, this.unitId, variableId);
   }
 
+  getCurrentCodingCaseKey(): string {
+    const variableId = this.codingService.currentVariableId;
+    if (!this.testPerson || !this.unitId || !variableId) {
+      return '';
+    }
+
+    return this.codingService.generateCompositeKey(this.testPerson, this.unitId, variableId);
+  }
+
   getPreSelectedCodingIssueOptionId(variableId: string): number | null {
     return this.codingService.getPreSelectedCodingIssueOptionId(this.testPerson, this.unitId, variableId);
   }

--- a/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.spec.ts
@@ -450,6 +450,31 @@ describe('ReplayCodingService', () => {
       expect(didFlush).toBe(true);
     });
 
+    it('reports a pending save for the affected coding unit', async () => {
+      const pendingSave = new Subject<CodingJob>();
+      codingJobBackendServiceMock.saveCodingProgress.mockReturnValueOnce(pendingSave.asObservable());
+      const unit = {
+        id: 1,
+        name: 'u1',
+        alias: null,
+        bookletId: 0,
+        testPerson: 'p1',
+        variableId: 'v1'
+      };
+
+      const savePromise = service.saveCodingProgress(1, 100, 'p1', 'u1', 'v1', { id: 1, label: 'one' });
+      await Promise.resolve();
+
+      expect(service.isUnitSavePending(unit)).toBe(true);
+
+      pendingSave.next({} as CodingJob);
+      pendingSave.complete();
+      await savePromise;
+      await Promise.resolve();
+
+      expect(service.isUnitSavePending(unit)).toBe(false);
+    });
+
     it('rejects a flush when a pending row mutation fails', async () => {
       const pendingSave = new Subject<CodingJob>();
       codingJobBackendServiceMock.saveCodingProgress.mockReturnValueOnce(pendingSave.asObservable());

--- a/apps/frontend/src/app/replay/services/replay-coding.service.ts
+++ b/apps/frontend/src/app/replay/services/replay-coding.service.ts
@@ -929,6 +929,18 @@ export class ReplayCodingService {
     return this.isUnitCodedByCompositeKey(compositeKey);
   }
 
+  isUnitSavePending(unit: UnitsReplayUnit): boolean {
+    if (!unit.variableId) return false;
+
+    const compositeKey = this.generateCompositeKey(
+      unit.testPerson || '',
+      unit.name,
+      unit.variableId
+    );
+
+    return this.rowMutationChains.has(compositeKey);
+  }
+
   private isUnitCodedByCompositeKey(compositeKey: string): boolean {
     return this.isCompletedSelection(compositeKey, this.selectedCodes.get(compositeKey));
   }


### PR DESCRIPTION
## Summary

- reset the local code selection whenever the concrete coding case changes
- enable forward navigation only after the current selection has been persisted
- keep forward navigation blocked while a first or updated selection is still being saved
- add regression coverage for case changes and pending saves

## Root cause

The selector tracked its selection locally and used that local state to enable the forward button. For consecutive cases of the same variable, the component inputs that previously triggered a reset could remain unchanged. A selection from the preceding case could therefore keep the button enabled while the backend save was still running, allowing the next uncoded case to be skipped without its own code.

## Impact

Coders can no longer advance an uncoded case using a stale selection from the previous case. Updates to an existing selection also finish saving before forward navigation becomes available.

## Validation

- `npx nx test frontend --runInBand --testFile=apps/frontend/src/app/coding/components/code-selector/code-selector.component.spec.ts` (38 tests)
- `npx nx test frontend --runInBand --testFile=apps/frontend/src/app/replay/services/replay-coding.service.spec.ts` (53 tests)
- `npx nx lint frontend`
- `npx nx build frontend`

Related to #954. The issue remains open for production verification and the separately identified web-table/export discrepancy.
