### PR TITLE
fix: preserve export worker PostgreSQL options during updates

### DIFF
--- a/.env.coding-box.template
+++ b/.env.coding-box.template
@@ -36,7 +36,7 @@ RESPONSE_CACHE_WORKSPACE_CONCURRENCY=1
 RESPONSE_CACHE_ITEM_CONCURRENCY=4
 CODING_FILE_LOAD_CONCURRENCY=4
 # Export worker DB session options. The default disables PostgreSQL JIT for large export queries.
-EXPORT_WORKER_PGOPTIONS=-c jit=off
+EXPORT_WORKER_PGOPTIONS="-c jit=off"
 # Keep long-running, consistent workspace export snapshots exempt from the API timeout.
 EXPORT_WORKER_POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS=0
 # Dedicated export worker PostgreSQL connection pool size.

--- a/.env.dev.template
+++ b/.env.dev.template
@@ -41,7 +41,7 @@ RESPONSE_CACHE_WORKSPACE_CONCURRENCY=1
 RESPONSE_CACHE_ITEM_CONCURRENCY=4
 CODING_FILE_LOAD_CONCURRENCY=4
 # Export worker DB session options. The default disables PostgreSQL JIT for large export queries.
-EXPORT_WORKER_PGOPTIONS=-c jit=off
+EXPORT_WORKER_PGOPTIONS="-c jit=off"
 # Keep long-running, consistent workspace export snapshots exempt from the API timeout.
 EXPORT_WORKER_POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS=0
 # Dedicated export worker PostgreSQL connection pool size.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -301,6 +301,12 @@ customize_settings() {
   # shellcheck source=.env.coding-box
   source ".env.${APP_NAME}"
 
+  if [ "${EXPORT_WORKER_PGOPTIONS:-}" = "-c" ]; then
+    printf >&2 "Invalid EXPORT_WORKER_PGOPTIONS in '.env.%s': the '-c' option requires a value.\n" "${APP_NAME}"
+    printf >&2 'Quote values containing spaces, for example: EXPORT_WORKER_PGOPTIONS="-c jit=off"\n'
+    exit 1
+  fi
+
   # Setup environment variables
   printf "5. Set Environment variables (default postgres password is generated randomly):\n\n"
 

--- a/scripts/make/dev.mk
+++ b/scripts/make/dev.mk
@@ -2,6 +2,10 @@ CODING_BOX_BASE_DIR := $(shell git rev-parse --show-toplevel)
 
 include $(CODING_BOX_BASE_DIR)/.env.dev
 
+# Docker Compose strips dotenv quotes, while GNU Make preserves them when it
+# includes the same file. Normalize this value before exporting it to Compose.
+EXPORT_WORKER_PGOPTIONS := $(subst ",,$(EXPORT_WORKER_PGOPTIONS))
+
 ## exports all variables (especially those of the included .env.dev file!)
 .EXPORT_ALL_VARIABLES:
 

--- a/scripts/make/prod.mk
+++ b/scripts/make/prod.mk
@@ -3,6 +3,10 @@ CMD ?= status
 
 include $(CODING_BOX_BASE_DIR)/.env.coding-box
 
+# Docker Compose strips dotenv quotes, while GNU Make preserves them when it
+# includes the same file. Normalize this value before exporting it to Compose.
+EXPORT_WORKER_PGOPTIONS := $(subst ",,$(EXPORT_WORKER_PGOPTIONS))
+
 # exports all variables (especially those of the included .env.coding-box file!)
 .EXPORT_ALL_VARIABLES:
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -95,6 +95,12 @@ create_app_dir_backup() {
 load_docker_environment_variables() {
   # shellcheck source=.env.studio-lite
   source ".env.${APP_NAME}"
+
+  if [ "${EXPORT_WORKER_PGOPTIONS:-}" = "-c" ]; then
+    printf >&2 "Invalid EXPORT_WORKER_PGOPTIONS in '.env.%s': the '-c' option requires a value.\n" "${APP_NAME}"
+    printf >&2 'Quote values containing spaces, for example: EXPORT_WORKER_PGOPTIONS="-c jit=off"\n'
+    exit 1
+  fi
 }
 
 data_services_up() {


### PR DESCRIPTION
## Summary

- quote the export-worker PostgreSQL options in development and production environment templates
- normalize the quoted dotenv value when Make exports it to Docker Compose
- stop installation or update with an actionable error if `PGOPTIONS` is reduced to the invalid value `-c`

## Root cause

The environment file is consumed both as a Docker Compose dotenv file and as shell/Make input. The unquoted value `EXPORT_WORKER_PGOPTIONS=-c jit=off` could be reduced to `-c` when the update script sourced an environment inherited from Make. The export worker then failed every PostgreSQL connection and remained in a restart loop.

## Impact

Updates retain the complete `-c jit=off` value, while invalid legacy configuration is rejected before a broken export worker is deployed.

Related to #958.

## Validation

- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
- verified direct dotenv parsing resolves `PGOPTIONS` to `-c jit=off`
- verified the Make-to-Compose path resolves `PGOPTIONS` to `-c jit=off`
- confirmed the corrected production worker runs with zero restarts and successfully completed export job 158
