### PR TITLE
Fix effective coding status display

### DIFF
--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -42,6 +42,7 @@ const mockQueryBuilder = () => ({
   getRawMany: jest.fn().mockResolvedValue([]),
   getCount: jest.fn().mockResolvedValue(0),
   getMany: jest.fn().mockResolvedValue([]),
+  getRawAndEntities: jest.fn().mockResolvedValue({ entities: [], raw: [] }),
   orderBy: jest.fn().mockReturnThis(),
   skip: jest.fn().mockReturnThis(),
   take: jest.fn().mockReturnThis(),
@@ -1134,6 +1135,61 @@ describe('WorkspaceTestResultsService', () => {
         expect.stringContaining('COALESCE(response.status_v3'),
         { codedStatus: 5 }
       );
+    });
+
+    it('should return the effective v2 status while preserving raw version statuses', async () => {
+      const qb = mockQueryBuilder();
+      (responseRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+      qb.getCount.mockResolvedValue(1);
+      qb.getRawAndEntities.mockResolvedValue({
+        entities: [{
+          id: 1,
+          variableid: '01',
+          value: 'answer',
+          status: 5,
+          status_v1: 8,
+          status_v2: null,
+          status_v3: null,
+          code_v1: null,
+          code_v2: null,
+          code_v3: null,
+          score_v1: null,
+          score_v2: null,
+          score_v3: null,
+          unit: {
+            id: 2,
+            name: 'Unit1',
+            alias: null,
+            booklet: {
+              id: 3,
+              bookletinfo: { name: 'Booklet1' },
+              person: {
+                id: 4,
+                login: 'login',
+                code: 'code',
+                group: 'group'
+              }
+            }
+          }
+        }],
+        raw: [{ effective_coding_status_output: '8' }]
+      });
+
+      const result = await service.searchResponses(
+        1,
+        { version: 'v2', responseSource: 'all' },
+        { page: 1, limit: 100 }
+      );
+
+      expect(qb.addSelect).toHaveBeenCalledWith(
+        getEffectiveCodingStatusExpression('v2'),
+        'effective_coding_status_output'
+      );
+      expect(result.data[0]).toMatchObject({
+        codedStatus: 'CODING_INCOMPLETE',
+        status_v1: 'CODING_INCOMPLETE',
+        status_v2: 'UNSET'
+      });
     });
 
     it('should apply DERIVE_ERROR codedStatus filters numerically', async () => {

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -110,6 +110,7 @@ export type ResponseSearchSortBy =
   'booklet_id';
 export type ResponseSearchSortDirection = 'asc' | 'desc';
 const EFFECTIVE_CODING_STATUS_SORT_ALIAS = 'effective_coding_status_sort';
+const EFFECTIVE_CODING_STATUS_OUTPUT_ALIAS = 'effective_coding_status_output';
 
 export type WorkspaceOverviewStats = {
   testPersons: number;
@@ -6999,7 +7000,12 @@ export class WorkspaceTestResultsService {
 
         query.skip(skip).take(limit);
 
-        const responses = await query.getMany();
+        query.addSelect(
+          getEffectiveCodingStatusExpression(version),
+          EFFECTIVE_CODING_STATUS_OUTPUT_ALIAS
+        );
+        const { entities: responses, raw: rawResponses } =
+          await query.getRawAndEntities();
 
         this.logger.log(
           `Found ${total} responses matching the criteria in workspace: ${workspaceId}, returning ${responses.length} for page ${page}`
@@ -7016,16 +7022,20 @@ export class WorkspaceTestResultsService {
           variablePageMaps.set(unitName, pageMap);
         }
 
-        const data = responses.map(response => {
+        const data = responses.map((response, responseIndex) => {
           const code = response[
             `code_${version}` as keyof ResponseEntity
           ] as number;
           const score = response[
             `score_${version}` as keyof ResponseEntity
           ] as number;
-          const codedStatus = response[
-            `status_${version}` as keyof ResponseEntity
-          ] as number;
+          const rawEffectiveCodingStatus = rawResponses[responseIndex]?.[
+            EFFECTIVE_CODING_STATUS_OUTPUT_ALIAS
+          ];
+          const codedStatus = rawEffectiveCodingStatus === null ||
+            rawEffectiveCodingStatus === undefined ?
+            null :
+            Number(rawEffectiveCodingStatus);
           const variablePage =
           variablePageMaps.get(response.unit.name)?.get(response.variableid) ||
           '0';


### PR DESCRIPTION
## Summary

- select the effective coding status for response search results
- return that value as `codedStatus`, matching the existing filter and sort semantics
- preserve the raw `status_v1`, `status_v2`, and `status_v3` fields
- add a regression test for inherited v2 statuses

## Root cause

The response search filtered by the effective status expression, but mapped the displayed status directly from `status_v2` or `status_v3`. A missing version-specific value was therefore shown as `UNSET` even when the effective status was inherited from an earlier coding version.

## Impact

The coding overview now displays the same effective status that is used for filtering and sorting. A real `UNSET` remains distinguishable from a missing version-specific status.

## Validation

- `npx nx test backend`: 163 suites passed, 2,408 tests passed
- `npx nx lint backend`: passed

Relates to #967.
