### PR TITLE
Kodierstatus-Snapshots und Server-Monitoring vervollständigen

### DIFF
--- a/api-dto/coding/coding-status-revision.dto.ts
+++ b/api-dto/coding/coding-status-revision.dto.ts
@@ -1,0 +1,6 @@
+export interface CodingStatusRevisionDto {
+  workspaceId: number;
+  revision: number;
+  statusRevision: string;
+  stable: boolean;
+}

--- a/api-dto/request-monitoring/request-monitoring-incident.dto.ts
+++ b/api-dto/request-monitoring/request-monitoring-incident.dto.ts
@@ -1,0 +1,66 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export enum RequestMonitoringIncidentKind {
+  Slow = 'slow',
+  Failed = 'failed',
+  InFlight = 'in_flight',
+  Aborted = 'aborted',
+  Closed = 'closed'
+}
+
+export class RequestMonitoringIncidentDto {
+  @ApiProperty()
+    id!: number;
+
+  @ApiProperty({ enum: RequestMonitoringIncidentKind })
+    kind!: RequestMonitoringIncidentKind;
+
+  @ApiProperty()
+    method!: string;
+
+  @ApiProperty()
+    path!: string;
+
+  @ApiPropertyOptional({ nullable: true })
+    workspaceId!: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+    statusCode!: number | null;
+
+  @ApiProperty()
+    occurrenceCount!: number;
+
+  @ApiProperty()
+    maxDurationMs!: number;
+
+  @ApiProperty()
+    lastRequestId!: string;
+
+  @ApiPropertyOptional({ nullable: true })
+    lastErrorMessage!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+    postgresTotalCount!: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+    postgresIdleCount!: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+    postgresWaitingCount!: number | null;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+    firstOccurredAt!: string;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+    lastOccurredAt!: string;
+
+  @ApiPropertyOptional({ type: String, format: 'date-time', nullable: true })
+    resolvedAt!: string | null;
+}
+
+export class ResolveRequestMonitoringIncidentDto {
+  @ApiProperty()
+  @IsBoolean()
+    resolved!: boolean;
+}

--- a/apps/backend/src/app/admin/core/core-admin.module.ts
+++ b/apps/backend/src/app/admin/core/core-admin.module.ts
@@ -33,6 +33,9 @@ import { SystemNotification } from '../../database/entities/system-notification.
 import { PublicSystemNotificationController } from '../system-notifications/system-notification.controller';
 import { AdminSystemNotificationController } from '../system-notifications/admin-system-notification.controller';
 import { SystemNotificationService } from '../system-notifications/system-notification.service';
+import { RequestMonitoringIncident } from '../../database/entities/request-monitoring-incident.entity';
+import { RequestMonitoringIncidentController } from '../request-monitoring/request-monitoring-incident.controller';
+import { RequestMonitoringIncidentService } from '../request-monitoring/request-monitoring-incident.service';
 
 const processorProviders = {
   'database-export': DatabaseExportProcessor
@@ -58,7 +61,12 @@ export function getEnabledCoreAdminProcessors(
     AuthModule,
     CodingModule,
     HttpModule,
-    TypeOrmModule.forFeature([Setting, FileUpload, SystemNotification]),
+    TypeOrmModule.forFeature([
+      Setting,
+      FileUpload,
+      SystemNotification,
+      RequestMonitoringIncident
+    ]),
     BullModule.registerQueue({
       name: 'database-export'
     }),
@@ -80,14 +88,17 @@ export function getEnabledCoreAdminProcessors(
     ContentPoolSettingsController,
     LegalNoticeController,
     PublicSystemNotificationController,
-    AdminSystemNotificationController
+    AdminSystemNotificationController,
+    RequestMonitoringIncidentController
   ],
   providers: [
     DatabaseExportService,
     ...getEnabledCoreAdminProcessors(),
     ContentPoolIntegrationService,
     LegalNoticeService,
-    SystemNotificationService
-  ]
+    SystemNotificationService,
+    RequestMonitoringIncidentService
+  ],
+  exports: [RequestMonitoringIncidentService]
 })
 export class CoreAdminModule { }

--- a/apps/backend/src/app/admin/request-monitoring/request-monitoring-incident.controller.ts
+++ b/apps/backend/src/app/admin/request-monitoring/request-monitoring-incident.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  Param,
+  ParseBoolPipe,
+  ParseIntPipe,
+  Patch,
+  Query,
+  UseGuards,
+  ValidationPipe
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiTags
+} from '@nestjs/swagger';
+import {
+  RequestMonitoringIncidentDto,
+  ResolveRequestMonitoringIncidentDto
+} from '../../../../../../api-dto/request-monitoring/request-monitoring-incident.dto';
+import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
+import { AdminGuard } from '../admin.guard';
+import { RequestMonitoringIncidentService } from './request-monitoring-incident.service';
+
+@ApiTags('admin/request-monitoring-incidents')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdminGuard)
+@Controller('admin/request-monitoring-incidents')
+export class RequestMonitoringIncidentController {
+  constructor(private readonly service: RequestMonitoringIncidentService) {}
+
+  @Get()
+  @ApiOkResponse({ type: [RequestMonitoringIncidentDto] })
+  findAll(
+    @Query('includeResolved', new DefaultValuePipe(false), ParseBoolPipe)
+      includeResolved: boolean,
+      @Query('limit', new DefaultValuePipe(200), ParseIntPipe)
+      limit: number
+  ): Promise<RequestMonitoringIncidentDto[]> {
+    return this.service.findAll(includeResolved, limit);
+  }
+
+  @Patch(':id/resolution')
+  @ApiOkResponse({ type: RequestMonitoringIncidentDto })
+  setResolved(
+    @Param('id', ParseIntPipe) id: number,
+      @Body(new ValidationPipe({ transform: true, whitelist: true })) input: ResolveRequestMonitoringIncidentDto
+  ): Promise<RequestMonitoringIncidentDto> {
+    return this.service.setResolved(id, input.resolved);
+  }
+}

