### PR TITLE
fix: Verteilungsvorschau gegen Anfragefluten absichern

### DIFF
--- a/apps/backend/src/app/admin/workspace-coding/distribution-preview-limiter.service.spec.ts
+++ b/apps/backend/src/app/admin/workspace-coding/distribution-preview-limiter.service.spec.ts
@@ -1,11 +1,17 @@
-import { RequestTimeoutException } from '@nestjs/common';
+import { HttpStatus, Logger, RequestTimeoutException } from '@nestjs/common';
 import { DistributionPreviewLimiterService } from './distribution-preview-limiter.service';
 
 describe('DistributionPreviewLimiterService', () => {
   let service: DistributionPreviewLimiterService;
 
   beforeEach(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
     service = new DistributionPreviewLimiterService();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('runs at most two distribution previews concurrently', async () => {
@@ -62,5 +68,56 @@ describe('DistributionPreviewLimiterService', () => {
     releases.forEach(release => release());
     await expect(Promise.all([first, second])).resolves.toEqual([1, 2]);
     expect(execute).toHaveBeenCalledTimes(2);
+    expect(service.getSnapshot()).toEqual(expect.objectContaining({
+      active: 0,
+      pending: 0,
+      cancelled: 1
+    }));
+  });
+
+  it('rejects excess previews instead of growing the queue without a limit', async () => {
+    const releases: Array<() => void> = [];
+    const execute = jest.fn((result: number) => new Promise<number>(resolve => {
+      releases.push(() => resolve(result));
+    }));
+    const accepted = Array.from(
+      { length: 10 },
+      (_, index) => service.run(() => execute(index + 1))
+    );
+
+    await Promise.resolve();
+    const rejected = service.run(() => execute(11));
+
+    await expect(rejected).rejects.toMatchObject({
+      status: HttpStatus.TOO_MANY_REQUESTS
+    });
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(service.getSnapshot()).toEqual({
+      active: 2,
+      pending: 8,
+      maxConcurrent: 2,
+      maxPending: 8,
+      rejected: 1,
+      cancelled: 0
+    });
+    expect(Logger.prototype.warn).toHaveBeenCalledWith(
+      expect.stringContaining('rejected=1')
+    );
+
+    for (let index = 0; index < accepted.length; index += 1) {
+      releases.shift()?.();
+      await new Promise(resolve => {
+        setImmediate(resolve);
+      });
+    }
+    await expect(Promise.all(accepted)).resolves.toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+    ]);
+    expect(execute).toHaveBeenCalledTimes(10);
+    expect(service.getSnapshot()).toEqual(expect.objectContaining({
+      active: 0,
+      pending: 0,
+      rejected: 1
+    }));
   });
 });

--- a/apps/backend/src/app/admin/workspace-coding/distribution-preview-limiter.service.spec.ts
+++ b/apps/backend/src/app/admin/workspace-coding/distribution-preview-limiter.service.spec.ts
@@ -1,0 +1,66 @@
+import { RequestTimeoutException } from '@nestjs/common';
+import { DistributionPreviewLimiterService } from './distribution-preview-limiter.service';
+
+describe('DistributionPreviewLimiterService', () => {
+  let service: DistributionPreviewLimiterService;
+
+  beforeEach(() => {
+    service = new DistributionPreviewLimiterService();
+  });
+
+  it('runs at most two distribution previews concurrently', async () => {
+    const releases: Array<() => void> = [];
+    let activePreviews = 0;
+    let maximumActivePreviews = 0;
+    const execute = jest.fn((result: number) => new Promise<number>(resolve => {
+      activePreviews += 1;
+      maximumActivePreviews = Math.max(
+        maximumActivePreviews,
+        activePreviews
+      );
+      releases.push(() => {
+        activePreviews -= 1;
+        resolve(result);
+      });
+    }));
+
+    const first = service.run(() => execute(1));
+    const second = service.run(() => execute(2));
+    const third = service.run(() => execute(3));
+
+    await Promise.resolve();
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(maximumActivePreviews).toBe(2);
+
+    releases.shift()?.();
+    await first;
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+    expect(execute).toHaveBeenCalledTimes(3);
+    expect(maximumActivePreviews).toBe(2);
+
+    releases.forEach(release => release());
+    await expect(Promise.all([second, third])).resolves.toEqual([2, 3]);
+  });
+
+  it('does not start a queued preview after its client disconnects', async () => {
+    const releases: Array<() => void> = [];
+    const execute = jest.fn((result: number) => new Promise<number>(resolve => {
+      releases.push(() => resolve(result));
+    }));
+    const cancellation = new AbortController();
+
+    const first = service.run(() => execute(1));
+    const second = service.run(() => execute(2));
+    const cancelled = service.run(() => execute(3), cancellation.signal);
+    cancellation.abort();
+
+    await expect(cancelled).rejects.toBeInstanceOf(RequestTimeoutException);
+    expect(execute).toHaveBeenCalledTimes(2);
+
+    releases.forEach(release => release());
+    await expect(Promise.all([first, second])).resolves.toEqual([1, 2]);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/src/app/admin/workspace-coding/distribution-preview-limiter.service.ts
+++ b/apps/backend/src/app/admin/workspace-coding/distribution-preview-limiter.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, RequestTimeoutException } from '@nestjs/common';
+
+interface PendingPreview {
+  execute: () => Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  signal?: AbortSignal;
+  abortHandler?: () => void;
+  started: boolean;
+}
+
+@Injectable()
+export class DistributionPreviewLimiterService {
+  private readonly maxConcurrentPreviews = 2;
+  private readonly pendingPreviews: PendingPreview[] = [];
+  private activePreviews = 0;
+
+  run<T>(execute: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    if (signal?.aborted) {
+      return Promise.reject(this.createCancellationError());
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const preview: PendingPreview = {
+        execute,
+        resolve: value => resolve(value as T),
+        reject,
+        signal,
+        started: false
+      };
+
+      if (signal) {
+        preview.abortHandler = () => this.cancelPendingPreview(preview);
+        signal.addEventListener('abort', preview.abortHandler, { once: true });
+      }
+
+      this.pendingPreviews.push(preview);
+      this.startPendingPreviews();
+    });
+  }
+
+  private startPendingPreviews(): void {
+    while (
+      this.activePreviews < this.maxConcurrentPreviews &&
+      this.pendingPreviews.length > 0
+    ) {
+      const preview = this.pendingPreviews.shift();
+      if (!preview) {
+        return;
+      }
+
+      if (preview.signal?.aborted) {
+        this.removeAbortListener(preview);
+        preview.reject(this.createCancellationError());
+        continue;
+      }
+
+      preview.started = true;
+      this.activePreviews += 1;
+
+      Promise.resolve()
+        .then(preview.execute)
+        .then(preview.resolve, preview.reject)
+        .finally(() => {
+          this.removeAbortListener(preview);
+          this.activePreviews -= 1;
+          this.startPendingPreviews();
+        });
+    }
+  }
+
+  private cancelPendingPreview(preview: PendingPreview): void {
+    if (preview.started) {
+      return;
+    }
+
+    const index = this.pendingPreviews.indexOf(preview);
+    if (index >= 0) {
+      this.pendingPreviews.splice(index, 1);
+    }
+    this.removeAbortListener(preview);
+    preview.reject(this.createCancellationError());
+  }
+
+  private removeAbortListener(preview: PendingPreview): void {
+    if (preview.signal && preview.abortHandler) {
+      preview.signal.removeEventListener('abort', preview.abortHandler);
+    }
+  }
+
+  private createCancellationError(): RequestTimeoutException {
+    return new RequestTimeoutException(
+      'Distribution preview request was cancelled.'
+    );
+  }
+}

--- a/apps/backend/src/app/admin/workspace-coding/distribution-preview-limiter.service.ts
+++ b/apps/backend/src/app/admin/workspace-coding/distribution-preview-limiter.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, RequestTimeoutException } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Logger,
+  RequestTimeoutException
+} from '@nestjs/common';
 
 interface PendingPreview {
   execute: () => Promise<unknown>;
@@ -9,15 +15,39 @@ interface PendingPreview {
   started: boolean;
 }
 
+export interface DistributionPreviewLimiterSnapshot {
+  active: number;
+  pending: number;
+  maxConcurrent: number;
+  maxPending: number;
+  rejected: number;
+  cancelled: number;
+}
+
 @Injectable()
 export class DistributionPreviewLimiterService {
+  private readonly logger = new Logger(DistributionPreviewLimiterService.name);
   private readonly maxConcurrentPreviews = 2;
+  private readonly maxPendingPreviews = 8;
   private readonly pendingPreviews: PendingPreview[] = [];
   private activePreviews = 0;
+  private rejectedPreviews = 0;
+  private cancelledPreviews = 0;
 
   run<T>(execute: () => Promise<T>, signal?: AbortSignal): Promise<T> {
     if (signal?.aborted) {
+      this.cancelledPreviews += 1;
+      this.logState('cancelled before queueing');
       return Promise.reject(this.createCancellationError());
+    }
+
+    if (
+      this.activePreviews >= this.maxConcurrentPreviews &&
+      this.pendingPreviews.length >= this.maxPendingPreviews
+    ) {
+      this.rejectedPreviews += 1;
+      this.logState('rejected because the queue is full', true);
+      return Promise.reject(this.createCapacityError());
     }
 
     return new Promise<T>((resolve, reject) => {
@@ -36,7 +66,21 @@ export class DistributionPreviewLimiterService {
 
       this.pendingPreviews.push(preview);
       this.startPendingPreviews();
+      if (!preview.started) {
+        this.logState('queued');
+      }
     });
+  }
+
+  getSnapshot(): DistributionPreviewLimiterSnapshot {
+    return {
+      active: this.activePreviews,
+      pending: this.pendingPreviews.length,
+      maxConcurrent: this.maxConcurrentPreviews,
+      maxPending: this.maxPendingPreviews,
+      rejected: this.rejectedPreviews,
+      cancelled: this.cancelledPreviews
+    };
   }
 
   private startPendingPreviews(): void {
@@ -51,7 +95,9 @@ export class DistributionPreviewLimiterService {
 
       if (preview.signal?.aborted) {
         this.removeAbortListener(preview);
+        this.cancelledPreviews += 1;
         preview.reject(this.createCancellationError());
+        this.logState('cancelled before execution');
         continue;
       }
 
@@ -79,7 +125,9 @@ export class DistributionPreviewLimiterService {
       this.pendingPreviews.splice(index, 1);
     }
     this.removeAbortListener(preview);
+    this.cancelledPreviews += 1;
     preview.reject(this.createCancellationError());
+    this.logState('cancelled while queued');
   }
 
   private removeAbortListener(preview: PendingPreview): void {
@@ -92,5 +140,27 @@ export class DistributionPreviewLimiterService {
     return new RequestTimeoutException(
       'Distribution preview request was cancelled.'
     );
+  }
+
+  private createCapacityError(): HttpException {
+    return new HttpException(
+      'Distribution preview capacity is temporarily exhausted. Please try again.',
+      HttpStatus.TOO_MANY_REQUESTS
+    );
+  }
+
+  private logState(event: string, warn = false): void {
+    const snapshot = this.getSnapshot();
+    const message =
+      `Distribution preview ${event}: ` +
+      `active=${snapshot.active}/${snapshot.maxConcurrent} ` +
+      `pending=${snapshot.pending}/${snapshot.maxPending} ` +
+      `rejected=${snapshot.rejected} cancelled=${snapshot.cancelled}`;
+
+    if (warn) {
+      this.logger.warn(message);
+    } else {
+      this.logger.log(message);
+    }
   }
 }

--- a/apps/backend/src/app/admin/workspace-coding/workspace-coding-admin.module.ts
+++ b/apps/backend/src/app/admin/workspace-coding/workspace-coding-admin.module.ts
@@ -23,6 +23,7 @@ import { WorkspaceCodingResultsController } from '../workspace/workspace-coding-
 import { WorkspaceTestCenterController } from '../workspace/workspace-test-center.controller';
 import { WorkspacePlayerController } from '../workspace/workspace-player.controller';
 import { Setting } from '../../database/entities/setting.entity';
+import { DistributionPreviewLimiterService } from './distribution-preview-limiter.service';
 
 @Module({
   imports: [
@@ -51,6 +52,7 @@ import { Setting } from '../../database/entities/setting.entity';
     WorkspaceCodingResultsController,
     WorkspaceTestCenterController,
     WorkspacePlayerController
-  ]
+  ],
+  providers: [DistributionPreviewLimiterService]
 })
 export class WorkspaceCodingAdminModule { }

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import { BadRequestException } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants';
 import * as ExcelJS from 'exceljs';
+import { EventEmitter } from 'events';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { AccessLevelGuard } from './access-level.guard';
 import { WorkspaceGuard } from './workspace.guard';
@@ -12,7 +13,10 @@ describe('WorkspaceCodingStatisticsController', () => {
     calculateCohensKappa: jest.Mock;
     roundKappaCalculationResult: jest.Mock;
   };
-  let codingJobService: { createDistributedCodingJobs: jest.Mock };
+  let codingJobService: {
+    calculateDistribution: jest.Mock;
+    createDistributedCodingJobs: jest.Mock;
+  };
   let codingReviewService: {
     getDoubleCodedVariablesForReview: jest.Mock;
     getCodedVariablesForKappa: jest.Mock;
@@ -22,6 +26,7 @@ describe('WorkspaceCodingStatisticsController', () => {
     getReadiness: jest.Mock;
     getReadinessFromCache: jest.Mock;
   };
+  let distributionPreviewLimiterService: { run: jest.Mock };
   let controller: WorkspaceCodingStatisticsController;
   const request = {
     protocol: 'http',
@@ -38,6 +43,17 @@ describe('WorkspaceCodingStatisticsController', () => {
       }))
     };
     codingJobService = {
+      calculateDistribution: jest.fn().mockResolvedValue({
+        distribution: {},
+        distributionByCoderId: {},
+        doubleCodingInfo: {},
+        aggregationInfo: {},
+        matchingFlags: [],
+        warnings: [],
+        pairDistribution: {},
+        tasksPerCoder: {},
+        coderWeights: {}
+      }),
       createDistributedCodingJobs: jest.fn().mockResolvedValue({
         success: true,
         jobsCreated: 0,
@@ -85,6 +101,9 @@ describe('WorkspaceCodingStatisticsController', () => {
       }),
       getReadinessFromCache: jest.fn().mockResolvedValue(null)
     };
+    distributionPreviewLimiterService = {
+      run: jest.fn().mockImplementation(execute => execute())
+    };
 
     controller = new WorkspaceCodingStatisticsController(
       codingStatisticsService as never,
@@ -96,7 +115,8 @@ describe('WorkspaceCodingStatisticsController', () => {
       {} as never,
       codingReadinessService as never,
       codingReplayService as never,
-      {} as never
+      {} as never,
+      distributionPreviewLimiterService as never
     );
     request.get.mockImplementation((name: string) => {
       if (name === 'host') {
@@ -157,6 +177,23 @@ describe('WorkspaceCodingStatisticsController', () => {
     await controller.createDistributedCodingJobs(5, body);
 
     expect(codingJobService.createDistributedCodingJobs).toHaveBeenCalledWith(5, body);
+  });
+
+  it('runs distribution previews through the concurrency limiter', async () => {
+    const body = {
+      selectedVariables: [{ unitName: 'UNIT', variableId: 'VAR' }],
+      selectedCoders: [{ id: 1, name: 'Coder', username: 'coder' }]
+    };
+    const response = Object.assign(new EventEmitter(), { writableEnded: false });
+
+    await controller.calculateDistribution(5, body, response as never);
+
+    expect(distributionPreviewLimiterService.run).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(AbortSignal)
+    );
+    expect(codingJobService.calculateDistribution).toHaveBeenCalledWith(5, body);
+    expect(response.listenerCount('close')).toBe(0);
   });
 
   it('delegates autocoding readiness requests with parsed options', async () => {

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
@@ -196,6 +196,38 @@ describe('WorkspaceCodingStatisticsController', () => {
     expect(response.listenerCount('close')).toBe(0);
   });
 
+  it('cancels a queued distribution preview when the response connection closes', async () => {
+    const body = {
+      selectedVariables: [{ unitName: 'UNIT', variableId: 'VAR' }],
+      selectedCoders: [{ id: 1, name: 'Coder', username: 'coder' }]
+    };
+    const response = Object.assign(new EventEmitter(), { writableEnded: false });
+    let receivedSignal: AbortSignal | undefined;
+    distributionPreviewLimiterService.run.mockImplementation((
+      _execute: () => Promise<unknown>,
+      signal: AbortSignal
+    ) => {
+      receivedSignal = signal;
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => reject(new Error('preview cancelled')),
+          { once: true }
+        );
+      });
+    });
+
+    const calculation = controller.calculateDistribution(5, body, response as never);
+    expect(response.listenerCount('close')).toBe(1);
+
+    response.emit('close');
+
+    await expect(calculation).rejects.toThrow('preview cancelled');
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(codingJobService.calculateDistribution).not.toHaveBeenCalled();
+    expect(response.listenerCount('close')).toBe(0);
+  });
+
   it('delegates autocoding readiness requests with parsed options', async () => {
     await controller.getAutocodingReadiness(5, '2', 'true');
 

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -48,6 +48,7 @@ import {
 import { AutocodingReadinessDto } from '../../../../../../api-dto/coding/autocoding-readiness.dto';
 import { JobQueueService } from '../../job-queue/job-queue.service';
 import { sanitizeCsvText } from '../../utils/csv.util';
+import { DistributionPreviewLimiterService } from '../workspace-coding/distribution-preview-limiter.service';
 
 type CodingStatisticsJobStatusResponse = {
   status: string;
@@ -257,7 +258,8 @@ export class WorkspaceCodingStatisticsController {
     private codingProcessService: CodingProcessService,
     private codingReadinessService: CodingReadinessService,
     private codingReplayService: CodingReplayService,
-    private jobQueueService: JobQueueService
+    private jobQueueService: JobQueueService,
+    private distributionPreviewLimiterService: DistributionPreviewLimiterService
   ) { }
 
   private calculateMeanKappa(
@@ -2782,9 +2784,25 @@ export class WorkspaceCodingStatisticsController {
                      caseOrderingMode?: 'continuous' | 'alternating';
                      maxCodingCases?: number;
                      distributionSeed?: string | number;
-                   }
+                   },
+                   @Res({ passthrough: true }) response: Response
   ): Promise<DistributionCalculationResponse> {
-    return this.codingJobService.calculateDistribution(workspace_id, body);
+    const cancellation = new AbortController();
+    const cancelOnDisconnect = () => {
+      if (!response.writableEnded) {
+        cancellation.abort();
+      }
+    };
+    response.once('close', cancelOnDisconnect);
+
+    try {
+      return await this.distributionPreviewLimiterService.run(
+        () => this.codingJobService.calculateDistribution(workspace_id, body),
+        cancellation.signal
+      );
+    } finally {
+      response.removeListener('close', cancelOnDisconnect);
+    }
   }
 
   @Post(':workspace_id/coding/create-distributed-jobs')

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
@@ -9,7 +9,7 @@ import {
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { of, Subject } from 'rxjs';
+import { Observable, of, Subject } from 'rxjs';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { CodingJobDefinitionDialogComponent, CodingJobDefinitionDialogData } from './coding-job-definition-dialog.component';
 import { CodingJobBackendService } from '../../services/coding-job-backend.service';
@@ -1559,6 +1559,50 @@ describe('CodingJobDefinitionDialogComponent', () => {
     expect(component.getTotalDoubleCodedCases()).toBe(4);
     expect(component.getTotalCodingTasks()).toBe(10);
     expect(component.getTimePerCoderInSeconds()).toBe(420);
+  }));
+
+  it('should cancel an outdated distribution preview before starting the next one', fakeAsync(() => {
+    const firstPreviewCancelled = jest.fn();
+    const firstPreview = new Observable(() => firstPreviewCancelled);
+    (mockDistributedCodingService.calculateDistribution as jest.Mock)
+      .mockReturnValueOnce(firstPreview)
+      .mockReturnValue(of(emptyDistributionPreview));
+    createComponent();
+    (mockDistributedCodingService.calculateDistribution as jest.Mock).mockClear();
+
+    component.selectedCoders.select(component.availableCoders[0]);
+    component.selectedVariables.select(component.variables[0]);
+    tick(300);
+
+    expect(mockDistributedCodingService.calculateDistribution).toHaveBeenCalledTimes(1);
+    expect(firstPreviewCancelled).not.toHaveBeenCalled();
+
+    component.codingJobForm.patchValue({ maxCodingCases: 5 });
+
+    expect(firstPreviewCancelled).toHaveBeenCalledTimes(1);
+    expect(mockDistributedCodingService.calculateDistribution).toHaveBeenCalledTimes(1);
+
+    tick(300);
+
+    expect(mockDistributedCodingService.calculateDistribution).toHaveBeenCalledTimes(2);
+  }));
+
+  it('should not recalculate distribution for unrelated definition fields', fakeAsync(() => {
+    createComponent();
+    component.selectedCoders.select(component.availableCoders[0]);
+    component.selectedVariables.select(component.variables[0]);
+    tick(300);
+    (mockDistributedCodingService.calculateDistribution as jest.Mock).mockClear();
+
+    component.codingJobForm.patchValue({
+      name: 'Neuer Name',
+      description: 'Neue Beschreibung',
+      durationSeconds: 60,
+      showScore: true
+    });
+    tick(300);
+
+    expect(mockDistributedCodingService.calculateDistribution).not.toHaveBeenCalled();
   }));
 
   it('should send a stable distribution seed when submitting a new definition for review', () => {

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.spec.ts
@@ -1605,6 +1605,19 @@ describe('CodingJobDefinitionDialogComponent', () => {
     expect(mockDistributedCodingService.calculateDistribution).not.toHaveBeenCalled();
   }));
 
+  it('should calculate distribution while the unrelated required name is empty', fakeAsync(() => {
+    createComponent(undefined, false, false);
+    (mockDistributedCodingService.calculateDistribution as jest.Mock).mockClear();
+
+    expect(component.codingJobForm.get('name')?.invalid).toBe(true);
+
+    component.selectedCoders.select(component.availableCoders[0]);
+    component.selectedVariables.select(component.variables[0]);
+    tick(300);
+
+    expect(mockDistributedCodingService.calculateDistribution).toHaveBeenCalledTimes(1);
+  }));
+
   it('should send a stable distribution seed when submitting a new definition for review', () => {
     createComponent();
     (mockCodingJobBackendService.createJobDefinition as jest.Mock).mockReturnValue(of({ id: 123 }));

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
@@ -29,7 +29,8 @@ import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { SelectionModel } from '@angular/cdk/collections';
 import { MatTooltip } from '@angular/material/tooltip';
 import {
-  debounceTime, forkJoin, Subject, Subscription, takeUntil, firstValueFrom
+  catchError, firstValueFrom, forkJoin, merge, Observable, of, Subject, Subscription,
+  switchMap, takeUntil, timer
 } from 'rxjs';
 import {
   CodingJob,
@@ -282,7 +283,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
   private definitionDistributionSeed?: string;
   private distributionPreviewSummary: DistributionPreviewSummary | null = null;
   private readonly distributionPreviewRefresh$ = new Subject<void>();
-  private distributionPreviewRequestId = 0;
+  private readonly distributionPreviewDebounceMs = 300;
   private selectionPreviewSubscription = new Subscription();
   existingJobDefinitions: JobDefinition[] = [];
   manualCodingScopeSummary: ManualCodingScopeSummary | null = null;
@@ -308,12 +309,26 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.restoreDefinitionRecoveryDraft());
     this.bindSelectionPreviewRefresh();
-    this.codingJobForm.valueChanges
-      .pipe(debounceTime(150), takeUntil(this.destroy$))
+    merge(
+      this.codingJobForm.get('doubleCodingAbsolute')!.valueChanges,
+      this.codingJobForm.get('doubleCodingPercentage')!.valueChanges,
+      this.codingJobForm.get('caseOrderingMode')!.valueChanges,
+      this.codingJobForm.get('maxCodingCases')!.valueChanges
+    )
+      .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.queueDistributionPreviewRefresh());
     this.distributionPreviewRefresh$
-      .pipe(debounceTime(150), takeUntil(this.destroy$))
-      .subscribe(() => this.loadDistributionPreview());
+      .pipe(
+        switchMap(() => timer(this.distributionPreviewDebounceMs).pipe(
+          switchMap(() => this.loadDistributionPreview())
+        )),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(preview => {
+        this.distributionPreviewSummary = preview ?
+          this.buildDistributionPreviewSummary(preview) :
+          null;
+      });
     this.loadIncludeDeriveErrorSetting();
     this.loadVariableBundles();
     this.loadAvailableCoders();
@@ -603,7 +618,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
     this.distributionPreviewRefresh$.next();
   }
 
-  private loadDistributionPreview(): void {
+  private loadDistributionPreview(): Observable<DistributionCalculationResponse | null> {
     if (
       this.data.mode !== 'definition' ||
       this.codingJobForm.invalid ||
@@ -613,20 +628,15 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
         this.selectedVariableBundles.selected.length === 0
       )
     ) {
-      this.distributionPreviewSummary = null;
-      return;
+      return of(null);
     }
 
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
-      this.distributionPreviewSummary = null;
-      return;
+      return of(null);
     }
 
-    const requestId = this.distributionPreviewRequestId + 1;
-    this.distributionPreviewRequestId = requestId;
-
-    this.distributedCodingService.calculateDistribution(
+    return this.distributedCodingService.calculateDistribution(
       workspaceId,
       this.getSelectedDefinitionVariables(),
       this.mapCodersForDistribution(this.getSelectedCodersForDistribution()),
@@ -637,21 +647,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
       this.sanitizeNumber(this.codingJobForm.value.maxCodingCases),
       this.getDistributionSeed()
     )
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: preview => {
-          if (requestId !== this.distributionPreviewRequestId) {
-            return;
-          }
-
-          this.distributionPreviewSummary = this.buildDistributionPreviewSummary(preview);
-        },
-        error: () => {
-          if (requestId === this.distributionPreviewRequestId) {
-            this.distributionPreviewSummary = null;
-          }
-        }
-      });
+      .pipe(catchError(() => of(null)));
   }
 
   private buildDistributionPreviewSummary(

--- a/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-job-definition-dialog/coding-job-definition-dialog.component.ts
@@ -621,7 +621,7 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
   private loadDistributionPreview(): Observable<DistributionCalculationResponse | null> {
     if (
       this.data.mode !== 'definition' ||
-      this.codingJobForm.invalid ||
+      this.hasInvalidDistributionPreviewControls() ||
       this.selectedCoders.selected.length === 0 ||
       (
         this.selectedVariables.selected.length === 0 &&
@@ -648,6 +648,15 @@ export class CodingJobDefinitionDialogComponent implements OnInit, OnDestroy {
       this.getDistributionSeed()
     )
       .pipe(catchError(() => of(null)));
+  }
+
+  private hasInvalidDistributionPreviewControls(): boolean {
+    return [
+      'doubleCodingAbsolute',
+      'doubleCodingPercentage',
+      'caseOrderingMode',
+      'maxCodingCases'
+    ].some(controlName => this.codingJobForm.get(controlName)?.invalid);
   }
 
   private buildDistributionPreviewSummary(

--- a/apps/frontend/src/app/coding/services/distributed-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/distributed-coding.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { DistributedCodingService } from './distributed-coding.service';
 import { SERVER_URL } from '../../injection-tokens';
+import { SUPPRESS_GLOBAL_HTTP_ERROR } from '../../core/interceptors/http-error-context';
 
 describe('DistributedCodingService', () => {
   let service: DistributedCodingService;
@@ -46,6 +47,7 @@ describe('DistributedCodingService', () => {
 
     const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/calculate-distribution`);
     expect(req.request.method).toBe('POST');
+    expect(req.request.context.get(SUPPRESS_GLOBAL_HTTP_ERROR)).toBe(true);
     req.flush(mockRes);
   });
 
@@ -98,6 +100,7 @@ describe('DistributedCodingService', () => {
 
     const req = httpMock.expectOne(`${mockServerUrl}admin/workspace/1/coding/create-distributed-jobs`);
     expect(req.request.method).toBe('POST');
+    expect(req.request.context.get(SUPPRESS_GLOBAL_HTTP_ERROR)).toBe(false);
     expect(req.request.body).not.toHaveProperty('jobDefinitionId');
     req.flush(mockRes);
   });

--- a/apps/frontend/src/app/coding/services/distributed-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/distributed-coding.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, catchError, throwError } from 'rxjs';
 import { SERVER_URL } from '../../injection-tokens';
+import { suppressGlobalHttpErrorContext } from '../../core/interceptors/http-error-context';
 
 export type DistributionVariable = { unitName: string; variableId: string; includeDeriveError?: boolean };
 
@@ -172,7 +173,7 @@ export class DistributedCodingService {
     }>(
       `${this.serverUrl}admin/workspace/${workspaceId}/coding/calculate-distribution`,
       body,
-      {}
+      { context: suppressGlobalHttpErrorContext() }
     )
       .pipe(
         catchError(error => throwError(() => new Error(this.getErrorMessage(error))))


### PR DESCRIPTION
## Zusammenfassung

Die Verteilungsvorschau beim Bearbeiten einer Kodierjob-Definition wird gegen Anfragefluten und Ressourcenengpässe abgesichert.

Refs #959

## Ursache

Mehrere schnell aufeinanderfolgende Formularänderungen starteten jeweils eine neue, rechen- und speicherintensive Verteilungsberechnung. Bereits überholte Anfragen liefen weiter und der Server begrenzte weder parallele Berechnungen noch wartende Anfragen. Dadurch konnten sich Berechnungen aufstauen und bei knappem Shared Memory als Serien von HTTP-500-Fehlern sichtbar werden.

## Änderungen

- bündelt verteilungsrelevante Formularänderungen mit 300 ms Verzögerung
- bricht überholte Client-Anfragen ab
- berechnet nur bei Feldern neu, die die Verteilung beeinflussen
- begrenzt serverseitig auf zwei aktive und acht wartende Berechnungen
- beantwortet weitere Anfragen kontrolliert mit HTTP 429
- entfernt getrennte Verbindungen aus der Warteschlange
- protokolliert aktive, wartende, abgelehnte und abgebrochene Berechnungen
- unterdrückt globale Fehlermeldungen ausschließlich für die optionale Vorschau
- lässt Fehler beim tatsächlichen Erstellen von Kodierjobs weiterhin global sichtbar

## Auswirkungen und Datenintegrität

Der betroffene Endpunkt berechnet eine Vorschau und schreibt keine Job-Definitionen oder Kodierungen. Es gibt daher keinen Hinweis auf verfälschte oder verlorene Daten. Die Änderungen reduzieren Lastspitzen und verhindern irreführende globale Fehlerdialoge bei erwartbaren Vorschaufehlern.

## Prüfung

- Frontend-Tests: 202 Testsuiten und 2.011 Tests erfolgreich
- Frontend-Lint erfolgreich
- Frontend-Produktions-Build erfolgreich
- Backend-Tests: 164 Testsuiten und 2.405 Tests erfolgreich; 2 Testsuiten und 10 Tests übersprungen
- Backend-Lint erfolgreich
- Backend-Build erfolgreich
