### PR TITLE
Planungsstatus innerhalb der Sitzung zwischenspeichern

### DIFF
--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -23,6 +23,7 @@ import type {
   ManualCodeAvailabilityWarningDto
 } from '../../../../../../../api-dto/coding/manual-code-availability.dto';
 import { DoubleCodedReviewComponent } from '../double-coded-review/double-coded-review.component';
+import type { ManualCodingPlanningSnapshot } from '../../services/manual-coding-planning-snapshot.model';
 
 type VariableCoverageOverview = NonNullable<
 CodingManagementManualComponent['variableCoverageOverview']
@@ -366,7 +367,9 @@ describe('CodingManagementManualComponent', () => {
         tab: string,
         options?: { reloadCodingJobs?: boolean; forceRefresh?: boolean }
       ): void;
-      loadCodingFreshness(options?: { force?: boolean }): void;
+      loadCodingFreshness(
+        options?: { force?: boolean; invalidateCache?: boolean }
+      ): void;
     };
     componentInternals.pendingManualStateRefreshAfterBackgroundJob = true;
     componentInternals.pendingForcedManualStateRefreshAfterBackgroundJob = true;
@@ -1602,12 +1605,16 @@ describe('CodingManagementManualComponent', () => {
     expect(refreshCodingJobsAfterDataChangeSpy).toHaveBeenCalledWith('productive');
   });
 
