### PR TITLE
Fix export worker recovery and stale jobs

### DIFF
--- a/api-dto/coding/export-request.dto.ts
+++ b/api-dto/coding/export-request.dto.ts
@@ -102,14 +102,14 @@ export type ExportJobErrorMetadataDto =
   | ExportJobWithoutStructuredErrorDto;
 
 export type ExportJobProgressPhaseDto =
-  | 'preparing'
+  'preparing'
   | 'counting'
   | 'writing'
   | 'finalizing'
   | 'completed';
 
 export type ExportJobStateDto =
-  | 'pending'
+  'pending'
   | 'processing'
   | 'completed'
   | 'failed'
@@ -159,7 +159,7 @@ export interface ExportJobStatusErrorDto {
 }
 
 export type ExportJobStatusResponseDto =
-  | ExportJobStatusDto
+  ExportJobStatusDto
   | ExportJobStatusErrorDto;
 
 export interface ItemDatasetSelection {
@@ -188,7 +188,7 @@ export type ItemDatasetMappingIssueCode =
   | 'unknown-selection';
 
 export type ItemDatasetMappingWarningCode =
-  | 'vomd-fallback-used'
+  'vomd-fallback-used'
   | 'vomd-fallback-ignored';
 
 interface ItemDatasetMappingDiagnosticDto {
@@ -374,8 +374,8 @@ export const parseExportRequest = (value: unknown): BackgroundExportRequest => {
       assertOptionalTabularFormat(value, value.exportType);
       assertOptionalVersion(value, value.exportType);
       if (
-        (!Number.isSafeInteger(value.missingsProfileId) ||
-          Number(value.missingsProfileId) <= 0)
+        !Number.isSafeInteger(value.missingsProfileId) ||
+        Number(value.missingsProfileId) <= 0
       ) {
         throw new ExportRequestValidationError(
           'results-by-version exports require missingsProfileId to be a positive integer'
@@ -429,7 +429,8 @@ export const parseExportRequest = (value: unknown): BackgroundExportRequest => {
       }
       if (
         value.recodeTrailingOmissions === true &&
-        (value.notReachedScope === undefined || value.notReachedScope === 'unit')
+        (value.notReachedScope === undefined ||
+          value.notReachedScope === 'unit')
       ) {
         throw new ExportRequestValidationError(
           'item-matrix recodeTrailingOmissions is supported only for testlet or booklet scope'
@@ -438,13 +439,14 @@ export const parseExportRequest = (value: unknown): BackgroundExportRequest => {
       if (
         value.items !== undefined &&
         (!Array.isArray(value.items) ||
-          value.items.some(item => (
-            !isRecord(item) ||
-            typeof item.unitId !== 'string' ||
-            item.unitId.trim() === '' ||
-            typeof item.itemId !== 'string' ||
-            item.itemId.trim() === ''
-          )))
+          value.items.some(
+            (item) =>
+              !isRecord(item) ||
+              typeof item.unitId !== 'string' ||
+              item.unitId.trim() === '' ||
+              typeof item.itemId !== 'string' ||
+              item.itemId.trim() === ''
+          ))
       ) {
         throw new ExportRequestValidationError(
           'item-matrix items must contain valid unitId/itemId pairs'

--- a/api-dto/coding/export-request.dto.ts
+++ b/api-dto/coding/export-request.dto.ts
@@ -16,6 +16,24 @@ export const BACKGROUND_EXPORT_TYPES = [
 ] as const;
 
 export type BackgroundExportType = (typeof BACKGROUND_EXPORT_TYPES)[number];
+export const CODING_EXPORT_TYPES = [
+  'aggregated',
+  'by-coder',
+  'by-variable',
+  'by-variable-compact',
+  'detailed',
+  'coding-times',
+  'results-by-version',
+  'coding-list',
+  'item-matrix',
+  'psychometrics'
+] as const satisfies readonly BackgroundExportType[];
+export type CodingExportType = (typeof CODING_EXPORT_TYPES)[number];
+export const isCodingExportType = (
+  value: unknown
+): value is CodingExportType =>
+  typeof value === 'string' &&
+  (CODING_EXPORT_TYPES as readonly string[]).includes(value);
 export type ExportVersion = 'v1' | 'v2' | 'v3';
 export type ExportFormat = 'csv' | 'json' | 'excel';
 export type ItemDatasetNotReachedScope = 'unit' | 'testlet' | 'booklet';
@@ -106,6 +124,7 @@ export interface ExportJobResultDto {
   userId: number;
   exportType: string;
   createdAt: number;
+  expiresAt: number;
 }
 
 export interface ExportJobStatusBaseDto {
@@ -121,6 +140,19 @@ export interface ExportJobStatusBaseDto {
 
 export type ExportJobStatusDto =
   ExportJobStatusBaseDto & ExportJobErrorMetadataDto;
+
+export type ExportJobDisplayVariantDto =
+  | 'manual-review-most-frequent'
+  | 'manual-review-new-column-per-coder'
+  | 'manual-review-new-row-per-variable'
+  | 'manual-review-by-variable-compact';
+
+export type ExportJobListItemDto = ExportJobStatusDto & {
+  jobId: string;
+  exportType: CodingExportType;
+  createdAt: number;
+  displayVariant?: ExportJobDisplayVariantDto;
+};
 
 export interface ExportJobStatusErrorDto {
   error: string;

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { BadRequestException } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { WorkspaceCodingExportController } from './workspace-coding-export.controller';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
@@ -50,7 +50,7 @@ const createController = (
 
 const requestForUser = (userId = 2): Request => ({
   user: { id: userId }
-} as unknown as Request);
+}) as unknown as Request;
 
 const createWritableResponse = () => {
   const res = new PassThrough() as PassThrough & {
@@ -1073,6 +1073,40 @@ describe('WorkspaceCodingExportController', () => {
       .toHaveBeenCalledWith('lease-1');
   });
 
+  it('propagates transient lease refresh failures for HTTP retry handling', async () => {
+    const jobQueueService = {
+      getExportJob: jest.fn().mockResolvedValue({
+        data: {
+          workspaceId: 5,
+          userId: 2,
+          exportType: 'detailed',
+          clientLeaseId: 'lease-1'
+        },
+        getState: jest.fn().mockResolvedValue('active'),
+        progress: jest.fn().mockResolvedValue(50)
+      })
+    };
+    const exportJobClientLeaseService = {
+      createLease: jest.fn(),
+      refreshLease: jest.fn().mockRejectedValue(new Error('redis unavailable')),
+      releaseLease: jest.fn(),
+      isLeaseActive: jest.fn()
+    } as unknown as ExportJobClientLeaseService;
+    const controller = createController(
+      {} as CodingListExportService,
+      {} as CodingExportService,
+      {} as CodingExportOrchestratorService,
+      jobQueueService as unknown as JobQueueService,
+      {} as CacheService,
+      codingPsychometricExportServiceMock,
+      exportJobClientLeaseService
+    );
+
+    await expect(
+      controller.getExportJobStatus(5, 'job-1', requestForUser())
+    ).rejects.toThrow('redis unavailable');
+  });
+
   it('reports cancellation-marked export jobs as cancelled', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
@@ -1204,35 +1238,38 @@ describe('WorkspaceCodingExportController', () => {
 
   it('maps cancelled export jobs consistently in the job list', async () => {
     const jobQueueService = {
-      getExportJobs: jest.fn().mockResolvedValue([
-        {
-          id: 'active-cancelled',
-          data: {
-            workspaceId: 5,
-            userId: 2,
-            exportType: 'coding-list',
-            isCancelled: true
+      getExportJobsWithHistoryState: jest.fn().mockResolvedValue({
+        jobs: [
+          {
+            id: 'active-cancelled',
+            data: {
+              workspaceId: 5,
+              userId: 2,
+              exportType: 'coding-list',
+              isCancelled: true
+            },
+            timestamp: 100,
+            getState: jest.fn().mockResolvedValue('active'),
+            progress: jest.fn().mockResolvedValue(55)
           },
-          timestamp: 100,
-          getState: jest.fn().mockResolvedValue('active'),
-          progress: jest.fn().mockResolvedValue(55)
-        },
-        {
-          id: 'failed-cancelled',
-          data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
-          timestamp: 101,
-          failedReason: 'Export job failed-cancelled was cancelled',
-          getState: jest.fn().mockResolvedValue('failed'),
-          progress: jest.fn().mockResolvedValue(20)
-        },
-        {
-          id: 'waiting-job',
-          data: { workspaceId: 5, userId: 2, exportType: 'by-variable' },
-          timestamp: 102,
-          getState: jest.fn().mockResolvedValue('waiting'),
-          progress: jest.fn().mockResolvedValue(0)
-        }
-      ])
+          {
+            id: 'failed-cancelled',
+            data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
+            timestamp: 101,
+            failedReason: 'Export job failed-cancelled was cancelled',
+            getState: jest.fn().mockResolvedValue('failed'),
+            progress: jest.fn().mockResolvedValue(20)
+          },
+          {
+            id: 'waiting-job',
+            data: { workspaceId: 5, userId: 2, exportType: 'by-variable' },
+            timestamp: 102,
+            getState: jest.fn().mockResolvedValue('waiting'),
+            progress: jest.fn().mockResolvedValue(0)
+          }
+        ],
+        historyPending: false
+      })
     };
     const controller = createController(
       {} as CodingListExportService,
@@ -1243,7 +1280,9 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobs(5, requestForUser())).resolves.toEqual([
+    const response = createWritableResponse();
+    await expect(controller.getExportJobs(5, requestForUser(), response as unknown as Response
+    )).resolves.toEqual([
       {
         jobId: 'active-cancelled',
         status: 'cancelled',
@@ -1257,8 +1296,19 @@ describe('WorkspaceCodingExportController', () => {
         progress: 20,
         exportType: 'detailed',
         createdAt: 101
+      },
+      {
+        jobId: 'waiting-job',
+        status: 'pending',
+        progress: 0,
+        exportType: 'by-variable',
+        createdAt: 102
       }
     ]);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      'X-Export-History-Pending',
+      'false'
+    );
   });
 
   it('lists only export jobs owned by the authenticated user', async () => {
@@ -1275,10 +1325,13 @@ describe('WorkspaceCodingExportController', () => {
       progress: jest.fn().mockResolvedValue(20)
     });
     const jobQueueService = {
-      getExportJobs: jest.fn().mockResolvedValue([
-        createFailedJob('own-job', 2),
-        createFailedJob('other-job', 3)
-      ])
+      getExportJobsWithHistoryState: jest.fn().mockResolvedValue({
+        jobs: [
+          createFailedJob('own-job', 2),
+          createFailedJob('other-job', 3)
+        ],
+        historyPending: false
+      })
     };
     const controller = createController(
       {} as CodingListExportService,
@@ -1291,7 +1344,7 @@ describe('WorkspaceCodingExportController', () => {
 
     const jobs = await controller.getExportJobs(5, requestForUser(2));
 
-    expect(jobQueueService.getExportJobs).toHaveBeenCalledWith(
+    expect(jobQueueService.getExportJobsWithHistoryState).toHaveBeenCalledWith(
       5,
       2,
       expect.arrayContaining(['coding-list', 'item-matrix'])
@@ -1348,33 +1401,36 @@ describe('WorkspaceCodingExportController', () => {
 
   it('returns display variants for manual coding exports', async () => {
     const jobQueueService = {
-      getExportJobs: jest.fn().mockResolvedValue([
-        {
-          id: 'manual-aggregated',
-          data: {
-            workspaceId: 5,
-            userId: 2,
-            exportType: 'aggregated',
-            excludeAutoCoded: true,
-            doubleCodingMethod: 'new-column-per-coder'
+      getExportJobsWithHistoryState: jest.fn().mockResolvedValue({
+        jobs: [
+          {
+            id: 'manual-aggregated',
+            data: {
+              workspaceId: 5,
+              userId: 2,
+              exportType: 'aggregated',
+              excludeAutoCoded: true,
+              doubleCodingMethod: 'new-column-per-coder'
+            },
+            timestamp: 100,
+            getState: jest.fn().mockResolvedValue('failed'),
+            progress: jest.fn().mockResolvedValue(80)
           },
-          timestamp: 100,
-          getState: jest.fn().mockResolvedValue('failed'),
-          progress: jest.fn().mockResolvedValue(80)
-        },
-        {
-          id: 'manual-compact',
-          data: {
-            workspaceId: 5,
-            userId: 2,
-            exportType: 'by-variable-compact',
-            excludeAutoCoded: true
-          },
-          timestamp: 101,
-          getState: jest.fn().mockResolvedValue('failed'),
-          progress: jest.fn().mockResolvedValue(80)
-        }
-      ])
+          {
+            id: 'manual-compact',
+            data: {
+              workspaceId: 5,
+              userId: 2,
+              exportType: 'by-variable-compact',
+              excludeAutoCoded: true
+            },
+            timestamp: 101,
+            getState: jest.fn().mockResolvedValue('failed'),
+            progress: jest.fn().mockResolvedValue(80)
+          }
+        ],
+        historyPending: false
+      })
     };
     const controller = createController(
       {} as CodingListExportService,
@@ -1399,15 +1455,18 @@ describe('WorkspaceCodingExportController', () => {
 
   it('returns structured item matrix error details in the job list', async () => {
     const jobQueueService = {
-      getExportJobs: jest.fn().mockResolvedValue([{
-        id: 'failed-matrix',
-        data: { workspaceId: 5, userId: 2, exportType: 'item-matrix' },
-        timestamp: 100,
-        failedReason:
+      getExportJobsWithHistoryState: jest.fn().mockResolvedValue({
+        jobs: [{
+          id: 'failed-matrix',
+          data: { workspaceId: 5, userId: 2, exportType: 'item-matrix' },
+          timestamp: 100,
+          failedReason:
           'ITEM_MATRIX_UNRESOLVED_CELLS:2 Itemdatensatz enthält 2 nicht exportierbare Zellen.',
-        getState: jest.fn().mockResolvedValue('failed'),
-        progress: jest.fn().mockResolvedValue(90)
-      }])
+          getState: jest.fn().mockResolvedValue('failed'),
+          progress: jest.fn().mockResolvedValue(90)
+        }],
+        historyPending: false
+      })
     };
     const cacheService = {
       get: jest.fn()
@@ -1458,23 +1517,26 @@ describe('WorkspaceCodingExportController', () => {
 
   it('omits completed jobs whose artifacts have expired', async () => {
     const jobQueueService = {
-      getExportJobs: jest.fn().mockResolvedValue([{
-        id: 'completed-expired',
-        data: { workspaceId: 5, userId: 2, exportType: 'aggregated' },
-        timestamp: 100,
-        getState: jest.fn().mockResolvedValue('completed'),
-        progress: jest.fn().mockResolvedValue(100),
-        returnvalue: {
-          fileId: 'completed-expired',
-          fileName: 'export.xlsx',
-          filePath: '/expired/export.xlsx',
-          fileSize: 10,
-          workspaceId: 5,
-          userId: 2,
-          exportType: 'aggregated',
-          createdAt: 100
-        }
-      }])
+      getExportJobsWithHistoryState: jest.fn().mockResolvedValue({
+        jobs: [{
+          id: 'completed-expired',
+          data: { workspaceId: 5, userId: 2, exportType: 'aggregated' },
+          timestamp: 100,
+          getState: jest.fn().mockResolvedValue('completed'),
+          progress: jest.fn().mockResolvedValue(100),
+          returnvalue: {
+            fileId: 'completed-expired',
+            fileName: 'export.xlsx',
+            filePath: '/expired/export.xlsx',
+            fileSize: 10,
+            workspaceId: 5,
+            userId: 2,
+            exportType: 'aggregated',
+            createdAt: 100
+          }
+        }],
+        historyPending: false
+      })
     };
     const cacheService = {
       get: jest.fn().mockResolvedValue(undefined)

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
@@ -1291,6 +1291,11 @@ describe('WorkspaceCodingExportController', () => {
 
     const jobs = await controller.getExportJobs(5, requestForUser(2));
 
+    expect(jobQueueService.getExportJobs).toHaveBeenCalledWith(
+      5,
+      2,
+      expect.arrayContaining(['coding-list', 'item-matrix'])
+    );
     expect(jobs.map(job => job.jobId)).toEqual(['own-job']);
   });
 

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { BadRequestException } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { Request } from 'express';
 import { WorkspaceCodingExportController } from './workspace-coding-export.controller';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { WorkspaceGuard } from './workspace.guard';
@@ -14,7 +15,8 @@ import {
   CodingExportOrchestratorService,
   CodingListExportService,
   CodingPsychometricExportService,
-  ExportArtifactService
+  ExportArtifactService,
+  ExportJobClientLeaseService
 } from '../../database/services/coding';
 import { JobQueueService } from '../../job-queue/job-queue.service';
 import { CacheService } from '../../cache/cache.service';
@@ -29,15 +31,26 @@ const createController = (
   codingExportOrchestratorService: CodingExportOrchestratorService,
   jobQueueService: JobQueueService,
   cacheService: CacheService,
-  codingPsychometricExportService: CodingPsychometricExportService
+  codingPsychometricExportService: CodingPsychometricExportService,
+  exportJobClientLeaseService: ExportJobClientLeaseService = {
+    createLease: jest.fn().mockResolvedValue('client-lease'),
+    refreshLease: jest.fn().mockResolvedValue(undefined),
+    releaseLease: jest.fn().mockResolvedValue(undefined),
+    isLeaseActive: jest.fn().mockResolvedValue(true)
+  } as unknown as ExportJobClientLeaseService
 ): WorkspaceCodingExportController => new WorkspaceCodingExportController(
   codingListExportService,
   codingExportService,
   codingExportOrchestratorService,
   jobQueueService,
   codingPsychometricExportService,
-  new ExportArtifactService(cacheService)
+  new ExportArtifactService(cacheService),
+  exportJobClientLeaseService
 );
+
+const requestForUser = (userId = 2): Request => ({
+  user: { id: userId }
+} as unknown as Request);
 
 const createWritableResponse = () => {
   const res = new PassThrough() as PassThrough & {
@@ -212,7 +225,7 @@ describe('WorkspaceCodingExportController', () => {
     res.json = jest.fn();
 
     try {
-      await controller.downloadExport('1', 5, res as never);
+      await controller.downloadExport('1', 5, res as never, requestForUser());
 
       expect(res.setHeader).toHaveBeenCalledWith(
         'Content-Type',
@@ -390,7 +403,8 @@ describe('WorkspaceCodingExportController', () => {
     expect(jobQueueService.addExportJob).toHaveBeenCalledWith({
       exportType: 'detailed',
       workspaceId: 5,
-      userId: 2
+      userId: 2,
+      clientLeaseId: 'client-lease'
     });
   });
 
@@ -596,7 +610,7 @@ describe('WorkspaceCodingExportController', () => {
     };
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, exportType: 'detailed' },
+        data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
         getState: jest.fn().mockResolvedValue('completed'),
         progress: jest.fn().mockResolvedValue(100),
         returnvalue: artifact
@@ -615,7 +629,11 @@ describe('WorkspaceCodingExportController', () => {
     );
 
     try {
-      const status = await controller.getExportJobStatus(5, 'job-1');
+      const status = await controller.getExportJobStatus(
+        5,
+        'job-1',
+        requestForUser()
+      );
 
       expect(status).toEqual({
         status: 'completed',
@@ -642,7 +660,7 @@ describe('WorkspaceCodingExportController', () => {
       'Der Export enthaelt 2578 Unit-Variable-Kombinationen und ueberschreitet das konfigurierte Limit von 1000 Tabellenblaettern.';
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, exportType: 'by-variable' },
+        data: { workspaceId: 5, userId: 2, exportType: 'by-variable' },
         getState: jest.fn().mockResolvedValue('failed'),
         progress: jest.fn().mockResolvedValue(20),
         failedReason
@@ -657,7 +675,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobStatus(5, 'job-1')).resolves.toEqual({
+    await expect(controller.getExportJobStatus(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       status: 'failed',
       progress: 20,
       error: failedReason,
@@ -688,7 +710,7 @@ describe('WorkspaceCodingExportController', () => {
     };
     const job = {
       id: 'job-1',
-      data: { workspaceId: 5, exportType: 'item-matrix' },
+      data: { workspaceId: 5, userId: 2, exportType: 'item-matrix' },
       getState: jest.fn().mockResolvedValue('failed'),
       progress: jest.fn().mockResolvedValue(90),
       failedReason:
@@ -731,7 +753,11 @@ describe('WorkspaceCodingExportController', () => {
     );
 
     try {
-      const status = await controller.getExportJobStatus(5, 'job-1');
+      const status = await controller.getExportJobStatus(
+        5,
+        'job-1',
+        requestForUser()
+      );
       expect(status).toEqual(expect.objectContaining({
         status: 'failed',
         errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
@@ -744,12 +770,21 @@ describe('WorkspaceCodingExportController', () => {
         })
       }));
       await expect(
-        controller.getItemMatrixExportDiagnostics(5, 'job-1')
+        controller.getItemMatrixExportDiagnostics(
+          5,
+          'job-1',
+          requestForUser()
+        )
       ).resolves.toEqual(diagnostics);
 
       const res = createWritableResponse();
       res.resume();
-      await controller.downloadIncompleteItemMatrix(5, 'job-1', res as never);
+      await controller.downloadIncompleteItemMatrix(
+        5,
+        'job-1',
+        res as never,
+        requestForUser()
+      );
       expect(res.setHeader).toHaveBeenCalledWith(
         'Content-Type',
         'application/zip'
@@ -766,7 +801,7 @@ describe('WorkspaceCodingExportController', () => {
   it('rejects diagnostics for wrong workspaces, job types and expired data', async () => {
     const job = {
       id: 'job-1',
-      data: { workspaceId: 5, exportType: 'item-matrix' },
+      data: { workspaceId: 5, userId: 2, exportType: 'item-matrix' },
       getState: jest.fn().mockResolvedValue('failed')
     };
     const jobQueueService = {
@@ -785,17 +820,17 @@ describe('WorkspaceCodingExportController', () => {
     );
 
     await expect(
-      controller.getItemMatrixExportDiagnostics(6, 'job-1')
+      controller.getItemMatrixExportDiagnostics(6, 'job-1', requestForUser())
     ).rejects.toThrow('Access denied');
 
     job.data.exportType = 'detailed';
     await expect(
-      controller.getItemMatrixExportDiagnostics(5, 'job-1')
+      controller.getItemMatrixExportDiagnostics(5, 'job-1', requestForUser())
     ).rejects.toThrow('only for failed item matrix exports');
 
     job.data.exportType = 'item-matrix';
     await expect(
-      controller.getItemMatrixExportDiagnostics(5, 'job-1')
+      controller.getItemMatrixExportDiagnostics(5, 'job-1', requestForUser())
     ).rejects.toThrow('not found or expired');
   });
 
@@ -809,7 +844,7 @@ describe('WorkspaceCodingExportController', () => {
     fs.writeFileSync(incompletePath, 'incomplete');
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, exportType: 'item-matrix' }
+        data: { workspaceId: 5, userId: 2, exportType: 'item-matrix' }
       }),
       deleteExportJob: jest.fn().mockResolvedValue(true)
     };
@@ -831,7 +866,11 @@ describe('WorkspaceCodingExportController', () => {
     );
 
     try {
-      await expect(controller.deleteExportJob(5, 'job-1')).resolves.toEqual({
+      await expect(controller.deleteExportJob(
+        5,
+        'job-1',
+        requestForUser()
+      )).resolves.toEqual({
         success: true,
         message: 'Export job deleted successfully'
       });
@@ -867,7 +906,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.deleteExportJob(5, 'missing')).resolves.toEqual({
+    await expect(controller.deleteExportJob(
+      5,
+      'missing',
+      requestForUser()
+    )).resolves.toEqual({
       success: true,
       message: 'Export job already deleted'
     });
@@ -879,7 +922,7 @@ describe('WorkspaceCodingExportController', () => {
   it('keeps the export job when an artifact file cannot be deleted', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, exportType: 'item-matrix' }
+        data: { workspaceId: 5, userId: 2, exportType: 'item-matrix' }
       }),
       deleteExportJob: jest.fn().mockResolvedValue(true)
     };
@@ -902,7 +945,11 @@ describe('WorkspaceCodingExportController', () => {
     );
 
     try {
-      await expect(controller.deleteExportJob(5, 'job-1')).resolves.toEqual({
+      await expect(controller.deleteExportJob(
+        5,
+        'job-1',
+        requestForUser()
+      )).resolves.toEqual({
         success: false,
         message: 'file is busy'
       });
@@ -916,7 +963,7 @@ describe('WorkspaceCodingExportController', () => {
   it('keeps the export job when artifact cache cleanup is incomplete', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, exportType: 'item-matrix' }
+        data: { workspaceId: 5, userId: 2, exportType: 'item-matrix' }
       }),
       deleteExportJob: jest.fn().mockResolvedValue(true)
     };
@@ -936,7 +983,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.deleteExportJob(5, 'job-1')).resolves.toEqual({
+    await expect(controller.deleteExportJob(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       success: false,
       message: 'Export artifacts could not be deleted completely'
     });
@@ -947,7 +998,7 @@ describe('WorkspaceCodingExportController', () => {
   it('normalizes structured export progress details in job status', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, exportType: 'detailed' },
+        data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
         getState: jest.fn().mockResolvedValue('active'),
         progress: jest.fn().mockResolvedValue({
           percentage: 57.4,
@@ -967,7 +1018,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobStatus(5, 'job-1')).resolves.toEqual({
+    await expect(controller.getExportJobStatus(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       status: 'processing',
       progress: 57,
       progressPhase: 'writing',
@@ -977,11 +1032,53 @@ describe('WorkspaceCodingExportController', () => {
     });
   });
 
+  it('refreshes the client lease while an owned export is active', async () => {
+    const jobQueueService = {
+      getExportJob: jest.fn().mockResolvedValue({
+        data: {
+          workspaceId: 5,
+          userId: 2,
+          exportType: 'detailed',
+          clientLeaseId: 'lease-1'
+        },
+        getState: jest.fn().mockResolvedValue('active'),
+        progress: jest.fn().mockResolvedValue(50)
+      })
+    };
+    const exportJobClientLeaseService = {
+      createLease: jest.fn(),
+      refreshLease: jest.fn().mockResolvedValue(undefined),
+      releaseLease: jest.fn(),
+      isLeaseActive: jest.fn()
+    } as unknown as ExportJobClientLeaseService;
+    const controller = createController(
+      {} as CodingListExportService,
+      {} as CodingExportService,
+      {} as CodingExportOrchestratorService,
+      jobQueueService as unknown as JobQueueService,
+      {} as CacheService,
+      codingPsychometricExportServiceMock,
+      exportJobClientLeaseService
+    );
+
+    await expect(controller.getExportJobStatus(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
+      status: 'processing',
+      progress: 50
+    });
+    expect(exportJobClientLeaseService.refreshLease)
+      .toHaveBeenCalledWith('lease-1');
+  });
+
   it('reports cancellation-marked export jobs as cancelled', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
         data: {
           workspaceId: 5,
+          userId: 2,
           exportType: 'detailed',
           isCancelled: true
         },
@@ -998,7 +1095,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobStatus(5, 'job-1')).resolves.toEqual({
+    await expect(controller.getExportJobStatus(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       status: 'cancelled',
       progress: 55
     });
@@ -1007,7 +1108,7 @@ describe('WorkspaceCodingExportController', () => {
   it('maps stuck export jobs to the public pending state', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, exportType: 'detailed' },
+        data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
         getState: jest.fn().mockResolvedValue('stuck'),
         progress: jest.fn().mockResolvedValue(0)
       })
@@ -1021,7 +1122,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobStatus(5, 'job-1')).resolves.toEqual({
+    await expect(controller.getExportJobStatus(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       status: 'pending',
       progress: 0
     });
@@ -1032,6 +1137,7 @@ describe('WorkspaceCodingExportController', () => {
       getExportJob: jest.fn().mockResolvedValue({
         data: {
           workspaceId: 5,
+          userId: 2,
           exportType: 'detailed',
           isCancelled: true
         },
@@ -1058,7 +1164,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobStatus(5, 'job-1')).resolves.toEqual({
+    await expect(controller.getExportJobStatus(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       status: 'cancelled',
       progress: 21
     });
@@ -1067,7 +1177,7 @@ describe('WorkspaceCodingExportController', () => {
   it('reports failed export jobs caused by cancellation as cancelled', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, exportType: 'detailed' },
+        data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
         getState: jest.fn().mockResolvedValue('failed'),
         progress: jest.fn().mockResolvedValue(20),
         failedReason: 'Export job job-1 was cancelled'
@@ -1082,7 +1192,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobStatus(5, 'job-1')).resolves.toEqual({
+    await expect(controller.getExportJobStatus(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       status: 'cancelled',
       progress: 20
     });
@@ -1095,6 +1209,7 @@ describe('WorkspaceCodingExportController', () => {
           id: 'active-cancelled',
           data: {
             workspaceId: 5,
+            userId: 2,
             exportType: 'coding-list',
             isCancelled: true
           },
@@ -1104,7 +1219,7 @@ describe('WorkspaceCodingExportController', () => {
         },
         {
           id: 'failed-cancelled',
-          data: { workspaceId: 5, exportType: 'detailed' },
+          data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
           timestamp: 101,
           failedReason: 'Export job failed-cancelled was cancelled',
           getState: jest.fn().mockResolvedValue('failed'),
@@ -1112,7 +1227,7 @@ describe('WorkspaceCodingExportController', () => {
         },
         {
           id: 'waiting-job',
-          data: { workspaceId: 5, exportType: 'by-variable' },
+          data: { workspaceId: 5, userId: 2, exportType: 'by-variable' },
           timestamp: 102,
           getState: jest.fn().mockResolvedValue('waiting'),
           progress: jest.fn().mockResolvedValue(0)
@@ -1128,7 +1243,7 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobs(5)).resolves.toEqual([
+    await expect(controller.getExportJobs(5, requestForUser())).resolves.toEqual([
       {
         jobId: 'active-cancelled',
         status: 'cancelled',
@@ -1142,15 +1257,88 @@ describe('WorkspaceCodingExportController', () => {
         progress: 20,
         exportType: 'detailed',
         createdAt: 101
-      },
-      {
-        jobId: 'waiting-job',
-        status: 'pending',
-        progress: 0,
-        exportType: 'by-variable',
-        createdAt: 102
       }
     ]);
+  });
+
+  it('lists only export jobs owned by the authenticated user', async () => {
+    const createFailedJob = (id: string, userId: number) => ({
+      id,
+      data: {
+        workspaceId: 5,
+        userId,
+        exportType: 'detailed'
+      },
+      timestamp: 100,
+      failedReason: 'failed',
+      getState: jest.fn().mockResolvedValue('failed'),
+      progress: jest.fn().mockResolvedValue(20)
+    });
+    const jobQueueService = {
+      getExportJobs: jest.fn().mockResolvedValue([
+        createFailedJob('own-job', 2),
+        createFailedJob('other-job', 3)
+      ])
+    };
+    const controller = createController(
+      {} as CodingListExportService,
+      {} as CodingExportService,
+      {} as CodingExportOrchestratorService,
+      jobQueueService as unknown as JobQueueService,
+      {} as CacheService,
+      codingPsychometricExportServiceMock
+    );
+
+    const jobs = await controller.getExportJobs(5, requestForUser(2));
+
+    expect(jobs.map(job => job.jobId)).toEqual(['own-job']);
+  });
+
+  it('rejects status, cancellation and deletion for another user job', async () => {
+    const job = {
+      data: { workspaceId: 5, userId: 3, exportType: 'detailed' },
+      getState: jest.fn()
+    };
+    const jobQueueService = {
+      getExportJob: jest.fn().mockResolvedValue(job),
+      markExportJobCancelled: jest.fn(),
+      cancelExportJob: jest.fn(),
+      deleteExportJob: jest.fn()
+    };
+    const controller = createController(
+      {} as CodingListExportService,
+      {} as CodingExportService,
+      {} as CodingExportOrchestratorService,
+      jobQueueService as unknown as JobQueueService,
+      {} as CacheService,
+      codingPsychometricExportServiceMock
+    );
+
+    await expect(controller.getExportJobStatus(
+      5,
+      'other-job',
+      requestForUser(2)
+    )).resolves.toEqual({ error: 'Access denied to this export' });
+    await expect(controller.cancelExportJob(
+      5,
+      'other-job',
+      requestForUser(2)
+    )).resolves.toEqual({
+      success: false,
+      message: 'Access denied to this export'
+    });
+    await expect(controller.deleteExportJob(
+      5,
+      'other-job',
+      requestForUser(2)
+    )).resolves.toEqual({
+      success: false,
+      message: 'Access denied to this export'
+    });
+    expect(job.getState).not.toHaveBeenCalled();
+    expect(jobQueueService.markExportJobCancelled).not.toHaveBeenCalled();
+    expect(jobQueueService.cancelExportJob).not.toHaveBeenCalled();
+    expect(jobQueueService.deleteExportJob).not.toHaveBeenCalled();
   });
 
   it('returns display variants for manual coding exports', async () => {
@@ -1160,24 +1348,26 @@ describe('WorkspaceCodingExportController', () => {
           id: 'manual-aggregated',
           data: {
             workspaceId: 5,
+            userId: 2,
             exportType: 'aggregated',
             excludeAutoCoded: true,
             doubleCodingMethod: 'new-column-per-coder'
           },
           timestamp: 100,
-          getState: jest.fn().mockResolvedValue('waiting'),
-          progress: jest.fn().mockResolvedValue(0)
+          getState: jest.fn().mockResolvedValue('failed'),
+          progress: jest.fn().mockResolvedValue(80)
         },
         {
           id: 'manual-compact',
           data: {
             workspaceId: 5,
+            userId: 2,
             exportType: 'by-variable-compact',
             excludeAutoCoded: true
           },
           timestamp: 101,
-          getState: jest.fn().mockResolvedValue('waiting'),
-          progress: jest.fn().mockResolvedValue(0)
+          getState: jest.fn().mockResolvedValue('failed'),
+          progress: jest.fn().mockResolvedValue(80)
         }
       ])
     };
@@ -1190,7 +1380,7 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobs(5)).resolves.toEqual([
+    await expect(controller.getExportJobs(5, requestForUser())).resolves.toEqual([
       expect.objectContaining({
         jobId: 'manual-aggregated',
         displayVariant: 'manual-review-new-column-per-coder'
@@ -1206,7 +1396,7 @@ describe('WorkspaceCodingExportController', () => {
     const jobQueueService = {
       getExportJobs: jest.fn().mockResolvedValue([{
         id: 'failed-matrix',
-        data: { workspaceId: 5, exportType: 'item-matrix' },
+        data: { workspaceId: 5, userId: 2, exportType: 'item-matrix' },
         timestamp: 100,
         failedReason:
           'ITEM_MATRIX_UNRESOLVED_CELLS:2 Itemdatensatz enthält 2 nicht exportierbare Zellen.',
@@ -1241,7 +1431,7 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobs(5)).resolves.toEqual([{
+    await expect(controller.getExportJobs(5, requestForUser())).resolves.toEqual([{
       jobId: 'failed-matrix',
       status: 'failed',
       progress: 90,
@@ -1265,7 +1455,7 @@ describe('WorkspaceCodingExportController', () => {
     const jobQueueService = {
       getExportJobs: jest.fn().mockResolvedValue([{
         id: 'completed-expired',
-        data: { workspaceId: 5, exportType: 'aggregated' },
+        data: { workspaceId: 5, userId: 2, exportType: 'aggregated' },
         timestamp: 100,
         getState: jest.fn().mockResolvedValue('completed'),
         progress: jest.fn().mockResolvedValue(100),
@@ -1293,12 +1483,12 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobs(5)).resolves.toEqual([]);
+    await expect(controller.getExportJobs(5, requestForUser())).resolves.toEqual([]);
   });
 
   it('does not clean up cached export metadata when cancelling coding export jobs', async () => {
     const job = {
-      data: { workspaceId: 5, exportType: 'detailed' },
+      data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
       getState: jest.fn().mockResolvedValue('active')
     };
     const jobQueueService = {
@@ -1319,7 +1509,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.cancelExportJob(5, 'job-1')).resolves.toEqual({
+    await expect(controller.cancelExportJob(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       success: true,
       message:
         'Export job cancellation requested (job will stop at next checkpoint)'
@@ -1336,6 +1530,7 @@ describe('WorkspaceCodingExportController', () => {
     const job = {
       data: {
         workspaceId: 5,
+        userId: 2,
         exportType: 'detailed',
         isCancelled: true
       },
@@ -1355,7 +1550,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.cancelExportJob(5, 'job-1')).resolves.toEqual({
+    await expect(controller.cancelExportJob(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       success: true,
       message: 'Export job cancelled successfully'
     });
@@ -1367,7 +1566,7 @@ describe('WorkspaceCodingExportController', () => {
 
   it('does not report coding export cancellation as successful when queue cancellation was not accepted', async () => {
     const job = {
-      data: { workspaceId: 5, exportType: 'detailed' },
+      data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
       getState: jest.fn().mockResolvedValue('active')
     };
     const jobQueueService = {
@@ -1384,7 +1583,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.cancelExportJob(5, 'job-1')).resolves.toEqual({
+    await expect(controller.cancelExportJob(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       success: false,
       message: 'Export job cancellation could not be requested'
     });
@@ -1396,7 +1599,7 @@ describe('WorkspaceCodingExportController', () => {
 
   it('reports coding export cancellation as successful when cancellation completes during the request', async () => {
     const job = {
-      data: { workspaceId: 5, exportType: 'detailed' },
+      data: { workspaceId: 5, userId: 2, exportType: 'detailed' },
       getState: jest
         .fn()
         .mockResolvedValueOnce('active')
@@ -1416,7 +1619,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.cancelExportJob(5, 'job-1')).resolves.toEqual({
+    await expect(controller.cancelExportJob(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       success: true,
       message:
         'Export job cancellation requested (job will stop at next checkpoint)'
@@ -1442,7 +1649,11 @@ describe('WorkspaceCodingExportController', () => {
       codingPsychometricExportServiceMock
     );
 
-    await expect(controller.getExportJobStatus(5, 'job-1')).resolves.toEqual({
+    await expect(controller.getExportJobStatus(
+      5,
+      'job-1',
+      requestForUser()
+    )).resolves.toEqual({
       error: 'Access denied to this export'
     });
   });

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.spec.ts
@@ -579,48 +579,62 @@ describe('WorkspaceCodingExportController', () => {
   });
 
   it('does not expose internal file paths in export job status results', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'export-status-controller-')
+    );
+    const filePath = path.join(tempDir, 'export_job-1.csv');
+    fs.writeFileSync(filePath, 'result');
+    const artifact = {
+      fileId: 'job-1',
+      fileName: 'export_job-1.csv',
+      filePath,
+      fileSize: 128,
+      workspaceId: 5,
+      userId: 2,
+      exportType: 'detailed' as const,
+      createdAt: 123
+    };
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5 },
+        data: { workspaceId: 5, exportType: 'detailed' },
         getState: jest.fn().mockResolvedValue('completed'),
         progress: jest.fn().mockResolvedValue(100),
-        returnvalue: {
-          fileId: 'job-1',
-          fileName: 'export_job-1.csv',
-          filePath: '/server/temp/export_job-1.csv',
-          fileSize: 128,
-          workspaceId: 5,
-          userId: 2,
-          exportType: 'detailed',
-          createdAt: 123
-        }
+        returnvalue: artifact
       })
+    };
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(artifact)
     };
     const controller = createController(
       {} as CodingListExportService,
       {} as CodingExportService,
       {} as CodingExportOrchestratorService,
       jobQueueService as unknown as JobQueueService,
-      {} as CacheService,
+      cacheService as unknown as CacheService,
       codingPsychometricExportServiceMock
     );
 
-    const status = await controller.getExportJobStatus(5, 'job-1');
+    try {
+      const status = await controller.getExportJobStatus(5, 'job-1');
 
-    expect(status).toEqual({
-      status: 'completed',
-      progress: 100,
-      result: {
-        fileId: 'job-1',
-        fileName: 'export_job-1.csv',
-        fileSize: 128,
-        workspaceId: 5,
-        userId: 2,
-        exportType: 'detailed',
-        createdAt: 123
-      }
-    });
-    expect(JSON.stringify(status)).not.toContain('filePath');
+      expect(status).toEqual({
+        status: 'completed',
+        progress: 100,
+        result: {
+          fileId: 'job-1',
+          fileName: 'export_job-1.csv',
+          fileSize: 128,
+          workspaceId: 5,
+          userId: 2,
+          exportType: 'detailed',
+          createdAt: 123,
+          expiresAt: 123 + ExportArtifactService.ttlSeconds * 1000
+        }
+      });
+      expect(JSON.stringify(status)).not.toContain('filePath');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('adds structured details for worksheet limit failures in export job status', async () => {
@@ -628,7 +642,7 @@ describe('WorkspaceCodingExportController', () => {
       'Der Export enthaelt 2578 Unit-Variable-Kombinationen und ueberschreitet das konfigurierte Limit von 1000 Tabellenblaettern.';
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5 },
+        data: { workspaceId: 5, exportType: 'by-variable' },
         getState: jest.fn().mockResolvedValue('failed'),
         progress: jest.fn().mockResolvedValue(20),
         failedReason
@@ -835,6 +849,33 @@ describe('WorkspaceCodingExportController', () => {
     }
   });
 
+  it('treats an already deleted export job as a successful deletion', async () => {
+    const jobQueueService = {
+      getExportJob: jest.fn().mockResolvedValue(null),
+      deleteExportJob: jest.fn()
+    };
+    const cacheService = {
+      get: jest.fn(),
+      delete: jest.fn()
+    };
+    const controller = createController(
+      {} as CodingListExportService,
+      {} as CodingExportService,
+      {} as CodingExportOrchestratorService,
+      jobQueueService as unknown as JobQueueService,
+      cacheService as unknown as CacheService,
+      codingPsychometricExportServiceMock
+    );
+
+    await expect(controller.deleteExportJob(5, 'missing')).resolves.toEqual({
+      success: true,
+      message: 'Export job already deleted'
+    });
+    expect(jobQueueService.deleteExportJob).not.toHaveBeenCalled();
+    expect(cacheService.get).not.toHaveBeenCalled();
+    expect(cacheService.delete).not.toHaveBeenCalled();
+  });
+
   it('keeps the export job when an artifact file cannot be deleted', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
@@ -906,7 +947,7 @@ describe('WorkspaceCodingExportController', () => {
   it('normalizes structured export progress details in job status', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5 },
+        data: { workspaceId: 5, exportType: 'detailed' },
         getState: jest.fn().mockResolvedValue('active'),
         progress: jest.fn().mockResolvedValue({
           percentage: 57.4,
@@ -939,7 +980,11 @@ describe('WorkspaceCodingExportController', () => {
   it('reports cancellation-marked export jobs as cancelled', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, isCancelled: true },
+        data: {
+          workspaceId: 5,
+          exportType: 'detailed',
+          isCancelled: true
+        },
         getState: jest.fn().mockResolvedValue('active'),
         progress: jest.fn().mockResolvedValue(55)
       })
@@ -962,7 +1007,7 @@ describe('WorkspaceCodingExportController', () => {
   it('maps stuck export jobs to the public pending state', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5 },
+        data: { workspaceId: 5, exportType: 'detailed' },
         getState: jest.fn().mockResolvedValue('stuck'),
         progress: jest.fn().mockResolvedValue(0)
       })
@@ -985,7 +1030,11 @@ describe('WorkspaceCodingExportController', () => {
   it('reports completed cancellation-marked export jobs as cancelled without result metadata', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5, isCancelled: true },
+        data: {
+          workspaceId: 5,
+          exportType: 'detailed',
+          isCancelled: true
+        },
         getState: jest.fn().mockResolvedValue('completed'),
         progress: jest.fn().mockResolvedValue(21),
         returnvalue: {
@@ -1018,7 +1067,7 @@ describe('WorkspaceCodingExportController', () => {
   it('reports failed export jobs caused by cancellation as cancelled', async () => {
     const jobQueueService = {
       getExportJob: jest.fn().mockResolvedValue({
-        data: { workspaceId: 5 },
+        data: { workspaceId: 5, exportType: 'detailed' },
         getState: jest.fn().mockResolvedValue('failed'),
         progress: jest.fn().mockResolvedValue(20),
         failedReason: 'Export job job-1 was cancelled'
@@ -1104,9 +1153,152 @@ describe('WorkspaceCodingExportController', () => {
     ]);
   });
 
+  it('returns display variants for manual coding exports', async () => {
+    const jobQueueService = {
+      getExportJobs: jest.fn().mockResolvedValue([
+        {
+          id: 'manual-aggregated',
+          data: {
+            workspaceId: 5,
+            exportType: 'aggregated',
+            excludeAutoCoded: true,
+            doubleCodingMethod: 'new-column-per-coder'
+          },
+          timestamp: 100,
+          getState: jest.fn().mockResolvedValue('waiting'),
+          progress: jest.fn().mockResolvedValue(0)
+        },
+        {
+          id: 'manual-compact',
+          data: {
+            workspaceId: 5,
+            exportType: 'by-variable-compact',
+            excludeAutoCoded: true
+          },
+          timestamp: 101,
+          getState: jest.fn().mockResolvedValue('waiting'),
+          progress: jest.fn().mockResolvedValue(0)
+        }
+      ])
+    };
+    const controller = createController(
+      {} as CodingListExportService,
+      {} as CodingExportService,
+      {} as CodingExportOrchestratorService,
+      jobQueueService as unknown as JobQueueService,
+      {} as CacheService,
+      codingPsychometricExportServiceMock
+    );
+
+    await expect(controller.getExportJobs(5)).resolves.toEqual([
+      expect.objectContaining({
+        jobId: 'manual-aggregated',
+        displayVariant: 'manual-review-new-column-per-coder'
+      }),
+      expect.objectContaining({
+        jobId: 'manual-compact',
+        displayVariant: 'manual-review-by-variable-compact'
+      })
+    ]);
+  });
+
+  it('returns structured item matrix error details in the job list', async () => {
+    const jobQueueService = {
+      getExportJobs: jest.fn().mockResolvedValue([{
+        id: 'failed-matrix',
+        data: { workspaceId: 5, exportType: 'item-matrix' },
+        timestamp: 100,
+        failedReason:
+          'ITEM_MATRIX_UNRESOLVED_CELLS:2 Itemdatensatz enthält 2 nicht exportierbare Zellen.',
+        getState: jest.fn().mockResolvedValue('failed'),
+        progress: jest.fn().mockResolvedValue(90)
+      }])
+    };
+    const cacheService = {
+      get: jest.fn()
+        .mockResolvedValueOnce({
+          diagnostics: {
+            total: 2,
+            sampleLimit: 20,
+            groups: [{
+              reasonCode: 'missing-score',
+              bookletName: 'BOOKLET',
+              columnName: 'ITEM_1',
+              count: 2,
+              sampleRowNumbers: []
+            }]
+          },
+          expiresAt: 500
+        })
+        .mockResolvedValueOnce(undefined)
+    };
+    const controller = createController(
+      {} as CodingListExportService,
+      {} as CodingExportService,
+      {} as CodingExportOrchestratorService,
+      jobQueueService as unknown as JobQueueService,
+      cacheService as unknown as CacheService,
+      codingPsychometricExportServiceMock
+    );
+
+    await expect(controller.getExportJobs(5)).resolves.toEqual([{
+      jobId: 'failed-matrix',
+      status: 'failed',
+      progress: 90,
+      error:
+        'ITEM_MATRIX_UNRESOLVED_CELLS:2 Itemdatensatz enthält 2 nicht exportierbare Zellen.',
+      errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
+      errorDetails: {
+        total: 2,
+        groupCount: 1,
+        sampleLimit: 20,
+        diagnosticsAvailable: true,
+        incompleteDownloadAvailable: false,
+        expiresAt: 500
+      },
+      exportType: 'item-matrix',
+      createdAt: 100
+    }]);
+  });
+
+  it('omits completed jobs whose artifacts have expired', async () => {
+    const jobQueueService = {
+      getExportJobs: jest.fn().mockResolvedValue([{
+        id: 'completed-expired',
+        data: { workspaceId: 5, exportType: 'aggregated' },
+        timestamp: 100,
+        getState: jest.fn().mockResolvedValue('completed'),
+        progress: jest.fn().mockResolvedValue(100),
+        returnvalue: {
+          fileId: 'completed-expired',
+          fileName: 'export.xlsx',
+          filePath: '/expired/export.xlsx',
+          fileSize: 10,
+          workspaceId: 5,
+          userId: 2,
+          exportType: 'aggregated',
+          createdAt: 100
+        }
+      }])
+    };
+    const cacheService = {
+      get: jest.fn().mockResolvedValue(undefined)
+    };
+    const controller = createController(
+      {} as CodingListExportService,
+      {} as CodingExportService,
+      {} as CodingExportOrchestratorService,
+      jobQueueService as unknown as JobQueueService,
+      cacheService as unknown as CacheService,
+      codingPsychometricExportServiceMock
+    );
+
+    await expect(controller.getExportJobs(5)).resolves.toEqual([]);
+  });
+
   it('does not clean up cached export metadata when cancelling coding export jobs', async () => {
     const job = {
-      data: { workspaceId: 5 },
+      data: { workspaceId: 5, exportType: 'detailed' },
       getState: jest.fn().mockResolvedValue('active')
     };
     const jobQueueService = {
@@ -1142,7 +1334,11 @@ describe('WorkspaceCodingExportController', () => {
 
   it('allows cancelling a job that already failed because of cancellation', async () => {
     const job = {
-      data: { workspaceId: 5, isCancelled: true },
+      data: {
+        workspaceId: 5,
+        exportType: 'detailed',
+        isCancelled: true
+      },
       getState: jest.fn().mockResolvedValue('failed')
     };
     const jobQueueService = {
@@ -1171,7 +1367,7 @@ describe('WorkspaceCodingExportController', () => {
 
   it('does not report coding export cancellation as successful when queue cancellation was not accepted', async () => {
     const job = {
-      data: { workspaceId: 5 },
+      data: { workspaceId: 5, exportType: 'detailed' },
       getState: jest.fn().mockResolvedValue('active')
     };
     const jobQueueService = {
@@ -1200,7 +1396,7 @@ describe('WorkspaceCodingExportController', () => {
 
   it('reports coding export cancellation as successful when cancellation completes during the request', async () => {
     const job = {
-      data: { workspaceId: 5 },
+      data: { workspaceId: 5, exportType: 'detailed' },
       getState: jest
         .fn()
         .mockResolvedValueOnce('active')

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
@@ -59,6 +59,7 @@ import {
   ItemDatasetOptionsDto,
   ItemMatrixExportDiagnosticsDto,
   ITEM_MATRIX_UNRESOLVED_CELLS_ERROR_CODE,
+  CODING_EXPORT_TYPES,
   isCodingExportType,
   parseExportRequest
 } from '../../../../../../api-dto/coding/export-request.dto';
@@ -1887,8 +1888,12 @@ export class WorkspaceCodingExportController {
       @Req() req: Request
   ): Promise<ExportJobListItemDto[]> {
     try {
-      const jobs = await this.jobQueueService.getExportJobs(workspace_id);
       const userId = this.getRequestUserId(req);
+      const jobs = await this.jobQueueService.getExportJobs(
+        workspace_id,
+        userId,
+        CODING_EXPORT_TYPES
+      );
 
       const codingJobs = jobs.filter(job => (
         Number(job.data.userId) === userId &&

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
@@ -23,10 +23,12 @@ import {
   ApiBody
 } from '@nestjs/swagger';
 import { Response, Request } from 'express';
+import { Job } from 'bull';
 import * as fs from 'fs';
 import { Readable } from 'stream';
 import {
   JobQueueService,
+  ExportJobData,
   ExportJobProgress,
   ExportJobResult
 } from '../../job-queue/job-queue.service';
@@ -44,15 +46,19 @@ import {
 import { PsychometricDomainCandidatesDto } from '../../../../../../api-dto/coding/psychometric-discrimination.dto';
 import {
   BackgroundExportRequest,
+  ExportJobDisplayVariantDto,
   ExportJobErrorMetadataDto,
+  ExportJobListItemDto,
   ExportJobProgressPhaseDto,
   ExportJobResultDto,
   ExportJobStateDto,
+  ExportJobStatusDto,
   ExportJobStatusResponseDto,
   ExportRequestValidationError,
   ItemDatasetOptionsDto,
   ItemMatrixExportDiagnosticsDto,
   ITEM_MATRIX_UNRESOLVED_CELLS_ERROR_CODE,
+  isCodingExportType,
   parseExportRequest
 } from '../../../../../../api-dto/coding/export-request.dto';
 import {
@@ -183,6 +189,57 @@ export class WorkspaceCodingExportController {
         max: Number(worksheetLimitMatch[2])
       }
     };
+  }
+
+  private async toPublicExportJobStatus(
+    job: Job<ExportJobData>,
+    jobId: string
+  ): Promise<ExportJobStatusDto> {
+    const state = await job.getState();
+    const progress = this.toPublicExportProgress(await job.progress());
+    const failedReason = job.failedReason;
+    const status = this.mapExportJobState(state, job);
+
+    const artifact = status === 'completed' ?
+      await this.exportArtifactService.getArtifact(jobId) :
+      null;
+
+    return {
+      status,
+      ...progress,
+      ...(artifact ?
+        {
+          result: this.toPublicExportJobResult(artifact)
+        } :
+        {}),
+      ...(status === 'failed' && failedReason ?
+        {
+          error: failedReason,
+          ...await this.getPublicExportErrorDetails(jobId, failedReason)
+        } :
+        {})
+    };
+  }
+
+  private getExportJobDisplayVariant(
+    data: ExportJobData
+  ): ExportJobDisplayVariantDto | undefined {
+    if (data.exportType === 'by-variable-compact' && data.excludeAutoCoded) {
+      return 'manual-review-by-variable-compact';
+    }
+    if (data.exportType !== 'aggregated' || !data.excludeAutoCoded) {
+      return undefined;
+    }
+
+    switch (data.doubleCodingMethod || 'most-frequent') {
+      case 'new-column-per-coder':
+        return 'manual-review-new-column-per-coder';
+      case 'new-row-per-variable':
+        return 'manual-review-new-row-per-variable';
+      case 'most-frequent':
+      default:
+        return 'manual-review-most-frequent';
+    }
   }
 
   private toPublicExportProgress(progress: unknown): {
@@ -1360,6 +1417,11 @@ export class WorkspaceCodingExportController {
       }
       throw error;
     }
+    if (!isCodingExportType(request.exportType)) {
+      throw new BadRequestException(
+        `Export type '${request.exportType}' is not available through the coding export API`
+      );
+    }
 
     try {
       const userId = this.getRequestUserId(req);
@@ -1489,32 +1551,14 @@ export class WorkspaceCodingExportController {
       if (job.data.workspaceId !== workspace_id) {
         return { error: 'Access denied to this export' };
       }
+      if (!isCodingExportType(job.data.exportType)) {
+        return { error: 'Access denied to this export' };
+      }
 
-      const state = await job.getState();
-      const progress = this.toPublicExportProgress(await job.progress());
-      const failedReason = job.failedReason;
-      const status = this.mapExportJobState(state, job);
-
-      return {
-        status,
-        ...progress,
-        ...(status === 'completed' && job.returnvalue ?
-          {
-            result: this.toPublicExportJobResult(
-              job.returnvalue as ExportJobResult
-            )
-          } :
-          {}),
-        ...(status === 'failed' && failedReason ?
-          {
-            error: failedReason,
-            ...await this.getPublicExportErrorDetails(
-              job.id?.toString() || jobId,
-              failedReason
-            )
-          } :
-          {})
-      };
+      return await this.toPublicExportJobStatus(
+        job,
+        job.id?.toString() || jobId
+      );
     } catch (error) {
       this.logger.error(
         `Error getting export job status: ${error.message}`,
@@ -1534,7 +1578,9 @@ export class WorkspaceCodingExportController {
       workspaceId: result.workspaceId,
       userId: result.userId,
       exportType: result.exportType,
-      createdAt: result.createdAt
+      createdAt: result.createdAt,
+      expiresAt:
+        result.createdAt + ExportArtifactService.ttlSeconds * 1000
     };
   }
 
@@ -1572,6 +1618,10 @@ export class WorkspaceCodingExportController {
       }
 
       if (metadata.workspaceId !== workspace_id) {
+        res.status(403).json({ error: 'Access denied to this export' });
+        return;
+      }
+      if (!isCodingExportType(metadata.exportType)) {
         res.status(403).json({ error: 'Access denied to this export' });
         return;
       }
@@ -1736,41 +1786,95 @@ export class WorkspaceCodingExportController {
           processedRows: { type: 'number' },
           totalRows: { type: 'number' },
           progressMessage: { type: 'string' },
+          result: {
+            type: 'object',
+            properties: {
+              fileId: { type: 'string' },
+              fileName: { type: 'string' },
+              fileSize: { type: 'number' },
+              workspaceId: { type: 'number' },
+              userId: { type: 'number' },
+              exportType: { type: 'string' },
+              createdAt: { type: 'number' }
+            }
+          },
+          error: { type: 'string' },
+          errorCode: {
+            type: 'string',
+            enum: [
+              ITEM_MATRIX_UNRESOLVED_CELLS_ERROR_CODE,
+              'EXPORT_TOO_MANY_WORKSHEETS'
+            ]
+          },
+          errorDetails: {
+            oneOf: [
+              {
+                type: 'object',
+                properties: {
+                  total: { type: 'number' },
+                  groupCount: { type: 'number' },
+                  sampleLimit: { type: 'number' },
+                  diagnosticsAvailable: { type: 'boolean' },
+                  incompleteDownloadAvailable: { type: 'boolean' },
+                  expiresAt: { type: 'number' }
+                }
+              },
+              {
+                type: 'object',
+                properties: {
+                  actual: { type: 'number' },
+                  max: { type: 'number' }
+                }
+              }
+            ]
+          },
           exportType: { type: 'string' },
-          createdAt: { type: 'number' }
+          createdAt: { type: 'number' },
+          displayVariant: {
+            type: 'string',
+            enum: [
+              'manual-review-most-frequent',
+              'manual-review-new-column-per-coder',
+              'manual-review-new-row-per-variable',
+              'manual-review-by-variable-compact'
+            ]
+          }
         }
       }
     }
   })
-  async getExportJobs(@WorkspaceId() workspace_id: number): Promise<
-  Array<{
-    jobId: string;
-    status: ExportJobStateDto;
-    progress: number;
-    progressPhase?: ExportJobProgressPhaseDto;
-    processedRows?: number;
-    totalRows?: number;
-    progressMessage?: string;
-    exportType: string;
-    createdAt: number;
-  }>
-  > {
+  async getExportJobs(
+    @WorkspaceId() workspace_id: number
+  ): Promise<ExportJobListItemDto[]> {
     try {
       const jobs = await this.jobQueueService.getExportJobs(workspace_id);
 
-      return await Promise.all(
-        jobs.map(async job => {
-          const state = await job.getState();
-          const progress = this.toPublicExportProgress(await job.progress());
+      const codingJobs = jobs.filter(job => isCodingExportType(
+        job.data.exportType
+      ));
+
+      const jobItems = await Promise.all(
+        codingJobs.map(async job => {
+          const jobId = job.id.toString();
+          const status = await this.toPublicExportJobStatus(job, jobId);
+          const displayVariant = this.getExportJobDisplayVariant(job.data);
+          if (status.status === 'completed' && !status.result) {
+            return null;
+          }
 
           return {
-            jobId: job.id.toString(),
-            status: this.mapExportJobState(state, job),
-            ...progress,
+            jobId,
+            ...status,
             exportType: job.data.exportType,
-            createdAt: job.timestamp
+            createdAt: job.timestamp,
+            ...(displayVariant ?
+              { displayVariant } :
+              {})
           };
         })
+      );
+      return jobItems.filter(
+        (job): job is ExportJobListItemDto => job !== null
       );
     } catch (error) {
       this.logger.error(
@@ -1808,11 +1912,17 @@ export class WorkspaceCodingExportController {
       const job = await this.jobQueueService.getExportJob(jobId);
       if (!job) {
         return {
-          success: false,
-          message: 'Export job not found'
+          success: true,
+          message: 'Export job already deleted'
         };
       }
       if (job.data.workspaceId !== workspace_id) {
+        return {
+          success: false,
+          message: 'Access denied to this export'
+        };
+      }
+      if (!isCodingExportType(job.data.exportType)) {
         return {
           success: false,
           message: 'Access denied to this export'
@@ -1877,6 +1987,12 @@ export class WorkspaceCodingExportController {
         };
       }
       if (job.data.workspaceId !== workspace_id) {
+        return {
+          success: false,
+          message: 'Access denied to this export'
+        };
+      }
+      if (!isCodingExportType(job.data.exportType)) {
         return {
           success: false,
           message: 'Access denied to this export'

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
@@ -222,7 +222,7 @@ export class WorkspaceCodingExportController {
       ...(status === 'failed' && failedReason ?
         {
           error: failedReason,
-          ...await this.getPublicExportErrorDetails(jobId, failedReason)
+          ...(await this.getPublicExportErrorDetails(jobId, failedReason))
         } :
         {})
     };
@@ -568,10 +568,8 @@ export class WorkspaceCodingExportController {
                    @Query('missingsProfileId') missingsProfileId?: string
   ): Promise<void> {
     try {
-      const resolvedMissingsProfileId = this.parseVersionedExportMissingsProfileId(
-        version,
-        missingsProfileId
-      );
+      const resolvedMissingsProfileId =
+        this.parseVersionedExportMissingsProfileId(version, missingsProfileId);
       const csvStream =
         await this.codingExportOrchestratorService.exportResultsByVersionAsCsv({
           workspaceId: workspace_id,
@@ -713,10 +711,8 @@ export class WorkspaceCodingExportController {
       );
     }
 
-    const resolvedMissingsProfileId = this.parseVersionedExportMissingsProfileId(
-      version,
-      missingsProfileId
-    );
+    const resolvedMissingsProfileId =
+      this.parseVersionedExportMissingsProfileId(version, missingsProfileId);
     const buffer =
       await this.codingExportOrchestratorService.exportResultsByVersionAsExcel({
         workspaceId: workspace_id,
@@ -1589,13 +1585,11 @@ export class WorkspaceCodingExportController {
         `Error getting export job status: ${error.message}`,
         error.stack
       );
-      return { error: error.message };
+      throw error;
     }
   }
 
-  private toPublicExportJobResult(
-    result: ExportJobResult
-  ): ExportJobResultDto {
+  private toPublicExportJobResult(result: ExportJobResult): ExportJobResultDto {
     return {
       fileId: result.fileId,
       fileName: result.fileName,
@@ -1604,8 +1598,7 @@ export class WorkspaceCodingExportController {
       userId: result.userId,
       exportType: result.exportType,
       createdAt: result.createdAt,
-      expiresAt:
-        result.createdAt + ExportArtifactService.ttlSeconds * 1000
+      expiresAt: result.createdAt + ExportArtifactService.ttlSeconds * 1000
     };
   }
 
@@ -1716,15 +1709,19 @@ export class WorkspaceCodingExportController {
     if (!this.isExportJobOwner(job, req)) {
       throw new ForbiddenException('Access denied to this export');
     }
-    if (job.data.exportType !== 'item-matrix' || await job.getState() !== 'failed') {
+    if (
+      job.data.exportType !== 'item-matrix' ||
+      (await job.getState()) !== 'failed'
+    ) {
       throw new BadRequestException(
         'Diagnostics are available only for failed item matrix exports'
       );
     }
-    const diagnostics =
-      await this.exportArtifactService.getDiagnostics(jobId);
+    const diagnostics = await this.exportArtifactService.getDiagnostics(jobId);
     if (!diagnostics) {
-      throw new NotFoundException('Item matrix diagnostics not found or expired');
+      throw new NotFoundException(
+        'Item matrix diagnostics not found or expired'
+      );
     }
     return diagnostics;
   }
@@ -1761,9 +1758,13 @@ export class WorkspaceCodingExportController {
       res.status(403).json({ error: 'Access denied to this export' });
       return;
     }
-    if (job.data.exportType !== 'item-matrix' || await job.getState() !== 'failed') {
+    if (
+      job.data.exportType !== 'item-matrix' ||
+      (await job.getState()) !== 'failed'
+    ) {
       res.status(400).json({
-        error: 'Incomplete downloads are available only for failed item matrix exports'
+        error:
+          'Incomplete downloads are available only for failed item matrix exports'
       });
       return;
     }
@@ -1794,6 +1795,12 @@ export class WorkspaceCodingExportController {
   @ApiParam({ name: 'workspace_id', type: Number })
   @ApiOkResponse({
     description: 'List of export jobs for the workspace',
+    headers: {
+      'X-Export-History-Pending': {
+        description: 'Whether legacy export history is still being indexed',
+        schema: { type: 'boolean' }
+      }
+    },
     schema: {
       type: 'array',
       items: {
@@ -1885,33 +1892,28 @@ export class WorkspaceCodingExportController {
   })
   async getExportJobs(
     @WorkspaceId() workspace_id: number,
-      @Req() req: Request
+      @Req() req: Request,
+      @Res({ passthrough: true }) res?: Response
   ): Promise<ExportJobListItemDto[]> {
     try {
       const userId = this.getRequestUserId(req);
-      const jobs = await this.jobQueueService.getExportJobs(
-        workspace_id,
-        userId,
-        CODING_EXPORT_TYPES
-      );
+      const { jobs, historyPending } =
+        await this.jobQueueService.getExportJobsWithHistoryState(
+          workspace_id,
+          userId,
+          CODING_EXPORT_TYPES
+        );
 
-      const codingJobs = jobs.filter(job => (
-        Number(job.data.userId) === userId &&
-        isCodingExportType(job.data.exportType)
-      ));
+      const codingJobs = jobs.filter(
+        job => Number(job.data.userId) === userId &&
+          isCodingExportType(job.data.exportType)
+      );
 
       const jobItems = await Promise.all(
         codingJobs.map(async job => {
           const jobId = job.id.toString();
           const status = await this.toPublicExportJobStatus(job, jobId);
           const displayVariant = this.getExportJobDisplayVariant(job.data);
-          if (
-            status.status === 'pending' ||
-            status.status === 'processing' ||
-            status.status === 'paused'
-          ) {
-            return null;
-          }
           if (status.status === 'completed' && !status.result) {
             return null;
           }
@@ -1921,11 +1923,13 @@ export class WorkspaceCodingExportController {
             ...status,
             exportType: job.data.exportType,
             createdAt: job.timestamp,
-            ...(displayVariant ?
-              { displayVariant } :
-              {})
+            ...(displayVariant ? { displayVariant } : {})
           };
         })
+      );
+      res?.setHeader(
+        'X-Export-History-Pending',
+        historyPending ? 'true' : 'false'
       );
       return jobItems.filter(
         (job): job is ExportJobListItemDto => job !== null

--- a/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-export.controller.ts
@@ -41,7 +41,8 @@ import {
   CodingExportOrchestratorService,
   CodingListExportService,
   CodingPsychometricExportService,
-  ExportArtifactService
+  ExportArtifactService,
+  ExportJobClientLeaseService
 } from '../../database/services/coding';
 import { PsychometricDomainCandidatesDto } from '../../../../../../api-dto/coding/psychometric-discrimination.dto';
 import {
@@ -85,7 +86,8 @@ export class WorkspaceCodingExportController {
     private codingExportOrchestratorService: CodingExportOrchestratorService,
     private jobQueueService: JobQueueService,
     private codingPsychometricExportService: CodingPsychometricExportService,
-    private readonly exportArtifactService: ExportArtifactService
+    private readonly exportArtifactService: ExportArtifactService,
+    private readonly exportJobClientLeaseService: ExportJobClientLeaseService
   ) {}
 
   private parseVersionedExportMissingsProfileId(
@@ -159,6 +161,10 @@ export class WorkspaceCodingExportController {
     }
 
     return userId;
+  }
+
+  private isExportJobOwner(job: Job<ExportJobData>, req: Request): boolean {
+    return Number(job.data.userId) === this.getRequestUserId(req);
   }
 
   private async getPublicExportErrorDetails(
@@ -1423,12 +1429,15 @@ export class WorkspaceCodingExportController {
       );
     }
 
+    let clientLeaseId: string | undefined;
     try {
       const userId = this.getRequestUserId(req);
+      clientLeaseId = await this.exportJobClientLeaseService.createLease();
       const job = await this.jobQueueService.addExportJob({
         ...request,
         workspaceId: workspace_id,
-        userId
+        userId,
+        clientLeaseId
       });
 
       this.logger.log(
@@ -1440,6 +1449,7 @@ export class WorkspaceCodingExportController {
         message: `Export job created successfully. Job ID: ${job.id}`
       };
     } catch (error) {
+      await this.exportJobClientLeaseService.releaseLease(clientLeaseId);
       this.logger.error(
         `Error creating export job: ${error.message}`,
         error.stack
@@ -1541,7 +1551,8 @@ export class WorkspaceCodingExportController {
   })
   async getExportJobStatus(
     @WorkspaceId() workspace_id: number,
-      @Param('jobId') jobId: string
+      @Param('jobId') jobId: string,
+      @Req() req: Request
   ): Promise<ExportJobStatusResponseDto> {
     try {
       const job = await this.jobQueueService.getExportJob(jobId);
@@ -1551,8 +1562,21 @@ export class WorkspaceCodingExportController {
       if (job.data.workspaceId !== workspace_id) {
         return { error: 'Access denied to this export' };
       }
+      if (!this.isExportJobOwner(job, req)) {
+        return { error: 'Access denied to this export' };
+      }
       if (!isCodingExportType(job.data.exportType)) {
         return { error: 'Access denied to this export' };
+      }
+
+      const state = await job.getState();
+      if (
+        job.data.clientLeaseId &&
+        ['active', 'waiting', 'delayed', 'stuck', 'paused'].includes(state)
+      ) {
+        await this.exportJobClientLeaseService.refreshLease(
+          job.data.clientLeaseId
+        );
       }
 
       return await this.toPublicExportJobStatus(
@@ -1607,7 +1631,8 @@ export class WorkspaceCodingExportController {
   async downloadExport(
     @Param('jobId') jobId: string,
       @WorkspaceId() workspace_id: number,
-      @Res() res: Response
+      @Res() res: Response,
+      @Req() req: Request
   ): Promise<void> {
     try {
       const metadata = await this.exportArtifactService.getArtifact(jobId);
@@ -1618,6 +1643,10 @@ export class WorkspaceCodingExportController {
       }
 
       if (metadata.workspaceId !== workspace_id) {
+        res.status(403).json({ error: 'Access denied to this export' });
+        return;
+      }
+      if (Number(metadata.userId) !== this.getRequestUserId(req)) {
         res.status(403).json({ error: 'Access denied to this export' });
         return;
       }
@@ -1673,13 +1702,17 @@ export class WorkspaceCodingExportController {
   @ApiOkResponse({ description: 'Non-personal item matrix diagnostics' })
   async getItemMatrixExportDiagnostics(
     @WorkspaceId() workspace_id: number,
-      @Param('jobId') jobId: string
+      @Param('jobId') jobId: string,
+      @Req() req: Request
   ): Promise<ItemMatrixExportDiagnosticsDto> {
     const job = await this.jobQueueService.getExportJob(jobId);
     if (!job) {
       throw new NotFoundException('Export job not found');
     }
     if (job.data.workspaceId !== workspace_id) {
+      throw new ForbiddenException('Access denied to this export');
+    }
+    if (!this.isExportJobOwner(job, req)) {
       throw new ForbiddenException('Access denied to this export');
     }
     if (job.data.exportType !== 'item-matrix' || await job.getState() !== 'failed') {
@@ -1711,7 +1744,8 @@ export class WorkspaceCodingExportController {
   async downloadIncompleteItemMatrix(
     @WorkspaceId() workspace_id: number,
       @Param('jobId') jobId: string,
-      @Res() res: Response
+      @Res() res: Response,
+      @Req() req: Request
   ): Promise<void> {
     const job = await this.jobQueueService.getExportJob(jobId);
     if (!job) {
@@ -1719,6 +1753,10 @@ export class WorkspaceCodingExportController {
       return;
     }
     if (job.data.workspaceId !== workspace_id) {
+      res.status(403).json({ error: 'Access denied to this export' });
+      return;
+    }
+    if (!this.isExportJobOwner(job, req)) {
       res.status(403).json({ error: 'Access denied to this export' });
       return;
     }
@@ -1795,7 +1833,8 @@ export class WorkspaceCodingExportController {
               workspaceId: { type: 'number' },
               userId: { type: 'number' },
               exportType: { type: 'string' },
-              createdAt: { type: 'number' }
+              createdAt: { type: 'number' },
+              expiresAt: { type: 'number' }
             }
           },
           error: { type: 'string' },
@@ -1844,13 +1883,16 @@ export class WorkspaceCodingExportController {
     }
   })
   async getExportJobs(
-    @WorkspaceId() workspace_id: number
+    @WorkspaceId() workspace_id: number,
+      @Req() req: Request
   ): Promise<ExportJobListItemDto[]> {
     try {
       const jobs = await this.jobQueueService.getExportJobs(workspace_id);
+      const userId = this.getRequestUserId(req);
 
-      const codingJobs = jobs.filter(job => isCodingExportType(
-        job.data.exportType
+      const codingJobs = jobs.filter(job => (
+        Number(job.data.userId) === userId &&
+        isCodingExportType(job.data.exportType)
       ));
 
       const jobItems = await Promise.all(
@@ -1858,6 +1900,13 @@ export class WorkspaceCodingExportController {
           const jobId = job.id.toString();
           const status = await this.toPublicExportJobStatus(job, jobId);
           const displayVariant = this.getExportJobDisplayVariant(job.data);
+          if (
+            status.status === 'pending' ||
+            status.status === 'processing' ||
+            status.status === 'paused'
+          ) {
+            return null;
+          }
           if (status.status === 'completed' && !status.result) {
             return null;
           }
@@ -1906,7 +1955,8 @@ export class WorkspaceCodingExportController {
   })
   async deleteExportJob(
     @WorkspaceId() workspace_id: number,
-      @Param('jobId') jobId: string
+      @Param('jobId') jobId: string,
+      @Req() req: Request
   ): Promise<{ success: boolean; message: string }> {
     try {
       const job = await this.jobQueueService.getExportJob(jobId);
@@ -1917,6 +1967,12 @@ export class WorkspaceCodingExportController {
         };
       }
       if (job.data.workspaceId !== workspace_id) {
+        return {
+          success: false,
+          message: 'Access denied to this export'
+        };
+      }
+      if (!this.isExportJobOwner(job, req)) {
         return {
           success: false,
           message: 'Access denied to this export'
@@ -1975,7 +2031,8 @@ export class WorkspaceCodingExportController {
   })
   async cancelExportJob(
     @WorkspaceId() workspace_id: number,
-      @Param('jobId') jobId: string
+      @Param('jobId') jobId: string,
+      @Req() req: Request
   ): Promise<{ success: boolean; message: string }> {
     try {
       // First, check the job state
@@ -1987,6 +2044,12 @@ export class WorkspaceCodingExportController {
         };
       }
       if (job.data.workspaceId !== workspace_id) {
+        return {
+          success: false,
+          message: 'Access denied to this export'
+        };
+      }
+      if (!this.isExportJobOwner(job, req)) {
         return {
           success: false,
           message: 'Access denied to this export'

--- a/apps/backend/src/app/admin/workspace/workspace-test-results-export.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-test-results-export.controller.spec.ts
@@ -403,5 +403,10 @@ describe('WorkspaceTestResultsExportController', () => {
         })
       ])
     );
+    expect(jobQueueService.getExportJobs).toHaveBeenCalledWith(
+      7,
+      undefined,
+      ['test-results', 'test-logs']
+    );
   });
 });

--- a/apps/backend/src/app/admin/workspace/workspace-test-results-export.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-test-results-export.controller.ts
@@ -494,7 +494,11 @@ export class WorkspaceTestResultsExportController {
   async getExportJobs(
     @Param('workspace_id', ParseIntPipe) workspace_id: number
   ): Promise<ExportJobStatus[]> {
-    const jobs = await this.jobQueueService.getExportJobs(Number(workspace_id));
+    const jobs = await this.jobQueueService.getExportJobs(
+      Number(workspace_id),
+      undefined,
+      ['test-results', 'test-logs']
+    );
 
     const result: ExportJobStatus[] = [];
     for (const job of jobs) {

--- a/apps/backend/src/app/cache/cache.service.spec.ts
+++ b/apps/backend/src/app/cache/cache.service.spec.ts
@@ -16,6 +16,7 @@ describe('CacheService', () => {
       set: jest.fn(),
       del: jest.fn(),
       exists: jest.fn(),
+      eval: jest.fn(),
       incr: jest.fn(),
       scan: jest.fn()
     };
@@ -77,6 +78,31 @@ describe('CacheService', () => {
     await expect(service.exists('a')).resolves.toBe(true);
     await expect(service.exists('b')).resolves.toBe(false);
     await expect(service.exists('c')).resolves.toBe(false);
+  });
+
+  it('propagates errors for strict cache operations', async () => {
+    redis.exists
+      .mockResolvedValueOnce(1)
+      .mockRejectedValueOnce(new Error('redis down'));
+    redis.eval
+      .mockResolvedValueOnce(1)
+      .mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(service.existsStrict('lease')).resolves.toBe(true);
+    await expect(service.existsStrict('lease')).rejects.toThrow('redis down');
+    await expect(service.executeScript<number>(
+      'return 1',
+      ['lease'],
+      ['value']
+    )).resolves.toBe(1);
+    expect(redis.eval).toHaveBeenCalledWith(
+      'return 1',
+      1,
+      'lease',
+      'value'
+    );
+    await expect(service.executeScript('return 1', []))
+      .rejects.toThrow('redis down');
   });
 
   it('stores and pages validation results', async () => {

--- a/apps/backend/src/app/cache/cache.service.ts
+++ b/apps/backend/src/app/cache/cache.service.ts
@@ -136,6 +136,48 @@ export class CacheService {
   }
 
   /**
+   * Check if a key exists and propagate Redis errors to the caller.
+   * Use this for decisions where treating an unavailable cache as a miss would
+   * cause destructive behaviour.
+   */
+  async existsStrict(key: string): Promise<boolean> {
+    try {
+      const exists = await this.redis.exists(key);
+      return exists === 1;
+    } catch (error) {
+      this.logger.error(
+        `Error checking if key exists in cache: ${error.message}`,
+        error.stack
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Execute a Redis script while preserving its atomicity and error semantics.
+   */
+  async executeScript<T>(
+    script: string,
+    keys: string[],
+    args: string[] = []
+  ): Promise<T> {
+    try {
+      return await this.redis.eval(
+        script,
+        keys.length,
+        ...keys,
+        ...args
+      ) as T;
+    } catch (error) {
+      this.logger.error(
+        `Error executing cache script: ${error.message}`,
+        error.stack
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Generate a cache key for unit responses
    * @param workspaceId The workspace ID
    * @param testPerson The test person ID

--- a/apps/backend/src/app/database/database.module.spec.ts
+++ b/apps/backend/src/app/database/database.module.spec.ts
@@ -40,4 +40,15 @@ describe('DatabaseModule configuration', () => {
       '-c jit=off -c idle_in_transaction_session_timeout=0'
     );
   });
+
+  it('rejects PostgreSQL options with literal wrapping quotes', () => {
+    expect(() => buildPostgresConnectionOptions('"-c jit=off"', '0'))
+      .toThrow(
+        'PGOPTIONS must not contain wrapping quote characters'
+      );
+    expect(() => buildPostgresConnectionOptions("'-c jit=off'", '0'))
+      .toThrow(
+        'PGOPTIONS must not contain wrapping quote characters'
+      );
+  });
 });

--- a/apps/backend/src/app/database/database.module.ts
+++ b/apps/backend/src/app/database/database.module.ts
@@ -70,6 +70,15 @@ export function buildPostgresConnectionOptions(
   idleInTransactionTimeout: string | number | undefined
 ): string {
   const existingOptions = options?.trim();
+  if (
+    existingOptions &&
+    ((existingOptions.startsWith('"') && existingOptions.endsWith('"')) ||
+      (existingOptions.startsWith("'") && existingOptions.endsWith("'")))
+  ) {
+    throw new Error(
+      'PGOPTIONS must not contain wrapping quote characters; configure the value without literal quotes'
+    );
+  }
   const timeout = parsePostgresIdleInTransactionTimeout(idleInTransactionTimeout);
   return [
     existingOptions,

--- a/apps/backend/src/app/database/services/coding/export-job-client-lease.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/export-job-client-lease.service.spec.ts
@@ -27,6 +27,7 @@ describe('ExportJobClientLeaseService', () => {
     const leaseId = await service.createLease();
 
     expect(leaseId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(ExportJobClientLeaseService.ttlSeconds).toBeGreaterThan(60);
     expect(cacheService.executeScript).toHaveBeenCalledWith(
       expect.stringContaining("redis.call('SET'"),
       [

--- a/apps/backend/src/app/database/services/coding/export-job-client-lease.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/export-job-client-lease.service.spec.ts
@@ -1,0 +1,53 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { CacheService } from '../../../cache/cache.service';
+import { ExportJobClientLeaseService } from './export-job-client-lease.service';
+
+describe('ExportJobClientLeaseService', () => {
+  const cacheService = {
+    set: jest.fn(),
+    exists: jest.fn(),
+    delete: jest.fn()
+  };
+  let service: ExportJobClientLeaseService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cacheService.set.mockResolvedValue(true);
+    cacheService.exists.mockResolvedValue(true);
+    cacheService.delete.mockResolvedValue(true);
+    service = new ExportJobClientLeaseService(
+      cacheService as unknown as CacheService
+    );
+  });
+
+  it('creates, refreshes and releases a lease with a bounded TTL', async () => {
+    const leaseId = await service.createLease();
+
+    expect(leaseId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(cacheService.set).toHaveBeenCalledWith(
+      `export-client-lease:${leaseId}`,
+      expect.objectContaining({ refreshedAt: expect.any(Number) }),
+      ExportJobClientLeaseService.ttlSeconds
+    );
+
+    await service.refreshLease(leaseId);
+    await expect(service.isLeaseActive(leaseId)).resolves.toBe(true);
+    await service.releaseLease(leaseId);
+
+    expect(cacheService.set).toHaveBeenCalledTimes(2);
+    expect(cacheService.exists).toHaveBeenCalledWith(
+      `export-client-lease:${leaseId}`
+    );
+    expect(cacheService.delete).toHaveBeenCalledWith(
+      `export-client-lease:${leaseId}`
+    );
+  });
+
+  it('rejects job creation when the initial lease cannot be persisted', async () => {
+    cacheService.set.mockResolvedValue(false);
+
+    await expect(service.createLease()).rejects.toBeInstanceOf(
+      ServiceUnavailableException
+    );
+  });
+});

--- a/apps/backend/src/app/database/services/coding/export-job-client-lease.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/export-job-client-lease.service.spec.ts
@@ -1,19 +1,22 @@
-import { ServiceUnavailableException } from '@nestjs/common';
+import {
+  ConflictException,
+  ServiceUnavailableException
+} from '@nestjs/common';
 import { CacheService } from '../../../cache/cache.service';
 import { ExportJobClientLeaseService } from './export-job-client-lease.service';
 
 describe('ExportJobClientLeaseService', () => {
   const cacheService = {
-    set: jest.fn(),
-    exists: jest.fn(),
+    executeScript: jest.fn(),
+    existsStrict: jest.fn(),
     delete: jest.fn()
   };
   let service: ExportJobClientLeaseService;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    cacheService.set.mockResolvedValue(true);
-    cacheService.exists.mockResolvedValue(true);
+    cacheService.executeScript.mockResolvedValue(1);
+    cacheService.existsStrict.mockResolvedValue(true);
     cacheService.delete.mockResolvedValue(true);
     service = new ExportJobClientLeaseService(
       cacheService as unknown as CacheService
@@ -24,18 +27,24 @@ describe('ExportJobClientLeaseService', () => {
     const leaseId = await service.createLease();
 
     expect(leaseId).toMatch(/^[0-9a-f-]{36}$/);
-    expect(cacheService.set).toHaveBeenCalledWith(
-      `export-client-lease:${leaseId}`,
-      expect.objectContaining({ refreshedAt: expect.any(Number) }),
-      ExportJobClientLeaseService.ttlSeconds
+    expect(cacheService.executeScript).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('SET'"),
+      [
+        `export-client-lease:${leaseId}`,
+        `export-client-lease-cleanup:${leaseId}`
+      ],
+      [
+        expect.stringContaining('refreshedAt'),
+        ExportJobClientLeaseService.ttlSeconds.toString()
+      ]
     );
 
     await service.refreshLease(leaseId);
     await expect(service.isLeaseActive(leaseId)).resolves.toBe(true);
     await service.releaseLease(leaseId);
 
-    expect(cacheService.set).toHaveBeenCalledTimes(2);
-    expect(cacheService.exists).toHaveBeenCalledWith(
+    expect(cacheService.executeScript).toHaveBeenCalledTimes(2);
+    expect(cacheService.existsStrict).toHaveBeenCalledWith(
       `export-client-lease:${leaseId}`
     );
     expect(cacheService.delete).toHaveBeenCalledWith(
@@ -44,9 +53,69 @@ describe('ExportJobClientLeaseService', () => {
   });
 
   it('rejects job creation when the initial lease cannot be persisted', async () => {
-    cacheService.set.mockResolvedValue(false);
+    cacheService.executeScript.mockRejectedValue(new Error('redis down'));
 
     await expect(service.createLease()).rejects.toBeInstanceOf(
+      ServiceUnavailableException
+    );
+  });
+
+  it('claims an expired lease atomically and releases only that claim', async () => {
+    const cleanupClaim = await service.tryClaimExpiredLease('lease-id');
+
+    expect(cleanupClaim).toMatch(/^[0-9a-f-]{36}$/);
+    expect(cacheService.executeScript).toHaveBeenCalledWith(
+      expect.stringContaining("'NX'"),
+      [
+        'export-client-lease:lease-id',
+        'export-client-lease-cleanup:lease-id'
+      ],
+      [cleanupClaim, '30']
+    );
+
+    await service.releaseCleanupClaim('lease-id', cleanupClaim as string);
+    expect(cacheService.executeScript).toHaveBeenLastCalledWith(
+      expect.stringContaining("redis.call('GET'"),
+      ['export-client-lease-cleanup:lease-id'],
+      [cleanupClaim]
+    );
+  });
+
+  it('confirms ownership and extends a cleanup claim atomically', async () => {
+    await expect(service.confirmCleanupClaim(
+      'lease-id',
+      'cleanup-claim'
+    )).resolves.toBe(true);
+
+    expect(cacheService.executeScript).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('EXPIRE'"),
+      [
+        'export-client-lease:lease-id',
+        'export-client-lease-cleanup:lease-id'
+      ],
+      ['cleanup-claim', '30']
+    );
+
+    cacheService.executeScript.mockResolvedValueOnce(0);
+    await expect(service.confirmCleanupClaim(
+      'lease-id',
+      'expired-claim'
+    )).resolves.toBe(false);
+  });
+
+  it('does not claim a lease that is active or already being cleaned up', async () => {
+    cacheService.executeScript.mockResolvedValue(0);
+
+    await expect(service.tryClaimExpiredLease('lease-id')).resolves.toBeNull();
+    await expect(service.refreshLease('lease-id')).rejects.toBeInstanceOf(
+      ConflictException
+    );
+  });
+
+  it('treats an unavailable lease status as unknown instead of expired', async () => {
+    cacheService.existsStrict.mockRejectedValue(new Error('redis down'));
+
+    await expect(service.isLeaseActive('lease-id')).rejects.toBeInstanceOf(
       ServiceUnavailableException
     );
   });

--- a/apps/backend/src/app/database/services/coding/export-job-client-lease.service.ts
+++ b/apps/backend/src/app/database/services/coding/export-job-client-lease.service.ts
@@ -8,7 +8,9 @@ import { CacheService } from '../../../cache/cache.service';
 
 @Injectable()
 export class ExportJobClientLeaseService {
-  static readonly ttlSeconds = 30;
+  // Browser timers may be throttled to one minute in background tabs. Keep a
+  // second interval of grace before treating the client as disconnected.
+  static readonly ttlSeconds = 2 * 60;
   private static readonly cleanupClaimTtlSeconds = 30;
 
   private static readonly writeLeaseScript = `

--- a/apps/backend/src/app/database/services/coding/export-job-client-lease.service.ts
+++ b/apps/backend/src/app/database/services/coding/export-job-client-lease.service.ts
@@ -1,4 +1,5 @@
 import {
+  ConflictException,
   Injectable,
   ServiceUnavailableException
 } from '@nestjs/common';
@@ -8,11 +9,51 @@ import { CacheService } from '../../../cache/cache.service';
 @Injectable()
 export class ExportJobClientLeaseService {
   static readonly ttlSeconds = 30;
+  private static readonly cleanupClaimTtlSeconds = 30;
+
+  private static readonly writeLeaseScript = `
+    if redis.call('EXISTS', KEYS[2]) == 1 then
+      return 0
+    end
+    redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+    return 1
+  `;
+
+  private static readonly claimExpiredLeaseScript = `
+    if redis.call('EXISTS', KEYS[1]) == 1 then
+      return 0
+    end
+    if redis.call('SET', KEYS[2], ARGV[1], 'EX', ARGV[2], 'NX') then
+      return 1
+    end
+    return 0
+  `;
+
+  private static readonly releaseCleanupClaimScript = `
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+      return redis.call('DEL', KEYS[1])
+    end
+    return 0
+  `;
+
+  private static readonly confirmCleanupClaimScript = `
+    if redis.call('GET', KEYS[2]) ~= ARGV[1] then
+      return 0
+    end
+    if redis.call('EXISTS', KEYS[1]) == 1 then
+      return 0
+    end
+    return redis.call('EXPIRE', KEYS[2], ARGV[2])
+  `;
 
   constructor(private readonly cacheService: CacheService) {}
 
   private static getCacheKey(leaseId: string): string {
     return `export-client-lease:${leaseId}`;
+  }
+
+  private static getCleanupClaimKey(leaseId: string): string {
+    return `export-client-lease-cleanup:${leaseId}`;
   }
 
   async createLease(): Promise<string> {
@@ -26,9 +67,78 @@ export class ExportJobClientLeaseService {
   }
 
   async isLeaseActive(leaseId: string): Promise<boolean> {
-    return this.cacheService.exists(
-      ExportJobClientLeaseService.getCacheKey(leaseId)
-    );
+    try {
+      return await this.cacheService.existsStrict(
+        ExportJobClientLeaseService.getCacheKey(leaseId)
+      );
+    } catch {
+      throw new ServiceUnavailableException(
+        'The export client lease status could not be determined'
+      );
+    }
+  }
+
+  async tryClaimExpiredLease(leaseId: string): Promise<string | null> {
+    const cleanupClaim = randomUUID();
+    try {
+      const claimed = await this.cacheService.executeScript<number>(
+        ExportJobClientLeaseService.claimExpiredLeaseScript,
+        [
+          ExportJobClientLeaseService.getCacheKey(leaseId),
+          ExportJobClientLeaseService.getCleanupClaimKey(leaseId)
+        ],
+        [
+          cleanupClaim,
+          ExportJobClientLeaseService.cleanupClaimTtlSeconds.toString()
+        ]
+      );
+      return Number(claimed) === 1 ? cleanupClaim : null;
+    } catch {
+      throw new ServiceUnavailableException(
+        'The expired export client lease could not be claimed'
+      );
+    }
+  }
+
+  async releaseCleanupClaim(
+    leaseId: string,
+    cleanupClaim: string
+  ): Promise<void> {
+    try {
+      await this.cacheService.executeScript<number>(
+        ExportJobClientLeaseService.releaseCleanupClaimScript,
+        [ExportJobClientLeaseService.getCleanupClaimKey(leaseId)],
+        [cleanupClaim]
+      );
+    } catch {
+      throw new ServiceUnavailableException(
+        'The export client lease cleanup claim could not be released'
+      );
+    }
+  }
+
+  async confirmCleanupClaim(
+    leaseId: string,
+    cleanupClaim: string
+  ): Promise<boolean> {
+    try {
+      const confirmed = await this.cacheService.executeScript<number>(
+        ExportJobClientLeaseService.confirmCleanupClaimScript,
+        [
+          ExportJobClientLeaseService.getCacheKey(leaseId),
+          ExportJobClientLeaseService.getCleanupClaimKey(leaseId)
+        ],
+        [
+          cleanupClaim,
+          ExportJobClientLeaseService.cleanupClaimTtlSeconds.toString()
+        ]
+      );
+      return Number(confirmed) === 1;
+    } catch {
+      throw new ServiceUnavailableException(
+        'The export client lease cleanup claim could not be confirmed'
+      );
+    }
   }
 
   async releaseLease(leaseId?: string): Promise<void> {
@@ -39,14 +149,27 @@ export class ExportJobClientLeaseService {
   }
 
   private async writeLease(leaseId: string): Promise<void> {
-    const written = await this.cacheService.set(
-      ExportJobClientLeaseService.getCacheKey(leaseId),
-      { refreshedAt: Date.now() },
-      ExportJobClientLeaseService.ttlSeconds
-    );
-    if (!written) {
+    let written: number;
+    try {
+      written = await this.cacheService.executeScript<number>(
+        ExportJobClientLeaseService.writeLeaseScript,
+        [
+          ExportJobClientLeaseService.getCacheKey(leaseId),
+          ExportJobClientLeaseService.getCleanupClaimKey(leaseId)
+        ],
+        [
+          JSON.stringify({ refreshedAt: Date.now() }),
+          ExportJobClientLeaseService.ttlSeconds.toString()
+        ]
+      );
+    } catch {
       throw new ServiceUnavailableException(
         'The export client lease could not be persisted'
+      );
+    }
+    if (Number(written) !== 1) {
+      throw new ConflictException(
+        'The export client lease is already being cleaned up'
       );
     }
   }

--- a/apps/backend/src/app/database/services/coding/export-job-client-lease.service.ts
+++ b/apps/backend/src/app/database/services/coding/export-job-client-lease.service.ts
@@ -1,0 +1,53 @@
+import {
+  Injectable,
+  ServiceUnavailableException
+} from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { CacheService } from '../../../cache/cache.service';
+
+@Injectable()
+export class ExportJobClientLeaseService {
+  static readonly ttlSeconds = 30;
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  private static getCacheKey(leaseId: string): string {
+    return `export-client-lease:${leaseId}`;
+  }
+
+  async createLease(): Promise<string> {
+    const leaseId = randomUUID();
+    await this.writeLease(leaseId);
+    return leaseId;
+  }
+
+  async refreshLease(leaseId: string): Promise<void> {
+    await this.writeLease(leaseId);
+  }
+
+  async isLeaseActive(leaseId: string): Promise<boolean> {
+    return this.cacheService.exists(
+      ExportJobClientLeaseService.getCacheKey(leaseId)
+    );
+  }
+
+  async releaseLease(leaseId?: string): Promise<void> {
+    if (!leaseId) return;
+    await this.cacheService.delete(
+      ExportJobClientLeaseService.getCacheKey(leaseId)
+    );
+  }
+
+  private async writeLease(leaseId: string): Promise<void> {
+    const written = await this.cacheService.set(
+      ExportJobClientLeaseService.getCacheKey(leaseId),
+      { refreshedAt: Date.now() },
+      ExportJobClientLeaseService.ttlSeconds
+    );
+    if (!written) {
+      throw new ServiceUnavailableException(
+        'The export client lease could not be persisted'
+      );
+    }
+  }
+}

--- a/apps/backend/src/app/database/services/coding/index.ts
+++ b/apps/backend/src/app/database/services/coding/index.ts
@@ -24,6 +24,7 @@ export { CodingExportOrchestratorService } from './coding-export-orchestrator.se
 export { CodingFreshnessService } from './coding-freshness.service';
 export { CodingItemMatrixExportService } from './coding-item-matrix-export.service';
 export { ExportArtifactService } from './export-artifact.service';
+export { ExportJobClientLeaseService } from './export-job-client-lease.service';
 export { ItemDatasetMetadataService } from './item-dataset-metadata.service';
 export {
   CodingPsychometricExportService,

--- a/apps/backend/src/app/job-queue/export-job-history-index.service.spec.ts
+++ b/apps/backend/src/app/job-queue/export-job-history-index.service.spec.ts
@@ -1,0 +1,73 @@
+import { CacheService } from '../cache/cache.service';
+import { ExportJobHistoryIndexService } from './export-job-history-index.service';
+
+describe('ExportJobHistoryIndexService', () => {
+  const cacheService = {
+    executeScript: jest.fn()
+  };
+  let service: ExportJobHistoryIndexService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cacheService.executeScript.mockResolvedValue(1);
+    service = new ExportJobHistoryIndexService(
+      cacheService as unknown as CacheService
+    );
+  });
+
+  it('indexes jobs for workspace-wide and user-specific history', async () => {
+    await service.addJob('job-1', {
+      workspaceId: 7,
+      userId: 3,
+      exportType: 'coding-list'
+    }, 1234);
+
+    expect(cacheService.executeScript).toHaveBeenCalledWith(
+      expect.stringMatching(/ZADD[\s\S]*ZCARD[\s\S]*entryCount > maxEntries/),
+      [
+        'export-job-history:v1:workspace:7:type:coding-list',
+        'export-job-history:v1:workspace:7:user:3:type:coding-list'
+      ],
+      ['job-1', '1234', '2000', '172800']
+    );
+  });
+
+  it('merges type-specific IDs by score before applying the limit', async () => {
+    cacheService.executeScript.mockResolvedValue([
+      'coding-older', '10',
+      'coding-newer', '30',
+      'matrix-middle', '20'
+    ]);
+
+    await expect(service.getRecentJobIds({
+      workspaceId: 7,
+      userId: 3,
+      exportTypes: ['coding-list', 'item-matrix']
+    }, 2)).resolves.toEqual(['coding-newer', 'matrix-middle']);
+
+    expect(cacheService.executeScript).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('ZREVRANGE'"),
+      [
+        'export-job-history:v1:workspace:7:user:3:type:coding-list',
+        'export-job-history:v1:workspace:7:user:3:type:item-matrix'
+      ],
+      ['2']
+    );
+  });
+
+  it('removes stale IDs from every queried type index', async () => {
+    await service.removeJobIds({
+      workspaceId: 7,
+      exportTypes: ['test-results', 'test-logs']
+    }, ['stale-1', 'stale-2']);
+
+    expect(cacheService.executeScript).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('ZREM'"),
+      [
+        'export-job-history:v1:workspace:7:type:test-results',
+        'export-job-history:v1:workspace:7:type:test-logs'
+      ],
+      ['stale-1', 'stale-2']
+    );
+  });
+});

--- a/apps/backend/src/app/job-queue/export-job-history-index.service.spec.ts
+++ b/apps/backend/src/app/job-queue/export-job-history-index.service.spec.ts
@@ -70,4 +70,65 @@ describe('ExportJobHistoryIndexService', () => {
       ['stale-1', 'stale-2']
     );
   });
+
+  it('claims the legacy backfill only when it is not complete or running', async () => {
+    await expect(service.claimLegacyBackfill()).resolves.toEqual({
+      status: 'claimed',
+      claim: expect.any(String)
+    });
+
+    expect(cacheService.executeScript).toHaveBeenCalledWith(
+      expect.stringMatching(/EXISTS[\s\S]*SET[\s\S]*NX/),
+      [
+        'export-job-history:v2:legacy-backfill-complete',
+        'export-job-history:v2:legacy-backfill-claim'
+      ],
+      [expect.any(String), '300']
+    );
+
+    cacheService.executeScript.mockResolvedValueOnce(0);
+    await expect(service.claimLegacyBackfill()).resolves.toEqual({
+      status: 'busy'
+    });
+
+    cacheService.executeScript.mockResolvedValueOnce(2);
+    await expect(service.claimLegacyBackfill()).resolves.toEqual({
+      status: 'complete'
+    });
+  });
+
+  it('completes and releases legacy backfill claims by ownership token', async () => {
+    await service.completeLegacyBackfill('claim-1');
+    await service.releaseLegacyBackfillClaim('claim-2');
+
+    expect(cacheService.executeScript).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/SET[\s\S]*DEL/),
+      [
+        'export-job-history:v2:legacy-backfill-complete',
+        'export-job-history:v2:legacy-backfill-claim'
+      ],
+      ['claim-1']
+    );
+    expect(cacheService.executeScript).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/GET[\s\S]*DEL/),
+      ['export-job-history:v2:legacy-backfill-claim'],
+      ['claim-2']
+    );
+  });
+
+  it('refreshes a legacy backfill claim only while it is still owned', async () => {
+    await service.refreshLegacyBackfillClaim('claim-1');
+
+    expect(cacheService.executeScript).toHaveBeenCalledWith(
+      expect.stringMatching(/GET[\s\S]*EXPIRE/),
+      ['export-job-history:v2:legacy-backfill-claim'],
+      ['claim-1', '300']
+    );
+
+    cacheService.executeScript.mockResolvedValueOnce(0);
+    await expect(service.refreshLegacyBackfillClaim('expired-claim'))
+      .rejects.toThrow('claim expired');
+  });
 });

--- a/apps/backend/src/app/job-queue/export-job-history-index.service.ts
+++ b/apps/backend/src/app/job-queue/export-job-history-index.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
 import { CacheService } from '../cache/cache.service';
 import type { ExportJobData } from './job-queue.service';
 
@@ -8,11 +9,23 @@ export interface ExportJobHistoryScope {
   exportTypes: readonly string[];
 }
 
+export type LegacyExportHistoryBackfillClaim =
+  | { status: 'claimed'; claim: string }
+  | { status: 'busy' }
+  | { status: 'complete' };
+
 @Injectable()
 export class ExportJobHistoryIndexService {
   static readonly candidateLimit = 2000;
   private static readonly maxEntriesPerKey = 2000;
   private static readonly indexTtlSeconds = 2 * 24 * 60 * 60;
+
+  private static readonly legacyBackfillClaimTtlSeconds = 5 * 60;
+  private static readonly legacyBackfillCompleteKey =
+    'export-job-history:v2:legacy-backfill-complete';
+
+  private static readonly legacyBackfillClaimKey =
+    'export-job-history:v2:legacy-backfill-claim';
 
   private static readonly addJobScript = `
     local maxEntries = tonumber(ARGV[3])
@@ -48,6 +61,40 @@ export class ExportJobHistoryIndexService {
       removed = removed + redis.call('ZREM', key, unpack(ARGV))
     end
     return removed
+  `;
+
+  private static readonly claimLegacyBackfillScript = `
+    if redis.call('EXISTS', KEYS[1]) == 1 then
+      return 2
+    end
+    if redis.call('SET', KEYS[2], ARGV[1], 'EX', ARGV[2], 'NX') then
+      return 1
+    end
+    return 0
+  `;
+
+  private static readonly completeLegacyBackfillScript = `
+    if redis.call('GET', KEYS[2]) ~= ARGV[1] then
+      return 0
+    end
+    redis.call('SET', KEYS[1], '1')
+    redis.call('DEL', KEYS[2])
+    return 1
+  `;
+
+  private static readonly refreshLegacyBackfillClaimScript = `
+    if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+      return 0
+    end
+    redis.call('EXPIRE', KEYS[1], ARGV[2])
+    return 1
+  `;
+
+  private static readonly releaseLegacyBackfillClaimScript = `
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+      return redis.call('DEL', KEYS[1])
+    end
+    return 0
   `;
 
   constructor(private readonly cacheService: CacheService) {}
@@ -117,6 +164,61 @@ export class ExportJobHistoryIndexService {
       ExportJobHistoryIndexService.removeJobsScript,
       keys,
       [...jobIds]
+    );
+  }
+
+  async claimLegacyBackfill(): Promise<LegacyExportHistoryBackfillClaim> {
+    const claim = randomUUID();
+    const claimed = await this.cacheService.executeScript<number>(
+      ExportJobHistoryIndexService.claimLegacyBackfillScript,
+      [
+        ExportJobHistoryIndexService.legacyBackfillCompleteKey,
+        ExportJobHistoryIndexService.legacyBackfillClaimKey
+      ],
+      [
+        claim,
+        ExportJobHistoryIndexService.legacyBackfillClaimTtlSeconds.toString()
+      ]
+    );
+    if (Number(claimed) === 1) {
+      return { status: 'claimed', claim };
+    }
+    return { status: Number(claimed) === 2 ? 'complete' : 'busy' };
+  }
+
+  async completeLegacyBackfill(claim: string): Promise<void> {
+    const completed = await this.cacheService.executeScript<number>(
+      ExportJobHistoryIndexService.completeLegacyBackfillScript,
+      [
+        ExportJobHistoryIndexService.legacyBackfillCompleteKey,
+        ExportJobHistoryIndexService.legacyBackfillClaimKey
+      ],
+      [claim]
+    );
+    if (Number(completed) !== 1) {
+      throw new Error('The legacy export history backfill claim expired');
+    }
+  }
+
+  async refreshLegacyBackfillClaim(claim: string): Promise<void> {
+    const refreshed = await this.cacheService.executeScript<number>(
+      ExportJobHistoryIndexService.refreshLegacyBackfillClaimScript,
+      [ExportJobHistoryIndexService.legacyBackfillClaimKey],
+      [
+        claim,
+        ExportJobHistoryIndexService.legacyBackfillClaimTtlSeconds.toString()
+      ]
+    );
+    if (Number(refreshed) !== 1) {
+      throw new Error('The legacy export history backfill claim expired');
+    }
+  }
+
+  async releaseLegacyBackfillClaim(claim: string): Promise<void> {
+    await this.cacheService.executeScript<number>(
+      ExportJobHistoryIndexService.releaseLegacyBackfillClaimScript,
+      [ExportJobHistoryIndexService.legacyBackfillClaimKey],
+      [claim]
     );
   }
 

--- a/apps/backend/src/app/job-queue/export-job-history-index.service.ts
+++ b/apps/backend/src/app/job-queue/export-job-history-index.service.ts
@@ -1,0 +1,143 @@
+import { Injectable } from '@nestjs/common';
+import { CacheService } from '../cache/cache.service';
+import type { ExportJobData } from './job-queue.service';
+
+export interface ExportJobHistoryScope {
+  workspaceId: number;
+  userId?: number;
+  exportTypes: readonly string[];
+}
+
+@Injectable()
+export class ExportJobHistoryIndexService {
+  static readonly candidateLimit = 2000;
+  private static readonly maxEntriesPerKey = 2000;
+  private static readonly indexTtlSeconds = 2 * 24 * 60 * 60;
+
+  private static readonly addJobScript = `
+    local maxEntries = tonumber(ARGV[3])
+    for _, key in ipairs(KEYS) do
+      redis.call('ZADD', key, ARGV[2], ARGV[1])
+      local entryCount = redis.call('ZCARD', key)
+      if entryCount > maxEntries then
+        redis.call('ZREMRANGEBYRANK', key, 0, entryCount - maxEntries - 1)
+      end
+      redis.call('EXPIRE', key, ARGV[4])
+    end
+    return 1
+  `;
+
+  private static readonly getRecentJobsScript = `
+    local result = {}
+    local limit = tonumber(ARGV[1])
+    for _, key in ipairs(KEYS) do
+      local entries = redis.call('ZREVRANGE', key, 0, limit - 1, 'WITHSCORES')
+      for _, entry in ipairs(entries) do
+        table.insert(result, entry)
+      end
+    end
+    return result
+  `;
+
+  private static readonly removeJobsScript = `
+    if #ARGV == 0 then
+      return 0
+    end
+    local removed = 0
+    for _, key in ipairs(KEYS) do
+      removed = removed + redis.call('ZREM', key, unpack(ARGV))
+    end
+    return removed
+  `;
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  async addJob(
+    jobId: string,
+    data: ExportJobData,
+    timestamp: number
+  ): Promise<void> {
+    await this.cacheService.executeScript<number>(
+      ExportJobHistoryIndexService.addJobScript,
+      this.getIndexKeys({
+        workspaceId: data.workspaceId,
+        userId: Number(data.userId),
+        exportTypes: [data.exportType]
+      }, true),
+      [
+        jobId,
+        timestamp.toString(),
+        ExportJobHistoryIndexService.maxEntriesPerKey.toString(),
+        ExportJobHistoryIndexService.indexTtlSeconds.toString()
+      ]
+    );
+  }
+
+  async getRecentJobIds(
+    scope: ExportJobHistoryScope,
+    limit = ExportJobHistoryIndexService.candidateLimit
+  ): Promise<string[]> {
+    const keys = this.getIndexKeys(scope, false);
+    if (!keys.length || limit <= 0) {
+      return [];
+    }
+
+    const entries = await this.cacheService.executeScript<string[]>(
+      ExportJobHistoryIndexService.getRecentJobsScript,
+      keys,
+      [limit.toString()]
+    );
+    const scoresByJobId = new Map<string, number>();
+    for (let index = 0; index < entries.length; index += 2) {
+      const jobId = entries[index];
+      const score = Number(entries[index + 1]);
+      const previousScore = scoresByJobId.get(jobId);
+      if (previousScore === undefined || score > previousScore) {
+        scoresByJobId.set(jobId, score);
+      }
+    }
+
+    return [...scoresByJobId.entries()]
+      .sort((first, second) => (
+        second[1] - first[1] || first[0].localeCompare(second[0])
+      ))
+      .slice(0, limit)
+      .map(([jobId]) => jobId);
+  }
+
+  async removeJobIds(
+    scope: ExportJobHistoryScope,
+    jobIds: readonly string[]
+  ): Promise<void> {
+    const keys = this.getIndexKeys(scope, false);
+    if (!keys.length || !jobIds.length) {
+      return;
+    }
+    await this.cacheService.executeScript<number>(
+      ExportJobHistoryIndexService.removeJobsScript,
+      keys,
+      [...jobIds]
+    );
+  }
+
+  private getIndexKeys(
+    scope: ExportJobHistoryScope,
+    includeWorkspaceKeyForUser: boolean
+  ): string[] {
+    const keys = new Set<string>();
+    [...new Set(scope.exportTypes)].forEach(exportType => {
+      if (scope.userId === undefined || includeWorkspaceKeyForUser) {
+        keys.add(
+          `export-job-history:v1:workspace:${scope.workspaceId}:type:${exportType}`
+        );
+      }
+      if (scope.userId !== undefined) {
+        keys.add(
+          `export-job-history:v1:workspace:${scope.workspaceId}:user:` +
+          `${scope.userId}:type:${exportType}`
+        );
+      }
+    });
+    return [...keys];
+  }
+}

--- a/apps/backend/src/app/job-queue/job-queue-client.module.ts
+++ b/apps/backend/src/app/job-queue/job-queue-client.module.ts
@@ -4,9 +4,17 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JobQueueService } from './job-queue.service';
 import { ValidationTask } from '../database/entities/validation-task.entity';
+import { CacheClientModule } from '../cache/cache-client.module';
+import {
+  ExportJobClientLeaseService
+} from '../database/services/coding/export-job-client-lease.service';
+import {
+  ExportJobHistoryIndexService
+} from './export-job-history-index.service';
 
 @Module({
   imports: [
+    CacheClientModule,
     TypeOrmModule.forFeature([ValidationTask]),
     BullModule.forRootAsync({
       imports: [ConfigModule],
@@ -56,7 +64,16 @@ import { ValidationTask } from '../database/entities/validation-task.entity';
       name: 'database-export'
     })
   ],
-  providers: [JobQueueService],
-  exports: [BullModule, JobQueueService]
+  providers: [
+    JobQueueService,
+    ExportJobClientLeaseService,
+    ExportJobHistoryIndexService
+  ],
+  exports: [
+    BullModule,
+    JobQueueService,
+    ExportJobClientLeaseService,
+    ExportJobHistoryIndexService
+  ]
 })
 export class JobQueueClientModule { }

--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -134,6 +134,23 @@ describe('JobQueueService', () => {
     expect(queues[2].add).not.toHaveBeenCalled();
   });
 
+  it('applies bounded retention to export jobs', async () => {
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    const data = {
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list' as const
+    };
+
+    await service.addExportJob(data, { attempts: 2 });
+
+    expect(queues[2].add).toHaveBeenCalledWith(data, {
+      removeOnComplete: { age: 3600 },
+      removeOnFail: { age: 86400 },
+      attempts: 2
+    });
+  });
+
   it('reuses active coding statistics jobs for the same workspace and version', async () => {
     const activeStatisticsJob = createJob({ workspaceId: 1, version: 'v2' });
     queues[1].getJobs.mockResolvedValue([activeStatisticsJob]);
@@ -307,6 +324,22 @@ describe('JobQueueService', () => {
     await expect(service.getVariableAnalysisJobs(1)).resolves.toHaveLength(1);
     await expect(service.getActiveCodingAnalysisJob(1)).resolves.toHaveProperty('id', 'job-1');
     await expect(service.getActiveResetCodingVersionJob(1)).resolves.toHaveProperty('id', 'job-1');
+  });
+
+  it('bounds terminal export-job history while retaining all in-progress jobs', async () => {
+    await service.getExportJobs(1);
+
+    expect(queues[2].getJobs).toHaveBeenNthCalledWith(
+      1,
+      ['active', 'waiting', 'delayed']
+    );
+    expect(queues[2].getJobs).toHaveBeenNthCalledWith(
+      2,
+      ['completed', 'failed'],
+      0,
+      499,
+      false
+    );
   });
 
   it('ignores stale null jobs when listing export jobs', async () => {

--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -1,4 +1,7 @@
-import { ConflictException } from '@nestjs/common';
+import {
+  ConflictException,
+  ServiceUnavailableException
+} from '@nestjs/common';
 import { JobQueueService } from './job-queue.service';
 
 const createJob = (
@@ -22,6 +25,7 @@ const createQueue = (job = createJob()) => ({
   add: jest.fn().mockImplementation(async data => ({ ...job, data })),
   getJob: jest.fn().mockResolvedValue(job),
   getJobs: jest.fn().mockResolvedValue([job]),
+  getWorkers: jest.fn().mockResolvedValue([{ name: 'export-worker' }]),
   getJobCounts: jest.fn().mockResolvedValue({
     waiting: 1, active: 0, completed: 0, failed: 0, delayed: 0
   }),
@@ -106,6 +110,28 @@ describe('JobQueueService', () => {
     await expect(service.addResetCodingVersionJob({ workspaceId: 1, version: 'v1' })).rejects.toBeInstanceOf(ConflictException);
     await expect(service.addValidationTaskJob({ taskId: 7 })).rejects.toBeInstanceOf(ConflictException);
     await expect(service.addExternalCodingImportJob({ workspaceId: 1, tempFilePath: '/tmp/a', fileName: 'a.csv' })).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('rejects new export jobs when no export worker is registered', async () => {
+    queues[2].getWorkers.mockResolvedValue([]);
+
+    await expect(service.addExportJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list'
+    })).rejects.toBeInstanceOf(ServiceUnavailableException);
+    expect(queues[2].add).not.toHaveBeenCalled();
+  });
+
+  it('reports export worker discovery failures as unavailable', async () => {
+    queues[2].getWorkers.mockRejectedValue(new Error('Redis unavailable'));
+
+    await expect(service.addExportJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list'
+    })).rejects.toBeInstanceOf(ServiceUnavailableException);
+    expect(queues[2].add).not.toHaveBeenCalled();
   });
 
   it('reuses active coding statistics jobs for the same workspace and version', async () => {

--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -36,12 +36,32 @@ const createQueue = (job = createJob()) => ({
 describe('JobQueueService', () => {
   let queues: ReturnType<typeof createQueue>[];
   let validationTaskRepository: { find: jest.Mock };
+  let exportJobClientLeaseService: {
+    tryClaimExpiredLease: jest.Mock;
+    confirmCleanupClaim: jest.Mock;
+    releaseCleanupClaim: jest.Mock;
+  };
+  let exportJobHistoryIndexService: {
+    addJob: jest.Mock;
+    getRecentJobIds: jest.Mock;
+    removeJobIds: jest.Mock;
+  };
   let service: JobQueueService;
 
   beforeEach(() => {
     queues = Array.from({ length: 12 }, () => createQueue());
     validationTaskRepository = {
       find: jest.fn().mockResolvedValue([{ id: 7, workspace_id: 1 }])
+    };
+    exportJobClientLeaseService = {
+      tryClaimExpiredLease: jest.fn().mockResolvedValue(null),
+      confirmCleanupClaim: jest.fn().mockResolvedValue(true),
+      releaseCleanupClaim: jest.fn().mockResolvedValue(undefined)
+    };
+    exportJobHistoryIndexService = {
+      addJob: jest.fn().mockResolvedValue(undefined),
+      getRecentJobIds: jest.fn().mockResolvedValue([]),
+      removeJobIds: jest.fn().mockResolvedValue(undefined)
     };
     service = new JobQueueService(
       queues[0] as never,
@@ -56,7 +76,9 @@ describe('JobQueueService', () => {
       queues[9] as never,
       queues[10] as never,
       queues[11] as never,
-      validationTaskRepository as never
+      validationTaskRepository as never,
+      exportJobClientLeaseService as never,
+      exportJobHistoryIndexService as never
     );
   });
 
@@ -134,6 +156,132 @@ describe('JobQueueService', () => {
     expect(queues[2].add).not.toHaveBeenCalled();
   });
 
+  it('removes an expired waiting export before checking for duplicates', async () => {
+    const expiredJob = createJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'expired-lease'
+    });
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[2].getJobs
+      .mockResolvedValueOnce([expiredJob])
+      .mockResolvedValueOnce([]);
+    exportJobClientLeaseService.tryClaimExpiredLease
+      .mockResolvedValue('cleanup-claim');
+
+    await expect(service.addExportJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'new-lease'
+    })).resolves.toHaveProperty('data.clientLeaseId', 'new-lease');
+
+    expect(expiredJob.getState).toHaveBeenCalled();
+    expect(exportJobClientLeaseService.tryClaimExpiredLease)
+      .toHaveBeenCalledWith('expired-lease');
+    expect(exportJobClientLeaseService.confirmCleanupClaim)
+      .toHaveBeenCalledWith('expired-lease', 'cleanup-claim');
+    expect(expiredJob.remove).toHaveBeenCalled();
+    expect(exportJobClientLeaseService.releaseCleanupClaim)
+      .not.toHaveBeenCalled();
+    expect(queues[2].add).toHaveBeenCalled();
+  });
+
+  it('does not remove an export if cleanup ownership expires before removal', async () => {
+    const waitingJob = createJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'renewed-lease'
+    });
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[2].getJobs.mockResolvedValue([waitingJob]);
+    exportJobClientLeaseService.tryClaimExpiredLease
+      .mockResolvedValue('expired-cleanup-claim');
+    exportJobClientLeaseService.confirmCleanupClaim.mockResolvedValue(false);
+
+    await expect(service.addExportJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'new-lease'
+    })).rejects.toBeInstanceOf(ConflictException);
+
+    expect(waitingJob.remove).not.toHaveBeenCalled();
+    expect(exportJobClientLeaseService.releaseCleanupClaim)
+      .toHaveBeenCalledWith('renewed-lease', 'expired-cleanup-claim');
+  });
+
+  it('does not remove an export whose cleanup claim cannot be acquired', async () => {
+    const renewedJob = createJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'renewed-lease'
+    });
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[2].getJobs.mockResolvedValue([renewedJob]);
+    exportJobClientLeaseService.tryClaimExpiredLease.mockResolvedValue(null);
+
+    await expect(service.addExportJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'new-lease'
+    })).rejects.toBeInstanceOf(ConflictException);
+
+    expect(renewedJob.remove).not.toHaveBeenCalled();
+    expect(queues[2].add).not.toHaveBeenCalled();
+  });
+
+  it('does not remove an export when Redis cannot establish lease expiry', async () => {
+    const waitingJob = createJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'unknown-lease'
+    });
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[2].getJobs.mockResolvedValue([waitingJob]);
+    exportJobClientLeaseService.tryClaimExpiredLease
+      .mockRejectedValue(new ServiceUnavailableException());
+
+    await expect(service.addExportJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'new-lease'
+    })).rejects.toBeInstanceOf(ConflictException);
+
+    expect(waitingJob.remove).not.toHaveBeenCalled();
+    expect(queues[2].add).not.toHaveBeenCalled();
+  });
+
+  it('releases the cleanup claim if the export has already become active', async () => {
+    const activeJob = createJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'expired-lease'
+    }, 'active');
+    queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
+    queues[2].getJobs.mockResolvedValue([activeJob]);
+    exportJobClientLeaseService.tryClaimExpiredLease
+      .mockResolvedValue('cleanup-claim');
+
+    await expect(service.addExportJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'coding-list',
+      clientLeaseId: 'new-lease'
+    })).rejects.toBeInstanceOf(ConflictException);
+
+    expect(activeJob.remove).not.toHaveBeenCalled();
+    expect(exportJobClientLeaseService.releaseCleanupClaim)
+      .toHaveBeenCalledWith('expired-lease', 'cleanup-claim');
+  });
+
   it('applies bounded retention to export jobs', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
     const data = {
@@ -149,6 +297,11 @@ describe('JobQueueService', () => {
       removeOnFail: { age: 86400 },
       attempts: 2
     });
+    expect(exportJobHistoryIndexService.addJob).toHaveBeenCalledWith(
+      'job-1',
+      data,
+      100
+    );
   });
 
   it('reuses active coding statistics jobs for the same workspace and version', async () => {
@@ -326,37 +479,113 @@ describe('JobQueueService', () => {
     await expect(service.getActiveResetCodingVersionJob(1)).resolves.toHaveProperty('id', 'job-1');
   });
 
-  it('bounds terminal export-job history while retaining all in-progress jobs', async () => {
-    await service.getExportJobs(1);
+  it('queries scoped history IDs while retaining in-progress jobs', async () => {
+    await service.getExportJobs(1, 2, ['coding-list']);
 
     expect(queues[2].getJobs).toHaveBeenNthCalledWith(
       1,
       ['active', 'waiting', 'delayed']
     );
-    expect(queues[2].getJobs).toHaveBeenNthCalledWith(
-      2,
-      ['completed', 'failed'],
-      0,
-      499,
-      false
-    );
+    expect(exportJobHistoryIndexService.getRecentJobIds).toHaveBeenCalledWith({
+      workspaceId: 1,
+      userId: 2,
+      exportTypes: ['coding-list']
+    });
+    expect(queues[2].getJobs).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores stale null jobs when listing export jobs', async () => {
-    queues[2].getJobs.mockResolvedValue([
-      null,
-      createJob(null),
-      createJob({ workspaceId: 2, exportType: 'test-results' }),
-      createJob({ workspaceId: 1, exportType: 'test-results' })
-    ] as never);
+  it('hydrates terminal jobs from the scoped history index', async () => {
+    const matchingJob = {
+      ...createJob({ workspaceId: 1, userId: 2, exportType: 'coding-list' }, 'completed'),
+      id: 'matching-job'
+    };
+    queues[2].getJobs.mockResolvedValue([]);
+    queues[2].getJob.mockResolvedValue(matchingJob);
+    exportJobHistoryIndexService.getRecentJobIds
+      .mockResolvedValue(['matching-job']);
 
-    const exportJobs = await service.getExportJobs(1);
+    await expect(service.getExportJobs(1, 2)).resolves.toEqual([matchingJob]);
+    expect(queues[2].getJob).toHaveBeenCalledWith('matching-job');
+    expect(matchingJob.getState).toHaveBeenCalled();
+  });
+
+  it('stops hydrating indexed jobs after reaching the terminal result limit', async () => {
+    const indexedJobIds = Array.from(
+      { length: 600 },
+      (_, index) => `job-${index}`
+    );
+    queues[2].getJobs.mockResolvedValue([]);
+    queues[2].getJob.mockImplementation(async jobId => ({
+      ...createJob({
+        workspaceId: 1,
+        userId: 2,
+        exportType: 'coding-list'
+      }, 'completed'),
+      id: jobId
+    }));
+    exportJobHistoryIndexService.getRecentJobIds
+      .mockResolvedValue(indexedJobIds);
+
+    await expect(service.getExportJobs(
+      1,
+      2,
+      ['coding-list']
+    )).resolves.toHaveLength(500);
+
+    expect(queues[2].getJob).toHaveBeenCalledTimes(500);
+  });
+
+  it('filters export types before applying the terminal-job result limit', async () => {
+    const codingJob = {
+      ...createJob({
+        workspaceId: 1,
+        userId: 2,
+        exportType: 'coding-list'
+      }, 'completed'),
+      id: 'coding-job'
+    };
+    queues[2].getJobs.mockResolvedValue([]);
+    queues[2].getJob.mockResolvedValue(codingJob);
+    exportJobHistoryIndexService.getRecentJobIds
+      .mockResolvedValue(['coding-job']);
+
+    await expect(service.getExportJobs(
+      1,
+      2,
+      ['coding-list']
+    )).resolves.toEqual([codingJob]);
+    expect(exportJobHistoryIndexService.getRecentJobIds).toHaveBeenCalledWith({
+      workspaceId: 1,
+      userId: 2,
+      exportTypes: ['coding-list']
+    });
+  });
+
+  it('prunes stale IDs while listing indexed export jobs', async () => {
+    const matchingJob = createJob({
+      workspaceId: 1,
+      userId: 2,
+      exportType: 'test-results'
+    }, 'failed');
+    queues[2].getJobs.mockResolvedValue([]);
+    queues[2].getJob
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(matchingJob);
+    exportJobHistoryIndexService.getRecentJobIds
+      .mockResolvedValue(['stale-job', 'job-1']);
+
+    const exportJobs = await service.getExportJobs(
+      1,
+      2,
+      ['test-results']
+    );
 
     expect(exportJobs).toHaveLength(1);
-    expect(exportJobs[0].data).toMatchObject({
+    expect(exportJobHistoryIndexService.removeJobIds).toHaveBeenCalledWith({
       workspaceId: 1,
-      exportType: 'test-results'
-    });
+      userId: 2,
+      exportTypes: ['test-results']
+    }, ['stale-job']);
   });
 
   it('covers all registered process overview queues', async () => {

--- a/apps/backend/src/app/job-queue/job-queue.service.spec.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.spec.ts
@@ -25,12 +25,16 @@ const createQueue = (job = createJob()) => ({
   add: jest.fn().mockImplementation(async data => ({ ...job, data })),
   getJob: jest.fn().mockResolvedValue(job),
   getJobs: jest.fn().mockResolvedValue([job]),
+  toKey: jest.fn().mockImplementation(state => `data-export:${state}`),
   getWorkers: jest.fn().mockResolvedValue([{ name: 'export-worker' }]),
   getJobCounts: jest.fn().mockResolvedValue({
     waiting: 1, active: 0, completed: 0, failed: 0, delayed: 0
   }),
   isReady: jest.fn().mockResolvedValue(undefined),
-  client: { ping: jest.fn().mockResolvedValue('PONG') }
+  client: {
+    ping: jest.fn().mockResolvedValue('PONG'),
+    zrevrange: jest.fn().mockResolvedValue([])
+  }
 });
 
 describe('JobQueueService', () => {
@@ -45,6 +49,10 @@ describe('JobQueueService', () => {
     addJob: jest.Mock;
     getRecentJobIds: jest.Mock;
     removeJobIds: jest.Mock;
+    claimLegacyBackfill: jest.Mock;
+    refreshLegacyBackfillClaim: jest.Mock;
+    completeLegacyBackfill: jest.Mock;
+    releaseLegacyBackfillClaim: jest.Mock;
   };
   let service: JobQueueService;
 
@@ -61,7 +69,11 @@ describe('JobQueueService', () => {
     exportJobHistoryIndexService = {
       addJob: jest.fn().mockResolvedValue(undefined),
       getRecentJobIds: jest.fn().mockResolvedValue([]),
-      removeJobIds: jest.fn().mockResolvedValue(undefined)
+      removeJobIds: jest.fn().mockResolvedValue(undefined),
+      claimLegacyBackfill: jest.fn().mockResolvedValue({ status: 'complete' }),
+      refreshLegacyBackfillClaim: jest.fn().mockResolvedValue(undefined),
+      completeLegacyBackfill: jest.fn().mockResolvedValue(undefined),
+      releaseLegacyBackfillClaim: jest.fn().mockResolvedValue(undefined)
     };
     service = new JobQueueService(
       queues[0] as never,
@@ -484,7 +496,9 @@ describe('JobQueueService', () => {
 
     expect(queues[2].getJobs).toHaveBeenNthCalledWith(
       1,
-      ['active', 'waiting', 'delayed']
+      ['active', 'waiting', 'delayed',
+        'paused'
+      ]
     );
     expect(exportJobHistoryIndexService.getRecentJobIds).toHaveBeenCalledWith({
       workspaceId: 1,
@@ -492,6 +506,306 @@ describe('JobQueueService', () => {
       exportTypes: ['coding-list']
     });
     expect(queues[2].getJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains in-progress jobs when the history index cannot be read', async () => {
+    const activeJob = {
+      ...createJob(
+        {
+          workspaceId: 1,
+          userId: 2,
+          exportType: 'coding-list'
+        },
+        'active'
+      ),
+      id: 'active-job'
+    };
+    queues[2].getJobs.mockResolvedValue([activeJob]);
+    exportJobHistoryIndexService.getRecentJobIds.mockRejectedValue(
+      new Error('history unavailable')
+    );
+
+    await expect(service.getExportJobs(1, 2, ['coding-list'])).resolves.toEqual(
+      [activeJob]
+    );
+  });
+
+  it('backfills legacy terminal jobs once', async () => {
+    const legacyJob = {
+      ...createJob(
+        {
+          workspaceId: 1,
+          userId: 2,
+          exportType: 'coding-list'
+        },
+        'completed'
+      ),
+      id: 'legacy-job'
+    };
+    exportJobHistoryIndexService.claimLegacyBackfill.mockResolvedValue({
+      status: 'claimed',
+      claim: 'backfill-claim'
+    });
+    queues[2].getJobs.mockResolvedValue([]);
+    queues[2].client.zrevrange.mockImplementation(async key => (
+      key === 'data-export:completed' ? ['legacy-job'] : []
+    ));
+    queues[2].getJob.mockResolvedValue(legacyJob);
+
+    await expect(
+      service.getExportJobsWithHistoryState(1, 2, ['coding-list'])
+    ).resolves.toEqual({
+      jobs: [],
+      historyPending: true
+    });
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+
+    expect(queues[2].client.zrevrange).toHaveBeenCalledWith(
+      'data-export:completed',
+      0,
+      -1
+    );
+    expect(queues[2].client.zrevrange).toHaveBeenCalledWith(
+      'data-export:failed',
+      0,
+      -1
+    );
+    expect(exportJobHistoryIndexService.addJob).toHaveBeenCalledWith(
+      'legacy-job',
+      legacyJob.data,
+      legacyJob.timestamp
+    );
+    expect(
+      exportJobHistoryIndexService.refreshLegacyBackfillClaim
+    ).toHaveBeenCalledWith('backfill-claim');
+    expect(
+      exportJobHistoryIndexService.completeLegacyBackfill
+    ).toHaveBeenCalledWith('backfill-claim');
+    expect(
+      exportJobHistoryIndexService.claimLegacyBackfill
+    ).toHaveBeenCalledTimes(1);
+
+    exportJobHistoryIndexService.getRecentJobIds.mockResolvedValue([
+      'legacy-job'
+    ]);
+    queues[2].getJob.mockResolvedValue(legacyJob);
+    await expect(
+      service.getExportJobsWithHistoryState(1, 2, ['coding-list'])
+    ).resolves.toEqual({
+      jobs: [legacyJob],
+      historyPending: false
+    });
+    expect(
+      exportJobHistoryIndexService.claimLegacyBackfill
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('backfills retained terminal jobs beyond the former global limit', async () => {
+    const legacyJobs = Array.from({ length: 2001 }, (_, index) => ({
+      ...createJob(
+        {
+          workspaceId: index + 1,
+          userId: 2,
+          exportType: 'coding-list'
+        },
+        'completed'
+      ),
+      id: `legacy-job-${index}`,
+      timestamp: index
+    }));
+    exportJobHistoryIndexService.claimLegacyBackfill.mockResolvedValue({
+      status: 'claimed',
+      claim: 'complete-backfill-claim'
+    });
+    const legacyJobsById = new Map(
+      legacyJobs.map(job => [job.id.toString(), job])
+    );
+    queues[2].getJobs.mockResolvedValue([]);
+    queues[2].client.zrevrange.mockImplementation(async key => (
+      key === 'data-export:completed' ? [...legacyJobsById.keys()] : []
+    ));
+    queues[2].getJob.mockImplementation(async jobId => (
+      legacyJobsById.get(jobId.toString())
+    ));
+
+    await service.getExportJobsWithHistoryState(1, 2, ['coding-list']);
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+
+    expect(exportJobHistoryIndexService.addJob).toHaveBeenCalledTimes(2001);
+    expect(exportJobHistoryIndexService.addJob).toHaveBeenCalledWith(
+      'legacy-job-2000',
+      legacyJobs[2000].data,
+      2000
+    );
+    expect(queues[2].getJob).toHaveBeenCalledWith(
+      'legacy-job-2000'
+    );
+    expect(
+      exportJobHistoryIndexService.completeLegacyBackfill
+    ).toHaveBeenCalledWith('complete-backfill-claim');
+  });
+
+  it('does not skip retained jobs when an earlier job is deleted between batches', async () => {
+    const legacyJobs = Array.from({ length: 101 }, (_, index) => ({
+      ...createJob(
+        {
+          workspaceId: 1,
+          userId: 2,
+          exportType: 'coding-list'
+        },
+        'completed'
+      ),
+      id: `legacy-job-${index}`,
+      timestamp: index
+    }));
+    const legacyJobsById = new Map(
+      legacyJobs.map(job => [job.id.toString(), job])
+    );
+    exportJobHistoryIndexService.claimLegacyBackfill.mockResolvedValue({
+      status: 'claimed',
+      claim: 'stable-snapshot-claim'
+    });
+    queues[2].getJobs.mockResolvedValue([]);
+    queues[2].client.zrevrange.mockImplementation(async key => (
+      key === 'data-export:completed' ? [...legacyJobsById.keys()] : []
+    ));
+    queues[2].getJob.mockImplementation(async jobId => (
+      legacyJobsById.get(jobId.toString())
+    ));
+    exportJobHistoryIndexService.refreshLegacyBackfillClaim
+      .mockImplementationOnce(async () => {
+        legacyJobsById.delete('legacy-job-0');
+      });
+
+    await service.getExportJobsWithHistoryState(1, 2, ['coding-list']);
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+
+    expect(exportJobHistoryIndexService.addJob).toHaveBeenCalledTimes(101);
+    expect(exportJobHistoryIndexService.addJob).toHaveBeenCalledWith(
+      'legacy-job-100',
+      legacyJobs[100].data,
+      100
+    );
+    expect(
+      exportJobHistoryIndexService.completeLegacyBackfill
+    ).toHaveBeenCalledWith('stable-snapshot-claim');
+  });
+
+  it('does not block active jobs while legacy history is being indexed', async () => {
+    const activeJob = {
+      ...createJob(
+        {
+          workspaceId: 1,
+          userId: 2,
+          exportType: 'coding-list'
+        },
+        'active'
+      ),
+      id: 'active-job'
+    };
+    const legacyJob = {
+      ...createJob(
+        {
+          workspaceId: 1,
+          userId: 2,
+          exportType: 'coding-list'
+        },
+        'completed'
+      ),
+      id: 'legacy-job'
+    };
+    let finishIndexing: () => void;
+    const indexing = new Promise<void>(resolve => {
+      finishIndexing = resolve;
+    });
+    exportJobHistoryIndexService.claimLegacyBackfill.mockResolvedValue({
+      status: 'claimed',
+      claim: 'backfill-claim'
+    });
+    exportJobHistoryIndexService.addJob.mockReturnValue(indexing);
+    queues[2].client.zrevrange.mockImplementation(async key => (
+      key === 'data-export:completed' ? ['legacy-job'] : []
+    ));
+    queues[2].getJob.mockResolvedValue(legacyJob);
+    queues[2].getJobs.mockImplementation(async states => (
+      states.includes('active') ? [activeJob] : []
+    ));
+
+    await expect(
+      service.getExportJobsWithHistoryState(1, 2, ['coding-list'])
+    ).resolves.toEqual({
+      jobs: [activeJob],
+      historyPending: true
+    });
+    expect(
+      exportJobHistoryIndexService.completeLegacyBackfill
+    ).not.toHaveBeenCalled();
+
+    finishIndexing!();
+    await indexing;
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+    expect(
+      exportJobHistoryIndexService.completeLegacyBackfill
+    ).toHaveBeenCalledWith('backfill-claim');
+  });
+
+  it('retries legacy backfill after another owner was busy', async () => {
+    exportJobHistoryIndexService.claimLegacyBackfill
+      .mockResolvedValueOnce({ status: 'busy' })
+      .mockResolvedValueOnce({
+        status: 'claimed',
+        claim: 'retry-claim'
+      });
+    queues[2].getJobs.mockResolvedValue([]);
+
+    await service.getExportJobs(1, 2, ['coding-list']);
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+    await service.getExportJobs(1, 2, ['coding-list']);
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+
+    expect(
+      exportJobHistoryIndexService.claimLegacyBackfill
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      exportJobHistoryIndexService.completeLegacyBackfill
+    ).toHaveBeenCalledWith('retry-claim');
+  });
+
+  it('retains paused export jobs while restoring scoped history', async () => {
+    const pausedJob = {
+      ...createJob(
+        {
+          workspaceId: 1,
+          userId: 2,
+          exportType: 'coding-list'
+        },
+        'paused'
+      ),
+      id: 'paused-job'
+    };
+    queues[2].getJobs.mockResolvedValue([pausedJob]);
+
+    await expect(service.getExportJobs(1, 2, ['coding-list'])).resolves.toEqual(
+      [pausedJob]
+    );
+    expect(queues[2].getJobs).toHaveBeenCalledWith([
+      'active',
+      'waiting',
+      'delayed',
+      'paused'
+    ]);
   });
 
   it('hydrates terminal jobs from the scoped history index', async () => {
@@ -516,44 +830,48 @@ describe('JobQueueService', () => {
     );
     queues[2].getJobs.mockResolvedValue([]);
     queues[2].getJob.mockImplementation(async jobId => ({
-      ...createJob({
-        workspaceId: 1,
-        userId: 2,
-        exportType: 'coding-list'
-      }, 'completed'),
+      ...createJob(
+        {
+          workspaceId: 1,
+          userId: 2,
+          exportType: 'coding-list'
+        },
+        'completed'
+      ),
       id: jobId
     }));
-    exportJobHistoryIndexService.getRecentJobIds
-      .mockResolvedValue(indexedJobIds);
+    exportJobHistoryIndexService.getRecentJobIds.mockResolvedValue(
+      indexedJobIds
+    );
 
-    await expect(service.getExportJobs(
-      1,
-      2,
-      ['coding-list']
-    )).resolves.toHaveLength(500);
+    await expect(
+      service.getExportJobs(1, 2, ['coding-list'])
+    ).resolves.toHaveLength(500);
 
     expect(queues[2].getJob).toHaveBeenCalledTimes(500);
   });
 
   it('filters export types before applying the terminal-job result limit', async () => {
     const codingJob = {
-      ...createJob({
-        workspaceId: 1,
-        userId: 2,
-        exportType: 'coding-list'
-      }, 'completed'),
+      ...createJob(
+        {
+          workspaceId: 1,
+          userId: 2,
+          exportType: 'coding-list'
+        },
+        'completed'
+      ),
       id: 'coding-job'
     };
     queues[2].getJobs.mockResolvedValue([]);
     queues[2].getJob.mockResolvedValue(codingJob);
-    exportJobHistoryIndexService.getRecentJobIds
-      .mockResolvedValue(['coding-job']);
+    exportJobHistoryIndexService.getRecentJobIds.mockResolvedValue([
+      'coding-job'
+    ]);
 
-    await expect(service.getExportJobs(
-      1,
-      2,
-      ['coding-list']
-    )).resolves.toEqual([codingJob]);
+    await expect(service.getExportJobs(1, 2, ['coding-list'])).resolves.toEqual(
+      [codingJob]
+    );
     expect(exportJobHistoryIndexService.getRecentJobIds).toHaveBeenCalledWith({
       workspaceId: 1,
       userId: 2,
@@ -562,30 +880,34 @@ describe('JobQueueService', () => {
   });
 
   it('prunes stale IDs while listing indexed export jobs', async () => {
-    const matchingJob = createJob({
-      workspaceId: 1,
-      userId: 2,
-      exportType: 'test-results'
-    }, 'failed');
+    const matchingJob = createJob(
+      {
+        workspaceId: 1,
+        userId: 2,
+        exportType: 'test-results'
+      },
+      'failed'
+    );
     queues[2].getJobs.mockResolvedValue([]);
     queues[2].getJob
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(matchingJob);
-    exportJobHistoryIndexService.getRecentJobIds
-      .mockResolvedValue(['stale-job', 'job-1']);
+    exportJobHistoryIndexService.getRecentJobIds.mockResolvedValue([
+      'stale-job',
+      'job-1'
+    ]);
 
-    const exportJobs = await service.getExportJobs(
-      1,
-      2,
-      ['test-results']
-    );
+    const exportJobs = await service.getExportJobs(1, 2, ['test-results']);
 
     expect(exportJobs).toHaveLength(1);
-    expect(exportJobHistoryIndexService.removeJobIds).toHaveBeenCalledWith({
-      workspaceId: 1,
-      userId: 2,
-      exportTypes: ['test-results']
-    }, ['stale-job']);
+    expect(exportJobHistoryIndexService.removeJobIds).toHaveBeenCalledWith(
+      {
+        workspaceId: 1,
+        userId: 2,
+        exportTypes: ['test-results']
+      },
+      ['stale-job']
+    );
   });
 
   it('covers all registered process overview queues', async () => {
@@ -609,18 +931,18 @@ describe('JobQueueService', () => {
 
   it('uses validation task progress and metadata from the task entity in the process overview', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
-    queues[7].getJobs.mockResolvedValue([
-      createJob({ taskId: 7 }, 'active')
+    queues[7].getJobs.mockResolvedValue([createJob({ taskId: 7 }, 'active')]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'processing',
+        progress: 65,
+        progress_message: 'Testdateien werden geprüft...',
+        error: 'Schema validation failed'
+      }
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'processing',
-      progress: 65,
-      progress_message: 'Testdateien werden geprüft...',
-      error: 'Schema validation failed'
-    }]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -644,15 +966,17 @@ describe('JobQueueService', () => {
     queues[7].getJobs.mockResolvedValue([
       createJob({ taskId: 7 }, 'completed')
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'cancelled',
-      progress: 30,
-      progress_message: 'Validierung abgebrochen.',
-      error: 'Cancelled by user'
-    }]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'cancelled',
+        progress: 30,
+        progress_message: 'Validierung abgebrochen.',
+        error: 'Cancelled by user'
+      }
+    ]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -673,18 +997,18 @@ describe('JobQueueService', () => {
 
   it('keeps active Bull validation tasks active even when the task entity is cancelled', async () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
-    queues[7].getJobs.mockResolvedValue([
-      createJob({ taskId: 7 }, 'active')
+    queues[7].getJobs.mockResolvedValue([createJob({ taskId: 7 }, 'active')]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'cancelled',
+        progress: 30,
+        progress_message: 'Validierung abgebrochen.',
+        error: 'Cancelled by user'
+      }
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'cancelled',
-      progress: 30,
-      progress_message: 'Validierung abgebrochen.',
-      error: 'Cancelled by user'
-    }]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -708,15 +1032,17 @@ describe('JobQueueService', () => {
     queues[7].getJobs.mockResolvedValue([
       createJob({ taskId: 7 }, 'completed')
     ]);
-    validationTaskRepository.find.mockResolvedValueOnce([{
-      id: 7,
-      workspace_id: 1,
-      validation_type: 'testFiles',
-      status: 'failed',
-      progress: 100,
-      progress_message: 'Validierung fehlgeschlagen.',
-      error: 'Schema validation failed'
-    }]);
+    validationTaskRepository.find.mockResolvedValueOnce([
+      {
+        id: 7,
+        workspace_id: 1,
+        validation_type: 'testFiles',
+        status: 'failed',
+        progress: 100,
+        progress_message: 'Validierung fehlgeschlagen.',
+        error: 'Schema validation failed'
+      }
+    ]);
 
     const workspaceJobs = await service.getAllWorkspaceJobs(1);
 
@@ -805,7 +1131,9 @@ describe('JobQueueService', () => {
         isCancelled: false
       }
     });
-    expect(JSON.stringify(workspaceJobs[0].data)).not.toContain('requestedByUserId');
+    expect(JSON.stringify(workspaceJobs[0].data)).not.toContain(
+      'requestedByUserId'
+    );
   });
 
   it('ignores stale null jobs returned by Bull when listing workspace jobs', async () => {
@@ -828,20 +1156,34 @@ describe('JobQueueService', () => {
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
     queues[1].getJobs.mockResolvedValue([null] as never);
 
-    await expect(service.assertNoDependencyConflicts('data-export', 1)).resolves.toBeUndefined();
+    await expect(
+      service.assertNoDependencyConflicts('data-export', 1)
+    ).resolves.toBeUndefined();
   });
 
   it('checks dependency conflicts and redis status', async () => {
-    await expect(service.assertNoActiveUploadForWorkspace(1)).rejects.toBeInstanceOf(ConflictException);
-    await expect(service.assertNoDependencyConflicts('data-export', 1)).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.assertNoActiveUploadForWorkspace(1)
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      service.assertNoDependencyConflicts('data-export', 1)
+    ).rejects.toBeInstanceOf(ConflictException);
 
     queues.forEach(queue => queue.getJobs.mockResolvedValue([]));
-    await expect(service.assertNoActiveUploadForWorkspace(1)).resolves.toBeUndefined();
-    await expect(service.assertNoDependencyConflicts('data-export', 1)).resolves.toBeUndefined();
+    await expect(
+      service.assertNoActiveUploadForWorkspace(1)
+    ).resolves.toBeUndefined();
+    await expect(
+      service.assertNoDependencyConflicts('data-export', 1)
+    ).resolves.toBeUndefined();
 
-    await expect(service.checkRedisConnection()).resolves.toMatchObject({ connected: true });
+    await expect(service.checkRedisConnection()).resolves.toMatchObject({
+      connected: true
+    });
     queues[0].client = null;
-    await expect(service.checkRedisConnection()).resolves.toMatchObject({ connected: false });
+    await expect(service.checkRedisConnection()).resolves.toMatchObject({
+      connected: false
+    });
   });
 
   it('deletes all variable analysis jobs including active ones', async () => {

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -15,7 +15,17 @@ import {
   CodebookExportFormat,
   CodebookTrainingRequirementFilter
 } from '../../../../../api-dto/coding/codebook-content-setting';
-import { BackgroundExportRequest } from '../../../../../api-dto/coding/export-request.dto';
+import {
+  BACKGROUND_EXPORT_TYPES,
+  BackgroundExportRequest
+} from '../../../../../api-dto/coding/export-request.dto';
+import {
+  ExportJobClientLeaseService
+} from '../database/services/coding/export-job-client-lease.service';
+import {
+  ExportJobHistoryIndexService,
+  ExportJobHistoryScope
+} from './export-job-history-index.service';
 
 type ProcessOverviewValidationTask = Pick<
 ValidationTask,
@@ -207,6 +217,7 @@ export class JobQueueService {
   private static readonly completedExportJobRetentionSeconds = 3600;
   private static readonly failedExportJobRetentionSeconds = 86400;
   private static readonly recentTerminalExportJobLimit = 500;
+  private static readonly exportJobHistoryHydrationBatchSize = 100;
   private readonly logger = new Logger(JobQueueService.name);
 
   private readonly exportCancellationControllers = new Map<string, AbortController>();
@@ -251,7 +262,9 @@ export class JobQueueService {
     @InjectQueue('external-coding-import') private externalCodingImportQueue: Queue,
     @InjectQueue('database-export') private databaseExportQueue: Queue<DatabaseExportJobData>,
     @InjectRepository(ValidationTask)
-    private readonly validationTaskRepository: Repository<ValidationTask>
+    private readonly validationTaskRepository: Repository<ValidationTask>,
+    private readonly exportJobClientLeaseService: ExportJobClientLeaseService,
+    private readonly exportJobHistoryIndexService: ExportJobHistoryIndexService
   ) { }
 
   private getQueue(name: string): Queue {
@@ -638,6 +651,68 @@ export class JobQueueService {
     return jobs.find(job => job.data && matchFn(job.data));
   }
 
+  private async removeExpiredWaitingExportJob(
+    job: Job<ExportJobData>
+  ): Promise<boolean> {
+    const leaseId = job.data.clientLeaseId;
+    if (!leaseId) {
+      return false;
+    }
+
+    let cleanupClaim: string | null = null;
+    try {
+      cleanupClaim = await this.exportJobClientLeaseService
+        .tryClaimExpiredLease(leaseId);
+      if (!cleanupClaim) {
+        return false;
+      }
+
+      const state = await job.getState();
+      if (state !== 'waiting' && state !== 'delayed') {
+        await this.exportJobClientLeaseService.releaseCleanupClaim(
+          leaseId,
+          cleanupClaim
+        );
+        cleanupClaim = null;
+        return false;
+      }
+
+      const cleanupConfirmed = await this.exportJobClientLeaseService
+        .confirmCleanupClaim(leaseId, cleanupClaim);
+      if (!cleanupConfirmed) {
+        await this.exportJobClientLeaseService.releaseCleanupClaim(
+          leaseId,
+          cleanupClaim
+        );
+        cleanupClaim = null;
+        return false;
+      }
+
+      await job.remove();
+      this.logger.log(
+        `Removed export job ${job.id} because its client lease expired before processing`
+      );
+      return true;
+    } catch (error) {
+      if (cleanupClaim) {
+        try {
+          await this.exportJobClientLeaseService.releaseCleanupClaim(
+            leaseId,
+            cleanupClaim
+          );
+        } catch (releaseError) {
+          this.logger.warn(
+            `Could not release cleanup claim for export job ${job.id}: ${releaseError.message}`
+          );
+        }
+      }
+      this.logger.warn(
+        `Could not remove export job ${job.id} with an expired client lease: ${error.message}`
+      );
+      return false;
+    }
+  }
+
   async addTestPersonCodingJob(
     data: TestPersonCodingJobData,
     options?: JobOptions
@@ -866,10 +941,16 @@ export class JobQueueService {
     }
 
     await this.assertNoDependencyConflicts('data-export', data.workspaceId);
-    const existing = await this.findActiveJob<ExportJobData>(
+    let existing = await this.findActiveJob<ExportJobData>(
       this.dataExportQueue,
       d => d.workspaceId === data.workspaceId && d.exportType === data.exportType
     );
+    while (existing && await this.removeExpiredWaitingExportJob(existing)) {
+      existing = await this.findActiveJob<ExportJobData>(
+        this.dataExportQueue,
+        d => d.workspaceId === data.workspaceId && d.exportType === data.exportType
+      );
+    }
     if (existing) {
       throw new ConflictException(
         `An export job of type '${data.exportType}' is already running for workspace ${data.workspaceId} (job ${existing.id})`
@@ -878,7 +959,7 @@ export class JobQueueService {
     this.logger.log(
       `Adding export job for workspace ${data.workspaceId}, type: ${data.exportType}`
     );
-    return this.dataExportQueue.add(data, {
+    const job = await this.dataExportQueue.add(data, {
       removeOnComplete: {
         age: JobQueueService.completedExportJobRetentionSeconds
       },
@@ -887,13 +968,113 @@ export class JobQueueService {
       },
       ...options
     });
+    await this.ensureExportJobIndexed(job);
+    return job;
   }
 
   async getExportJob(jobId: string): Promise<Job<ExportJobData>> {
     return this.dataExportQueue.getJob(jobId);
   }
 
-  async getExportJobs(workspaceId: number): Promise<Job<ExportJobData>[]> {
+  private exportJobMatchesScope(
+    job: Job<ExportJobData> | null | undefined,
+    workspaceId: number,
+    userId?: number,
+    exportTypes?: readonly string[]
+  ): job is Job<ExportJobData> {
+    return !!job &&
+      this.jobMatchesWorkspace(job, workspaceId) &&
+      (userId === undefined || Number(job.data.userId) === userId) &&
+      (!exportTypes || exportTypes.includes(job.data.exportType));
+  }
+
+  private async getRecentTerminalExportJobs(
+    workspaceId: number,
+    userId?: number,
+    exportTypes?: readonly string[]
+  ): Promise<Job<ExportJobData>[]> {
+    const scope: ExportJobHistoryScope = {
+      workspaceId,
+      userId,
+      exportTypes: exportTypes || BACKGROUND_EXPORT_TYPES
+    };
+    const jobIds = await this.exportJobHistoryIndexService.getRecentJobIds(
+      scope
+    );
+    const terminalJobs: Job<ExportJobData>[] = [];
+    const staleJobIds: string[] = [];
+
+    for (
+      let start = 0;
+      start < jobIds.length &&
+      terminalJobs.length < JobQueueService.recentTerminalExportJobLimit;
+      start += JobQueueService.exportJobHistoryHydrationBatchSize
+    ) {
+      const batchIds = jobIds.slice(
+        start,
+        start + JobQueueService.exportJobHistoryHydrationBatchSize
+      );
+      const candidates = await Promise.allSettled(batchIds.map(async jobId => {
+        const job = await this.dataExportQueue.getJob(jobId);
+        if (!job) {
+          return { jobId };
+        }
+        return {
+          jobId,
+          job,
+          state: await job.getState()
+        };
+      }));
+
+      candidates.forEach(candidate => {
+        if (candidate.status === 'rejected') {
+          this.logger.warn(
+            `Could not hydrate an indexed export job: ${candidate.reason?.message || candidate.reason}`
+          );
+          return;
+        }
+        if (!candidate.value.job) {
+          staleJobIds.push(candidate.value.jobId);
+          return;
+        }
+        if (
+          (candidate.value.state === 'completed' ||
+            candidate.value.state === 'failed') &&
+          this.exportJobMatchesScope(
+            candidate.value.job,
+            workspaceId,
+            userId,
+            exportTypes
+          )
+        ) {
+          terminalJobs.push(candidate.value.job);
+        }
+      });
+    }
+
+    if (staleJobIds.length) {
+      try {
+        await this.exportJobHistoryIndexService.removeJobIds(
+          scope,
+          staleJobIds
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Could not prune stale export history entries: ${error.message}`
+        );
+      }
+    }
+
+    return terminalJobs
+      .sort((first, second) => second.timestamp - first.timestamp)
+      .slice(0, JobQueueService.recentTerminalExportJobLimit);
+  }
+
+  async getExportJobs(
+    workspaceId: number,
+    userId?: number,
+    exportTypes?: readonly string[]
+  ): Promise<Job<ExportJobData>[]> {
     this.logger.log(`Fetching all export jobs for workspace ${workspaceId}`);
     const [inProgressJobs, terminalJobs] = await Promise.all([
       this.dataExportQueue.getJobs([
@@ -901,20 +1082,38 @@ export class JobQueueService {
         'waiting',
         'delayed'
       ]),
-      this.dataExportQueue.getJobs(
-        ['completed', 'failed'],
-        0,
-        JobQueueService.recentTerminalExportJobLimit - 1,
-        false
+      this.getRecentTerminalExportJobs(
+        workspaceId,
+        userId,
+        exportTypes
       )
     ]);
     const jobs = [...new Map(
       [...inProgressJobs, ...terminalJobs]
-        .filter((job): job is Job<ExportJobData> => !!job)
+        .filter(job => this.exportJobMatchesScope(
+          job,
+          workspaceId,
+          userId,
+          exportTypes
+        ))
         .map(job => [job.id.toString(), job])
     ).values()];
     this.logger.log(`Found ${jobs.length} export jobs in total`);
-    return jobs.filter(job => this.jobMatchesWorkspace(job, workspaceId));
+    return jobs;
+  }
+
+  async ensureExportJobIndexed(job: Job<ExportJobData>): Promise<void> {
+    try {
+      await this.exportJobHistoryIndexService.addJob(
+        job.id.toString(),
+        job.data,
+        job.timestamp
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Could not index export job ${job.id}: ${error.message}`
+      );
+    }
   }
 
   createExportJobCancellationSignal(jobId: string): AbortSignal {

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -1,7 +1,8 @@
 import {
   Injectable,
   Logger,
-  ConflictException
+  ConflictException,
+  ServiceUnavailableException
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -842,6 +843,24 @@ export class JobQueueService {
     data: ExportJobData,
     options?: JobOptions
   ): Promise<Job<ExportJobData>> {
+    let workers: { [index: string]: string }[];
+    try {
+      workers = await this.dataExportQueue.getWorkers();
+    } catch (error) {
+      this.logger.error(
+        `Unable to determine export worker availability: ${error.message}`,
+        error.stack
+      );
+      throw new ServiceUnavailableException(
+        'The export worker is currently unavailable'
+      );
+    }
+    if (workers.length === 0) {
+      throw new ServiceUnavailableException(
+        'The export worker is currently unavailable'
+      );
+    }
+
     await this.assertNoDependencyConflicts('data-export', data.workspaceId);
     const existing = await this.findActiveJob<ExportJobData>(
       this.dataExportQueue,

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -154,6 +154,7 @@ export type ExportJobData = BackgroundExportRequest & {
   workspaceId: number;
   userId: number;
   isCancelled?: boolean;
+  clientLeaseId?: string;
 };
 
 export type ExportJobProgressPhase = 'preparing'
@@ -203,6 +204,9 @@ export interface RedisConnectionStatus {
 
 @Injectable()
 export class JobQueueService {
+  private static readonly completedExportJobRetentionSeconds = 3600;
+  private static readonly failedExportJobRetentionSeconds = 86400;
+  private static readonly recentTerminalExportJobLimit = 500;
   private readonly logger = new Logger(JobQueueService.name);
 
   private readonly exportCancellationControllers = new Map<string, AbortController>();
@@ -874,7 +878,15 @@ export class JobQueueService {
     this.logger.log(
       `Adding export job for workspace ${data.workspaceId}, type: ${data.exportType}`
     );
-    return this.dataExportQueue.add(data, options);
+    return this.dataExportQueue.add(data, {
+      removeOnComplete: {
+        age: JobQueueService.completedExportJobRetentionSeconds
+      },
+      removeOnFail: {
+        age: JobQueueService.failedExportJobRetentionSeconds
+      },
+      ...options
+    });
   }
 
   async getExportJob(jobId: string): Promise<Job<ExportJobData>> {
@@ -883,13 +895,24 @@ export class JobQueueService {
 
   async getExportJobs(workspaceId: number): Promise<Job<ExportJobData>[]> {
     this.logger.log(`Fetching all export jobs for workspace ${workspaceId}`);
-    const jobs = await this.dataExportQueue.getJobs([
-      'completed',
-      'failed',
-      'active',
-      'waiting',
-      'delayed'
+    const [inProgressJobs, terminalJobs] = await Promise.all([
+      this.dataExportQueue.getJobs([
+        'active',
+        'waiting',
+        'delayed'
+      ]),
+      this.dataExportQueue.getJobs(
+        ['completed', 'failed'],
+        0,
+        JobQueueService.recentTerminalExportJobLimit - 1,
+        false
+      )
     ]);
+    const jobs = [...new Map(
+      [...inProgressJobs, ...terminalJobs]
+        .filter((job): job is Job<ExportJobData> => !!job)
+        .map(job => [job.id.toString(), job])
+    ).values()];
     this.logger.log(`Found ${jobs.length} export jobs in total`);
     return jobs.filter(job => this.jobMatchesWorkspace(job, workspaceId));
   }

--- a/apps/backend/src/app/job-queue/job-queue.service.ts
+++ b/apps/backend/src/app/job-queue/job-queue.service.ts
@@ -192,6 +192,11 @@ export interface ExportJobResult {
   createdAt: number;
 }
 
+export interface ExportJobsWithHistoryState {
+  jobs: Job<ExportJobData>[];
+  historyPending: boolean;
+}
+
 export interface RedisConnectionStatus {
   connected: boolean;
   message: string;
@@ -218,7 +223,11 @@ export class JobQueueService {
   private static readonly failedExportJobRetentionSeconds = 86400;
   private static readonly recentTerminalExportJobLimit = 500;
   private static readonly exportJobHistoryHydrationBatchSize = 100;
+  private static readonly legacyExportHistoryBackfillBatchSize = 100;
   private readonly logger = new Logger(JobQueueService.name);
+
+  private legacyExportHistoryBackfill?: Promise<void>;
+  private legacyExportHistoryBackfillComplete = false;
 
   private readonly exportCancellationControllers = new Map<string, AbortController>();
 
@@ -661,8 +670,8 @@ export class JobQueueService {
 
     let cleanupClaim: string | null = null;
     try {
-      cleanupClaim = await this.exportJobClientLeaseService
-        .tryClaimExpiredLease(leaseId);
+      cleanupClaim =
+        await this.exportJobClientLeaseService.tryClaimExpiredLease(leaseId);
       if (!cleanupClaim) {
         return false;
       }
@@ -677,8 +686,11 @@ export class JobQueueService {
         return false;
       }
 
-      const cleanupConfirmed = await this.exportJobClientLeaseService
-        .confirmCleanupClaim(leaseId, cleanupClaim);
+      const cleanupConfirmed =
+        await this.exportJobClientLeaseService.confirmCleanupClaim(
+          leaseId,
+          cleanupClaim
+        );
       if (!cleanupConfirmed) {
         await this.exportJobClientLeaseService.releaseCleanupClaim(
           leaseId,
@@ -760,7 +772,7 @@ export class JobQueueService {
       }
       throw new ConflictException(
         `A coding statistics job is already running for workspace ${workspaceId} ` +
-        `(version: ${existingVersion}, job ${existing.id})`
+          `(version: ${existingVersion}, job ${existing.id})`
       );
     }
     this.logger.log(
@@ -945,7 +957,7 @@ export class JobQueueService {
       this.dataExportQueue,
       d => d.workspaceId === data.workspaceId && d.exportType === data.exportType
     );
-    while (existing && await this.removeExpiredWaitingExportJob(existing)) {
+    while (existing && (await this.removeExpiredWaitingExportJob(existing))) {
       existing = await this.findActiveJob<ExportJobData>(
         this.dataExportQueue,
         d => d.workspaceId === data.workspaceId && d.exportType === data.exportType
@@ -982,10 +994,12 @@ export class JobQueueService {
     userId?: number,
     exportTypes?: readonly string[]
   ): job is Job<ExportJobData> {
-    return !!job &&
+    return (
+      !!job &&
       this.jobMatchesWorkspace(job, workspaceId) &&
       (userId === undefined || Number(job.data.userId) === userId) &&
-      (!exportTypes || exportTypes.includes(job.data.exportType));
+      (!exportTypes || exportTypes.includes(job.data.exportType))
+    );
   }
 
   private async getRecentTerminalExportJobs(
@@ -998,9 +1012,8 @@ export class JobQueueService {
       userId,
       exportTypes: exportTypes || BACKGROUND_EXPORT_TYPES
     };
-    const jobIds = await this.exportJobHistoryIndexService.getRecentJobIds(
-      scope
-    );
+    const jobIds =
+      await this.exportJobHistoryIndexService.getRecentJobIds(scope);
     const terminalJobs: Job<ExportJobData>[] = [];
     const staleJobIds: string[] = [];
 
@@ -1014,17 +1027,19 @@ export class JobQueueService {
         start,
         start + JobQueueService.exportJobHistoryHydrationBatchSize
       );
-      const candidates = await Promise.allSettled(batchIds.map(async jobId => {
-        const job = await this.dataExportQueue.getJob(jobId);
-        if (!job) {
-          return { jobId };
-        }
-        return {
-          jobId,
-          job,
-          state: await job.getState()
-        };
-      }));
+      const candidates = await Promise.allSettled(
+        batchIds.map(async jobId => {
+          const job = await this.dataExportQueue.getJob(jobId);
+          if (!job) {
+            return { jobId };
+          }
+          return {
+            jobId,
+            job,
+            state: await job.getState()
+          };
+        })
+      );
 
       candidates.forEach(candidate => {
         if (candidate.status === 'rejected') {
@@ -1070,36 +1085,137 @@ export class JobQueueService {
       .slice(0, JobQueueService.recentTerminalExportJobLimit);
   }
 
+  private triggerLegacyExportHistoryBackfill(): boolean {
+    if (this.legacyExportHistoryBackfillComplete) {
+      return false;
+    }
+    if (this.legacyExportHistoryBackfill) {
+      return true;
+    }
+
+    const backfill = this.backfillLegacyExportHistory();
+    this.legacyExportHistoryBackfill = backfill;
+    backfill.finally(() => {
+      if (this.legacyExportHistoryBackfill === backfill) {
+        this.legacyExportHistoryBackfill = undefined;
+      }
+    });
+    return true;
+  }
+
+  private async backfillLegacyExportHistory(): Promise<void> {
+    let claim: string | null = null;
+    try {
+      const claimResult =
+        await this.exportJobHistoryIndexService.claimLegacyBackfill();
+      if (claimResult.status === 'complete') {
+        this.legacyExportHistoryBackfillComplete = true;
+        return;
+      }
+      if (claimResult.status === 'busy') {
+        return;
+      }
+      claim = claimResult.claim;
+
+      let backfilledJobCount = 0;
+      for (const state of ['completed', 'failed'] as const) {
+        const legacyJobIds = await this.dataExportQueue.client.zrevrange(
+          this.dataExportQueue.toKey(state),
+          0,
+          -1
+        );
+        for (
+          let start = 0;
+          start < legacyJobIds.length;
+          start += JobQueueService.legacyExportHistoryBackfillBatchSize
+        ) {
+          const batchIds = legacyJobIds.slice(
+            start,
+            start + JobQueueService.legacyExportHistoryBackfillBatchSize
+          );
+          const legacyJobs = (await Promise.all(
+            batchIds.map(jobId => this.dataExportQueue.getJob(jobId))
+          )).filter((job): job is Job<ExportJobData> => !!job);
+          if (legacyJobs.length) {
+            await Promise.all(
+              legacyJobs.map(job => this.exportJobHistoryIndexService.addJob(
+                job.id.toString(),
+                job.data,
+                job.timestamp
+              ))
+            );
+            backfilledJobCount += legacyJobs.length;
+          }
+          await this.exportJobHistoryIndexService.refreshLegacyBackfillClaim(
+            claim
+          );
+        }
+      }
+      await this.exportJobHistoryIndexService.completeLegacyBackfill(claim);
+      this.legacyExportHistoryBackfillComplete = true;
+      this.logger.log(
+        `Backfilled ${backfilledJobCount} legacy export history entries`
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Could not backfill legacy export history: ${error.message}`
+      );
+      if (claim) {
+        try {
+          await this.exportJobHistoryIndexService.releaseLegacyBackfillClaim(
+            claim
+          );
+        } catch (releaseError) {
+          this.logger.warn(
+            'Could not release legacy export history backfill claim: ' +
+              `${releaseError.message}`
+          );
+        }
+      }
+    }
+  }
+
   async getExportJobs(
     workspaceId: number,
     userId?: number,
     exportTypes?: readonly string[]
   ): Promise<Job<ExportJobData>[]> {
+    const result = await this.getExportJobsWithHistoryState(
+      workspaceId,
+      userId,
+      exportTypes
+    );
+    return result.jobs;
+  }
+
+  async getExportJobsWithHistoryState(
+    workspaceId: number,
+    userId?: number,
+    exportTypes?: readonly string[]
+  ): Promise<ExportJobsWithHistoryState> {
     this.logger.log(`Fetching all export jobs for workspace ${workspaceId}`);
+    const historyPending = this.triggerLegacyExportHistoryBackfill();
     const [inProgressJobs, terminalJobs] = await Promise.all([
-      this.dataExportQueue.getJobs([
-        'active',
-        'waiting',
-        'delayed'
-      ]),
-      this.getRecentTerminalExportJobs(
-        workspaceId,
-        userId,
-        exportTypes
+      this.dataExportQueue.getJobs(['active', 'waiting', 'delayed', 'paused']),
+      this.getRecentTerminalExportJobs(workspaceId, userId, exportTypes).catch(
+        error => {
+          this.logger.warn(
+            `Could not read indexed export history: ${error.message}`
+          );
+          return [];
+        }
       )
     ]);
-    const jobs = [...new Map(
-      [...inProgressJobs, ...terminalJobs]
-        .filter(job => this.exportJobMatchesScope(
-          job,
-          workspaceId,
-          userId,
-          exportTypes
-        ))
-        .map(job => [job.id.toString(), job])
-    ).values()];
+    const jobs = [
+      ...new Map(
+        [...inProgressJobs, ...terminalJobs]
+          .filter(job => this.exportJobMatchesScope(job, workspaceId, userId, exportTypes)
+          )
+          .map(job => [job.id.toString(), job])
+      ).values()
+    ];
     this.logger.log(`Found ${jobs.length} export jobs in total`);
-    return jobs;
+    return { jobs, historyPending };
   }
 
   async ensureExportJobIndexed(job: Job<ExportJobData>): Promise<void> {
@@ -1416,7 +1532,7 @@ export class JobQueueService {
         if (state === 'active') {
           await job.discard();
           // If removal fails for an active job, we at least discarded it to prevent retries
-          await job.remove().catch(() => { });
+          await job.remove().catch(() => {});
         } else {
           await job.remove();
         }

--- a/apps/backend/src/app/job-queue/processors/export-job.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/export-job.processor.spec.ts
@@ -97,6 +97,7 @@ describe('ExportJobProcessor', () => {
     };
     const jobQueueService = {
       isExportJobCancelled: jest.fn().mockResolvedValue(false),
+      ensureExportJobIndexed: jest.fn().mockResolvedValue(undefined),
       createExportJobCancellationSignal: jest.fn(
         () => new AbortController().signal
       ),

--- a/apps/backend/src/app/job-queue/processors/export-job.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/export-job.processor.spec.ts
@@ -69,6 +69,9 @@ describe('ExportJobProcessor', () => {
     };
     const exportJobClientLeaseService = {
       isLeaseActive: jest.fn().mockResolvedValue(true),
+      tryClaimExpiredLease: jest.fn().mockResolvedValue(null),
+      confirmCleanupClaim: jest.fn().mockResolvedValue(true),
+      releaseCleanupClaim: jest.fn().mockResolvedValue(undefined),
       releaseLease: jest.fn().mockResolvedValue(undefined)
     };
     const codingExportOrchestratorService = {
@@ -242,7 +245,9 @@ describe('ExportJobProcessor', () => {
       codingExportService,
       exportJobClientLeaseService
     } = createProcessor();
-    exportJobClientLeaseService.isLeaseActive.mockResolvedValue(false);
+    exportJobClientLeaseService.tryClaimExpiredLease.mockResolvedValue(
+      'cleanup-claim'
+    );
     const job = createJob({
       format: 'excel',
       clientLeaseId: 'expired-client-lease'
@@ -260,6 +265,85 @@ describe('ExportJobProcessor', () => {
       .not.toHaveBeenCalled();
     expect(exportJobClientLeaseService.releaseLease)
       .toHaveBeenCalledWith('expired-client-lease');
+    expect(
+      exportJobClientLeaseService.confirmCleanupClaim
+    ).toHaveBeenCalledWith('expired-client-lease', 'cleanup-claim');
+    expect(
+      exportJobClientLeaseService.releaseCleanupClaim
+    ).toHaveBeenCalledWith('expired-client-lease', 'cleanup-claim');
+  });
+
+  it('continues when the client renews its lease before cleanup is confirmed', async () => {
+    const { processor, codingExportService, exportJobClientLeaseService } =
+      createProcessor();
+    exportJobClientLeaseService.tryClaimExpiredLease.mockResolvedValue(
+      'cleanup-claim'
+    );
+    exportJobClientLeaseService.confirmCleanupClaim.mockResolvedValue(false);
+    const job = createJob({
+      format: 'excel',
+      clientLeaseId: 'renewed-client-lease'
+    });
+    let filePath: string | undefined;
+
+    try {
+      const result = await processor.process(job);
+      filePath = result.filePath;
+
+      expect(job.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          isCancelled: true
+        })
+      );
+      expect(
+        codingExportService.exportCodingListForJobAsExcelToFile
+      ).toHaveBeenCalled();
+      expect(
+        exportJobClientLeaseService.releaseCleanupClaim
+      ).toHaveBeenCalledWith('renewed-client-lease', 'cleanup-claim');
+    } finally {
+      cleanup(filePath);
+    }
+  });
+
+  it('continues an export when the client lease status is unavailable', async () => {
+    const { processor, codingExportService, exportJobClientLeaseService } =
+      createProcessor();
+    exportJobClientLeaseService.tryClaimExpiredLease.mockRejectedValue(
+      new Error('redis unavailable')
+    );
+    const logger = (
+      processor as unknown as {
+        logger: { warn: jest.Mock };
+      }
+    ).logger;
+    const warningSpy = jest.spyOn(logger, 'warn').mockImplementation(jest.fn());
+    const job = createJob({
+      format: 'excel',
+      clientLeaseId: 'unknown-client-lease'
+    });
+    let filePath: string | undefined;
+
+    try {
+      const result = await processor.process(job);
+      filePath = result.filePath;
+
+      expect(result.fileSize).toBeGreaterThan(0);
+      expect(job.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          isCancelled: true
+        })
+      );
+      expect(
+        exportJobClientLeaseService.tryClaimExpiredLease.mock.calls.length
+      ).toBeGreaterThan(1);
+      expect(warningSpy).toHaveBeenCalledTimes(1);
+      expect(
+        codingExportService.exportCodingListForJobAsExcelToFile
+      ).toHaveBeenCalled();
+    } finally {
+      cleanup(filePath);
+    }
   });
 
   it('passes trainingRequired to coding-list Excel exports', async () => {
@@ -815,9 +899,9 @@ describe('ExportJobProcessor', () => {
         3600
       );
       expect(rawMatrixPath && fs.existsSync(rawMatrixPath)).toBe(false);
-      expect(
-        rawMatrixPath && fs.existsSync(path.dirname(rawMatrixPath))
-      ).toBe(false);
+      expect(rawMatrixPath && fs.existsSync(path.dirname(rawMatrixPath))).toBe(
+        false
+      );
     } finally {
       cleanup(metadata.filePath);
     }
@@ -878,36 +962,38 @@ describe('ExportJobProcessor', () => {
         return {
           total: 1,
           sampleLimit: 20,
-          groups: [{
-            reasonCode: 'unresolved-status',
-            bookletName: 'BOOKLET-1',
-            columnName: 'UNIT1_1',
-            count: 1,
-            sampleRowNumbers: [2]
-          }]
+          groups: [
+            {
+              reasonCode: 'unresolved-status',
+              bookletName: 'BOOKLET-1',
+              columnName: 'UNIT1_1',
+              count: 1,
+              sampleRowNumbers: [2]
+            }
+          ]
         };
       }
     );
-    cacheService.set.mockImplementation(
-      async (key: string, value: unknown) => {
-        if (key === 'item-matrix-incomplete-result:job-1') {
-          packagePath = (value as { filePath: string }).filePath;
-          return true;
-        }
-        if (key === 'item-matrix-diagnostics:job-1') {
-          return false;
-        }
+    cacheService.set.mockImplementation(async (key: string, value: unknown) => {
+      if (key === 'item-matrix-incomplete-result:job-1') {
+        packagePath = (value as { filePath: string }).filePath;
         return true;
       }
-    );
+      if (key === 'item-matrix-diagnostics:job-1') {
+        return false;
+      }
+      return true;
+    });
 
     await expect(
-      processor.process(createJob({
-        exportType: 'item-matrix',
-        format: 'csv',
-        matrixValue: 'score',
-        missingsProfileId: 4
-      }))
+      processor.process(
+        createJob({
+          exportType: 'item-matrix',
+          format: 'csv',
+          matrixValue: 'score',
+          missingsProfileId: 4
+        })
+      )
     ).rejects.toThrow('nicht vollständig veröffentlicht');
 
     expect(rawMatrixPath && fs.existsSync(rawMatrixPath)).toBe(false);

--- a/apps/backend/src/app/job-queue/processors/export-job.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/export-job.processor.spec.ts
@@ -7,7 +7,8 @@ import { PassThrough, Readable } from 'stream';
 import {
   CodingExportOrchestratorService,
   CodingExportService,
-  CodingPsychometricExportService
+  CodingPsychometricExportService,
+  ExportJobClientLeaseService
 } from '../../database/services/coding';
 import {
   ExportArtifactService
@@ -20,7 +21,8 @@ import { ExportJobProcessor } from './export-job.processor';
 jest.mock('../../database/services/coding', () => ({
   CodingExportOrchestratorService: jest.fn(),
   CodingExportService: jest.fn(),
-  CodingPsychometricExportService: jest.fn()
+  CodingPsychometricExportService: jest.fn(),
+  ExportJobClientLeaseService: jest.fn()
 }));
 jest.mock('../../database/services/test-results', () => ({
   WorkspaceTestResultsService: jest.fn()
@@ -32,16 +34,22 @@ describe('ExportJobProcessor', () => {
     sampleLimit: 20,
     groups: []
   };
-  const createJob = (data: Partial<ExportJobData>): Job<ExportJobData> => ({
-    id: 'job-1',
-    data: {
-      workspaceId: 7,
-      userId: 3,
-      exportType: 'coding-list',
-      ...data
-    } as ExportJobData,
-    progress: jest.fn().mockResolvedValue(undefined)
-  }) as unknown as Job<ExportJobData>;
+  const createJob = (data: Partial<ExportJobData>): Job<ExportJobData> => {
+    const job = {
+      id: 'job-1',
+      data: {
+        workspaceId: 7,
+        userId: 3,
+        exportType: 'coding-list',
+        ...data
+      } as ExportJobData,
+      progress: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockImplementation(async updatedData => {
+        job.data = updatedData;
+      })
+    };
+    return job as unknown as Job<ExportJobData>;
+  };
 
   const createProcessor = () => {
     const codingExportService = {
@@ -58,6 +66,10 @@ describe('ExportJobProcessor', () => {
       exportCodingTimesReportToFile: jest.fn((filePath: string) => fs.promises.writeFile(filePath, 'coding-times')
       ),
       exportCodingResultsByVariableCompactAsCsvStream: jest.fn()
+    };
+    const exportJobClientLeaseService = {
+      isLeaseActive: jest.fn().mockResolvedValue(true),
+      releaseLease: jest.fn().mockResolvedValue(undefined)
     };
     const codingExportOrchestratorService = {
       exportResultsByVersionAsCsv: jest.fn(),
@@ -106,7 +118,8 @@ describe('ExportJobProcessor', () => {
       codingPsychometricExportService as unknown as CodingPsychometricExportService,
       new ExportArtifactService(
         cacheService as unknown as CacheService
-      )
+      ),
+      exportJobClientLeaseService as unknown as ExportJobClientLeaseService
     );
 
     return {
@@ -115,7 +128,8 @@ describe('ExportJobProcessor', () => {
       codingExportOrchestratorService,
       cacheService,
       jobQueueService,
-      codingPsychometricExportService
+      codingPsychometricExportService,
+      exportJobClientLeaseService
     };
   };
 
@@ -219,6 +233,32 @@ describe('ExportJobProcessor', () => {
     } finally {
       cleanup(filePath);
     }
+  });
+
+  it('cancels an export when its client lease has expired', async () => {
+    const {
+      processor,
+      codingExportService,
+      exportJobClientLeaseService
+    } = createProcessor();
+    exportJobClientLeaseService.isLeaseActive.mockResolvedValue(false);
+    const job = createJob({
+      format: 'excel',
+      clientLeaseId: 'expired-client-lease'
+    });
+
+    await expect(processor.process(job)).resolves.toMatchObject({
+      filePath: '',
+      fileSize: 0
+    });
+
+    expect(job.update).toHaveBeenCalledWith(expect.objectContaining({
+      isCancelled: true
+    }));
+    expect(codingExportService.exportCodingListForJobAsExcelToFile)
+      .not.toHaveBeenCalled();
+    expect(exportJobClientLeaseService.releaseLease)
+      .toHaveBeenCalledWith('expired-client-lease');
   });
 
   it('passes trainingRequired to coding-list Excel exports', async () => {

--- a/apps/backend/src/app/job-queue/processors/export-job.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/export-job.processor.ts
@@ -375,6 +375,8 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
     );
     const startedAt = Date.now();
 
+    await this.jobQueueService.ensureExportJobIndexed(job);
+
     parseExportRequest(job.data);
 
     const jobId = job.id.toString();

--- a/apps/backend/src/app/job-queue/processors/export-job.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/export-job.processor.ts
@@ -21,7 +21,8 @@ import {
 import {
   CodingExportOrchestratorService,
   CodingExportService,
-  CodingPsychometricExportService
+  CodingPsychometricExportService,
+  ExportJobClientLeaseService
 } from '../../database/services/coding';
 import {
   ExportArtifactService
@@ -59,7 +60,8 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
     private cacheService: CacheService,
     private jobQueueService: JobQueueService,
     private codingPsychometricExportService: CodingPsychometricExportService,
-    private exportArtifactService: ExportArtifactService
+    private exportArtifactService: ExportArtifactService,
+    private exportJobClientLeaseService: ExportJobClientLeaseService
   ) { }
 
   async onModuleInit(): Promise<void> {
@@ -191,6 +193,16 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
     job: Job<ExportJobData>,
     filePath?: string
   ): Promise<void> {
+    if (
+      job.data.clientLeaseId &&
+      !await this.exportJobClientLeaseService.isLeaseActive(
+        job.data.clientLeaseId
+      )
+    ) {
+      const cancelledData = { ...job.data, isCancelled: true };
+      await job.update(cancelledData);
+      job.data = cancelledData;
+    }
     if (
       job.data.isCancelled ||
       (await this.jobQueueService.isExportJobCancelled(job.id.toString()))
@@ -854,6 +866,9 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
       this.cleanupPartialExportFile(filePath);
       throw error;
     } finally {
+      await this.exportJobClientLeaseService.releaseLease(
+        job.data.clientLeaseId
+      );
       await this.stopExportWorkingDirectoryLease(workingDirectory);
       this.cleanupExportWorkingDirectory(workingDirectory);
       this.jobQueueService.clearExportJobCancellationSignal(jobId);

--- a/apps/backend/src/app/job-queue/processors/export-job.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/export-job.processor.ts
@@ -50,6 +50,8 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
   ReturnType<typeof setInterval>
   >();
 
+  private readonly jobsWithUnavailableClientLease = new Set<string>();
+
   constructor(
     @Inject(forwardRef(() => CodingExportService))
     private codingExportService: CodingExportService,
@@ -75,9 +77,7 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
             `Failed to clean up expired export files: ${error.message}`
           );
         });
-      },
-      ExportJobProcessor.expiredFileCleanupIntervalMs
-    );
+      }, ExportJobProcessor.expiredFileCleanupIntervalMs);
     this.expiredFileCleanupTimer.unref?.();
   }
 
@@ -86,9 +86,8 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
       clearInterval(this.expiredFileCleanupTimer);
       this.expiredFileCleanupTimer = undefined;
     }
-    this.workingDirectoryHeartbeatTimers.forEach(timer => (
-      clearInterval(timer)
-    ));
+    this.workingDirectoryHeartbeatTimers.forEach(timer => clearInterval(timer)
+    );
     this.workingDirectoryHeartbeatTimers.clear();
   }
 
@@ -143,19 +142,15 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
     jobId: string
   ): Promise<void> {
     await this.refreshExportWorkingDirectoryLease(workingDirectory, jobId);
-    const timer = setInterval(
-      () => {
-        this.refreshExportWorkingDirectoryLease(
-          workingDirectory,
-          jobId
-        ).catch(error => {
+    const timer = setInterval(() => {
+      this.refreshExportWorkingDirectoryLease(workingDirectory, jobId).catch(
+        error => {
           this.logger.warn(
             `Failed to refresh export working directory lease for ${workingDirectory}: ${error.message}`
           );
-        });
-      },
-      ExportJobProcessor.workingDirectoryHeartbeatIntervalMs
-    );
+        }
+      );
+    }, ExportJobProcessor.workingDirectoryHeartbeatIntervalMs);
     timer.unref?.();
     this.workingDirectoryHeartbeatTimers.set(workingDirectory, timer);
   }
@@ -193,15 +188,50 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
     job: Job<ExportJobData>,
     filePath?: string
   ): Promise<void> {
-    if (
-      job.data.clientLeaseId &&
-      !await this.exportJobClientLeaseService.isLeaseActive(
-        job.data.clientLeaseId
-      )
-    ) {
-      const cancelledData = { ...job.data, isCancelled: true };
-      await job.update(cancelledData);
-      job.data = cancelledData;
+    const jobId = job.id.toString();
+    if (job.data.clientLeaseId) {
+      const clientLeaseId = job.data.clientLeaseId;
+      let cleanupClaim: string | null = null;
+      try {
+        cleanupClaim =
+          await this.exportJobClientLeaseService.tryClaimExpiredLease(
+            clientLeaseId
+          );
+        if (
+          cleanupClaim &&
+          (await this.exportJobClientLeaseService.confirmCleanupClaim(
+            clientLeaseId,
+            cleanupClaim
+          ))
+        ) {
+          const cancelledData = { ...job.data, isCancelled: true };
+          await job.update(cancelledData);
+          job.data = cancelledData;
+        }
+        this.jobsWithUnavailableClientLease.delete(jobId);
+      } catch (error) {
+        if (!this.jobsWithUnavailableClientLease.has(jobId)) {
+          this.jobsWithUnavailableClientLease.add(jobId);
+          this.logger.warn(
+            `Could not determine the client lease for export job ${job.id}; ` +
+              `continuing until expiry can be confirmed: ${error.message}`
+          );
+        }
+      } finally {
+        if (cleanupClaim) {
+          try {
+            await this.exportJobClientLeaseService.releaseCleanupClaim(
+              clientLeaseId,
+              cleanupClaim
+            );
+          } catch (error) {
+            this.logger.warn(
+              'Could not release the client lease cleanup claim for export ' +
+                `job ${job.id}: ${error.message}`
+            );
+          }
+        }
+      }
     }
     if (
       job.data.isCancelled ||
@@ -237,17 +267,15 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
   private async cleanupExpiredExportFiles(tempDir: string): Promise<void> {
     try {
       this.exportArtifactService.cleanupExpiredArtifacts(tempDir);
-      const expiresBefore = Date.now() -
-        ExportArtifactService.ttlSeconds * 1000;
+      const expiresBefore =
+        Date.now() - ExportArtifactService.ttlSeconds * 1000;
       const entries = fs.readdirSync(tempDir, { withFileTypes: true });
       for (const entry of entries) {
         const expiredPath = path.join(tempDir, entry.name);
         try {
           if (
             !entry.isDirectory() ||
-            !entry.name.startsWith(
-              ExportJobProcessor.workingDirectoryPrefix
-            ) ||
+            !entry.name.startsWith(ExportJobProcessor.workingDirectoryPrefix) ||
             fs.statSync(expiredPath).mtimeMs >= expiresBefore
           ) {
             continue;
@@ -842,9 +870,9 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
 
       this.logger.log(
         `Export file generated successfully: ${finalFileName} (${metadata.fileSize} bytes) ` +
-        `in ${fileWriteFinishedAt - startedAt}ms ` +
-        `(generation: ${generationFinishedAt - generationStartedAt}ms, ` +
-        `file write: ${fileWriteFinishedAt - generationFinishedAt}ms)`
+          `in ${fileWriteFinishedAt - startedAt}ms ` +
+          `(generation: ${generationFinishedAt - generationStartedAt}ms, ` +
+          `file write: ${fileWriteFinishedAt - generationFinishedAt}ms)`
       );
 
       await this.updateJobProgress(job, 100, { phase: 'completed' });
@@ -868,6 +896,7 @@ export class ExportJobProcessor implements OnModuleInit, OnModuleDestroy {
       this.cleanupPartialExportFile(filePath);
       throw error;
     } finally {
+      this.jobsWithUnavailableClientLease.delete(jobId);
       await this.exportJobClientLeaseService.releaseLease(
         job.data.clientLeaseId
       );

--- a/apps/backend/src/app/workspace/workspace.module.ts
+++ b/apps/backend/src/app/workspace/workspace.module.ts
@@ -85,8 +85,7 @@ import {
   CodingResponseQueryService,
   CodingFreshnessService,
   CodingItemMatrixExportService,
-  ExportArtifactService,
-  ExportJobClientLeaseService
+  ExportArtifactService
 } from '../database/services/coding';
 import {
   JobService,
@@ -188,7 +187,6 @@ import { CodingModule } from '../coding/coding.module';
     CodingFreshnessService,
     CodingItemMatrixExportService,
     ExportArtifactService,
-    ExportJobClientLeaseService,
     UnitInfoService,
     BookletInfoService,
     WorkspaceExclusionService
@@ -234,7 +232,6 @@ import { CodingModule } from '../coding/coding.module';
     CodingFreshnessService,
     CodingItemMatrixExportService,
     ExportArtifactService,
-    ExportJobClientLeaseService,
     UnitInfoService,
     BookletInfoService,
     WorkspaceExclusionService

--- a/apps/backend/src/app/workspace/workspace.module.ts
+++ b/apps/backend/src/app/workspace/workspace.module.ts
@@ -85,7 +85,8 @@ import {
   CodingResponseQueryService,
   CodingFreshnessService,
   CodingItemMatrixExportService,
-  ExportArtifactService
+  ExportArtifactService,
+  ExportJobClientLeaseService
 } from '../database/services/coding';
 import {
   JobService,
@@ -187,6 +188,7 @@ import { CodingModule } from '../coding/coding.module';
     CodingFreshnessService,
     CodingItemMatrixExportService,
     ExportArtifactService,
+    ExportJobClientLeaseService,
     UnitInfoService,
     BookletInfoService,
     WorkspaceExclusionService
@@ -232,6 +234,7 @@ import { CodingModule } from '../coding/coding.module';
     CodingFreshnessService,
     CodingItemMatrixExportService,
     ExportArtifactService,
+    ExportJobClientLeaseService,
     UnitInfoService,
     BookletInfoService,
     WorkspaceExclusionService

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -20,10 +20,16 @@ import { createPostgresPoolSnapshotProvider } from './app/database/postgres-pool
 import { releaseCacheStartupWarmups } from './app/cache/cache-startup-warmup.queue';
 import { RuntimeConfigService } from './app/config/runtime-config.service';
 
+const exportWorkerReadyFile =
+  process.env.EXPORT_WORKER_READY_FILE ||
+  '/tmp/coding-box-export-worker-ready';
+
 async function bootstrap() {
   if (isExportWorkerProcess()) {
+    fs.rmSync(exportWorkerReadyFile, { force: true });
     const workerApp = await NestFactory.createApplicationContext(ExportWorkerModule);
     workerApp.enableShutdownHooks();
+    fs.writeFileSync(exportWorkerReadyFile, new Date().toISOString());
     Logger.log('Export worker started');
     return;
   }

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -814,6 +814,27 @@ describe('CodingJobBackendService', () => {
   });
 
   describe('item dataset exports', () => {
+    it('loads export jobs for workspace rehydration', () => {
+      service.getExportJobs(5).subscribe(result => {
+        expect(result[0]).toEqual(expect.objectContaining({
+          jobId: 'job-1',
+          status: 'processing'
+        }));
+      });
+
+      const req = httpMock.expectOne(
+        `${mockServerUrl}admin/workspace/5/coding/export/jobs`
+      );
+      expect(req.request.method).toBe('GET');
+      req.flush([{
+        jobId: 'job-1',
+        status: 'processing',
+        progress: 50,
+        exportType: 'item-matrix',
+        createdAt: 10
+      }]);
+    });
+
     it('loads selectable VOMD items and mapping issues', () => {
       service.getItemDatasetOptions(5).subscribe(result => {
         expect(result.items[0].columnName).toBe('Aufgabe1_ITEM1');

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.spec.ts
@@ -816,23 +816,35 @@ describe('CodingJobBackendService', () => {
   describe('item dataset exports', () => {
     it('loads export jobs for workspace rehydration', () => {
       service.getExportJobs(5).subscribe(result => {
-        expect(result[0]).toEqual(expect.objectContaining({
-          jobId: 'job-1',
-          status: 'processing'
-        }));
+        expect(result).toEqual(
+          expect.objectContaining({
+            historyPending: false
+          })
+        );
+        expect(result.jobs[0]).toEqual(
+          expect.objectContaining({
+            jobId: 'job-1',
+            status: 'processing'
+          })
+        );
       });
 
       const req = httpMock.expectOne(
         `${mockServerUrl}admin/workspace/5/coding/export/jobs`
       );
       expect(req.request.method).toBe('GET');
-      req.flush([{
-        jobId: 'job-1',
-        status: 'processing',
-        progress: 50,
-        exportType: 'item-matrix',
-        createdAt: 10
-      }]);
+      req.flush(
+        [
+          {
+            jobId: 'job-1',
+            status: 'processing',
+            progress: 50,
+            exportType: 'item-matrix',
+            createdAt: 10
+          }
+        ],
+        { headers: { 'X-Export-History-Pending': 'false' } }
+      );
     });
 
     it('loads selectable VOMD items and mapping issues', () => {
@@ -847,20 +859,23 @@ describe('CodingJobBackendService', () => {
       );
       expect(req.request.method).toBe('GET');
       req.flush({
-        items: [{
-          unitId: 'UNIT1',
-          unitLabel: 'Aufgabe 1',
-          itemId: 'ITEM1',
-          itemLabel: 'Item 1',
-          columnName: 'Aufgabe1_ITEM1'
-        }],
+        items: [
+          {
+            unitId: 'UNIT1',
+            unitLabel: 'Aufgabe 1',
+            itemId: 'ITEM1',
+            itemLabel: 'Item 1',
+            columnName: 'Aufgabe1_ITEM1'
+          }
+        ],
         mappingIssues: [],
         mappingWarnings: []
       });
     });
 
     it('loads diagnostics for a failed item matrix export', () => {
-      service.getItemMatrixExportDiagnostics(5, 'job-1')
+      service
+        .getItemMatrixExportDiagnostics(5, 'job-1')
         .subscribe(result => expect(result.total).toBe(2));
 
       const req = httpMock.expectOne(

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -19,6 +19,7 @@ import type { PsychometricDomainCandidatesDto } from '../../../../../../api-dto/
 import type { ReplayCodingSessionDto } from '../../../../../../api-dto/coding/replay-coding-session.dto';
 import type {
   BackgroundExportRequest,
+  ExportJobListItemDto,
   ExportJobStatusResponseDto,
   ItemDatasetOptionsDto,
   ItemMatrixExportDiagnosticsDto
@@ -1224,6 +1225,13 @@ export class CodingJobBackendService {
   ): Observable<ExportJobStatusResponseDto> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/export/job/${jobId}`;
     return this.http.get<ExportJobStatusResponseDto>(url, {
+      headers: this.authHeader
+    });
+  }
+
+  getExportJobs(workspaceId: number): Observable<ExportJobListItemDto[]> {
+    const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/export/jobs`;
+    return this.http.get<ExportJobListItemDto[]>(url, {
       headers: this.authHeader
     });
   }

--- a/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-job-backend.service.ts
@@ -52,6 +52,11 @@ export interface CodingJobUnitDto {
   otherCoders: string[];
 }
 
+export interface ExportJobListResponse {
+  jobs: ExportJobListItemDto[];
+  historyPending: boolean;
+}
+
 export type CodingExportConfig = BackgroundExportRequest & {
   userId?: number;
 };
@@ -1229,11 +1234,16 @@ export class CodingJobBackendService {
     });
   }
 
-  getExportJobs(workspaceId: number): Observable<ExportJobListItemDto[]> {
+  getExportJobs(workspaceId: number): Observable<ExportJobListResponse> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/export/jobs`;
     return this.http.get<ExportJobListItemDto[]>(url, {
-      headers: this.authHeader
-    });
+      headers: this.authHeader,
+      observe: 'response'
+    }).pipe(map(response => ({
+      jobs: response.body || [],
+      historyPending:
+        response.headers.get('X-Export-History-Pending') === 'true'
+    })));
   }
 
   downloadExportFile(workspaceId: number, jobId: string): Observable<Blob> {
@@ -1259,18 +1269,20 @@ export class CodingJobBackendService {
     jobId: string
   ): Observable<IncompleteItemMatrixDownload> {
     const url = `${this.serverUrl}admin/workspace/${workspaceId}/coding/export/job/${jobId}/download-incomplete`;
-    return this.http.get(url, {
-      responseType: 'blob',
-      observe: 'response',
-      headers: this.authHeader
-    }).pipe(
-      map(response => ({
-        blob: response.body || new Blob(),
-        fileName: getDownloadFileName(
-          response.headers.get('content-disposition')
-        )
-      }))
-    );
+    return this.http
+      .get(url, {
+        responseType: 'blob',
+        observe: 'response',
+        headers: this.authHeader
+      })
+      .pipe(
+        map(response => ({
+          blob: response.body || new Blob(),
+          fileName: getDownloadFileName(
+            response.headers.get('content-disposition')
+          )
+        }))
+      );
   }
 
   deleteExportJob(

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.html
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.html
@@ -35,7 +35,7 @@
             <span class="progress-message">{{ getProgressDescription(job) }}</span>
           </div>
 
-          <div class="job-error" *ngIf="job.status === 'failed' && job.error">
+          <div class="job-error" *ngIf="(job.status === 'failed' || job.status === 'unavailable') && job.error">
             <div class="error-title">{{ getErrorTitle(job) }}</div>
             <div class="error-text">{{ getErrorMessage(job) }}</div>
             <details *ngIf="hasTechnicalDetails(job)" class="error-details">
@@ -87,7 +87,7 @@
             </button>
             <button
               mat-icon-button
-              *ngIf="job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled'"
+              *ngIf="job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled' || job.status === 'unavailable'"
               (click)="removeJob(job)"
               matTooltip="{{ 'export-toast.remove' | translate }}"
               [attr.aria-label]="'export-toast.remove' | translate">
@@ -97,7 +97,7 @@
         </div>
       </div>
 
-      <div class="toast-footer" *ngIf="completedJobCount > 0 || failedJobCount > 0">
+      <div class="toast-footer" *ngIf="completedJobCount > 0 || failedJobCount > 0 || unavailableJobCount > 0">
         <button mat-button (click)="clearCompleted()">
           {{ 'export-toast.clear-all' | translate }}
         </button>

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.scss
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.scss
@@ -113,6 +113,10 @@
       &.status-cancelled {
         color: #9e9e9e;
       }
+
+      &.status-unavailable {
+        color: #ef6c00;
+      }
     }
 
     .job-type {

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.spec.ts
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.spec.ts
@@ -62,6 +62,13 @@ describe('ExportToastComponent', () => {
       workspaceId: 1,
       exportType: 'coding-times',
       status: 'cancelled'
+    },
+    {
+      jobId: 'unavailable',
+      workspaceId: 1,
+      exportType: 'psychometrics',
+      status: 'unavailable',
+      error: 'Failed to get job status'
     }
   ] as ExportJob[];
 
@@ -123,6 +130,9 @@ describe('ExportToastComponent', () => {
           'item-matrix-incomplete-expired':
             '{{total}} Zellen konnten nicht sicher aufgelöst werden; abgelaufen.',
           'item-matrix-incomplete-download-failed': 'Download fehlgeschlagen',
+          'status-unavailable-title': 'Exportstatus nicht verfügbar',
+          'status-unavailable-message':
+            'Der aktuelle Zustand des Exports konnte nicht ermittelt werden.',
           'remove-failed': 'Löschen fehlgeschlagen',
           'generic-title': 'Export fehlgeschlagen'
         },
@@ -162,12 +172,14 @@ describe('ExportToastComponent', () => {
     expect(component.activeJobCount).toBe(2);
     expect(component.completedJobCount).toBe(1);
     expect(component.failedJobCount).toBe(1);
+    expect(component.unavailableJobCount).toBe(1);
     expect(component.getStatusIcon('waiting')).toBe('hourglass_empty');
     expect(component.getStatusIcon('active')).toBe('sync');
     expect(component.getStatusIcon('downloading')).toBe('file_download');
     expect(component.getStatusIcon('completed')).toBe('check_circle');
     expect(component.getStatusIcon('failed')).toBe('error');
     expect(component.getStatusIcon('cancelled')).toBe('cancel');
+    expect(component.getStatusIcon('unavailable')).toBe('cloud_off');
     expect(component.getStatusIcon('unknown' as never)).toBe('help');
     expect(component.getStatusClass('failed')).toBe('status-failed');
     expect(component.getExportTypeLabel('aggregated')).toBe(
@@ -188,6 +200,13 @@ describe('ExportToastComponent', () => {
     );
     expect(component.getExportTypeLabel('custom')).toBe('custom');
     expect(component.getErrorTitle(jobs[3])).toBe('Export fehlgeschlagen');
+    expect(component.getErrorTitle(jobs[5])).toBe(
+      'Exportstatus nicht verfügbar'
+    );
+    expect(component.getErrorMessage(jobs[5])).toBe(
+      'Der aktuelle Zustand des Exports konnte nicht ermittelt werden.'
+    );
+    expect(component.hasTechnicalDetails(jobs[5])).toBe(true);
 
     component.toggleCollapse();
     expect(component.isCollapsed).toBe(true);
@@ -208,6 +227,7 @@ describe('ExportToastComponent', () => {
     expect(exportJobService.removeJob).toHaveBeenCalledWith('done');
     expect(exportJobService.removeJob).toHaveBeenCalledWith('bad');
     expect(exportJobService.removeJob).toHaveBeenCalledWith('cancelled');
+    expect(exportJobService.removeJob).toHaveBeenCalledWith('unavailable');
   });
 
   it('updates from the jobs stream and tears down subscriptions', () => {

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.spec.ts
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BehaviorSubject, of, throwError } from 'rxjs';
+import {
+  BehaviorSubject, Subject, of, throwError
+} from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -8,6 +10,7 @@ import {
   ExportJob,
   ExportJobService
 } from '../../shared/services/file/export-job.service';
+import { AppService } from '../../core/services/app.service';
 
 describe('ExportToastComponent', () => {
   let fixture: ComponentFixture<ExportToastComponent>;
@@ -20,7 +23,9 @@ describe('ExportToastComponent', () => {
     cancelJob: jest.Mock;
     getItemMatrixDiagnostics: jest.Mock;
     downloadIncompleteItemMatrix: jest.Mock;
+    restoreWorkspaceJobs: jest.Mock;
   };
+  let selectedWorkspaceId$: Subject<number>;
   let dialog: { open: jest.Mock };
   let snackBar: { open: jest.Mock };
 
@@ -62,13 +67,15 @@ describe('ExportToastComponent', () => {
 
   beforeEach(async () => {
     jobs$ = new BehaviorSubject<ExportJob[]>(jobs);
+    selectedWorkspaceId$ = new Subject<number>();
     exportJobService = {
       jobs$,
       downloadFile: jest.fn(),
       removeJob: jest.fn().mockReturnValue(of(true)),
       cancelJob: jest.fn(),
       getItemMatrixDiagnostics: jest.fn(),
-      downloadIncompleteItemMatrix: jest.fn().mockReturnValue(of(undefined))
+      downloadIncompleteItemMatrix: jest.fn().mockReturnValue(of(undefined)),
+      restoreWorkspaceJobs: jest.fn().mockReturnValue(of([]))
     };
     dialog = {
       open: jest.fn().mockReturnValue({ afterClosed: () => of(true) })
@@ -79,6 +86,13 @@ describe('ExportToastComponent', () => {
       imports: [ExportToastComponent, TranslateModule.forRoot()],
       providers: [
         { provide: ExportJobService, useValue: exportJobService },
+        {
+          provide: AppService,
+          useValue: {
+            selectedWorkspaceId: 5,
+            selectedWorkspaceId$: selectedWorkspaceId$
+          }
+        },
         { provide: MatDialog, useValue: dialog },
         { provide: MatSnackBar, useValue: snackBar }
       ]
@@ -206,6 +220,21 @@ describe('ExportToastComponent', () => {
     component.ngOnDestroy();
     jobs$.next(jobs);
     expect(component.jobs).toEqual([]);
+  });
+
+  it('restores export jobs globally for the selected workspace', () => {
+    component.ngOnInit();
+
+    expect(exportJobService.restoreWorkspaceJobs).toHaveBeenCalledWith(5);
+
+    selectedWorkspaceId$.next(7);
+
+    expect(exportJobService.restoreWorkspaceJobs).toHaveBeenCalledWith(7);
+
+    component.ngOnDestroy();
+    selectedWorkspaceId$.next(8);
+
+    expect(exportJobService.restoreWorkspaceJobs).not.toHaveBeenCalledWith(8);
   });
 
   it('keeps a job visible and reports a failed removal', () => {

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.ts
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.ts
@@ -25,6 +25,7 @@ import {
   ItemMatrixExportJobErrorDto
 } from '../../../../../../api-dto/coding/export-request.dto';
 import { ItemMatrixDiagnosticsDialogComponent } from './item-matrix-diagnostics-dialog.component';
+import { AppService } from '../../core/services/app.service';
 
 @Component({
   selector: 'coding-box-export-toast',
@@ -45,6 +46,7 @@ import { ItemMatrixDiagnosticsDialogComponent } from './item-matrix-diagnostics-
 })
 export class ExportToastComponent implements OnInit, OnDestroy {
   private exportJobService = inject(ExportJobService);
+  private appService = inject(AppService);
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
   private snackBar = inject(MatSnackBar);
@@ -70,6 +72,17 @@ export class ExportToastComponent implements OnInit, OnDestroy {
       .subscribe(jobs => {
         this.jobs = jobs;
       });
+    this.restoreWorkspaceJobs(this.appService.selectedWorkspaceId);
+    this.appService.selectedWorkspaceId$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(workspaceId => this.restoreWorkspaceJobs(workspaceId));
+  }
+
+  private restoreWorkspaceJobs(workspaceId: number): void {
+    if (!workspaceId) return;
+    this.exportJobService.restoreWorkspaceJobs(workspaceId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe();
   }
 
   ngOnDestroy(): void {

--- a/apps/frontend/src/app/components/export-toast/export-toast.component.ts
+++ b/apps/frontend/src/app/components/export-toast/export-toast.component.ts
@@ -110,6 +110,10 @@ export class ExportToastComponent implements OnInit, OnDestroy {
     return this.jobs.filter(j => j.status === 'failed').length;
   }
 
+  get unavailableJobCount(): number {
+    return this.jobs.filter(j => j.status === 'unavailable').length;
+  }
+
   toggleCollapse(): void {
     this.isCollapsed = !this.isCollapsed;
   }
@@ -128,6 +132,8 @@ export class ExportToastComponent implements OnInit, OnDestroy {
         return 'error';
       case 'cancelled':
         return 'cancel';
+      case 'unavailable':
+        return 'cloud_off';
       default:
         return 'help';
     }
@@ -202,6 +208,11 @@ export class ExportToastComponent implements OnInit, OnDestroy {
   }
 
   getErrorTitle(job: ExportJob): string {
+    if (job.status === 'unavailable') {
+      return this.translateService.instant(
+        'export-toast.errors.status-unavailable-title'
+      );
+    }
     if (this.isItemMatrixResolutionError(job)) {
       return this.translateService.instant(
         'export-toast.errors.item-matrix-incomplete-title'
@@ -216,6 +227,11 @@ export class ExportToastComponent implements OnInit, OnDestroy {
   }
 
   getErrorMessage(job: ExportJob): string {
+    if (job.status === 'unavailable') {
+      return this.translateService.instant(
+        'export-toast.errors.status-unavailable-message'
+      );
+    }
     if (this.isItemMatrixResolutionError(job)) {
       const key = this.hasItemMatrixArtifacts(job) ?
         'export-toast.errors.item-matrix-incomplete-message' :
@@ -355,7 +371,8 @@ export class ExportToastComponent implements OnInit, OnDestroy {
     const completedJobs = this.jobs.filter(
       j => j.status === 'completed' ||
         j.status === 'failed' ||
-        j.status === 'cancelled'
+        j.status === 'cancelled' ||
+        j.status === 'unavailable'
     );
     completedJobs.forEach(job => this.removeJob(job));
   }

--- a/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
@@ -122,7 +122,7 @@ describe('ExportJobService', () => {
       }));
     });
 
-    it('resumes polling for restored active jobs', fakeAsync(() => {
+    it('does not restore active jobs after a client reload', fakeAsync(() => {
       codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([{
         jobId: 'active',
         status: 'processing',
@@ -136,13 +136,13 @@ describe('ExportJobService', () => {
       }));
 
       service.restoreWorkspaceJobs(5).subscribe();
-      expect(service.activeJobs[0].status).toBe('active');
+      expect(service.activeJobs).toEqual([]);
 
       tick(2000);
 
       expect(codingJobBackendServiceMock.getExportJobStatus)
-        .toHaveBeenCalledWith(5, 'active');
-      expect(service.completedJobs[0].jobId).toBe('active');
+        .not.toHaveBeenCalled();
+      expect(service.completedJobs).toEqual([]);
     }));
 
     it('omits jobs whose artifacts have expired', () => {

--- a/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
@@ -218,6 +218,61 @@ describe('ExportJobService', () => {
         .toHaveBeenCalledWith(5, 'started-during-restore');
     }));
 
+    it('keeps an already running local job when its workspace is restored', fakeAsync(() => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(of({
+        jobId: 'running-before-restore',
+        message: 'Job started'
+      }));
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([]));
+      codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(of({
+        status: 'processing',
+        progress: 25
+      }));
+
+      service.startJob(5, { exportType: 'aggregated' }).subscribe();
+      service.restoreWorkspaceJobs(5).subscribe();
+
+      expect(service.activeJobs.map(job => job.jobId))
+        .toEqual(['running-before-restore']);
+
+      tick(2000);
+
+      expect(codingJobBackendServiceMock.getExportJobStatus)
+        .toHaveBeenCalledWith(5, 'running-before-restore');
+    }));
+
+    it('keeps a local job that completes while restoration is in flight', fakeAsync(() => {
+      const restoration = new Subject<ExportJobListItemDto[]>();
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(of({
+        jobId: 'completed-during-restore',
+        message: 'Job started'
+      }));
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(restoration);
+      codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(of({
+        status: 'completed',
+        progress: 100,
+        result: {
+          fileId: 'completed-during-restore',
+          fileName: 'export.csv',
+          fileSize: 42,
+          workspaceId: 5,
+          userId: 2,
+          exportType: 'aggregated',
+          createdAt: 10,
+          expiresAt: 3_600_010
+        }
+      }));
+
+      service.startJob(5, { exportType: 'aggregated' }).subscribe();
+      service.restoreWorkspaceJobs(5).subscribe();
+      tick(2000);
+      restoration.next([]);
+      restoration.complete();
+
+      expect(service.completedJobs.map(job => job.jobId))
+        .toEqual(['completed-during-restore']);
+    }));
+
     it('ignores an older overlapping restoration response', () => {
       const firstRestore = new Subject<ExportJobListItemDto[]>();
       const secondRestore = new Subject<ExportJobListItemDto[]>();

--- a/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_EXTERNAL_REPLAY_TOKEN_DURATION_DAYS,
   EXTERNAL_REPLAY_WORKSPACE_TOKEN_SCOPES
 } from '../../../core/services/auth-session.config';
+import { ExportJobListItemDto } from '../../../../../../../api-dto/coding/export-request.dto';
 
 describe('ExportJobService', () => {
   let service: ExportJobService;
@@ -23,6 +24,7 @@ describe('ExportJobService', () => {
   beforeEach(() => {
     codingJobBackendServiceMock = {
       startExportJob: jest.fn(),
+      getExportJobs: jest.fn(),
       getExportJobStatus: jest.fn(),
       cancelExportJob: jest.fn(),
       downloadExportFile: jest.fn(),
@@ -62,6 +64,205 @@ describe('ExportJobService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('restoreWorkspaceJobs', () => {
+    it('restores completed and structured failed jobs', () => {
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([
+        {
+          jobId: 'completed',
+          status: 'completed',
+          progress: 100,
+          exportType: 'item-matrix',
+          createdAt: 10,
+          result: {
+            fileId: 'completed',
+            fileName: 'Itemdatensatz.csv',
+            fileSize: 42,
+            workspaceId: 5,
+            userId: 2,
+            exportType: 'item-matrix',
+            createdAt: 10,
+            expiresAt: 3_600_010
+          }
+        },
+        {
+          jobId: 'failed',
+          status: 'failed',
+          progress: 90,
+          exportType: 'item-matrix',
+          createdAt: 11,
+          error: 'incomplete',
+          errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
+          errorDetails: {
+            total: 2,
+            groupCount: 1,
+            sampleLimit: 20,
+            diagnosticsAvailable: true,
+            incompleteDownloadAvailable: true
+          }
+        }
+      ]));
+
+      service.restoreWorkspaceJobs(5).subscribe();
+
+      expect(service.completedJobs[0]).toEqual(expect.objectContaining({
+        jobId: 'completed',
+        workspaceId: 5,
+        downloadFilePrefix: 'Itemdatensatz',
+        result: { fileName: 'Itemdatensatz.csv', fileSize: 42 }
+      }));
+      expect(service.failedJobs[0]).toEqual(expect.objectContaining({
+        jobId: 'failed',
+        errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
+        errorDetails: expect.objectContaining({
+          diagnosticsAvailable: true,
+          incompleteDownloadAvailable: true
+        })
+      }));
+    });
+
+    it('resumes polling for restored active jobs', fakeAsync(() => {
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([{
+        jobId: 'active',
+        status: 'processing',
+        progress: 50,
+        exportType: 'aggregated',
+        createdAt: 10
+      }]));
+      codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(of({
+        status: 'completed',
+        progress: 100
+      }));
+
+      service.restoreWorkspaceJobs(5).subscribe();
+      expect(service.activeJobs[0].status).toBe('active');
+
+      tick(2000);
+
+      expect(codingJobBackendServiceMock.getExportJobStatus)
+        .toHaveBeenCalledWith(5, 'active');
+      expect(service.completedJobs[0].jobId).toBe('active');
+    }));
+
+    it('omits jobs whose artifacts have expired', () => {
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([
+        {
+          jobId: 'completed',
+          status: 'completed',
+          progress: 100,
+          exportType: 'aggregated',
+          createdAt: 10
+        },
+        {
+          jobId: 'failed',
+          status: 'failed',
+          progress: 90,
+          exportType: 'item-matrix',
+          createdAt: 11,
+          errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
+          errorDetails: {
+            total: 2,
+            groupCount: 0,
+            sampleLimit: 20,
+            diagnosticsAvailable: false,
+            incompleteDownloadAvailable: false
+          }
+        }
+      ]));
+
+      service.restoreWorkspaceJobs(5).subscribe();
+
+      expect(service.completedJobs).toEqual([]);
+      expect(service.failedJobs).toEqual([]);
+    });
+
+    it('keeps the current jobs when restoration fails', () => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(of({
+        jobId: 'local',
+        message: 'Job started'
+      }));
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(
+        throwError(() => new Error('offline'))
+      );
+      service.startJob(5, { exportType: 'aggregated' }).subscribe();
+
+      service.restoreWorkspaceJobs(5).subscribe();
+
+      expect(service.activeJobs.map(job => job.jobId)).toEqual(['local']);
+    });
+
+    it('keeps jobs started while restoration is in flight', fakeAsync(() => {
+      const restoration = new Subject<ExportJobListItemDto[]>();
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(restoration);
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(of({
+        jobId: 'started-during-restore',
+        message: 'Job started'
+      }));
+      codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(of({
+        status: 'processing',
+        progress: 25
+      }));
+
+      service.restoreWorkspaceJobs(5).subscribe();
+      service.startJob(5, { exportType: 'aggregated' }).subscribe();
+      restoration.next([]);
+      restoration.complete();
+
+      expect(service.activeJobs.map(job => job.jobId))
+        .toEqual(['started-during-restore']);
+
+      tick(2000);
+
+      expect(codingJobBackendServiceMock.getExportJobStatus)
+        .toHaveBeenCalledWith(5, 'started-during-restore');
+    }));
+
+    it('ignores an older overlapping restoration response', () => {
+      const firstRestore = new Subject<ExportJobListItemDto[]>();
+      const secondRestore = new Subject<ExportJobListItemDto[]>();
+      codingJobBackendServiceMock.getExportJobs
+        .mockReturnValueOnce(firstRestore)
+        .mockReturnValueOnce(secondRestore);
+
+      service.restoreWorkspaceJobs(5).subscribe();
+      service.restoreWorkspaceJobs(5).subscribe();
+      secondRestore.next([{
+        jobId: 'latest',
+        status: 'failed',
+        progress: 10,
+        exportType: 'aggregated',
+        createdAt: 20
+      }]);
+      firstRestore.next([{
+        jobId: 'stale',
+        status: 'failed',
+        progress: 10,
+        exportType: 'aggregated',
+        createdAt: 10
+      }]);
+
+      expect(service.failedJobs.map(job => job.jobId)).toEqual(['latest']);
+    });
+
+    it('restores manual export display metadata', () => {
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([{
+        jobId: 'manual-review',
+        status: 'failed',
+        progress: 80,
+        exportType: 'aggregated',
+        createdAt: 10,
+        displayVariant: 'manual-review-new-column-per-coder'
+      }]));
+
+      service.restoreWorkspaceJobs(5).subscribe();
+
+      expect(service.failedJobs[0]).toEqual(expect.objectContaining({
+        displayLabelKey:
+          'export-toast.types.manual-review-new-column-per-coder',
+        downloadFilePrefix: 'manual-review-new-column-per-coder'
+      }));
+    });
   });
 
   it.each([

--- a/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.spec.ts
@@ -6,14 +6,16 @@ import {
   REPLAY_AUTH_TOKEN_ERROR_CODE,
   isReplayAuthTokenError
 } from './export-job.service';
-import { CodingJobBackendService } from '../../../coding/services/coding-job-backend.service';
+import {
+  CodingJobBackendService,
+  ExportJobListResponse
+} from '../../../coding/services/coding-job-backend.service';
 import { AppService } from '../../../core/services/app.service';
 import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-settings.service';
 import {
   DEFAULT_EXTERNAL_REPLAY_TOKEN_DURATION_DAYS,
   EXTERNAL_REPLAY_WORKSPACE_TOKEN_SCOPES
 } from '../../../core/services/auth-session.config';
-import { ExportJobListItemDto } from '../../../../../../../api-dto/coding/export-request.dto';
 
 describe('ExportJobService', () => {
   let service: ExportJobService;
@@ -68,41 +70,44 @@ describe('ExportJobService', () => {
 
   describe('restoreWorkspaceJobs', () => {
     it('restores completed and structured failed jobs', () => {
-      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([
-        {
-          jobId: 'completed',
-          status: 'completed',
-          progress: 100,
-          exportType: 'item-matrix',
-          createdAt: 10,
-          result: {
-            fileId: 'completed',
-            fileName: 'Itemdatensatz.csv',
-            fileSize: 42,
-            workspaceId: 5,
-            userId: 2,
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of({
+        jobs: [
+          {
+            jobId: 'completed',
+            status: 'completed',
+            progress: 100,
             exportType: 'item-matrix',
             createdAt: 10,
-            expiresAt: 3_600_010
+            result: {
+              fileId: 'completed',
+              fileName: 'Itemdatensatz.csv',
+              fileSize: 42,
+              workspaceId: 5,
+              userId: 2,
+              exportType: 'item-matrix',
+              createdAt: 10,
+              expiresAt: 3_600_010
+            }
+          },
+          {
+            jobId: 'failed',
+            status: 'failed',
+            progress: 90,
+            exportType: 'item-matrix',
+            createdAt: 11,
+            error: 'incomplete',
+            errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
+            errorDetails: {
+              total: 2,
+              groupCount: 1,
+              sampleLimit: 20,
+              diagnosticsAvailable: true,
+              incompleteDownloadAvailable: true
+            }
           }
-        },
-        {
-          jobId: 'failed',
-          status: 'failed',
-          progress: 90,
-          exportType: 'item-matrix',
-          createdAt: 11,
-          error: 'incomplete',
-          errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
-          errorDetails: {
-            total: 2,
-            groupCount: 1,
-            sampleLimit: 20,
-            diagnosticsAvailable: true,
-            incompleteDownloadAvailable: true
-          }
-        }
-      ]));
+        ],
+        historyPending: false
+      }));
 
       service.restoreWorkspaceJobs(5).subscribe();
 
@@ -122,54 +127,64 @@ describe('ExportJobService', () => {
       }));
     });
 
-    it('does not restore active jobs after a client reload', fakeAsync(() => {
-      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([{
-        jobId: 'active',
-        status: 'processing',
-        progress: 50,
-        exportType: 'aggregated',
-        createdAt: 10
-      }]));
+    it('restores active jobs and resumes polling after a client reload', fakeAsync(() => {
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of({
+        jobs: [{
+          jobId: 'active',
+          status: 'processing',
+          progress: 50,
+          exportType: 'aggregated',
+          createdAt: 10
+        }],
+        historyPending: false
+      }));
       codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(of({
         status: 'completed',
         progress: 100
       }));
 
       service.restoreWorkspaceJobs(5).subscribe();
-      expect(service.activeJobs).toEqual([]);
+      expect(service.activeJobs).toEqual([
+        expect.objectContaining({ jobId: 'active', status: 'active' })
+      ]);
 
       tick(2000);
 
       expect(codingJobBackendServiceMock.getExportJobStatus)
-        .not.toHaveBeenCalled();
-      expect(service.completedJobs).toEqual([]);
+        .toHaveBeenCalledWith(5, 'active');
+      expect(service.completedJobs).toEqual([
+        expect.objectContaining({ jobId: 'active' })
+      ]);
     }));
 
     it('omits jobs whose artifacts have expired', () => {
-      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([
-        {
-          jobId: 'completed',
-          status: 'completed',
-          progress: 100,
-          exportType: 'aggregated',
-          createdAt: 10
-        },
-        {
-          jobId: 'failed',
-          status: 'failed',
-          progress: 90,
-          exportType: 'item-matrix',
-          createdAt: 11,
-          errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
-          errorDetails: {
-            total: 2,
-            groupCount: 0,
-            sampleLimit: 20,
-            diagnosticsAvailable: false,
-            incompleteDownloadAvailable: false
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of({
+        jobs: [
+          {
+            jobId: 'completed',
+            status: 'completed',
+            progress: 100,
+            exportType: 'aggregated',
+            createdAt: 10
+          },
+          {
+            jobId: 'failed',
+            status: 'failed',
+            progress: 90,
+            exportType: 'item-matrix',
+            createdAt: 11,
+            errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
+            errorDetails: {
+              total: 2,
+              groupCount: 0,
+              sampleLimit: 20,
+              diagnosticsAvailable: false,
+              incompleteDownloadAvailable: false
+            }
           }
-        }
-      ]));
+        ],
+        historyPending: false
+      }));
 
       service.restoreWorkspaceJobs(5).subscribe();
 
@@ -192,8 +207,131 @@ describe('ExportJobService', () => {
       expect(service.activeJobs.map(job => job.jobId)).toEqual(['local']);
     });
 
+    it('retries restoration after a transient request failure', fakeAsync(() => {
+      codingJobBackendServiceMock.getExportJobs
+        .mockReturnValueOnce(
+          throwError(
+            () => new HttpErrorResponse({
+              status: 503
+            })
+          )
+        )
+        .mockReturnValueOnce(
+          of({
+            jobs: [
+              {
+                jobId: 'restored',
+                status: 'processing',
+                progress: 25,
+                exportType: 'aggregated',
+                createdAt: 10
+              }
+            ],
+            historyPending: false
+          })
+        );
+      codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(
+        of({
+          status: 'processing',
+          progress: 30
+        })
+      );
+
+      service.restoreWorkspaceJobs(5).subscribe();
+
+      expect(codingJobBackendServiceMock.getExportJobs).toHaveBeenCalledTimes(
+        1
+      );
+      tick(2000);
+      expect(codingJobBackendServiceMock.getExportJobs).toHaveBeenCalledTimes(
+        2
+      );
+      expect(service.activeJobs).toEqual([
+        expect.objectContaining({ jobId: 'restored', workspaceId: 5 })
+      ]);
+
+      service.ngOnDestroy();
+    }));
+
+    it('reloads the job list until legacy history is ready', fakeAsync(() => {
+      codingJobBackendServiceMock.getExportJobs
+        .mockReturnValueOnce(
+          of({
+            jobs: [
+              {
+                jobId: 'active',
+                status: 'processing',
+                progress: 25,
+                exportType: 'aggregated',
+                createdAt: 20
+              }
+            ],
+            historyPending: true
+          })
+        )
+        .mockReturnValueOnce(
+          of({
+            jobs: [
+              {
+                jobId: 'legacy-failure',
+                status: 'failed',
+                progress: 80,
+                exportType: 'aggregated',
+                createdAt: 10,
+                error: 'legacy failure'
+              }
+            ],
+            historyPending: false
+          })
+        );
+      codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(
+        of({
+          status: 'processing',
+          progress: 30
+        })
+      );
+
+      service.restoreWorkspaceJobs(5).subscribe();
+
+      expect(service.activeJobs.map(job => job.jobId)).toEqual(['active']);
+      expect(codingJobBackendServiceMock.getExportJobs).toHaveBeenCalledTimes(
+        1
+      );
+
+      tick(2000);
+
+      expect(codingJobBackendServiceMock.getExportJobs).toHaveBeenCalledTimes(
+        2
+      );
+      expect(service.failedJobs.map(job => job.jobId)).toEqual([
+        'legacy-failure'
+      ]);
+
+      service.ngOnDestroy();
+    }));
+
+    it('backs off repeated reloads while legacy history remains pending', fakeAsync(() => {
+      codingJobBackendServiceMock.getExportJobs
+        .mockReturnValueOnce(of({ jobs: [], historyPending: true }))
+        .mockReturnValueOnce(of({ jobs: [], historyPending: true }))
+        .mockReturnValueOnce(of({ jobs: [], historyPending: false }));
+
+      service.restoreWorkspaceJobs(5).subscribe();
+
+      expect(codingJobBackendServiceMock.getExportJobs).toHaveBeenCalledTimes(1);
+      tick(2000);
+      expect(codingJobBackendServiceMock.getExportJobs).toHaveBeenCalledTimes(2);
+
+      tick(3999);
+      expect(codingJobBackendServiceMock.getExportJobs).toHaveBeenCalledTimes(2);
+      tick(1);
+      expect(codingJobBackendServiceMock.getExportJobs).toHaveBeenCalledTimes(3);
+
+      service.ngOnDestroy();
+    }));
+
     it('keeps jobs started while restoration is in flight', fakeAsync(() => {
-      const restoration = new Subject<ExportJobListItemDto[]>();
+      const restoration = new Subject<ExportJobListResponse>();
       codingJobBackendServiceMock.getExportJobs.mockReturnValue(restoration);
       codingJobBackendServiceMock.startExportJob.mockReturnValue(of({
         jobId: 'started-during-restore',
@@ -206,7 +344,7 @@ describe('ExportJobService', () => {
 
       service.restoreWorkspaceJobs(5).subscribe();
       service.startJob(5, { exportType: 'aggregated' }).subscribe();
-      restoration.next([]);
+      restoration.next({ jobs: [], historyPending: false });
       restoration.complete();
 
       expect(service.activeJobs.map(job => job.jobId))
@@ -223,7 +361,10 @@ describe('ExportJobService', () => {
         jobId: 'running-before-restore',
         message: 'Job started'
       }));
-      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([]));
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of({
+        jobs: [],
+        historyPending: false
+      }));
       codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(of({
         status: 'processing',
         progress: 25
@@ -242,7 +383,7 @@ describe('ExportJobService', () => {
     }));
 
     it('keeps a local job that completes while restoration is in flight', fakeAsync(() => {
-      const restoration = new Subject<ExportJobListItemDto[]>();
+      const restoration = new Subject<ExportJobListResponse>();
       codingJobBackendServiceMock.startExportJob.mockReturnValue(of({
         jobId: 'completed-during-restore',
         message: 'Job started'
@@ -266,7 +407,7 @@ describe('ExportJobService', () => {
       service.startJob(5, { exportType: 'aggregated' }).subscribe();
       service.restoreWorkspaceJobs(5).subscribe();
       tick(2000);
-      restoration.next([]);
+      restoration.next({ jobs: [], historyPending: false });
       restoration.complete();
 
       expect(service.completedJobs.map(job => job.jobId))
@@ -274,41 +415,50 @@ describe('ExportJobService', () => {
     }));
 
     it('ignores an older overlapping restoration response', () => {
-      const firstRestore = new Subject<ExportJobListItemDto[]>();
-      const secondRestore = new Subject<ExportJobListItemDto[]>();
+      const firstRestore = new Subject<ExportJobListResponse>();
+      const secondRestore = new Subject<ExportJobListResponse>();
       codingJobBackendServiceMock.getExportJobs
         .mockReturnValueOnce(firstRestore)
         .mockReturnValueOnce(secondRestore);
 
       service.restoreWorkspaceJobs(5).subscribe();
       service.restoreWorkspaceJobs(5).subscribe();
-      secondRestore.next([{
-        jobId: 'latest',
-        status: 'failed',
-        progress: 10,
-        exportType: 'aggregated',
-        createdAt: 20
-      }]);
-      firstRestore.next([{
-        jobId: 'stale',
-        status: 'failed',
-        progress: 10,
-        exportType: 'aggregated',
-        createdAt: 10
-      }]);
+      secondRestore.next({
+        jobs: [{
+          jobId: 'latest',
+          status: 'failed',
+          progress: 10,
+          exportType: 'aggregated',
+          createdAt: 20
+        }],
+        historyPending: false
+      });
+      firstRestore.next({
+        jobs: [{
+          jobId: 'stale',
+          status: 'failed',
+          progress: 10,
+          exportType: 'aggregated',
+          createdAt: 10
+        }],
+        historyPending: false
+      });
 
       expect(service.failedJobs.map(job => job.jobId)).toEqual(['latest']);
     });
 
     it('restores manual export display metadata', () => {
-      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of([{
-        jobId: 'manual-review',
-        status: 'failed',
-        progress: 80,
-        exportType: 'aggregated',
-        createdAt: 10,
-        displayVariant: 'manual-review-new-column-per-coder'
-      }]));
+      codingJobBackendServiceMock.getExportJobs.mockReturnValue(of({
+        jobs: [{
+          jobId: 'manual-review',
+          status: 'failed',
+          progress: 80,
+          exportType: 'aggregated',
+          createdAt: 10,
+          displayVariant: 'manual-review-new-column-per-coder'
+        }],
+        historyPending: false
+      }));
 
       service.restoreWorkspaceJobs(5).subscribe();
 
@@ -413,6 +563,204 @@ describe('ExportJobService', () => {
         totalRows: 200,
         progressMessage: '100/200 rows'
       }));
+
+      service.ngOnDestroy();
+    }));
+
+    it('keeps polling after a transient status request failure', fakeAsync(() => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(
+        of({
+          jobId: 'j1',
+          message: 'Job started'
+        })
+      );
+      codingJobBackendServiceMock.getExportJobStatus
+        .mockReturnValueOnce(
+          throwError(
+            () => new HttpErrorResponse({
+              status: 0,
+              statusText: 'Offline'
+            })
+          )
+        )
+        .mockReturnValueOnce(of({ status: 'completed', progress: 100 }));
+
+      service
+        .startJob(1, {
+          exportType: 'aggregated',
+          userId: 1
+        })
+        .subscribe();
+
+      tick(2000);
+      expect(service.activeJobs).toEqual([
+        expect.objectContaining({ jobId: 'j1' })
+      ]);
+
+      tick(2000);
+      expect(
+        codingJobBackendServiceMock.getExportJobStatus
+      ).toHaveBeenCalledTimes(2);
+      expect(service.completedJobs).toEqual([
+        expect.objectContaining({ jobId: 'j1' })
+      ]);
+
+      service.ngOnDestroy();
+    }));
+
+    it('keeps polling while a lease cleanup claim is being released', fakeAsync(() => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(
+        of({
+          jobId: 'j1',
+          message: 'Job started'
+        })
+      );
+      codingJobBackendServiceMock.getExportJobStatus
+        .mockReturnValueOnce(
+          throwError(
+            () => new HttpErrorResponse({
+              status: 409,
+              statusText: 'Lease cleanup in progress'
+            })
+          )
+        )
+        .mockReturnValueOnce(of({ status: 'processing', progress: 40 }));
+
+      service
+        .startJob(1, {
+          exportType: 'aggregated',
+          userId: 1
+        })
+        .subscribe();
+
+      tick(2000);
+      expect(service.activeJobs).toEqual([
+        expect.objectContaining({ jobId: 'j1' })
+      ]);
+
+      tick(2000);
+      expect(
+        codingJobBackendServiceMock.getExportJobStatus
+      ).toHaveBeenCalledTimes(2);
+      expect(service.activeJobs).toEqual([
+        expect.objectContaining({ jobId: 'j1', progress: 40 })
+      ]);
+      expect(service.unavailableJobs).toEqual([]);
+
+      service.ngOnDestroy();
+    }));
+
+    it('marks the status unavailable after a terminal request failure', fakeAsync(() => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(
+        of({
+          jobId: 'j1',
+          message: 'Job started'
+        })
+      );
+      codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 403 }))
+      );
+
+      service
+        .startJob(1, {
+          exportType: 'aggregated',
+          userId: 1
+        })
+        .subscribe();
+
+      tick(2000);
+      expect(service.unavailableJobs).toEqual([
+        expect.objectContaining({
+          jobId: 'j1',
+          error: 'Failed to get job status'
+        })
+      ]);
+      expect(service.failedJobs).toEqual([]);
+
+      tick(2000);
+      expect(
+        codingJobBackendServiceMock.getExportJobStatus
+      ).toHaveBeenCalledTimes(1);
+
+      service.ngOnDestroy();
+    }));
+
+    it('does not classify a status API error as an export failure', fakeAsync(() => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(
+        of({
+          jobId: 'j1',
+          message: 'Job started'
+        })
+      );
+      codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(
+        of({
+          error: 'Export job not found'
+        })
+      );
+
+      service
+        .startJob(1, {
+          exportType: 'aggregated',
+          userId: 1
+        })
+        .subscribe();
+
+      tick(2000);
+      expect(service.unavailableJobs).toEqual([
+        expect.objectContaining({
+          jobId: 'j1',
+          error: 'Export job not found'
+        })
+      ]);
+      expect(service.failedJobs).toEqual([]);
+
+      tick(2000);
+      expect(
+        codingJobBackendServiceMock.getExportJobStatus
+      ).toHaveBeenCalledTimes(1);
+
+      service.ngOnDestroy();
+    }));
+
+    it('backs off persistent transient failures and eventually recovers', fakeAsync(() => {
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(
+        of({
+          jobId: 'j1',
+          message: 'Job started'
+        })
+      );
+      let failuresRemaining = 7;
+      codingJobBackendServiceMock.getExportJobStatus.mockImplementation(() => {
+        if (failuresRemaining > 0) {
+          failuresRemaining -= 1;
+          return throwError(() => new HttpErrorResponse({ status: 503 }));
+        }
+        return of({ status: 'completed', progress: 100 });
+      });
+
+      service
+        .startJob(1, {
+          exportType: 'aggregated',
+          userId: 1
+        })
+        .subscribe();
+
+      tick(120000);
+      expect(
+        codingJobBackendServiceMock.getExportJobStatus
+      ).toHaveBeenCalledTimes(7);
+      expect(service.activeJobs).toEqual([
+        expect.objectContaining({ jobId: 'j1' })
+      ]);
+      expect(service.failedJobs).toEqual([]);
+
+      tick(2000);
+      expect(
+        codingJobBackendServiceMock.getExportJobStatus
+      ).toHaveBeenCalledTimes(8);
+      expect(service.completedJobs).toEqual([
+        expect.objectContaining({ jobId: 'j1' })
+      ]);
 
       service.ngOnDestroy();
     }));
@@ -646,16 +994,21 @@ describe('ExportJobService', () => {
         'manual-review-most-frequent'
       );
 
-      expect(anchor.download).toBe(`export-manual-review-most-frequent-${date}.xlsx`);
+      expect(anchor.download).toBe(`export-manual-review-most-frequent-${date}.xlsx`
+      );
       expect(clickSpy).toHaveBeenCalled();
 
       createElementSpy.mockRestore();
     });
 
     it('should allow cancelling an in-flight file download without cancelling the completed job', () => {
-      codingJobBackendServiceMock.startExportJob.mockReturnValue(of({ jobId: 'j1', message: 'Job started' }));
+      codingJobBackendServiceMock.startExportJob.mockReturnValue(
+        of({ jobId: 'j1', message: 'Job started' })
+      );
       const fileDownload$ = new Subject<Blob>();
-      codingJobBackendServiceMock.downloadExportFile.mockReturnValue(fileDownload$);
+      codingJobBackendServiceMock.downloadExportFile.mockReturnValue(
+        fileDownload$
+      );
 
       service.startJob(1, { exportType: 'aggregated', userId: 1 }).subscribe();
       service.downloadFile(1, 'j1', 'aggregated', 'export.xlsx');
@@ -666,7 +1019,9 @@ describe('ExportJobService', () => {
       service.cancelJob(service.activeJobs[0]);
 
       expect(fileDownload$.observers.length).toBe(0);
-      expect(codingJobBackendServiceMock.cancelExportJob).not.toHaveBeenCalled();
+      expect(
+        codingJobBackendServiceMock.cancelExportJob
+      ).not.toHaveBeenCalled();
       expect(service.completedJobs[0].status).toBe('completed');
     });
   });
@@ -681,16 +1036,19 @@ describe('ExportJobService', () => {
       status: 'failed' as const,
       progress: 90
     };
-    codingJobBackendServiceMock.getItemMatrixExportDiagnostics
-      .mockReturnValue(of(diagnostics));
-    codingJobBackendServiceMock.downloadIncompleteItemMatrix
-      .mockReturnValue(of({
+    codingJobBackendServiceMock.getItemMatrixExportDiagnostics.mockReturnValue(
+      of(diagnostics)
+    );
+    codingJobBackendServiceMock.downloadIncompleteItemMatrix.mockReturnValue(
+      of({
         blob,
         fileName: 'Itemdatensatz-UNVOLLSTAENDIG-2026-07-25.zip'
-      }));
+      })
+    );
     const anchor = document.createElement('a');
     jest.spyOn(anchor, 'click').mockImplementation();
-    const createElementSpy = jest.spyOn(document, 'createElement')
+    const createElementSpy = jest
+      .spyOn(document, 'createElement')
       .mockReturnValue(anchor);
     Object.defineProperty(window.URL, 'createObjectURL', {
       value: jest.fn().mockReturnValue('blob:url'),
@@ -711,9 +1069,7 @@ describe('ExportJobService', () => {
     expect(
       codingJobBackendServiceMock.downloadIncompleteItemMatrix
     ).toHaveBeenCalledWith(1, 'j1');
-    expect(anchor.download).toBe(
-      'Itemdatensatz-UNVOLLSTAENDIG-2026-07-25.zip'
-    );
+    expect(anchor.download).toBe('Itemdatensatz-UNVOLLSTAENDIG-2026-07-25.zip');
     expect(job.status).toBe('failed');
     createElementSpy.mockRestore();
   });
@@ -723,15 +1079,18 @@ describe('ExportJobService', () => {
       blob: Blob;
       fileName?: string;
     }>();
-    codingJobBackendServiceMock.downloadIncompleteItemMatrix
-      .mockReturnValue(download$);
-    service.downloadIncompleteItemMatrix({
-      jobId: 'j1',
-      workspaceId: 1,
-      exportType: 'item-matrix',
-      status: 'failed',
-      progress: 90
-    }).subscribe();
+    codingJobBackendServiceMock.downloadIncompleteItemMatrix.mockReturnValue(
+      download$
+    );
+    service
+      .downloadIncompleteItemMatrix({
+        jobId: 'j1',
+        workspaceId: 1,
+        exportType: 'item-matrix',
+        status: 'failed',
+        progress: 90
+      })
+      .subscribe();
 
     expect(download$.observers).toHaveLength(1);
     service.ngOnDestroy();
@@ -739,40 +1098,48 @@ describe('ExportJobService', () => {
   });
 
   it('marks item matrix artifacts expired after a 404 download', fakeAsync(() => {
-    codingJobBackendServiceMock.startExportJob.mockReturnValue(of({
-      jobId: 'j1',
-      message: 'Job started'
-    }));
-    codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(of({
-      status: 'failed',
-      progress: 90,
-      errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
-      errorDetails: {
-        total: 2,
-        groupCount: 1,
-        sampleLimit: 20,
-        diagnosticsAvailable: true,
-        incompleteDownloadAvailable: true,
-        expiresAt: Date.now() + 3600000
-      }
-    }));
+    codingJobBackendServiceMock.startExportJob.mockReturnValue(
+      of({
+        jobId: 'j1',
+        message: 'Job started'
+      })
+    );
+    codingJobBackendServiceMock.getExportJobStatus.mockReturnValue(
+      of({
+        status: 'failed',
+        progress: 90,
+        errorCode: 'ITEM_MATRIX_UNRESOLVED_CELLS',
+        errorDetails: {
+          total: 2,
+          groupCount: 1,
+          sampleLimit: 20,
+          diagnosticsAvailable: true,
+          incompleteDownloadAvailable: true,
+          expiresAt: Date.now() + 3600000
+        }
+      })
+    );
     codingJobBackendServiceMock.downloadIncompleteItemMatrix.mockReturnValue(
       throwError(() => new HttpErrorResponse({ status: 404 }))
     );
-    service.startJob(1, {
-      exportType: 'item-matrix',
-      missingsProfileId: 4
-    }).subscribe();
+    service
+      .startJob(1, {
+        exportType: 'item-matrix',
+        missingsProfileId: 4
+      })
+      .subscribe();
     tick(2000);
 
     service.downloadIncompleteItemMatrix(service.failedJobs[0]).subscribe({
       error: () => undefined
     });
 
-    expect(service.failedJobs[0].errorDetails).toEqual(expect.objectContaining({
-      diagnosticsAvailable: false,
-      incompleteDownloadAvailable: false
-    }));
+    expect(service.failedJobs[0].errorDetails).toEqual(
+      expect.objectContaining({
+        diagnosticsAvailable: false,
+        incompleteDownloadAvailable: false
+      })
+    );
     service.ngOnDestroy();
   }));
 });

--- a/apps/frontend/src/app/shared/services/file/export-job.service.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.ts
@@ -153,6 +153,15 @@ export class ExportJobService implements OnDestroy {
         .filter(job => job.workspaceId === workspaceId)
         .map(job => job.jobId)
     );
+    const locallyActiveJobIdsAtStart = new Set(
+      this.jobsSubject.value
+        .filter(job => job.workspaceId === workspaceId && (
+          job.status === 'waiting' ||
+          job.status === 'active' ||
+          job.status === 'downloading'
+        ))
+        .map(job => job.jobId)
+    );
 
     return this.codingJobBackendService.getExportJobs(workspaceId).pipe(
       map(statuses => statuses
@@ -186,8 +195,13 @@ export class ExportJobService implements OnDestroy {
         const jobsAddedDuringRestore = currentWorkspaceJobs.filter(
           job => !jobIdsAtStart.has(job.jobId) && !restoredJobIds.has(job.jobId)
         );
+        const locallyActiveJobs = currentWorkspaceJobs.filter(
+          job => locallyActiveJobIdsAtStart.has(job.jobId) &&
+            !restoredJobIds.has(job.jobId)
+        );
         const nextWorkspaceJobs = [
           ...restoredWithLocalMetadata,
+          ...locallyActiveJobs,
           ...jobsAddedDuringRestore
         ];
 

--- a/apps/frontend/src/app/shared/services/file/export-job.service.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.ts
@@ -332,6 +332,13 @@ export class ExportJobService implements OnDestroy {
   }
 
   private isRestorableJob(status: ExportJobListItemDto): boolean {
+    if (
+      status.status === 'pending' ||
+      status.status === 'processing' ||
+      status.status === 'paused'
+    ) {
+      return false;
+    }
     if (status.status === 'completed') {
       return !!status.result;
     }

--- a/apps/frontend/src/app/shared/services/file/export-job.service.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.ts
@@ -8,12 +8,16 @@ import {
   Subject,
   Subscription,
   catchError,
-  interval,
   of,
+  timer as rxTimer,
   throwError
 } from 'rxjs';
 import {
-  finalize, map, switchMap, takeUntil, tap
+  expand,
+  finalize, map,
+  repeat,
+  retry,
+  switchMap, takeUntil, tap
 } from 'rxjs/operators';
 import {
   CodingExportEstimate,
@@ -46,7 +50,8 @@ interface ExportJobBase {
   jobId: string;
   workspaceId: number;
   status:
-  'waiting' | 'active' | 'downloading' | 'completed' | 'failed' | 'cancelled';
+  | 'waiting' | 'active' | 'downloading' | 'completed' | 'failed' | 'cancelled'
+  | 'unavailable';
   progress: number;
   progressPhase?: ExportJobProgressPhaseDto;
   processedRows?: number;
@@ -104,6 +109,8 @@ export function isReplayAuthTokenError(
   providedIn: 'root'
 })
 export class ExportJobService implements OnDestroy {
+  private static readonly statusPollingIntervalMs = 2000;
+  private static readonly maxStatusRetryDelayMs = 30000;
   private jobsSubject = new BehaviorSubject<ExportJob[]>([]);
   private pollingSubscriptions = new Map<string, Subscription>();
   private downloadSubscriptions = new Map<string, Subscription>();
@@ -141,6 +148,10 @@ export class ExportJobService implements OnDestroy {
     return this.jobsSubject.value.filter(job => job.status === 'failed');
   }
 
+  get unavailableJobs(): ExportJob[] {
+    return this.jobsSubject.value.filter(job => job.status === 'unavailable');
+  }
+
   get cancelledJobs(): ExportJob[] {
     return this.jobsSubject.value.filter(job => job.status === 'cancelled');
   }
@@ -163,8 +174,45 @@ export class ExportJobService implements OnDestroy {
         .map(job => job.jobId)
     );
 
-    return this.codingJobBackendService.getExportJobs(workspaceId).pipe(
-      map(statuses => statuses
+    let consecutiveRestoreFailures = 0;
+    let consecutiveHistoryPendingResponses = 0;
+    const loadJobs = () => defer(() => this.codingJobBackendService.getExportJobs(workspaceId)).pipe(
+      tap(() => {
+        consecutiveRestoreFailures = 0;
+      }),
+      retry({
+        delay: error => {
+          if (!this.isRetryableRequestError(error)) {
+            return throwError(() => error);
+          }
+          consecutiveRestoreFailures += 1;
+          return rxTimer(
+            this.getRequestRetryDelay(consecutiveRestoreFailures)
+          );
+        }
+      })
+    );
+    return loadJobs().pipe(
+      expand(response => {
+        if (
+          !response.historyPending ||
+          this.restoreVersions.get(workspaceId) !== restoreVersion
+        ) {
+          consecutiveHistoryPendingResponses = 0;
+          return EMPTY;
+        }
+        consecutiveHistoryPendingResponses += 1;
+        return rxTimer(
+          this.getRequestRetryDelay(consecutiveHistoryPendingResponses)
+        ).pipe(
+          switchMap(() => (
+            this.restoreVersions.get(workspaceId) === restoreVersion ?
+              loadJobs() :
+              EMPTY
+          ))
+        );
+      }),
+      map(response => response.jobs
         .filter(status => this.isRestorableJob(status))
         .map(status => this.toExportJob(workspaceId, status))
       ),
@@ -347,18 +395,14 @@ export class ExportJobService implements OnDestroy {
 
   private isRestorableJob(status: ExportJobListItemDto): boolean {
     if (
-      status.status === 'pending' ||
-      status.status === 'processing' ||
-      status.status === 'paused'
-    ) {
-      return false;
-    }
-    if (status.status === 'completed') {
+      status.status === 'completed') {
       return !!status.result;
     }
     if (status.errorCode === ITEM_MATRIX_UNRESOLVED_CELLS_ERROR_CODE) {
-      return status.errorDetails.diagnosticsAvailable ||
-        status.errorDetails.incompleteDownloadAvailable;
+      return (
+        status.errorDetails.diagnosticsAvailable ||
+        status.errorDetails.incompleteDownloadAvailable
+      );
     }
     return true;
   }
@@ -431,17 +475,44 @@ export class ExportJobService implements OnDestroy {
       return;
     }
 
-    const subscription = interval(2000)
+    let consecutiveStatusRequestFailures = 0;
+    let nextStatusRequestDelayMs = ExportJobService.statusPollingIntervalMs;
+    const statusRequest$ = defer(() => this.codingJobBackendService.getExportJobStatus(workspaceId, jobId).pipe(
+      catchError(error => {
+        if (this.isRetryableStatusRequestError(error)) {
+          consecutiveStatusRequestFailures += 1;
+          nextStatusRequestDelayMs = this.getRequestRetryDelay(
+            consecutiveStatusRequestFailures
+          );
+          return EMPTY;
+        }
+
+        this.updateJob(jobId, {
+          status: 'unavailable',
+          error: 'Failed to get job status'
+        });
+        this.stopPollingForJob(jobId);
+        return EMPTY;
+      })
+    )
+    );
+    const subscription = rxTimer(ExportJobService.statusPollingIntervalMs)
       .pipe(
-        takeUntil(this.stopPolling$),
-        switchMap(() => this.codingJobBackendService.getExportJobStatus(workspaceId, jobId)
+        switchMap(() => statusRequest$.pipe(
+          repeat({
+            delay: () => rxTimer(nextStatusRequestDelayMs)
+          })
         )
+        ),
+        takeUntil(this.stopPolling$)
       )
       .subscribe({
         next: status => {
+          consecutiveStatusRequestFailures = 0;
+          nextStatusRequestDelayMs = ExportJobService.statusPollingIntervalMs;
           if (!('status' in status)) {
             this.updateJob(jobId, {
-              status: 'failed',
+              status: 'unavailable',
               error: status.error
             });
             this.stopPollingForJob(jobId);
@@ -477,17 +548,34 @@ export class ExportJobService implements OnDestroy {
           ) {
             this.stopPollingForJob(jobId);
           }
-        },
-        error: () => {
-          this.updateJob(jobId, {
-            status: 'failed',
-            error: 'Failed to get job status'
-          });
-          this.stopPollingForJob(jobId);
         }
       });
 
     this.pollingSubscriptions.set(jobId, subscription);
+  }
+
+  private isRetryableStatusRequestError(error: unknown): boolean {
+    return (
+      this.isRetryableRequestError(error) ||
+      (error instanceof HttpErrorResponse && error.status === 409)
+    );
+  }
+
+  private isRetryableRequestError(error: unknown): boolean {
+    return (
+      error instanceof HttpErrorResponse &&
+      (error.status === 0 ||
+        error.status === 408 ||
+        error.status === 429 ||
+        error.status >= 500)
+    );
+  }
+
+  private getRequestRetryDelay(consecutiveFailures: number): number {
+    const exponentialDelay =
+      ExportJobService.statusPollingIntervalMs *
+      2 ** Math.max(0, consecutiveFailures - 1);
+    return Math.min(exponentialDelay, ExportJobService.maxStatusRetryDelayMs);
   }
 
   private mapStatus(status: ExportJobStateDto): ExportJob['status'] {
@@ -535,7 +623,9 @@ export class ExportJobService implements OnDestroy {
           this.stopDownloadForJob(jobId);
           this.clearItemMatrixExpirationTimer(jobId);
           this.jobsSubject.next(
-            this.jobsSubject.value.filter(candidate => candidate.jobId !== jobId)
+            this.jobsSubject.value.filter(
+              candidate => candidate.jobId !== jobId
+            )
           );
           return true;
         }),

--- a/apps/frontend/src/app/shared/services/file/export-job.service.ts
+++ b/apps/frontend/src/app/shared/services/file/export-job.service.ts
@@ -31,7 +31,9 @@ import { WorkspaceSettingsService } from '../../../ws-admin/services/workspace-s
 import type { PsychometricDomainCandidatesDto } from '../../../../../../../api-dto/coding/psychometric-discrimination.dto';
 import {
   BackgroundExportRequest,
+  ExportJobDisplayVariantDto,
   ExportJobErrorMetadataDto,
+  ExportJobListItemDto,
   ExportJobProgressPhaseDto,
   ExportJobStateDto,
   ExportJobStatusDto,
@@ -111,6 +113,8 @@ export class ExportJobService implements OnDestroy {
   ReturnType<typeof setTimeout>
   >();
 
+  private restoreVersions = new Map<number, number>();
+
   private stopPolling$ = new Subject<void>();
 
   readonly jobs$ = this.jobsSubject.asObservable();
@@ -139,6 +143,72 @@ export class ExportJobService implements OnDestroy {
 
   get cancelledJobs(): ExportJob[] {
     return this.jobsSubject.value.filter(job => job.status === 'cancelled');
+  }
+
+  restoreWorkspaceJobs(workspaceId: number): Observable<ExportJob[]> {
+    const restoreVersion = (this.restoreVersions.get(workspaceId) || 0) + 1;
+    this.restoreVersions.set(workspaceId, restoreVersion);
+    const jobIdsAtStart = new Set(
+      this.jobsSubject.value
+        .filter(job => job.workspaceId === workspaceId)
+        .map(job => job.jobId)
+    );
+
+    return this.codingJobBackendService.getExportJobs(workspaceId).pipe(
+      map(statuses => statuses
+        .filter(status => this.isRestorableJob(status))
+        .map(status => this.toExportJob(workspaceId, status))
+      ),
+      tap(restoredJobs => {
+        if (this.restoreVersions.get(workspaceId) !== restoreVersion) {
+          return;
+        }
+
+        const currentJobs = this.jobsSubject.value;
+        const currentWorkspaceJobs = currentJobs.filter(
+          job => job.workspaceId === workspaceId
+        );
+        const currentJobsById = new Map(
+          currentWorkspaceJobs.map(job => [job.jobId, job])
+        );
+        const restoredWithLocalMetadata = restoredJobs.map(job => {
+          const localJob = currentJobsById.get(job.jobId);
+          return localJob ? {
+            ...job,
+            displayLabelKey: localJob.displayLabelKey || job.displayLabelKey,
+            downloadFilePrefix:
+              localJob.downloadFilePrefix || job.downloadFilePrefix
+          } : job;
+        });
+        const restoredJobIds = new Set(
+          restoredWithLocalMetadata.map(job => job.jobId)
+        );
+        const jobsAddedDuringRestore = currentWorkspaceJobs.filter(
+          job => !jobIdsAtStart.has(job.jobId) && !restoredJobIds.has(job.jobId)
+        );
+        const nextWorkspaceJobs = [
+          ...restoredWithLocalMetadata,
+          ...jobsAddedDuringRestore
+        ];
+
+        currentWorkspaceJobs.forEach(job => {
+          this.stopPollingForJob(job.jobId);
+          this.clearItemMatrixExpirationTimer(job.jobId);
+        });
+        const jobsFromOtherWorkspaces = currentJobs.filter(
+          job => job.workspaceId !== workspaceId
+        );
+        this.jobsSubject.next([...jobsFromOtherWorkspaces, ...nextWorkspaceJobs]);
+
+        nextWorkspaceJobs.forEach(job => {
+          if (job.status === 'waiting' || job.status === 'active') {
+            this.startPollingForJob(workspaceId, job.jobId);
+          }
+          this.scheduleItemMatrixArtifactExpiration(job.jobId, job);
+        });
+      }),
+      catchError(() => of([]))
+    );
   }
 
   startJob(
@@ -259,6 +329,66 @@ export class ExportJobService implements OnDestroy {
   private addJob(job: ExportJob): void {
     const currentJobs = this.jobsSubject.value;
     this.jobsSubject.next([...currentJobs, job]);
+  }
+
+  private isRestorableJob(status: ExportJobListItemDto): boolean {
+    if (status.status === 'completed') {
+      return !!status.result;
+    }
+    if (status.errorCode === ITEM_MATRIX_UNRESOLVED_CELLS_ERROR_CODE) {
+      return status.errorDetails.diagnosticsAvailable ||
+        status.errorDetails.incompleteDownloadAvailable;
+    }
+    return true;
+  }
+
+  private toExportJob(
+    workspaceId: number,
+    status: ExportJobListItemDto
+  ): ExportJob {
+    const displayMetadata = this.getDisplayMetadata(status.displayVariant);
+    return {
+      jobId: status.jobId,
+      workspaceId,
+      status: this.mapStatus(status.status),
+      progress: status.progress,
+      progressPhase: status.progressPhase,
+      processedRows: status.processedRows,
+      totalRows: status.totalRows,
+      progressMessage: status.progressMessage,
+      exportType: status.exportType,
+      displayLabelKey: displayMetadata.displayLabelKey,
+      downloadFilePrefix: displayMetadata.downloadFilePrefix ||
+        (status.exportType === 'item-matrix' ? 'Itemdatensatz' : undefined),
+      result: status.result ? {
+        fileName: status.result.fileName,
+        fileSize: status.result.fileSize
+      } : undefined,
+      error: status.error,
+      createdAt: status.createdAt,
+      ...this.getExportJobErrorMetadata(status)
+    };
+  }
+
+  private getDisplayMetadata(
+    variant?: ExportJobDisplayVariantDto
+  ): Pick<ExportJob, 'displayLabelKey' | 'downloadFilePrefix'> {
+    switch (variant) {
+      case 'manual-review-most-frequent':
+      case 'manual-review-new-column-per-coder':
+      case 'manual-review-new-row-per-variable':
+        return {
+          displayLabelKey: `export-toast.types.${variant}`,
+          downloadFilePrefix: variant
+        };
+      case 'manual-review-by-variable-compact':
+        return {
+          displayLabelKey: 'export-toast.types.by-variable-compact',
+          downloadFilePrefix: variant
+        };
+      default:
+        return {};
+    }
   }
 
   private updateJob(
@@ -522,7 +652,7 @@ export class ExportJobService implements OnDestroy {
 
   private scheduleItemMatrixArtifactExpiration(
     jobId: string,
-    status: ExportJobStatusDto
+    status: ExportJobErrorMetadataDto
   ): void {
     this.clearItemMatrixExpirationTimer(jobId);
     if (status.errorCode !== ITEM_MATRIX_UNRESOLVED_CELLS_ERROR_CODE) {

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -77,6 +77,8 @@
       "item-matrix-incomplete-expired": "{{total}} Zellen konnten nicht sicher aufgelöst werden. Diagnose und unvollständiges Paket sind abgelaufen; starten Sie den Export erneut.",
       "item-matrix-diagnostics-load-failed": "Die Matrixdiagnose konnte nicht geladen werden. Starten Sie den Export gegebenenfalls erneut.",
       "item-matrix-incomplete-download-failed": "Das unvollständige Paket konnte nicht heruntergeladen werden. Falls es abgelaufen ist, starten Sie den Export erneut.",
+      "status-unavailable-title": "Exportstatus nicht verfügbar",
+      "status-unavailable-message": "Der aktuelle Zustand des Exports konnte nicht ermittelt werden. Das bedeutet nicht, dass der Export fehlgeschlagen ist.",
       "remove-failed": "Der Export konnte nicht vollständig gelöscht werden und bleibt deshalb in der Liste. Versuchen Sie es erneut.",
       "generic-title": "Export fehlgeschlagen"
     },

--- a/docker-compose.coding-box.prod.yaml
+++ b/docker-compose.coding-box.prod.yaml
@@ -50,10 +50,13 @@ services:
   backend-export-worker:
     image: ${REGISTRY_PATH}iqbberlin/coding-box-backend:${TAG}
     depends_on:
+      db:
+        condition: service_healthy
       redis:
         condition: service_healthy
     environment:
       APP_ROLE: export-worker
+      EXPORT_WORKER_READY_FILE: /tmp/coding-box-export-worker-ready
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PREFIX: ${REDIS_PREFIX:-coding-box}
@@ -74,6 +77,12 @@ services:
         limits:
           cpus: ${EXPORT_WORKER_CPU_LIMIT:-2}
           memory: ${EXPORT_WORKER_MEMORY_LIMIT:-3G}
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /tmp/coding-box-export-worker-ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
     restart: always
 
   frontend:


### PR DESCRIPTION
## Summary

- restores running export jobs after reconnects and server restarts
- adds worker availability guards, client leases, expiration, and cleanup behavior
- scopes restored jobs to workspace and export type
- adds a bounded history index to avoid repeated global queue scans
- hardens lease cleanup against races and retries history indexing

## Root cause

Export jobs could outlive the browser connection while the system lacked a reliable, scoped way to rediscover them. Cleanup also depended on session-level database timeout behavior and queue-wide lookups, which caused stale jobs and unstable recovery.

## Validation

- backend tests: 165 suites passed, 2431 tests passed
- backend lint and build passed
- frontend tests: 202 suites passed, 2020 tests passed
- frontend lint and build passed
- full diff check passed

## Review status

Draft: remaining follow-up risks around background-tab leases, transient polling failures, one fallback queue scan, and defensive worker lookup still need resolution before merge.

Fixes #958