### PR TITLE
fix: preserve export worker PostgreSQL options in develop

### DIFF
--- a/.env.coding-box.template
+++ b/.env.coding-box.template
@@ -36,7 +36,7 @@ RESPONSE_CACHE_WORKSPACE_CONCURRENCY=1
 RESPONSE_CACHE_ITEM_CONCURRENCY=4
 CODING_FILE_LOAD_CONCURRENCY=4
 # Export worker DB session options. The default disables PostgreSQL JIT for large export queries.
-EXPORT_WORKER_PGOPTIONS=-c jit=off
+EXPORT_WORKER_PGOPTIONS="-c jit=off"
 # Keep long-running, consistent workspace export snapshots exempt from the API timeout.
 EXPORT_WORKER_POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS=0
 # Dedicated export worker PostgreSQL connection pool size.

--- a/.env.dev.template
+++ b/.env.dev.template
@@ -41,7 +41,7 @@ RESPONSE_CACHE_WORKSPACE_CONCURRENCY=1
 RESPONSE_CACHE_ITEM_CONCURRENCY=4
 CODING_FILE_LOAD_CONCURRENCY=4
 # Export worker DB session options. The default disables PostgreSQL JIT for large export queries.
-EXPORT_WORKER_PGOPTIONS=-c jit=off
+EXPORT_WORKER_PGOPTIONS="-c jit=off"
 # Keep long-running, consistent workspace export snapshots exempt from the API timeout.
 EXPORT_WORKER_POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS=0
 # Dedicated export worker PostgreSQL connection pool size.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -301,6 +301,12 @@ customize_settings() {
   # shellcheck source=.env.coding-box
   source ".env.${APP_NAME}"
 
+  if [ "${EXPORT_WORKER_PGOPTIONS:-}" = "-c" ]; then
+    printf >&2 "Invalid EXPORT_WORKER_PGOPTIONS in '.env.%s': the '-c' option requires a value.\n" "${APP_NAME}"
+    printf >&2 'Quote values containing spaces, for example: EXPORT_WORKER_PGOPTIONS="-c jit=off"\n'
+    exit 1
+  fi
+
   # Setup environment variables
   printf "5. Set Environment variables (default postgres password is generated randomly):\n\n"
 

--- a/scripts/make/dev.mk
+++ b/scripts/make/dev.mk
@@ -2,6 +2,10 @@ CODING_BOX_BASE_DIR := $(shell git rev-parse --show-toplevel)
 
 include $(CODING_BOX_BASE_DIR)/.env.dev
 
+# Docker Compose strips dotenv quotes, while GNU Make preserves them when it
+# includes the same file. Normalize this value before exporting it to Compose.
+EXPORT_WORKER_PGOPTIONS := $(subst ",,$(EXPORT_WORKER_PGOPTIONS))
+
 ## exports all variables (especially those of the included .env.dev file!)
 .EXPORT_ALL_VARIABLES:
 

--- a/scripts/make/prod.mk
+++ b/scripts/make/prod.mk
@@ -3,6 +3,10 @@ CMD ?= status
 
 include $(CODING_BOX_BASE_DIR)/.env.coding-box
 
+# Docker Compose strips dotenv quotes, while GNU Make preserves them when it
+# includes the same file. Normalize this value before exporting it to Compose.
+EXPORT_WORKER_PGOPTIONS := $(subst ",,$(EXPORT_WORKER_PGOPTIONS))
+
 # exports all variables (especially those of the included .env.coding-box file!)
 .EXPORT_ALL_VARIABLES:
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -95,6 +95,12 @@ create_app_dir_backup() {
 load_docker_environment_variables() {
   # shellcheck source=.env.studio-lite
   source ".env.${APP_NAME}"
+
+  if [ "${EXPORT_WORKER_PGOPTIONS:-}" = "-c" ]; then
+    printf >&2 "Invalid EXPORT_WORKER_PGOPTIONS in '.env.%s': the '-c' option requires a value.\n" "${APP_NAME}"
+    printf >&2 'Quote values containing spaces, for example: EXPORT_WORKER_PGOPTIONS="-c jit=off"\n'
+    exit 1
+  fi
 }
 
 data_services_up() {


### PR DESCRIPTION
## What changed

- reapplies the export worker PostgreSQL option preservation fix to `develop`
- keeps the environment templates, install/update scripts, and Make workflows aligned

## Why

PR #983 was accidentally merged into `release/1.17.1` after that release branch had already been merged into `develop`. As a result, the fix commit was present on the release branch but missing from `develop`.

## Impact

Export worker PostgreSQL options are preserved consistently for development and production installations based on `develop`.

## Validation

- verified the cherry-picked patch is identical to the original fix from PR #983
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check origin/develop...HEAD`
- the original patch completed pipeline #97818 successfully