-  it('should not load bundled planning data when the planning tab is opened', () => {
+  it('should load bundled planning data once when planning is first opened', () => {
     component.selectedManualTabIndex = 1;
     component.autoRefreshManualCodingJobs = true;
     const componentInternals = component as unknown as {
       hasLoadedManualCodingJobRefreshSetting: boolean;
+      hasLoadedPlanningDataBundle: boolean;
       appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        getManualCodingPlanningSnapshot(workspaceId: number): unknown;
+      };
       loadManualTabData(tab: 'planning'): void;
       loadVariableCoverageOverview(): void;
       loadCaseCoverageOverview(): void;
@@ -1643,15 +1650,197 @@ describe('CodingManagementManualComponent', () => {
 
     componentInternals.loadManualTabData('planning');
 
-    expect(variableCoverageSpy).not.toHaveBeenCalled();
-    expect(caseCoverageSpy).not.toHaveBeenCalled();
-    expect(codingProgressSpy).not.toHaveBeenCalled();
-    expect(incompleteVariablesSpy).not.toHaveBeenCalled();
-    expect(manualFreshnessDecisionSpy).not.toHaveBeenCalled();
-    expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
-    expect(loadResponseAnalysisSpy).not.toHaveBeenCalled();
+    expect(variableCoverageSpy).toHaveBeenCalledTimes(1);
+    expect(caseCoverageSpy).toHaveBeenCalledTimes(1);
+    expect(codingProgressSpy).toHaveBeenCalledTimes(1);
+    expect(incompleteVariablesSpy).toHaveBeenCalledTimes(1);
+    expect(manualFreshnessDecisionSpy).toHaveBeenCalledTimes(1);
+    expect(loadCodingFreshnessSpy).toHaveBeenCalledTimes(1);
+    expect(loadResponseAnalysisSpy).toHaveBeenCalledTimes(1);
+    expect(componentInternals.testPersonCodingService
+      .getManualCodingPlanningSnapshot(5)).not.toBeNull();
     expect(component.shouldRenderManualTabData('planning')).toBe(true);
     expect(component.shouldShowManualRefreshButton()).toBe(true);
+  });
+
+  it('should defer a forced planning reload until the current load completes', () => {
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      isLoadingCodingProgress: boolean;
+      loadPlanningDataBundle(forceRefresh: boolean): void;
+      trySavePlanningDataBundleSnapshot(): void;
+      loadVariableCoverageOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadCodingProgressOverview(): void;
+      loadCodingIncompleteVariables(): void;
+      loadManualFreshnessDecisionData(): void;
+      loadCodingFreshness(
+        options?: { force?: boolean; invalidateCache?: boolean }
+      ): void;
+      loadResponseAnalysis(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.isLoadingCodingProgress = true;
+    const variableCoverageSpy = jest
+      .spyOn(componentInternals, 'loadVariableCoverageOverview')
+      .mockImplementation();
+    jest.spyOn(componentInternals, 'loadCaseCoverageOverview')
+      .mockImplementation();
+    jest.spyOn(componentInternals, 'loadCodingProgressOverview')
+      .mockImplementation();
+    jest.spyOn(componentInternals, 'loadCodingIncompleteVariables')
+      .mockImplementation();
+    jest.spyOn(componentInternals, 'loadManualFreshnessDecisionData')
+      .mockImplementation();
+    const loadCodingFreshnessSpy = jest
+      .spyOn(componentInternals, 'loadCodingFreshness')
+      .mockImplementation();
+    jest.spyOn(componentInternals, 'loadResponseAnalysis')
+      .mockImplementation();
+
+    componentInternals.loadPlanningDataBundle(true);
+
+    expect(variableCoverageSpy).not.toHaveBeenCalled();
+
+    componentInternals.isLoadingCodingProgress = false;
+    componentInternals.trySavePlanningDataBundleSnapshot();
+
+    expect(variableCoverageSpy).toHaveBeenCalledTimes(1);
+    expect(loadCodingFreshnessSpy).toHaveBeenCalledWith({
+      force: true,
+      invalidateCache: false
+    });
+  });
+
+  it('should not cache a planning bundle after response analysis failed', () => {
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      responseAnalysisError: string | null;
+      isPlanningDataBundleLoadPending: boolean;
+      planningDataBundleCacheGeneration: number | null;
+      testPersonCodingService: {
+        beginManualCodingPlanningSnapshot(): number;
+        saveManualCodingPlanningSnapshot: jest.Mock;
+      };
+      trySavePlanningDataBundleSnapshot(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.responseAnalysisError = 'Analyse fehlgeschlagen';
+    componentInternals.isPlanningDataBundleLoadPending = true;
+    componentInternals.planningDataBundleCacheGeneration =
+      componentInternals.testPersonCodingService
+        .beginManualCodingPlanningSnapshot();
+    const saveSnapshotSpy = jest
+      .spyOn(
+        componentInternals.testPersonCodingService,
+        'saveManualCodingPlanningSnapshot'
+      )
+      .mockImplementation();
+
+    componentInternals.trySavePlanningDataBundleSnapshot();
+
+    expect(saveSnapshotSpy).not.toHaveBeenCalled();
+    expect(componentInternals.isPlanningDataBundleLoadPending).toBe(false);
+    expect(componentInternals.planningDataBundleCacheGeneration).toBeNull();
+  });
+
+  it('should restore planning data without requests after navigation', () => {
+    component.selectedManualTabIndex = 1;
+    component.autoRefreshManualCodingJobs = false;
+    const componentInternals = component as unknown as {
+      hasLoadedManualCodingJobRefreshSetting: boolean;
+      hasLoadedPlanningDataBundle: boolean;
+      appService: { selectedWorkspaceId: number };
+      testPersonCodingService: {
+        beginManualCodingPlanningSnapshot(): number;
+        saveManualCodingPlanningSnapshot(
+          workspaceId: number,
+          snapshot: ManualCodingPlanningSnapshot,
+          cacheGeneration: number
+        ): void;
+      };
+      invalidateCodingStatusCache(): void;
+      loadManualTabData(tab: 'planning'): void;
+      loadVariableCoverageOverview(): void;
+      loadCaseCoverageOverview(): void;
+      loadCodingProgressOverview(): void;
+      loadCodingIncompleteVariables(): void;
+      loadManualFreshnessDecisionData(): void;
+      loadCodingFreshness(): void;
+      loadResponseAnalysis(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.hasLoadedManualCodingJobRefreshSetting = true;
+    componentInternals.hasLoadedPlanningDataBundle = false;
+    const responseAnalysis = {
+      emptyResponses: { total: 0, totalUncoded: 0, items: [] },
+      duplicateValues: {
+        total: 0,
+        totalResponses: 0,
+        groups: [],
+        isAggregationApplied: false
+      },
+      aggregationSummary: {
+        duplicateGroups: 0,
+        duplicateResponses: 0,
+        collapsedCases: 0,
+        rawCases: 10,
+        effectiveCases: 10,
+        threshold: 2,
+        aggregationActive: false
+      },
+      matchingFlags: [],
+      analysisTimestamp: '2026-07-30T12:00:00.000Z',
+      isCalculating: false
+    };
+    const cacheGeneration = componentInternals.testPersonCodingService
+      .beginManualCodingPlanningSnapshot();
+    componentInternals.testPersonCodingService.saveManualCodingPlanningSnapshot(
+      5,
+      {
+        responseAnalysis,
+        codingProgressOverview: null,
+        variableCoverageOverview: null,
+        caseCoverageOverview: null,
+        codingIncompleteVariables: [],
+        manualCodingScopeSummary: null,
+        manualCodeAvailabilityWarnings: [],
+        appliedResultsOverview: null,
+        manualFreshnessJobSummary: null,
+        openDoubleCodingConflictCount: 0,
+        codingFreshnessSummary: {
+          workspaceId: 5,
+          currentRevision: 0,
+          items: []
+        }
+      },
+      cacheGeneration
+    );
+    const requestSpies = [
+      jest.spyOn(componentInternals, 'loadVariableCoverageOverview'),
+      jest.spyOn(componentInternals, 'loadCaseCoverageOverview'),
+      jest.spyOn(componentInternals, 'loadCodingProgressOverview'),
+      jest.spyOn(componentInternals, 'loadCodingIncompleteVariables'),
+      jest.spyOn(componentInternals, 'loadManualFreshnessDecisionData'),
+      jest.spyOn(componentInternals, 'loadCodingFreshness'),
+      jest.spyOn(componentInternals, 'loadResponseAnalysis')
+    ].map(spy => spy.mockImplementation());
+
+    componentInternals.loadManualTabData('planning');
+
+    expect(component.responseAnalysis).toBe(responseAnalysis);
+    requestSpies.forEach(spy => expect(spy).not.toHaveBeenCalled());
+    expect(component.shouldRenderManualTabData('planning')).toBe(true);
+    expect(component.getPlanningStatusTitle()).not.toBe(
+      'Planungsdaten aktualisieren'
+    );
+
+    componentInternals.invalidateCodingStatusCache();
+
+    expect(componentInternals.hasLoadedPlanningDataBundle).toBe(false);
+    expect(component.getPlanningStatusTitle()).toBe(
+      'Planungsdaten aktualisieren'
+    );
   });
 
   it('should skip automatic planning metrics when auto-refresh is disabled', () => {
@@ -1753,7 +1942,10 @@ describe('CodingManagementManualComponent', () => {
     expect(codingProgressSpy).toHaveBeenCalled();
     expect(incompleteVariablesSpy).toHaveBeenCalled();
     expect(manualFreshnessDecisionSpy).toHaveBeenCalled();
-    expect(loadCodingFreshnessSpy).toHaveBeenCalledWith({ force: true });
+    expect(loadCodingFreshnessSpy).toHaveBeenCalledWith({
+      force: true,
+      invalidateCache: false
+    });
     expect(component.shouldRenderManualTabData('planning')).toBe(true);
   });
 
@@ -1761,6 +1953,7 @@ describe('CodingManagementManualComponent', () => {
     component.autoRefreshManualCodingJobs = true;
     const componentInternals = component as unknown as {
       hasLoadedManualCodingJobRefreshSetting: boolean;
+      hasLoadedPlanningDataBundle: boolean;
       testPersonCodingService: {
         notifyAutoCodingCompleted(jobId?: string): void;
       };
@@ -1771,6 +1964,7 @@ describe('CodingManagementManualComponent', () => {
       loadJobDefinitionsForExport(): void;
     };
     componentInternals.hasLoadedManualCodingJobRefreshSetting = false;
+    componentInternals.hasLoadedPlanningDataBundle = true;
     const refreshAllStatisticsSpy = jest
       .spyOn(componentInternals, 'refreshAllStatistics')
       .mockImplementation();
@@ -1789,6 +1983,7 @@ describe('CodingManagementManualComponent', () => {
 
     componentInternals.testPersonCodingService.notifyAutoCodingCompleted();
 
+    expect(componentInternals.hasLoadedPlanningDataBundle).toBe(false);
     expect(refreshAllStatisticsSpy).not.toHaveBeenCalled();
     expect(loadCodingFreshnessSpy).not.toHaveBeenCalled();
     expect(loadResponseAnalysisSpy).not.toHaveBeenCalled();

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -1744,6 +1744,38 @@ describe('CodingManagementManualComponent', () => {
     expect(componentInternals.planningDataBundleCacheGeneration).toBeNull();
   });
 
+  it('should not cache a planning bundle after another bundle request failed', () => {
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      planningDataBundleLoadFailed: boolean;
+      isPlanningDataBundleLoadPending: boolean;
+      planningDataBundleCacheGeneration: number | null;
+      testPersonCodingService: {
+        beginManualCodingPlanningSnapshot(): number;
+        saveManualCodingPlanningSnapshot: jest.Mock;
+      };
+      trySavePlanningDataBundleSnapshot(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.planningDataBundleLoadFailed = true;
+    componentInternals.isPlanningDataBundleLoadPending = true;
+    componentInternals.planningDataBundleCacheGeneration =
+      componentInternals.testPersonCodingService
+        .beginManualCodingPlanningSnapshot();
+    const saveSnapshotSpy = jest
+      .spyOn(
+        componentInternals.testPersonCodingService,
+        'saveManualCodingPlanningSnapshot'
+      )
+      .mockImplementation();
+
+    componentInternals.trySavePlanningDataBundleSnapshot();
+
+    expect(saveSnapshotSpy).not.toHaveBeenCalled();
+    expect(componentInternals.isPlanningDataBundleLoadPending).toBe(false);
+    expect(componentInternals.planningDataBundleCacheGeneration).toBeNull();
+  });
+
   it('should restore planning data without requests after navigation', () => {
     component.selectedManualTabIndex = 1;
     component.autoRefreshManualCodingJobs = false;
@@ -1816,17 +1848,25 @@ describe('CodingManagementManualComponent', () => {
       },
       cacheGeneration
     );
+    fixture.destroy();
+    fixture = TestBed.createComponent(CodingManagementManualComponent);
+    component = fixture.componentInstance;
+    component.selectedManualTabIndex = 1;
+    component.autoRefreshManualCodingJobs = false;
+    const restoredComponentInternals = component as unknown as typeof componentInternals;
+    restoredComponentInternals.appService.selectedWorkspaceId = 5;
+    restoredComponentInternals.hasLoadedManualCodingJobRefreshSetting = true;
     const requestSpies = [
-      jest.spyOn(componentInternals, 'loadVariableCoverageOverview'),
-      jest.spyOn(componentInternals, 'loadCaseCoverageOverview'),
-      jest.spyOn(componentInternals, 'loadCodingProgressOverview'),
-      jest.spyOn(componentInternals, 'loadCodingIncompleteVariables'),
-      jest.spyOn(componentInternals, 'loadManualFreshnessDecisionData'),
-      jest.spyOn(componentInternals, 'loadCodingFreshness'),
-      jest.spyOn(componentInternals, 'loadResponseAnalysis')
+      jest.spyOn(restoredComponentInternals, 'loadVariableCoverageOverview'),
+      jest.spyOn(restoredComponentInternals, 'loadCaseCoverageOverview'),
+      jest.spyOn(restoredComponentInternals, 'loadCodingProgressOverview'),
+      jest.spyOn(restoredComponentInternals, 'loadCodingIncompleteVariables'),
+      jest.spyOn(restoredComponentInternals, 'loadManualFreshnessDecisionData'),
+      jest.spyOn(restoredComponentInternals, 'loadCodingFreshness'),
+      jest.spyOn(restoredComponentInternals, 'loadResponseAnalysis')
     ].map(spy => spy.mockImplementation());
 
-    componentInternals.loadManualTabData('planning');
+    restoredComponentInternals.loadManualTabData('planning');
 
     expect(component.responseAnalysis).toBe(responseAnalysis);
     requestSpies.forEach(spy => expect(spy).not.toHaveBeenCalled());
@@ -1835,9 +1875,9 @@ describe('CodingManagementManualComponent', () => {
       'Planungsdaten aktualisieren'
     );
 
-    componentInternals.invalidateCodingStatusCache();
+    restoredComponentInternals.invalidateCodingStatusCache();
 
-    expect(componentInternals.hasLoadedPlanningDataBundle).toBe(false);
+    expect(restoredComponentInternals.hasLoadedPlanningDataBundle).toBe(false);
     expect(component.getPlanningStatusTitle()).toBe(
       'Planungsdaten aktualisieren'
     );

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.spec.ts
@@ -264,20 +264,37 @@ describe('CodingManagementManualComponent', () => {
     }
   });
 
-  it('should cancel response analysis when leaving the preparation flow', () => {
+  it('should discard a pending snapshot when leaving the planning flow', () => {
     const componentInternals = component as unknown as {
       appService: { selectedWorkspaceId: number };
+      hasLoadedPlanningDataBundle: boolean;
+      isPlanningDataBundleLoadPending: boolean;
+      planningDataBundleCacheGeneration: number | null;
       testPersonCodingService: {
+        beginManualCodingPlanningSnapshot(): number;
+        saveManualCodingPlanningSnapshot: jest.Mock;
         getResponseAnalysis: jest.Mock;
         setResponseAnalysisGuardRunning: (
           workspaceId: number,
           isRunning: boolean
         ) => void;
       };
+      trySavePlanningDataBundleSnapshot(): void;
     };
     componentInternals.appService.selectedWorkspaceId = 5;
-    component.selectedManualTabIndex = 0;
+    component.selectedManualTabIndex = 1;
+    componentInternals.hasLoadedPlanningDataBundle = true;
+    componentInternals.isPlanningDataBundleLoadPending = true;
+    componentInternals.planningDataBundleCacheGeneration =
+      componentInternals.testPersonCodingService
+        .beginManualCodingPlanningSnapshot();
     let responseAnalysisUnsubscribed = false;
+    const saveSnapshotSpy = jest
+      .spyOn(
+        componentInternals.testPersonCodingService,
+        'saveManualCodingPlanningSnapshot'
+      )
+      .mockImplementation();
     jest
       .spyOn(componentInternals.testPersonCodingService, 'setResponseAnalysisGuardRunning')
       .mockImplementation(() => undefined);
@@ -293,9 +310,46 @@ describe('CodingManagementManualComponent', () => {
     expect(component.isLoadingResponseAnalysis).toBe(true);
 
     component.onManualTabChanged(2);
+    componentInternals.trySavePlanningDataBundleSnapshot();
 
     expect(responseAnalysisUnsubscribed).toBe(true);
     expect(component.isLoadingResponseAnalysis).toBe(false);
+    expect(componentInternals.hasLoadedPlanningDataBundle).toBe(false);
+    expect(componentInternals.isPlanningDataBundleLoadPending).toBe(false);
+    expect(saveSnapshotSpy).not.toHaveBeenCalled();
+  });
+
+  it('should discard a pending planning snapshot before destroy finalizers run', () => {
+    const componentInternals = component as unknown as {
+      appService: { selectedWorkspaceId: number };
+      hasLoadedPlanningDataBundle: boolean;
+      isPlanningDataBundleLoadPending: boolean;
+      planningDataBundleCacheGeneration: number | null;
+      testPersonCodingService: {
+        beginManualCodingPlanningSnapshot(): number;
+        saveManualCodingPlanningSnapshot: jest.Mock;
+      };
+      trySavePlanningDataBundleSnapshot(): void;
+    };
+    componentInternals.appService.selectedWorkspaceId = 5;
+    componentInternals.hasLoadedPlanningDataBundle = true;
+    componentInternals.isPlanningDataBundleLoadPending = true;
+    componentInternals.planningDataBundleCacheGeneration =
+      componentInternals.testPersonCodingService
+        .beginManualCodingPlanningSnapshot();
+    const saveSnapshotSpy = jest
+      .spyOn(
+        componentInternals.testPersonCodingService,
+        'saveManualCodingPlanningSnapshot'
+      )
+      .mockImplementation();
+
+    component.ngOnDestroy();
+    componentInternals.trySavePlanningDataBundleSnapshot();
+
+    expect(componentInternals.hasLoadedPlanningDataBundle).toBe(false);
+    expect(componentInternals.isPlanningDataBundleLoadPending).toBe(false);
+    expect(saveSnapshotSpy).not.toHaveBeenCalled();
   });
 
   it('should hand off the response-analysis guard when leaving the preparation flow while analysis is calculating', () => {

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -620,6 +620,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.discardPendingPlanningDataBundle();
     this.cancelResponseAnalysisRequest();
     this.responseAnalysisRequestCancel$.complete();
     this.finalizeResponseAnalysisGuardOnDestroy();
@@ -680,6 +681,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private stopResponseAnalysisView(): void {
+    this.discardPendingPlanningDataBundle();
     this.cancelResponseAnalysisRequest();
     this.handOffResponseAnalysisGuardUntilComplete();
   }
@@ -3431,6 +3433,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private markPlanningDataBundleLoadFailed(): void {
     if (this.isPlanningDataBundleLoadPending) {
       this.planningDataBundleLoadFailed = true;
+    }
+  }
+
+  private discardPendingPlanningDataBundle(): void {
+    if (this.isPlanningDataBundleLoadPending) {
+      this.resetPlanningDataBundleState();
     }
   }
 

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -126,6 +126,7 @@ import {
 import { CohensKappaStatisticsComponent } from '../cohens-kappa-statistics/cohens-kappa-statistics.component';
 import { DoubleCodedReviewComponent } from '../double-coded-review/double-coded-review.component';
 import { CodingBackgroundJobsService } from '../../services/coding-background-jobs.service';
+import type { ManualCodingPlanningSnapshot } from '../../services/manual-coding-planning-snapshot.model';
 
 interface SavedCodeProgress {
   id?: number;
@@ -264,6 +265,10 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   };
 
   private hasLoadedPlanningDataBundle = false;
+  private isPlanningDataBundleLoadPending = false;
+  private planningDataBundleCacheGeneration: number | null = null;
+  private deferredPlanningDataBundleForceRefresh: boolean | null = null;
+  private isStartingPlanningDataBundleLoad = false;
 
   private pendingAutomaticManualTabLoad: ManualCodingTab | null = null;
 
@@ -284,6 +289,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   isLoadingCaseCoverage = false;
   isLoadingCodingProgress = false;
   isLoadingManualCodeAvailability = false;
+  private isLoadingManualCodingScopeSummary = false;
   isLoadingCodingIncompleteVariables = false;
   isLoadingAppliedResultsOverview = false;
   isLoadingKappaSummary = false;
@@ -521,7 +527,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.jobDefinitionChangeSubject
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(reloadScope => {
-        this.hasLoadedPlanningDataBundle = false;
+        this.invalidateCodingStatusCache();
         this.loadJobDefinitionsForExport();
         this.loadManualTabData(this.activeManualTab);
         this.refreshCodingJobsAfterDataChange(reloadScope);
@@ -572,13 +578,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.testPersonCodingService.autoCodingCompleted$
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
+        this.resetPlanningDataBundleState();
         if (!this.hasLoadedManualCodingJobRefreshSetting ||
           !this.autoRefreshManualCodingJobs) {
           return;
         }
 
         if (this.activeManualTab === 'planning') {
-          this.hasLoadedPlanningDataBundle = false;
           this.refreshCodingJobsAfterDataChange('rendered');
           return;
         }
@@ -2073,6 +2079,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.isLoadingVariableCoverage ||
       this.isLoadingCaseCoverage ||
       this.isLoadingManualCodeAvailability ||
+      this.isLoadingManualCodingScopeSummary ||
       this.isLoadingCodingIncompleteVariables ||
       this.isLoadingAppliedResultsOverview ||
       this.isLoadingManualFreshnessJobSummary ||
@@ -3200,6 +3207,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         finalize(() => {
           this.isLoadingMatchingMode = false;
           this.focusManualFreshnessTargetIfReady();
+          this.trySavePlanningDataBundleSnapshot();
         }),
         takeUntil(this.destroy$)
       )
@@ -3237,7 +3245,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     const codingJobsReloadScope = options.codingJobsReloadScope ?? 'active';
     const forceRefresh = options.forceRefresh ?? false;
     const deferStatusChecks = options.deferStatusChecks ?? false;
-    if (this.shouldSkipAutomaticManualTabLoad(forceRefresh, tab)) {
+    const hasPlanningDataSnapshot = !forceRefresh &&
+      this.restorePlanningDataBundleSnapshot();
+    const canUsePlanningDataSnapshot =
+      tab === 'preparation' || tab === 'planning';
+    if (this.shouldSkipAutomaticManualTabLoad(forceRefresh, tab) &&
+      !(hasPlanningDataSnapshot && canUsePlanningDataSnapshot)) {
       return;
     }
 
@@ -3245,10 +3258,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
 
     switch (tab) {
       case 'preparation':
-        this.loadResponseAnalysis();
+        if (!hasPlanningDataSnapshot) {
+          this.loadResponseAnalysis();
+        }
         return;
       case 'planning':
-        if (forceRefresh && !deferStatusChecks) {
+        if (!hasPlanningDataSnapshot && !deferStatusChecks &&
+          (forceRefresh || this.autoRefreshManualCodingJobs)) {
           this.loadPlanningDataBundle(forceRefresh);
         }
         return;
@@ -3283,14 +3299,139 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   }
 
   private loadPlanningDataBundle(forceRefresh: boolean): void {
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      return;
+    }
+
+    if (this.isPlanningDataBundleBusy()) {
+      this.deferredPlanningDataBundleForceRefresh =
+        (this.deferredPlanningDataBundleForceRefresh ?? false) || forceRefresh;
+      return;
+    }
+
+    this.deferredPlanningDataBundleForceRefresh = null;
     this.hasLoadedPlanningDataBundle = true;
+    this.isPlanningDataBundleLoadPending = true;
+    this.planningDataBundleCacheGeneration =
+      this.testPersonCodingService.beginManualCodingPlanningSnapshot();
+    this.isStartingPlanningDataBundleLoad = true;
     this.loadVariableCoverageOverview();
     this.loadCaseCoverageOverview();
     this.loadCodingProgressOverview();
     this.loadCodingIncompleteVariables();
     this.loadManualFreshnessDecisionData();
-    this.loadCodingFreshness({ force: forceRefresh });
+    this.loadCodingFreshness({
+      force: forceRefresh,
+      invalidateCache: false
+    });
     this.loadResponseAnalysisForPlanningIfNeeded();
+    this.isStartingPlanningDataBundleLoad = false;
+    this.trySavePlanningDataBundleSnapshot();
+  }
+
+  private restorePlanningDataBundleSnapshot(): boolean {
+    if (this.hasLoadedPlanningDataBundle) {
+      return true;
+    }
+
+    const workspaceId = this.appService.selectedWorkspaceId;
+    if (!workspaceId) {
+      return false;
+    }
+
+    const snapshot = this.testPersonCodingService
+      .getManualCodingPlanningSnapshot(workspaceId);
+    if (!snapshot) {
+      return false;
+    }
+
+    this.applyPlanningDataBundleSnapshot(snapshot);
+    this.hasLoadedPlanningDataBundle = true;
+    this.loadedManualTabData.planning = true;
+    this.focusManualFreshnessTargetIfReady();
+    return true;
+  }
+
+  private applyPlanningDataBundleSnapshot(
+    snapshot: ManualCodingPlanningSnapshot
+  ): void {
+    this.responseAnalysis = snapshot.responseAnalysis;
+    this.responseAnalysisError = null;
+    this.codingProgressOverview = snapshot.codingProgressOverview;
+    this.variableCoverageOverview = snapshot.variableCoverageOverview;
+    this.caseCoverageOverview = snapshot.caseCoverageOverview;
+    this.codingIncompleteVariables = [...snapshot.codingIncompleteVariables];
+    this.manualCodingScopeSummary = snapshot.manualCodingScopeSummary;
+    this.setManualCodeAvailabilityWarnings([
+      ...snapshot.manualCodeAvailabilityWarnings
+    ]);
+    this.appliedResultsOverview = snapshot.appliedResultsOverview;
+    this.manualFreshnessJobSummary = snapshot.manualFreshnessJobSummary;
+    this.openDoubleCodingConflictCount =
+      snapshot.openDoubleCodingConflictCount;
+    this.codingFreshnessSummary = snapshot.codingFreshnessSummary;
+    this.lastCodingFreshnessRefreshAt = snapshot.codingFreshnessSummary ?
+      Date.now() : 0;
+  }
+
+  private trySavePlanningDataBundleSnapshot(): void {
+    if (this.isPlanningDataBundleBusy()) {
+      return;
+    }
+
+    const deferredForceRefresh = this.deferredPlanningDataBundleForceRefresh;
+    if (deferredForceRefresh !== null) {
+      this.deferredPlanningDataBundleForceRefresh = null;
+      this.loadPlanningDataBundle(deferredForceRefresh);
+      return;
+    }
+
+    if (!this.isPlanningDataBundleLoadPending) {
+      return;
+    }
+
+    if (this.responseAnalysisError) {
+      this.isPlanningDataBundleLoadPending = false;
+      this.planningDataBundleCacheGeneration = null;
+      return;
+    }
+
+    const workspaceId = this.appService.selectedWorkspaceId;
+    const cacheGeneration = this.planningDataBundleCacheGeneration;
+    if (!workspaceId || cacheGeneration === null) {
+      return;
+    }
+
+    this.testPersonCodingService.saveManualCodingPlanningSnapshot(
+      workspaceId,
+      {
+        responseAnalysis: this.responseAnalysis,
+        codingProgressOverview: this.codingProgressOverview,
+        variableCoverageOverview: this.variableCoverageOverview,
+        caseCoverageOverview: this.caseCoverageOverview,
+        codingIncompleteVariables: [...this.codingIncompleteVariables],
+        manualCodingScopeSummary: this.manualCodingScopeSummary,
+        manualCodeAvailabilityWarnings: [
+          ...this.manualCodeAvailabilityWarnings
+        ],
+        appliedResultsOverview: this.appliedResultsOverview,
+        manualFreshnessJobSummary: this.manualFreshnessJobSummary,
+        openDoubleCodingConflictCount: this.openDoubleCodingConflictCount,
+        codingFreshnessSummary: this.codingFreshnessSummary
+      },
+      cacheGeneration
+    );
+    this.isPlanningDataBundleLoadPending = false;
+    this.planningDataBundleCacheGeneration = null;
+  }
+
+  private isPlanningDataBundleBusy(): boolean {
+    return this.isStartingPlanningDataBundleLoad ||
+      this.isAnyPlanningDataLoading() ||
+      this.isLoadingCodingFreshness ||
+      this.responseAnalysisGuardActive ||
+      this.responseAnalysis?.isCalculating === true;
   }
 
   private loadManualCodingJobRefreshSetting(): void {
@@ -3618,7 +3759,9 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     return score === null ? 'NA' : score;
   }
 
-  private loadCodingFreshness(options: { force?: boolean } = {}): void {
+  private loadCodingFreshness(
+    options: { force?: boolean; invalidateCache?: boolean } = {}
+  ): void {
     const workspaceId = this.appService.selectedWorkspaceId;
     if (!workspaceId) {
       this.codingFreshnessRequestGeneration += 1;
@@ -3649,7 +3792,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (options.force) {
+    if (options.force && options.invalidateCache !== false) {
       this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
     }
 
@@ -3677,6 +3820,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
             this.appService.selectedWorkspaceId === workspaceId
           ) {
             this.isLoadingCodingFreshness = false;
+            this.trySavePlanningDataBundleSnapshot();
           }
         })
       )
@@ -3717,6 +3861,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         finalize(() => {
           this.isLoadingCodingProgress = false;
           this.focusManualFreshnessTargetIfReady();
+          this.trySavePlanningDataBundleSnapshot();
         })
       )
       .subscribe({
@@ -3758,6 +3903,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.openDoubleCodingConflictCount = 0;
           this.isLoadingDoubleCodingConflictSummary = false;
           this.focusManualFreshnessTargetIfReady();
+          this.trySavePlanningDataBundleSnapshot();
         })
       )
       .subscribe({
@@ -3806,6 +3952,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         finalize(() => {
           this.isLoadingDoubleCodingConflictSummary = false;
           this.focusManualFreshnessTargetIfReady();
+          this.trySavePlanningDataBundleSnapshot();
         })
       )
       .subscribe({
@@ -3896,6 +4043,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         finalize(() => {
           this.isLoadingVariableCoverage = false;
           this.focusManualFreshnessTargetIfReady();
+          this.trySavePlanningDataBundleSnapshot();
         })
       )
       .subscribe({
@@ -3954,6 +4102,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         finalize(() => {
           this.isLoadingCaseCoverage = false;
           this.focusManualFreshnessTargetIfReady();
+          this.trySavePlanningDataBundleSnapshot();
         })
       )
       .subscribe({
@@ -4018,6 +4167,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       this.setManualCodeAvailabilityWarnings([]);
       this.isLoadingCodingIncompleteVariables = false;
       this.isLoadingManualCodeAvailability = false;
+      this.isLoadingManualCodingScopeSummary = false;
       return;
     }
 
@@ -4029,6 +4179,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         finalize(() => {
           this.isLoadingCodingIncompleteVariables = false;
           this.focusManualFreshnessTargetIfReady();
+          this.trySavePlanningDataBundleSnapshot();
         })
       )
       .subscribe({
@@ -4050,9 +4201,16 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         }
       });
 
+    this.isLoadingManualCodingScopeSummary = true;
     this.codingJobBackendService
       .getManualCodingScopeSummary(workspaceId)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.isLoadingManualCodingScopeSummary = false;
+          this.trySavePlanningDataBundleSnapshot();
+        })
+      )
       .subscribe({
         next: summary => {
           this.manualCodingScopeSummary = summary;
@@ -4070,6 +4228,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         finalize(() => {
           this.isLoadingManualCodeAvailability = false;
           this.focusManualFreshnessTargetIfReady();
+          this.trySavePlanningDataBundleSnapshot();
         })
       )
       .subscribe({
@@ -4160,6 +4319,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         finalize(() => {
           this.isLoadingAppliedResultsOverview = false;
           this.focusManualFreshnessTargetIfReady();
+          this.trySavePlanningDataBundleSnapshot();
         })
       )
       .subscribe({
@@ -4333,6 +4493,14 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     if (workspaceId) {
       this.testPersonCodingService.invalidateCodingStatusCache(workspaceId);
     }
+    this.resetPlanningDataBundleState();
+  }
+
+  private resetPlanningDataBundleState(): void {
+    this.hasLoadedPlanningDataBundle = false;
+    this.isPlanningDataBundleLoadPending = false;
+    this.planningDataBundleCacheGeneration = null;
+    this.deferredPlanningDataBundleForceRefresh = null;
   }
 
   private formatApplyCodingResultsMessage(
@@ -4807,6 +4975,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
               }
             }, 5000);
           }
+          this.trySavePlanningDataBundleSnapshot();
         },
         error: error => {
           if (!this.shouldAcceptResponseAnalysisResult(requestId, workspaceId)) {
@@ -4832,6 +5001,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.setResponseAnalysisGuardActive(false);
           this.responseAnalysis = null;
           this.responseAnalysisError = responseAnalysisError;
+          this.trySavePlanningDataBundleSnapshot();
           this.snackBar.open(
             this.responseAnalysisError,
             'OK',

--- a/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management-manual/coding-management-manual.component.ts
@@ -269,6 +269,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
   private planningDataBundleCacheGeneration: number | null = null;
   private deferredPlanningDataBundleForceRefresh: boolean | null = null;
   private isStartingPlanningDataBundleLoad = false;
+  private planningDataBundleLoadFailed = false;
 
   private pendingAutomaticManualTabLoad: ManualCodingTab | null = null;
 
@@ -3313,6 +3314,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.deferredPlanningDataBundleForceRefresh = null;
     this.hasLoadedPlanningDataBundle = true;
     this.isPlanningDataBundleLoadPending = true;
+    this.planningDataBundleLoadFailed = false;
     this.planningDataBundleCacheGeneration =
       this.testPersonCodingService.beginManualCodingPlanningSnapshot();
     this.isStartingPlanningDataBundleLoad = true;
@@ -3391,7 +3393,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (this.responseAnalysisError) {
+    if (this.responseAnalysisError || this.planningDataBundleLoadFailed) {
       this.isPlanningDataBundleLoadPending = false;
       this.planningDataBundleCacheGeneration = null;
       return;
@@ -3424,6 +3426,12 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     );
     this.isPlanningDataBundleLoadPending = false;
     this.planningDataBundleCacheGeneration = null;
+  }
+
+  private markPlanningDataBundleLoadFailed(): void {
+    if (this.isPlanningDataBundleLoadPending) {
+      this.planningDataBundleLoadFailed = true;
+    }
   }
 
   private isPlanningDataBundleBusy(): boolean {
@@ -3867,9 +3875,13 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (overview: CodingProgressOverview | null) => {
           this.codingProgressOverview = overview;
+          if (!overview) {
+            this.markPlanningDataBundleLoadFailed();
+          }
         },
         error: () => {
           this.codingProgressOverview = null;
+          this.markPlanningDataBundleLoadFailed();
         }
       });
   }
@@ -3913,6 +3925,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.manualFreshnessJobSummary = null;
+          this.markPlanningDataBundleLoadFailed();
         }
       });
   }
@@ -3961,6 +3974,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.openDoubleCodingConflictCount = 0;
+          this.markPlanningDataBundleLoadFailed();
         }
       });
   }
@@ -4084,6 +4098,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.variableCoverageOverview = null;
+          this.markPlanningDataBundleLoadFailed();
         }
       });
   }
@@ -4111,6 +4126,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.caseCoverageOverview = null;
+          this.markPlanningDataBundleLoadFailed();
         }
       });
   }
@@ -4197,6 +4213,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.codingIncompleteVariables = [];
+          this.markPlanningDataBundleLoadFailed();
           this.loadAppliedResultsOverview();
         }
       });
@@ -4217,6 +4234,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.manualCodingScopeSummary = null;
+          this.markPlanningDataBundleLoadFailed();
         }
       });
 
@@ -4237,6 +4255,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.setManualCodeAvailabilityWarnings([]);
+          this.markPlanningDataBundleLoadFailed();
         }
       });
   }
