### PR TITLE
MC-Antworten mit leerer Begründung korrekt abschließen

### DIFF
--- a/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-item-matrix-export.service.spec.ts
@@ -705,6 +705,89 @@ describe('CodingItemMatrixExportService', () => {
     });
   });
 
+  it('exports a stored MIR result on a derived target without resolving its sources', async () => {
+    const service = createService();
+    const derived = column('1', 'UNIT1', 'DERIVED', true);
+    const manualSourceKey = 'UNIT1\u001FMANUAL_SOURCE';
+    const autoSourceKey = 'UNIT1\u001FAUTO_SOURCE';
+    const mir = {
+      id: 'mir',
+      label: 'missing response',
+      code: -98,
+      score: 0
+    };
+    const exportProfile = {
+      byId: new Map([
+        ...profile.byId,
+        ['mir', mir]
+      ]),
+      byCode: new Map([
+        ...profile.byCode,
+        [mir.code, mir]
+      ])
+    };
+    const design = {
+      units: new Map([[
+        'UNIT1',
+        { unitId: 'UNIT1', order: 0, testletKey: '0:T1' }
+      ]])
+    };
+    const values = new Map([
+      [derived.key, { code: -98, score: 0, status: 5 }],
+      [autoSourceKey, { code: 1, score: 1, status: 5 }],
+      [manualSourceKey, { code: null, score: null, status: 12 }]
+    ]);
+    const derivedSources = new Map([
+      [derived.key, [autoSourceKey, manualSourceKey]]
+    ]);
+
+    const cells = await (
+      service as never as {
+        resolveRowCells: (
+          columnsValue: unknown[],
+          designValue: unknown,
+          responseValues: unknown,
+          profileValue: unknown,
+          derivedValue: unknown,
+          configValue: ItemMatrixExportConfiguration
+        ) => Promise<Array<{
+          state: string;
+          code: number | null;
+          score: number | null;
+          unresolved: boolean;
+          failureReason?: string;
+        }>>;
+      }
+    ).resolveRowCells(
+      [derived],
+      design,
+      values,
+      exportProfile,
+      derivedSources,
+      configuration
+    );
+
+    expect(cells[0]).toMatchObject({
+      state: 'mir',
+      code: -98,
+      score: 0,
+      unresolved: false
+    });
+    expect(cells[0].failureReason).toBeUndefined();
+    const getExportValue = (
+      requestedValue: 'code' | 'score'
+    ) => (
+      service as unknown as {
+        getExportValue: (
+          cell: unknown,
+          requested: 'code' | 'score'
+        ) => string | number;
+      }
+    ).getExportValue(cells[0], requestedValue);
+    expect(getExportValue('code')).toBe(-98);
+    expect(getExportValue('score')).toBe(0);
+  });
+
   it('distinguishes unresolved statuses, derived failures and design conflicts', async () => {
     const service = createService();
     const direct = column('1', 'UNIT1', 'DIRECT');

--- a/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/coding-results.service.spec.ts
@@ -1340,6 +1340,9 @@ describe('CodingResultsService', () => {
       call[0] === 'response.status_v1 IN (:...statuses)'
     ));
     expect(statusFilterCall?.[1].statuses).not.toContain(statusStringToNumber('DERIVE_ERROR'));
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'response.status_v2 IS NULL'
+    );
     expect(codingValidationService.invalidateIncompleteVariablesCache).toHaveBeenCalledWith(17);
     expect(codingStatisticsService.invalidateCache).toHaveBeenCalledWith(17);
     expect(codingAnalysisService.invalidateCache).toHaveBeenCalledWith(17);
@@ -1391,7 +1394,11 @@ describe('CodingResultsService', () => {
     expect(queryRunner.manager.update).toHaveBeenCalledWith(
       ResponseEntity,
       1,
-      expect.objectContaining({ code_v2: -98 })
+      {
+        code_v2: -98,
+        score_v2: 0,
+        status_v2: statusStringToNumber('CODING_COMPLETE')
+      }
     );
 
     const candidateBrackets = queryBuilder.andWhere.mock.calls

--- a/apps/backend/src/app/database/services/coding/empty-response-selection.service.spec.ts
+++ b/apps/backend/src/app/database/services/coding/empty-response-selection.service.spec.ts
@@ -2,6 +2,7 @@ import { Repository } from 'typeorm';
 import { ResponseEntity } from '../../entities/response.entity';
 import { getManualCodingScopeKey } from '../../utils/manual-coding-scope.util';
 import {
+  CODING_COMPLETE_STATUS,
   CODING_INCOMPLETE_STATUS,
   INTENDED_INCOMPLETE_STATUS
 } from '../../utils/manual-coding-candidate.util';
@@ -139,7 +140,7 @@ describe('EmptyResponseSelectionService', () => {
     expect(result).toEqual([]);
   });
 
-  it('checks every leaf source regardless of its coding status', async () => {
+  it('uses empty intended-incomplete sources for mixed MC+reason targets', async () => {
     workspaceFilesService.getDerivedVariableMetadata.mockResolvedValue({
       metadataAvailable: true,
       derivedVariableMap: new Map([
@@ -151,36 +152,200 @@ describe('EmptyResponseSelectionService', () => {
       ])
     });
     sourceRows = [
-      withStatus(response(10, 1, 'AUTO_SOURCE', 'selected'), 5),
       withStatus(
-        response(11, 1, 'MANUAL_SOURCE', ''),
-        INTENDED_INCOMPLETE_STATUS
-      )
+        response(10, 1, 'AUTO_SOURCE', 'selected'),
+        CODING_COMPLETE_STATUS
+      ),
+      {
+        ...withStatus(
+          response(11, 1, 'MANUAL_SOURCE', ''),
+          INTENDED_INCOMPLETE_STATUS
+        ),
+        status_v2: CODING_COMPLETE_STATUS,
+        code_v2: -98,
+        score_v2: 0
+      }
     ];
+    const target = withStatus(
+      response(1, 1, 'DERIVED', 'technical solver value'),
+      CODING_INCOMPLETE_STATUS
+    );
 
     const context = await service.createContext(17);
     const result = await service.filterEffectivelyEmptyResponses(
-      [response(1, 1, 'DERIVED', '')],
+      [target],
       context
     );
 
-    expect(result).toEqual([]);
+    expect(result).toEqual([target]);
+  });
 
-    sourceRows[0] = withStatus(
-      response(10, 1, 'AUTO_SOURCE', ''),
-      5
+  it('keeps mixed MC+reason targets open when an intended source is answered', async () => {
+    workspaceFilesService.getDerivedVariableMetadata.mockResolvedValue({
+      metadataAvailable: true,
+      derivedVariableMap: new Map([
+        ['UNIT', new Set(['DERIVED'])]
+      ]),
+      derivedVariablesBySourceMap: new Map([
+        [getManualCodingScopeKey('UNIT', 'AUTO_SOURCE'), new Set(['DERIVED'])],
+        [getManualCodingScopeKey('UNIT', 'MANUAL_SOURCE'), new Set(['DERIVED'])]
+      ])
+    });
+    sourceRows = [
+      withStatus(
+        response(10, 1, 'AUTO_SOURCE', ''),
+        CODING_COMPLETE_STATUS
+      ),
+      withStatus(
+        response(11, 1, 'MANUAL_SOURCE', 'reason'),
+        INTENDED_INCOMPLETE_STATUS
+      )
+    ];
+    const target = withStatus(
+      response(1, 1, 'DERIVED', ''),
+      CODING_INCOMPLETE_STATUS
     );
+
+    const context = await service.createContext(17);
+
     await expect(service.filterEffectivelyEmptyResponses(
-      [response(1, 1, 'DERIVED', '')],
+      [target],
       context
-    )).resolves.toEqual([response(1, 1, 'DERIVED', '')]);
+    )).resolves.toEqual([]);
+  });
+
+  it('keeps the all-leaf-sources fallback when no source is intended-incomplete', async () => {
+    workspaceFilesService.getDerivedVariableMetadata.mockResolvedValue({
+      metadataAvailable: true,
+      derivedVariableMap: new Map([
+        ['UNIT', new Set(['DERIVED'])]
+      ]),
+      derivedVariablesBySourceMap: new Map([
+        [getManualCodingScopeKey('UNIT', 'SOURCE_A'), new Set(['DERIVED'])],
+        [getManualCodingScopeKey('UNIT', 'SOURCE_B'), new Set(['DERIVED'])]
+      ])
+    });
+    sourceRows = [
+      withStatus(response(10, 1, 'SOURCE_A', ''), CODING_COMPLETE_STATUS),
+      withStatus(response(11, 1, 'SOURCE_B', ''), CODING_INCOMPLETE_STATUS)
+    ];
+    const target = withStatus(
+      response(1, 1, 'DERIVED', ''),
+      CODING_INCOMPLETE_STATUS
+    );
+
+    const context = await service.createContext(17);
+
+    await expect(service.filterEffectivelyEmptyResponses(
+      [target],
+      context
+    )).resolves.toEqual([target]);
 
     sourceRows[1] = withStatus(
-      response(11, 1, 'MANUAL_SOURCE', 'answered'),
+      response(11, 1, 'SOURCE_B', 'answered'),
       CODING_INCOMPLETE_STATUS
     );
     await expect(service.filterEffectivelyEmptyResponses(
-      [response(1, 1, 'DERIVED', '')],
+      [target],
+      context
+    )).resolves.toEqual([]);
+  });
+
+  it('fails closed for ambiguous MC+reason source status combinations', async () => {
+    workspaceFilesService.getDerivedVariableMetadata.mockResolvedValue({
+      metadataAvailable: true,
+      derivedVariableMap: new Map([
+        ['UNIT', new Set(['DERIVED'])]
+      ]),
+      derivedVariablesBySourceMap: new Map([
+        [getManualCodingScopeKey('UNIT', 'AUTO_SOURCE'), new Set(['DERIVED'])],
+        [getManualCodingScopeKey('UNIT', 'MANUAL_SOURCE'), new Set(['DERIVED'])],
+        [getManualCodingScopeKey('UNIT', 'OTHER_SOURCE'), new Set(['DERIVED'])]
+      ])
+    });
+    sourceRows = [
+      withStatus(response(10, 1, 'AUTO_SOURCE', ''), CODING_COMPLETE_STATUS),
+      withStatus(
+        response(11, 1, 'MANUAL_SOURCE', ''),
+        INTENDED_INCOMPLETE_STATUS
+      ),
+      withStatus(response(12, 1, 'OTHER_SOURCE', ''), CODING_INCOMPLETE_STATUS)
+    ];
+    const target = withStatus(
+      response(1, 1, 'DERIVED', ''),
+      CODING_INCOMPLETE_STATUS
+    );
+
+    const context = await service.createContext(17);
+
+    await expect(service.filterEffectivelyEmptyResponses(
+      [target],
+      context
+    )).resolves.toEqual([]);
+
+    sourceRows = sourceRows.map(source => withStatus(
+      source,
+      INTENDED_INCOMPLETE_STATUS
+    ));
+    await expect(service.filterEffectivelyEmptyResponses(
+      [target],
+      context
+    )).resolves.toEqual([]);
+  });
+
+  it('fails closed for missing source statuses on coding-incomplete targets', async () => {
+    workspaceFilesService.getDerivedVariableMetadata.mockResolvedValue({
+      metadataAvailable: true,
+      derivedVariableMap: new Map([
+        ['UNIT', new Set(['DERIVED'])]
+      ]),
+      derivedVariablesBySourceMap: new Map([
+        [getManualCodingScopeKey('UNIT', 'SOURCE'), new Set(['DERIVED'])]
+      ])
+    });
+    sourceRows = [response(10, 1, 'SOURCE', '')];
+    const target = withStatus(
+      response(1, 1, 'DERIVED', ''),
+      CODING_INCOMPLETE_STATUS
+    );
+
+    const context = await service.createContext(17);
+
+    await expect(service.filterEffectivelyEmptyResponses(
+      [target],
+      context
+    )).resolves.toEqual([]);
+
+    sourceRows[0] = withStatus(response(10, 1, 'SOURCE', ''), 64);
+    await expect(service.filterEffectivelyEmptyResponses(
+      [target],
+      context
+    )).resolves.toEqual([]);
+  });
+
+  it('fails closed when a leaf source has multiple response rows', async () => {
+    workspaceFilesService.getDerivedVariableMetadata.mockResolvedValue({
+      metadataAvailable: true,
+      derivedVariableMap: new Map([
+        ['UNIT', new Set(['DERIVED'])]
+      ]),
+      derivedVariablesBySourceMap: new Map([
+        [getManualCodingScopeKey('UNIT', 'SOURCE'), new Set(['DERIVED'])]
+      ])
+    });
+    sourceRows = [
+      withStatus(response(10, 1, 'SOURCE', ''), CODING_COMPLETE_STATUS),
+      withStatus(response(11, 1, 'SOURCE', ''), CODING_COMPLETE_STATUS)
+    ];
+    const target = withStatus(
+      response(1, 1, 'DERIVED', ''),
+      CODING_INCOMPLETE_STATUS
+    );
+
+    const context = await service.createContext(17);
+
+    await expect(service.filterEffectivelyEmptyResponses(
+      [target],
       context
     )).resolves.toEqual([]);
   });

--- a/apps/backend/src/app/database/services/coding/empty-response-selection.service.ts
+++ b/apps/backend/src/app/database/services/coding/empty-response-selection.service.ts
@@ -8,6 +8,12 @@ import {
   splitManualCodingScopeKey
 } from '../../utils/manual-coding-scope.util';
 import {
+  CODING_COMPLETE_STATUS,
+  CODING_INCOMPLETE_STATUS,
+  INTENDED_INCOMPLETE_STATUS
+} from '../../utils/manual-coding-candidate.util';
+import { statusNumberToString } from '../../utils/response-status-converter';
+import {
   isAggregatableValue,
   isDerivedAggregationVariable
 } from './aggregation-metrics.util';
@@ -127,12 +133,17 @@ export class EmptyResponseSelectionService {
           sourceVariableIds
         })
         .getMany();
-      const sourceResponsesByKey = new Map(
-        sourceResponses.map(response => [
-          this.getUnitResponseKey(response.unitid, response.variableid),
-          response
-        ])
-      );
+      const sourceResponsesByKey = new Map<string, ResponseEntity | null>();
+      sourceResponses.forEach(sourceResponse => {
+        const sourceKey = this.getUnitResponseKey(
+          sourceResponse.unitid,
+          sourceResponse.variableid
+        );
+        sourceResponsesByKey.set(
+          sourceKey,
+          sourceResponsesByKey.has(sourceKey) ? null : sourceResponse
+        );
+      });
 
       chunk.forEach(plan => {
         const resolvedSources = Array.from(plan.sourceVariableIds).map(variableId => (
@@ -140,18 +151,67 @@ export class EmptyResponseSelectionService {
             this.getUnitResponseKey(plan.response.unitid, variableId)
           )
         ));
-        const allSourcesExist = resolvedSources.every(source => source !== undefined);
-        const allSourcesEmpty = resolvedSources.every(source => (
-          source !== undefined && !isAggregatableValue(source.value)
-        ));
+        const allSourcesExistExactlyOnce = resolvedSources.every(
+          (source): source is ResponseEntity => source !== undefined && source !== null
+        );
 
-        if (allSourcesExist && allSourcesEmpty) {
+        if (
+          allSourcesExistExactlyOnce &&
+          this.isDerivedResponseEffectivelyEmpty(plan.response, resolvedSources)
+        ) {
           selectedById.set(plan.response.id, plan.response);
         }
       });
     }
 
     return responses.filter(response => selectedById.has(response.id));
+  }
+
+  private isDerivedResponseEffectivelyEmpty(
+    target: ResponseEntity,
+    sources: ResponseEntity[]
+  ): boolean {
+    const allSourcesEmpty = sources.every(
+      source => !isAggregatableValue(source.value)
+    );
+
+    // The MC+reason exception is intentionally limited to the target state
+    // specified in #972. Other target states keep the conservative behavior
+    // introduced for derived responses in #970.
+    if (target.status_v1 !== CODING_INCOMPLETE_STATUS) {
+      return allSourcesEmpty;
+    }
+
+    const sourceStatuses = sources.map(source => source.status_v1);
+    const allSourceStatusesKnown = sourceStatuses.every(status => (
+      status !== null && statusNumberToString(status) !== null
+    ));
+    if (!allSourceStatusesKnown) {
+      return false;
+    }
+
+    const intendedIncompleteSources = sources.filter(
+      source => source.status_v1 === INTENDED_INCOMPLETE_STATUS
+    );
+    if (intendedIncompleteSources.length === 0) {
+      return allSourcesEmpty;
+    }
+
+    // A mixed MC+reason response is unambiguous only when all leaf sources
+    // belong to the automatic or manually intended status groups. Any third
+    // status fails closed instead of applying a potentially wrong MIR result.
+    const sourceStatusSet = new Set(sourceStatuses);
+    const isUnambiguousMcReasonCombination =
+      sourceStatusSet.size === 2 &&
+      sourceStatusSet.has(CODING_COMPLETE_STATUS) &&
+      sourceStatusSet.has(INTENDED_INCOMPLETE_STATUS);
+    if (!isUnambiguousMcReasonCombination) {
+      return false;
+    }
+
+    return intendedIncompleteSources.every(
+      source => !isAggregatableValue(source.value)
+    );
   }
 
   private invertDerivedSourceMap(

--- a/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
+++ b/apps/backend/src/app/database/utils/manual-coding-candidate.util.ts
@@ -13,6 +13,7 @@ function requireStatusNumber(status: string): number {
 }
 
 export const CODING_INCOMPLETE_STATUS = requireStatusNumber('CODING_INCOMPLETE');
+export const CODING_COMPLETE_STATUS = requireStatusNumber('CODING_COMPLETE');
 export const INTENDED_INCOMPLETE_STATUS = requireStatusNumber('INTENDED_INCOMPLETE');
 export const DERIVE_ERROR_STATUS = requireStatusNumber('DERIVE_ERROR');
 


### PR DESCRIPTION
Closes #972

## Änderungen

- Erkennt den in #972 beschriebenen MC-plus-Begründung-Fall gezielt: Eine automatisch abgeschlossene MC-Quelle zusammen mit einer leeren, als `INTENDED_INCOMPLETE` markierten Begründungsquelle kann als effektiv leere abgeleitete Antwort behandelt werden.
- Schließt unbekannte, mehrdeutige oder doppelte Quellantworten weiterhin konservativ aus.
- Speichert beim Anwenden des Missing-Response-Ergebnisses das vollständige V2-Tupel aus Status, Code und Score.
- Exportiert ein bereits gespeichertes Missing-Response-Ergebnis für das abgeleitete Item direkt, ohne die Quellen erneut auflösen zu müssen.
- Ergänzt Unit- und Exporttests für Erfolgs- und Abgrenzungsfälle.

## Ursache

Die bisherige Erkennung verlangte bei abgeleiteten Antworten, dass alle Blattquellen leer sind. Bei MC-Aufgaben mit Begründung ist die automatisch ausgewertete MC-Quelle jedoch befüllt, während ausschließlich die manuelle Begründungsquelle leer sein kann. Dadurch wurde das konfigurierte Missing-Response-Ergebnis nicht angewendet und der Itemdatensatz-Export blieb unvollständig.

## Auswirkung

Leere Begründungen im beschriebenen MC-Fall erhalten zuverlässig das konfigurierte Missing-Response-Ergebnis. Andere abgeleitete Antworten behalten das konservative Verhalten aus #970.

## Validierung

- Backend-Unit-Tests erfolgreich
- Backend-Linting erfolgreich
- Vollständiger Itemdatensatz-Export über die Benutzeroberfläche erfolgreich
- Exportierter V2-Code für `d3y9i6 / MAP_EM_TH03 / MMV062_01`: `-98`
- Reguläre CSV ohne Kennzeichnung als unvollständig