--- a/apps/backend/src/app/admin/request-monitoring/request-monitoring-incident.service.spec.ts
+++ b/apps/backend/src/app/admin/request-monitoring/request-monitoring-incident.service.spec.ts
@@ -1,0 +1,113 @@
+import { NotFoundException } from '@nestjs/common';
+import { RequestMonitoringIncidentKind } from '../../../../../../api-dto/request-monitoring/request-monitoring-incident.dto';
+import { RequestMonitoringIncident } from '../../database/entities/request-monitoring-incident.entity';
+import { RequestMonitoringIncidentService } from './request-monitoring-incident.service';
+
+function incident(
+  overrides: Partial<RequestMonitoringIncident> = {}
+): RequestMonitoringIncident {
+  return {
+    id: 1,
+    fingerprint: 'a'.repeat(64),
+    kind: RequestMonitoringIncidentKind.Failed,
+    method: 'GET',
+    path: '/api/admin/workspace/:id/test-results/log-anomaly-summary',
+    workspaceId: 3,
+    statusCode: 500,
+    occurrenceCount: 2,
+    maxDurationMs: 12_000,
+    lastRequestId: 'request-2',
+    lastErrorMessage: 'query failed',
+    postgresTotalCount: 10,
+    postgresIdleCount: 0,
+    postgresWaitingCount: 3,
+    firstOccurredAt: new Date('2026-07-30T10:00:00Z'),
+    lastOccurredAt: new Date('2026-07-30T10:05:00Z'),
+    resolvedAt: null,
+    ...overrides
+  };
+}
+
+function repositoryMock(found: RequestMonitoringIncident | null = null) {
+  return {
+    query: jest.fn().mockResolvedValue([]),
+    find: jest.fn().mockResolvedValue(found ? [found] : []),
+    findOne: jest.fn().mockResolvedValue(found),
+    save: jest.fn().mockImplementation(value => Promise.resolve(value))
+  };
+}
+
+describe('RequestMonitoringIncidentService', () => {
+  it('upserts a normalized incident without exposing query parameters', async () => {
+    const repository = repositoryMock();
+    const service = new RequestMonitoringIncidentService(repository as never);
+
+    await service.record({
+      durationMs: 12_345.7,
+      errorMessage: ' query failed ',
+      kind: RequestMonitoringIncidentKind.Failed,
+      method: 'get',
+      path: '/api/admin/workspace/:id/test-results/log-anomaly-summary',
+      requestId: 'request-2',
+      statusCode: 500,
+      workspaceId: 3,
+      poolSnapshot: { totalCount: 10, idleCount: 0, waitingCount: 3 }
+    });
+
+    expect(repository.query).toHaveBeenCalledTimes(1);
+    const parameters = repository.query.mock.calls[0][1];
+    expect(parameters[1]).toBe(RequestMonitoringIncidentKind.Failed);
+    expect(parameters[2]).toBe('GET');
+    expect(parameters[3]).toBe(
+      '/api/admin/workspace/:id/test-results/log-anomaly-summary'
+    );
+    expect(parameters.slice(4)).toEqual([
+      3,
+      500,
+      12_346,
+      'request-2',
+      'query failed',
+      10,
+      0,
+      3,
+      expect.any(Date)
+    ]);
+  });
+
+  it('lists open incidents and maps timestamps', async () => {
+    const repository = repositoryMock(incident());
+    const service = new RequestMonitoringIncidentService(repository as never);
+
+    const result = await service.findAll(false, 50);
+
+    expect(repository.find).toHaveBeenCalledWith(expect.objectContaining({
+      take: 50
+    }));
+    expect(result[0]).toEqual(expect.objectContaining({
+      occurrenceCount: 2,
+      lastOccurredAt: '2026-07-30T10:05:00.000Z',
+      resolvedAt: null
+    }));
+  });
+
+  it('resolves an incident and reopens it on request', async () => {
+    const existing = incident();
+    const repository = repositoryMock(existing);
+    const service = new RequestMonitoringIncidentService(repository as never);
+
+    const resolved = await service.setResolved(1, true);
+    expect(resolved.resolvedAt).not.toBeNull();
+
+    const reopened = await service.setResolved(1, false);
+    expect(reopened.resolvedAt).toBeNull();
+  });
+
+  it('rejects an unknown incident', async () => {
+    const service = new RequestMonitoringIncidentService(
+      repositoryMock() as never
+    );
+
+    await expect(service.setResolved(404, true))
+      .rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/apps/backend/src/app/admin/request-monitoring/request-monitoring-incident.service.ts
+++ b/apps/backend/src/app/admin/request-monitoring/request-monitoring-incident.service.ts
@@ -1,0 +1,162 @@
+import { createHash } from 'crypto';
+import {
+  Injectable,
+  NotFoundException
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import {
+  RequestMonitoringIncidentDto,
+  RequestMonitoringIncidentKind
+} from '../../../../../../api-dto/request-monitoring/request-monitoring-incident.dto';
+import { RequestMonitoringIncident } from '../../database/entities/request-monitoring-incident.entity';
+import { PostgresPoolSnapshot } from '../../database/postgres-pool-monitor';
+
+export interface RecordRequestMonitoringIncident {
+  durationMs: number;
+  errorMessage?: string;
+  kind: RequestMonitoringIncidentKind;
+  method: string;
+  path: string;
+  poolSnapshot?: PostgresPoolSnapshot;
+  requestId: string;
+  statusCode?: number;
+  workspaceId?: number;
+}
+
+@Injectable()
+export class RequestMonitoringIncidentService {
+  constructor(
+    @InjectRepository(RequestMonitoringIncident)
+    private readonly repository: Repository<RequestMonitoringIncident>
+  ) {}
+
+  async record(input: RecordRequestMonitoringIncident): Promise<void> {
+    const method = input.method.trim().toUpperCase().slice(0, 10) || 'UNKNOWN';
+    const path = input.path.trim().slice(0, 500) || '/';
+    const workspaceId = this.toPositiveIntegerOrNull(input.workspaceId);
+    const statusCode = this.toPositiveIntegerOrNull(input.statusCode);
+    const durationMs = Math.min(
+      Math.max(0, Math.round(Number(input.durationMs) || 0)),
+      2_147_483_647
+    );
+    const fingerprint = createHash('sha256')
+      .update([
+        input.kind,
+        method,
+        path,
+        workspaceId ?? '',
+        statusCode ?? ''
+      ].join('|'))
+      .digest('hex');
+    const occurredAt = new Date();
+    const errorMessage = input.errorMessage?.trim().slice(0, 1000) || null;
+    const pool = input.poolSnapshot;
+
+    await this.repository.query(
+      `
+        INSERT INTO request_monitoring_incident (
+          fingerprint,
+          kind,
+          method,
+          path,
+          workspace_id,
+          status_code,
+          occurrence_count,
+          max_duration_ms,
+          last_request_id,
+          last_error_message,
+          postgres_total_count,
+          postgres_idle_count,
+          postgres_waiting_count,
+          first_occurred_at,
+          last_occurred_at,
+          resolved_at
+        ) VALUES (
+          $1, $2, $3, $4, $5, $6, 1, $7, $8, $9, $10, $11, $12, $13, $13, NULL
+        )
+        ON CONFLICT (fingerprint) DO UPDATE SET
+          occurrence_count = request_monitoring_incident.occurrence_count + 1,
+          max_duration_ms = GREATEST(
+            request_monitoring_incident.max_duration_ms,
+            EXCLUDED.max_duration_ms
+          ),
+          last_request_id = EXCLUDED.last_request_id,
+          last_error_message = EXCLUDED.last_error_message,
+          postgres_total_count = EXCLUDED.postgres_total_count,
+          postgres_idle_count = EXCLUDED.postgres_idle_count,
+          postgres_waiting_count = EXCLUDED.postgres_waiting_count,
+          last_occurred_at = EXCLUDED.last_occurred_at,
+          resolved_at = NULL
+      `,
+      [
+        fingerprint,
+        input.kind,
+        method,
+        path,
+        workspaceId,
+        statusCode,
+        durationMs,
+        input.requestId.slice(0, 128),
+        errorMessage,
+        pool?.totalCount ?? null,
+        pool?.idleCount ?? null,
+        pool?.waitingCount ?? null,
+        occurredAt
+      ]
+    );
+  }
+
+  async findAll(
+    includeResolved = false,
+    requestedLimit = 200
+  ): Promise<RequestMonitoringIncidentDto[]> {
+    const limit = Math.min(Math.max(Math.round(requestedLimit) || 200, 1), 1000);
+    const incidents = await this.repository.find({
+      where: includeResolved ? {} : { resolvedAt: IsNull() },
+      order: { lastOccurredAt: 'DESC' },
+      take: limit
+    });
+    return incidents.map(incident => this.toDto(incident));
+  }
+
+  async setResolved(
+    id: number,
+    resolved: boolean
+  ): Promise<RequestMonitoringIncidentDto> {
+    const incident = await this.repository.findOne({ where: { id } });
+    if (!incident) {
+      throw new NotFoundException('Servermeldung wurde nicht gefunden.');
+    }
+    incident.resolvedAt = resolved ? new Date() : null;
+    return this.toDto(await this.repository.save(incident));
+  }
+
+  private toPositiveIntegerOrNull(value: unknown): number | null {
+    const parsed = Number(value);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  private toDto(
+    incident: RequestMonitoringIncident
+  ): RequestMonitoringIncidentDto {
+    return {
+      id: incident.id,
+      kind: incident.kind,
+      method: incident.method,
+      path: incident.path,
+      workspaceId: incident.workspaceId,
+      statusCode: incident.statusCode,
+      occurrenceCount: incident.occurrenceCount,
+      maxDurationMs: incident.maxDurationMs,
+      lastRequestId: incident.lastRequestId,
+      lastErrorMessage: incident.lastErrorMessage,
+      postgresTotalCount: incident.postgresTotalCount,
+      postgresIdleCount: incident.postgresIdleCount,
+      postgresWaitingCount: incident.postgresWaitingCount,
+      firstOccurredAt: incident.firstOccurredAt.toISOString(),
+      lastOccurredAt: incident.lastOccurredAt.toISOString(),
+      resolvedAt: incident.resolvedAt?.toISOString() ?? null
+    };
+  }
+}

--- a/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.spec.ts
+++ b/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.spec.ts
@@ -25,7 +25,7 @@ describe('CodingStatusRevisionInterceptor', () => {
     '/api/admin/workspace/7/coding/double-coded-review/12/draft',
     '/api/admin/workspace/7/coding/jobs/12/apply-results',
     '/api/admin/workspace/7/coding/reset-version'
-  ])('increments around a successful coding mutation at %s', async originalUrl => {
+  ])('increments after a successful coding mutation at %s', async originalUrl => {
     const query = jest.fn().mockResolvedValue([]);
     const interceptor = new CodingStatusRevisionInterceptor({
       manager: { query }
@@ -41,11 +41,11 @@ describe('CodingStatusRevisionInterceptor', () => {
       )
     ).resolves.toBe('ok');
 
-    expect(query).toHaveBeenCalledTimes(2);
+    expect(query).toHaveBeenCalledTimes(1);
     expect(next.handle).toHaveBeenCalledTimes(1);
   });
 
-  it('invalidates once before a failed coding mutation', async () => {
+  it('does not invalidate after a failed coding mutation', async () => {
     const query = jest.fn().mockResolvedValue([]);
     const interceptor = new CodingStatusRevisionInterceptor({
       manager: { query }
@@ -68,7 +68,7 @@ describe('CodingStatusRevisionInterceptor', () => {
       )
     ).rejects.toThrow('failed');
 
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).not.toHaveBeenCalled();
   });
 
   it('does not increment for reads or unrelated coding exports', async () => {

--- a/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.spec.ts
+++ b/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.spec.ts
@@ -1,0 +1,96 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { lastValueFrom, Observable, of } from 'rxjs';
+import { CodingStatusRevisionInterceptor } from './coding-status-revision.interceptor';
+
+describe('CodingStatusRevisionInterceptor', () => {
+  const createContext = (
+    method: string,
+    originalUrl: string,
+    workspaceId: string | undefined = '7'
+  ) => ({
+    switchToHttp: () => ({
+      getRequest: () => ({
+        method,
+        originalUrl,
+        params: { workspace_id: workspaceId }
+      })
+    })
+  }) as unknown as ExecutionContext;
+
+  it.each([
+    '/api/admin/workspace/7/coding/job-definitions',
+    '/api/admin/workspace/7/missings-profiles/IQB-Standard',
+    '/api/admin/workspace/7/variable-bundle',
+    '/api/admin/workspace/7/coding/external-coding-import/apply',
+    '/api/admin/workspace/7/coding/double-coded-review/12/draft',
+    '/api/admin/workspace/7/coding/jobs/12/apply-results',
+    '/api/admin/workspace/7/coding/reset-version'
+  ])('increments around a successful coding mutation at %s', async originalUrl => {
+    const query = jest.fn().mockResolvedValue([]);
+    const interceptor = new CodingStatusRevisionInterceptor({
+      manager: { query }
+    } as never);
+    const next = { handle: jest.fn().mockReturnValue(of('ok')) } as CallHandler;
+
+    await expect(
+      lastValueFrom(
+        interceptor.intercept(
+          createContext('POST', originalUrl),
+          next
+        )
+      )
+    ).resolves.toBe('ok');
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(next.handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates once before a failed coding mutation', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+    const interceptor = new CodingStatusRevisionInterceptor({
+      manager: { query }
+    } as never);
+    const next = {
+      handle: jest.fn().mockReturnValue(new Observable(subscriber => {
+        subscriber.error(new Error('failed'));
+      }))
+    } as CallHandler;
+
+    await expect(
+      lastValueFrom(
+        interceptor.intercept(
+          createContext(
+            'POST',
+            '/api/admin/workspace/7/coding/job-definitions'
+          ),
+          next
+        )
+      )
+    ).rejects.toThrow('failed');
+
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not increment for reads or unrelated coding exports', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+    const interceptor = new CodingStatusRevisionInterceptor({
+      manager: { query }
+    } as never);
+    const next = { handle: jest.fn().mockReturnValue(of('ok')) } as CallHandler;
+
+    await lastValueFrom(
+      interceptor.intercept(
+        createContext('GET', '/api/admin/workspace/7/coding/job-definitions'),
+        next
+      )
+    );
+    await lastValueFrom(
+      interceptor.intercept(
+        createContext('POST', '/api/admin/workspace/7/coding/export/start'),
+        next
+      )
+    );
+
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.spec.ts
+++ b/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.spec.ts
@@ -93,4 +93,25 @@ describe('CodingStatusRevisionInterceptor', () => {
 
     expect(query).not.toHaveBeenCalled();
   });
+
+  it.each([
+    '/api/admin/workspace/7/coding/external-coding-import',
+    '/api/admin/workspace/7/coding/external-coding-import/stream',
+    '/api/admin/workspace/7/coding/job-definitions/12/refresh-preview',
+    '/api/admin/workspace/7/coding/job-definitions/12/update-refresh-preview',
+    '/api/admin/workspace/7/coding/coder-trainings/12/apply-discussion-results-preview'
+  ])('does not increment for the read-only POST endpoint %s', async originalUrl => {
+    const query = jest.fn().mockResolvedValue([]);
+    const interceptor = new CodingStatusRevisionInterceptor({
+      manager: { query }
+    } as never);
+    const next = { handle: jest.fn().mockReturnValue(of('ok')) } as CallHandler;
+
+    await lastValueFrom(
+      interceptor.intercept(createContext('POST', originalUrl), next)
+    );
+
+    expect(next.handle).toHaveBeenCalledTimes(1);
+    expect(query).not.toHaveBeenCalled();
+  });
 });

--- a/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.spec.ts
+++ b/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.spec.ts
@@ -3,6 +3,18 @@ import { lastValueFrom, Observable, of } from 'rxjs';
 import { CodingStatusRevisionInterceptor } from './coding-status-revision.interceptor';
 
 describe('CodingStatusRevisionInterceptor', () => {
+  const createConnection = () => {
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue([]),
+      release: jest.fn().mockResolvedValue(undefined)
+    };
+    const connection = {
+      createQueryRunner: jest.fn().mockReturnValue(queryRunner)
+    };
+    return { connection, queryRunner };
+  };
+
   const createContext = (
     method: string,
     originalUrl: string,
@@ -26,10 +38,8 @@ describe('CodingStatusRevisionInterceptor', () => {
     '/api/admin/workspace/7/coding/jobs/12/apply-results',
     '/api/admin/workspace/7/coding/reset-version'
   ])('increments after a successful coding mutation at %s', async originalUrl => {
-    const query = jest.fn().mockResolvedValue([]);
-    const interceptor = new CodingStatusRevisionInterceptor({
-      manager: { query }
-    } as never);
+    const { connection, queryRunner } = createConnection();
+    const interceptor = new CodingStatusRevisionInterceptor(connection as never);
     const next = { handle: jest.fn().mockReturnValue(of('ok')) } as CallHandler;
 
     await expect(
@@ -41,15 +51,25 @@ describe('CodingStatusRevisionInterceptor', () => {
       )
     ).resolves.toBe('ok');
 
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      'SELECT pg_advisory_lock_shared($1::int, $2::int)',
+      expect.any(Array)
+    );
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO workspace_test_results_revision'),
+      [7]
+    );
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      'SELECT pg_advisory_unlock_shared($1::int, $2::int)',
+      expect.any(Array)
+    );
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
     expect(next.handle).toHaveBeenCalledTimes(1);
   });
 
   it('does not invalidate after a failed coding mutation', async () => {
-    const query = jest.fn().mockResolvedValue([]);
-    const interceptor = new CodingStatusRevisionInterceptor({
-      manager: { query }
-    } as never);
+    const { connection, queryRunner } = createConnection();
+    const interceptor = new CodingStatusRevisionInterceptor(connection as never);
     const next = {
       handle: jest.fn().mockReturnValue(new Observable(subscriber => {
         subscriber.error(new Error('failed'));
@@ -68,14 +88,24 @@ describe('CodingStatusRevisionInterceptor', () => {
       )
     ).rejects.toThrow('failed');
 
-    expect(query).not.toHaveBeenCalled();
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      'SELECT pg_advisory_lock_shared($1::int, $2::int)',
+      expect.any(Array)
+    );
+    expect(queryRunner.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO workspace_test_results_revision'),
+      expect.any(Array)
+    );
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      'SELECT pg_advisory_unlock_shared($1::int, $2::int)',
+      expect.any(Array)
+    );
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
   });
 
   it('does not increment for reads or unrelated coding exports', async () => {
-    const query = jest.fn().mockResolvedValue([]);
-    const interceptor = new CodingStatusRevisionInterceptor({
-      manager: { query }
-    } as never);
+    const { connection } = createConnection();
+    const interceptor = new CodingStatusRevisionInterceptor(connection as never);
     const next = { handle: jest.fn().mockReturnValue(of('ok')) } as CallHandler;
 
     await lastValueFrom(
@@ -91,7 +121,7 @@ describe('CodingStatusRevisionInterceptor', () => {
       )
     );
 
-    expect(query).not.toHaveBeenCalled();
+    expect(connection.createQueryRunner).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -101,10 +131,8 @@ describe('CodingStatusRevisionInterceptor', () => {
     '/api/admin/workspace/7/coding/job-definitions/12/update-refresh-preview',
     '/api/admin/workspace/7/coding/coder-trainings/12/apply-discussion-results-preview'
   ])('does not increment for the read-only POST endpoint %s', async originalUrl => {
-    const query = jest.fn().mockResolvedValue([]);
-    const interceptor = new CodingStatusRevisionInterceptor({
-      manager: { query }
-    } as never);
+    const { connection } = createConnection();
+    const interceptor = new CodingStatusRevisionInterceptor(connection as never);
     const next = { handle: jest.fn().mockReturnValue(of('ok')) } as CallHandler;
 
     await lastValueFrom(
@@ -112,6 +140,6 @@ describe('CodingStatusRevisionInterceptor', () => {
     );
 
     expect(next.handle).toHaveBeenCalledTimes(1);
-    expect(query).not.toHaveBeenCalled();
+    expect(connection.createQueryRunner).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.ts
+++ b/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.ts
@@ -1,0 +1,76 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor
+} from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import {
+  Observable, concatMap, defer, from, map, switchMap
+} from 'rxjs';
+import { touchWorkspaceCodingStatusRevision } from '../../database/services/shared/workspace-coding-status-revision.util';
+
+const MUTATING_HTTP_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+// Keep this list aligned with HTTP mutations that change cached coding status.
+// Long-running test-result writes also invalidate through the shared DB lock.
+const CODING_STATUS_MUTATION_PATHS = [
+  '/coding-job',
+  '/missings-profiles',
+  '/variable-bundle',
+  '/coding/aggregation-settings',
+  '/coding/apply-duplicate-aggregation',
+  '/coding/apply-empty-responses',
+  '/coding/coder-training',
+  '/coding/create-distributed-jobs',
+  '/coding/double-coded-review',
+  '/coding/external-coding-import',
+  '/coding/freshness/code',
+  '/coding/job-definitions',
+  '/coding/jobs',
+  '/coding/reset-version'
+] as const;
+
+type WorkspaceRequest = {
+  method?: string;
+  originalUrl?: string;
+  params?: { workspace_id?: string | number };
+};
+
+@Injectable()
+export class CodingStatusRevisionInterceptor implements NestInterceptor {
+  constructor(private readonly connection: DataSource) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<WorkspaceRequest>();
+    const workspaceId = Number(request.params?.workspace_id);
+    if (!this.isCodingStatusMutation(request, workspaceId)) {
+      return next.handle();
+    }
+
+    return defer(() => from(
+      touchWorkspaceCodingStatusRevision(this.connection.manager, workspaceId)
+    )).pipe(
+      switchMap(() => next.handle()),
+      concatMap(value => from(
+        touchWorkspaceCodingStatusRevision(
+          this.connection.manager,
+          workspaceId
+        )
+      ).pipe(map(() => value)))
+    );
+  }
+
+  private isCodingStatusMutation(
+    request: WorkspaceRequest,
+    workspaceId: number
+  ): boolean {
+    const method = request.method?.toUpperCase() || '';
+    const path = request.originalUrl?.split('?')[0] || '';
+    return (
+      Number.isInteger(workspaceId) &&
+      workspaceId > 0 &&
+      MUTATING_HTTP_METHODS.has(method) &&
+      CODING_STATUS_MUTATION_PATHS.some(fragment => path.includes(fragment))
+    );
+  }
+}

--- a/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.ts
+++ b/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.ts
@@ -30,6 +30,15 @@ const CODING_STATUS_MUTATION_PATHS = [
   '/coding/reset-version'
 ] as const;
 
+// These POST endpoints perform validation/calculation only. They deliberately
+// share their URL prefix with the corresponding apply endpoints, so the broad
+// mutation fragments above must not classify them as writes.
+const CODING_STATUS_READ_ONLY_POST_PATHS = [
+  /\/coding\/external-coding-import(?:\/stream)?$/,
+  /\/coding\/job-definitions\/[^/]+\/(?:refresh-preview|update-refresh-preview)$/,
+  /\/coding\/coder-trainings\/[^/]+\/apply-discussion-results-preview$/
+] as const;
+
 type WorkspaceRequest = {
   method?: string;
   originalUrl?: string;
@@ -70,6 +79,10 @@ export class CodingStatusRevisionInterceptor implements NestInterceptor {
       Number.isInteger(workspaceId) &&
       workspaceId > 0 &&
       MUTATING_HTTP_METHODS.has(method) &&
+      !(
+        method === 'POST' &&
+        CODING_STATUS_READ_ONLY_POST_PATHS.some(pattern => pattern.test(path))
+      ) &&
       CODING_STATUS_MUTATION_PATHS.some(fragment => path.includes(fragment))
     );
   }

--- a/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.ts
+++ b/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import {
-  Observable, concatMap, defer, from, map, switchMap
+  Observable, concatMap, from, map
 } from 'rxjs';
 import { touchWorkspaceCodingStatusRevision } from '../../database/services/shared/workspace-coding-status-revision.util';
 
@@ -56,10 +56,7 @@ export class CodingStatusRevisionInterceptor implements NestInterceptor {
       return next.handle();
     }
 
-    return defer(() => from(
-      touchWorkspaceCodingStatusRevision(this.connection.manager, workspaceId)
-    )).pipe(
-      switchMap(() => next.handle()),
+    return next.handle().pipe(
       concatMap(value => from(
         touchWorkspaceCodingStatusRevision(
           this.connection.manager,

--- a/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.ts
+++ b/apps/backend/src/app/admin/workspace-coding/coding-status-revision.interceptor.ts
@@ -5,10 +5,8 @@ import {
   NestInterceptor
 } from '@nestjs/common';
 import { DataSource } from 'typeorm';
-import {
-  Observable, concatMap, from, map
-} from 'rxjs';
-import { touchWorkspaceCodingStatusRevision } from '../../database/services/shared/workspace-coding-status-revision.util';
+import { from, lastValueFrom, Observable } from 'rxjs';
+import { withWorkspaceCodingStatusMutationLock } from '../../database/services/shared/workspace-coding-status-revision.util';
 
 const MUTATING_HTTP_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 // Keep this list aligned with HTTP mutations that change cached coding status.
@@ -56,14 +54,11 @@ export class CodingStatusRevisionInterceptor implements NestInterceptor {
       return next.handle();
     }
 
-    return next.handle().pipe(
-      concatMap(value => from(
-        touchWorkspaceCodingStatusRevision(
-          this.connection.manager,
-          workspaceId
-        )
-      ).pipe(map(() => value)))
-    );
+    return from(withWorkspaceCodingStatusMutationLock(
+      this.connection,
+      workspaceId,
+      () => lastValueFrom(next.handle())
+    ));
   }
 
   private isCodingStatusMutation(

--- a/apps/backend/src/app/admin/workspace-coding/workspace-coding-admin.module.ts
+++ b/apps/backend/src/app/admin/workspace-coding/workspace-coding-admin.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { HttpModule } from '@nestjs/axios';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '../../database/database.module';
@@ -23,6 +24,7 @@ import { WorkspaceCodingResultsController } from '../workspace/workspace-coding-
 import { WorkspaceTestCenterController } from '../workspace/workspace-test-center.controller';
 import { WorkspacePlayerController } from '../workspace/workspace-player.controller';
 import { Setting } from '../../database/entities/setting.entity';
+import { CodingStatusRevisionInterceptor } from './coding-status-revision.interceptor';
 
 @Module({
   imports: [
@@ -51,6 +53,12 @@ import { Setting } from '../../database/entities/setting.entity';
     WorkspaceCodingResultsController,
     WorkspaceTestCenterController,
     WorkspacePlayerController
+  ],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CodingStatusRevisionInterceptor
+    }
   ]
 })
 export class WorkspaceCodingAdminModule { }

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.spec.ts
@@ -22,6 +22,7 @@ describe('WorkspaceCodingStatisticsController', () => {
     getReadiness: jest.Mock;
     getReadinessFromCache: jest.Mock;
   };
+  let codingFreshnessService: { getWorkspaceStatusRevision: jest.Mock };
   let controller: WorkspaceCodingStatisticsController;
   const request = {
     protocol: 'http',
@@ -85,6 +86,13 @@ describe('WorkspaceCodingStatisticsController', () => {
       }),
       getReadinessFromCache: jest.fn().mockResolvedValue(null)
     };
+    codingFreshnessService = {
+      getWorkspaceStatusRevision: jest.fn().mockResolvedValue({
+        revision: 12,
+        statusRevision: '34',
+        stable: true
+      })
+    };
 
     controller = new WorkspaceCodingStatisticsController(
       codingStatisticsService as never,
@@ -92,7 +100,7 @@ describe('WorkspaceCodingStatisticsController', () => {
       {} as never,
       {} as never,
       codingReviewService as never,
-      {} as never,
+      codingFreshnessService as never,
       {} as never,
       codingReadinessService as never,
       codingReplayService as never,
@@ -104,6 +112,17 @@ describe('WorkspaceCodingStatisticsController', () => {
       }
       return undefined;
     });
+  });
+
+  it('returns the workspace coding-status revision', async () => {
+    await expect(controller.getCodingStatusRevision(5)).resolves.toEqual({
+      workspaceId: 5,
+      revision: 12,
+      statusRevision: '34',
+      stable: true
+    });
+    expect(codingFreshnessService.getWorkspaceStatusRevision)
+      .toHaveBeenCalledWith(5);
   });
 
   it('requires coding-manager access for applied results overview', () => {

--- a/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
+++ b/apps/backend/src/app/admin/workspace/workspace-coding-statistics.controller.ts
@@ -46,6 +46,7 @@ import {
   StartCodingFreshnessJobDto
 } from '../../../../../../api-dto/coding/coding-freshness.dto';
 import { AutocodingReadinessDto } from '../../../../../../api-dto/coding/autocoding-readiness.dto';
+import { CodingStatusRevisionDto } from '../../../../../../api-dto/coding/coding-status-revision.dto';
 import { JobQueueService } from '../../job-queue/job-queue.service';
 import { sanitizeCsvText } from '../../utils/csv.util';
 
@@ -1036,6 +1037,24 @@ export class WorkspaceCodingStatisticsController {
     @WorkspaceId() workspace_id: number
   ): Promise<CodingFreshnessSummaryDto> {
     return this.codingFreshnessService.getSummary(workspace_id);
+  }
+
+  @Get(':workspace_id/coding/revision')
+  @UseGuards(JwtAuthGuard, WorkspaceGuard)
+  @ApiTags('coding')
+  @ApiParam({ name: 'workspace_id', type: Number })
+  @ApiOkResponse({
+    description: 'Current workspace coding-status revision retrieved successfully.'
+  })
+  async getCodingStatusRevision(
+    @WorkspaceId() workspace_id: number
+  ): Promise<CodingStatusRevisionDto> {
+    const statusRevision = await this.codingFreshnessService
+      .getWorkspaceStatusRevision(workspace_id);
+    return {
+      workspaceId: workspace_id,
+      ...statusRevision
+    };
   }
 
   @Get(':workspace_id/coding/freshness/scope')

--- a/apps/backend/src/app/database/database.module.ts
+++ b/apps/backend/src/app/database/database.module.ts
@@ -42,6 +42,7 @@ import { CoderTrainingDiscussionResult } from './entities/coder-training-discuss
 import { CodingUnitFreshness } from './entities/coding-unit-freshness.entity';
 import { SystemNotification } from './entities/system-notification.entity';
 import { DoubleCodingReviewDecision } from './entities/double-coding-review-decision.entity';
+import { RequestMonitoringIncident } from './entities/request-monitoring-incident.entity';
 import { RuntimeConfigModule } from '../config/runtime-config.module';
 import {
   RuntimeConfigService,
@@ -132,7 +133,8 @@ export function buildPostgresConnectionOptions(
           CodingUnitFreshness,
           MissingsProfile,
           SystemNotification,
-          DoubleCodingReviewDecision
+          DoubleCodingReviewDecision,
+          RequestMonitoringIncident
         ],
         synchronize: false,
         extra: {

--- a/apps/backend/src/app/database/entities/request-monitoring-incident.entity.ts
+++ b/apps/backend/src/app/database/entities/request-monitoring-incident.entity.ts
@@ -1,0 +1,70 @@
+import {
+  Column,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn
+} from 'typeorm';
+import { RequestMonitoringIncidentKind } from '../../../../../../api-dto/request-monitoring/request-monitoring-incident.dto';
+
+@Entity('request_monitoring_incident')
+@Index('uq_request_monitoring_incident_fingerprint', ['fingerprint'], {
+  unique: true
+})
+@Index('idx_request_monitoring_incident_open_last', ['resolvedAt', 'lastOccurredAt'])
+export class RequestMonitoringIncident {
+  @PrimaryGeneratedColumn()
+    id!: number;
+
+  @Column({ type: 'char', length: 64 })
+    fingerprint!: string;
+
+  @Column({ type: 'varchar', length: 20 })
+    kind!: RequestMonitoringIncidentKind;
+
+  @Column({ type: 'varchar', length: 10 })
+    method!: string;
+
+  @Column({ type: 'varchar', length: 500 })
+    path!: string;
+
+  @Column({ name: 'workspace_id', type: 'integer', nullable: true })
+    workspaceId!: number | null;
+
+  @Column({ name: 'status_code', type: 'integer', nullable: true })
+    statusCode!: number | null;
+
+  @Column({ name: 'occurrence_count', type: 'integer', default: 1 })
+    occurrenceCount!: number;
+
+  @Column({ name: 'max_duration_ms', type: 'integer' })
+    maxDurationMs!: number;
+
+  @Column({ name: 'last_request_id', type: 'varchar', length: 128 })
+    lastRequestId!: string;
+
+  @Column({
+    name: 'last_error_message',
+    type: 'varchar',
+    length: 1000,
+    nullable: true
+  })
+    lastErrorMessage!: string | null;
+
+  @Column({ name: 'postgres_total_count', type: 'integer', nullable: true })
+    postgresTotalCount!: number | null;
+
+  @Column({ name: 'postgres_idle_count', type: 'integer', nullable: true })
+    postgresIdleCount!: number | null;
+
+  @Column({ name: 'postgres_waiting_count', type: 'integer', nullable: true })
+    postgresWaitingCount!: number | null;
+
+  @Column({ name: 'first_occurred_at', type: 'timestamptz' })
+    firstOccurredAt!: Date;
+
+  @Column({ name: 'last_occurred_at', type: 'timestamptz' })
+    lastOccurredAt!: Date;
+
+  @Column({ name: 'resolved_at', type: 'timestamptz', nullable: true })
+    resolvedAt!: Date | null;
+}

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.spec.ts
@@ -25,6 +25,7 @@ jest.mock('./coding-statistics.service', () => ({
 
 describe('CodingAnalysisService aggregation settings', () => {
   function createService() {
+    const statusRevisionQuery = jest.fn().mockResolvedValue([]);
     const queryBuilder = {
       select: jest.fn().mockReturnThis(),
       innerJoin: jest.fn().mockReturnThis(),
@@ -34,7 +35,8 @@ describe('CodingAnalysisService aggregation settings', () => {
     };
     const responseRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
-      update: jest.fn().mockResolvedValue(undefined)
+      update: jest.fn().mockResolvedValue(undefined),
+      manager: { query: statusRevisionQuery }
     } as unknown as Repository<ResponseEntity>;
     const codingJobService = {
       getAggregationThreshold: jest.fn().mockResolvedValue(2),
@@ -82,7 +84,8 @@ describe('CodingAnalysisService aggregation settings', () => {
       codingValidationService,
       codingStatisticsService,
       cacheService,
-      jobQueueService
+      jobQueueService,
+      statusRevisionQuery
     };
   }
 
@@ -138,7 +141,8 @@ describe('CodingAnalysisService aggregation settings', () => {
     const {
       service,
       cacheService,
-      jobQueueService
+      jobQueueService,
+      statusRevisionQuery
     } = createService();
 
     await service.startAnalysis(7, [ResponseMatchingFlag.IGNORE_CASE], 4, {
@@ -158,6 +162,7 @@ describe('CodingAnalysisService aggregation settings', () => {
       cacheKey: 'response-analysis:7_IGNORE_CASE_t4',
       runId: expect.any(String)
     });
+    expect(statusRevisionQuery).toHaveBeenCalledTimes(1);
   });
 
   it('queues a superseding forced restart even when an older workspace analysis is active', async () => {

--- a/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-analysis.service.ts
@@ -27,6 +27,7 @@ import {
   getCodingAnalysisCacheKey,
   getCodingAnalysisRunMarkerKey
 } from './coding-analysis-cache-key.util';
+import { touchWorkspaceCodingStatusRevision } from '../shared/workspace-coding-status-revision.util';
 
 export interface AggregationSettingsResult {
   success: boolean;
@@ -208,6 +209,10 @@ export class CodingAnalysisService {
 
     const runId = randomUUID();
     await this.cacheService.set(getCodingAnalysisRunMarkerKey(cacheKey), runId, 0);
+    await touchWorkspaceCodingStatusRevision(
+      this.responseRepository.manager,
+      workspaceId
+    );
 
     await this.jobQueueService.addCodingAnalysisJob({
       workspaceId,

--- a/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
+++ b/apps/backend/src/app/database/services/coding/coding-freshness.service.ts
@@ -34,6 +34,7 @@ import { statusStringToNumber } from '../../utils/response-status-converter';
 import { IQB_STANDARD_MISSING_CODES, MissingsProfilesService } from './missings-profiles.service';
 import { getNonCodingIssueReviewJobSqlCondition } from './coding-job-type.util';
 import { getCodingVariableIdCandidateSql } from './coding-response-candidate.util';
+import { getWorkspaceCodingStatusRevision } from '../shared/workspace-coding-status-revision.util';
 
 type UnitCodingPresence = Record<CodingFreshnessVersion, boolean>;
 
@@ -159,6 +160,14 @@ export class CodingFreshnessService {
         affectedResponseCount: Number(row.affectedResponseCount || 0)
       }))
     };
+  }
+
+  async getWorkspaceStatusRevision(workspaceId: number): Promise<{
+    revision: number;
+    statusRevision: string;
+    stable: boolean;
+  }> {
+    return getWorkspaceCodingStatusRevision(this.connection, workspaceId);
   }
 
   async getScope(

--- a/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-job.service.spec.ts
@@ -1476,8 +1476,10 @@ describe('CodingJobService', () => {
     const callOrder: string[] = [];
     const transactionManager = {
       getRepository: jest.fn(),
-      query: jest.fn().mockImplementation(async () => {
-        callOrder.push('advisory-lock');
+      query: jest.fn().mockImplementation(async (sql: string) => {
+        callOrder.push(sql.includes('status_revision') ?
+          'status-revision' :
+          'advisory-lock');
       })
     };
     const plan = {
@@ -1623,6 +1625,7 @@ describe('CodingJobService', () => {
     );
     expect(callOrder).toEqual([
       'advisory-lock',
+      'status-revision',
       'assert',
       'lock',
       'existing',

--- a/apps/backend/src/app/database/services/shared/index.ts
+++ b/apps/backend/src/app/database/services/shared/index.ts
@@ -5,3 +5,7 @@ export {
   lockWorkspaceTestResultsMutationInTransaction,
   withWorkspaceTestResultsMutationLock
 } from './workspace-test-results-lock.util';
+export {
+  getWorkspaceCodingStatusRevision,
+  touchWorkspaceCodingStatusRevision
+} from './workspace-coding-status-revision.util';

--- a/apps/backend/src/app/database/services/shared/workspace-coding-status-revision.util.spec.ts
+++ b/apps/backend/src/app/database/services/shared/workspace-coding-status-revision.util.spec.ts
@@ -21,7 +21,9 @@ describe('workspace coding status revision', () => {
       query: jest
         .fn()
         .mockResolvedValueOnce([{ acquired: true }])
+        .mockResolvedValueOnce([{ acquired: true }])
         .mockResolvedValueOnce([{ revision: '12', status_revision: '34' }])
+        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([]),
       release: jest.fn().mockResolvedValue(undefined)
     };
@@ -43,15 +45,21 @@ describe('workspace coding status revision', () => {
       expect.stringContaining('pg_advisory_unlock_shared'),
       expect.any(Array)
     );
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_unlock('),
+      expect.any(Array)
+    );
     expect(queryRunner.release).toHaveBeenCalledTimes(1);
   });
 
-  it('marks the revision unstable while an exclusive mutation lock is held', async () => {
+  it('marks the revision unstable while a test-result mutation lock is held', async () => {
     const queryRunner = {
       connect: jest.fn().mockResolvedValue(undefined),
       query: jest
         .fn()
         .mockResolvedValueOnce([{ acquired: false }])
+        .mockResolvedValueOnce([{ acquired: true }])
+        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([]),
       release: jest.fn().mockResolvedValue(undefined)
     };
@@ -70,6 +78,46 @@ describe('workspace coding status revision', () => {
     });
 
     expect(queryRunner.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_unlock_shared'),
+      expect.any(Array)
+    );
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_unlock('),
+      expect.any(Array)
+    );
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the revision unstable while a coding-status mutation is running', async () => {
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([{ acquired: true }])
+        .mockResolvedValueOnce([{ acquired: false }])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]),
+      release: jest.fn().mockResolvedValue(undefined)
+    };
+
+    await expect(
+      getWorkspaceCodingStatusRevision(
+        {
+          createQueryRunner: jest.fn().mockReturnValue(queryRunner)
+        },
+        7
+      )
+    ).resolves.toEqual({
+      revision: 0,
+      statusRevision: '0',
+      stable: false
+    });
+
+    expect(queryRunner.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_unlock('),
+      expect.any(Array)
+    );
+    expect(queryRunner.query).toHaveBeenCalledWith(
       expect.stringContaining('pg_advisory_unlock_shared'),
       expect.any(Array)
     );

--- a/apps/backend/src/app/database/services/shared/workspace-coding-status-revision.util.spec.ts
+++ b/apps/backend/src/app/database/services/shared/workspace-coding-status-revision.util.spec.ts
@@ -1,0 +1,78 @@
+import {
+  getWorkspaceCodingStatusRevision,
+  touchWorkspaceCodingStatusRevision
+} from './workspace-coding-status-revision.util';
+
+describe('workspace coding status revision', () => {
+  it('increments only the status revision', async () => {
+    const executor = { query: jest.fn().mockResolvedValue([]) };
+
+    await touchWorkspaceCodingStatusRevision(executor, 7);
+
+    expect(executor.query).toHaveBeenCalledWith(
+      expect.stringContaining('status_revision'),
+      [7]
+    );
+  });
+
+  it('returns a stable revision while no exclusive mutation lock is held', async () => {
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([{ acquired: true }])
+        .mockResolvedValueOnce([{ revision: '12', status_revision: '34' }])
+        .mockResolvedValueOnce([]),
+      release: jest.fn().mockResolvedValue(undefined)
+    };
+
+    await expect(
+      getWorkspaceCodingStatusRevision(
+        {
+          createQueryRunner: jest.fn().mockReturnValue(queryRunner)
+        },
+        7
+      )
+    ).resolves.toEqual({
+      revision: 12,
+      statusRevision: '34',
+      stable: true
+    });
+
+    expect(queryRunner.query).toHaveBeenLastCalledWith(
+      expect.stringContaining('pg_advisory_unlock_shared'),
+      expect.any(Array)
+    );
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the revision unstable while an exclusive mutation lock is held', async () => {
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([{ acquired: false }])
+        .mockResolvedValueOnce([]),
+      release: jest.fn().mockResolvedValue(undefined)
+    };
+
+    await expect(
+      getWorkspaceCodingStatusRevision(
+        {
+          createQueryRunner: jest.fn().mockReturnValue(queryRunner)
+        },
+        7
+      )
+    ).resolves.toEqual({
+      revision: 0,
+      statusRevision: '0',
+      stable: false
+    });
+
+    expect(queryRunner.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_unlock_shared'),
+      expect.any(Array)
+    );
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/app/database/services/shared/workspace-coding-status-revision.util.ts
+++ b/apps/backend/src/app/database/services/shared/workspace-coding-status-revision.util.ts
@@ -1,0 +1,91 @@
+import { DataSource, EntityManager, QueryRunner } from 'typeorm';
+
+export const WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE = 774020251;
+
+type QueryExecutor = Pick<EntityManager, 'query'> | Pick<QueryRunner, 'query'>;
+type QueryRunnerFactory = Pick<DataSource, 'createQueryRunner'>;
+
+export interface WorkspaceCodingStatusRevision {
+  revision: number;
+  statusRevision: string;
+  stable: boolean;
+}
+
+export function normalizeWorkspaceId(workspaceId: number): number {
+  const normalized = Number(workspaceId);
+  if (!Number.isInteger(normalized) || normalized < 1) {
+    throw new Error(
+      'A valid workspace id is required for the coding-status revision.'
+    );
+  }
+  return normalized;
+}
+
+export async function touchWorkspaceCodingStatusRevision(
+  executor: QueryExecutor,
+  workspaceId: number
+): Promise<void> {
+  await executor.query(
+    `
+      INSERT INTO workspace_test_results_revision (
+        workspace_id,
+        revision,
+        status_revision,
+        updated_at
+      )
+      VALUES ($1, 0, 1, now())
+      ON CONFLICT (workspace_id)
+      DO UPDATE SET
+        status_revision = workspace_test_results_revision.status_revision + 1,
+        updated_at = now()
+    `,
+    [normalizeWorkspaceId(workspaceId)]
+  );
+}
+
+export async function getWorkspaceCodingStatusRevision(
+  connection: QueryRunnerFactory,
+  workspaceId: number
+): Promise<WorkspaceCodingStatusRevision> {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  const queryRunner = connection.createQueryRunner();
+  let sharedLockAcquired = false;
+
+  await queryRunner.connect();
+  try {
+    const lockRows = (await queryRunner.query(
+      'SELECT pg_try_advisory_lock_shared($1::int, $2::int) AS acquired',
+      [WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE, normalizedWorkspaceId]
+    )) as Array<{ acquired: boolean }>;
+    sharedLockAcquired = lockRows[0]?.acquired === true;
+
+    const rows = (await queryRunner.query(
+      `
+        SELECT revision, status_revision
+        FROM workspace_test_results_revision
+        WHERE workspace_id = $1
+      `,
+      [normalizedWorkspaceId]
+    )) as Array<{
+      revision: number | string;
+      status_revision: number | string;
+    }>;
+
+    return {
+      revision: Number(rows[0]?.revision || 0),
+      statusRevision: String(rows[0]?.status_revision || 0),
+      stable: sharedLockAcquired
+    };
+  } finally {
+    try {
+      if (sharedLockAcquired) {
+        await queryRunner.query(
+          'SELECT pg_advisory_unlock_shared($1::int, $2::int)',
+          [WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE, normalizedWorkspaceId]
+        );
+      }
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}

--- a/apps/backend/src/app/database/services/shared/workspace-coding-status-revision.util.ts
+++ b/apps/backend/src/app/database/services/shared/workspace-coding-status-revision.util.ts
@@ -1,6 +1,7 @@
 import { DataSource, EntityManager, QueryRunner } from 'typeorm';
 
 export const WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE = 774020251;
+export const WORKSPACE_CODING_STATUS_MUTATION_LOCK_NAMESPACE = 774020252;
 
 type QueryExecutor = Pick<EntityManager, 'query'> | Pick<QueryRunner, 'query'>;
 type QueryRunnerFactory = Pick<DataSource, 'createQueryRunner'>;
@@ -43,13 +44,54 @@ export async function touchWorkspaceCodingStatusRevision(
   );
 }
 
+export async function withWorkspaceCodingStatusMutationLock<T>(
+  connection: QueryRunnerFactory,
+  workspaceId: number,
+  callback: () => Promise<T>
+): Promise<T> {
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  const queryRunner = connection.createQueryRunner();
+  let locked = false;
+
+  await queryRunner.connect();
+  try {
+    await queryRunner.query(
+      'SELECT pg_advisory_lock_shared($1::int, $2::int)',
+      [
+        WORKSPACE_CODING_STATUS_MUTATION_LOCK_NAMESPACE,
+        normalizedWorkspaceId
+      ]
+    );
+    locked = true;
+
+    const result = await callback();
+    await touchWorkspaceCodingStatusRevision(queryRunner, normalizedWorkspaceId);
+    return result;
+  } finally {
+    try {
+      if (locked) {
+        await queryRunner.query(
+          'SELECT pg_advisory_unlock_shared($1::int, $2::int)',
+          [
+            WORKSPACE_CODING_STATUS_MUTATION_LOCK_NAMESPACE,
+            normalizedWorkspaceId
+          ]
+        );
+      }
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}
+
 export async function getWorkspaceCodingStatusRevision(
   connection: QueryRunnerFactory,
   workspaceId: number
 ): Promise<WorkspaceCodingStatusRevision> {
   const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
   const queryRunner = connection.createQueryRunner();
-  let sharedLockAcquired = false;
+  let testResultsLockAcquired = false;
+  let statusMutationLockAcquired = false;
 
   await queryRunner.connect();
   try {
@@ -57,7 +99,17 @@ export async function getWorkspaceCodingStatusRevision(
       'SELECT pg_try_advisory_lock_shared($1::int, $2::int) AS acquired',
       [WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE, normalizedWorkspaceId]
     )) as Array<{ acquired: boolean }>;
-    sharedLockAcquired = lockRows[0]?.acquired === true;
+    testResultsLockAcquired = lockRows[0]?.acquired === true;
+
+    const statusMutationLockRows = (await queryRunner.query(
+      'SELECT pg_try_advisory_lock($1::int, $2::int) AS acquired',
+      [
+        WORKSPACE_CODING_STATUS_MUTATION_LOCK_NAMESPACE,
+        normalizedWorkspaceId
+      ]
+    )) as Array<{ acquired: boolean }>;
+    statusMutationLockAcquired =
+      statusMutationLockRows[0]?.acquired === true;
 
     const rows = (await queryRunner.query(
       `
@@ -74,11 +126,20 @@ export async function getWorkspaceCodingStatusRevision(
     return {
       revision: Number(rows[0]?.revision || 0),
       statusRevision: String(rows[0]?.status_revision || 0),
-      stable: sharedLockAcquired
+      stable: testResultsLockAcquired && statusMutationLockAcquired
     };
   } finally {
     try {
-      if (sharedLockAcquired) {
+      if (statusMutationLockAcquired) {
+        await queryRunner.query(
+          'SELECT pg_advisory_unlock($1::int, $2::int)',
+          [
+            WORKSPACE_CODING_STATUS_MUTATION_LOCK_NAMESPACE,
+            normalizedWorkspaceId
+          ]
+        );
+      }
+      if (testResultsLockAcquired) {
         await queryRunner.query(
           'SELECT pg_advisory_unlock_shared($1::int, $2::int)',
           [WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE, normalizedWorkspaceId]

--- a/apps/backend/src/app/database/services/shared/workspace-test-results-lock.util.spec.ts
+++ b/apps/backend/src/app/database/services/shared/workspace-test-results-lock.util.spec.ts
@@ -55,4 +55,34 @@ describe('workspace test results mutation lock', () => {
     );
     expect(queryRunner.release).toHaveBeenCalledTimes(1);
   });
+
+  it('touches the status revision again and unlocks after a failed callback', async () => {
+    const callbackError = new Error('mutation failed');
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue([]),
+      release: jest.fn().mockResolvedValue(undefined)
+    };
+    const connection = {
+      createQueryRunner: jest.fn().mockReturnValue(queryRunner)
+    };
+
+    await expect(withWorkspaceTestResultsMutationLock(
+      connection as never,
+      3,
+      async () => {
+        throw callbackError;
+      }
+    )).rejects.toThrow(callbackError);
+
+    const revisionTouches = queryRunner.query.mock.calls.filter(
+      ([query]) => String(query).includes('INSERT INTO workspace_test_results_revision')
+    );
+    expect(revisionTouches).toHaveLength(2);
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      'SELECT pg_advisory_unlock($1::int, $2::int)',
+      expect.any(Array)
+    );
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/backend/src/app/database/services/shared/workspace-test-results-lock.util.ts
+++ b/apps/backend/src/app/database/services/shared/workspace-test-results-lock.util.ts
@@ -1,16 +1,11 @@
 import { DataSource, EntityManager, QueryRunner } from 'typeorm';
-
-const WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE = 774020251;
+import {
+  normalizeWorkspaceId,
+  touchWorkspaceCodingStatusRevision,
+  WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE
+} from './workspace-coding-status-revision.util';
 
 type QueryRunnerFactory = Pick<DataSource, 'createQueryRunner'>;
-
-function normalizeWorkspaceId(workspaceId: number): number {
-  const normalized = Number(workspaceId);
-  if (!Number.isInteger(normalized) || normalized < 1) {
-    throw new Error('A valid workspace id is required for the test-results mutation lock.');
-  }
-  return normalized;
-}
 
 export async function lockWorkspaceTestResultsMutationInTransaction(
   manager: EntityManager,
@@ -20,6 +15,7 @@ export async function lockWorkspaceTestResultsMutationInTransaction(
     'SELECT pg_advisory_xact_lock($1::int, $2::int)',
     [WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE, normalizeWorkspaceId(workspaceId)]
   );
+  await touchWorkspaceCodingStatusRevision(manager, workspaceId);
 }
 
 export async function withWorkspaceTestResultsMutationLock<T>(
@@ -39,7 +35,12 @@ export async function withWorkspaceTestResultsMutationLock<T>(
       [WORKSPACE_TEST_RESULTS_LOCK_NAMESPACE, normalizedWorkspaceId]
     );
     locked = true;
-    return await callback();
+    await touchWorkspaceCodingStatusRevision(queryRunner, normalizedWorkspaceId);
+    try {
+      return await callback();
+    } finally {
+      await touchWorkspaceCodingStatusRevision(queryRunner, normalizedWorkspaceId);
+    }
   } finally {
     try {
       if (locked) {

--- a/apps/backend/src/app/database/services/test-results/person-persistence.postgres.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/person-persistence.postgres.spec.ts
@@ -1,4 +1,5 @@
 import { DataSource, Repository } from 'typeorm';
+import { createMock } from '@golevelup/ts-jest';
 import { PersonPersistenceService } from './person-persistence.service';
 import Persons from '../../entities/persons.entity';
 import { Booklet } from '../../entities/booklet.entity';
@@ -13,6 +14,7 @@ import { UnitLog } from '../../entities/unitLog.entity';
 import { UnitTag } from '../../entities/unitTag.entity';
 import { UnitNote } from '../../entities/unitNote.entity';
 import { Person } from '../shared';
+import { CacheService } from '../../../cache/cache.service';
 
 // Opt-in: set POSTGRES_INTEGRATION_TESTS=true and POSTGRES_* if the local
 // development defaults below do not match the target database.
@@ -78,7 +80,8 @@ describePostgres('PersonPersistenceService Postgres integration', () => {
       dataSource.getRepository(ChunkEntity),
       dataSource.getRepository(BookletLog),
       dataSource.getRepository(Session),
-      dataSource.getRepository(UnitLog)
+      dataSource.getRepository(UnitLog),
+      createMock<CacheService>()
     );
   }, 30000);
 

--- a/apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/person-persistence.service.spec.ts
@@ -14,6 +14,7 @@ import { BookletLog } from '../../entities/bookletLog.entity';
 import { Session } from '../../entities/session.entity';
 import { UnitLog } from '../../entities/unitLog.entity';
 import { Person } from '../shared';
+import { CacheService } from '../../../cache/cache.service';
 
 describe('PersonPersistenceService', () => {
   let service: PersonPersistenceService;
@@ -25,6 +26,7 @@ describe('PersonPersistenceService', () => {
   let bookletLogRepository: Repository<BookletLog>;
   let bookletSessionRepository: Repository<Session>;
   let chunkRepository: Repository<ChunkEntity>;
+  let cacheService: jest.Mocked<Pick<CacheService, 'deleteByPattern'>>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -39,7 +41,11 @@ describe('PersonPersistenceService', () => {
         { provide: getRepositoryToken(ChunkEntity), useValue: createMock<Repository<ChunkEntity>>() },
         { provide: getRepositoryToken(BookletLog), useValue: createMock<Repository<BookletLog>>() },
         { provide: getRepositoryToken(Session), useValue: createMock<Repository<Session>>() },
-        { provide: getRepositoryToken(UnitLog), useValue: createMock<Repository<UnitLog>>() }
+        { provide: getRepositoryToken(UnitLog), useValue: createMock<Repository<UnitLog>>() },
+        {
+          provide: CacheService,
+          useValue: { deleteByPattern: jest.fn().mockResolvedValue(undefined) }
+        }
       ]
     }).compile();
 
@@ -52,9 +58,38 @@ describe('PersonPersistenceService', () => {
     bookletLogRepository = module.get(getRepositoryToken(BookletLog));
     bookletSessionRepository = module.get(getRepositoryToken(Session));
     chunkRepository = module.get(getRepositoryToken(ChunkEntity));
+    cacheService = module.get(CacheService);
 
     jest.spyOn(unitRepository, 'create').mockImplementation(entity => entity as Unit);
   });
+
+  it.each([
+    ['not considered', 'markPersonsAsNotConsidered', false],
+    ['considered', 'markPersonsAsConsidered', true]
+  ] as const)(
+    'increments the coding-status revision when persons are marked as %s',
+    async (_label, method, consider) => {
+      jest.spyOn(personsRepository, 'update').mockResolvedValue({
+        affected: 1,
+        raw: [],
+        generatedMaps: []
+      });
+      const statusRevisionQuery = jest
+        .spyOn(personsRepository.manager, 'query')
+        .mockResolvedValue([]);
+
+      await expect(service[method](7, ['person-1'])).resolves.toBe(true);
+
+      expect(personsRepository.update).toHaveBeenCalledWith(
+        { workspace_id: 7, login: expect.anything() },
+        { consider }
+      );
+      expect(statusRevisionQuery).toHaveBeenCalledTimes(1);
+      expect(cacheService.deleteByPattern).toHaveBeenCalledWith(
+        'response-analysis:7_*'
+      );
+    }
+  );
 
   it('should process logs from input persons even if they are not in DB booklets array', async () => {
     const inputPersons: Person[] = [

--- a/apps/backend/src/app/database/services/test-results/person-persistence.service.ts
+++ b/apps/backend/src/app/database/services/test-results/person-persistence.service.ts
@@ -22,6 +22,9 @@ import { Session } from '../../entities/session.entity';
 import { UnitLog } from '../../entities/unitLog.entity';
 import { statusStringToNumber } from '../../utils/response-status-converter';
 import { TestResultsUploadIssueDto } from '../../../../../../../api-dto/files/test-results-upload-result.dto';
+import { CacheService } from '../../../cache/cache.service';
+import { CODING_ANALYSIS_CACHE_KEY_PREFIX } from '../coding/coding-analysis-cache-key.util';
+import { touchWorkspaceCodingStatusRevision } from '../shared/workspace-coding-status-revision.util';
 
 export interface TestResultsMutationSummary {
   addedUnitIds: number[];
@@ -84,7 +87,8 @@ export class PersonPersistenceService {
     @InjectRepository(Session)
     private bookletSessionRepository: Repository<Session>,
     @InjectRepository(UnitLog)
-    private unitLogRepository: Repository<UnitLog>
+    private unitLogRepository: Repository<UnitLog>,
+    private cacheService: CacheService
   ) { }
 
   /**
@@ -110,7 +114,19 @@ export class PersonPersistenceService {
       );
 
       this.logger.log(`Marked ${result.affected} persons as not to be considered in workspace ${workspaceId}`);
-      return result.affected > 0;
+      const changed = (result.affected || 0) > 0;
+      if (changed) {
+        await Promise.all([
+          touchWorkspaceCodingStatusRevision(
+            this.personsRepository.manager,
+            workspaceId
+          ),
+          this.cacheService.deleteByPattern(
+            `${CODING_ANALYSIS_CACHE_KEY_PREFIX}:${workspaceId}_*`
+          )
+        ]);
+      }
+      return changed;
     } catch (error) {
       this.logger.error(`Error marking persons as not considered: ${error.message}`, error.stack);
       return false;
@@ -140,7 +156,19 @@ export class PersonPersistenceService {
       );
 
       this.logger.log(`Marked ${result.affected} persons as considered in workspace ${workspaceId}`);
-      return result.affected > 0;
+      const changed = (result.affected || 0) > 0;
+      if (changed) {
+        await Promise.all([
+          touchWorkspaceCodingStatusRevision(
+            this.personsRepository.manager,
+            workspaceId
+          ),
+          this.cacheService.deleteByPattern(
+            `${CODING_ANALYSIS_CACHE_KEY_PREFIX}:${workspaceId}_*`
+          )
+        ]);
+      }
+      return changed;
     } catch (error) {
       this.logger.error(`Error marking persons as considered: ${error.message}`, error.stack);
       return false;

--- a/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/upload-results.service.spec.ts
@@ -27,6 +27,7 @@ import { BookletLog } from '../../entities/bookletLog.entity';
 import { Session } from '../../entities/session.entity';
 import { UnitLog } from '../../entities/unitLog.entity';
 import { Person } from '../shared';
+import { CacheService } from '../../../cache/cache.service';
 
 describe('UploadResultsService', () => {
   let service: UploadResultsService;
@@ -1057,7 +1058,8 @@ existing-group;existing-login;existing-code;booklet1;unit2;"[{""subForm"":"""","
           chunkRepository,
           bookletLogRepository,
           sessionRepository,
-          unitLogRepository
+          unitLogRepository,
+          createMock<CacheService>()
         )
       );
       const realUploadService = new UploadResultsService(

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.spec.ts
@@ -71,6 +71,13 @@ type WorkspaceTestResultsServiceWithLogAnomalyLookup = {
   ) => Promise<Map<number, unknown[]>>;
 };
 
+type WorkspaceTestResultsServiceWithBatchLoader = {
+  loadLogAnomalyRowsInBatches: <T>(
+    ids: number[],
+    loadBatch: (ids: number[]) => Promise<T[]>
+  ) => Promise<T[]>;
+};
+
 describe('WorkspaceTestResultsService', () => {
   let service: WorkspaceTestResultsService;
   let responseManagementService: ResponseManagementService;
@@ -1805,6 +1812,20 @@ describe('WorkspaceTestResultsService', () => {
       repeatedStartThreshold: 2
     };
 
+    it('collects very large query results without spreading them as arguments', async () => {
+      const batchRows = Array.from({ length: 150_000 }, (_, index) => index);
+      const serviceWithBatchLoader =
+        service as unknown as WorkspaceTestResultsServiceWithBatchLoader;
+
+      const rows = await serviceWithBatchLoader.loadLogAnomalyRowsInBatches(
+        [1],
+        async () => batchRows
+      );
+
+      expect(rows).toHaveLength(150_000);
+      expect(rows[149_999]).toBe(149_999);
+    });
+
     it('should split booklet-scoped log anomaly lookups into batches', async () => {
       const bookletIds = Array.from({ length: 1001 }, (_, index) => index + 1);
       const bookletLogQbs: Array<ReturnType<typeof mockQueryBuilder>> = [];
@@ -2098,6 +2119,31 @@ describe('WorkspaceTestResultsService', () => {
         logAnomaly1UnitProgressAvailableIgnoredUnits: ['IGNORED-UNIT'],
         logAnomaly1UnitProgressMissingIgnoredUnits: ['IGNORED-UNIT']
       });
+    });
+  });
+
+  describe('getLogAnomalySummary', () => {
+    it('processes large workspaces in bounded sequential batches', async () => {
+      const summaryQb = mockQueryBuilder();
+      (bookletRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValue(summaryQb);
+      summaryQb.getRawMany.mockResolvedValue(
+        Array.from({ length: 201 }, (_, index) => ({ id: index + 1 }))
+      );
+      const serviceWithLogAnomalyLookup =
+        service as unknown as WorkspaceTestResultsServiceWithLogAnomalyLookup;
+      const anomalyLookup = jest.spyOn(
+        serviceWithLogAnomalyLookup,
+        'findLogAnomaliesForBooklets'
+      ).mockResolvedValue(new Map());
+
+      const result = await service.getLogAnomalySummary(1);
+
+      expect(result.totalBooklets).toBe(201);
+      expect(anomalyLookup).toHaveBeenCalledTimes(3);
+      expect(anomalyLookup.mock.calls[0][0]).toHaveLength(100);
+      expect(anomalyLookup.mock.calls[1][0]).toHaveLength(100);
+      expect(anomalyLookup.mock.calls[2][0]).toEqual([201]);
     });
   });
 

--- a/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
+++ b/apps/backend/src/app/database/services/test-results/workspace-test-results.service.ts
@@ -313,6 +313,7 @@ type LogAnomalySessionRow = {
 export class WorkspaceTestResultsService {
   private readonly logger = new Logger(WorkspaceTestResultsService.name);
   private static readonly logAnomalyQueryBatchSize = 1000;
+  private static readonly logAnomalyProcessingBatchSize = 100;
   private static readonly responseValueSearchPrefixLength = 2000;
   private static readonly codingResponseStatuses = [
     statusStringToNumber('NOT_REACHED') || 1,
@@ -1066,21 +1067,28 @@ export class WorkspaceTestResultsService {
     );
   }
 
-  private getLogAnomalyIdBatches(ids: number[]): number[][] {
+  private getLogAnomalyIdBatches(
+    ids: number[],
+    batchSize = WorkspaceTestResultsService.logAnomalyQueryBatchSize
+  ): number[][] {
     const batches: number[][] = [];
     for (
       let index = 0;
       index < ids.length;
-      index += WorkspaceTestResultsService.logAnomalyQueryBatchSize
+      index += batchSize
     ) {
       batches.push(
-        ids.slice(
-          index,
-          index + WorkspaceTestResultsService.logAnomalyQueryBatchSize
-        )
+        ids.slice(index, index + batchSize)
       );
     }
     return batches;
+  }
+
+  private getLogAnomalyProcessingBatches(ids: number[]): number[][] {
+    return this.getLogAnomalyIdBatches(
+      ids,
+      WorkspaceTestResultsService.logAnomalyProcessingBatchSize
+    );
   }
 
   private async loadLogAnomalyRowsInBatches<T>(
@@ -1089,7 +1097,10 @@ export class WorkspaceTestResultsService {
   ): Promise<T[]> {
     const rows: T[] = [];
     for (const batchIds of this.getLogAnomalyIdBatches(ids)) {
-      rows.push(...await loadBatch(batchIds));
+      const batchRows = await loadBatch(batchIds);
+      for (const row of batchRows) {
+        rows.push(row);
+      }
     }
     return rows;
   }
@@ -1582,6 +1593,83 @@ export class WorkspaceTestResultsService {
     return result;
   }
 
+  private mergeLogAnomalySummary(
+    summary: LogAnomalyDashboardSummary,
+    anomaliesByBooklet: Map<number, LogAnomalySummary[]>
+  ): void {
+    anomaliesByBooklet.forEach(anomalies => {
+      if (anomalies.length === 0) {
+        return;
+      }
+      summary.affectedBooklets += 1;
+      summary.totalAnomalyRules += anomalies.length;
+
+      if (anomalies.some(anomaly => anomaly.severity === 'critical')) {
+        summary.criticalBooklets += 1;
+      }
+      if (anomalies.some(anomaly => anomaly.severity === 'warning')) {
+        summary.warningBooklets += 1;
+      }
+      if (anomalies.some(anomaly => anomaly.severity === 'info')) {
+        summary.infoBooklets += 1;
+      }
+
+      anomalies.forEach(anomaly => {
+        summary.totalAnomalyEvents += anomaly.count;
+        summary.byCode[anomaly.code] =
+          (summary.byCode[anomaly.code] || 0) + 1;
+      });
+    });
+  }
+
+  private toLogAnomalyDetailRow(
+    row: {
+      bookletId: number | string;
+      booklet: string | null;
+      personId: number | string;
+      code: string | null;
+      group: string | null;
+      login: string | null;
+    },
+    anomaliesByBooklet: Map<number, LogAnomalySummary[]>
+  ): LogAnomalyDetailRow | null {
+    const bookletId = Number(row.bookletId);
+    const anomalies = anomaliesByBooklet.get(bookletId) || [];
+    if (anomalies.length === 0) {
+      return null;
+    }
+    const maxSeverity = anomalies.reduce<LogAnomalySeverity>(
+      (current, anomaly) => {
+        const anomalySort = this.getLogAnomalySortValue(anomaly.severity);
+        const currentSort = this.getLogAnomalySortValue(current);
+        return anomalySort < currentSort ? anomaly.severity : current;
+      },
+      'info'
+    );
+    return {
+      bookletId,
+      booklet: String(row.booklet || ''),
+      personId: Number(row.personId),
+      code: String(row.code || ''),
+      group: String(row.group || ''),
+      login: String(row.login || ''),
+      maxSeverity,
+      anomalies
+    };
+  }
+
+  private compareLogAnomalyDetails(
+    a: LogAnomalyDetailRow,
+    b: LogAnomalyDetailRow
+  ): number {
+    const severityDelta =
+      this.getLogAnomalySortValue(a.maxSeverity) -
+      this.getLogAnomalySortValue(b.maxSeverity);
+    return severityDelta ||
+      a.code.localeCompare(b.code) ||
+      a.booklet.localeCompare(b.booklet);
+  }
+
   async getLogAnomalySummary(
     workspaceId: number,
     options: {
@@ -1629,41 +1717,20 @@ export class WorkspaceTestResultsService {
       return emptySummary;
     }
 
-    const anomaliesByBooklet = await this.findLogAnomaliesForBooklets(
-      bookletIds,
-      this.buildLogAnomalyThresholds(options),
-      exclusions
-    );
-
     const summary: LogAnomalyDashboardSummary = {
       ...emptySummary,
       totalBooklets: bookletIds.length,
       byCode: {}
     };
-
-    anomaliesByBooklet.forEach(anomalies => {
-      if (anomalies.length === 0) {
-        return;
-      }
-      summary.affectedBooklets += 1;
-      summary.totalAnomalyRules += anomalies.length;
-
-      if (anomalies.some(anomaly => anomaly.severity === 'critical')) {
-        summary.criticalBooklets += 1;
-      }
-      if (anomalies.some(anomaly => anomaly.severity === 'warning')) {
-        summary.warningBooklets += 1;
-      }
-      if (anomalies.some(anomaly => anomaly.severity === 'info')) {
-        summary.infoBooklets += 1;
-      }
-
-      anomalies.forEach(anomaly => {
-        summary.totalAnomalyEvents += anomaly.count;
-        summary.byCode[anomaly.code] =
-          (summary.byCode[anomaly.code] || 0) + 1;
-      });
-    });
+    const thresholds = this.buildLogAnomalyThresholds(options);
+    for (const batchIds of this.getLogAnomalyProcessingBatches(bookletIds)) {
+      const anomaliesByBooklet = await this.findLogAnomaliesForBooklets(
+        batchIds,
+        thresholds,
+        exclusions
+      );
+      this.mergeLogAnomalySummary(summary, anomaliesByBooklet);
+    }
 
     return summary;
   }
@@ -1726,55 +1793,31 @@ export class WorkspaceTestResultsService {
       );
       return !ignoredBooklets.has(normalizedBooklet);
     });
-    const bookletIds = filteredRows
-      .map(row => Number(row.bookletId))
-      .filter(id => Number.isFinite(id) && id > 0);
-
-    const anomaliesByBooklet = await this.findLogAnomaliesForBooklets(
-      bookletIds,
-      this.buildLogAnomalyThresholds(options),
-      exclusions
-    );
-
-    const details = filteredRows
-      .map((row): LogAnomalyDetailRow | null => {
-        const bookletId = Number(row.bookletId);
-        const anomalies = anomaliesByBooklet.get(bookletId) || [];
-        if (anomalies.length === 0) {
-          return null;
-        }
-        const maxSeverity = anomalies.reduce<LogAnomalySeverity>(
-          (current, anomaly) => {
-            const anomalySort = this.getLogAnomalySortValue(anomaly.severity);
-            const currentSort = this.getLogAnomalySortValue(current);
-            return anomalySort < currentSort ? anomaly.severity : current;
-          },
-          'info'
-        );
-        return {
-          bookletId,
-          booklet: String(row.booklet || ''),
-          personId: Number(row.personId),
-          code: String(row.code || ''),
-          group: String(row.group || ''),
-          login: String(row.login || ''),
-          maxSeverity,
-          anomalies
-        };
-      })
-      .filter((row): row is LogAnomalyDetailRow => row !== null)
-      .sort((a, b) => {
-        const severityDelta =
-          this.getLogAnomalySortValue(a.maxSeverity) -
-          this.getLogAnomalySortValue(b.maxSeverity);
-        return severityDelta ||
-          a.code.localeCompare(b.code) ||
-          a.booklet.localeCompare(b.booklet);
-      });
+    const thresholds = this.buildLogAnomalyThresholds(options);
+    let total = 0;
+    let details: LogAnomalyDetailRow[] = [];
+    for (const rowBatch of this.getLogAnomalyIdBatches(
+      filteredRows.map((_row, index) => index),
+      WorkspaceTestResultsService.logAnomalyProcessingBatchSize
+    )) {
+      const rowsInBatch = rowBatch.map(index => filteredRows[index]);
+      const anomaliesByBooklet = await this.findLogAnomaliesForBooklets(
+        rowsInBatch.map(row => Number(row.bookletId)),
+        thresholds,
+        exclusions
+      );
+      const batchDetails = rowsInBatch
+        .map(row => this.toLogAnomalyDetailRow(row, anomaliesByBooklet))
+        .filter((row): row is LogAnomalyDetailRow => row !== null);
+      total += batchDetails.length;
+      details = [...details, ...batchDetails]
+        .sort((a, b) => this.compareLogAnomalyDetails(a, b))
+        .slice(0, limit);
+    }
 
     return {
-      total: details.length,
-      data: details.slice(0, limit)
+      total,
+      data: details
     };
   }
 

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.spec.ts
@@ -25,6 +25,7 @@ describe('WorkspaceCoreService', () => {
     manager: { delete: jest.Mock };
   };
   let managerSave: jest.Mock;
+  let statusRevisionQuery: jest.Mock;
   let service: WorkspaceCoreService;
 
   beforeEach(() => {
@@ -49,9 +50,11 @@ describe('WorkspaceCoreService', () => {
       }
       return Promise.resolve(value);
     });
+    statusRevisionQuery = jest.fn().mockResolvedValue([]);
     service = new WorkspaceCoreService(
       repo as never,
       {
+        manager: { query: statusRevisionQuery },
         createQueryRunner: () => queryRunner,
         transaction: (callback: (manager: { save: jest.Mock }) => Promise<unknown>) => callback({ save: managerSave })
       } as never,
@@ -92,6 +95,7 @@ describe('WorkspaceCoreService', () => {
     await expect(service.patch({ id: 1, name: 'Patched', settings: { a: true } } as never)).resolves.toBeUndefined();
     expect(cacheService.delete).toHaveBeenCalled();
     expect(workspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
+    expect(statusRevisionQuery).toHaveBeenCalledTimes(1);
     await expect(service.remove([])).resolves.toBeUndefined();
     await expect(service.remove([1])).resolves.toBeUndefined();
     expect(queryRunner.commitTransaction).toHaveBeenCalled();
@@ -136,5 +140,6 @@ describe('WorkspaceCoreService', () => {
     expect(cacheService.deleteByPattern).toHaveBeenCalledWith('response-analysis:1_*');
     expect(cacheService.deleteByPattern).toHaveBeenCalledWith('responses:1:*');
     expect(cacheService.deleteByPattern).toHaveBeenCalledWith('flat_response_filter_options:1:*');
+    expect(statusRevisionQuery).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-core.service.ts
@@ -24,6 +24,7 @@ import {
   getCodingIncompleteVariablesCacheKeys,
   getCodingIncompleteVariablesCacheVersionKey
 } from '../coding/coding-incomplete-variables-cache-key.util';
+import { touchWorkspaceCodingStatusRevision } from '../shared/workspace-coding-status-revision.util';
 
 @Injectable()
 export class WorkspaceCoreService {
@@ -122,6 +123,10 @@ export class WorkspaceCoreService {
       if (workspaceData.settings) {
         await this.workspaceTestResultsService.invalidateWorkspaceStatsCache(workspaceData.id);
         await this.invalidateCachesAffectedByExclusions(workspaceData.id);
+        await touchWorkspaceCodingStatusRevision(
+          this.connection.manager,
+          workspaceData.id
+        );
       }
     }
   }
@@ -183,6 +188,10 @@ export class WorkspaceCoreService {
     await this.cacheService.delete(`${EXCLUSION_CACHE_PREFIX}${workspaceId}`);
     await this.workspaceTestResultsService.invalidateWorkspaceStatsCache(workspaceId);
     await this.invalidateCachesAffectedByExclusions(workspaceId);
+    await touchWorkspaceCodingStatusRevision(
+      this.connection.manager,
+      workspaceId
+    );
   }
 
   async getWorkspaceSettings(workspaceId: number): Promise<WorkspaceSettingsDto> {
@@ -199,6 +208,10 @@ export class WorkspaceCoreService {
     await this.cacheService.delete(`${EXCLUSION_CACHE_PREFIX}${workspaceId}`);
     await this.workspaceTestResultsService.invalidateWorkspaceStatsCache(workspaceId);
     await this.invalidateCachesAffectedByExclusions(workspaceId);
+    await touchWorkspaceCodingStatusRevision(
+      this.connection.manager,
+      workspaceId
+    );
   }
 
   private async invalidateCachesAffectedByExclusions(workspaceId: number): Promise<void> {

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.spec.ts
@@ -3,6 +3,17 @@ import { WorkspaceFilesService } from './workspace-files.service';
 import { FileIo } from '../../../admin/workspace/file-io.interface';
 import { getManualCodingScopeKey } from '../../utils/manual-coding-scope.util';
 import { NO_CODING_SCHEME_REF_NORMALIZED } from '../../entities/file_upload.entity';
+import { withWorkspaceTestResultsMutationLock } from '../shared/workspace-test-results-lock.util';
+
+jest.mock('../shared/workspace-test-results-lock.util', () => ({
+  withWorkspaceTestResultsMutationLock: jest.fn(
+    (_connection: unknown, _workspaceId: number, callback: () => Promise<unknown>) => callback()
+  )
+}));
+
+const mockWithWorkspaceTestResultsMutationLock = jest.mocked(
+  withWorkspaceTestResultsMutationLock
+);
 
 describe('WorkspaceFilesService.handleFile', () => {
   beforeAll(() => {
@@ -233,7 +244,10 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
     createQueryBuilder: jest.fn(),
     find: jest.fn(),
     findOne: jest.fn(),
-    upsert: jest.fn().mockResolvedValue(undefined)
+    upsert: jest.fn().mockResolvedValue(undefined),
+    manager: {
+      connection: {}
+    }
   };
   const mockCodingStatisticsService = {
     invalidateCache: jest.fn().mockResolvedValue(undefined),
@@ -442,6 +456,38 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
       .toHaveBeenCalledWith(1);
     expect(mockWorkspaceTestResultsService.invalidateWorkspaceStatsCache)
       .toHaveBeenCalledWith(1);
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      1,
+      expect.any(Function)
+    );
+  });
+
+  it('keeps failed uploads inside the coding-status mutation lock', async () => {
+    const service = makeService();
+    jest.spyOn(service, 'handleFile').mockReturnValue([
+      Promise.resolve({
+        failed: true,
+        filename: 'broken.zip',
+        reason: 'Invalid ZIP entry'
+      })
+    ]);
+
+    const result = await service.uploadTestFiles(1, [{
+      fieldname: 'files',
+      originalname: 'broken.zip',
+      encoding: '7bit',
+      mimetype: 'application/zip',
+      buffer: Buffer.from('broken'),
+      size: 6
+    }], false);
+
+    expect(result.failed).toBe(1);
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      1,
+      expect.any(Function)
+    );
   });
 
   it('extracts coding scheme refs for unit XML files uploaded as octet-stream', async () => {
@@ -566,6 +612,11 @@ describe('WorkspaceFilesService coding scheme freshness', () => {
     ]);
 
     expect(invalidateSpy).toHaveBeenCalledWith(1);
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      1,
+      expect.any(Function)
+    );
   });
 
   it('extracts coding scheme refs for Unit files imported from Testcenter', async () => {
@@ -732,7 +783,10 @@ describe('WorkspaceFilesService.deleteTestFiles', () => {
   };
 
   const mockFileUploadRepository = {
-    createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder)
+    createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+    manager: {
+      connection: {}
+    }
   };
 
   const mockCodingStatisticsService = {
@@ -781,6 +835,11 @@ describe('WorkspaceFilesService.deleteTestFiles', () => {
       { ids: [1, 2, 3] }
     );
     expect(mockQueryBuilder.execute).toHaveBeenCalled();
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      workspaceId,
+      expect.any(Function)
+    );
     expect(result).toBe(true);
   });
 
@@ -819,6 +878,20 @@ describe('WorkspaceFilesService.deleteTestFiles', () => {
     expect(result).toBe(false);
     expect(mockFileUploadRepository.createQueryBuilder).not.toHaveBeenCalled();
     expect(mockCodingStatisticsService.invalidateCache).not.toHaveBeenCalled();
+    expect(mockWithWorkspaceTestResultsMutationLock).not.toHaveBeenCalled();
+  });
+
+  it('should keep the mutation lock when no matching file was deleted', async () => {
+    const service = makeService();
+    mockQueryBuilder.execute.mockResolvedValueOnce({ affected: 0 });
+
+    await service.deleteTestFiles(1, ['1']);
+
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      1,
+      expect.any(Function)
+    );
   });
 
   it('should return false when not all requested files were deleted', async () => {
@@ -834,6 +907,87 @@ describe('WorkspaceFilesService.deleteTestFiles', () => {
   });
 });
 
+describe('WorkspaceFilesService.createDummyTestTakerFile', () => {
+  type CtorParams = ConstructorParameters<typeof WorkspaceFilesService>;
+
+  const mockFileUploadRepository = {
+    find: jest.fn(),
+    create: jest.fn((file: unknown) => file),
+    save: jest.fn(),
+    manager: {
+      connection: {}
+    }
+  };
+
+  function makeService(): WorkspaceFilesService {
+    return new WorkspaceFilesService(
+      mockFileUploadRepository as unknown as CtorParams[0],
+      {} as unknown as CtorParams[1],
+      {} as unknown as CtorParams[2],
+      {} as unknown as CtorParams[3],
+      {} as unknown as CtorParams[4],
+      {} as unknown as CtorParams[5],
+      {} as unknown as CtorParams[6],
+      {} as unknown as CtorParams[7],
+      {} as unknown as CtorParams[8],
+      {} as unknown as CtorParams[9],
+      { delete: jest.fn() } as unknown as CtorParams[10],
+      { invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined) } as unknown as CtorParams[11]
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFileUploadRepository.create.mockImplementation((file: unknown) => file);
+    mockFileUploadRepository.save.mockImplementation(async (file: unknown) => file);
+  });
+
+  it('should lock the mutation and invalidate caches after creating a dummy TestTakers file', async () => {
+    mockFileUploadRepository.find.mockResolvedValueOnce([
+      { file_id: 'BOOKLET_1' }
+    ]);
+    const service = makeService();
+    const invalidateSpy = jest
+      .spyOn(service, 'invalidateWorkspaceFileCaches')
+      .mockResolvedValue(undefined);
+
+    const result = await service.createDummyTestTakerFile(1);
+
+    expect(result).toBe(true);
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      1,
+      expect.any(Function)
+    );
+    expect(mockFileUploadRepository.save).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('should invalidate caches when creating the TestTakers file fails after the booklet was saved', async () => {
+    mockFileUploadRepository.find
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ file_id: 'UNIT_1' }]);
+    mockFileUploadRepository.save
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('TestTakers save failed'));
+    const service = makeService();
+    const invalidateSpy = jest
+      .spyOn(service, 'invalidateWorkspaceFileCaches')
+      .mockResolvedValue(undefined);
+
+    const result = await service.createDummyTestTakerFile(1);
+
+    expect(result).toBe(false);
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      1,
+      expect.any(Function)
+    );
+    expect(mockFileUploadRepository.save).toHaveBeenCalledTimes(2);
+    expect(invalidateSpy).toHaveBeenCalledWith(1);
+  });
+});
+
 describe('WorkspaceFilesService response deletion cache invalidation', () => {
   type CtorParams = ConstructorParameters<typeof WorkspaceFilesService>;
 
@@ -846,9 +1000,15 @@ describe('WorkspaceFilesService response deletion cache invalidation', () => {
     invalidateWorkspaceStatsCache: jest.fn().mockResolvedValue(undefined)
   };
 
+  const mockFileUploadRepository = {
+    manager: {
+      connection: {}
+    }
+  };
+
   function makeService(): WorkspaceFilesService {
     return new WorkspaceFilesService(
-      {} as unknown as CtorParams[0],
+      mockFileUploadRepository as unknown as CtorParams[0],
       {} as unknown as CtorParams[1],
       {} as unknown as CtorParams[2],
       {} as unknown as CtorParams[3],
@@ -874,6 +1034,11 @@ describe('WorkspaceFilesService response deletion cache invalidation', () => {
     const deletedCount = await service.deleteInvalidResponses(1, [10, 11]);
 
     expect(deletedCount).toBe(2);
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      1,
+      expect.any(Function)
+    );
     expect(mockWorkspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
   });
 
@@ -884,6 +1049,11 @@ describe('WorkspaceFilesService response deletion cache invalidation', () => {
     const deletedCount = await service.deleteInvalidResponses(1, [10]);
 
     expect(deletedCount).toBe(0);
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      1,
+      expect.any(Function)
+    );
     expect(mockWorkspaceTestResultsService.invalidateWorkspaceStatsCache).not.toHaveBeenCalled();
   });
 
@@ -894,6 +1064,11 @@ describe('WorkspaceFilesService response deletion cache invalidation', () => {
     const deletedCount = await service.deleteAllInvalidResponses(1, 'variables');
 
     expect(deletedCount).toBe(3);
+    expect(mockWithWorkspaceTestResultsMutationLock).toHaveBeenCalledWith(
+      mockFileUploadRepository.manager.connection,
+      1,
+      expect.any(Function)
+    );
     expect(mockWorkspaceTestResultsService.invalidateWorkspaceStatsCache).toHaveBeenCalledWith(1);
   });
 });

--- a/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
+++ b/apps/backend/src/app/database/services/workspace/workspace-files.service.ts
@@ -80,6 +80,7 @@ import {
 } from '../../../utils/regex-search.util';
 import { hasVisibleManualInstruction } from '../../../utils/manual-instruction.util';
 import { isExportWorkerProcess } from '../../../export-worker/export-worker-role';
+import { withWorkspaceTestResultsMutationLock } from '../shared/workspace-test-results-lock.util';
 
 type WorkspaceUnitVisibility = {
   globalIgnoredUnits: Set<string>;
@@ -858,29 +859,35 @@ export class WorkspaceFilesService implements OnModuleInit {
       return false;
     }
 
-    const res = await this.fileUploadRepository
-      .createQueryBuilder()
-      .delete()
-      .from(FileUpload)
-      .where('workspace_id = :workspaceId', { workspaceId: workspace_id })
-      .andWhere('id IN (:...ids)', { ids: numericIds })
-      .execute();
+    return withWorkspaceTestResultsMutationLock(
+      this.fileUploadRepository.manager.connection,
+      workspace_id,
+      async () => {
+        const res = await this.fileUploadRepository
+          .createQueryBuilder()
+          .delete()
+          .from(FileUpload)
+          .where('workspace_id = :workspaceId', { workspaceId: workspace_id })
+          .andWhere('id IN (:...ids)', { ids: numericIds })
+          .execute();
 
-    // Invalidate memory caches inside this service
-    await this.invalidateWorkspaceFileCaches(workspace_id);
+        // Invalidate memory caches inside this service
+        await this.invalidateWorkspaceFileCaches(workspace_id);
 
-    // Invalidate coding statistics cache since test files changed
-    await this.codingStatisticsService.invalidateCache(workspace_id);
+        // Invalidate coding statistics cache since test files changed
+        await this.codingStatisticsService.invalidateCache(workspace_id);
 
-    const deletedCount = res.affected ?? 0;
-    const success = deletedCount === numericIds.length;
-    if (!success) {
-      this.logger.warn(
-        `Requested deletion of ${numericIds.length} test files for workspace ${workspace_id}, but deleted ${deletedCount}`
-      );
-    }
+        const deletedCount = res.affected ?? 0;
+        const success = deletedCount === numericIds.length;
+        if (!success) {
+          this.logger.warn(
+            `Requested deletion of ${numericIds.length} test files for workspace ${workspace_id}, but deleted ${deletedCount}`
+          );
+        }
 
-    return success;
+        return success;
+      }
+    );
   }
 
   async validateTestFiles(
@@ -911,28 +918,35 @@ export class WorkspaceFilesService implements OnModuleInit {
 
   async createDummyTestTakerFile(workspaceId: number): Promise<boolean> {
     try {
-      const booklets = await this.fileUploadRepository.find({
-        where: { workspace_id: workspaceId, file_type: 'Booklet' }
-      });
+      return await withWorkspaceTestResultsMutationLock(
+        this.fileUploadRepository.manager.connection,
+        workspaceId,
+        async () => {
+          let hasMutatedWorkspaceFiles = false;
 
-      if (!booklets || booklets.length === 0) {
-        const units = await this.fileUploadRepository.find({
-          where: { workspace_id: workspaceId, file_type: 'Unit' }
-        });
+          try {
+            const booklets = await this.fileUploadRepository.find({
+              where: { workspace_id: workspaceId, file_type: 'Booklet' }
+            });
 
-        if (!units || units.length === 0) {
-          this.logger.warn(
-            `No booklets or units found in workspace with ID ${workspaceId}.`
-          );
-          return false;
-        }
+            if (!booklets || booklets.length === 0) {
+              const units = await this.fileUploadRepository.find({
+                where: { workspace_id: workspaceId, file_type: 'Unit' }
+              });
 
-        // Create a fake booklet that includes all available units
-        const unitRefs = units
-          .map(unit => `  <Unit id="${unit.file_id}"/>`)
-          .join('\n');
-        const fakeBookletId = 'AUTO-GENERATED-BOOKLET';
-        const fakeBookletXml = `<?xml version="1.0" encoding="utf-8"?>
+              if (!units || units.length === 0) {
+                this.logger.warn(
+                  `No booklets or units found in workspace with ID ${workspaceId}.`
+                );
+                return false;
+              }
+
+              // Create a fake booklet that includes all available units
+              const unitRefs = units
+                .map(unit => `  <Unit id="${unit.file_id}"/>`)
+                .join('\n');
+              const fakeBookletId = 'AUTO-GENERATED-BOOKLET';
+              const fakeBookletXml = `<?xml version="1.0" encoding="utf-8"?>
 <Booklet>
   <Metadata>
     <Id>${fakeBookletId}</Id>
@@ -944,21 +958,22 @@ ${unitRefs}
   </Units>
 </Booklet>`;
 
-        const fakeBooklet = this.fileUploadRepository.create({
-          workspace_id: workspaceId,
-          filename: 'auto-generated-booklet.xml',
-          file_id: fakeBookletId,
-          file_type: 'Booklet',
-          file_size: fakeBookletXml.length,
-          data: fakeBookletXml
-        });
+              const fakeBooklet = this.fileUploadRepository.create({
+                workspace_id: workspaceId,
+                filename: 'auto-generated-booklet.xml',
+                file_id: fakeBookletId,
+                file_type: 'Booklet',
+                file_size: fakeBookletXml.length,
+                data: fakeBookletXml
+              });
 
-        await this.fileUploadRepository.save(fakeBooklet);
-        this.logger.log(
-          `Created fake booklet for workspace ${workspaceId} with ${units.length} units.`
-        );
+              await this.fileUploadRepository.save(fakeBooklet);
+              hasMutatedWorkspaceFiles = true;
+              this.logger.log(
+                `Created fake booklet for workspace ${workspaceId} with ${units.length} units.`
+              );
 
-        const dummyTestTakerXml = `<?xml version="1.0" encoding="utf-8"?>
+              const dummyTestTakerXml = `<?xml version="1.0" encoding="utf-8"?>
 <TestTakers>
   <Metadata>
     <Description>Auto-generated TestTakers file with auto-generated booklet</Description>
@@ -970,27 +985,28 @@ ${unitRefs}
   </Group>
 </TestTakers>`;
 
-        const newTestTakerFile = this.fileUploadRepository.create({
-          workspace_id: workspaceId,
-          filename: 'auto-generated-testtakers.xml',
-          file_id: 'AUTO-GENERATED-TESTTAKERS',
-          file_type: 'TestTakers',
-          file_size: dummyTestTakerXml.length,
-          data: dummyTestTakerXml
-        });
+              const newTestTakerFile = this.fileUploadRepository.create({
+                workspace_id: workspaceId,
+                filename: 'auto-generated-testtakers.xml',
+                file_id: 'AUTO-GENERATED-TESTTAKERS',
+                file_type: 'TestTakers',
+                file_size: dummyTestTakerXml.length,
+                data: dummyTestTakerXml
+              });
 
-        await this.fileUploadRepository.save(newTestTakerFile);
-        this.logger.log(
-          `Created dummy TestTakers file for workspace ${workspaceId} with auto-generated booklet.`
-        );
-        return true;
-      }
+              await this.fileUploadRepository.save(newTestTakerFile);
+              hasMutatedWorkspaceFiles = true;
+              this.logger.log(
+                `Created dummy TestTakers file for workspace ${workspaceId} with auto-generated booklet.`
+              );
+              return true;
+            }
 
-      const bookletRefs = booklets
-        .map(booklet => `    <Booklet>${booklet.file_id}</Booklet>`)
-        .join('\n');
+            const bookletRefs = booklets
+              .map(booklet => `    <Booklet>${booklet.file_id}</Booklet>`)
+              .join('\n');
 
-      const dummyTestTakerXml = `<?xml version="1.0" encoding="utf-8"?>
+            const dummyTestTakerXml = `<?xml version="1.0" encoding="utf-8"?>
 <TestTakers>
   <Metadata>
     <Description>Auto-generated TestTakers file including all booklets</Description>
@@ -1002,21 +1018,29 @@ ${bookletRefs}
   </Group>
 </TestTakers>`;
 
-      const newTestTakerFile = this.fileUploadRepository.create({
-        workspace_id: workspaceId,
-        filename: 'auto-generated-testtakers.xml',
-        file_id: 'AUTO-GENERATED-TESTTAKERS',
-        file_type: 'TestTakers',
-        file_size: dummyTestTakerXml.length,
-        data: dummyTestTakerXml
-      });
+            const newTestTakerFile = this.fileUploadRepository.create({
+              workspace_id: workspaceId,
+              filename: 'auto-generated-testtakers.xml',
+              file_id: 'AUTO-GENERATED-TESTTAKERS',
+              file_type: 'TestTakers',
+              file_size: dummyTestTakerXml.length,
+              data: dummyTestTakerXml
+            });
 
-      await this.fileUploadRepository.save(newTestTakerFile);
+            await this.fileUploadRepository.save(newTestTakerFile);
+            hasMutatedWorkspaceFiles = true;
 
-      this.logger.log(
-        `Created dummy TestTakers file for workspace ${workspaceId} with ${booklets.length} booklets.`
+            this.logger.log(
+              `Created dummy TestTakers file for workspace ${workspaceId} with ${booklets.length} booklets.`
+            );
+            return true;
+          } finally {
+            if (hasMutatedWorkspaceFiles) {
+              await this.invalidateWorkspaceFileCaches(workspaceId);
+            }
+          }
+        }
       );
-      return true;
     } catch (error) {
       this.logger.error(
         `Error creating dummy TestTakers file for workspace ${workspaceId}: ${error.message}`,
@@ -1297,24 +1321,30 @@ ${bookletRefs}
     };
 
     try {
-      const result = await processInBatches(
-        originalFiles,
-        MAX_CONCURRENT_UPLOADS,
-        overwriteExisting,
-        overwriteAllowList
-      );
-      // Invalidate memory caches inside this service
-      await this.invalidateWorkspaceFileCaches(workspace_id);
+      return await withWorkspaceTestResultsMutationLock(
+        this.fileUploadRepository.manager.connection,
+        workspace_id,
+        async () => {
+          const result = await processInBatches(
+            originalFiles,
+            MAX_CONCURRENT_UPLOADS,
+            overwriteExisting,
+            overwriteAllowList
+          );
+          // Invalidate memory caches inside this service
+          await this.invalidateWorkspaceFileCaches(workspace_id);
 
-      if (this.shouldInvalidateCodingStatisticsAfterUpload(result)) {
-        await this.codingStatisticsService.invalidateCache(workspace_id);
-      }
-      if (this.hasUploadedFiles(result)) {
-        await this.codingStatisticsService.invalidateIncompleteVariablesCache(
-          workspace_id
-        );
-      }
-      return result;
+          if (this.shouldInvalidateCodingStatisticsAfterUpload(result)) {
+            await this.codingStatisticsService.invalidateCache(workspace_id);
+          }
+          if (this.hasUploadedFiles(result)) {
+            await this.codingStatisticsService.invalidateIncompleteVariablesCache(
+              workspace_id
+            );
+          }
+          return result;
+        }
+      );
     } catch (error) {
       this.logger.error(
         `Unexpected error while uploading files for workspace ${workspace_id}:`,
@@ -2115,108 +2145,114 @@ ${bookletRefs}
         (normalized[0] as { workspace_id?: unknown } | undefined)?.workspace_id
       );
 
-      const requestedFileIds = normalized
-        .map(e => String((e as { file_id?: unknown }).file_id ?? ''))
-        .filter(Boolean);
+      return await withWorkspaceTestResultsMutationLock(
+        this.fileUploadRepository.manager.connection,
+        workspaceId,
+        async () => {
+          const requestedFileIds = normalized
+            .map(e => String((e as { file_id?: unknown }).file_id ?? ''))
+            .filter(Boolean);
 
-      const conflicts: TestFilesUploadConflictDto[] =
-        workspaceId && requestedFileIds.length ?
-          (
+          const conflicts: TestFilesUploadConflictDto[] =
+            workspaceId && requestedFileIds.length ?
+              (
+                await this.fileUploadRepository
+                  .createQueryBuilder('file')
+                  .select(['file.file_id', 'file.filename', 'file.file_type'])
+                  .where('file.workspace_id = :workspaceId', { workspaceId })
+                  .andWhere('file.file_id IN (:...fileIds)', {
+                    fileIds: requestedFileIds
+                  })
+                  .getMany()
+              ).map(f => ({
+                fileId: String(f.file_id || ''),
+                filename: String(f.filename || ''),
+                fileType: String(f.file_type || '')
+              })) :
+              [];
+
+          const conflictIds = new Set(conflicts.map(c => c.fileId));
+          const overwriteIdSet = new Set((overwriteFileIds || []).filter(Boolean));
+
+          const attemptedFiles: TestFilesUploadUploadedDto[] = normalized
+            .map(e => ({
+              fileId: String((e as { file_id?: unknown }).file_id ?? ''),
+              filename: String((e as { filename?: unknown }).filename ?? ''),
+              fileType: String((e as { file_type?: unknown }).file_type ?? '')
+            }))
+            .filter(f => !!f.fileId && !!f.filename);
+
+          const shouldOverwrite = (fileId: string): boolean => !!fileId && overwriteIdSet.has(fileId);
+
+          const insertableFiles = attemptedFiles.filter(
+            f => !conflictIds.has(f.fileId)
+          );
+          const overwriteFiles = attemptedFiles.filter(
+            f => conflictIds.has(f.fileId) && shouldOverwrite(f.fileId)
+          );
+          const remainingConflicts = conflicts.filter(
+            c => !shouldOverwrite(c.fileId)
+          );
+
+          const insertableEntries = normalized.filter(e => {
+            const id = String((e as { file_id?: unknown }).file_id ?? '');
+            return !!id && !conflictIds.has(id);
+          });
+          const overwriteEntries = normalized.filter(e => {
+            const id = String((e as { file_id?: unknown }).file_id ?? '');
+            return !!id && conflictIds.has(id) && shouldOverwrite(id);
+          });
+          const changedCodingSchemes =
+            await this.collectCodingSchemeChangesForFreshness(
+              workspaceId,
+              [...insertableEntries, ...overwriteEntries]
+            );
+
+          const registry = this.fileUploadRepository.create(insertableEntries);
+          if (registry.length > 0) {
             await this.fileUploadRepository
-              .createQueryBuilder('file')
-              .select(['file.file_id', 'file.filename', 'file.file_type'])
-              .where('file.workspace_id = :workspaceId', { workspaceId })
-              .andWhere('file.file_id IN (:...fileIds)', {
-                fileIds: requestedFileIds
-              })
-              .getMany()
-          ).map(f => ({
-            fileId: String(f.file_id || ''),
-            filename: String(f.filename || ''),
-            fileType: String(f.file_type || '')
-          })) :
-          [];
+              .createQueryBuilder()
+              .insert()
+              .into(FileUpload)
+              .values(registry)
+              .orIgnore()
+              .execute();
+          }
 
-      const conflictIds = new Set(conflicts.map(c => c.fileId));
-      const overwriteIdSet = new Set((overwriteFileIds || []).filter(Boolean));
-
-      const attemptedFiles: TestFilesUploadUploadedDto[] = normalized
-        .map(e => ({
-          fileId: String((e as { file_id?: unknown }).file_id ?? ''),
-          filename: String((e as { filename?: unknown }).filename ?? ''),
-          fileType: String((e as { file_type?: unknown }).file_type ?? '')
-        }))
-        .filter(f => !!f.fileId && !!f.filename);
-
-      const shouldOverwrite = (fileId: string): boolean => !!fileId && overwriteIdSet.has(fileId);
-
-      const insertableFiles = attemptedFiles.filter(
-        f => !conflictIds.has(f.fileId)
+          const overwriteRegistry = this.fileUploadRepository.create(
+            overwriteEntries.map(e => ({
+              ...(e as Record<string, unknown>),
+              created_at: new Date() as unknown as number
+            }))
+          );
+          if (overwriteRegistry.length > 0) {
+            await this.fileUploadRepository.upsert(overwriteRegistry, [
+              'file_id',
+              'workspace_id'
+            ]);
+          }
+          const freshnessIssues = (await Promise.all(changedCodingSchemes.map(change => (
+            this.markCodingSchemeFreshnessAfterFileChange(
+              workspaceId,
+              change.fileId,
+              change.previousData,
+              change.nextData
+            )
+          )))).filter((issue): issue is TestResultsUploadIssueDto => !!issue);
+          if (registry.length > 0 || overwriteRegistry.length > 0) {
+            await this.invalidateWorkspaceFileCaches(workspaceId);
+          }
+          return {
+            total: attemptedFiles.length,
+            uploaded: insertableFiles.length + overwriteFiles.length,
+            failed: 0,
+            uploadedFiles: [...insertableFiles, ...overwriteFiles],
+            conflicts: remainingConflicts.length ? remainingConflicts : undefined,
+            failedFiles: undefined,
+            issues: freshnessIssues.length ? freshnessIssues : undefined
+          };
+        }
       );
-      const overwriteFiles = attemptedFiles.filter(
-        f => conflictIds.has(f.fileId) && shouldOverwrite(f.fileId)
-      );
-      const remainingConflicts = conflicts.filter(
-        c => !shouldOverwrite(c.fileId)
-      );
-
-      const insertableEntries = normalized.filter(e => {
-        const id = String((e as { file_id?: unknown }).file_id ?? '');
-        return !!id && !conflictIds.has(id);
-      });
-      const overwriteEntries = normalized.filter(e => {
-        const id = String((e as { file_id?: unknown }).file_id ?? '');
-        return !!id && conflictIds.has(id) && shouldOverwrite(id);
-      });
-      const changedCodingSchemes =
-        await this.collectCodingSchemeChangesForFreshness(
-          workspaceId,
-          [...insertableEntries, ...overwriteEntries]
-        );
-
-      const registry = this.fileUploadRepository.create(insertableEntries);
-      if (registry.length > 0) {
-        await this.fileUploadRepository
-          .createQueryBuilder()
-          .insert()
-          .into(FileUpload)
-          .values(registry)
-          .orIgnore()
-          .execute();
-      }
-
-      const overwriteRegistry = this.fileUploadRepository.create(
-        overwriteEntries.map(e => ({
-          ...(e as Record<string, unknown>),
-          created_at: new Date() as unknown as number
-        }))
-      );
-      if (overwriteRegistry.length > 0) {
-        await this.fileUploadRepository.upsert(overwriteRegistry, [
-          'file_id',
-          'workspace_id'
-        ]);
-      }
-      const freshnessIssues = (await Promise.all(changedCodingSchemes.map(change => (
-        this.markCodingSchemeFreshnessAfterFileChange(
-          workspaceId,
-          change.fileId,
-          change.previousData,
-          change.nextData
-        )
-      )))).filter((issue): issue is TestResultsUploadIssueDto => !!issue);
-      if (registry.length > 0 || overwriteRegistry.length > 0) {
-        await this.invalidateWorkspaceFileCaches(workspaceId);
-      }
-      return {
-        total: attemptedFiles.length,
-        uploaded: insertableFiles.length + overwriteFiles.length,
-        failed: 0,
-        uploadedFiles: [...insertableFiles, ...overwriteFiles],
-        conflicts: remainingConflicts.length ? remainingConflicts : undefined,
-        failedFiles: undefined,
-        issues: freshnessIssues.length ? freshnessIssues : undefined
-      };
     } catch (error) {
       this.logger.error('Error during test center import', error);
       return {
@@ -2953,16 +2989,22 @@ ${bookletRefs}
     workspaceId: number,
     responseIds: number[]
   ): Promise<number> {
-    const deletedCount = await this.workspaceResponseValidationService.deleteInvalidResponses(
+    return withWorkspaceTestResultsMutationLock(
+      this.fileUploadRepository.manager.connection,
       workspaceId,
-      responseIds
+      async () => {
+        const deletedCount = await this.workspaceResponseValidationService.deleteInvalidResponses(
+          workspaceId,
+          responseIds
+        );
+        if (deletedCount > 0) {
+          await this.workspaceTestResultsService.invalidateWorkspaceStatsCache(
+            workspaceId
+          );
+        }
+        return deletedCount;
+      }
     );
-    if (deletedCount > 0) {
-      await this.workspaceTestResultsService.invalidateWorkspaceStatsCache(
-        workspaceId
-      );
-    }
-    return deletedCount;
   }
 
   async deleteAllInvalidResponses(
@@ -2973,16 +3015,22 @@ ${bookletRefs}
     | 'responseStatus'
     | 'duplicateResponses'
   ): Promise<number> {
-    const deletedCount = await this.workspaceResponseValidationService.deleteAllInvalidResponses(
+    return withWorkspaceTestResultsMutationLock(
+      this.fileUploadRepository.manager.connection,
       workspaceId,
-      validationType
+      async () => {
+        const deletedCount = await this.workspaceResponseValidationService.deleteAllInvalidResponses(
+          workspaceId,
+          validationType
+        );
+        if (deletedCount > 0) {
+          await this.workspaceTestResultsService.invalidateWorkspaceStatsCache(
+            workspaceId
+          );
+        }
+        return deletedCount;
+      }
     );
-    if (deletedCount > 0) {
-      await this.workspaceTestResultsService.invalidateWorkspaceStatsCache(
-        workspaceId
-      );
-    }
-    return deletedCount;
   }
 
   async onModuleInit(): Promise<void> {

--- a/apps/backend/src/app/http/global-http-exception.filter.ts
+++ b/apps/backend/src/app/http/global-http-exception.filter.ts
@@ -34,6 +34,9 @@ export class GlobalHttpExceptionFilter implements ExceptionFilter {
     const requestId = request.requestId || createRequestId();
 
     request.requestId = requestId;
+    if (status >= HttpStatus.INTERNAL_SERVER_ERROR) {
+      request.monitoringErrorMessage = this.getExceptionMessage(exception);
+    }
     if (!response.headersSent) {
       response.setHeader(REQUEST_ID_HEADER, requestId);
     }
@@ -113,13 +116,18 @@ export class GlobalHttpExceptionFilter implements ExceptionFilter {
     status: number,
     requestId: string
   ): void {
-    const message = exception instanceof Error ? exception.message : String(exception);
+    const message = this.getExceptionMessage(exception);
     const stack = exception instanceof Error ? exception.stack : undefined;
 
     this.logger.error(
       `[${requestId}] ${request.method} ${request.originalUrl || request.url} failed with ${status}: ${message}`,
       stack
     );
+  }
+
+  private getExceptionMessage(exception: unknown): string {
+    return (exception instanceof Error ? exception.message : String(exception))
+      .slice(0, 1000);
   }
 
   private isObject(value: unknown): value is Record<string, unknown> {

--- a/apps/backend/src/app/http/request-id.ts
+++ b/apps/backend/src/app/http/request-id.ts
@@ -5,6 +5,7 @@ export const REQUEST_ID_HEADER = 'X-Request-Id';
 export const REPLAY_ATTEMPT_ID_HEADER = 'X-Replay-Attempt-Id';
 
 export interface RequestWithRequestId extends Request {
+  monitoringErrorMessage?: string;
   requestId?: string;
 }
 

--- a/apps/backend/src/app/http/request-monitoring.middleware.spec.ts
+++ b/apps/backend/src/app/http/request-monitoring.middleware.spec.ts
@@ -9,6 +9,7 @@ import {
   parseSlowRequestThresholdMs
 } from './request-monitoring.middleware';
 import { RequestWithRequestId } from './request-id';
+import { RequestMonitoringIncidentKind } from '../../../../../api-dto/request-monitoring/request-monitoring-incident.dto';
 
 describe('requestMonitoringMiddleware', () => {
   const createRequest = (request: Partial<RequestWithRequestId> = {}) => Object.assign(new EventEmitter(), {
@@ -95,6 +96,34 @@ describe('requestMonitoringMiddleware', () => {
       '[request-1] GET /api/admin/workspace/:id/coding/incomplete-variables/scope-summary failed with 500 in 100 ms'
     );
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should persist aggregated incident data for administrators', async () => {
+    const reportIncident = jest.fn().mockResolvedValue(undefined);
+    const now = createClock(BigInt(0), BigInt(1500000000));
+    const middleware = createRequestMonitoringMiddleware({
+      logger: { error: jest.fn(), warn: jest.fn() },
+      now,
+      reportIncident,
+      slowRequestThresholdMs: 1000
+    });
+    const response = createResponse(200);
+
+    middleware(createRequest(), response, jest.fn());
+    response.emit('finish');
+    await Promise.resolve();
+
+    expect(reportIncident).toHaveBeenCalledWith({
+      durationMs: 1500,
+      errorMessage: undefined,
+      kind: RequestMonitoringIncidentKind.Slow,
+      method: 'GET',
+      path: '/api/admin/workspace/:id/coding/incomplete-variables/scope-summary',
+      poolSnapshot: undefined,
+      requestId: 'request-1',
+      statusCode: 200,
+      workspaceId: 3
+    });
   });
 
   it('should normalize repeated slashes in monitored paths', () => {

--- a/apps/backend/src/app/http/request-monitoring.middleware.ts
+++ b/apps/backend/src/app/http/request-monitoring.middleware.ts
@@ -14,6 +14,7 @@ import {
   parseInFlightRequestThresholdMs,
   parseSlowRequestThresholdMs
 } from '../config/runtime-config.service';
+import { RequestMonitoringIncidentKind } from '../../../../../api-dto/request-monitoring/request-monitoring-incident.dto';
 
 export {
   DEFAULT_IN_FLIGHT_REQUEST_THRESHOLD_MS,
@@ -36,11 +37,24 @@ interface RequestMonitoringOptions {
   logStartedRequests?: boolean;
   logger?: RequestMonitoringLogger;
   now?: () => bigint;
+  reportIncident?: (incident: RequestMonitoringIncidentReport) => Promise<void> | void;
   setTimer?: (
     callback: () => void,
     delayMs: number
   ) => NodeJS.Timeout;
   slowRequestThresholdMs?: number;
+}
+
+export interface RequestMonitoringIncidentReport {
+  durationMs: number;
+  errorMessage?: string;
+  kind: RequestMonitoringIncidentKind;
+  method: string;
+  path: string;
+  poolSnapshot?: PostgresPoolSnapshot;
+  requestId: string;
+  statusCode?: number;
+  workspaceId?: number;
 }
 
 const NANOSECONDS_PER_MILLISECOND = BigInt(1000000);
@@ -71,7 +85,39 @@ export function createRequestMonitoringMiddleware(options: RequestMonitoringOpti
       `${request.method} ${getRequestPath(request)}${replayAttemptId ?
         ` attempt=${replayAttemptId}` :
         ''}`;
+    const requestPath = getRequestPath(request);
+    const workspaceId = getWorkspaceId(request);
     let terminalStateRecorded = false;
+
+    const reportIncident = (
+      kind: RequestMonitoringIncidentKind,
+      durationMs: number,
+      poolSnapshot?: PostgresPoolSnapshot,
+      statusCode?: number
+    ): void => {
+      if (!options.reportIncident) {
+        return;
+      }
+      try {
+        Promise.resolve(options.reportIncident({
+          durationMs,
+          errorMessage: request.monitoringErrorMessage,
+          kind,
+          method: request.method,
+          path: requestPath,
+          poolSnapshot,
+          requestId,
+          statusCode,
+          workspaceId
+        })).catch(error => logger.error(
+          `[${requestId}] Could not persist request monitoring incident: ${String(error)}`
+        ));
+      } catch (error) {
+        logger.error(
+          `[${requestId}] Could not persist request monitoring incident: ${String(error)}`
+        );
+      }
+    };
 
     if (options.logStartedRequests) {
       logger.log?.(`[${requestId}] ${requestDescription} started`);
@@ -81,11 +127,17 @@ export function createRequestMonitoringMiddleware(options: RequestMonitoringOpti
       if (terminalStateRecorded) {
         return;
       }
+      const poolSnapshot = options.getPoolSnapshot?.();
       logger.warn(
         `[${requestId}] ${requestDescription} still running after ` +
         `${inFlightRequestThresholdMs} ms${formatPoolSnapshot(
-          options.getPoolSnapshot?.()
+          poolSnapshot
         )}`
+      );
+      reportIncident(
+        RequestMonitoringIncidentKind.InFlight,
+        inFlightRequestThresholdMs,
+        poolSnapshot
       );
     }, inFlightRequestThresholdMs);
 
@@ -105,12 +157,25 @@ export function createRequestMonitoringMiddleware(options: RequestMonitoringOpti
         logger.warn(
           `[${requestId}] ${requestDescription} ${state} after ${durationMs} ms${formatPoolSnapshot(poolSnapshot)}`
         );
+        reportIncident(
+          state === 'aborted' ?
+            RequestMonitoringIncidentKind.Aborted :
+            RequestMonitoringIncidentKind.Closed,
+          durationMs,
+          poolSnapshot
+        );
         return;
       }
 
       if (response.statusCode >= 500) {
         logger.error(
           `[${requestId}] ${requestDescription} failed with ${response.statusCode} in ${durationMs} ms${formatPoolSnapshot(poolSnapshot)}`
+        );
+        reportIncident(
+          RequestMonitoringIncidentKind.Failed,
+          durationMs,
+          poolSnapshot,
+          response.statusCode
         );
         return;
       }
@@ -119,6 +184,12 @@ export function createRequestMonitoringMiddleware(options: RequestMonitoringOpti
         logger.warn(
           `[${requestId}] ${requestDescription} completed with ${response.statusCode} in ${durationMs} ms ` +
           `(slow request; threshold ${slowRequestThresholdMs} ms)${formatPoolSnapshot(poolSnapshot)}`
+        );
+        reportIncident(
+          RequestMonitoringIncidentKind.Slow,
+          durationMs,
+          poolSnapshot,
+          response.statusCode
         );
       }
     };
@@ -135,6 +206,13 @@ export function createRequestMonitoringMiddleware(options: RequestMonitoringOpti
 
     next();
   };
+}
+
+function getWorkspaceId(request: RequestWithRequestId): number | undefined {
+  const url = request.originalUrl || request.url || '';
+  const match = url.match(/\/workspace\/(\d+)(?:\/|$)/i);
+  const parsed = Number(match?.[1]);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function getHeaderValue(

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.spec.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.spec.ts
@@ -7,8 +7,9 @@ import { CodingAnalysisProcessor } from './coding-analysis.processor';
 
 describe('CodingAnalysisProcessor', () => {
   function createProcessor(cacheService: Partial<CacheService>) {
+    const statusRevisionQuery = jest.fn().mockResolvedValue([]);
     const processor = new CodingAnalysisProcessor(
-      {} as never,
+      { manager: { query: statusRevisionQuery } } as never,
       cacheService as CacheService,
       {} as WorkspaceExclusionService,
       {} as WorkspaceFilesService
@@ -49,7 +50,8 @@ describe('CodingAnalysisProcessor', () => {
 
     return {
       processor,
-      analysis
+      analysis,
+      statusRevisionQuery
     };
   }
 
@@ -71,12 +73,17 @@ describe('CodingAnalysisProcessor', () => {
       get: jest.fn().mockResolvedValue('newer-run'),
       set: jest.fn().mockResolvedValue(true)
     };
-    const { processor, analysis } = createProcessor(cacheService);
+    const {
+      processor,
+      analysis,
+      statusRevisionQuery
+    } = createProcessor(cacheService);
 
     await expect(processor.handleResponseAnalysis(createJob('old-run'))).resolves.toBe(analysis);
 
     expect(cacheService.get).toHaveBeenCalledWith('response-analysis:7__t2:run');
     expect(cacheService.set).not.toHaveBeenCalled();
+    expect(statusRevisionQuery).not.toHaveBeenCalled();
   });
 
   it('caches analysis results for the latest marked run', async () => {
@@ -84,10 +91,15 @@ describe('CodingAnalysisProcessor', () => {
       get: jest.fn().mockResolvedValue('current-run'),
       set: jest.fn().mockResolvedValue(true)
     };
-    const { processor, analysis } = createProcessor(cacheService);
+    const {
+      processor,
+      analysis,
+      statusRevisionQuery
+    } = createProcessor(cacheService);
 
     await expect(processor.handleResponseAnalysis(createJob('current-run'))).resolves.toBe(analysis);
 
     expect(cacheService.set).toHaveBeenCalledWith('response-analysis:7__t2', analysis);
+    expect(statusRevisionQuery).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
+++ b/apps/backend/src/app/job-queue/processors/coding-analysis.processor.ts
@@ -29,6 +29,7 @@ import {
   IQB_STANDARD_MISSING_CODES,
   MissingsProfilesService
 } from '../../database/services/coding/missings-profiles.service';
+import { touchWorkspaceCodingStatusRevision } from '../../database/services/shared/workspace-coding-status-revision.util';
 
 @Processor('response-analysis')
 export class CodingAnalysisProcessor {
@@ -79,6 +80,10 @@ export class CodingAnalysisProcessor {
       }
 
       await this.cacheService.set(cacheKey, analysis);
+      await touchWorkspaceCodingStatusRevision(
+        this.responseRepository.manager,
+        workspaceId
+      );
 
       this.logger.log(`Response analysis for workspace ${workspaceId} completed and cached.`);
       return analysis;

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -19,6 +19,7 @@ import { requestIdMiddleware } from './app/http/request-id.middleware';
 import { createPostgresPoolSnapshotProvider } from './app/database/postgres-pool-monitor';
 import { releaseCacheStartupWarmups } from './app/cache/cache-startup-warmup.queue';
 import { RuntimeConfigService } from './app/config/runtime-config.service';
+import { RequestMonitoringIncidentService } from './app/admin/request-monitoring/request-monitoring-incident.service';
 
 async function bootstrap() {
   if (isExportWorkerProcess()) {
@@ -37,6 +38,9 @@ async function bootstrap() {
   const getPoolSnapshot = createPostgresPoolSnapshotProvider(
     app.get(DataSource)
   );
+  const requestMonitoringIncidentService = app.get(
+    RequestMonitoringIncidentService
+  );
 
   app.use(requestIdMiddleware);
   app.useGlobalFilters(new GlobalHttpExceptionFilter());
@@ -51,6 +55,7 @@ async function bootstrap() {
     getPoolSnapshot,
     inFlightRequestThresholdMs: runtimeConfig.inFlightRequestThresholdMs,
     logStartedRequests: runtimeConfig.requestStartLogging,
+    reportIncident: incident => requestMonitoringIncidentService.record(incident),
     slowRequestThresholdMs: runtimeConfig.slowRequestThresholdMs
   }));
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1678,7 +1678,22 @@ describe('CodingManagementManualComponent', () => {
     expect(loadCodingFreshnessSpy).toHaveBeenCalledTimes(1);
     expect(loadResponseAnalysisSpy).toHaveBeenCalledTimes(1);
     expect(component.shouldRenderManualTabData('planning')).toBe(true);
+    expect(component.shouldShowManualRefreshButton()).toBe(false);
+  });
+
+  it('should show manual refresh actions only when automatic refresh is disabled', () => {
+    const componentInternals = component as unknown as {
+      hasLoadedManualCodingJobRefreshSetting: boolean;
+      appService: { selectedWorkspaceId: number };
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.hasLoadedManualCodingJobRefreshSetting = true;
+
+    component.autoRefreshManualCodingJobs = false;
     expect(component.shouldShowManualRefreshButton()).toBe(true);
+
+    component.autoRefreshManualCodingJobs = true;
+    expect(component.shouldShowManualRefreshButton()).toBe(false);
   });
 
   it('should cancel a deferred planning load when another tab becomes active', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1681,6 +1681,23 @@ describe('CodingManagementManualComponent', () => {
     expect(component.shouldShowManualRefreshButton()).toBe(true);
   });
 
+  it('should cancel a deferred planning load when another tab becomes active', () => {
+    component.selectedManualTabIndex = component.manualCodingTabs.indexOf('planning');
+    const componentInternals = component as unknown as {
+      pendingAutomaticManualTabLoad: 'planning' | null;
+      loadManualTabData(tab: string): void;
+    };
+    componentInternals.pendingAutomaticManualTabLoad = 'planning';
+    jest.spyOn(componentInternals, 'loadManualTabData').mockImplementation();
+
+    component.onManualTabChanged(
+      component.manualCodingTabs.indexOf('training')
+    );
+
+    expect(componentInternals.pendingAutomaticManualTabLoad).toBeNull();
+    expect(componentInternals.loadManualTabData).toHaveBeenCalledWith('training');
+  });
+
   it('should wait for the initial revision and reject a mixed planning snapshot', () => {
     const initialRevision$ = new Subject<{
       workspaceId: number;

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1681,6 +1681,27 @@ describe('CodingManagementManualComponent', () => {
     expect(component.shouldShowManualRefreshButton()).toBe(false);
   });
 
+  it('should load planning data on first open after restoring a status snapshot', () => {
+    component.autoRefreshManualCodingJobs = true;
+    const componentInternals = component as unknown as {
+      hasLoadedManualCodingJobRefreshSetting: boolean;
+      hasLoadedPlanningDataBundle: boolean;
+      restoredManualStatusSnapshot: unknown;
+      loadManualTabData(tab: 'planning'): void;
+      loadPlanningDataBundle(forceRefresh: boolean): void;
+    };
+    componentInternals.hasLoadedManualCodingJobRefreshSetting = true;
+    componentInternals.hasLoadedPlanningDataBundle = false;
+    componentInternals.restoredManualStatusSnapshot = {};
+    const loadPlanningDataBundleSpy = jest
+      .spyOn(componentInternals, 'loadPlanningDataBundle')
+      .mockImplementation();
+
+    componentInternals.loadManualTabData('planning');
+
+    expect(loadPlanningDataBundleSpy).toHaveBeenCalledWith(false);
+  });
+
   it('should show manual refresh actions only when automatic refresh is disabled', () => {
     const componentInternals = component as unknown as {
       hasLoadedManualCodingJobRefreshSetting: boolean;

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1713,6 +1713,145 @@ describe('CodingManagementManualComponent', () => {
     expect(componentInternals.loadManualTabData).toHaveBeenCalledWith('training');
   });
 
+  it('should not start planning data after leaving while the revision is pending', () => {
+    const revision$ = new Subject<{
+      workspaceId: number;
+      revision: number;
+      statusRevision: string;
+      stable: boolean;
+    }>();
+    const snapshotService = TestBed.inject(CodingStatusSnapshotService);
+    (snapshotService.getRevision as jest.Mock)
+      .mockReset()
+      .mockReturnValue(revision$.asObservable());
+    component.selectedManualTabIndex = component.manualCodingTabs.indexOf('planning');
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      loadPlanningDataBundle(forceRefresh: boolean): void;
+      startPlanningDataBundleLoad(forceRefresh: boolean): void;
+      loadManualTabData(tab: string): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    const startPlanningDataSpy = jest
+      .spyOn(componentInternals, 'startPlanningDataBundleLoad')
+      .mockImplementation();
+    jest.spyOn(componentInternals, 'loadManualTabData').mockImplementation();
+
+    componentInternals.loadPlanningDataBundle(false);
+    component.onManualTabChanged(component.manualCodingTabs.indexOf('training'));
+    revision$.next({
+      workspaceId: 5,
+      revision: 1,
+      statusRevision: '1',
+      stable: true
+    });
+    revision$.complete();
+
+    expect(startPlanningDataSpy).not.toHaveBeenCalled();
+  });
+
+  it('should restore freshness warnings from a manual status snapshot', () => {
+    const freshness = {
+      workspaceId: 5,
+      currentRevision: 4,
+      items: [{
+        version: 'v2' as const,
+        state: 'STALE' as const,
+        unitCount: 2,
+        affectedResponseCount: 7
+      }]
+    };
+    const snapshotService = TestBed.inject(CodingStatusSnapshotService);
+    jest.spyOn(snapshotService, 'restoreManual').mockReturnValue(of({
+      schemaVersion: 1,
+      userId: 7,
+      workspaceId: 5,
+      revision: 4,
+      statusRevision: '9',
+      checkedAt: new Date().toISOString(),
+      surface: 'manual',
+      fullyChecked: true,
+      planningStatus: 'warning',
+      displayParameters: {
+        variableConflicts: 0,
+        missingVariables: 0,
+        unassignedCases: 0,
+        activeTrainingJobs: 0,
+        staleSourceJobs: 0,
+        openDoubleCodingConflicts: 0,
+        manualCodeAvailabilityWarnings: 0
+      },
+      freshness,
+      nextTarget: {
+        tab: 'planning',
+        sectionId: 'manual-planning',
+        action: 'navigate'
+      }
+    }));
+    const componentInternals = component as unknown as {
+      appService: {
+        selectedWorkspaceId: number;
+        updateAuthData(authData: unknown): void;
+      };
+      restoreManualCodingStatusSnapshot(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.appService.updateAuthData({ userId: 7 });
+    component.autoRefreshManualCodingJobs = false;
+
+    componentInternals.restoreManualCodingStatusSnapshot();
+
+    expect(component.codingFreshnessSummary).toEqual(freshness);
+    expect(component.hasCodingFreshnessWarnings).toBe(true);
+  });
+
+  it('should not save a fully checked snapshot after a planning request fails', () => {
+    setCompletePlanningState();
+    const snapshotService = TestBed.inject(CodingStatusSnapshotService);
+    const saveSnapshotSpy = jest
+      .spyOn(snapshotService, 'saveManual')
+      .mockImplementation();
+    const componentInternals = component as unknown as {
+      appService: {
+        selectedWorkspaceId: number;
+        updateAuthData(authData: unknown): void;
+      };
+      testPersonCodingService: {
+        getVariableCoverageOverview(workspaceId: number): Observable<never>;
+      };
+      planningDataLoadRequestId: number;
+      failedPlanningDataLoadRequestId: number | null;
+      manualSnapshotLoadRevision: {
+        workspaceId: number;
+        revision: number;
+        statusRevision: string;
+        stable: boolean;
+      };
+      loadVariableCoverageOverview(): void;
+      trySaveManualCodingStatusSnapshot(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.appService.updateAuthData({ userId: 7 });
+    componentInternals.planningDataLoadRequestId = 3;
+    componentInternals.failedPlanningDataLoadRequestId = null;
+    componentInternals.manualSnapshotLoadRevision = {
+      workspaceId: 5,
+      revision: 4,
+      statusRevision: '9',
+      stable: true
+    };
+    jest.spyOn(
+      componentInternals.testPersonCodingService,
+      'getVariableCoverageOverview'
+    ).mockReturnValue(throwError(() => new Error('failed')));
+
+    componentInternals.loadVariableCoverageOverview();
+    componentInternals.trySaveManualCodingStatusSnapshot();
+
+    expect(componentInternals.failedPlanningDataLoadRequestId).toBe(3);
+    expect(saveSnapshotSpy).not.toHaveBeenCalled();
+  });
+
   it('should wait for the initial revision and reject a mixed planning snapshot', () => {
     const initialRevision$ = new Subject<{
       workspaceId: number;
@@ -1749,6 +1888,7 @@ describe('CodingManagementManualComponent', () => {
     };
     componentInternals.appService.selectedWorkspaceId = 5;
     componentInternals.appService.updateAuthData({ userId: 7 });
+    component.selectedManualTabIndex = component.manualCodingTabs.indexOf('planning');
     const dataLoadSpies = [
       jest.spyOn(componentInternals, 'loadVariableCoverageOverview').mockImplementation(),
       jest.spyOn(componentInternals, 'loadCaseCoverageOverview').mockImplementation(),

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1586,7 +1586,7 @@ describe('CodingManagementManualComponent', () => {
     expect(refreshCodingJobsAfterDataChangeSpy).toHaveBeenCalledWith('productive');
   });
 
-  it('should not load bundled planning data when the planning tab is opened', () => {
+  it('should load bundled planning data when planning is opened without a snapshot', () => {
     component.selectedManualTabIndex = 1;
     component.autoRefreshManualCodingJobs = true;
     const componentInternals = component as unknown as {
@@ -1627,13 +1627,13 @@ describe('CodingManagementManualComponent', () => {
 
     componentInternals.loadManualTabData('planning');
 
-    expect(variableCoverageSpy).not.toHaveBeenCalled();
-    expect(caseCoverageSpy).not.toHaveBeenCalled();
-    expect(codingProgressSpy).not.toHaveBeenCalled();
-    expect(incompleteVariablesSpy).not.toHaveBeenCalled();
-    expect(manualFreshnessDecisionSpy).not.toHaveBeenCalled();
-    expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
-    expect(loadResponseAnalysisSpy).not.toHaveBeenCalled();
+    expect(variableCoverageSpy).toHaveBeenCalledTimes(1);
+    expect(caseCoverageSpy).toHaveBeenCalledTimes(1);
+    expect(codingProgressSpy).toHaveBeenCalledTimes(1);
+    expect(incompleteVariablesSpy).toHaveBeenCalledTimes(1);
+    expect(manualFreshnessDecisionSpy).toHaveBeenCalledTimes(1);
+    expect(loadCodingFreshnessSpy).toHaveBeenCalledTimes(1);
+    expect(loadResponseAnalysisSpy).toHaveBeenCalledTimes(1);
     expect(component.shouldRenderManualTabData('planning')).toBe(true);
     expect(component.shouldShowManualRefreshButton()).toBe(true);
   });

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -23,6 +23,7 @@ import type {
   ManualCodeAvailabilityWarningDto
 } from '../../../../../../../api-dto/coding/manual-code-availability.dto';
 import { DoubleCodedReviewComponent } from '../double-coded-review/double-coded-review.component';
+import { CodingStatusSnapshotService } from '../../services/coding-status-snapshot.service';
 
 type VariableCoverageOverview = NonNullable<
 CodingManagementManualComponent['variableCoverageOverview']
@@ -160,6 +161,15 @@ describe('CodingManagementManualComponent', () => {
 
     fixture = TestBed.createComponent(CodingManagementManualComponent);
     component = fixture.componentInstance;
+    jest.spyOn(
+      TestBed.inject(CodingStatusSnapshotService),
+      'getRevision'
+    ).mockReturnValue(of({
+      workspaceId: 5,
+      revision: 0,
+      statusRevision: '0',
+      stable: true
+    }));
     fixture.detectChanges();
   });
 
@@ -1173,6 +1183,39 @@ describe('CodingManagementManualComponent', () => {
     expect(component.getPlanningStatusTitle()).toBe('Status wird aktualisiert');
   });
 
+  it('should keep a neutral planning status when execution loaded only partial data', () => {
+    component.selectedManualTabIndex = component.manualCodingTabs.indexOf('execution');
+    component.caseCoverageOverview = {
+      totalCasesToCode: 10,
+      effectiveTotalCasesToCode: 10,
+      casesInJobs: 5,
+      effectiveCasesInJobs: 5,
+      doubleCodedCases: 0,
+      singleCodedCases: 5,
+      unassignedCases: 5,
+      effectiveUnassignedCases: 5,
+      coveragePercentage: 50,
+      rawCoveragePercentage: 50,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0
+    } satisfies CaseCoverageOverview;
+    component.codingProgressOverview = {
+      totalCasesToCode: 10,
+      completedCases: 2,
+      completionPercentage: 20,
+      rawTotalCasesToCode: 10,
+      rawCompletedCases: 2,
+      rawCompletionPercentage: 20,
+      aggregationActive: false,
+      aggregationThreshold: null,
+      aggregatedDuplicateCases: 0
+    } satisfies CodingProgressOverview;
+
+    expect(component.getPlanningStatusIcon()).toBe('help_outline');
+    expect(component.getPlanningStatusTitle()).toBe('Kodierstand nicht geprüft');
+  });
+
   it('should ask for an explicit planning data refresh before loading planning snapshots', () => {
     component.selectedManualTabIndex = 1;
     const componentInternals = component as unknown as {
@@ -1636,6 +1679,68 @@ describe('CodingManagementManualComponent', () => {
     expect(loadResponseAnalysisSpy).toHaveBeenCalledTimes(1);
     expect(component.shouldRenderManualTabData('planning')).toBe(true);
     expect(component.shouldShowManualRefreshButton()).toBe(true);
+  });
+
+  it('should wait for the initial revision and reject a mixed planning snapshot', () => {
+    const initialRevision$ = new Subject<{
+      workspaceId: number;
+      revision: number;
+      statusRevision: string;
+      stable: boolean;
+    }>();
+    const snapshotService = TestBed.inject(CodingStatusSnapshotService);
+    (snapshotService.getRevision as jest.Mock)
+      .mockReset()
+      .mockReturnValueOnce(initialRevision$.asObservable())
+      .mockReturnValueOnce(of({
+        workspaceId: 5,
+        revision: 0,
+        statusRevision: '2',
+        stable: true
+      }));
+    const saveSnapshotSpy = jest
+      .spyOn(snapshotService, 'saveManual')
+      .mockImplementation();
+    const componentInternals = component as unknown as {
+      appService: {
+        selectedWorkspaceId: number;
+        updateAuthData(authData: unknown): void;
+      };
+      loadPlanningDataBundle(forceRefresh: boolean): void;
+      loadVariableCoverageOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadCodingProgressOverview(): void;
+      loadCodingIncompleteVariables(): void;
+      loadManualFreshnessDecisionData(): void;
+      loadCodingFreshness(): void;
+      loadResponseAnalysisForPlanningIfNeeded(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.appService.updateAuthData({ userId: 7 });
+    const dataLoadSpies = [
+      jest.spyOn(componentInternals, 'loadVariableCoverageOverview').mockImplementation(),
+      jest.spyOn(componentInternals, 'loadCaseCoverageOverview').mockImplementation(),
+      jest.spyOn(componentInternals, 'loadCodingProgressOverview').mockImplementation(),
+      jest.spyOn(componentInternals, 'loadCodingIncompleteVariables').mockImplementation(),
+      jest.spyOn(componentInternals, 'loadManualFreshnessDecisionData').mockImplementation(),
+      jest.spyOn(componentInternals, 'loadCodingFreshness').mockImplementation(),
+      jest.spyOn(componentInternals, 'loadResponseAnalysisForPlanningIfNeeded').mockImplementation()
+    ];
+
+    componentInternals.loadPlanningDataBundle(false);
+
+    dataLoadSpies.forEach(spy => expect(spy).not.toHaveBeenCalled());
+
+    initialRevision$.next({
+      workspaceId: 5,
+      revision: 0,
+      statusRevision: '1',
+      stable: true
+    });
+    initialRevision$.complete();
+
+    dataLoadSpies.forEach(spy => expect(spy).toHaveBeenCalledTimes(1));
+    expect(saveSnapshotSpy).not.toHaveBeenCalled();
   });
 
   it('should skip automatic planning metrics when auto-refresh is disabled', () => {
@@ -3671,6 +3776,8 @@ describe('CodingManagementManualComponent', () => {
   }
 
   function setEmptyPlanningSnapshots(): void {
+    (component as unknown as { hasLoadedPlanningDataBundle: boolean })
+      .hasLoadedPlanningDataBundle = true;
     component.variableCoverageOverview = {
       totalVariables: 0,
       coveredVariables: 0,

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -751,6 +751,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
     const previousTab = this.activeManualTab;
     this.selectedManualTabIndex = index;
+    this.clearPendingPlanningLoadWhenInactive();
     if (this.isResponseAnalysisTab(previousTab) &&
       !this.isResponseAnalysisTab(this.activeManualTab)) {
       this.stopResponseAnalysisView();
@@ -767,6 +768,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     if (this.selectedManualTabIndex !== tabIndex) {
       const previousTab = this.activeManualTab;
       this.selectedManualTabIndex = tabIndex;
+      this.clearPendingPlanningLoadWhenInactive();
       if (this.isResponseAnalysisTab(previousTab) &&
         !this.isResponseAnalysisTab(tab)) {
         this.stopResponseAnalysisView();
@@ -3275,9 +3277,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         finalize(() => {
           this.isRestoringManualStatusSnapshot = false;
           if (this.hasLoadedManualCodingJobRefreshSetting &&
-              this.pendingAutomaticManualTabLoad === 'planning') {
+              this.pendingAutomaticManualTabLoad === 'planning' &&
+              this.activeManualTab === 'planning') {
             this.pendingAutomaticManualTabLoad = null;
             this.loadManualTabData('planning');
+          } else if (this.activeManualTab !== 'planning') {
+            this.pendingAutomaticManualTabLoad = null;
           }
         }),
         takeUntil(this.destroy$)
@@ -3358,6 +3363,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         return;
       default:
         this.refreshAllStatistics();
+    }
+  }
+
+  private clearPendingPlanningLoadWhenInactive(): void {
+    if (this.activeManualTab !== 'planning' &&
+        this.pendingAutomaticManualTabLoad === 'planning') {
+      this.pendingAutomaticManualTabLoad = null;
     }
   }
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -261,7 +261,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private manualSnapshotSavePending = false;
   private isRestoringManualStatusSnapshot = false;
   private planningDataLoadRequestId = 0;
+  private failedPlanningDataLoadRequestId: number | null = null;
   private isLoadingPlanningDataRevision = false;
+  private isStartingPlanningDataBundle = false;
 
   private pendingAutomaticManualTabLoad: ManualCodingTab | null = null;
 
@@ -283,6 +285,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   isLoadingCodingProgress = false;
   isLoadingManualCodeAvailability = false;
   isLoadingCodingIncompleteVariables = false;
+  isLoadingManualCodingScopeSummary = false;
   isLoadingAppliedResultsOverview = false;
   isLoadingKappaSummary = false;
 
@@ -2076,6 +2079,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingCaseCoverage ||
       this.isLoadingManualCodeAvailability ||
       this.isLoadingCodingIncompleteVariables ||
+      this.isLoadingManualCodingScopeSummary ||
       this.isLoadingAppliedResultsOverview ||
       this.isLoadingManualFreshnessJobSummary ||
       this.isLoadingDoubleCodingConflictSummary ||
@@ -2090,6 +2094,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingCaseCoverage ||
       this.isLoadingManualCodeAvailability ||
       this.isLoadingCodingIncompleteVariables ||
+      this.isLoadingManualCodingScopeSummary ||
       this.isLoadingAppliedResultsOverview ||
       this.isLoadingManualFreshnessJobSummary ||
       this.isLoadingDoubleCodingConflictSummary ||
@@ -3291,6 +3296,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           return;
         }
         this.restoredManualStatusSnapshot = snapshot;
+        if (snapshot && this.lastCodingFreshnessRefreshAt === 0) {
+          this.codingFreshnessSummary = snapshot.freshness;
+        }
       });
   }
 
@@ -3366,9 +3374,23 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private clearPendingPlanningLoadWhenInactive(): void {
-    if (this.activeManualTab !== 'planning' &&
-        this.pendingAutomaticManualTabLoad === 'planning') {
+    if (this.activeManualTab === 'planning') {
+      return;
+    }
+
+    if (this.pendingAutomaticManualTabLoad === 'planning') {
       this.pendingAutomaticManualTabLoad = null;
+    }
+
+    if (this.isLoadingPlanningDataRevision) {
+      this.planningDataLoadRequestId += 1;
+      this.isLoadingPlanningDataRevision = false;
+    }
+  }
+
+  private markPlanningDataLoadFailed(requestId: number): void {
+    if (requestId === this.planningDataLoadRequestId) {
+      this.failedPlanningDataLoadRequestId = requestId;
     }
   }
 
@@ -3376,6 +3398,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const workspaceId = this.appService.selectedWorkspaceId;
     this.planningDataLoadRequestId += 1;
     const requestId = this.planningDataLoadRequestId;
+    this.failedPlanningDataLoadRequestId = null;
     this.restoredManualStatusSnapshot = null;
     this.manualSnapshotLoadRevision = null;
     if (!workspaceId) {
@@ -3397,7 +3420,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       )
       .subscribe(revision => {
         if (requestId !== this.planningDataLoadRequestId ||
-          this.appService.selectedWorkspaceId !== workspaceId) {
+          this.appService.selectedWorkspaceId !== workspaceId ||
+          this.activeManualTab !== 'planning') {
           return;
         }
 
@@ -3408,13 +3432,19 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private startPlanningDataBundleLoad(forceRefresh: boolean): void {
     this.hasLoadedPlanningDataBundle = true;
-    this.loadVariableCoverageOverview();
-    this.loadCaseCoverageOverview();
-    this.loadCodingProgressOverview();
-    this.loadCodingIncompleteVariables();
-    this.loadManualFreshnessDecisionData();
-    this.loadCodingFreshness({ force: forceRefresh });
-    this.loadResponseAnalysisForPlanningIfNeeded();
+    this.isStartingPlanningDataBundle = true;
+    try {
+      this.loadVariableCoverageOverview();
+      this.loadCaseCoverageOverview();
+      this.loadCodingProgressOverview();
+      this.loadCodingIncompleteVariables();
+      this.loadManualFreshnessDecisionData();
+      this.loadCodingFreshness({ force: forceRefresh });
+      this.loadResponseAnalysisForPlanningIfNeeded();
+    } finally {
+      this.isStartingPlanningDataBundle = false;
+      this.trySaveManualCodingStatusSnapshot();
+    }
   }
 
   private loadManualCodingJobRefreshSetting(): void {
@@ -3542,6 +3572,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const initialRevision = this.manualSnapshotLoadRevision;
     if (!workspaceId || userId <= 0 || !initialRevision ||
       this.manualSnapshotSavePending || !this.hasLoadedPlanningDataBundle ||
+      this.failedPlanningDataLoadRequestId === this.planningDataLoadRequestId ||
+      this.isStartingPlanningDataBundle ||
       this.isPlanningStatusLoading() || this.isLoadingCodingFreshness) {
       return;
     }
@@ -3881,6 +3913,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     if (!workspaceId) {
       return;
     }
+    const planningDataLoadRequestId = this.planningDataLoadRequestId;
 
     this.isLoadingCodingProgress = true;
     this.testPersonCodingService
@@ -3898,6 +3931,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.codingProgressOverview = null;
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
         }
       });
   }
@@ -3915,6 +3949,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingDoubleCodingConflictSummary = false;
       return;
     }
+    const planningDataLoadRequestId = this.planningDataLoadRequestId;
 
     this.isLoadingManualFreshnessJobSummary = true;
     this.codingJobBackendService
@@ -3940,6 +3975,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.manualFreshnessJobSummary = null;
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
         }
       });
   }
@@ -3960,6 +3996,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingDoubleCodingConflictSummary = false;
       return;
     }
+    const planningDataLoadRequestId = this.planningDataLoadRequestId;
 
     this.isLoadingDoubleCodingConflictSummary = true;
     this.doubleCodedReviewApi
@@ -3987,6 +4024,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.openDoubleCodingConflictCount = 0;
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
         }
       });
   }
@@ -4060,6 +4098,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     if (!workspaceId) {
       return;
     }
+    const planningDataLoadRequestId = this.planningDataLoadRequestId;
 
     this.isLoadingVariableCoverage = true;
     this.testPersonCodingService
@@ -4106,9 +4145,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           coveredSourceResponseCount?: number;
         } | null) => {
           this.variableCoverageOverview = overview;
+          if (!overview) {
+            this.markPlanningDataLoadFailed(planningDataLoadRequestId);
+          }
         },
         error: () => {
           this.variableCoverageOverview = null;
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
         }
       });
   }
@@ -4118,6 +4161,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     if (!workspaceId) {
       return;
     }
+    const planningDataLoadRequestId = this.planningDataLoadRequestId;
 
     this.isLoadingCaseCoverage = true;
     this.testPersonCodingService
@@ -4132,9 +4176,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (overview: CaseCoverageOverview | null) => {
           this.caseCoverageOverview = overview;
+          if (!overview) {
+            this.markPlanningDataLoadFailed(planningDataLoadRequestId);
+          }
         },
         error: () => {
           this.caseCoverageOverview = null;
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
         }
       });
   }
@@ -4190,9 +4238,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.manualCodingScopeSummary = null;
       this.setManualCodeAvailabilityWarnings([]);
       this.isLoadingCodingIncompleteVariables = false;
+      this.isLoadingManualCodingScopeSummary = false;
       this.isLoadingManualCodeAvailability = false;
       return;
     }
+    const planningDataLoadRequestId = this.planningDataLoadRequestId;
 
     this.isLoadingCodingIncompleteVariables = true;
     this.codingJobBackendService
@@ -4219,19 +4269,28 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.codingIncompleteVariables = [];
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
           this.loadAppliedResultsOverview();
         }
       });
 
+    this.isLoadingManualCodingScopeSummary = true;
     this.codingJobBackendService
       .getManualCodingScopeSummary(workspaceId)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.isLoadingManualCodingScopeSummary = false;
+          this.focusManualFreshnessTargetIfReady();
+        })
+      )
       .subscribe({
         next: summary => {
           this.manualCodingScopeSummary = summary;
         },
         error: () => {
           this.manualCodingScopeSummary = null;
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
         }
       });
 
@@ -4251,6 +4310,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.setManualCodeAvailabilityWarnings([]);
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
         }
       });
   }
@@ -4324,6 +4384,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingAppliedResultsOverview = false;
       return;
     }
+    const planningDataLoadRequestId = this.planningDataLoadRequestId;
 
     this.isLoadingAppliedResultsOverview = true;
     this.testPersonCodingService
@@ -4355,6 +4416,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.appliedResultsOverview = null;
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
         }
       });
   }
@@ -4506,6 +4568,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.restoredManualStatusSnapshot = null;
     this.manualSnapshotLoadRevision = null;
     this.planningDataLoadRequestId += 1;
+    this.failedPlanningDataLoadRequestId = null;
     this.isLoadingPlanningDataRevision = false;
     if (workspaceId) {
       this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
@@ -4935,6 +4998,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingResponseAnalysis = false;
       return;
     }
+    const planningDataLoadRequestId = this.planningDataLoadRequestId;
 
     if (!this.isResponseAnalysisTab(this.activeManualTab)) {
       this.stopResponseAnalysisView();
@@ -5009,6 +5073,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.setResponseAnalysisGuardActive(false);
           this.responseAnalysis = null;
           this.responseAnalysisError = responseAnalysisError;
+          this.markPlanningDataLoadFailed(planningDataLoadRequestId);
           this.snackBar.open(
             this.responseAnalysisError,
             'OK',

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -725,8 +725,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   shouldShowManualRefreshButton(): boolean {
     return !!this.appService.selectedWorkspaceId &&
       this.hasLoadedManualCodingJobRefreshSetting &&
-      (this.activeManualTab === 'planning' ||
-        !this.autoRefreshManualCodingJobs);
+      !this.autoRefreshManualCodingJobs;
   }
 
   shouldShowManualTabLoadHint(tab: ManualCodingTab): boolean {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -18,6 +18,7 @@ import { MatInputModule } from '@angular/material/input';
 import {
   Subject, takeUntil, debounceTime, finalize, Observable, of, tap,
   distinctUntilChanged,
+  catchError,
   firstValueFrom,
   map,
   switchMap
@@ -259,6 +260,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private manualSnapshotLoadRevision: CodingStatusRevisionDto | null = null;
   private manualSnapshotSavePending = false;
   private isRestoringManualStatusSnapshot = false;
+  private planningDataLoadRequestId = 0;
+  private isLoadingPlanningDataRevision = false;
 
   private pendingAutomaticManualTabLoad: ManualCodingTab | null = null;
 
@@ -2079,7 +2082,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private isPlanningStatusLoading(): boolean {
-    return this.isLoadingInitialResponseAnalysisForStatus() ||
+    return this.isLoadingPlanningDataRevision ||
+      this.isLoadingInitialResponseAnalysisForStatus() ||
       this.isLoadingCodingProgress ||
       this.isLoadingVariableCoverage ||
       this.isLoadingCaseCoverage ||
@@ -2631,8 +2635,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     if (this.activeManualTab !== 'planning' &&
-        !this.hasLoadedPlanningDataBundle &&
-        !this.hasLivePlanningStatusData()) {
+      !this.hasLoadedPlanningDataBundle) {
       return 'not-checked';
     }
 
@@ -2693,16 +2696,6 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     return 'planning-ready';
-  }
-
-  private hasLivePlanningStatusData(): boolean {
-    return this.variableCoverageOverview !== null ||
-      this.caseCoverageOverview !== null ||
-      this.codingProgressOverview !== null ||
-      this.appliedResultsOverview !== null ||
-      this.manualFreshnessJobSummary !== null ||
-      this.manualCodeAvailabilityWarnings.length > 0 ||
-      this.openDoubleCodingConflictCount > 0;
   }
 
   getPlanningStatusIcon(): string {
@@ -3370,19 +3363,39 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private loadPlanningDataBundle(forceRefresh: boolean): void {
     const workspaceId = this.appService.selectedWorkspaceId;
+    this.planningDataLoadRequestId += 1;
+    const requestId = this.planningDataLoadRequestId;
     this.restoredManualStatusSnapshot = null;
     this.manualSnapshotLoadRevision = null;
-    if (workspaceId) {
-      this.codingStatusSnapshotService.getRevision(workspaceId, true)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(revision => {
-          if (revision.stable &&
-            this.appService.selectedWorkspaceId === workspaceId) {
-            this.manualSnapshotLoadRevision = revision;
+    if (!workspaceId) {
+      this.startPlanningDataBundleLoad(forceRefresh);
+      return;
+    }
+
+    this.isLoadingPlanningDataRevision = true;
+    this.codingStatusSnapshotService.getRevision(workspaceId, true)
+      .pipe(
+        catchError(() => of(null)),
+        finalize(() => {
+          if (requestId === this.planningDataLoadRequestId) {
+            this.isLoadingPlanningDataRevision = false;
             this.trySaveManualCodingStatusSnapshot();
           }
-        });
-    }
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(revision => {
+        if (requestId !== this.planningDataLoadRequestId ||
+          this.appService.selectedWorkspaceId !== workspaceId) {
+          return;
+        }
+
+        this.manualSnapshotLoadRevision = revision?.stable ? revision : null;
+        this.startPlanningDataBundleLoad(forceRefresh);
+      });
+  }
+
+  private startPlanningDataBundleLoad(forceRefresh: boolean): void {
     this.hasLoadedPlanningDataBundle = true;
     this.loadVariableCoverageOverview();
     this.loadCaseCoverageOverview();
@@ -4481,6 +4494,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const workspaceId = this.appService.selectedWorkspaceId;
     this.restoredManualStatusSnapshot = null;
     this.manualSnapshotLoadRevision = null;
+    this.planningDataLoadRequestId += 1;
+    this.isLoadingPlanningDataRevision = false;
     if (workspaceId) {
       this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
     }

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -3338,8 +3338,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         if (!deferStatusChecks &&
           (forceRefresh ||
             (this.autoRefreshManualCodingJobs &&
-              !this.hasLoadedPlanningDataBundle &&
-              !this.restoredManualStatusSnapshot))) {
+              !this.hasLoadedPlanningDataBundle))) {
           this.loadPlanningDataBundle(forceRefresh);
         }
         return;

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -126,27 +126,18 @@ import {
 import { CohensKappaStatisticsComponent } from '../cohens-kappa-statistics/cohens-kappa-statistics.component';
 import { DoubleCodedReviewComponent } from '../double-coded-review/double-coded-review.component';
 import { CodingBackgroundJobsService } from '../../services/coding-background-jobs.service';
+import { CodingStatusSnapshotService } from '../../services/coding-status-snapshot.service';
+import {
+  ManualCodingStatusSnapshot,
+  PlanningStatusState
+} from '../../services/coding-status-snapshot.model';
+import { CodingStatusRevisionDto } from '../../../../../../../api-dto/coding/coding-status-revision.dto';
 
 interface SavedCodeProgress {
   id?: number;
   codingIssueOption?: number;
   [key: string]: unknown;
 }
-
-type PlanningStatusState =
-  'loading' |
-  'planning-data-required' |
-  'preparation-required' |
-  'warning' |
-  'planning-incomplete' |
-  'planning-ready' |
-  'training-ready' |
-  'execution-ready' |
-  'double-coding-review-ready' |
-  'stale-source-review' |
-  'completion-ready' |
-  'progress-unavailable' |
-  'complete';
 
 type ManualCodingTab = 'preparation' | 'planning' | 'training' | 'execution' | 'completion';
 type ConcreteCodingJobsReloadScope = 'productive' | 'training';
@@ -226,6 +217,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
   private codingBackgroundJobsService = inject(CodingBackgroundJobsService);
+  private codingStatusSnapshotService = inject(CodingStatusSnapshotService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private document = inject(DOCUMENT);
@@ -263,6 +255,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   };
 
   private hasLoadedPlanningDataBundle = false;
+  private restoredManualStatusSnapshot: ManualCodingStatusSnapshot | null = null;
+  private manualSnapshotLoadRevision: CodingStatusRevisionDto | null = null;
+  private manualSnapshotSavePending = false;
+  private isRestoringManualStatusSnapshot = false;
 
   private pendingAutomaticManualTabLoad: ManualCodingTab | null = null;
 
@@ -521,6 +517,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(reloadScope => {
         this.hasLoadedPlanningDataBundle = false;
+        this.restoredManualStatusSnapshot = null;
         this.loadJobDefinitionsForExport();
         this.loadManualTabData(this.activeManualTab);
         this.refreshCodingJobsAfterDataChange(reloadScope);
@@ -578,6 +575,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
         if (this.activeManualTab === 'planning') {
           this.hasLoadedPlanningDataBundle = false;
+          this.restoredManualStatusSnapshot = null;
           this.refreshCodingJobsAfterDataChange('rendered');
           return;
         }
@@ -605,6 +603,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .subscribe(() => this.restoreCoderTrainingRecoveryOverlay());
     this.restoreCoderTrainingRecoveryOverlay();
 
+    this.restoreManualCodingStatusSnapshot();
     this.loadInitialManualCodingState();
     this.loadManualCodingJobRefreshSetting();
     this.loadManualCodingApplyPermission();
@@ -2279,7 +2278,38 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   hasVariableCoverageConflicts(): boolean {
-    return (this.variableCoverageOverview?.conflictedVariables || 0) > 0;
+    return this.getVariableConflictCount() > 0;
+  }
+
+  private getVariableConflictCount(): number {
+    return this.variableCoverageOverview?.conflictedVariables ??
+      this.restoredManualStatusSnapshot?.displayParameters.variableConflicts ?? 0;
+  }
+
+  private getMissingVariableCount(): number {
+    return this.variableCoverageOverview?.missingVariables ??
+      this.restoredManualStatusSnapshot?.displayParameters.missingVariables ?? 0;
+  }
+
+  private getUnassignedCaseCount(): number {
+    return this.caseCoverageOverview?.effectiveUnassignedCases ??
+      this.restoredManualStatusSnapshot?.displayParameters.unassignedCases ?? 0;
+  }
+
+  private getActiveTrainingJobCount(): number {
+    return this.manualFreshnessJobSummary?.activeTrainingJobs ??
+      this.restoredManualStatusSnapshot?.displayParameters.activeTrainingJobs ?? 0;
+  }
+
+  private getStaleSourceJobCount(): number {
+    return this.manualFreshnessJobSummary?.staleSourceJobs ??
+      this.restoredManualStatusSnapshot?.displayParameters.staleSourceJobs ?? 0;
+  }
+
+  private getOpenDoubleCodingConflictCount(): number {
+    return this.hasLoadedPlanningDataBundle || this.openDoubleCodingConflictCount > 0 ?
+      this.openDoubleCodingConflictCount :
+      (this.restoredManualStatusSnapshot?.displayParameters.openDoubleCodingConflicts || 0);
   }
 
   isPlanningReady(): boolean {
@@ -2298,7 +2328,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private hasActiveTrainingCodingJobs(): boolean {
-    return (this.manualFreshnessJobSummary?.activeTrainingJobs ?? 0) > 0;
+    return this.getActiveTrainingJobCount() > 0;
   }
 
   private hasOpenProductiveManualJobs(): boolean {
@@ -2310,11 +2340,11 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private hasStaleSourceManualJobs(): boolean {
-    return (this.manualFreshnessJobSummary?.staleSourceJobs ?? 0) > 0;
+    return this.getStaleSourceJobCount() > 0;
   }
 
   private hasOpenDoubleCodingReviewConflicts(): boolean {
-    return this.openDoubleCodingConflictCount > 0;
+    return this.getOpenDoubleCodingConflictCount() > 0;
   }
 
   private hasManualFreshnessJobSummary(): boolean {
@@ -2580,6 +2610,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         return 'status-attention';
       case 'complete':
         return 'status-complete';
+      case 'not-checked':
       case 'loading':
       case 'planning-data-required':
       case 'planning-ready':
@@ -2591,11 +2622,23 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private getPlanningStatusState(): PlanningStatusState {
+    if (!this.hasLoadedPlanningDataBundle && this.restoredManualStatusSnapshot) {
+      return this.restoredManualStatusSnapshot.planningStatus;
+    }
+
     if (this.isPlanningStatusLoading()) {
       return 'loading';
     }
 
-    if (this.shouldRequirePlanningDataRefresh()) {
+    if (this.activeManualTab !== 'planning' &&
+        !this.hasLoadedPlanningDataBundle &&
+        !this.hasLivePlanningStatusData()) {
+      return 'not-checked';
+    }
+
+    if (this.shouldRequirePlanningDataRefresh() &&
+        !this.hasManualCodeAvailabilityWarnings &&
+        !this.hasVariableCoverageConflicts()) {
       return 'planning-data-required';
     }
 
@@ -2611,8 +2654,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return 'warning';
     }
 
-    if ((this.variableCoverageOverview?.missingVariables || 0) > 0 ||
-        (this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0) {
+    if (this.getMissingVariableCount() > 0 ||
+        this.getUnassignedCaseCount() > 0) {
       return 'planning-incomplete';
     }
 
@@ -2652,8 +2695,20 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return 'planning-ready';
   }
 
+  private hasLivePlanningStatusData(): boolean {
+    return this.variableCoverageOverview !== null ||
+      this.caseCoverageOverview !== null ||
+      this.codingProgressOverview !== null ||
+      this.appliedResultsOverview !== null ||
+      this.manualFreshnessJobSummary !== null ||
+      this.manualCodeAvailabilityWarnings.length > 0 ||
+      this.openDoubleCodingConflictCount > 0;
+  }
+
   getPlanningStatusIcon(): string {
     switch (this.getPlanningStatusState()) {
+      case 'not-checked':
+        return 'help_outline';
       case 'loading':
         return 'sync';
       case 'planning-data-required':
@@ -2685,6 +2740,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   getPlanningStatusTitle(): string {
     switch (this.getPlanningStatusState()) {
+      case 'not-checked':
+        return 'Kodierstand nicht geprüft';
       case 'loading':
         return 'Status wird aktualisiert';
       case 'planning-data-required':
@@ -2721,6 +2778,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   getPlanningStatusDescription(): string {
     const planningStatusState = this.getPlanningStatusState();
 
+    if (planningStatusState === 'not-checked') {
+      return 'Öffnen oder aktualisieren Sie die Planung, um den aktuellen Kodierstand zu prüfen.';
+    }
+
     if (planningStatusState === 'loading') {
       return 'Die Planungs- und Kodierfortschritte werden geladen.';
     }
@@ -2741,48 +2802,42 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     }
 
     if (this.hasVariableCoverageConflicts()) {
-      return `${this.variableCoverageOverview?.conflictedVariables || 0} Variablenkonflikte müssen vor der verlässlichen Jobplanung geklärt werden.`;
+      return `${this.getVariableConflictCount()} Variablenkonflikte müssen vor der verlässlichen Jobplanung geklärt werden.`;
     }
 
     if (this.hasManualCodeAvailabilityWarnings) {
       return `${this.manualCodeAvailabilityWarningCount} Variablen haben keine regulären Codes mit manueller Instruktion. Kodierer können dort nur Sonderoptionen wie "Code-Vergabe unsicher" oder "Neuer Code nötig" auswählen.`;
     }
 
-    if ((this.variableCoverageOverview?.missingVariables || 0) > 0) {
-      return `${this.variableCoverageOverview?.missingVariables || 0} Variablen sind noch keiner Jobdefinition zugeordnet.`;
+    if (this.getMissingVariableCount() > 0) {
+      return `${this.getMissingVariableCount()} Variablen sind noch keiner Jobdefinition zugeordnet.`;
     }
 
-    if ((this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0) {
-      return `${this.caseCoverageOverview?.effectiveUnassignedCases || 0} Fälle sind noch nicht in Kodierjobs verteilt.`;
+    if (this.getUnassignedCaseCount() > 0) {
+      return `${this.getUnassignedCaseCount()} Fälle sind noch nicht in Kodierjobs verteilt.`;
     }
 
-    if (this.isCompletionComplete()) {
+    if (planningStatusState === 'complete') {
       return 'Alle manuellen Kodierungen sind abgeschlossen und final übernommen.';
     }
 
-    if (this.isPlanningReady() &&
-        this.hasActiveTrainingCodingJobs()) {
-      return `${this.manualFreshnessJobSummary?.activeTrainingJobs || 0} aktive Schulungskodierjob(s) sollten vor der produktiven Durchführung geprüft werden.`;
+    if (planningStatusState === 'training-ready') {
+      return `${this.getActiveTrainingJobCount()} aktive Schulungskodierjob(s) sollten vor der produktiven Durchführung geprüft werden.`;
     }
 
-    if (this.isPlanningReady() &&
-        !!this.codingProgressOverview &&
-        this.hasExecutionOpenWorkForFreshness()) {
+    if (planningStatusState === 'execution-ready') {
       return 'Die Planung ist vollständig. Bearbeiten Sie nun die offenen Kodierfälle im Abschnitt Durchführung.';
     }
 
-    if (this.isPlanningReady() && this.hasOpenDoubleCodingReviewConflicts()) {
-      return `${this.openDoubleCodingConflictCount} offene Doppelkodierungs-Konflikt(e) müssen im Review aufgelöst werden.`;
+    if (planningStatusState === 'double-coding-review-ready') {
+      return `${this.getOpenDoubleCodingConflictCount()} offene Doppelkodierungs-Konflikt(e) müssen im Review aufgelöst werden.`;
     }
 
-    if (this.isPlanningReady() && this.hasStaleSourceManualJobs()) {
-      return `${this.manualFreshnessJobSummary?.staleSourceJobs || 0} Kodierjob(s) enthalten veraltete Quellfälle. Prüfen Sie diese Jobs in der Durchführung, bevor Ergebnisse angewendet oder weitergeführt werden.`;
+    if (planningStatusState === 'stale-source-review') {
+      return `${this.getStaleSourceJobCount()} Kodierjob(s) enthalten veraltete Quellfälle. Prüfen Sie diese Jobs in der Durchführung, bevor Ergebnisse angewendet oder weitergeführt werden.`;
     }
 
-    if (this.isPlanningReady() &&
-        !!this.codingProgressOverview &&
-        !!this.appliedResultsOverview &&
-        this.hasCompletionReadyWorkForFreshness()) {
+    if (planningStatusState === 'completion-ready') {
       return this.canShowManualCompletionTab() ?
         'Alle Kodierfälle sind abgeschlossen. Übernehmen Sie nun die Kodierergebnisse in den Datenbestand.' :
         'Alle Kodierfälle sind abgeschlossen. Die Übernahme der Ergebnisse in den Datenbestand bleibt Studienmanager:innen vorbehalten.';
@@ -2793,6 +2848,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   getPlanningNextStepTitle(): string {
     switch (this.getPlanningStatusState()) {
+      case 'not-checked':
+        return 'Kodierstand prüfen';
       case 'loading':
         return 'Planungsstand wird geladen';
       case 'planning-data-required':
@@ -2831,6 +2888,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const unavailableCases = this.getUnavailableCasesForNewJobs();
 
     switch (this.getPlanningStatusState()) {
+      case 'not-checked':
+        return 'Öffnen Sie die Planung, um den Kodierstand zu laden.';
       case 'loading':
         return 'Warten Sie kurz, bis die Planungsdaten aktualisiert sind.';
       case 'planning-data-required':
@@ -2845,11 +2904,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           'Aktualisieren Sie Antwortanalyse und Aggregationsgrundlage, bevor die manuelle Zielnavigation fortgesetzt wird.' :
           'Klären Sie offene Vorbereitungsbefunde wie leere Antworten oder Duplikate ohne aktive Aggregation.';
       case 'planning-incomplete':
-        if ((this.caseCoverageOverview?.effectiveUnassignedCases || 0) > 0) {
+        if (this.getUnassignedCaseCount() > 0) {
+          if (!this.hasLoadedPlanningDataBundle) {
+            return `${this.getUnassignedCaseCount()} Fälle waren beim letzten vollständigen Prüfen noch nicht in Kodierjobs verteilt. Öffnen Sie die Planung, um die Details zu laden.`;
+          }
           const unavailableHint = unavailableCases > 0 ?
             ` ${unavailableCases} Fälle sind bereits in Jobs verteilt oder durch andere Definitionen reserviert.` :
             '';
-          return `${this.caseCoverageOverview?.effectiveUnassignedCases || 0} Fälle sind noch nicht in Kodierjobs. Für neue Jobdefinitionen sind aktuell ${availableCases} Fälle verfügbar.${unavailableHint} Danach Definition freigeben und Jobs erstellen.`;
+          return `${this.getUnassignedCaseCount()} Fälle sind noch nicht in Kodierjobs. Für neue Jobdefinitionen sind aktuell ${availableCases} Fälle verfügbar.${unavailableHint} Danach Definition freigeben und Jobs erstellen.`;
         }
         return 'Ordnen Sie die fehlenden Variablen einer Jobdefinition zu. Danach Definition freigeben und Jobs erstellen.';
       case 'training-ready':
@@ -2875,6 +2937,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   getPlanningNextStepActionLabel(): string {
     switch (this.getPlanningStatusState()) {
+      case 'not-checked':
+        return 'Zur Planung';
       case 'warning':
         return this.hasVariableCoverageConflicts() ?
           'Zu den Jobdefinitionen' :
@@ -2911,6 +2975,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private getPlanningNextStepTarget(): ManualFreshnessTarget {
+    if (!this.hasLoadedPlanningDataBundle && this.restoredManualStatusSnapshot) {
+      return this.restoredManualStatusSnapshot.nextTarget;
+    }
+
     switch (this.getPlanningStatusState()) {
       case 'preparation-required':
         return {
@@ -2982,6 +3050,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   getPlanningNextStepIcon(): string {
     switch (this.getPlanningStatusState()) {
+      case 'not-checked':
+        return 'fact_check';
       case 'planning-data-required':
         return 'refresh';
       case 'warning':
@@ -3030,7 +3100,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   get manualCodeAvailabilityWarningCount(): number {
-    return this.manualCodeAvailabilityWarnings.length;
+    return this.hasLoadedPlanningDataBundle ||
+      this.manualCodeAvailabilityWarnings.length > 0 ?
+      this.manualCodeAvailabilityWarnings.length :
+      (this.restoredManualStatusSnapshot?.displayParameters.manualCodeAvailabilityWarnings || 0);
   }
 
   get hasManualCodeAvailabilityWarnings(): boolean {
@@ -3196,6 +3269,34 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       });
   }
 
+  private restoreManualCodingStatusSnapshot(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    const userId = this.appService.authData?.userId || 0;
+    if (!workspaceId || userId <= 0) {
+      return;
+    }
+
+    this.isRestoringManualStatusSnapshot = true;
+    this.codingStatusSnapshotService.restoreManual(userId, workspaceId)
+      .pipe(
+        finalize(() => {
+          this.isRestoringManualStatusSnapshot = false;
+          if (this.hasLoadedManualCodingJobRefreshSetting &&
+              this.pendingAutomaticManualTabLoad === 'planning') {
+            this.pendingAutomaticManualTabLoad = null;
+            this.loadManualTabData('planning');
+          }
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(snapshot => {
+        if (this.appService.selectedWorkspaceId !== workspaceId) {
+          return;
+        }
+        this.restoredManualStatusSnapshot = snapshot;
+      });
+  }
+
   private loadManualTabData(
     tab: ManualCodingTab,
     options: {
@@ -3225,7 +3326,15 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         this.loadResponseAnalysis();
         return;
       case 'planning':
-        if (forceRefresh && !deferStatusChecks) {
+        if (this.isRestoringManualStatusSnapshot && !forceRefresh) {
+          this.pendingAutomaticManualTabLoad = 'planning';
+          return;
+        }
+        if (!deferStatusChecks &&
+          (forceRefresh ||
+            (this.autoRefreshManualCodingJobs &&
+              !this.hasLoadedPlanningDataBundle &&
+              !this.restoredManualStatusSnapshot))) {
           this.loadPlanningDataBundle(forceRefresh);
         }
         return;
@@ -3260,6 +3369,20 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private loadPlanningDataBundle(forceRefresh: boolean): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    this.restoredManualStatusSnapshot = null;
+    this.manualSnapshotLoadRevision = null;
+    if (workspaceId) {
+      this.codingStatusSnapshotService.getRevision(workspaceId, true)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(revision => {
+          if (revision.stable &&
+            this.appService.selectedWorkspaceId === workspaceId) {
+            this.manualSnapshotLoadRevision = revision;
+            this.trySaveManualCodingStatusSnapshot();
+          }
+        });
+    }
     this.hasLoadedPlanningDataBundle = true;
     this.loadVariableCoverageOverview();
     this.loadCaseCoverageOverview();
@@ -3377,6 +3500,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private focusManualFreshnessTargetIfReady(): void {
+    this.trySaveManualCodingStatusSnapshot();
     if (!this.pendingManualFreshnessFocus ||
         !this.manualFreshnessPlanningRequested ||
         this.isAnyPlanningDataLoading() ||
@@ -3386,6 +3510,53 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
     this.pendingManualFreshnessFocus = false;
     this.followManualFreshnessTarget();
+  }
+
+  private trySaveManualCodingStatusSnapshot(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    const userId = this.appService.authData?.userId || 0;
+    const initialRevision = this.manualSnapshotLoadRevision;
+    if (!workspaceId || userId <= 0 || !initialRevision ||
+      this.manualSnapshotSavePending || !this.hasLoadedPlanningDataBundle ||
+      this.isPlanningStatusLoading() || this.isLoadingCodingFreshness) {
+      return;
+    }
+
+    this.manualSnapshotSavePending = true;
+    this.codingStatusSnapshotService.getRevision(workspaceId, true)
+      .pipe(
+        finalize(() => {
+          this.manualSnapshotSavePending = false;
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(revision => {
+        if (!revision.stable ||
+          revision.revision !== initialRevision.revision ||
+          revision.statusRevision !== initialRevision.statusRevision ||
+          this.appService.selectedWorkspaceId !== workspaceId) {
+          return;
+        }
+
+        this.codingStatusSnapshotService.saveManual({
+          userId,
+          workspaceId,
+          revision: revision.revision,
+          statusRevision: revision.statusRevision,
+          planningStatus: this.getPlanningStatusState(),
+          displayParameters: {
+            variableConflicts: this.variableCoverageOverview?.conflictedVariables || 0,
+            missingVariables: this.variableCoverageOverview?.missingVariables || 0,
+            unassignedCases: this.caseCoverageOverview?.effectiveUnassignedCases || 0,
+            activeTrainingJobs: this.manualFreshnessJobSummary?.activeTrainingJobs || 0,
+            staleSourceJobs: this.manualFreshnessJobSummary?.staleSourceJobs || 0,
+            openDoubleCodingConflicts: this.openDoubleCodingConflictCount,
+            manualCodeAvailabilityWarnings: this.manualCodeAvailabilityWarnings.length
+          },
+          freshness: this.codingFreshnessSummary,
+          nextTarget: this.getPlanningNextStepTarget()
+        });
+      });
   }
 
   private followManualFreshnessTarget(): void {
@@ -3654,6 +3825,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
             this.appService.selectedWorkspaceId === workspaceId
           ) {
             this.isLoadingCodingFreshness = false;
+            this.trySaveManualCodingStatusSnapshot();
           }
         })
       )
@@ -4307,6 +4479,8 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
   private invalidateCodingStatusCache(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
+    this.restoredManualStatusSnapshot = null;
+    this.manualSnapshotLoadRevision = null;
     if (workspaceId) {
       this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
     }

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -354,11 +354,13 @@ describe('CodingManagementComponent', () => {
       expect(mockCodingManagementService.cancelViewBoundStatisticsFetches).toHaveBeenCalledWith(1);
     });
 
-    it('should only load lightweight coding freshness on init when auto-refresh is enabled', () => {
+    it('should fall back to a full status load on init when the readiness cache is empty', () => {
       expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalledWith(1);
       expect(mockTestPersonCodingService.getCachedAutocodingReadiness).toHaveBeenCalledWith(1, 1);
-      expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
-      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
+      expect(component.hasLoadedFullCodingStatusOverview).toBe(true);
+      expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(false);
     });
 
     it('should restore a session snapshot when auto-refresh is disabled', () => {
@@ -402,33 +404,23 @@ describe('CodingManagementComponent', () => {
       isolatedFixture.destroy();
     });
 
-    it('should not show full-check loading copy during the lightweight initial refresh', () => {
+    it('should show full-check loading copy during the cold-cache fallback', () => {
       fixture.destroy();
-      const codingFreshnessSubject = new Subject<{
-        workspaceId: number;
-        currentRevision: number;
-        items: never[];
-      }>();
-      (mockTestPersonCodingService.getCodingFreshness as jest.Mock)
-        .mockReturnValueOnce(codingFreshnessSubject.asObservable());
+      const autocodingReadinessSubject = new Subject<never>();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock)
+        .mockReturnValueOnce(autocodingReadinessSubject.asObservable());
 
       const isolatedFixture = TestBed.createComponent(CodingManagementComponent);
       const isolatedComponent = isolatedFixture.componentInstance;
       isolatedFixture.detectChanges();
 
       const text = isolatedFixture.nativeElement.textContent;
-      expect(isolatedComponent.isLoadingCodingFreshness).toBe(true);
-      expect(isolatedComponent.isFullCodingStatusCheckLoading).toBe(false);
-      expect(text).toContain('Der vollständige Kodierstand wurde noch nicht geprüft');
-      expect(text).not.toContain('Zustand wird geprüft');
-      expect(isolatedFixture.nativeElement.querySelector('.coding-freshness-state-spinner')).toBeNull();
+      expect(isolatedComponent.isFullCodingStatusCheckLoading).toBe(true);
+      expect(text).toContain('Zustand wird geprüft');
+      expect(text).not.toContain('Der vollständige Kodierstand wurde noch nicht geprüft');
+      expect(isolatedFixture.nativeElement.querySelector('.coding-freshness-state-spinner')).not.toBeNull();
 
-      codingFreshnessSubject.next({
-        workspaceId: 1,
-        currentRevision: 0,
-        items: []
-      });
-      codingFreshnessSubject.complete();
+      autocodingReadinessSubject.complete();
       isolatedFixture.destroy();
     });
 
@@ -455,6 +447,7 @@ describe('CodingManagementComponent', () => {
           invalidVariableSamples: [],
           fromCache: true
         }));
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
 
       const isolatedFixture = TestBed.createComponent(CodingManagementComponent);
       const isolatedComponent = isolatedFixture.componentInstance;
@@ -469,14 +462,24 @@ describe('CodingManagementComponent', () => {
       isolatedFixture.destroy();
     });
 
-    it('should keep the manual full status refresh available after the initial light load', () => {
+    it('should hide the manual full status refresh after the automatic cold-cache fallback', () => {
+      expect(component.autoRefreshManualCodingJobs).toBe(true);
+      expect(component.hasLoadedFullCodingStatusOverview).toBe(true);
+      expect(component.shouldShowManualCodingStatusRefresh()).toBe(false);
+      expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(false);
+    });
+
+    it('should keep the full status refresh available in manual mode', () => {
+      component.autoRefreshManualCodingJobs = false;
+      component.hasLoadedFullCodingStatusOverview = false;
+
       expect(component.shouldShowManualCodingStatusRefresh()).toBe(true);
       expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(true);
 
       component.refreshCodingStatusOverview();
 
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
-      expect(component.shouldShowManualCodingStatusRefresh()).toBe(false);
+      expect(component.shouldShowManualCodingStatusRefresh()).toBe(true);
       expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(false);
     });
 
@@ -542,19 +545,10 @@ describe('CodingManagementComponent', () => {
       isolatedFixture.detectChanges();
 
       expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalledWith(1);
-      expect(mockTestPersonCodingService.getCodingFreshnessScope).not.toHaveBeenCalled();
-      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getCodingFreshnessScope).toHaveBeenCalledWith(1);
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
 
       isolatedFixture.destroy();
-    });
-
-    it('should defer autocoding readiness until a forced coding status refresh', () => {
-      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
-
-      component.refreshCodingStatusOverview();
-
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledTimes(1);
-      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
     });
 
     it('should show full-check loading copy during a manual status refresh', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -31,6 +31,7 @@ import { SERVER_URL } from '../../../injection-tokens';
 import { environment } from '../../../../environments/environment';
 import { Success } from '../../models/success.model';
 import { TestPersonCodingDialogComponent } from '../test-person-coding-dialog/test-person-coding-dialog.component';
+import { CodingStatusSnapshotService } from '../../services/coding-status-snapshot.service';
 
 describe('CodingManagementComponent', () => {
   let component: CodingManagementComponent;
@@ -42,6 +43,7 @@ describe('CodingManagementComponent', () => {
   let mockWorkspaceSettingsService: jest.Mocked<Partial<WorkspaceSettingsService>>;
   let mockTestPersonCodingService: jest.Mocked<Partial<TestPersonCodingService>>;
   let mockCodingBackgroundJobsService: jest.Mocked<Partial<CodingBackgroundJobsService>>;
+  let mockCodingStatusSnapshotService: jest.Mocked<Partial<CodingStatusSnapshotService>>;
   let mockRouter: jest.Mocked<Partial<Router>>;
   let mockSnackBar: jest.Mocked<Partial<MatSnackBar>>;
   let autoCodingCompletedSubject: Subject<{ jobId?: string }>;
@@ -96,7 +98,20 @@ describe('CodingManagementComponent', () => {
 
     mockAppService = {
       selectedWorkspaceId: 1,
-      loggedUser: { sub: 'test-user' }
+      loggedUser: { sub: 'test-user' },
+      authData: { userId: 7 } as never
+    };
+
+    mockCodingStatusSnapshotService = {
+      restoreOverview: jest.fn().mockReturnValue(of(null)),
+      getRevision: jest.fn().mockReturnValue(of({
+        workspaceId: 1,
+        revision: 0,
+        statusRevision: '0',
+        stable: true
+      })),
+      saveOverview: jest.fn(),
+      clearWorkspace: jest.fn()
     };
 
     mockWorkspaceSettingsService = {
@@ -243,6 +258,10 @@ describe('CodingManagementComponent', () => {
           useValue: mockCodingBackgroundJobsService
         },
         {
+          provide: CodingStatusSnapshotService,
+          useValue: mockCodingStatusSnapshotService
+        },
+        {
           provide: Router,
           useValue: mockRouter
         }
@@ -342,6 +361,47 @@ describe('CodingManagementComponent', () => {
       expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
     });
 
+    it('should restore a session snapshot when auto-refresh is disabled', () => {
+      fixture.destroy();
+      const freshness = {
+        workspaceId: 1,
+        currentRevision: 12,
+        items: []
+      };
+      const readiness = {
+        workspaceId: 1,
+        readiness: 'READY'
+      } as never;
+      (mockWorkspaceSettingsService.getAutoRefreshManualCodingJobs as jest.Mock)
+        .mockReturnValueOnce(of(false));
+      (mockCodingStatusSnapshotService.restoreOverview as jest.Mock)
+        .mockReturnValueOnce(of({
+          userId: 7,
+          workspaceId: 1,
+          revision: 12,
+          statusRevision: '34',
+          freshness,
+          readiness,
+          appliedResultsOverview: null
+        }));
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getCachedAutocodingReadiness as jest.Mock).mockClear();
+
+      const isolatedFixture = TestBed.createComponent(CodingManagementComponent);
+      const isolatedComponent = isolatedFixture.componentInstance;
+      isolatedFixture.detectChanges();
+
+      expect(mockCodingStatusSnapshotService.restoreOverview)
+        .toHaveBeenLastCalledWith(7, 1);
+      expect(isolatedComponent.codingFreshnessSummary).toBe(freshness);
+      expect(isolatedComponent.autocodingReadiness).toBe(readiness);
+      expect(isolatedComponent.hasLoadedFullCodingStatusOverview).toBe(true);
+      expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getCachedAutocodingReadiness).not.toHaveBeenCalled();
+
+      isolatedFixture.destroy();
+    });
+
     it('should not show full-check loading copy during the lightweight initial refresh', () => {
       fixture.destroy();
       const codingFreshnessSubject = new Subject<{
@@ -418,6 +478,47 @@ describe('CodingManagementComponent', () => {
       expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalledWith(1, 1, false);
       expect(component.shouldShowManualCodingStatusRefresh()).toBe(false);
       expect(component.isCodingStatusOverviewPendingManualRefresh).toBe(false);
+    });
+
+    it('should bracket a full refresh and reject a snapshot when the revision changed', () => {
+      const initialRevision$ = new Subject<{
+        workspaceId: number;
+        revision: number;
+        statusRevision: string;
+        stable: boolean;
+      }>();
+      (mockCodingStatusSnapshotService.getRevision as jest.Mock)
+        .mockReset()
+        .mockReturnValueOnce(initialRevision$.asObservable())
+        .mockReturnValueOnce(of({
+          workspaceId: 1,
+          revision: 0,
+          statusRevision: '2',
+          stable: true
+        }));
+      (mockCodingStatusSnapshotService.saveOverview as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
+      (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+
+      component.refreshCodingStatusOverview();
+
+      expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+
+      initialRevision$.next({
+        workspaceId: 1,
+        revision: 0,
+        statusRevision: '1',
+        stable: true
+      });
+      initialRevision$.complete();
+
+      expect(mockTestPersonCodingService.getCodingFreshness).toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAppliedResultsOverview).toHaveBeenCalled();
+      expect(mockTestPersonCodingService.getAutocodingReadiness).toHaveBeenCalled();
+      expect(mockCodingStatusSnapshotService.saveOverview).not.toHaveBeenCalled();
     });
 
     it('should load manual applied results on init when second auto-coding freshness is open', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -99,6 +99,7 @@ import {
 } from '../../../shared/utils/coding-freshness-text.util';
 import { getResponseStatusLabel } from '../../../shared/utils/response-status-metadata.util';
 import { extractGeoGebraBase64 } from '../../utils/geogebra-value.util';
+import { CodingStatusSnapshotService } from '../../services/coding-status-snapshot.service';
 
 @Component({
   selector: 'app-coding-management',
@@ -134,6 +135,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private translateService = inject(TranslateService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
+  private codingStatusSnapshotService = inject(CodingStatusSnapshotService);
   private readonly reviewBatchSize = 500;
   private readonly maxReviewResponses = 5000;
 
@@ -224,6 +226,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private readonly responseTableRequestCancel$ = new Subject<void>();
   private responseTableRequestId = 0;
   private readonly automaticCodingStatusRefreshDebounceMs = 250;
+  private overviewSnapshotSavePending = false;
 
   ngOnInit(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
@@ -453,6 +456,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       .pipe(
         finalize(() => {
           this.isLoadingCodingFreshness = false;
+          this.trySaveCodingStatusOverviewSnapshot();
         }),
         takeUntil(this.destroy$)
       )
@@ -466,6 +470,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         if (!loadScopeOnWarnings && this.hasSecondAutocodingFreshnessWarnings) {
           this.loadManualAppliedResultsOverview();
         }
+        this.trySaveCodingStatusOverviewSnapshot();
       });
   }
 
@@ -500,12 +505,14 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       .pipe(
         finalize(() => {
           this.isLoadingManualAppliedResultsOverview = false;
+          this.trySaveCodingStatusOverviewSnapshot();
         }),
         takeUntil(this.destroy$)
       )
       .subscribe(overview => {
         this.manualAppliedResultsOverview = overview;
         this.manualAppliedResultsOverviewLoadFailed = overview === null;
+        this.trySaveCodingStatusOverviewSnapshot();
       });
   }
 
@@ -525,6 +532,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       .pipe(
         finalize(() => {
           this.isLoadingAutocodingReadiness = false;
+          this.trySaveCodingStatusOverviewSnapshot();
         }),
         takeUntil(this.destroy$)
       )
@@ -532,6 +540,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         next: readiness => {
           this.autocodingReadiness = readiness;
           this.hasLoadedFullCodingStatusOverview = true;
+          this.trySaveCodingStatusOverviewSnapshot();
         },
         error: () => {
           this.autocodingReadiness = null;
@@ -623,9 +632,73 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return;
     }
 
+    const workspaceId = this.appService.selectedWorkspaceId;
+    const userId = this.appService.authData?.userId || 0;
+    if (!workspaceId || userId <= 0) {
+      this.loadInitialCodingStatusOverviewWithoutSnapshot();
+      return;
+    }
+
+    this.codingStatusSnapshotService.restoreOverview(userId, workspaceId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(snapshot => {
+        if (!snapshot || this.appService.selectedWorkspaceId !== workspaceId) {
+          this.loadInitialCodingStatusOverviewWithoutSnapshot();
+          return;
+        }
+
+        this.codingFreshnessSummary = snapshot.freshness;
+        this.autocodingReadiness = snapshot.readiness;
+        this.manualAppliedResultsOverview = snapshot.appliedResultsOverview;
+        this.autocodingReadinessLoadFailed = false;
+        this.manualAppliedResultsOverviewLoadFailed = false;
+        this.hasLoadedFullCodingStatusOverview = true;
+      });
+  }
+
+  private loadInitialCodingStatusOverviewWithoutSnapshot(): void {
     this.hasLoadedFullCodingStatusOverview = false;
     this.loadCodingFreshness(false);
     this.loadCachedAutocodingReadiness();
+  }
+
+  private trySaveCodingStatusOverviewSnapshot(): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    const userId = this.appService.authData?.userId || 0;
+    if (!workspaceId || userId <= 0 || this.overviewSnapshotSavePending ||
+      !this.hasLoadedFullCodingStatusOverview ||
+      !this.codingFreshnessSummary || !this.autocodingReadiness ||
+      this.isLoadingCodingFreshness || this.isLoadingAutocodingReadiness ||
+      this.isLoadingManualAppliedResultsOverview ||
+      this.autocodingReadinessLoadFailed ||
+      this.manualAppliedResultsOverviewLoadFailed) {
+      return;
+    }
+
+    this.overviewSnapshotSavePending = true;
+    this.codingStatusSnapshotService.getRevision(workspaceId, true)
+      .pipe(
+        finalize(() => {
+          this.overviewSnapshotSavePending = false;
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(revision => {
+        if (!revision.stable ||
+          revision.revision !== this.codingFreshnessSummary?.currentRevision ||
+          this.appService.selectedWorkspaceId !== workspaceId) {
+          return;
+        }
+        this.codingStatusSnapshotService.saveOverview({
+          userId,
+          workspaceId,
+          revision: revision.revision,
+          statusRevision: revision.statusRevision,
+          freshness: this.codingFreshnessSummary,
+          readiness: this.autocodingReadiness!,
+          appliedResultsOverview: this.manualAppliedResultsOverview
+        });
+      });
   }
 
   private scheduleAutomaticCodingStatusOverviewRefresh(): void {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -12,7 +12,13 @@ import {
   reduce,
   takeUntil
 } from 'rxjs/operators';
-import { combineLatest, range, Subject } from 'rxjs';
+import {
+  catchError,
+  combineLatest,
+  of,
+  range,
+  Subject
+} from 'rxjs';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatIcon } from '@angular/material/icon';
 import {
@@ -100,6 +106,7 @@ import {
 import { getResponseStatusLabel } from '../../../shared/utils/response-status-metadata.util';
 import { extractGeoGebraBase64 } from '../../utils/geogebra-value.util';
 import { CodingStatusSnapshotService } from '../../services/coding-status-snapshot.service';
+import { CodingStatusRevisionDto } from '../../../../../../../api-dto/coding/coding-status-revision.dto';
 
 @Component({
   selector: 'app-coding-management',
@@ -227,6 +234,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private responseTableRequestId = 0;
   private readonly automaticCodingStatusRefreshDebounceMs = 250;
   private overviewSnapshotSavePending = false;
+  private overviewSnapshotLoadRevision: CodingStatusRevisionDto | null = null;
+  private overviewStatusLoadRequestId = 0;
 
   ngOnInit(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
@@ -256,9 +265,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
           if (shouldFetchInitialStatistics) {
             this.fetchCodingStatistics();
           }
-          if (effectiveAutoRefresh) {
-            this.loadInitialCodingStatusOverview();
-          }
+          this.loadInitialCodingStatusOverview(effectiveAutoRefresh);
         });
       this.workspaceSettingsService
         .getEnableRegexSearch(workspaceId)
@@ -607,7 +614,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private invalidateCodingStatusOverviewCache(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (workspaceId) {
+      this.overviewStatusLoadRequestId += 1;
       this.hasLoadedFullCodingStatusOverview = false;
+      this.overviewSnapshotLoadRevision = null;
       this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
     }
   }
@@ -617,6 +626,34 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return;
     }
 
+    const workspaceId = this.appService.selectedWorkspaceId;
+    this.overviewStatusLoadRequestId += 1;
+    const requestId = this.overviewStatusLoadRequestId;
+    this.overviewSnapshotLoadRevision = null;
+    if (!workspaceId) {
+      this.startCodingStatusOverviewLoad(includeAutocodingReadiness);
+      return;
+    }
+
+    this.codingStatusSnapshotService.getRevision(workspaceId, true)
+      .pipe(
+        catchError(() => of(null)),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(revision => {
+        if (requestId !== this.overviewStatusLoadRequestId ||
+          this.appService.selectedWorkspaceId !== workspaceId) {
+          return;
+        }
+
+        this.overviewSnapshotLoadRevision = revision?.stable ? revision : null;
+        this.startCodingStatusOverviewLoad(includeAutocodingReadiness);
+      });
+  }
+
+  private startCodingStatusOverviewLoad(
+    includeAutocodingReadiness: boolean
+  ): void {
     if (includeAutocodingReadiness) {
       this.hasLoadedFullCodingStatusOverview = false;
     }
@@ -627,7 +664,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     }
   }
 
-  private loadInitialCodingStatusOverview(): void {
+  private loadInitialCodingStatusOverview(allowNetworkReload: boolean): void {
     if (this.deferCodingStatusRefreshIfBackgroundJobIsRunning(false)) {
       return;
     }
@@ -635,7 +672,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
     const workspaceId = this.appService.selectedWorkspaceId;
     const userId = this.appService.authData?.userId || 0;
     if (!workspaceId || userId <= 0) {
-      this.loadInitialCodingStatusOverviewWithoutSnapshot();
+      if (allowNetworkReload) {
+        this.loadInitialCodingStatusOverviewWithoutSnapshot();
+      }
       return;
     }
 
@@ -643,10 +682,18 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(snapshot => {
         if (!snapshot || this.appService.selectedWorkspaceId !== workspaceId) {
-          this.loadInitialCodingStatusOverviewWithoutSnapshot();
+          if (allowNetworkReload) {
+            this.loadInitialCodingStatusOverviewWithoutSnapshot();
+          }
           return;
         }
 
+        this.overviewSnapshotLoadRevision = {
+          workspaceId,
+          revision: snapshot.revision,
+          statusRevision: snapshot.statusRevision,
+          stable: true
+        };
         this.codingFreshnessSummary = snapshot.freshness;
         this.autocodingReadiness = snapshot.readiness;
         this.manualAppliedResultsOverview = snapshot.appliedResultsOverview;
@@ -665,7 +712,9 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   private trySaveCodingStatusOverviewSnapshot(): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     const userId = this.appService.authData?.userId || 0;
-    if (!workspaceId || userId <= 0 || this.overviewSnapshotSavePending ||
+    const initialRevision = this.overviewSnapshotLoadRevision;
+    if (!workspaceId || userId <= 0 || !initialRevision ||
+      this.overviewSnapshotSavePending ||
       !this.hasLoadedFullCodingStatusOverview ||
       !this.codingFreshnessSummary || !this.autocodingReadiness ||
       this.isLoadingCodingFreshness || this.isLoadingAutocodingReadiness ||
@@ -685,6 +734,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       )
       .subscribe(revision => {
         if (!revision.stable ||
+          revision.revision !== initialRevision.revision ||
+          revision.statusRevision !== initialRevision.statusRevision ||
           revision.revision !== this.codingFreshnessSummary?.currentRevision ||
           this.appService.selectedWorkspaceId !== workspaceId) {
           return;

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -570,12 +570,16 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(readiness => {
         if (!readiness) {
+          if (this.autoRefreshManualCodingJobs) {
+            this.loadCodingStatusOverview(true);
+          }
           return;
         }
 
         this.autocodingReadiness = readiness;
         this.autocodingReadinessLoadFailed = false;
         this.hasLoadedFullCodingStatusOverview = true;
+        this.loadCodingFreshness(false);
       });
   }
 
@@ -705,7 +709,6 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   private loadInitialCodingStatusOverviewWithoutSnapshot(): void {
     this.hasLoadedFullCodingStatusOverview = false;
-    this.loadCodingFreshness(false);
     this.loadCachedAutocodingReadiness();
   }
 
@@ -836,8 +839,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
       return false;
     }
 
-    return !this.autoRefreshManualCodingJobs ||
-      !this.hasLoadedFullCodingStatusOverview;
+    return !this.autoRefreshManualCodingJobs;
   }
 
   startFreshnessCoding(version: 'v1' | 'v3'): void {
@@ -1201,7 +1203,8 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
 
   get isCodingStatusOverviewPendingManualRefresh(): boolean {
     return !this.hasLoadedFullCodingStatusOverview &&
-      this.shouldShowManualCodingStatusRefresh() &&
+      !this.isStartingFreshnessCoding &&
+      !this.activeFreshnessJobId &&
       !this.hasAutocodingReadinessLoadFailed &&
       !this.isAutocodingReadinessBlocked &&
       !this.hasCodingFreshnessWarnings &&

--- a/apps/frontend/src/app/coding/services/coding-status-snapshot.model.ts
+++ b/apps/frontend/src/app/coding/services/coding-status-snapshot.model.ts
@@ -1,0 +1,66 @@
+import { AutocodingReadinessDto } from '../../../../../../api-dto/coding/autocoding-readiness.dto';
+import { CodingFreshnessSummaryDto } from '../../../../../../api-dto/coding/coding-freshness.dto';
+import type { AppliedResultsOverview } from './test-person-coding.service';
+
+export type CodingStatusSnapshotSurface = 'overview' | 'manual';
+
+export interface CodingStatusSnapshotMetadata {
+  schemaVersion: 1;
+  userId: number;
+  workspaceId: number;
+  revision: number;
+  statusRevision: string;
+  checkedAt: string;
+  surface: CodingStatusSnapshotSurface;
+  fullyChecked: true;
+}
+
+export interface CodingOverviewStatusSnapshot extends CodingStatusSnapshotMetadata {
+  surface: 'overview';
+  freshness: CodingFreshnessSummaryDto;
+  readiness: AutocodingReadinessDto;
+  appliedResultsOverview: AppliedResultsOverview | null;
+}
+
+export type PlanningStatusState =
+  | 'not-checked'
+  | 'loading'
+  | 'planning-data-required'
+  | 'preparation-required'
+  | 'warning'
+  | 'planning-incomplete'
+  | 'planning-ready'
+  | 'training-ready'
+  | 'execution-ready'
+  | 'double-coding-review-ready'
+  | 'stale-source-review'
+  | 'completion-ready'
+  | 'progress-unavailable'
+  | 'complete';
+
+export type ManualCodingSnapshotTab =
+  'preparation' | 'planning' | 'training' | 'execution' | 'completion';
+
+export interface ManualCodingSnapshotTarget {
+  tab: ManualCodingSnapshotTab;
+  sectionId: string;
+  action: 'navigate' | 'double-coding-review';
+}
+
+export interface ManualCodingSnapshotDisplayParameters {
+  variableConflicts: number;
+  missingVariables: number;
+  unassignedCases: number;
+  activeTrainingJobs: number;
+  staleSourceJobs: number;
+  openDoubleCodingConflicts: number;
+  manualCodeAvailabilityWarnings: number;
+}
+
+export interface ManualCodingStatusSnapshot extends CodingStatusSnapshotMetadata {
+  surface: 'manual';
+  planningStatus: PlanningStatusState;
+  displayParameters: ManualCodingSnapshotDisplayParameters;
+  freshness: CodingFreshnessSummaryDto | null;
+  nextTarget: ManualCodingSnapshotTarget;
+}

--- a/apps/frontend/src/app/coding/services/coding-status-snapshot.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/coding-status-snapshot.service.spec.ts
@@ -1,0 +1,150 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { SERVER_URL } from '../../injection-tokens';
+import { CODING_STATUS_SNAPSHOT_KEY_PREFIX } from '../../core/services/coding-status-session-storage';
+import { CodingStatusSnapshotService } from './coding-status-snapshot.service';
+
+describe('CodingStatusSnapshotService', () => {
+  let service: CodingStatusSnapshotService;
+  let http: HttpTestingController;
+  const serverUrl = 'http://localhost/api/';
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    TestBed.configureTestingModule({
+      providers: [
+        CodingStatusSnapshotService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: SERVER_URL, useValue: serverUrl }
+      ]
+    });
+    service = TestBed.inject(CodingStatusSnapshotService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+    sessionStorage.clear();
+  });
+
+  it('restores a matching overview snapshot', () => {
+    service.saveOverview({
+      userId: 3,
+      workspaceId: 7,
+      revision: 12,
+      statusRevision: '34',
+      freshness: { workspaceId: 7, currentRevision: 12, items: [] },
+      readiness: { workspaceId: 7 } as never,
+      appliedResultsOverview: null
+    });
+
+    let restored: unknown;
+    service.restoreOverview(3, 7).subscribe(value => {
+      restored = value;
+    });
+    http.expectOne(`${serverUrl}admin/workspace/7/coding/revision`).flush({
+      workspaceId: 7,
+      revision: 12,
+      statusRevision: '34',
+      stable: true
+    });
+
+    expect(restored).toMatchObject({ workspaceId: 7, revision: 12 });
+  });
+
+  it('drops a snapshot when the server revision changed', () => {
+    service.saveManual({
+      userId: 3,
+      workspaceId: 7,
+      revision: 12,
+      statusRevision: '34',
+      planningStatus: 'planning-ready',
+      displayParameters: {
+        variableConflicts: 0,
+        missingVariables: 0,
+        unassignedCases: 0,
+        activeTrainingJobs: 0,
+        staleSourceJobs: 0,
+        openDoubleCodingConflicts: 0,
+        manualCodeAvailabilityWarnings: 0
+      },
+      freshness: null,
+      nextTarget: {
+        tab: 'planning',
+        sectionId: 'manual-planning',
+        action: 'navigate'
+      }
+    });
+
+    let restored: unknown = 'pending';
+    service.restoreManual(3, 7).subscribe(value => {
+      restored = value;
+    });
+    http.expectOne(`${serverUrl}admin/workspace/7/coding/revision`).flush({
+      workspaceId: 7,
+      revision: 13,
+      statusRevision: '34',
+      stable: true
+    });
+
+    expect(restored).toBeNull();
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it('drops malformed manual status data without contacting the server', () => {
+    sessionStorage.setItem(
+      `${CODING_STATUS_SNAPSHOT_KEY_PREFIX}3:7:manual`,
+      JSON.stringify({
+        schemaVersion: 1,
+        userId: 3,
+        workspaceId: 7,
+        revision: 12,
+        statusRevision: '34',
+        checkedAt: new Date().toISOString(),
+        surface: 'manual',
+        fullyChecked: true,
+        planningStatus: 'invented-status',
+        displayParameters: {},
+        freshness: null,
+        nextTarget: {
+          tab: 'planning',
+          sectionId: 'manual-planning',
+          action: 'navigate'
+        }
+      })
+    );
+
+    let restored: unknown = 'pending';
+    service.restoreManual(3, 7).subscribe(value => {
+      restored = value;
+    });
+
+    expect(restored).toBeNull();
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it('clears only snapshots for the selected workspace', () => {
+    sessionStorage.setItem(
+      `${CODING_STATUS_SNAPSHOT_KEY_PREFIX}3:7:manual`,
+      '{}'
+    );
+    sessionStorage.setItem(
+      `${CODING_STATUS_SNAPSHOT_KEY_PREFIX}3:8:manual`,
+      '{}'
+    );
+
+    service.clearWorkspace(7);
+
+    expect(
+      sessionStorage.getItem(`${CODING_STATUS_SNAPSHOT_KEY_PREFIX}3:7:manual`)
+    ).toBeNull();
+    expect(
+      sessionStorage.getItem(`${CODING_STATUS_SNAPSHOT_KEY_PREFIX}3:8:manual`)
+    ).toBe('{}');
+  });
+});

--- a/apps/frontend/src/app/coding/services/coding-status-snapshot.service.ts
+++ b/apps/frontend/src/app/coding/services/coding-status-snapshot.service.ts
@@ -1,0 +1,311 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import {
+  Observable, catchError, finalize, map, of, shareReplay
+} from 'rxjs';
+import { CodingStatusRevisionDto } from '../../../../../../api-dto/coding/coding-status-revision.dto';
+import { SERVER_URL } from '../../injection-tokens';
+import {
+  CODING_STATUS_SNAPSHOT_KEY_PREFIX,
+  clearCodingStatusSnapshots,
+  getCodingStatusSessionStorage
+} from '../../core/services/coding-status-session-storage';
+import {
+  CodingOverviewStatusSnapshot,
+  CodingStatusSnapshotSurface,
+  ManualCodingSnapshotDisplayParameters,
+  ManualCodingSnapshotTab,
+  ManualCodingStatusSnapshot,
+  PlanningStatusState
+} from './coding-status-snapshot.model';
+
+type CodingStatusSnapshot =
+  CodingOverviewStatusSnapshot | ManualCodingStatusSnapshot;
+type SnapshotMetadataKeys =
+  'schemaVersion' | 'checkedAt' | 'surface' | 'fullyChecked';
+
+const PLANNING_STATUS_STATES = new Set<PlanningStatusState>([
+  'not-checked',
+  'loading',
+  'planning-data-required',
+  'preparation-required',
+  'warning',
+  'planning-incomplete',
+  'planning-ready',
+  'training-ready',
+  'execution-ready',
+  'double-coding-review-ready',
+  'stale-source-review',
+  'completion-ready',
+  'progress-unavailable',
+  'complete'
+]);
+const MANUAL_CODING_TABS = new Set<ManualCodingSnapshotTab>([
+  'preparation',
+  'planning',
+  'training',
+  'execution',
+  'completion'
+]);
+const MANUAL_DISPLAY_PARAMETER_KEYS: (keyof ManualCodingSnapshotDisplayParameters)[] = [
+  'variableConflicts',
+  'missingVariables',
+  'unassignedCases',
+  'activeTrainingJobs',
+  'staleSourceJobs',
+  'openDoubleCodingConflicts',
+  'manualCodeAvailabilityWarnings'
+];
+
+@Injectable({ providedIn: 'root' })
+export class CodingStatusSnapshotService {
+  private readonly http = inject(HttpClient);
+  private readonly serverUrl = inject(SERVER_URL);
+  private readonly revisionRequests = new Map<
+  number,
+  Observable<CodingStatusRevisionDto>
+  >();
+
+  restoreOverview(userId: number, workspaceId: number) {
+    return this.restore<CodingOverviewStatusSnapshot>(
+      userId,
+      workspaceId,
+      'overview'
+    );
+  }
+
+  restoreManual(userId: number, workspaceId: number) {
+    return this.restore<ManualCodingStatusSnapshot>(
+      userId,
+      workspaceId,
+      'manual'
+    );
+  }
+
+  saveOverview(
+    snapshot: Omit<CodingOverviewStatusSnapshot, SnapshotMetadataKeys>
+  ): void {
+    this.save({
+      ...snapshot,
+      schemaVersion: 1,
+      checkedAt: new Date().toISOString(),
+      surface: 'overview',
+      fullyChecked: true
+    });
+  }
+
+  saveManual(
+    snapshot: Omit<ManualCodingStatusSnapshot, SnapshotMetadataKeys>
+  ): void {
+    this.save({
+      ...snapshot,
+      schemaVersion: 1,
+      checkedAt: new Date().toISOString(),
+      surface: 'manual',
+      fullyChecked: true
+    });
+  }
+
+  getRevision(
+    workspaceId: number,
+    fresh = false
+  ): Observable<CodingStatusRevisionDto> {
+    if (fresh) {
+      return this.requestRevision(workspaceId);
+    }
+    const pending = this.revisionRequests.get(workspaceId);
+    if (pending) {
+      return pending;
+    }
+
+    const request$ = this.requestRevision(workspaceId).pipe(
+      finalize(() => this.revisionRequests.delete(workspaceId)),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+    this.revisionRequests.set(workspaceId, request$);
+    return request$;
+  }
+
+  clearWorkspace(workspaceId: number): void {
+    clearCodingStatusSnapshots(workspaceId);
+  }
+
+  clearAll(): void {
+    clearCodingStatusSnapshots();
+  }
+
+  private requestRevision(
+    workspaceId: number
+  ): Observable<CodingStatusRevisionDto> {
+    return this.http.get<CodingStatusRevisionDto>(
+      `${this.serverUrl}admin/workspace/${workspaceId}/coding/revision`
+    );
+  }
+
+  private restore<T extends CodingStatusSnapshot>(
+    userId: number,
+    workspaceId: number,
+    surface: CodingStatusSnapshotSurface
+  ): Observable<T | null> {
+    const key = this.buildKey(userId, workspaceId, surface);
+    const snapshot = this.read<T>(key, userId, workspaceId, surface);
+    if (!snapshot) {
+      return of(null);
+    }
+
+    return this.getRevision(workspaceId).pipe(
+      map(revision => {
+        if (
+          !this.isRevisionValid(revision, workspaceId) ||
+          !revision.stable ||
+          revision.revision !== snapshot.revision ||
+          revision.statusRevision !== snapshot.statusRevision
+        ) {
+          this.remove(key);
+          return null;
+        }
+        return snapshot;
+      }),
+      catchError(() => of(null))
+    );
+  }
+
+  private save(snapshot: CodingStatusSnapshot): void {
+    if (
+      !this.isSnapshotValid(
+        snapshot,
+        snapshot.userId,
+        snapshot.workspaceId,
+        snapshot.surface
+      )
+    ) {
+      return;
+    }
+    try {
+      getCodingStatusSessionStorage()?.setItem(
+        this.buildKey(snapshot.userId, snapshot.workspaceId, snapshot.surface),
+        JSON.stringify(snapshot)
+      );
+    } catch {
+      // Browser storage is optional.
+    }
+  }
+
+  private read<T extends CodingStatusSnapshot>(
+    key: string,
+    userId: number,
+    workspaceId: number,
+    surface: CodingStatusSnapshotSurface
+  ): T | null {
+    try {
+      const raw = getCodingStatusSessionStorage()?.getItem(key);
+      if (!raw) {
+        return null;
+      }
+      const parsed = JSON.parse(raw) as CodingStatusSnapshot;
+      if (!this.isSnapshotValid(parsed, userId, workspaceId, surface)) {
+        this.remove(key);
+        return null;
+      }
+      return parsed as T;
+    } catch {
+      this.remove(key);
+      return null;
+    }
+  }
+
+  private isSnapshotValid(
+    value: unknown,
+    userId: number,
+    workspaceId: number,
+    surface: CodingStatusSnapshotSurface
+  ): value is CodingStatusSnapshot {
+    if (
+      !this.isObject(value) ||
+      value.schemaVersion !== 1 ||
+      value.userId !== userId ||
+      value.workspaceId !== workspaceId ||
+      value.surface !== surface ||
+      value.fullyChecked !== true ||
+      !this.isPositiveInteger(value.userId) ||
+      !this.isPositiveInteger(value.workspaceId) ||
+      !this.isNonNegativeInteger(value.revision) ||
+      typeof value.statusRevision !== 'string' ||
+      !/^(0|[1-9]\d*)$/.test(value.statusRevision) ||
+      typeof value.checkedAt !== 'string' ||
+      !Number.isFinite(Date.parse(value.checkedAt))
+    ) {
+      return false;
+    }
+    if (surface === 'overview') {
+      return (
+        this.isObject(value.freshness) &&
+        this.isObject(value.readiness) &&
+        value.freshness.workspaceId === workspaceId &&
+        value.readiness.workspaceId === workspaceId
+      );
+    }
+    return (
+      typeof value.planningStatus === 'string' &&
+      PLANNING_STATUS_STATES.has(value.planningStatus as PlanningStatusState) &&
+      this.isObject(value.displayParameters) &&
+      MANUAL_DISPLAY_PARAMETER_KEYS.every(key => this.isNonNegativeNumber(
+        (value.displayParameters as Record<string, unknown>)[key]
+      )) &&
+      (value.freshness === null || (
+        this.isObject(value.freshness) &&
+        value.freshness.workspaceId === workspaceId
+      )) &&
+      this.isObject(value.nextTarget) &&
+      typeof value.nextTarget.tab === 'string' &&
+      MANUAL_CODING_TABS.has(value.nextTarget.tab as ManualCodingSnapshotTab) &&
+      typeof value.nextTarget.sectionId === 'string' &&
+      (value.nextTarget.action === 'navigate' ||
+        value.nextTarget.action === 'double-coding-review')
+    );
+  }
+
+  private isRevisionValid(
+    value: unknown,
+    workspaceId: number
+  ): value is CodingStatusRevisionDto {
+    return (
+      this.isObject(value) &&
+      value.workspaceId === workspaceId &&
+      this.isNonNegativeInteger(value.revision) &&
+      typeof value.statusRevision === 'string' &&
+      /^(0|[1-9]\d*)$/.test(value.statusRevision) &&
+      typeof value.stable === 'boolean'
+    );
+  }
+
+  private buildKey(
+    userId: number,
+    workspaceId: number,
+    surface: CodingStatusSnapshotSurface
+  ) {
+    return `${CODING_STATUS_SNAPSHOT_KEY_PREFIX}${userId}:${workspaceId}:${surface}`;
+  }
+
+  private remove(key: string): void {
+    try {
+      getCodingStatusSessionStorage()?.removeItem(key);
+    } catch {
+      // Browser storage is optional.
+    }
+  }
+
+  private isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+  }
+
+  private isPositiveInteger(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value > 0;
+  }
+
+  private isNonNegativeInteger(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+  }
+
+  private readonly isNonNegativeNumber = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -47,6 +47,7 @@ import {
   WorkspaceSettingsService
 } from '../../ws-admin/services/workspace-settings.service';
 import { CodingBackgroundJobsService } from './coding-background-jobs.service';
+import { clearCodingStatusSnapshots } from '../../core/services/coding-status-session-storage';
 
 interface ExternalCodingImportWithPreviewDto {
   file: string;
@@ -372,6 +373,7 @@ export class TestPersonCodingService {
   }
 
   invalidateCodingStatusCache(workspaceId?: number): void {
+    clearCodingStatusSnapshots(workspaceId);
     this.codingStatusCacheGeneration += 1;
     if (!workspaceId) {
       this.codingFreshnessCache.clear();

--- a/apps/frontend/src/app/core/services/app.service.spec.ts
+++ b/apps/frontend/src/app/core/services/app.service.spec.ts
@@ -60,6 +60,15 @@ describe('AppService', () => {
     expect(service).toBeTruthy();
   });
 
+  it('clears coding-status snapshots when the authenticated user changes', () => {
+    service.updateAuthData({ ...AppService.defaultAuthData, userId: 1 });
+    sessionStorage.setItem('coding-status-snapshot:v1:1:7:manual', '{}');
+
+    service.updateAuthData({ ...AppService.defaultAuthData, userId: 2 });
+
+    expect(sessionStorage.length).toBe(0);
+  });
+
   describe('selectedWorkspaceId', () => {
     it('should emit selected workspace changes', () => {
       const workspaceIds: number[] = [];

--- a/apps/frontend/src/app/core/services/app.service.ts
+++ b/apps/frontend/src/app/core/services/app.service.ts
@@ -24,6 +24,7 @@ import { SERVER_URL } from '../../injection-tokens';
 import { suppressGlobalHttpErrorContext } from '../interceptors/http-error-context';
 import { WorkspaceTokenScope } from './auth-session.config';
 import { SessionRecoveryService } from './session-recovery.service';
+import { clearCodingStatusSnapshots } from './coding-status-session-storage';
 
 export interface WorkspaceTokenPolicy {
   scopes: Record<WorkspaceTokenScope, {
@@ -266,6 +267,10 @@ export class AppService {
   }
 
   updateAuthData(newAuthData: AuthDataDto): void {
+    const previousUserId = this.authDataSubject.value.userId;
+    if (previousUserId > 0 && previousUserId !== newAuthData.userId) {
+      clearCodingStatusSnapshots();
+    }
     this.authDataSubject.next(newAuthData);
   }
 
@@ -378,6 +383,7 @@ export class AppService {
     clearRecoveryDrafts?: boolean;
   } = {}): void {
     localStorage.removeItem('id_token');
+    clearCodingStatusSnapshots();
     this.keycloakIdentity = undefined;
     this.userProfile = {};
     this.isLoggedInKeycloak = false;

--- a/apps/frontend/src/app/core/services/coding-status-session-storage.ts
+++ b/apps/frontend/src/app/core/services/coding-status-session-storage.ts
@@ -1,0 +1,33 @@
+export const CODING_STATUS_SNAPSHOT_KEY_PREFIX = 'coding-status-snapshot:v1:';
+
+export function getCodingStatusSessionStorage(): Storage | null {
+  try {
+    return globalThis.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearCodingStatusSnapshots(workspaceId?: number): void {
+  const storage = getCodingStatusSessionStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    const keys = Array.from({ length: storage.length }, (_, index) => storage.key(index)
+    ).filter(
+      (key): key is string => !!key && key.startsWith(CODING_STATUS_SNAPSHOT_KEY_PREFIX)
+    );
+    keys
+      .filter(
+        key => workspaceId === undefined ||
+          Number(
+            key.slice(CODING_STATUS_SNAPSHOT_KEY_PREFIX.length).split(':')[1]
+          ) === workspaceId
+      )
+      .forEach(key => storage.removeItem(key));
+  } catch {
+    // Browser storage is optional; coding must keep working without it.
+  }
+}

--- a/apps/frontend/src/app/core/services/request-monitoring-incident.service.spec.ts
+++ b/apps/frontend/src/app/core/services/request-monitoring-incident.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting
+} from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { SERVER_URL } from '../../injection-tokens';
+import { RequestMonitoringIncidentService } from './request-monitoring-incident.service';
+
+describe('RequestMonitoringIncidentService', () => {
+  let service: RequestMonitoringIncidentService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: SERVER_URL, useValue: '/api/' }
+      ]
+    });
+    service = TestBed.inject(RequestMonitoringIncidentService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('loads open and resolved server incidents on demand', () => {
+    service.getAll(true, 50).subscribe();
+
+    const request = httpMock.expectOne(req => (
+      req.url === '/api/admin/request-monitoring-incidents' &&
+      req.params.get('includeResolved') === 'true' &&
+      req.params.get('limit') === '50'
+    ));
+    expect(request.request.method).toBe('GET');
+    request.flush([]);
+  });
+
+  it('updates the resolution state', () => {
+    service.setResolved(7, true).subscribe();
+
+    const request = httpMock.expectOne(
+      '/api/admin/request-monitoring-incidents/7/resolution'
+    );
+    expect(request.request.method).toBe('PATCH');
+    expect(request.request.body).toEqual({ resolved: true });
+    request.flush({});
+  });
+});

--- a/apps/frontend/src/app/core/services/request-monitoring-incident.service.ts
+++ b/apps/frontend/src/app/core/services/request-monitoring-incident.service.ts
@@ -1,0 +1,36 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import {
+  RequestMonitoringIncidentDto
+} from '../../../../../../api-dto/request-monitoring/request-monitoring-incident.dto';
+import { SERVER_URL } from '../../injection-tokens';
+
+@Injectable({ providedIn: 'root' })
+export class RequestMonitoringIncidentService {
+  private readonly http = inject(HttpClient);
+  private readonly serverUrl = inject(SERVER_URL);
+
+  getAll(
+    includeResolved = false,
+    limit = 200
+  ): Observable<RequestMonitoringIncidentDto[]> {
+    const params = new HttpParams()
+      .set('includeResolved', String(includeResolved))
+      .set('limit', String(limit));
+    return this.http.get<RequestMonitoringIncidentDto[]>(
+      `${this.serverUrl}admin/request-monitoring-incidents`,
+      { params }
+    );
+  }
+
+  setResolved(
+    id: number,
+    resolved: boolean
+  ): Observable<RequestMonitoringIncidentDto> {
+    return this.http.patch<RequestMonitoringIncidentDto>(
+      `${this.serverUrl}admin/request-monitoring-incidents/${id}/resolution`,
+      { resolved }
+    );
+  }
+}

--- a/apps/frontend/src/app/sys-admin/components/admin/admin.component.ts
+++ b/apps/frontend/src/app/sys-admin/components/admin/admin.component.ts
@@ -14,6 +14,7 @@ export class AdminComponent {
   navLinks = [
     'users',
     'workspaces',
+    'monitoring',
     'notifications',
     'settings'
   ];

--- a/apps/frontend/src/app/sys-admin/components/request-monitoring-incidents/request-monitoring-incidents.component.html
+++ b/apps/frontend/src/app/sys-admin/components/request-monitoring-incidents/request-monitoring-incidents.component.html
@@ -1,0 +1,96 @@
+<mat-card class="monitoring-card">
+  <mat-card-header>
+    <mat-card-title>{{ 'request-monitoring.title' | translate }}</mat-card-title>
+    <mat-card-subtitle>{{ 'request-monitoring.description' | translate }}</mat-card-subtitle>
+  </mat-card-header>
+
+  <mat-card-content>
+    <div class="toolbar">
+      <mat-checkbox
+        [checked]="includeResolved"
+        (change)="toggleResolved($event.checked)">
+        {{ 'request-monitoring.include-resolved' | translate }}
+      </mat-checkbox>
+      <button mat-stroked-button type="button" (click)="load()">
+        <mat-icon>refresh</mat-icon>
+        {{ 'request-monitoring.refresh' | translate }}
+      </button>
+    </div>
+
+    @if (loading) {
+      <div class="loading"><mat-spinner diameter="36"></mat-spinner></div>
+    } @else if (incidents.length === 0) {
+      <p class="empty">{{ 'request-monitoring.empty' | translate }}</p>
+    } @else {
+      <div class="table-wrapper">
+        <table mat-table [dataSource]="incidents">
+          <ng-container matColumnDef="state">
+            <th mat-header-cell *matHeaderCellDef>{{ 'request-monitoring.state' | translate }}</th>
+            <td mat-cell *matCellDef="let incident">
+              <span class="kind" [class.resolved]="incident.resolvedAt">
+                {{ 'request-monitoring.kinds.' + incident.kind | translate }}
+              </span>
+              @if (incident.statusCode) {
+                <span class="status">HTTP {{ incident.statusCode }}</span>
+              }
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="request">
+            <th mat-header-cell *matHeaderCellDef>{{ 'request-monitoring.request' | translate }}</th>
+            <td mat-cell *matCellDef="let incident">
+              <code>{{ incident.method }} {{ incident.path }}</code>
+              @if (incident.workspaceId) {
+                <small>{{ 'request-monitoring.workspace' | translate }} {{ incident.workspaceId }}</small>
+              }
+              @if (incident.lastErrorMessage) {
+                <small class="error">{{ incident.lastErrorMessage }}</small>
+              }
+              <small>{{ 'request-monitoring.request-id' | translate }} {{ incident.lastRequestId }}</small>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="occurrences">
+            <th mat-header-cell *matHeaderCellDef>{{ 'request-monitoring.occurrences' | translate }}</th>
+            <td mat-cell *matCellDef="let incident">{{ incident.occurrenceCount }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="duration">
+            <th mat-header-cell *matHeaderCellDef>{{ 'request-monitoring.max-duration' | translate }}</th>
+            <td mat-cell *matCellDef="let incident">{{ incident.maxDurationMs }} ms</td>
+          </ng-container>
+
+          <ng-container matColumnDef="database">
+            <th mat-header-cell *matHeaderCellDef>{{ 'request-monitoring.database' | translate }}</th>
+            <td mat-cell *matCellDef="let incident">
+              @if (incident.postgresTotalCount !== null) {
+                {{ incident.postgresTotalCount }} / {{ incident.postgresIdleCount }} / {{ incident.postgresWaitingCount }}
+              } @else {
+                –
+              }
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="lastOccurred">
+            <th mat-header-cell *matHeaderCellDef>{{ 'request-monitoring.last-occurred' | translate }}</th>
+            <td mat-cell *matCellDef="let incident">
+              {{ incident.lastOccurredAt | date:'dd.MM.yyyy HH:mm:ss' }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef>{{ 'request-monitoring.actions' | translate }}</th>
+            <td mat-cell *matCellDef="let incident">
+              <button mat-button type="button" (click)="setResolved(incident)">
+                {{ (incident.resolvedAt ? 'request-monitoring.reopen' : 'request-monitoring.resolve') | translate }}
+              </button>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        </table>
+      </div>
+    }
+  </mat-card-content>
+</mat-card>

--- a/apps/frontend/src/app/sys-admin/components/request-monitoring-incidents/request-monitoring-incidents.component.scss
+++ b/apps/frontend/src/app/sys-admin/components/request-monitoring-incidents/request-monitoring-incidents.component.scss
@@ -1,0 +1,64 @@
+.monitoring-card {
+  margin: 16px;
+}
+
+.toolbar {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin: 16px 0;
+}
+
+.loading,
+.empty {
+  display: flex;
+  justify-content: center;
+  padding: 32px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+}
+
+code,
+small {
+  display: block;
+}
+
+code {
+  max-width: 520px;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+small {
+  color: var(--mat-sys-on-surface-variant);
+  margin-top: 4px;
+}
+
+.error {
+  color: var(--mat-sys-error);
+}
+
+.kind {
+  font-weight: 600;
+}
+
+.kind.resolved {
+  opacity: 0.6;
+}
+
+.status {
+  display: block;
+  margin-top: 4px;
+}
+
+th,
+td {
+  padding-right: 16px;
+  vertical-align: top;
+}

--- a/apps/frontend/src/app/sys-admin/components/request-monitoring-incidents/request-monitoring-incidents.component.spec.ts
+++ b/apps/frontend/src/app/sys-admin/components/request-monitoring-incidents/request-monitoring-incidents.component.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import {
+  RequestMonitoringIncidentDto,
+  RequestMonitoringIncidentKind
+} from '../../../../../../../api-dto/request-monitoring/request-monitoring-incident.dto';
+import { RequestMonitoringIncidentService } from '../../../core/services/request-monitoring-incident.service';
+import { RequestMonitoringIncidentsComponent } from './request-monitoring-incidents.component';
+
+function incident(
+  overrides: Partial<RequestMonitoringIncidentDto> = {}
+): RequestMonitoringIncidentDto {
+  return {
+    id: 1,
+    kind: RequestMonitoringIncidentKind.Failed,
+    method: 'GET',
+    path: '/api/admin/workspace/:id/test-results/log-anomaly-summary',
+    workspaceId: 3,
+    statusCode: 500,
+    occurrenceCount: 2,
+    maxDurationMs: 12_000,
+    lastRequestId: 'request-2',
+    lastErrorMessage: 'query failed',
+    postgresTotalCount: 10,
+    postgresIdleCount: 0,
+    postgresWaitingCount: 3,
+    firstOccurredAt: '2026-07-30T10:00:00.000Z',
+    lastOccurredAt: '2026-07-30T10:05:00.000Z',
+    resolvedAt: null,
+    ...overrides
+  };
+}
+
+describe('RequestMonitoringIncidentsComponent', () => {
+  let fixture: ComponentFixture<RequestMonitoringIncidentsComponent>;
+  let component: RequestMonitoringIncidentsComponent;
+  const service = {
+    getAll: jest.fn().mockReturnValue(of([incident()])),
+    setResolved: jest.fn().mockReturnValue(of(incident({
+      resolvedAt: '2026-07-30T10:10:00.000Z'
+    })))
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    service.getAll.mockReturnValue(of([incident()]));
+    await TestBed.configureTestingModule({
+      imports: [
+        RequestMonitoringIncidentsComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [{
+        provide: RequestMonitoringIncidentService,
+        useValue: service
+      }, {
+        provide: MatSnackBar,
+        useValue: { open: jest.fn() }
+      }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RequestMonitoringIncidentsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('loads open incidents on initialization', () => {
+    expect(service.getAll).toHaveBeenCalledWith(false);
+    expect(component.incidents).toHaveLength(1);
+  });
+
+  it('removes a resolved incident from the open list', () => {
+    component.setResolved(component.incidents[0]);
+
+    expect(service.setResolved).toHaveBeenCalledWith(1, true);
+    expect(component.incidents).toEqual([]);
+  });
+
+  it('reloads when resolved incidents are requested', () => {
+    component.toggleResolved(true);
+
+    expect(service.getAll).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/apps/frontend/src/app/sys-admin/components/request-monitoring-incidents/request-monitoring-incidents.component.ts
+++ b/apps/frontend/src/app/sys-admin/components/request-monitoring-incidents/request-monitoring-incidents.component.ts
@@ -1,0 +1,92 @@
+import { DatePipe } from '@angular/common';
+import { Component, inject, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { finalize } from 'rxjs';
+import {
+  RequestMonitoringIncidentDto
+} from '../../../../../../../api-dto/request-monitoring/request-monitoring-incident.dto';
+import { RequestMonitoringIncidentService } from '../../../core/services/request-monitoring-incident.service';
+
+@Component({
+  selector: 'coding-box-request-monitoring-incidents',
+  templateUrl: './request-monitoring-incidents.component.html',
+  styleUrl: './request-monitoring-incidents.component.scss',
+  imports: [
+    DatePipe,
+    MatButtonModule,
+    MatCardModule,
+    MatCheckboxModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatSnackBarModule,
+    MatTableModule,
+    TranslateModule
+  ]
+})
+export class RequestMonitoringIncidentsComponent implements OnInit {
+  private readonly service = inject(RequestMonitoringIncidentService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly translate = inject(TranslateService);
+
+  readonly displayedColumns = [
+    'state',
+    'request',
+    'occurrences',
+    'duration',
+    'database',
+    'lastOccurred',
+    'actions'
+  ];
+
+  incidents: RequestMonitoringIncidentDto[] = [];
+  includeResolved = false;
+  loading = false;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.service.getAll(this.includeResolved)
+      .pipe(finalize(() => { this.loading = false; }))
+      .subscribe({
+        next: incidents => { this.incidents = incidents; },
+        error: () => this.showMessage('request-monitoring.load-error')
+      });
+  }
+
+  toggleResolved(checked: boolean): void {
+    this.includeResolved = checked;
+    this.load();
+  }
+
+  setResolved(incident: RequestMonitoringIncidentDto): void {
+    const resolved = incident.resolvedAt === null;
+    this.service.setResolved(incident.id, resolved).subscribe({
+      next: updated => {
+        if (resolved && !this.includeResolved) {
+          this.incidents = this.incidents.filter(item => item.id !== updated.id);
+        } else {
+          this.incidents = this.incidents.map(item => (
+            item.id === updated.id ? updated : item
+          ));
+        }
+      },
+      error: () => this.showMessage('request-monitoring.update-error')
+    });
+  }
+
+  private showMessage(key: string): void {
+    this.snackBar.open(this.translate.instant(key), undefined, {
+      duration: 4000
+    });
+  }
+}

--- a/apps/frontend/src/app/sys-admin/sys-admin.routes.ts
+++ b/apps/frontend/src/app/sys-admin/sys-admin.routes.ts
@@ -11,6 +11,7 @@ export const sysAdminRoutes: Routes = [
       { path: 'users', loadComponent: () => import('./components/users/users.component').then(m => m.UsersComponent) },
       { path: 'settings', loadComponent: () => import('./components/sys-admin-settings/sys-admin-settings.component').then(m => m.SysAdminSettingsComponent) },
       { path: 'notifications', loadComponent: () => import('./components/system-notifications/system-notifications.component').then(m => m.SystemNotificationsComponent) },
+      { path: 'monitoring', loadComponent: () => import('./components/request-monitoring-incidents/request-monitoring-incidents.component').then(m => m.RequestMonitoringIncidentsComponent) },
       { path: 'workspaces', loadComponent: () => import('./components/workspaces/workspaces.component').then(m => m.WorkspacesComponent) },
       { path: 'workspace/:ws', loadComponent: () => import('./components/workspaces/workspaces.component').then(m => m.WorkspacesComponent) },
       { path: '**', loadComponent: () => import('./components/users/users.component').then(m => m.UsersComponent) }

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -422,6 +422,7 @@
     "users-deleted": "Nutzer:in(en) gelöscht",
     "users-not-deleted": "Nutzer:in(en) konnten nicht gelöscht werden",
     "workspaces": "Arbeitsbereiche",
+    "monitoring": "Servermeldungen",
     "notifications": "Systemhinweise",
     "settings": "Einstellungen",
     "upload-resource-package": "Resource-Package hochladen/aktualisieren",
@@ -466,6 +467,33 @@
     "deleting-workspace-persons": "Personendaten werden gelöscht...",
     "deleting-workspace-finish": "Löschen wird abgeschlossen...",
     "deleting-workspace-success": "Arbeitsbereich erfolgreich gelöscht!"
+  },
+  "request-monitoring": {
+    "title": "Servermeldungen",
+    "description": "Langsame, fehlgeschlagene und abgebrochene Anfragen werden ohne Query-Parameter gruppiert. Ein erneutes Auftreten öffnet eine erledigte Meldung automatisch wieder.",
+    "include-resolved": "Erledigte Meldungen anzeigen",
+    "refresh": "Aktualisieren",
+    "empty": "Keine offenen Servermeldungen vorhanden.",
+    "state": "Art",
+    "request": "Anfrage",
+    "workspace": "Arbeitsbereich:",
+    "request-id": "Letzte Fehler-ID:",
+    "occurrences": "Anzahl",
+    "max-duration": "Max. Dauer",
+    "database": "PostgreSQL gesamt / frei / wartend",
+    "last-occurred": "Zuletzt",
+    "actions": "Aktionen",
+    "resolve": "Als erledigt markieren",
+    "reopen": "Wieder öffnen",
+    "load-error": "Servermeldungen konnten nicht geladen werden.",
+    "update-error": "Die Servermeldung konnte nicht aktualisiert werden.",
+    "kinds": {
+      "slow": "Langsam",
+      "failed": "Fehlgeschlagen",
+      "in_flight": "Läuft ungewöhnlich lange",
+      "aborted": "Abgebrochen",
+      "closed": "Verbindung geschlossen"
+    }
   },
   "system-notifications": {
     "banner-label": "Systemhinweis",

--- a/cypress/e2e/coding-status-snapshot.cy.ts
+++ b/cypress/e2e/coding-status-snapshot.cy.ts
@@ -97,6 +97,7 @@ describe('Kodierstatus-Sitzungsspeicher', () => {
 
     cy.visit('/');
     cy.wait('@authData');
+    cy.contains('a.workspace', 'E2E Workspace').should('be.visible');
     cy.window().then(window => {
       window.sessionStorage.setItem(
         `coding-status-snapshot:v1:${userId}:${workspaceId}:overview`,

--- a/cypress/e2e/coding-status-snapshot.cy.ts
+++ b/cypress/e2e/coding-status-snapshot.cy.ts
@@ -1,0 +1,147 @@
+describe('Kodierstatus-Sitzungsspeicher', () => {
+  it('restores the checked overview after leaving the view when automatic refresh is disabled', () => {
+    const workspaceId = 5;
+    const userId = 2;
+    const revision = 12;
+    const statusRevision = '34';
+    const readiness = {
+      workspaceId,
+      autoCoderRun: 1,
+      readiness: 'READY',
+      blockers: [],
+      rawResponsesTotal: 0,
+      rawResponsesWithRelevantStatus: 0,
+      resultUnitsTotal: 0,
+      resultUnitKeysTotal: 0,
+      matchedUnitFiles: 0,
+      missingUnitFiles: [],
+      matchedCodingSchemes: 0,
+      missingCodingSchemes: [],
+      invalidCodingSchemes: [],
+      validVariablePairs: 0,
+      validResponses: 0,
+      codeableResponses: 0,
+      invalidVariableSamples: []
+    };
+    let freshnessRequests = 0;
+    let readinessRequests = 0;
+    let appliedResultsOverviewRequests = 0;
+
+    cy.mockKeycloakAuthentication();
+    cy.stubWorkspace({ workspaceId, userId });
+
+    const settings: Array<[string, boolean]> = [
+      ['evaluation-mode', false],
+      ['auto-fetch-coding-statistics', false],
+      ['auto-refresh-manual-coding-jobs', false],
+      ['enable-regex-search', false]
+    ];
+    settings.forEach(([key, enabled]) => {
+      cy.intercept(
+        'GET',
+        `**/api/workspace/${workspaceId}/settings/${key}`,
+        {
+          body: {
+            key,
+            value: JSON.stringify({ enabled })
+          }
+        }
+      );
+    });
+
+    cy.intercept(
+      'GET',
+      `**/api/admin/workspace/${workspaceId}/coding/revision`,
+      {
+        body: {
+          workspaceId,
+          revision,
+          statusRevision,
+          stable: true
+        }
+      }
+    ).as('codingStatusRevision');
+    cy.intercept(
+      'GET',
+      `**/api/admin/workspace/${workspaceId}/coding/reset-version/active`,
+      { body: { hasActiveJob: false } }
+    );
+    cy.intercept(
+      'GET',
+      `**/api/admin/workspace/${workspaceId}/coding/freshness`,
+      request => {
+        freshnessRequests += 1;
+        request.reply({
+          workspaceId,
+          currentRevision: revision,
+          items: []
+        });
+      }
+    );
+    cy.intercept(
+      'GET',
+      `**/api/admin/workspace/${workspaceId}/coding/readiness*`,
+      request => {
+        readinessRequests += 1;
+        request.reply(readiness);
+      }
+    );
+    cy.intercept(
+      'GET',
+      `**/api/admin/workspace/${workspaceId}/coding/applied-results-overview`,
+      request => {
+        appliedResultsOverviewRequests += 1;
+        request.reply({});
+      }
+    );
+
+    cy.visit('/');
+    cy.wait('@authData');
+    cy.window().then(window => {
+      window.sessionStorage.setItem(
+        `coding-status-snapshot:v1:${userId}:${workspaceId}:overview`,
+        JSON.stringify({
+          schemaVersion: 1,
+          userId,
+          workspaceId,
+          revision,
+          statusRevision,
+          checkedAt: new Date().toISOString(),
+          surface: 'overview',
+          fullyChecked: true,
+          freshness: {
+            workspaceId,
+            currentRevision: revision,
+            items: []
+          },
+          readiness,
+          appliedResultsOverview: null
+        })
+      );
+      window.location.hash = `/workspace-admin/${workspaceId}/coding/management`;
+    });
+
+    cy.wait('@codingStatusRevision');
+    cy.get('.coding-freshness-panel')
+      .should('contain.text', 'Für die aktuell berücksichtigten Testergebnisse')
+      .and('not.contain.text', 'noch nicht geprüft');
+
+    cy.window().then(window => {
+      window.location.hash = '/home';
+    });
+    cy.get('coding-box-home').should('exist');
+    cy.window().then(window => {
+      window.location.hash = `/workspace-admin/${workspaceId}/coding/management`;
+    });
+
+    cy.wait('@codingStatusRevision');
+    cy.get('.coding-freshness-panel')
+      .should('contain.text', 'Für die aktuell berücksichtigten Testergebnisse')
+      .and('not.contain.text', 'noch nicht geprüft');
+    cy.then(() => {
+      expect(freshnessRequests).to.equal(0);
+      expect(readinessRequests).to.equal(0);
+      expect(appliedResultsOverviewRequests).to.equal(0);
+    });
+  });
+});

--- a/database/changelog/coding-box.changelog-1.17.1.sql
+++ b/database/changelog/coding-box.changelog-1.17.1.sql
@@ -6,3 +6,33 @@ ALTER TABLE "public"."workspace_test_results_revision"
   ADD COLUMN IF NOT EXISTS "status_revision" BIGINT NOT NULL DEFAULT 0;
 
 -- rollback ALTER TABLE "public"."workspace_test_results_revision" DROP COLUMN IF EXISTS "status_revision";
+
+-- changeset jurei733:813-2
+-- comment: Persist aggregated slow and failed HTTP requests for the server administration
+CREATE TABLE "public"."request_monitoring_incident" (
+  "id" SERIAL PRIMARY KEY,
+  "fingerprint" CHAR(64) NOT NULL,
+  "kind" VARCHAR(20) NOT NULL,
+  "method" VARCHAR(10) NOT NULL,
+  "path" VARCHAR(500) NOT NULL,
+  "workspace_id" INTEGER,
+  "status_code" INTEGER,
+  "occurrence_count" INTEGER NOT NULL DEFAULT 1,
+  "max_duration_ms" INTEGER NOT NULL,
+  "last_request_id" VARCHAR(128) NOT NULL,
+  "last_error_message" VARCHAR(1000),
+  "postgres_total_count" INTEGER,
+  "postgres_idle_count" INTEGER,
+  "postgres_waiting_count" INTEGER,
+  "first_occurred_at" TIMESTAMPTZ NOT NULL,
+  "last_occurred_at" TIMESTAMPTZ NOT NULL,
+  "resolved_at" TIMESTAMPTZ,
+  CONSTRAINT "uq_request_monitoring_incident_fingerprint" UNIQUE ("fingerprint"),
+  CONSTRAINT "chk_request_monitoring_incident_kind"
+    CHECK ("kind" IN ('slow', 'failed', 'in_flight', 'aborted', 'closed'))
+);
+
+CREATE INDEX "idx_request_monitoring_incident_open_last"
+  ON "public"."request_monitoring_incident" ("resolved_at", "last_occurred_at" DESC);
+
+-- rollback DROP TABLE "public"."request_monitoring_incident";

--- a/database/changelog/coding-box.changelog-1.17.1.sql
+++ b/database/changelog/coding-box.changelog-1.17.1.sql
@@ -1,0 +1,8 @@
+-- liquibase formatted sql
+
+-- changeset jurei733:813-1
+-- comment: Extend the existing workspace revision with a coding-status revision
+ALTER TABLE "public"."workspace_test_results_revision"
+  ADD COLUMN IF NOT EXISTS "status_revision" BIGINT NOT NULL DEFAULT 0;
+
+-- rollback ALTER TABLE "public"."workspace_test_results_revision" DROP COLUMN IF EXISTS "status_revision";

--- a/database/changelog/coding-box.changelog-root.xml
+++ b/database/changelog/coding-box.changelog-root.xml
@@ -44,4 +44,5 @@
   <include file="coding-box.changelog-1.16.3.sql"/>
   <include file="coding-box.changelog-1.16.4.sql"/>
   <include file="coding-box.changelog-1.17.0.sql"/>
+  <include file="coding-box.changelog-1.17.1.sql"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Zusammenfassung

- stellt vollständig geprüfte Kodierstatus-Snapshots innerhalb des aktuellen Browser-Tabs wieder her
- validiert Snapshots gegen Benutzer, Workspace, Testdatenrevision und Kodierstatusrevision
- verarbeitet die produktionskritische Log-Anomalieauswertung speicherbegrenzt in Batches
- erfasst langsame, fehlgeschlagene, laufende und abgebrochene HTTP-Anfragen persistent für die Serveradministration
- ergänzt unter `/admin/monitoring` eine Admin-Ansicht mit Fehlertext, Request-ID, Workspace, Laufzeit, Häufigkeit und PostgreSQL-Poolstatus
- korrigiert die beiden Review-Findings zu unnötiger Revisionsinvalidierung und verzögertem Laden eines nicht mehr aktiven Planungstabs

## Ursache und Ansatz

Die Kodierübersicht und die manuelle Planung verloren ihren bereits geprüften Status bei Navigation und Neuladen. Gleichzeitig konnten reine Vorschau-POSTs den Kodierstatus unnötig invalidieren und ein verzögertes Planungsladen nach einem Tabwechsel noch ausgeführt werden.

Der Produktions-500 der Log-Anomalieübersicht entstand durch große, unbeschränkt zusammengeführte Ergebnismengen. Insbesondere konnte das Einfügen sehr großer Arrays per Spread einen `RangeError` auslösen. Die Abfragen und Aggregationen werden nun in begrenzten Batches verarbeitet; Detailergebnisse halten nur noch die tatsächlich benötigten Top-Ergebnisse im Speicher.

Bisher waren langsame und fehlgeschlagene Requests nur in Serverlogs sichtbar. Die Request-Überwachung gruppiert diese Meldungen nun persistent und stellt sie ausschließlich Administratoren zur Verfügung. Aufgelöste Meldungen können erledigt und bei erneutem Auftreten automatisch wieder geöffnet werden.

## Datenbankauswirkung

- zusätzliche `status_revision` in `workspace_test_results_revision`
- neue Tabelle `request_monitoring_incident` für aggregierte Servermeldungen
- Index für offene Meldungen nach letztem Auftreten
- keine fachlichen Test- oder Kodierdaten werden verändert

## Auswirkung

- weniger unnötige Status- und Planungsabfragen
- keine Revisionsänderung durch Vorschau- und Validierungsanfragen
- kein nachlaufendes Planungsladen nach einem Tabwechsel
- stabilere Log-Anomalieauswertung bei sehr großen Workspaces
- vollständige, dauerhafte und bearbeitbare Fehlermeldungen im Server-Adminbereich

## Validierung

- `npx nx lint backend`: erfolgreich
- `npx nx test backend --runInBand`: 166 Suites / 2427 Tests erfolgreich, 2 Suites bzw. 10 Tests übersprungen
- `npx nx build backend`: erfolgreich
- `npx nx lint frontend`: erfolgreich
- `npx nx test frontend --runInBand`: 205 Suites / 2024 Tests erfolgreich
- `npx nx build frontend`: erfolgreich
- DTO-Typecheck: erfolgreich
- großer Anomalie-Test mit 150.000 Ergebniszeilen: erfolgreich
- `git diff --check`: erfolgreich

## Noch extern zu prüfen

- Liquibase-Container-Validierung des neuen Changesets konnte lokal nicht starten, weil der Zugriff auf die private HU-Container-Registry nicht autorisiert war.
- Der vorhandene Cypress-Snapshot-Test wartet auf einen Revisionsrequest, den sein aktueller Startablauf nicht auslöst; die betroffene P2-Regression ist durch einen neuen Komponententest abgedeckt.
- Nach dem Deployment sollte der große Produktions-Workspace erneut gegen den Anomalie-Endpunkt geprüft werden.

Teil von #813.