@@ -4326,6 +4345,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         next: overview => {
           if (!overview) {
             this.appliedResultsOverview = null;
+            this.markPlanningDataBundleLoadFailed();
             return;
           }
 
@@ -4342,6 +4362,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.appliedResultsOverview = null;
+          this.markPlanningDataBundleLoadFailed();
         }
       });
   }
@@ -4501,6 +4522,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
     this.isPlanningDataBundleLoadPending = false;
     this.planningDataBundleCacheGeneration = null;
     this.deferredPlanningDataBundleForceRefresh = null;
+    this.planningDataBundleLoadFailed = false;
   }
 
   private formatApplyCodingResultsMessage(
@@ -5001,6 +5023,7 @@ export class CodingManagementManualComponent implements OnInit, OnDestroy {
           this.setResponseAnalysisGuardActive(false);
           this.responseAnalysis = null;
           this.responseAnalysisError = responseAnalysisError;
+          this.markPlanningDataBundleLoadFailed();
           this.trySavePlanningDataBundleSnapshot();
           this.snackBar.open(
             this.responseAnalysisError,

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -1473,6 +1473,7 @@ describe('CodingManagementComponent', () => {
 
     it('should not refresh coding status after a reset completes when auto-refresh is disabled', () => {
       component.autoRefreshManualCodingJobs = false;
+      component.hasLoadedFullCodingStatusOverview = true;
       (mockCodingManagementService.fetchCodingStatistics as jest.Mock).mockClear();
       (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
       (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
@@ -1485,6 +1486,7 @@ describe('CodingManagementComponent', () => {
       expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+      expect(component.hasLoadedFullCodingStatusOverview).toBe(false);
     });
 
     it('should consume a pending statistics version when opened after results changed', () => {

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.spec.ts
@@ -1478,6 +1478,8 @@ describe('CodingManagementComponent', () => {
       (mockTestPersonCodingService.getCodingFreshness as jest.Mock).mockClear();
       (mockTestPersonCodingService.getAppliedResultsOverview as jest.Mock).mockClear();
       (mockTestPersonCodingService.getAutocodingReadiness as jest.Mock).mockClear();
+      (mockTestPersonCodingService.invalidateCodingStatusCache as jest.Mock)
+        .mockClear();
 
       resetProgressSubject.next(50);
       resetProgressSubject.next(null);
@@ -1486,6 +1488,8 @@ describe('CodingManagementComponent', () => {
       expect(mockTestPersonCodingService.getCodingFreshness).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAppliedResultsOverview).not.toHaveBeenCalled();
       expect(mockTestPersonCodingService.getAutocodingReadiness).not.toHaveBeenCalled();
+      expect(mockTestPersonCodingService.invalidateCodingStatusCache)
+        .toHaveBeenCalledWith(1);
       expect(component.hasLoadedFullCodingStatusOverview).toBe(false);
     });
 

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -318,6 +318,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
         if (previousProgress !== undefined &&
           previousProgress !== null &&
           progress === null) {
+          this.invalidateCodingStatusOverviewCache();
           if (this.resetCompletionRefreshHandledAfterGuardClear) {
             this.resetCompletionRefreshHandledAfterGuardClear = false;
             return;

--- a/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
+++ b/apps/frontend/src/app/coding/components/coding-management/coding-management.component.ts
@@ -596,6 +596,7 @@ export class CodingManagementComponent implements OnInit, OnDestroy {
   }
 
   private refreshCodingStatusOverviewAfterChange(): void {
+    this.hasLoadedFullCodingStatusOverview = false;
     if (!this.hasLoadedManualCodingJobRefreshSetting ||
       !this.autoRefreshManualCodingJobs) {
       return;

--- a/apps/frontend/src/app/coding/services/manual-coding-planning-snapshot.model.ts
+++ b/apps/frontend/src/app/coding/services/manual-coding-planning-snapshot.model.ts
@@ -1,0 +1,82 @@
+import type { ResponseAnalysisDto } from '../../../../../../api-dto/coding/response-analysis.dto';
+import type { CodingFreshnessSummaryDto } from '../../../../../../api-dto/coding/coding-freshness.dto';
+import type { ManualCodeAvailabilityWarningDto } from '../../../../../../api-dto/coding/manual-code-availability.dto';
+import type { ManualCodingScopeSummary } from './coding-job-backend.service';
+import type {
+  AppliedResultsOverview,
+  CaseCoverageOverview,
+  CodingProgressOverview
+} from './test-person-coding.service';
+
+export interface ManualCodingVariableCoverageOverview {
+  totalVariables: number;
+  coveredVariables: number;
+  coveredByDraft: number;
+  coveredByPendingReview: number;
+  coveredByApproved: number;
+  conflictedVariables: number;
+  missingVariables: number;
+  partiallyAbgedeckteVariablen?: number;
+  fullyAbgedeckteVariablen?: number;
+  coveragePercentage: number;
+  variableCaseCounts: Array<{
+    unitName: string;
+    variableId: string;
+    caseCount: number;
+  }>;
+  coverageByStatus: {
+    draft: string[];
+    pending_review: string[];
+    approved: string[];
+    conflicted: Array<{
+      variableKey: string;
+      conflictingDefinitions: Array<{
+        id: number;
+        name?: string;
+        status: string;
+      }>;
+    }>;
+  };
+  statusTotalVariables?: number;
+  coveredSourceVariableCount?: number;
+  coveredSourceResponseCount?: number;
+}
+
+export interface ManualCodingIncompleteVariable {
+  unitName: string;
+  variableId: string;
+  responseCount: number;
+  availableCases?: number;
+  uniqueCasesAfterAggregation?: number;
+}
+
+export interface ManualCodingFreshnessJobSummary {
+  activeTrainingJobs: number;
+  openProductiveJobs: number;
+  completedProductiveJobs: number;
+  staleSourceJobs: number;
+}
+
+export type ManualCodingAppliedResultsOverview = AppliedResultsOverview & {
+  totalIncompleteVariables: number;
+  finalStatusBreakdown: {
+    codingComplete: number;
+    invalid: number;
+    codingError: number;
+    other: number;
+  };
+};
+
+export interface ManualCodingPlanningSnapshot {
+  responseAnalysis: ResponseAnalysisDto | null;
+  codingProgressOverview: CodingProgressOverview | null;
+  variableCoverageOverview: ManualCodingVariableCoverageOverview | null;
+  caseCoverageOverview: CaseCoverageOverview | null;
+  codingIncompleteVariables: ManualCodingIncompleteVariable[];
+  manualCodingScopeSummary: ManualCodingScopeSummary | null;
+  manualCodeAvailabilityWarnings: ManualCodeAvailabilityWarningDto[];
+  appliedResultsOverview: ManualCodingAppliedResultsOverview | null;
+  manualFreshnessJobSummary: ManualCodingFreshnessJobSummary | null;
+  openDoubleCodingConflictCount: number;
+  codingFreshnessSummary: CodingFreshnessSummaryDto | null;
+}

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.spec.ts
@@ -24,6 +24,7 @@ import {
   WorkspaceSettingsService
 } from '../../ws-admin/services/workspace-settings.service';
 import { CodingBackgroundJobsService } from './coding-background-jobs.service';
+import type { ManualCodingPlanningSnapshot } from './manual-coding-planning-snapshot.model';
 
 describe('TestPersonCodingService', () => {
   let service: TestPersonCodingService;
@@ -1142,6 +1143,60 @@ describe('TestPersonCodingService', () => {
   });
 
   describe('coding freshness', () => {
+    const createPlanningSnapshot = (): ManualCodingPlanningSnapshot => ({
+      responseAnalysis: null,
+      codingProgressOverview: null,
+      variableCoverageOverview: null,
+      caseCoverageOverview: null,
+      codingIncompleteVariables: [],
+      manualCodingScopeSummary: null,
+      manualCodeAvailabilityWarnings: [],
+      appliedResultsOverview: null,
+      manualFreshnessJobSummary: null,
+      openDoubleCodingConflictCount: 0,
+      codingFreshnessSummary: {
+        workspaceId: mockWorkspaceId,
+        currentRevision: 0,
+        items: []
+      }
+    });
+
+    it('should keep a planning snapshot until its workspace is invalidated', () => {
+      const snapshot = createPlanningSnapshot();
+      const generation = service.beginManualCodingPlanningSnapshot();
+
+      service.saveManualCodingPlanningSnapshot(
+        mockWorkspaceId,
+        snapshot,
+        generation
+      );
+
+      expect(service.getManualCodingPlanningSnapshot(mockWorkspaceId)).toBe(
+        snapshot
+      );
+
+      service.invalidateCodingStatusCache(mockWorkspaceId);
+
+      expect(
+        service.getManualCodingPlanningSnapshot(mockWorkspaceId)
+      ).toBeNull();
+    });
+
+    it('should ignore a planning snapshot completed after invalidation', () => {
+      const generation = service.beginManualCodingPlanningSnapshot();
+
+      service.invalidateCodingStatusCache(mockWorkspaceId);
+      service.saveManualCodingPlanningSnapshot(
+        mockWorkspaceId,
+        createPlanningSnapshot(),
+        generation
+      );
+
+      expect(
+        service.getManualCodingPlanningSnapshot(mockWorkspaceId)
+      ).toBeNull();
+    });
+
     it('should reuse cached coding freshness until coding status is invalidated', () => {
       const mockResponse = {
         workspaceId: mockWorkspaceId,

--- a/apps/frontend/src/app/coding/services/test-person-coding.service.ts
+++ b/apps/frontend/src/app/coding/services/test-person-coding.service.ts
@@ -47,6 +47,7 @@ import {
   WorkspaceSettingsService
 } from '../../ws-admin/services/workspace-settings.service';
 import { CodingBackgroundJobsService } from './coding-background-jobs.service';
+import type { ManualCodingPlanningSnapshot } from './manual-coding-planning-snapshot.model';
 
 interface ExternalCodingImportWithPreviewDto {
   file: string;
@@ -304,6 +305,11 @@ export class TestPersonCodingService {
   Observable<AppliedResultsOverview | null>
   >();
 
+  private manualCodingPlanningSnapshots = new Map<
+  number,
+  ManualCodingPlanningSnapshot
+  >();
+
   private responseAnalysisGuardPollTimers = new Map<
   number,
   ReturnType<typeof setTimeout>
@@ -389,6 +395,7 @@ export class TestPersonCodingService {
       this.codingFreshnessScopeRequests.clear();
       this.appliedResultsOverviewCache.clear();
       this.appliedResultsOverviewRequests.clear();
+      this.manualCodingPlanningSnapshots.clear();
       return;
     }
 
@@ -396,6 +403,7 @@ export class TestPersonCodingService {
     this.codingFreshnessRequests.delete(workspaceId);
     this.appliedResultsOverviewCache.delete(workspaceId);
     this.appliedResultsOverviewRequests.delete(workspaceId);
+    this.manualCodingPlanningSnapshots.delete(workspaceId);
     this.deleteCacheKeysForWorkspace(
       this.autocodingReadinessCache,
       workspaceId
@@ -416,6 +424,26 @@ export class TestPersonCodingService {
       this.codingFreshnessScopeRequests,
       workspaceId
     );
+  }
+
+  getManualCodingPlanningSnapshot(
+    workspaceId: number
+  ): ManualCodingPlanningSnapshot | null {
+    return this.manualCodingPlanningSnapshots.get(workspaceId) ?? null;
+  }
+
+  beginManualCodingPlanningSnapshot(): number {
+    return this.codingStatusCacheGeneration;
+  }
+
+  saveManualCodingPlanningSnapshot(
+    workspaceId: number,
+    snapshot: ManualCodingPlanningSnapshot,
+    cacheGeneration: number
+  ): void {
+    if (cacheGeneration === this.codingStatusCacheGeneration) {
+      this.manualCodingPlanningSnapshots.set(workspaceId, snapshot);
+    }
   }
 
   getCachedCodingStatusOverview(


### PR DESCRIPTION
## Überblick

- bündelt die teuren Planungs- und Kodierfortschrittsdaten zu einem konsistenten Snapshot pro Arbeitsbereich und Sitzung
- verwendet einen vollständig geladenen Snapshot beim Wechsel zwischen Kodierungsansichten erneut
- lädt die Daten weiterhin gezielt bei einer ausdrücklichen Aktualisierung oder relevanten lokalen Änderung neu
- verwirft unvollständige Snapshots beim schnellen Tabwechsel oder beim Verlassen der Komponente
- trennt zwischengespeicherte Werte strikt nach Arbeitsbereich

Damit werden die in #813 beschriebenen wiederholten Statusberechnungen beim bloßen Navigieren vermieden, ohne veraltete oder nur teilweise geladene Werte anzuzeigen.

## Umfang

Dieser PR baut bewusst auf #978 auf und enthält nur die ergänzende Frontend-Logik für den Planungs-Snapshot. Eine Revisionsplattform im Backend, Fremdnutzer-Invalidierung und zusätzliche Planungs-Cache-Infrastruktur werden nicht erneut eingeführt.

## Validierung

- Frontend-Jest: 202 Test-Suites und 2.019 Tests erfolgreich
- neue Abbruchtests: 2/2 erfolgreich
- Frontend-Lint erfolgreich
- Frontend-Produktionsbuild erfolgreich
- reguläre Cypress-Flows gegen Entwicklungs- und Produktionskonfiguration: jeweils 7/7 erfolgreich
- manueller Browser-Smoke-Test mit VERA_3: 17.757 offene Fälle und 82 fehlende Variablen konsistent
- Cache-Wiederverwendung, manuelle Aktualisierung, Auto-Aktualisierung an/aus, schneller Tabwechsel und Trennung zweier Arbeitsbereiche geprüft
- keine Browserkonsolenfehler oder -warnungen

Bezieht sich auf #813.
